### PR TITLE
feat: don't load metadata from clickhouse recording events

### DIFF
--- a/posthog/api/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/api/test/__snapshots__/test_session_recordings.ambr
@@ -679,8 +679,8 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
-                                                     '1')
+  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -1004,9 +1004,9 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
                                                      '3',
-                                                     '1')
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '

--- a/posthog/api/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/api/test/__snapshots__/test_session_recordings.ambr
@@ -679,8 +679,8 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
-                                                     '2')
+  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -1004,9 +1004,9 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
                                                      '3',
-                                                     '2')
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '

--- a/posthog/api/test/test_session_recordings.py
+++ b/posthog/api/test/test_session_recordings.py
@@ -15,6 +15,7 @@ from posthog.models import Organization, Person, SessionRecording
 from posthog.models.filters.session_recordings_filter import SessionRecordingsFilter
 from posthog.models.session_recording_event import SessionRecordingViewed
 from posthog.models.team import Team
+from posthog.queries.session_recordings.test.session_replay_sql import produce_replay_summary
 from posthog.session_recordings.test.test_factory import create_session_recording_events
 from posthog.test.base import (
     APIBaseTest,
@@ -233,23 +234,48 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             team=self.team, distinct_ids=["u1"], properties={"$some_prop": "something", "email": "bob@bob.com"}
         )
         base_time = (now() - relativedelta(days=1)).replace(microsecond=0)
-        self.create_snapshot("u1", "1", base_time)
-        response = self.client.get(f"/api/projects/{self.team.id}/session_recordings")
+
+        produce_replay_summary(
+            session_id="1",
+            team_id=self.team.pk,
+            first_timestamp=base_time.isoformat(),
+            last_timestamp=base_time.isoformat(),
+            distinct_id="u1",
+            first_url="https://example.io/home",
+            click_count=2,
+            keypress_count=2,
+            mouse_activity_count=2,
+            active_milliseconds=50 * 1000 * 0.5,
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/session_recordings?version=3")
         response_data = response.json()
         # Make sure it starts not viewed
-        self.assertEqual(response_data["results"][0]["viewed"], False)
+        assert response_data["results"][0]["viewed"] is False
+        assert response_data["results"][0]["id"] == "1"
 
-        response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1")
-        response = self.client.get(f"/api/projects/{self.team.id}/session_recordings")
-        response_data = response.json()
+        # can get it directly
+        get_session_response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1")
+        assert get_session_response.status_code == 200
+        assert get_session_response.json()["viewed"] is False
+        assert get_session_response.json()["id"] == "1"
+
+        # being loaded doesn't mark it as viewed
+        all_sessions_response = self.client.get(f"/api/projects/{self.team.id}/session_recordings?version=3")
+        response_data = all_sessions_response.json()
         # Make sure it remains not viewed
-        self.assertEqual(response_data["results"][0]["viewed"], False)
+        assert response_data["results"][0]["viewed"] is False
+        assert response_data["results"][0]["id"] == "1"
 
-        response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1?save_view=True")
-        response = self.client.get(f"/api/projects/{self.team.id}/session_recordings")
-        response_data = response.json()
+        # can set it to viewed
+        save_as_viewed_response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1?save_view=True")
+        assert save_as_viewed_response.status_code == 200
+
+        final_view_response = self.client.get(f"/api/projects/{self.team.id}/session_recordings?version=3")
+        response_data = final_view_response.json()
         # Make sure the query param sets it to viewed
-        self.assertEqual(response_data["results"][0]["viewed"], True)
+        assert response_data["results"][0]["viewed"] is True
+        assert response_data["results"][0]["id"] == "1"
 
         response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/1")
         response_data = response.json()
@@ -263,8 +289,13 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             )
             session_recording_id = "session_1"
             base_time = (now() - relativedelta(days=1)).replace(microsecond=0)
-            self.create_snapshot("d1", session_recording_id, base_time)
-            self.create_snapshot("d1", session_recording_id, base_time + relativedelta(seconds=30))
+            produce_replay_summary(
+                session_id=session_recording_id,
+                team_id=self.team.pk,
+                first_timestamp=base_time.isoformat(),
+                last_timestamp=(base_time + relativedelta(seconds=30)).isoformat(),
+                distinct_id="d1",
+            )
 
         response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/{session_recording_id}")
         response_data = response.json()
