### PR TITLE
fix: Blob ingester unknown error

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -311,7 +311,7 @@ export class SessionManager {
             histogramS3LinesWritten.observe(count)
             histogramS3KbWritten.observe(sizeEstimate / 1024)
         } catch (error: any) {
-            if ('name' in error && error.name === 'AbortError' && this.destroying) {
+            if (error !== undefined && 'name' in error && error.name === 'AbortError' && this.destroying) {
                 // abort of inProgressUpload while destroying is expected
                 return
             }

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -311,10 +311,7 @@ export class SessionManager {
             histogramS3LinesWritten.observe(count)
             histogramS3KbWritten.observe(sizeEstimate / 1024)
         } catch (error: any) {
-            // TRICKY: error can for some reason sometimes be undefined...
-            error = error || new Error('Unknown Error')
-
-            if (error.name === 'AbortError' && this.destroying) {
+            if ('name' in error && error.name === 'AbortError' && this.destroying) {
                 // abort of inProgressUpload while destroying is expected
                 return
             }

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -310,7 +310,10 @@ export class SessionManager {
             counterS3FilesWritten.labels(reason).inc(1)
             histogramS3LinesWritten.observe(count)
             histogramS3KbWritten.observe(sizeEstimate / 1024)
-        } catch (error) {
+        } catch (error: any) {
+            // TRICKY: error can for some reason sometimes be undefined...
+            error = error || new Error('Unknown Error')
+
             if (error.name === 'AbortError' && this.destroying) {
                 // abort of inProgressUpload while destroying is expected
                 return

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-manager.ts
@@ -311,7 +311,10 @@ export class SessionManager {
             histogramS3LinesWritten.observe(count)
             histogramS3KbWritten.observe(sizeEstimate / 1024)
         } catch (error: any) {
-            if (error !== undefined && 'name' in error && error.name === 'AbortError' && this.destroying) {
+            // TRICKY: error can for some reason sometimes be undefined...
+            error = error || new Error('Unknown Error')
+
+            if (error.name === 'AbortError' && this.destroying) {
                 // abort of inProgressUpload while destroying is expected
                 return
             }


### PR DESCRIPTION
## Problem

We seem to have [an error](https://posthog.sentry.io/issues/4323316880/?query=is%3Aunresolved+PLUGIN_SERVER_MODE%3Arecordings-blob-ingestion&referrer=issue-stream&statsPeriod=14d&stream_index=2) that occurs due to the caught error being undefined. No idea why but for now we should at least handle that situation

## Changes

* Handles the issue that the error could be undefined

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
