### PR TITLE
feat: Blob flush timeout handling

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -78,7 +78,7 @@ type SessionBuffer = {
     createdAt: number
 }
 
-const MAX_FLUSH_TIME_MS = 30 * 1000
+const MAX_FLUSH_TIME_MS = 60 * 1000
 
 export class SessionManager {
     buffer: SessionBuffer

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -251,6 +251,16 @@ export class SessionManager {
                     try {
                         const fileStream = createReadStream(file).pipe(zlib.createGzip())
 
+                        fileStream.on('error', (err) => {
+                            // TODO: What should we do here?
+                            status.error('🧨', 'blob_ingester_session_manager readstream errored', {
+                                ...this.logContext(),
+                                error: err,
+                            })
+
+                            this.captureException(err)
+                        })
+
                         this.inProgressUpload = new Upload({
                             client: this.s3Client,
                             params: {
@@ -335,6 +345,16 @@ export class SessionManager {
                 },
                 eventsRange: null,
             }
+
+            buffer.fileStream.on('error', (err) => {
+                // TODO: What should we do here?
+                status.error('🧨', 'blob_ingester_session_manager writestream errored', {
+                    ...this.logContext(),
+                    error: err,
+                })
+
+                this.captureException(err)
+            })
 
             return buffer
         } catch (error) {

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-manager.test.ts
@@ -7,23 +7,22 @@ import { SessionManager } from '../../../../../src/main/ingestion-queues/session
 import { now } from '../../../../../src/main/ingestion-queues/session-recording/blob-ingester/utils'
 import { createIncomingRecordingMessage } from '../fixtures'
 
+const createMockStream = () => {
+    return {
+        write: jest.fn(),
+        pipe: jest.fn(() => createMockStream()),
+        close: jest.fn((cb) => cb?.()),
+        end: jest.fn((cb) => cb?.()),
+        on: jest.fn(),
+    }
+}
+
 jest.mock('fs', () => {
     return {
         ...jest.requireActual('fs'),
         writeFileSync: jest.fn(),
-        createReadStream: jest.fn().mockImplementation(() => {
-            return {
-                pipe: () => ({ close: jest.fn() }),
-            }
-        }),
-        createWriteStream: jest.fn().mockImplementation(() => {
-            return {
-                write: jest.fn(),
-                pipe: () => ({ close: jest.fn() }),
-                close: jest.fn((cb) => cb?.()),
-                end: jest.fn((cb) => cb?.()),
-            }
-        }),
+        createReadStream: jest.fn(() => createMockStream()),
+        createWriteStream: jest.fn(() => createMockStream()),
     }
 })
 


### PR DESCRIPTION
## Problem

Currently we log if there is a timeout. We should actually handle this and close out the current flush.

## Changes

* Wraps the possibly problematic code better and handles multiple failure mods, including the timeout.
* 1 min timeout for now to be extra leniant. Probably we should gauge the times taken to understand what an optimal timeout looks like.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

🙈 