### PR TITLE
fix: Use new tailscale key on cleanup that doesn't need renewing

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -35,10 +35,13 @@ jobs:
                   role-duration-seconds: 3600
 
             - name: connect to tailscale
-              uses: tailscale/github-action@ce41a99162202a647a4b24c30c558a567b926709
+              uses: tailscale/github-action@8b804aa882ac3429b804a2a22f9803a2101a0db9
+              env:
+                  TS_EXPERIMENT_OAUTH_AUTHKEY: true
               with:
-                  authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-                  hostname: github-posthog-${{ github.action }}-${{ github.job }}
+                  version: 1.42.0
+                  authkey: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
+                  args: --advertise-tags tag:github-runner
 
             - name: Delete preview deployment
               id: cleanup


### PR DESCRIPTION
## Problem

The current key needs renewing every 90 days, now it supports using an oauth key that doesn't expire so switch to that (already done for pr-deploy.yml but missed this)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