@@ -366,21 +397,6 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
 
                 next_url = response_data["next"]
 
-    def test_get_metadata_for_chunked_session_recording(self):
-        p = Person.objects.create(
-            team=self.team, distinct_ids=["d1"], properties={"$some_prop": "something", "email": "bob@bob.com"}
-        )
-        chunked_session_id = "chunked_session_id"
-        num_chunks = 60
-        snapshots_per_chunk = 2
-        for index in range(num_chunks):
-            self.create_snapshots(snapshots_per_chunk, "d1", chunked_session_id, now() + relativedelta(minutes=index))
-        response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/{chunked_session_id}")
-        response_data = response.json()
-        self.assertEqual(response_data["person"]["id"], p.pk)
-        self.assertEqual(response_data["viewed"], False)
-        self.assertEqual(response_data["id"], chunked_session_id)
-
     def test_single_session_recording_doesnt_leak_teams(self):
         another_team = Team.objects.create(organization=self.organization)
         self.create_snapshot("user", "id_no_team_leaking", now() - relativedelta(days=1), team_id=another_team.pk)
@@ -391,7 +407,14 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_session_recording_with_no_person(self):
-        self.create_snapshot("d1", "id_no_person", now() - relativedelta(days=1))
+        produce_replay_summary(
+            session_id="id_no_person",
+            team_id=self.team.pk,
+            first_timestamp=(now() - relativedelta(days=1)).isoformat(),
+            last_timestamp=(now() - relativedelta(days=1)).isoformat(),
+            distinct_id="d1",
+        )
+
         response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/id_no_person")
         response_data = response.json()
         self.assertEqual(response_data["person"], None)
@@ -604,6 +627,13 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
 
         session_id = str(uuid.uuid4())
         with freeze_time("2023-01-01T12:00:00Z"):
