### PR TITLE
feat(dashboards): make the modal wider

### DIFF
--- a/frontend/src/lib/components/AddToDashboard/AddToDashboardModal.tsx
+++ b/frontend/src/lib/components/AddToDashboard/AddToDashboardModal.tsx
@@ -56,7 +56,13 @@ const DashboardRelationRow = ({
             style={style}
             className={clsx('flex items-center space-x-2', isHighlighted && 'highlighted')}
         >
-            <Link to={urls.dashboard(dashboard.id)}>{dashboard.name || 'Untitled'}</Link>
+            <Link
+                to={urls.dashboard(dashboard.id)}
+                className="overflow-hidden text-ellipsis whitespace-nowrap"
+                title={dashboard.name}
+            >
+                {dashboard.name || 'Untitled'}
+            </Link>
             {isPrimary && (
                 <Tooltip title="Primary dashboards are shown on the project home page">
                     <IconCottage className="text-warning text-base" />
@@ -143,7 +149,7 @@ export function AddToDashboardModal({
                 </>
             }
         >
-            <div className="space-y-2">
+            <div className="space-y-2 w-md max-w-full">
                 <LemonInput
                     data-attr="dashboard-searchfield"
                     type="search"


### PR DESCRIPTION
## Problem

The dashboard modal was too narrow to fit several default dashboard names, and started to wrap text onto each other.

## Changes

Makes the modal wider (if there's space), and adds "..." to the end of the dashboard name to fit it on one line.

![2023-07-18 14 53 31](https://github.com/PostHog/posthog/assets/53387/e8cdba83-7df3-4587-a977-5b5c2a6aa538)


## How did you test this code?

👀 