### PR TITLE
chore: remove more depot build caching in GH Actions

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -66,8 +66,6 @@ jobs:
               with:
                   project: x19jffd9zf # posthog
                   buildx-fallback: false # the fallback is so slow it's better to just fail
-                  cache-from: type=gha # always pull the layers from GHA
-                  cache-to: type=gha,mode=max # always push the layers to GHA
                   push: true
                   tags: posthog/posthog:latest,${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:master
                   platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
there's another bit of caching between depot and GH actions we can remove