### PR TITLE
chore: change sentry breadcrumbs

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-metrics.ts
@@ -108,17 +108,6 @@ export function addSentryBreadcrumbsEventListeners(consumer: KafkaConsumer): voi
             },
         })
     })
-
-    consumer.on('partition.eof', (topicPartitionOffset) => {
-        Sentry.addBreadcrumb({
-            category: 'kafka_lifecycle',
-            message: 'partition.eof',
-            level: 'info',
-            data: {
-                topicPartitionOffset,
-            },
-        })
-    })
 }
 
 export async function emitConsumerGroupMetrics(


### PR DESCRIPTION
## Problem

We added kafka lifecycle to sentry breadcrumbs

## Changes

We see lots of partition.eof breadcrumbs, that just means that the consumer is up-to-date, and isn't useful. So, it's noise.

