### PR TITLE
fix(refresh): fix tooltip for refresh button and it's disabled state for long-term insights

### DIFF
--- a/frontend/src/lib/lemon-ui/Link/Link.tsx
+++ b/frontend/src/lib/lemon-ui/Link/Link.tsx
@@ -92,7 +92,10 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
                 {typeof children === 'string' && target === '_blank' ? <IconOpenInNew /> : null}
             </a>
         ) : (
-            <Tooltip title={!!disabledReason ? <span className="italic">{disabledReason}</span> : undefined}>
+            <Tooltip
+                isDefaultTooltip
+                title={!!disabledReason ? <span className="italic">{disabledReason}</span> : undefined}
+            >
                 <span>
                     <button
                         ref={ref as any}

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -394,8 +394,8 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
         nextAllowedRefresh: [
             (s, p) => [p.query, s.response],
             (query, response): string | null => {
-                return isInsightQueryNode(query) && response && 'next_allowed_refresh' in response
-                    ? response.next_allowed_refresh
+                return isInsightQueryNode(query) && response && 'next_allowed_client_refresh' in response
+                    ? response.next_allowed_client_refresh
                     : null
             },
         ],

--- a/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
@@ -9,8 +9,6 @@ import { dataNodeLogic } from '../DataNode/dataNodeLogic'
 import { Link } from '@posthog/lemon-ui'
 
 export function ComputationTimeWithRefresh({ disableRefresh }: { disableRefresh?: boolean }): JSX.Element | null {
-    const showRefreshOnInsight = !disableRefresh
-
     const { lastRefresh, response } = useValues(dataNodeLogic)
 
     const { insightProps } = useValues(insightLogic)
@@ -26,7 +24,7 @@ export function ComputationTimeWithRefresh({ disableRefresh }: { disableRefresh?
     return (
         <div className="flex items-center text-muted-alt">
             Computed {lastRefresh ? dayjs(lastRefresh).fromNow() : 'a while ago'}
-            {showRefreshOnInsight && (
+            {!disableRefresh && (
                 <>
                     <span className="px-1">•</span>
                     <Link disabledReason={getInsightRefreshButtonDisabledReason()} onClick={() => loadData(true)}>


### PR DESCRIPTION
## Problem

1. The tooltip for the refresh button hasn't been going away.
2. The refresh button would not be disabled for insights with a refresh time longer than 3 minutes (frontend-side default)

## Changes

This PR:
- Fixes (1) by using AntD's standard tooltip behaviour for links. This doesn't break disabled links elsewhere, as the disabled state for Lemon links was introduced when moving the refresh button out of the menu again.
- Fixes (2) by using the correct backend property `next_allowed_client_refresh`. The property must have been renamed at some point and never updated here.
- Removes a variable only used for negation after the feature flag is gone.

## How did you test this code?

Tried the refresh behaviour and tooltip locally