### PR TITLE
fix(funnels): actions with all events

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -266,6 +266,8 @@ def action_to_expr(action: Action) -> ast.Expr:
             or_queries.append(exprs[0])
         elif len(exprs) > 1:
             or_queries.append(ast.And(exprs=exprs))
+        else:
+            or_queries.append(ast.Constant(value=True))
 
     if len(or_queries) == 1:
         return or_queries[0]

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -388,6 +388,14 @@ class TestProperty(BaseTest):
             ),
         )
 
+        action4 = Action.objects.create(team=self.team)
+        ActionStep.objects.create(event="$pageview", action=action4)
+        ActionStep.objects.create(event=None, action=action4)
+        self.assertEqual(
+            clear_locations(action_to_expr(action4)),
+            self._parse_expr("event = '$pageview' OR true"),  # All events just resolve to "true"
+        )
+
     def test_cohort_filter_static(self):
         cohort = Cohort.objects.create(
             team=self.team,


### PR DESCRIPTION
## Problem

A funnel query that contained an action, which contained an "all events" filter without any properties... caused the query to fail.

## Changes

No more failures.

## How did you test this code?

Wrote tests to cover regressions.