### PR TITLE
feat: Switch to inserted_at for batch exports

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -41,6 +41,7 @@ EventValues = TypedDict(
         "event": str,
         "_timestamp": str,
         "timestamp": str,
+        "inserted_at": str,
         "created_at": str,
         "distinct_id": str,
         "person_id": str,
@@ -65,8 +66,8 @@ async def insert_events(client: ChClient, events: list[EventValues]):
             team_id,
             properties,
             elements_chain,
-
             distinct_id,
+            inserted_at,
             created_at,
             person_properties
         )
@@ -83,6 +84,7 @@ async def insert_events(client: ChClient, events: list[EventValues]):
                 json.dumps(event["properties"]) if isinstance(event["properties"], dict) else event["properties"],
                 event["elements_chain"],
                 event["distinct_id"],
+                event["inserted_at"],
                 event["created_at"],
                 json.dumps(event["person_properties"])
                 if isinstance(event["person_properties"], dict)
@@ -201,6 +203,7 @@ async def test_insert_into_s3_activity_puts_data_into_s3(bucket_name, s3_client,
             "event": "test",
             "_timestamp": "2023-04-20 14:30:00",
             "timestamp": f"2023-04-20 14:30:00.{i:06d}",
+            "inserted_at": f"2023-04-20 14:30:00.{i:06d}",
             "created_at": "2023-04-20 14:30:00.000000",
             "distinct_id": str(uuid4()),
             "person_id": str(uuid4()),
@@ -223,6 +226,7 @@ async def test_insert_into_s3_activity_puts_data_into_s3(bucket_name, s3_client,
                 "event": "test",
                 "_timestamp": "2023-04-20 14:29:00",
                 "timestamp": "2023-04-20 14:29:00.000000",
+                "inserted_at": "2023-04-20 14:30:00.000000",
                 "created_at": "2023-04-20 14:29:00.000000",
                 "distinct_id": str(uuid4()),
                 "person_id": str(uuid4()),
@@ -252,6 +256,7 @@ async def test_insert_into_s3_activity_puts_data_into_s3(bucket_name, s3_client,
                 "event": "test",
                 "timestamp": "2023-04-20 13:30:00",
                 "_timestamp": "2023-04-20 13:30:00",
+                "inserted_at": "2023-04-20 13:30:00.000000",
                 "created_at": "2023-04-20 13:30:00.000000",
                 "person_id": str(uuid4()),
                 "distinct_id": str(uuid4()),
@@ -265,6 +270,7 @@ async def test_insert_into_s3_activity_puts_data_into_s3(bucket_name, s3_client,
                 "event": "test",
                 "timestamp": "2023-04-20 15:30:00",
                 "_timestamp": "2023-04-20 13:30:00",
+                "inserted_at": "2023-04-20 13:30:00.000000",
                 "created_at": "2023-04-20 13:30:00.000000",
                 "person_id": str(uuid4()),
                 "distinct_id": str(uuid4()),
@@ -278,6 +284,7 @@ async def test_insert_into_s3_activity_puts_data_into_s3(bucket_name, s3_client,
                 "event": "test",
                 "timestamp": "2023-04-20 14:30:00",
                 "_timestamp": "2023-04-20 14:30:00",
+                "inserted_at": "2023-04-20 14:30:00.000000",
                 "created_at": "2023-04-20 14:30:00.000000",
                 "person_id": str(uuid4()),
                 "distinct_id": str(uuid4()),
@@ -310,33 +317,7 @@ async def test_insert_into_s3_activity_puts_data_into_s3(bucket_name, s3_client,
         with mock.patch("posthog.temporal.workflows.s3_batch_export.boto3.client", side_effect=create_test_client):
             await activity_environment.run(insert_into_s3_activity, insert_inputs)
 
-    # Check that the data was written to S3.
-    # List the objects in the bucket with the prefix.
-    objects = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=prefix)
-
-    # Check that there is only one object.
-    assert len(objects.get("Contents", [])) == 1
-
-    # Get the object.
-    key = objects["Contents"][0].get("Key")
-    assert key
-    object = s3_client.get_object(Bucket=bucket_name, Key=key)
-    data = object["Body"].read()
-
-    # Check that the data is correct.
-    json_data = [json.loads(line) for line in data.decode("utf-8").split("\n") if line]
-    # Pull out the fields we inserted only
-
-    json_data.sort(key=lambda x: x["timestamp"])
-
-    # Remove team_id, _timestamp from events
-    expected_events = [{k: v for k, v in event.items() if k not in ["team_id", "_timestamp"]} for event in events]
-    expected_events.sort(key=lambda x: x["timestamp"])
-
-    # First check one event, the first one, so that we can get a nice diff if
-    # the included data is different.
-    assert json_data[0] == expected_events[0]
-    assert json_data == expected_events
+    assert_events_in_s3(s3_client, bucket_name, prefix, events)
 
 
 @pytest.mark.django_db
@@ -388,6 +369,7 @@ async def test_s3_export_workflow_with_minio_bucket(client: HttpClient, s3_clien
             "event": "test",
             "timestamp": "2023-04-25 13:30:00.000000",
             "created_at": "2023-04-25 13:30:00.000000",
+            "inserted_at": "2023-04-25 13:30:00.000000",
             "_timestamp": "2023-04-25 13:30:00",
             "person_id": str(uuid4()),
             "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
@@ -401,6 +383,7 @@ async def test_s3_export_workflow_with_minio_bucket(client: HttpClient, s3_clien
             "event": "test",
             "timestamp": "2023-04-25 14:29:00.000000",
             "created_at": "2023-04-25 14:29:00.000000",
+            "inserted_at": "2023-04-25 14:29:00.000000",
             "_timestamp": "2023-04-25 14:29:00",
             "person_id": str(uuid4()),
             "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
@@ -501,6 +484,7 @@ async def test_s3_export_workflow_continues_on_json_decode_error(client: HttpCli
             "event": "test",
             "timestamp": "2023-04-25 13:30:00.000000",
             "created_at": "2023-04-25 13:30:00.000000",
+            "inserted_at": "2023-04-25 13:30:00.000000",
             "_timestamp": "2023-04-25 13:30:00",
             "person_id": str(uuid4()),
             "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
@@ -513,6 +497,7 @@ async def test_s3_export_workflow_continues_on_json_decode_error(client: HttpCli
             "uuid": str(uuid4()),
             "event": "test",
             "timestamp": "2023-04-25 14:29:00.000000",
+            "inserted_at": "2023-04-25 14:29:00.000000",
             "created_at": "2023-04-25 14:29:00.000000",
             "_timestamp": "2023-04-25 14:29:00",
             "person_id": str(uuid4()),
@@ -649,6 +634,7 @@ async def test_s3_export_workflow_continues_on_multiple_json_decode_error(client
             "uuid": str(uuid4()),
             "event": str(i),
             "timestamp": f"2023-04-25 13:3{i}:00.000000",
+            "inserted_at": f"2023-04-25 13:3{i}:00.000000",
             "created_at": f"2023-04-25 13:3{i}:00.000000",
             "_timestamp": f"2023-04-25 13:3{i}:00",
             "person_id": str(uuid4()),
@@ -722,31 +708,31 @@ async def test_s3_export_workflow_continues_on_multiple_json_decode_error(client
             ),
             mock.call(
                 client=mock.ANY,
-                interval_start="2023-04-25 13:30:00",
+                interval_start="2023-04-25 13:30:00.000000",
                 interval_end="2023-04-25T14:30:00",
                 team_id=team.pk,
             ),
             mock.call(
                 client=mock.ANY,
-                interval_start="2023-04-25 13:32:00",
+                interval_start="2023-04-25 13:32:00.000000",
                 interval_end="2023-04-25T14:30:00",
                 team_id=team.pk,
             ),
             mock.call(
                 client=mock.ANY,
-                interval_start="2023-04-25 13:34:00",
+                interval_start="2023-04-25 13:34:00.000000",
                 interval_end="2023-04-25T14:30:00",
                 team_id=team.pk,
             ),
             mock.call(
                 client=mock.ANY,
-                interval_start="2023-04-25 13:36:00",
+                interval_start="2023-04-25 13:36:00.000000",
                 interval_end="2023-04-25T14:30:00",
                 team_id=team.pk,
             ),
             mock.call(
                 client=mock.ANY,
-                interval_start="2023-04-25 13:38:00",
+                interval_start="2023-04-25 13:38:00.000000",
                 interval_end="2023-04-25T14:30:00",
                 team_id=team.pk,
             ),

--- a/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
@@ -35,6 +35,7 @@ class EventValues(TypedDict):
     event: str
     timestamp: str
     _timestamp: str
+    inserted_at: str
     person_id: str
     team_id: int
     properties: dict
@@ -49,6 +50,7 @@ async def insert_events(client: ChClient, events: list[EventValues]):
             event,
             timestamp,
             _timestamp,
+            inserted_at,
             person_id,
             team_id,
             properties
@@ -61,6 +63,7 @@ async def insert_events(client: ChClient, events: list[EventValues]):
                 event["event"],
                 event["timestamp"],
                 event["_timestamp"],
+                event["inserted_at"],
                 event["person_id"],
                 event["team_id"],
                 json.dumps(event["properties"]),
@@ -274,6 +277,7 @@ async def test_snowflake_export_workflow_exports_events_in_the_last_hour_for_the
             "event": "test",
             "timestamp": f"2023-04-20 14:30:00.{i:06d}",
             "_timestamp": "2023-04-20 14:30:00",
+            "inserted_at": f"2023-04-20 14:30:00.{i:06d}",
             "person_id": str(uuid4()),
             "team_id": team.pk,
             "properties": {"$browser": "Chrome", "$os": "Mac OS X"},
@@ -302,6 +306,7 @@ async def test_snowflake_export_workflow_exports_events_in_the_last_hour_for_the
                 "event": "test",
                 "timestamp": "2023-04-20 13:30:00",
                 "_timestamp": "2023-04-20 13:30:00",
+                "inserted_at": f"2023-04-20 13:30:00",
                 "person_id": str(uuid4()),
                 "team_id": team.pk,
                 "properties": {"$browser": "Chrome", "$os": "Mac OS X"},
@@ -311,6 +316,7 @@ async def test_snowflake_export_workflow_exports_events_in_the_last_hour_for_the
                 "event": "test",
                 "timestamp": "2023-04-20 15:30:00",
                 "_timestamp": "2023-04-20 15:30:00",
+                "inserted_at": f"2023-04-20 15:30:00",
                 "person_id": str(uuid4()),
                 "team_id": team.pk,
                 "properties": {"$browser": "Chrome", "$os": "Mac OS X"},
@@ -320,6 +326,7 @@ async def test_snowflake_export_workflow_exports_events_in_the_last_hour_for_the
                 "event": "test",
                 "timestamp": "2023-04-20 14:30:00",
                 "_timestamp": "2023-04-20 14:30:00",
+                "inserted_at": f"2023-04-20 14:30:00",
                 "person_id": str(uuid4()),
                 "team_id": other_team.pk,
                 "properties": {"$browser": "Chrome", "$os": "Mac OS X"},
@@ -385,7 +392,7 @@ async def test_snowflake_export_workflow_exports_events_in_the_last_hour_for_the
                 json_data.sort(key=lambda x: x["timestamp"])
                 # Drop _timestamp and team_id from events
                 events = [
-                    {key: value for key, value in event.items() if key not in ("team_id", "_timestamp")}
+                    {key: value for key, value in event.items() if key not in ("team_id", "_timestamp", "inserted_at")}
                     for event in events
                 ]
                 assert json_data[0] == events[0]
@@ -501,6 +508,7 @@ async def test_snowflake_export_workflow_raises_error_on_put_fail():
             "event": "test",
             "timestamp": f"2023-04-20 14:30:00.{i:06d}",
             "_timestamp": "2023-04-20 14:30:00",
+            "inserted_at": f"2023-04-20 14:30:00.{i:06d}",
             "person_id": str(uuid4()),
             "team_id": team.pk,
             "properties": {"$browser": "Chrome", "$os": "Mac OS X"},
@@ -595,6 +603,7 @@ async def test_snowflake_export_workflow_raises_error_on_copy_fail():
             "event": "test",
             "timestamp": f"2023-04-20 14:30:00.{i:06d}",
             "_timestamp": "2023-04-20 14:30:00",
+            "inserted_at": f"2023-04-20 14:30:00.{i:06d}",
             "person_id": str(uuid4()),
             "team_id": team.pk,
             "properties": {"$browser": "Chrome", "$os": "Mac OS X"},

--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -14,8 +14,8 @@ SELECT_QUERY_TEMPLATE = Template(
         -- As a side-effect, this heuristic will discard historical loads older than 2 days.
         timestamp >= toDateTime({data_interval_start}, 'UTC') - INTERVAL 2 DAY
         AND timestamp < toDateTime({data_interval_end}, 'UTC') + INTERVAL 1 DAY
-        AND inserted_at >= toDateTime64({data_interval_start}, 6, 'UTC')
-        AND inserted_at < toDateTime64({data_interval_end}, 6, 'UTC')
+        AND COALESCE(inserted_at, _timestamp) >= toDateTime64({data_interval_start}, 6, 'UTC')
+        AND COALESCE(inserted_at, _timestamp) < toDateTime64({data_interval_end}, 6, 'UTC')
         AND team_id = {team_id}
     $order_by
     """

--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -14,8 +14,8 @@ SELECT_QUERY_TEMPLATE = Template(
         -- As a side-effect, this heuristic will discard historical loads older than 2 days.
         timestamp >= toDateTime({data_interval_start}, 'UTC') - INTERVAL 2 DAY
         AND timestamp < toDateTime({data_interval_end}, 'UTC') + INTERVAL 1 DAY
-        AND _timestamp >= toDateTime({data_interval_start}, 'UTC')
-        AND _timestamp < toDateTime({data_interval_end}, 'UTC')
+        AND inserted_at >= toDateTime64({data_interval_start}, 6, 'UTC')
+        AND inserted_at < toDateTime64({data_interval_end}, 6, 'UTC')
         AND team_id = {team_id}
     $order_by
     """
@@ -50,7 +50,7 @@ async def get_results_iterator(client: ChClient, team_id: int, interval_start: s
             fields="""
                     uuid,
                     timestamp,
-                    _timestamp,
+                    inserted_at,
                     created_at,
                     event,
                     properties,

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -2,7 +2,6 @@ import datetime as dt
 import json
 import tempfile
 from dataclasses import dataclass
-from string import Template
 
 import snowflake.connector
 from django.conf import settings
@@ -23,17 +22,6 @@ from posthog.temporal.workflows.batch_exports import (
     get_rows_count,
 )
 from posthog.temporal.workflows.clickhouse import get_client
-
-SELECT_QUERY_TEMPLATE = Template(
-    """
-    SELECT $fields
-    FROM events
-    WHERE
-        timestamp >= toDateTime({data_interval_start}, 'UTC')
-        AND timestamp < toDateTime({data_interval_end}, 'UTC')
-        AND team_id = {team_id}
-    """
-)
 
 
 class SnowflakeFileNotUploadedError(Exception):

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -103,18 +103,9 @@ def put_file_to_snowflake_table(cursor: SnowflakeCursor, file_name: str, table_n
 
 @activity.defn
 async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs):
-    """
-    Activity streams data from ClickHouse to Snowflake.
+    """Activity streams data from ClickHouse to Snowflake.
 
     TODO: We're using JSON here, it's not the most efficient way to do this.
-
-    TODO: at the moment this doesn't do anything about catching data that might
-    be late being ingested into the specified time range. To work around this,
-    as a little bit of a hack we should export data only up to an hour ago with
-    the assumption that that will give it enough time to settle. I is a little
-    tricky with the existing setup to properly partition the data into data we
-    have or haven't processed yet. We have `_timestamp` in the events table, but
-    this is the time
     """
     activity.logger.info("Running Snowflake export batch %s - %s", inputs.data_interval_start, inputs.data_interval_end)
 
@@ -201,7 +192,7 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs):
                             # We failed right at the beginning
                             new_interval_start = None
                         else:
-                            new_interval_start = result.get("_timestamp", None)
+                            new_interval_start = result.get("inserted_at", None)
 
                         if not isinstance(new_interval_start, str):
                             new_interval_start = inputs.data_interval_start
@@ -218,9 +209,7 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs):
                         break
 
                     # Write the results to a local file
-                    local_results_file.write(
-                        json.dumps({k: v for k, v in result.items() if k != "_timestamp"}).encode("utf-8")
-                    )
+                    local_results_file.write(json.dumps(result).encode("utf-8"))
                     local_results_file.write("\n".encode("utf-8"))
 
                     # Write results to Snowflake when the file reaches 50MB and


### PR DESCRIPTION
## Problem

PR https://github.com/PostHog/posthog/pull/16021 added a new field for us to use as reference for BatchExports. This refactors the exports code to use the new field.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Pretty much add `inserted_at` everywhere, and use that field in place of `_timestamp` in the main batch exports query.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unit tests have been updated to use `inserted_at`, so they should raise any issues.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
