### PR TITLE
feat: Add exception catching for stream errors

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -251,6 +251,16 @@ export class SessionManager {
                     try {
                         const fileStream = createReadStream(file).pipe(zlib.createGzip())
 
+                        fileStream.on('error', (err) => {
+                            // TODO: What should we do here?
+                            status.error('🧨', 'blob_ingester_session_manager readstream errored', {
+                                ...this.logContext(),
+                                error: err,
+                            })
+
+                            this.captureException(err)
+                        })
+
                         this.inProgressUpload = new Upload({
                             client: this.s3Client,
                             params: {
@@ -335,6 +345,16 @@ export class SessionManager {
                 },
                 eventsRange: null,
             }
+
+            buffer.fileStream.on('error', (err) => {
+                // TODO: What should we do here?
+                status.error('🧨', 'blob_ingester_session_manager writestream errored', {
+                    ...this.logContext(),
+                    error: err,
+                })
+
+                this.captureException(err)
+            })
 
             return buffer
         } catch (error) {

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -7,23 +7,22 @@ import { SessionManager } from '../../../../../src/main/ingestion-queues/session
 import { now } from '../../../../../src/main/ingestion-queues/session-recording/blob-ingester/utils'
 import { createIncomingRecordingMessage } from '../fixtures'
 
+const createMockStream = () => {
+    return {
+        write: jest.fn(),
+        pipe: jest.fn(() => createMockStream()),
+        close: jest.fn((cb) => cb?.()),
+        end: jest.fn((cb) => cb?.()),
+        on: jest.fn(),
+    }
+}
+
 jest.mock('fs', () => {
     return {
         ...jest.requireActual('fs'),
         writeFileSync: jest.fn(),
-        createReadStream: jest.fn().mockImplementation(() => {
-            return {
-                pipe: () => ({ close: jest.fn() }),
-            }
-        }),
-        createWriteStream: jest.fn().mockImplementation(() => {
-            return {
-                write: jest.fn(),
-                pipe: () => ({ close: jest.fn() }),
-                close: jest.fn((cb) => cb?.()),
-                end: jest.fn((cb) => cb?.()),
-            }
-        }),
+        createReadStream: jest.fn(() => createMockStream()),
+        createWriteStream: jest.fn(() => createMockStream()),
     }
 })
 


### PR DESCRIPTION
## Problem

I think the source of our errors _could_ be coming from the streams so this adds some exception handling

## Changes

* Listen for stream errors

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