+            produce_replay_summary(
+                session_id=session_id,
+                team_id=self.team.pk,
+                first_timestamp=(now() - relativedelta(days=1)).isoformat(),
+                last_timestamp=(now() - relativedelta(days=1)).isoformat(),
+                distinct_id="user",
+            )
             self.create_snapshot("user", session_id, now() - relativedelta(days=1), team_id=self.team.pk)
 
         token = self.client.patch(

--- a/posthog/models/session_recording/metadata.py
+++ b/posthog/models/session_recording/metadata.py
@@ -53,8 +53,13 @@ class RecordingMetadata(TypedDict):
     end_time: datetime
     click_count: int
     keypress_count: int
-    urls: List[str]
+    mouse_activity_count: int
+    console_log_count: int
+    console_warn_count: int
+    console_error_count: int
+    first_url: str
     duration: int
+    active_seconds: int
 
 
 class RecordingMatchingEvents(TypedDict):

--- a/posthog/models/session_recording/session_recording.py
+++ b/posthog/models/session_recording/session_recording.py
@@ -15,6 +15,7 @@ from posthog.models.session_recording.metadata import (
 from posthog.models.session_recording_event.session_recording_event import SessionRecordingViewed
 from posthog.models.team.team import Team
 from posthog.models.utils import UUIDModel
+from posthog.queries.session_recordings.session_replay_events import SessionReplayEvents
 
 
 class SessionRecording(UUIDModel):
@@ -61,8 +62,6 @@ class SessionRecording(UUIDModel):
     _snapshots: Optional[DecompressedRecordingData] = None
 
     def load_metadata(self) -> bool:
-        from posthog.queries.session_recordings.session_recording_events import SessionRecordingEvents
-
         if self._metadata:
             return True
 
@@ -71,11 +70,11 @@ class SessionRecording(UUIDModel):
             pass
         else:
             # Try to load from Clickhouse
-            metadata = SessionRecordingEvents(
+            metadata = SessionReplayEvents().get_metadata(
                 team=self.team,
-                session_recording_id=self.session_id,
+                session_id=self.session_id,
                 recording_start_time=self.start_time,
-            ).get_metadata()
+            )
 
             if not metadata:
                 return False
@@ -83,13 +82,14 @@ class SessionRecording(UUIDModel):
             self._metadata = metadata
 
             # Some fields of the metadata are persisted fully in the model
+            # TODO there are more fields that can be stored on the model here
             self.distinct_id = metadata["distinct_id"]
             self.start_time = metadata["start_time"]
             self.end_time = metadata["end_time"]
             self.duration = metadata["duration"]
             self.click_count = metadata["click_count"]
             self.keypress_count = metadata["keypress_count"]
-            self.set_start_url_from_urls(metadata["urls"])
+            self.set_start_url_from_urls(first_url=metadata["first_url"])
 
         return True
 

--- a/posthog/queries/session_recordings/session_replay_events.py
+++ b/posthog/queries/session_recordings/session_replay_events.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+from typing import Optional, Tuple, List
+
+from posthog.clickhouse.client import sync_execute
+from posthog.models.team import Team
+from posthog.models.session_recording.metadata import (
+    RecordingMetadata,
+)
+
+
+class SessionReplayEvents:
+    def get_metadata(
+        self, session_id: str, team: Team, recording_start_time: Optional[datetime] = None
+    ) -> Optional[RecordingMetadata]:
+        query = """
+            SELECT
+                any(distinct_id),
+                min(min_first_timestamp) as start_time,
+                max(max_last_timestamp) as end_time,
+                dateDiff('SECOND', start_time, end_time) as duration,
+                argMinMerge(first_url) as first_url,
+                sum(click_count),
+                sum(keypress_count),
+                sum(mouse_activity_count),
+                sum(active_milliseconds)/1000 as active_seconds,
+                sum(console_log_count) as console_log_count,
+                sum(console_warn_count) as console_warn_count,
+                sum(console_error_count) as console_error_count
+            FROM
+                session_replay_events
+            PREWHERE
+                team_id = %(team_id)s
+                AND session_id = %(session_id)s
+                {optional_timestamp_clause}
+            GROUP BY
+                session_id
+        """
+        query = query.format(
+            optional_timestamp_clause="AND min_first_timestamp >= %(recording_start_time)s"
+            if recording_start_time
+            else ""
+        )
+
+        replay_response: List[Tuple] = sync_execute(
+            query,
+            {"team_id": team.pk, "session_id": session_id, "recording_start_time": recording_start_time},
+        )
+
+        if len(replay_response) == 0:
+            return None
+        if len(replay_response) > 1:
+            raise ValueError("Multiple sessions found for session_id: {}".format(session_id))
+
+        replay = replay_response[0]
+        return RecordingMetadata(
+            distinct_id=replay[0],
+            start_time=replay[1],
+            end_time=replay[2],
+            duration=replay[3],
+            first_url=replay[4],
+            click_count=replay[5],
+            keypress_count=replay[6],
+            mouse_activity_count=replay[7],
+            active_seconds=replay[8],
+            console_log_count=replay[9],
+            console_warn_count=replay[10],
+            console_error_count=replay[11],
+        )

--- a/posthog/queries/session_recordings/test/test_session_recording.py
+++ b/posthog/queries/session_recordings/test/test_session_recording.py
@@ -1,6 +1,3 @@
-import random
-from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
 from urllib.parse import urlencode
 
 from dateutil.relativedelta import relativedelta
@@ -10,9 +7,8 @@ from freezegun import freeze_time
 from rest_framework.request import Request
 
 from posthog.models import Filter
-from posthog.models.session_recording.metadata import SessionRecordingEvent
 from posthog.models.team import Team
-from posthog.queries.session_recordings.session_recording_events import RecordingMetadata, SessionRecordingEvents
+from posthog.queries.session_recordings.session_recording_events import SessionRecordingEvents
 from posthog.session_recordings.session_recording_helpers import (
     DecompressedRecordingData,
 )
@@ -165,94 +161,6 @@ class TestClickhouseSessionRecording(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(recording["snapshot_data_by_window_id"][""][0]["timestamp"], 1_600_000_300_000)
             self.assertTrue(recording["has_next"])
 
-    def test_get_metadata(self):
-        with freeze_time("2020-09-13T12:26:40.000Z"):
-            timestamp = now()
-            create_snapshots(
-                team_id=self.team.id,
-                snapshot_count=1,
-                distinct_id="u",
-                session_id="1",
-                timestamp=timestamp,
-                window_id="1",
-            )
-            create_snapshots(
-                team_id=self.team.id,
-                snapshot_count=1,
-                distinct_id="u",
-                session_id="1",
-                timestamp=timestamp + relativedelta(seconds=3),
-                window_id="1",
-                has_full_snapshot=False,
-                source=3,
-            )
-            create_snapshots(
-                team_id=self.team.id,
-                snapshot_count=1,
-                distinct_id="u",
-                session_id="1",
-                timestamp=timestamp + relativedelta(seconds=1),
-                window_id="1",
-                has_full_snapshot=False,
-                source=3,
-            )
-
-            recording = SessionRecordingEvents(team=self.team, session_recording_id="1").get_metadata()
-
-            self.assertEqual(
-                recording,
-                RecordingMetadata(
-                    distinct_id="u",
-                    duration=3,
-                    click_count=0,
-                    keypress_count=0,
-                    urls=[],
-                    start_time=now(),
-                    end_time=now() + relativedelta(seconds=3),
-                ),
-            )
-
-    def test_get_metadata_for_non_existant_session_id(self):
-        with freeze_time("2020-09-13T12:26:40.000Z"):
-            recording = SessionRecordingEvents(team=self.team, session_recording_id="1").get_metadata()
-            self.assertEqual(recording, None)
-
-    def test_get_metadata_does_not_leak_teams(self):
-        with freeze_time("2020-09-13T12:26:40.000Z"):
-            another_team = Team.objects.create(organization=self.organization)
-            create_snapshot(
-                has_full_snapshot=False,
-                distinct_id="user",
-                session_id="1",
-                timestamp=now(),
-                team_id=another_team.pk,
-            )
-            create_snapshot(
-                has_full_snapshot=False,
-                distinct_id="user",
-                session_id="1",
-                timestamp=now() + relativedelta(seconds=10),
-                team_id=self.team.id,
-            )
-            create_snapshot(
-                has_full_snapshot=False,
-                distinct_id="user",
-                session_id="1",
-                timestamp=now() + relativedelta(seconds=20),
-                team_id=self.team.id,
-            )
-            create_snapshot(
-                has_full_snapshot=False,
-                distinct_id="user",
-                session_id="1",
-                timestamp=now() + relativedelta(seconds=30),
-                team_id=self.team.id,
-            )
-
-            recording = SessionRecordingEvents(team=self.team, session_recording_id="1").get_metadata()
-            assert recording is not None
-            assert recording["start_time"] != now()
-
     def test_get_snapshots_with_date_filter(self):
         with freeze_time("2020-09-13T12:26:40.000Z"):
             # This snapshot should be filtered out
@@ -280,55 +188,3 @@ class TestClickhouseSessionRecording(ClickhouseTestMixin, APIBaseTest):
             ).get_snapshots(filter.limit, filter.offset)
 
             self.assertEqual(len(recording["snapshot_data_by_window_id"][""]), 1)
-
-    def test_should_parse_metadata_efficiently(self):
-        """
-        We can end up with a lot of metadata events so it is important to see if any of our parsing slows things down at scale.
-        """
-
-        start_time = datetime(2023, 1, 1, 0, 0, tzinfo=timezone.utc)
-        random_event_times = list(range(0, 100000))
-        end_time = datetime(2023, 1, 1, tzinfo=timezone.utc) + timedelta(seconds=len(random_event_times) - 1)
-
-        # Create a bunch of mock events in the wrong order
-        random.shuffle(random_event_times)
-        start_timestamp = round(start_time.timestamp() * 1000)
-        mock_events = [
-            SessionRecordingEvent(
-                session_id="18586b7d1d3c52-0d746e4c6fc6b3-17525635-384000-18586b7d1d4276e",
-                window_id="18586b7d1d528f6-026e4b0f3a575c-17525635-384000-18586b7d1d6760",
-                distinct_id="123456789123456789",
-                timestamp=datetime(2023, 1, 1) - timedelta(seconds=x),
-                events_summary=[
-                    {"timestamp": start_timestamp + (x * 1000), "type": 2, "data": {}},
-                    {"timestamp": start_timestamp + (x * 1000), "type": 3, "data": {"source": 0}},
-                    {"timestamp": start_timestamp + (x * 1000), "type": 3, "data": {"source": 1}},
-                    {"timestamp": start_timestamp + (x * 1000), "type": 3, "data": {"source": 0}},
-                    {"timestamp": start_timestamp + (x * 1000), "type": 3, "data": {"source": 1}},
-                    {"timestamp": start_timestamp + (x * 1000), "type": 3, "data": {"source": 0}},
-                    {"timestamp": start_timestamp + (x * 1000), "type": 3, "data": {"source": 0}},
-                ],
-                snapshot_data={},
-            )
-            for x in random_event_times
-        ]
-
-        task = SessionRecordingEvents(team=self.team, session_recording_id="1", recording_start_time=now())
-
-        time = datetime.now()
-        with patch.object(task, "_query_recording_snapshots", return_value=mock_events):
-            metadata = task.get_metadata()
-            assert metadata == RecordingMetadata(
-                click_count=0,
-                keypress_count=0,
-                duration=13599,
-                start_time=start_time,
-                end_time=end_time,
-                distinct_id="123456789123456789",
-                urls=[],
-            )
-
-        duration = datetime.now() - time
-        print("Took " + str(duration.total_seconds()) + " seconds to parse metadata.")  # noqa
-
-        assert duration < timedelta(seconds=5)

--- a/posthog/queries/session_recordings/test/test_session_replay_events.py
+++ b/posthog/queries/session_recordings/test/test_session_replay_events.py
@@ -1,0 +1,69 @@
+from posthog.models import Team
+from posthog.queries.session_recordings.session_replay_events import SessionReplayEvents
+from posthog.queries.session_recordings.test.session_replay_sql import produce_replay_summary
+from posthog.test.base import ClickhouseTestMixin, APIBaseTest
+from dateutil.relativedelta import relativedelta
+from django.utils.timezone import now
+
+
+class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.base_time = (now() - relativedelta(days=1)).replace(microsecond=0)
+        produce_replay_summary(
+            session_id="1",
+            team_id=self.team.pk,
+            first_timestamp=self.base_time.isoformat(),
+            last_timestamp=self.base_time.isoformat(),
+            distinct_id="u1",
+            first_url="https://example.io/home",
+            click_count=2,
+            keypress_count=2,
+            mouse_activity_count=2,
+            active_milliseconds=50 * 1000 * 0.5,
+        )
+        produce_replay_summary(
+            session_id="2",
+            team_id=self.team.pk,
+            first_timestamp=self.base_time.isoformat(),
+            last_timestamp=self.base_time.isoformat(),
+            distinct_id="u1",
+            first_url="https://example.io/home",
+            click_count=2,
+            keypress_count=2,
+            mouse_activity_count=2,
+            active_milliseconds=50 * 1000 * 0.5,
+        )
+
+    def test_get_metadata(self) -> None:
+
+        metadata = SessionReplayEvents().get_metadata(session_id="1", team=self.team)
+        assert metadata == {
+            "active_seconds": 25.0,
+            "click_count": 2,
+            "console_error_count": 0,
+            "console_log_count": 0,
+            "console_warn_count": 0,
+            "distinct_id": "u1",
+            "duration": 0,
+            "end_time": self.base_time,
+            "first_url": "https://example.io/home",
+            "keypress_count": 2,
+            "mouse_activity_count": 2,
+            "start_time": self.base_time,
+        }
+
+    def test_get_nonexistent_metadata(self) -> None:
+        metadata = SessionReplayEvents().get_metadata(session_id="not a session", team=self.team)
+        assert metadata is None
+
+    def test_get_metadata_does_not_leak_between_teams(self) -> None:
+        another_team = Team.objects.create(organization=self.organization, name="Another Team")
+        metadata = SessionReplayEvents().get_metadata(session_id="1", team=another_team)
+        assert metadata is None
+
+    def test_get_metadata_filters_by_date(self) -> None:
+        metadata = SessionReplayEvents().get_metadata(
+            session_id="1", team=self.team, recording_start_time=self.base_time + relativedelta(days=2)
+        )
+        assert metadata is None


### PR DESCRIPTION
## Problem

We're still loading metadata from ClickHouse session_recording_events 🤯 

## Changes

Not any more

## How did you test this code?

developer tests and 👀 locally
