### PR TITLE
fix(elements): support # in selectors

### DIFF
--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -328,6 +328,14 @@ class TestProperty(BaseTest):
             self._selector_to_expr("#with-dashed-id"),
             self._selector_to_expr("[id='with-dashed-id']"),
         )
+        self.assertEqual(
+            self._selector_to_expr("#with\\slashed\\id"),
+            clear_locations(
+                elements_chain_match(
+                    '.*?attr_id="with\\\\slashed\\\\id".*?([-_a-zA-Z0-9\\.:"= ]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                )
+            ),
+        )
 
     def test_elements_chain_key_filter(self):
         self.assertEqual(

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -312,7 +312,21 @@ class TestProperty(BaseTest):
         )
         self.assertEqual(
             self._selector_to_expr("#withid"),
-            clear_locations(elements_chain_match('#withid([-_a-zA-Z0-9\\.:"= ]*?)?($|;|:([^;^\\s]*(;|$|\\s)))')),
+            clear_locations(
+                elements_chain_match('.*?attr_id="withid".*?([-_a-zA-Z0-9\\.:"= ]*?)?($|;|:([^;^\\s]*(;|$|\\s)))')
+            ),
+        )
+        self.assertEqual(
+            self._selector_to_expr("#with-dashed-id"),
+            clear_locations(
+                elements_chain_match(
+                    '.*?attr_id="with\\-dashed\\-id".*?([-_a-zA-Z0-9\\.:"= ]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                )
+            ),
+        )
+        self.assertEqual(
+            self._selector_to_expr("#with-dashed-id"),
+            self._selector_to_expr("[id='with-dashed-id']"),
         )
 
     def test_elements_chain_key_filter(self):
@@ -358,7 +372,7 @@ class TestProperty(BaseTest):
                 "event = '$autocapture' and match(elements_chain, {regex1}) and match(elements_chain, {regex2})",
                 {
                     "regex1": ast.Constant(
-                        value='a.*?\\.active\\..*?nav-link([-_a-zA-Z0-9\\.:"= ]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
+                        value='a.*?\\.active\\..*?nav\\-link([-_a-zA-Z0-9\\.:"= ]*?)?($|;|:([^;^\\s]*(;|$|\\s)))'
                     ),
                     "regex2": ast.Constant(value="(^|;)a(\\.|$|;|:)"),
                 },

--- a/posthog/models/event/event.py
+++ b/posthog/models/event/event.py
@@ -48,6 +48,12 @@ class SelectorPart:
             # Strip all slashes that are not followed by another slash
             self.data["attr_class__contains"] = [self._unescape_class(p) if escape_slashes else p for p in parts[1:]]
             tag = parts[0]
+        if "#" in tag:
+            parts = tag.split("#")
+            if len(parts) > 1:
+                self.data["attr_id"] = self._unescape_class(parts[1]) if escape_slashes else parts[1]
+                self.ch_attributes["attr_id"] = self.data["attr_id"]
+            tag = parts[0]
         if tag:
             self.data["tag_name"] = tag
 

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -764,13 +764,13 @@ def build_selector_regex(selector: Selector) -> str:
             if tag.data["tag_name"] == "*":
                 regex += ".+"
             else:
-                regex += tag.data["tag_name"]
+                regex += re.escape(tag.data["tag_name"])
         if tag.data.get("attr_class__contains"):
-            regex += r".*?\.{}".format(r"\..*?".join(sorted(tag.data["attr_class__contains"])))
+            regex += r".*?\.{}".format(r"\..*?".join([re.escape(s) for s in sorted(tag.data["attr_class__contains"])]))
         if tag.ch_attributes:
             regex += ".*?"
             for key, value in sorted(tag.ch_attributes.items()):
-                regex += '{}="{}".*?'.format(key, value)
+                regex += '{}="{}".*?'.format(re.escape(key), re.escape(value))
         regex += r'([-_a-zA-Z0-9\.:"= ]*?)?($|;|:([^;^\s]*(;|$|\s)))'
         if tag.direct_descendant:
             regex += ".*"

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -770,7 +770,7 @@ def build_selector_regex(selector: Selector) -> str:
         if tag.ch_attributes:
             regex += ".*?"
             for key, value in sorted(tag.ch_attributes.items()):
-                regex += '{}="{}".*?'.format(re.escape(key), re.escape(value))
+                regex += '{}="{}".*?'.format(re.escape(key), re.escape(str(value)))
         regex += r'([-_a-zA-Z0-9\.:"= ]*?)?($|;|:([^;^\s]*(;|$|\s)))'
         if tag.direct_descendant:
             regex += ".*"

--- a/posthog/models/test/test_event_model.py
+++ b/posthog/models/test/test_event_model.py
@@ -260,9 +260,7 @@ def filter_by_actions_factory(_create_event, _create_person, _get_events_for_act
         def test_with_class_with_escaped_symbols(self):
             _create_person(distinct_ids=["whatever"], team=self.team)
             action1 = Action.objects.create(team=self.team)
-            ActionStep.objects.create(
-                event="$autocapture", action=action1, selector="a.na\\\\v-link\\:b\\@ld", tag_name="a"
-            )
+            ActionStep.objects.create(event="$autocapture", action=action1, selector="a.na\\v-link:b@ld", tag_name="a")
             event1_uuid = _create_event(
                 event="$autocapture",
                 team=self.team,
@@ -281,7 +279,7 @@ def filter_by_actions_factory(_create_event, _create_person, _get_events_for_act
             _create_person(distinct_ids=["whatever"], team=self.team)
             action1 = Action.objects.create(team=self.team)
             ActionStep.objects.create(
-                event="$autocapture", action=action1, selector="a.na\\\\\\\\\\\\v-link\\:b\\@ld", tag_name="a"
+                event="$autocapture", action=action1, selector="a.na\\\\\\v-link:b@ld", tag_name="a"
             )
             event1_uuid = _create_event(
                 event="$autocapture",


### PR DESCRIPTION
## Problem

When searching for a selector to match elements, you had to write `#my-id` as `[id="my-id"]`

## Changes

- Makes # selectors work
- Adds escaping code to make selectors with dashes not crash

## How did you test this code?

Updated the tests. Clicked around in the interface and could find a #root selector