### PR TITLE
chore: upgrade to Webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -266,8 +266,8 @@
         "ts-json-schema-generator": "^1.2.0",
         "ts-node": "^10.9.1",
         "typescript": "~4.9.5",
-        "webpack": "^4.46.0",
-        "webpack-cli": "^4.5.0",
+        "webpack": "^5.88.2",
+        "webpack-cli": "^5.1.4",
         "whatwg-fetch": "^3.6.2"
     },
     "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -257,6 +257,7 @@
         "pngjs": "^6.0.0",
         "postcss": "^8.4.14",
         "postcss-loader": "^4.3.0",
+        "process": "^0.11.10",
         "raw-loader": "^4.0.2",
         "sass-loader": "^10.0.1",
         "storybook-addon-pseudo-states": "1.15.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -329,7 +329,7 @@ devDependencies:
     version: 7.20.1
   '@cypress/webpack-preprocessor':
     specifier: ^5.17.1
-    version: 5.17.1(@babel/core@7.20.2)(@babel/preset-env@7.20.2)(babel-loader@8.3.0)(webpack@4.46.0)
+    version: 5.17.1(@babel/core@7.20.2)(@babel/preset-env@7.20.2)(babel-loader@8.3.0)(webpack@5.88.2)
   '@hot-loader/react-dom':
     specifier: ^16.14.0
     version: 16.14.0(react@16.14.0)
@@ -347,7 +347,7 @@ devDependencies:
     version: 6.5.16(react-dom@16.14.0)(react@16.14.0)
   '@storybook/addon-essentials':
     specifier: ^6.5.16
-    version: 6.5.16(@babel/core@7.20.2)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)(webpack@4.46.0)
+    version: 6.5.16(@babel/core@7.20.2)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)(webpack@5.88.2)
   '@storybook/addon-links':
     specifier: ^6.5.16
     version: 6.5.16(react-dom@16.14.0)(react@16.14.0)
@@ -368,13 +368,13 @@ devDependencies:
     version: 6.5.16
   '@storybook/react':
     specifier: ^6.5.16
-    version: 6.5.16(@babel/core@7.20.2)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(require-from-string@2.0.2)(typescript@4.9.5)(webpack-cli@4.10.0)
+    version: 6.5.16(@babel/core@7.20.2)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(require-from-string@2.0.2)(typescript@4.9.5)(webpack-cli@5.1.4)
   '@storybook/source-loader':
     specifier: ^6.5.16
     version: 6.5.16(react-dom@16.14.0)(react@16.14.0)
   '@storybook/test-runner':
     specifier: ^0.9.4
-    version: 0.9.4(@types/node@18.11.9)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(ts-node@10.9.1)(typescript@4.9.5)(webpack-cli@4.10.0)
+    version: 0.9.4(@types/node@18.11.9)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(ts-node@10.9.1)(typescript@4.9.5)(webpack-cli@5.1.4)
   '@storybook/theming':
     specifier: ^6.5.16
     version: 6.5.16(react-dom@16.14.0)(react@16.14.0)
@@ -461,7 +461,7 @@ devDependencies:
     version: 4.5.1
   babel-loader:
     specifier: ^8.0.6
-    version: 8.3.0(@babel/core@7.20.2)(webpack@4.46.0)
+    version: 8.3.0(@babel/core@7.20.2)(webpack@5.88.2)
   babel-plugin-import:
     specifier: ^1.13.0
     version: 1.13.5
@@ -470,7 +470,7 @@ devDependencies:
     version: 5.3.0
   css-loader:
     specifier: ^3.4.2
-    version: 3.6.0(webpack@4.46.0)
+    version: 3.6.0(webpack@5.88.2)
   cssnano:
     specifier: ^4.1.10
     version: 4.1.11
@@ -509,7 +509,7 @@ devDependencies:
     version: 0.6.11(eslint@7.32.0)(typescript@4.9.5)
   file-loader:
     specifier: ^6.1.0
-    version: 6.2.0(webpack@4.46.0)
+    version: 6.2.0(webpack@5.88.2)
   givens:
     specifier: ^1.3.6
     version: 1.3.9
@@ -518,10 +518,10 @@ devDependencies:
     version: 5.3.0
   html-webpack-harddisk-plugin:
     specifier: ^1.0.2
-    version: 1.0.2(html-webpack-plugin@4.5.2)(webpack@4.46.0)
+    version: 1.0.2(html-webpack-plugin@4.5.2)(webpack@5.88.2)
   html-webpack-plugin:
     specifier: ^4.5.2
-    version: 4.5.2(webpack@4.46.0)
+    version: 4.5.2(webpack@5.88.2)
   jest:
     specifier: ^29.3.1
     version: 29.3.1(@types/node@18.11.9)(ts-node@10.9.1)
@@ -542,7 +542,7 @@ devDependencies:
     version: 3.13.1
   less-loader:
     specifier: ^7.0.2
-    version: 7.3.0(less@3.13.1)(webpack@4.46.0)
+    version: 7.3.0(less@3.13.1)(webpack@5.88.2)
   lint-staged:
     specifier: ~10.2.13
     version: 10.2.13
@@ -551,7 +551,7 @@ devDependencies:
     version: 3.0.5
   monaco-editor-webpack-plugin:
     specifier: ^7.0.1
-    version: 7.0.1(monaco-editor@0.39.0)(webpack@4.46.0)
+    version: 7.0.1(monaco-editor@0.39.0)(webpack@5.88.2)
   msw:
     specifier: ^0.49.0
     version: 0.49.3(typescript@4.9.5)
@@ -572,19 +572,19 @@ devDependencies:
     version: 8.4.18
   postcss-loader:
     specifier: ^4.3.0
-    version: 4.3.0(postcss@8.4.18)(webpack@4.46.0)
+    version: 4.3.0(postcss@8.4.18)(webpack@5.88.2)
   raw-loader:
     specifier: ^4.0.2
-    version: 4.0.2(webpack@4.46.0)
+    version: 4.0.2(webpack@5.88.2)
   sass-loader:
     specifier: ^10.0.1
-    version: 10.3.1(sass@1.56.0)(webpack@4.46.0)
+    version: 10.3.1(sass@1.56.0)(webpack@5.88.2)
   storybook-addon-pseudo-states:
     specifier: 1.15.1
     version: 1.15.1(@storybook/addons@6.5.16)(@storybook/api@6.5.16)(@storybook/components@6.5.16)(@storybook/core-events@6.5.16)(@storybook/theming@6.5.16)(react-dom@16.14.0)(react@16.14.0)
   style-loader:
     specifier: ^2.0.0
-    version: 2.0.0(webpack@4.46.0)
+    version: 2.0.0(webpack@5.88.2)
   sucrase:
     specifier: ^3.29.0
     version: 3.29.0
@@ -601,11 +601,11 @@ devDependencies:
     specifier: ~4.9.5
     version: 4.9.5
   webpack:
-    specifier: ^4.46.0
-    version: 4.46.0(webpack-cli@4.10.0)
+    specifier: ^5.88.2
+    version: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
   webpack-cli:
-    specifier: ^4.5.0
-    version: 4.10.0(webpack@4.46.0)
+    specifier: ^5.1.4
+    version: 5.1.4(webpack@5.88.2)
   whatwg-fetch:
     specifier: ^3.6.2
     version: 3.6.2
@@ -2269,7 +2269,7 @@ packages:
       uuid: 8.3.2
     dev: true
 
-  /@cypress/webpack-preprocessor@5.17.1(@babel/core@7.20.2)(@babel/preset-env@7.20.2)(babel-loader@8.3.0)(webpack@4.46.0):
+  /@cypress/webpack-preprocessor@5.17.1(@babel/core@7.20.2)(@babel/preset-env@7.20.2)(babel-loader@8.3.0)(webpack@5.88.2):
     resolution: {integrity: sha512-FE/e8ikPc8z4EVopJCaior3RGy0jd2q9Xcp5NtiwNG4XnLfEnUFTZlAGwXe75sEh4fNMPrBJW1KIz77PX5vGAw==}
     peerDependencies:
       '@babel/core': ^7.0.1
@@ -2279,11 +2279,11 @@ packages:
     dependencies:
       '@babel/core': 7.20.2
       '@babel/preset-env': 7.20.2(@babel/core@7.20.2)
-      babel-loader: 8.3.0(@babel/core@7.20.2)(webpack@4.46.0)
+      babel-loader: 8.3.0(@babel/core@7.20.2)(webpack@5.88.2)
       bluebird: 3.7.1
       debug: 4.3.4(supports-color@8.1.1)
       lodash: 4.17.21
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2308,7 +2308,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@eslint-community/eslint-utils@4.2.0(eslint@7.32.0):
@@ -2927,6 +2926,13 @@ packages:
       '@jridgewell/trace-mapping': 0.3.17
     dev: true
 
+  /@jridgewell/source-map@0.3.5:
+    resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/trace-mapping': 0.3.17
+    dev: true
+
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
 
@@ -3156,7 +3162,7 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.1.1
       source-map: 0.7.4
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
     dev: true
 
   /@popperjs/core@2.11.6:
@@ -3413,7 +3419,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/addon-controls@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0):
+  /@storybook/addon-controls@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-kShSGjq1MjmmyL3l8i+uPz6yddtf82mzys0l82VKtcuyjrr5944wYFJ5NTXMfZxrO/U6FeFsfuFZE/k6ex3EMg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3428,7 +3434,7 @@ packages:
       '@storybook/api': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/client-logger': 6.5.16
       '@storybook/components': 6.5.16(react-dom@16.14.0)(react@16.14.0)
-      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)
+      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/node-logger': 6.5.16
       '@storybook/store': 6.5.16(react-dom@16.14.0)(react@16.14.0)
@@ -3447,7 +3453,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-docs@6.5.16(@babel/core@7.20.2)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)(webpack@4.46.0):
+  /@storybook/addon-docs@6.5.16(@babel/core@7.20.2)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)(webpack@5.88.2):
     resolution: {integrity: sha512-QM9WDZG9P02UvbzLu947a8ZngOrQeAKAT8jCibQFM/+RJ39xBlfm8rm+cQy3dm94wgtjmVkA3mKGOV/yrrsddg==}
     peerDependencies:
       '@storybook/mdx2-csf': ^0.0.3
@@ -3468,7 +3474,7 @@ packages:
       '@storybook/addons': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/api': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/components': 6.5.16(react-dom@16.14.0)(react@16.14.0)
-      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)
+      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)
       '@storybook/core-events': 6.5.16
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.16(react-dom@16.14.0)(react@16.14.0)
@@ -3479,7 +3485,7 @@ packages:
       '@storybook/source-loader': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/store': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/theming': 6.5.16(react-dom@16.14.0)(react@16.14.0)
-      babel-loader: 8.3.0(@babel/core@7.20.2)(webpack@4.46.0)
+      babel-loader: 8.3.0(@babel/core@7.20.2)(webpack@5.88.2)
       core-js: 3.15.2
       fast-deep-equal: 3.1.3
       global: 4.4.0
@@ -3502,7 +3508,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-essentials@6.5.16(@babel/core@7.20.2)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)(webpack@4.46.0):
+  /@storybook/addon-essentials@6.5.16(@babel/core@7.20.2)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)(webpack@5.88.2):
     resolution: {integrity: sha512-TeoMr6tEit4Pe91GH6f8g/oar1P4M0JL9S6oMcFxxrhhtOGO7XkWD5EnfyCx272Ok2VYfE58FNBTGPNBVIqYKQ==}
     peerDependencies:
       '@babel/core': ^7.9.6
@@ -3562,22 +3568,22 @@ packages:
       '@babel/core': 7.20.2
       '@storybook/addon-actions': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/addon-backgrounds': 6.5.16(react-dom@16.14.0)(react@16.14.0)
-      '@storybook/addon-controls': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)
-      '@storybook/addon-docs': 6.5.16(@babel/core@7.20.2)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)(webpack@4.46.0)
+      '@storybook/addon-controls': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)
+      '@storybook/addon-docs': 6.5.16(@babel/core@7.20.2)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)(webpack@5.88.2)
       '@storybook/addon-measure': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/addon-outline': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/addon-toolbars': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/addon-viewport': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/addons': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/api': 6.5.16(react-dom@16.14.0)(react@16.14.0)
-      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)
+      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)
       '@storybook/node-logger': 6.5.16
       core-js: 3.15.2
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
       regenerator-runtime: 0.13.10
       ts-dedent: 2.2.0
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - eslint
@@ -3835,7 +3841,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-webpack4@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0):
+  /@storybook/builder-webpack4@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-YqDIrVNsUo8r9xc6AxsYDLxVYtMgl5Bxk+8/h1adsOko+jAFhdg6hOcAVxEmoSI0TMASOOVMFlT2hr23ppN2rQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3853,7 +3859,7 @@ packages:
       '@storybook/client-api': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/client-logger': 6.5.16
       '@storybook/components': 6.5.16(react-dom@16.14.0)(react@16.14.0)
-      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)
+      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)
       '@storybook/core-events': 6.5.16
       '@storybook/node-logger': 6.5.16
       '@storybook/preview-web': 6.5.16(react-dom@16.14.0)(react@16.14.0)
@@ -3890,7 +3896,7 @@ packages:
       typescript: 4.9.5
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@4.46.0)
       util-deprecate: 1.0.2
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
       webpack-dev-middleware: 3.7.3(webpack@4.46.0)
       webpack-filter-warnings-plugin: 1.2.1(webpack@4.46.0)
       webpack-hot-middleware: 2.25.2
@@ -4038,10 +4044,10 @@ packages:
       typescript: 4.9.5
       unfetch: 4.2.0
       util-deprecate: 1.0.2
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
     dev: true
 
-  /@storybook/core-common@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0):
+  /@storybook/core-common@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-2qtnKP3TTOzt2cp6LXKRTh7XrI9z5VanMnMTgeoFcA5ebnndD4V6BExQUdYPClE/QooLx6blUWNgS9dFEpjSqQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -4103,7 +4109,7 @@ packages:
       ts-dedent: 2.2.0
       typescript: 4.9.5
       util-deprecate: 1.0.2
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -4124,7 +4130,7 @@ packages:
       core-js: 3.15.2
     dev: true
 
-  /@storybook/core-server@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0):
+  /@storybook/core-server@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-/3NPfmNyply395Dm0zaVZ8P9aruwO+tPx4D6/jpw8aqrRSwvAMndPMpoMCm0NXcpSm5rdX+Je4S3JW6JcggFkA==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -4141,17 +4147,17 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)
+      '@storybook/builder-webpack4': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)
       '@storybook/core-client': 6.5.16(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack@4.46.0)
-      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)
+      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)
       '@storybook/core-events': 6.5.16
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.16
-      '@storybook/manager-webpack4': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)
+      '@storybook/manager-webpack4': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)
       '@storybook/node-logger': 6.5.16
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.16(react-dom@16.14.0)(react@16.14.0)
-      '@storybook/telemetry': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)
+      '@storybook/telemetry': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)
       '@types/node': 16.18.3
       '@types/node-fetch': 2.6.2
       '@types/pretty-hrtime': 1.0.1
@@ -4185,7 +4191,7 @@ packages:
       typescript: 4.9.5
       util-deprecate: 1.0.2
       watchpack: 2.4.0
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
       ws: 8.11.0
       x-default-browser: 0.4.0
     transitivePeerDependencies:
@@ -4201,7 +4207,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)(webpack@4.46.0):
+  /@storybook/core@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)(webpack@4.46.0):
     resolution: {integrity: sha512-CEF3QFTsm/VMnMKtRNr4rRdLeIkIG0g1t26WcmxTdSThNPBd8CsWzQJ7Jqu7CKiut+MU4A1LMOwbwCE5F2gmyA==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -4219,11 +4225,11 @@ packages:
         optional: true
     dependencies:
       '@storybook/core-client': 6.5.16(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack@4.46.0)
-      '@storybook/core-server': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)
+      '@storybook/core-server': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
       typescript: 4.9.5
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - bluebird
@@ -4317,7 +4323,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/manager-webpack4@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0):
+  /@storybook/manager-webpack4@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-5VJZwmQU6AgdsBPsYdu886UKBHQ9SJEnFMaeUxKEclXk+iRsmbzlL4GHKyVd6oGX/ZaecZtcHPR6xrzmA4Ziew==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -4332,7 +4338,7 @@ packages:
       '@babel/preset-react': 7.18.6(@babel/core@7.20.2)
       '@storybook/addons': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/core-client': 6.5.16(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack@4.46.0)
-      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)
+      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)
       '@storybook/node-logger': 6.5.16
       '@storybook/theming': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/ui': 6.5.16(react-dom@16.14.0)(react@16.14.0)
@@ -4362,7 +4368,7 @@ packages:
       typescript: 4.9.5
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@4.46.0)
       util-deprecate: 1.0.2
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
       webpack-dev-middleware: 3.7.3(webpack@4.46.0)
       webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
@@ -4450,12 +4456,12 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@4.9.5)
       tslib: 2.4.1
       typescript: 4.9.5
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@storybook/react@6.5.16(@babel/core@7.20.2)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(require-from-string@2.0.2)(typescript@4.9.5)(webpack-cli@4.10.0):
+  /@storybook/react@6.5.16(@babel/core@7.20.2)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(require-from-string@2.0.2)(typescript@4.9.5)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-cBtNlOzf/MySpNLBK22lJ8wFU22HnfTB2xJyBk7W7Zi71Lm7Uxkhv1Pz8HdiQndJ0SlsAAQOWjQYsSZsGkZIaA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -4489,8 +4495,8 @@ packages:
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.8(react-refresh@0.11.0)(webpack@4.46.0)
       '@storybook/addons': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/client-logger': 6.5.16
-      '@storybook/core': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)(webpack@4.46.0)
-      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)
+      '@storybook/core': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)(webpack@4.46.0)
+      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.16(react-dom@16.14.0)(react@16.14.0)
       '@storybook/node-logger': 6.5.16
@@ -4522,7 +4528,7 @@ packages:
       ts-dedent: 2.2.0
       typescript: 4.9.5
       util-deprecate: 1.0.2
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - '@types/webpack'
@@ -4651,11 +4657,11 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/telemetry@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0):
+  /@storybook/telemetry@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-CWr5Uko1l9jJW88yTXsZTj/3GTabPvw0o7pDPOXPp8JRZiJTxv1JFaFCafhK9UzYbgcRuGfCC8kEWPZims7iKA==}
     dependencies:
       '@storybook/client-logger': 6.5.16
-      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)
+      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)
       chalk: 4.1.2
       core-js: 3.15.2
       detect-package-manager: 2.0.1
@@ -4678,7 +4684,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/test-runner@0.9.4(@types/node@18.11.9)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(ts-node@10.9.1)(typescript@4.9.5)(webpack-cli@4.10.0):
+  /@storybook/test-runner@0.9.4(@types/node@18.11.9)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(ts-node@10.9.1)(typescript@4.9.5)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-cYtv3nM1vcjA39HahPxqQtqSNKSFyjUcnAkEdNgLAwG23PPCy6+7kaB01GGxWnxfmds/vwUa1W3PLaVby+vtgw==}
     hasBin: true
     dependencies:
@@ -4689,7 +4695,7 @@ packages:
       '@babel/preset-typescript': 7.21.0(@babel/core@7.20.2)
       '@babel/template': 7.18.10
       '@babel/types': 7.20.2
-      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@4.10.0)
+      '@storybook/core-common': 6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@5.1.4)
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.14
       '@storybook/store': 6.5.14(react-dom@16.14.0)(react@16.14.0)
@@ -5393,8 +5399,26 @@ packages:
       '@types/ms': 0.7.31
     dev: true
 
+  /@types/eslint-scope@3.7.4:
+    resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
+    dependencies:
+      '@types/eslint': 8.44.0
+      '@types/estree': 1.0.1
+    dev: true
+
+  /@types/eslint@8.44.0:
+    resolution: {integrity: sha512-gsF+c/0XOguWgaOgvFs+xnnRqt9GwgTvIks36WpE6ueeI4KCEHHd8K/CKHqhOqrJKsYH8m27kRzQEvWXAwXUTw==}
+    dependencies:
+      '@types/estree': 1.0.1
+      '@types/json-schema': 7.0.11
+    dev: true
+
   /@types/estree@0.0.51:
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
+    dev: true
+
+  /@types/estree@1.0.1:
+    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
     dev: true
 
   /@types/geojson@7946.0.10:
@@ -5973,6 +5997,13 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
+  /@webassemblyjs/ast@1.11.6:
+    resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}
+    dependencies:
+      '@webassemblyjs/helper-numbers': 1.11.6
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+    dev: true
+
   /@webassemblyjs/ast@1.9.0:
     resolution: {integrity: sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==}
     dependencies:
@@ -5981,12 +6012,24 @@ packages:
       '@webassemblyjs/wast-parser': 1.9.0
     dev: true
 
+  /@webassemblyjs/floating-point-hex-parser@1.11.6:
+    resolution: {integrity: sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==}
+    dev: true
+
   /@webassemblyjs/floating-point-hex-parser@1.9.0:
     resolution: {integrity: sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==}
     dev: true
 
+  /@webassemblyjs/helper-api-error@1.11.6:
+    resolution: {integrity: sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==}
+    dev: true
+
   /@webassemblyjs/helper-api-error@1.9.0:
     resolution: {integrity: sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==}
+    dev: true
+
+  /@webassemblyjs/helper-buffer@1.11.6:
+    resolution: {integrity: sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==}
     dev: true
 
   /@webassemblyjs/helper-buffer@1.9.0:
@@ -6009,8 +6052,29 @@ packages:
       '@webassemblyjs/ast': 1.9.0
     dev: true
 
+  /@webassemblyjs/helper-numbers@1.11.6:
+    resolution: {integrity: sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==}
+    dependencies:
+      '@webassemblyjs/floating-point-hex-parser': 1.11.6
+      '@webassemblyjs/helper-api-error': 1.11.6
+      '@xtuc/long': 4.2.2
+    dev: true
+
+  /@webassemblyjs/helper-wasm-bytecode@1.11.6:
+    resolution: {integrity: sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==}
+    dev: true
+
   /@webassemblyjs/helper-wasm-bytecode@1.9.0:
     resolution: {integrity: sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==}
+    dev: true
+
+  /@webassemblyjs/helper-wasm-section@1.11.6:
+    resolution: {integrity: sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==}
+    dependencies:
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/helper-buffer': 1.11.6
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+      '@webassemblyjs/wasm-gen': 1.11.6
     dev: true
 
   /@webassemblyjs/helper-wasm-section@1.9.0:
@@ -6022,10 +6086,22 @@ packages:
       '@webassemblyjs/wasm-gen': 1.9.0
     dev: true
 
+  /@webassemblyjs/ieee754@1.11.6:
+    resolution: {integrity: sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==}
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+    dev: true
+
   /@webassemblyjs/ieee754@1.9.0:
     resolution: {integrity: sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==}
     dependencies:
       '@xtuc/ieee754': 1.2.0
+    dev: true
+
+  /@webassemblyjs/leb128@1.11.6:
+    resolution: {integrity: sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==}
+    dependencies:
+      '@xtuc/long': 4.2.2
     dev: true
 
   /@webassemblyjs/leb128@1.9.0:
@@ -6034,8 +6110,25 @@ packages:
       '@xtuc/long': 4.2.2
     dev: true
 
+  /@webassemblyjs/utf8@1.11.6:
+    resolution: {integrity: sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==}
+    dev: true
+
   /@webassemblyjs/utf8@1.9.0:
     resolution: {integrity: sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==}
+    dev: true
+
+  /@webassemblyjs/wasm-edit@1.11.6:
+    resolution: {integrity: sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==}
+    dependencies:
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/helper-buffer': 1.11.6
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+      '@webassemblyjs/helper-wasm-section': 1.11.6
+      '@webassemblyjs/wasm-gen': 1.11.6
+      '@webassemblyjs/wasm-opt': 1.11.6
+      '@webassemblyjs/wasm-parser': 1.11.6
+      '@webassemblyjs/wast-printer': 1.11.6
     dev: true
 
   /@webassemblyjs/wasm-edit@1.9.0:
@@ -6051,6 +6144,16 @@ packages:
       '@webassemblyjs/wast-printer': 1.9.0
     dev: true
 
+  /@webassemblyjs/wasm-gen@1.11.6:
+    resolution: {integrity: sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==}
+    dependencies:
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+      '@webassemblyjs/ieee754': 1.11.6
+      '@webassemblyjs/leb128': 1.11.6
+      '@webassemblyjs/utf8': 1.11.6
+    dev: true
+
   /@webassemblyjs/wasm-gen@1.9.0:
     resolution: {integrity: sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==}
     dependencies:
@@ -6061,6 +6164,15 @@ packages:
       '@webassemblyjs/utf8': 1.9.0
     dev: true
 
+  /@webassemblyjs/wasm-opt@1.11.6:
+    resolution: {integrity: sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==}
+    dependencies:
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/helper-buffer': 1.11.6
+      '@webassemblyjs/wasm-gen': 1.11.6
+      '@webassemblyjs/wasm-parser': 1.11.6
+    dev: true
+
   /@webassemblyjs/wasm-opt@1.9.0:
     resolution: {integrity: sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==}
     dependencies:
@@ -6068,6 +6180,17 @@ packages:
       '@webassemblyjs/helper-buffer': 1.9.0
       '@webassemblyjs/wasm-gen': 1.9.0
       '@webassemblyjs/wasm-parser': 1.9.0
+    dev: true
+
+  /@webassemblyjs/wasm-parser@1.11.6:
+    resolution: {integrity: sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==}
+    dependencies:
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/helper-api-error': 1.11.6
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+      '@webassemblyjs/ieee754': 1.11.6
+      '@webassemblyjs/leb128': 1.11.6
+      '@webassemblyjs/utf8': 1.11.6
     dev: true
 
   /@webassemblyjs/wasm-parser@1.9.0:
@@ -6092,6 +6215,13 @@ packages:
       '@xtuc/long': 4.2.2
     dev: true
 
+  /@webassemblyjs/wast-printer@1.11.6:
+    resolution: {integrity: sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==}
+    dependencies:
+      '@webassemblyjs/ast': 1.11.6
+      '@xtuc/long': 4.2.2
+    dev: true
+
   /@webassemblyjs/wast-printer@1.9.0:
     resolution: {integrity: sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==}
     dependencies:
@@ -6100,35 +6230,41 @@ packages:
       '@xtuc/long': 4.2.2
     dev: true
 
-  /@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0)(webpack@4.46.0):
-    resolution: {integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==}
+  /@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.88.2):
+    resolution: {integrity: sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==}
+    engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack: 4.x.x || 5.x.x
-      webpack-cli: 4.x.x
+      webpack: 5.x.x
+      webpack-cli: 5.x.x
     dependencies:
-      webpack: 4.46.0(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack@4.46.0)
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack@5.88.2)
     dev: true
 
-  /@webpack-cli/info@1.5.0(webpack-cli@4.10.0):
-    resolution: {integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==}
+  /@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.88.2):
+    resolution: {integrity: sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==}
+    engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack-cli: 4.x.x
+      webpack: 5.x.x
+      webpack-cli: 5.x.x
     dependencies:
-      envinfo: 7.8.1
-      webpack-cli: 4.10.0(webpack@4.46.0)
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack@5.88.2)
     dev: true
 
-  /@webpack-cli/serve@1.7.0(webpack-cli@4.10.0):
-    resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
+  /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.88.2):
+    resolution: {integrity: sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==}
+    engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack-cli: 4.x.x
+      webpack: 5.x.x
+      webpack-cli: 5.x.x
       webpack-dev-server: '*'
     peerDependenciesMeta:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.10.0(webpack@4.46.0)
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack@5.88.2)
     dev: true
 
   /@wessberg/ts-clone-node@0.3.19(typescript@4.9.5):
@@ -6186,6 +6322,14 @@ packages:
       acorn-walk: 8.2.0
     dev: true
 
+  /acorn-import-assertions@1.9.0(acorn@8.8.1):
+    resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
+    peerDependencies:
+      acorn: ^8
+    dependencies:
+      acorn: 8.8.1
+    dev: true
+
   /acorn-jsx@5.3.2(acorn@7.4.1):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -6212,6 +6356,12 @@ packages:
 
   /acorn@7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /acorn@8.10.0:
+    resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -6827,7 +6977,22 @@ packages:
       loader-utils: 2.0.3
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
+    dev: true
+
+  /babel-loader@8.3.0(@babel/core@7.20.2)(webpack@5.88.2):
+    resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
+    engines: {node: '>= 8.9'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      webpack: '>=2'
+    dependencies:
+      '@babel/core': 7.20.2
+      find-cache-dir: 3.3.2
+      loader-utils: 2.0.3
+      make-dir: 3.1.0
+      schema-utils: 2.7.1
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
     dev: true
 
   /babel-plugin-add-react-displayname@0.0.5:
@@ -7893,6 +8058,11 @@ packages:
   /comma-separated-tokens@1.0.8:
     resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
 
+  /commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+    dev: true
+
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
@@ -7919,6 +8089,7 @@ packages:
   /commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
+    dev: false
 
   /commander@9.4.1:
     resolution: {integrity: sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==}
@@ -8288,7 +8459,29 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 6.3.0
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
+    dev: true
+
+  /css-loader@3.6.0(webpack@5.88.2):
+    resolution: {integrity: sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==}
+    engines: {node: '>= 8.9.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      camelcase: 5.3.1
+      cssesc: 3.0.0
+      icss-utils: 4.1.1
+      loader-utils: 1.4.0
+      normalize-path: 3.0.0
+      postcss: 7.0.39
+      postcss-modules-extract-imports: 2.0.0
+      postcss-modules-local-by-default: 3.0.3
+      postcss-modules-scope: 2.2.0
+      postcss-modules-values: 3.0.0
+      postcss-value-parser: 4.2.0
+      schema-utils: 2.7.1
+      semver: 6.3.0
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
     dev: true
 
   /css-select-base-adapter@0.1.1:
@@ -9325,6 +9518,14 @@ packages:
       tapable: 1.1.3
     dev: true
 
+  /enhanced-resolve@5.15.0:
+    resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.2.1
+    dev: true
+
   /enquirer@2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
     engines: {node: '>=8.6'}
@@ -9418,6 +9619,10 @@ packages:
       is-string: 1.0.7
       isarray: 2.0.5
 
+  /es-module-lexer@1.3.0:
+    resolution: {integrity: sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==}
+    dev: true
+
   /es-shim-unscopables@1.0.0:
     resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==}
     dependencies:
@@ -9452,7 +9657,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-android-arm64@0.14.54:
@@ -9461,7 +9665,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-darwin-64@0.14.54:
@@ -9470,7 +9673,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-darwin-arm64@0.14.54:
@@ -9479,7 +9681,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-freebsd-64@0.14.54:
@@ -9488,7 +9689,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-freebsd-arm64@0.14.54:
@@ -9497,7 +9697,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-32@0.14.54:
@@ -9506,7 +9705,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-64@0.14.54:
@@ -9515,7 +9713,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-arm64@0.14.54:
@@ -9524,7 +9721,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-arm@0.14.54:
@@ -9533,7 +9729,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-mips64le@0.14.54:
@@ -9542,7 +9737,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-ppc64le@0.14.54:
@@ -9551,7 +9745,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-riscv64@0.14.54:
@@ -9560,7 +9753,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-s390x@0.14.54:
@@ -9569,7 +9761,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-netbsd-64@0.14.54:
@@ -9578,7 +9769,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-openbsd-64@0.14.54:
@@ -9587,7 +9777,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-plugin-less@1.1.9(esbuild@0.14.54):
@@ -9617,7 +9806,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-windows-32@0.14.54:
@@ -9626,7 +9814,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-windows-64@0.14.54:
@@ -9635,7 +9822,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-windows-arm64@0.14.54:
@@ -9644,7 +9830,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild@0.14.54:
@@ -9674,7 +9859,6 @@ packages:
       esbuild-windows-32: 0.14.54
       esbuild-windows-64: 0.14.54
       esbuild-windows-arm64: 0.14.54
-    dev: false
 
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -10330,7 +10514,18 @@ packages:
     dependencies:
       loader-utils: 2.0.3
       schema-utils: 3.1.1
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
+    dev: true
+
+  /file-loader@6.2.0(webpack@5.88.2):
+    resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      loader-utils: 2.0.3
+      schema-utils: 3.1.1
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
     dev: true
 
   /file-system-cache@1.1.0:
@@ -10537,7 +10732,7 @@ packages:
       semver: 5.7.1
       tapable: 1.1.3
       typescript: 4.9.5
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
@@ -10572,7 +10767,7 @@ packages:
       semver: 7.3.8
       tapable: 1.1.3
       typescript: 4.9.5
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
     dev: true
 
   /form-data@2.3.3:
@@ -11278,16 +11473,16 @@ packages:
     resolution: {integrity: sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==}
     dev: true
 
-  /html-webpack-harddisk-plugin@1.0.2(html-webpack-plugin@4.5.2)(webpack@4.46.0):
+  /html-webpack-harddisk-plugin@1.0.2(html-webpack-plugin@4.5.2)(webpack@5.88.2):
     resolution: {integrity: sha512-s0F0qAxug9fgztJyWWa8cUlVvgbAD/+J9Dhg22REU637DV9RhrKt0EsFBOXkRuSuwSeYLUtyLcQYpARPBZe51g==}
     engines: {node: '>=6.9'}
     peerDependencies:
       html-webpack-plugin: ^2.0.0 || ^3.0.0 || ^4.0.0
       webpack: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
     dependencies:
-      html-webpack-plugin: 4.5.2(webpack@4.46.0)
+      html-webpack-plugin: 4.5.2(webpack@5.88.2)
       mkdirp: 0.5.6
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
     dev: true
 
   /html-webpack-plugin@4.5.2(webpack@4.46.0):
@@ -11305,7 +11500,25 @@ packages:
       pretty-error: 2.1.2
       tapable: 1.1.3
       util.promisify: 1.0.0
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
+    dev: true
+
+  /html-webpack-plugin@4.5.2(webpack@5.88.2):
+    resolution: {integrity: sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==}
+    engines: {node: '>=6.9'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      '@types/html-minifier-terser': 5.1.2
+      '@types/tapable': 1.0.8
+      '@types/webpack': 4.41.33
+      html-minifier-terser: 5.1.1
+      loader-utils: 1.4.0
+      lodash: 4.17.21
+      pretty-error: 2.1.2
+      tapable: 1.1.3
+      util.promisify: 1.0.0
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
     dev: true
 
   /htmlparser2@3.10.1:
@@ -11583,6 +11796,11 @@ packages:
   /interpret@2.2.0:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
     engines: {node: '>= 0.10'}
+    dev: true
+
+  /interpret@3.1.1:
+    resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
+    engines: {node: '>=10.13.0'}
     dev: true
 
   /invariant@2.2.4:
@@ -13114,6 +13332,15 @@ packages:
       supports-color: 7.2.0
     dev: true
 
+  /jest-worker@27.5.1:
+    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
+    engines: {node: '>= 10.13.0'}
+    dependencies:
+      '@types/node': 18.11.9
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+    dev: true
+
   /jest-worker@28.1.3:
     resolution: {integrity: sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -13319,7 +13546,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
 
   /jsprim@2.0.2:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
@@ -13488,7 +13715,7 @@ packages:
       dotenv-expand: 5.1.0
     dev: true
 
-  /less-loader@7.3.0(less@3.13.1)(webpack@4.46.0):
+  /less-loader@7.3.0(less@3.13.1)(webpack@5.88.2):
     resolution: {integrity: sha512-Mi8915g7NMaLlgi77mgTTQvK022xKRQBIVDSyfl3ErTuBhmZBQab0mjeJjNNqGbdR+qrfTleKXqbGI4uEFavxg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -13499,7 +13726,7 @@ packages:
       less: 3.13.1
       loader-utils: 2.0.3
       schema-utils: 3.1.1
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
     dev: true
 
   /less@3.13.1:
@@ -13645,6 +13872,11 @@ packages:
   /loader-runner@2.4.0:
     resolution: {integrity: sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==}
     engines: {node: '>=4.3.0 <5.0.0 || >=5.10'}
+    dev: true
+
+  /loader-runner@4.3.0:
+    resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
+    engines: {node: '>=6.11.5'}
     dev: true
 
   /loader-utils@1.4.0:
@@ -14228,7 +14460,7 @@ packages:
   /moment@2.29.4:
     resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
 
-  /monaco-editor-webpack-plugin@7.0.1(monaco-editor@0.39.0)(webpack@4.46.0):
+  /monaco-editor-webpack-plugin@7.0.1(monaco-editor@0.39.0)(webpack@5.88.2):
     resolution: {integrity: sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw==}
     peerDependencies:
       monaco-editor: '>= 0.31.0'
@@ -14236,7 +14468,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       monaco-editor: 0.39.0
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
     dev: true
 
   /monaco-editor@0.39.0:
@@ -15319,10 +15551,10 @@ packages:
       postcss: 7.0.39
       schema-utils: 3.1.1
       semver: 7.3.8
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
     dev: true
 
-  /postcss-loader@4.3.0(postcss@8.4.18)(webpack@4.46.0):
+  /postcss-loader@4.3.0(postcss@8.4.18)(webpack@5.88.2):
     resolution: {integrity: sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -15335,7 +15567,7 @@ packages:
       postcss: 8.4.18
       schema-utils: 3.1.1
       semver: 7.3.8
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
     dev: true
 
   /postcss-merge-longhand@4.0.11:
@@ -16063,7 +16295,18 @@ packages:
     dependencies:
       loader-utils: 2.0.3
       schema-utils: 3.1.1
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
+    dev: true
+
+  /raw-loader@4.0.2(webpack@5.88.2):
+    resolution: {integrity: sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      loader-utils: 2.0.3
+      schema-utils: 3.1.1
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
     dev: true
 
   /rc-align@4.0.12(react-dom@16.14.0)(react@16.14.0):
@@ -17053,9 +17296,9 @@ packages:
       tslib: 2.4.1
     dev: true
 
-  /rechoir@0.7.1:
-    resolution: {integrity: sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==}
-    engines: {node: '>= 0.10'}
+  /rechoir@0.8.0:
+    resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
+    engines: {node: '>= 10.13.0'}
     dependencies:
       resolve: 1.22.1
     dev: true
@@ -17542,7 +17785,7 @@ packages:
       - supports-color
     dev: true
 
-  /sass-loader@10.3.1(sass@1.56.0)(webpack@4.46.0):
+  /sass-loader@10.3.1(sass@1.56.0)(webpack@5.88.2):
     resolution: {integrity: sha512-y2aBdtYkbqorVavkC3fcJIUDGIegzDWPn3/LAFhsf3G+MzPKTJx37sROf5pXtUeggSVbNbmfj8TgRaSLMelXRA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -17564,7 +17807,7 @@ packages:
       sass: 1.56.0
       schema-utils: 3.1.1
       semver: 7.3.8
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
     dev: true
 
   /sass@1.56.0:
@@ -17621,6 +17864,15 @@ packages:
 
   /schema-utils@3.1.1:
     resolution: {integrity: sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==}
+    engines: {node: '>= 10.13.0'}
+    dependencies:
+      '@types/json-schema': 7.0.11
+      ajv: 6.12.6
+      ajv-keywords: 3.5.2(ajv@6.12.6)
+    dev: true
+
+  /schema-utils@3.3.0:
+    resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
       '@types/json-schema': 7.0.11
@@ -17687,6 +17939,12 @@ packages:
 
   /serialize-javascript@5.0.1:
     resolution: {integrity: sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==}
+    dependencies:
+      randombytes: 2.1.0
+    dev: true
+
+  /serialize-javascript@6.0.1:
+    resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
     dependencies:
       randombytes: 2.1.0
     dev: true
@@ -18341,10 +18599,10 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 2.7.1
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
     dev: true
 
-  /style-loader@2.0.0(webpack@4.46.0):
+  /style-loader@2.0.0(webpack@5.88.2):
     resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -18352,7 +18610,7 @@ packages:
     dependencies:
       loader-utils: 2.0.3
       schema-utils: 3.1.1
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
     dev: true
 
   /style-to-object@0.3.0:
@@ -18483,6 +18741,11 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /tapable@2.2.1:
+    resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
+    engines: {node: '>=6'}
+    dev: true
+
   /tar@6.1.12:
     resolution: {integrity: sha512-jU4TdemS31uABHd+Lt5WEYJuzn+TJTCBLljvIAHZOz6M9Os5pJ4dD+vRFLxPa/n3T0iEFzpi+0x1UfuDZYbRMw==}
     engines: {node: '>=10'}
@@ -18545,7 +18808,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.1
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: true
@@ -18564,10 +18827,35 @@ packages:
       serialize-javascript: 5.0.1
       source-map: 0.6.1
       terser: 5.15.1
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
       webpack-sources: 1.4.3
     transitivePeerDependencies:
       - bluebird
+    dev: true
+
+  /terser-webpack-plugin@5.3.9(esbuild@0.14.54)(webpack@5.88.2):
+    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.17
+      esbuild: 0.14.54
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.1
+      terser: 5.19.1
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
     dev: true
 
   /terser@4.8.1:
@@ -18588,6 +18876,17 @@ packages:
     dependencies:
       '@jridgewell/source-map': 0.3.2
       acorn: 8.8.1
+      commander: 2.20.3
+      source-map-support: 0.5.21
+    dev: true
+
+  /terser@5.19.1:
+    resolution: {integrity: sha512-27hxBUVdV6GoNg1pKQ7Z5cbR6V9txPVyBA+FQw3BaZ1Wuzvztce5p156DaP0NVZNrMZZ+6iG9Syf7WgMNKDg2Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/source-map': 0.3.5
+      acorn: 8.10.0
       commander: 2.20.3
       source-map-support: 0.5.21
     dev: true
@@ -19217,7 +19516,7 @@ packages:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.1.1
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
     dev: true
 
   /url-parse@1.5.10:
@@ -19539,20 +19838,17 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /webpack-cli@4.10.0(webpack@4.46.0):
-    resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
-    engines: {node: '>=10.13.0'}
+  /webpack-cli@5.1.4(webpack@5.88.2):
+    resolution: {integrity: sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==}
+    engines: {node: '>=14.15.0'}
     hasBin: true
     peerDependencies:
       '@webpack-cli/generators': '*'
-      '@webpack-cli/migrate': '*'
-      webpack: 4.x.x || 5.x.x
+      webpack: 5.x.x
       webpack-bundle-analyzer: '*'
       webpack-dev-server: '*'
     peerDependenciesMeta:
       '@webpack-cli/generators':
-        optional: true
-      '@webpack-cli/migrate':
         optional: true
       webpack-bundle-analyzer:
         optional: true
@@ -19560,17 +19856,18 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0)(webpack@4.46.0)
-      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0)
-      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.88.2)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.88.2)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.88.2)
       colorette: 2.0.19
-      commander: 7.2.0
+      commander: 10.0.1
       cross-spawn: 7.0.3
+      envinfo: 7.8.1
       fastest-levenshtein: 1.0.16
       import-local: 3.1.0
-      interpret: 2.2.0
-      rechoir: 0.7.1
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      interpret: 3.1.1
+      rechoir: 0.8.0
+      webpack: 5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4)
       webpack-merge: 5.8.0
     dev: true
 
@@ -19584,7 +19881,7 @@ packages:
       mime: 2.6.0
       mkdirp: 0.5.6
       range-parser: 1.2.1
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
       webpack-log: 2.0.0
     dev: true
 
@@ -19594,7 +19891,7 @@ packages:
     peerDependencies:
       webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
     dependencies:
-      webpack: 4.46.0(webpack-cli@4.10.0)
+      webpack: 4.46.0(webpack-cli@5.1.4)
     dev: true
 
   /webpack-hot-middleware@2.25.2:
@@ -19628,6 +19925,11 @@ packages:
       source-map: 0.6.1
     dev: true
 
+  /webpack-sources@3.2.3:
+    resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
+    engines: {node: '>=10.13.0'}
+    dev: true
+
   /webpack-virtual-modules@0.2.2:
     resolution: {integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==}
     dependencies:
@@ -19636,7 +19938,7 @@ packages:
       - supports-color
     dev: true
 
-  /webpack@4.46.0(webpack-cli@4.10.0):
+  /webpack@4.46.0(webpack-cli@5.1.4):
     resolution: {integrity: sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==}
     engines: {node: '>=6.11.5'}
     hasBin: true
@@ -19671,10 +19973,51 @@ packages:
       tapable: 1.1.3
       terser-webpack-plugin: 1.4.5(webpack@4.46.0)
       watchpack: 1.7.5
-      webpack-cli: 4.10.0(webpack@4.46.0)
+      webpack-cli: 5.1.4(webpack@5.88.2)
       webpack-sources: 1.4.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /webpack@5.88.2(esbuild@0.14.54)(webpack-cli@5.1.4):
+    resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.4
+      '@types/estree': 1.0.1
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/wasm-edit': 1.11.6
+      '@webassemblyjs/wasm-parser': 1.11.6
+      acorn: 8.8.1
+      acorn-import-assertions: 1.9.0(acorn@8.8.1)
+      browserslist: 4.21.4
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.15.0
+      es-module-lexer: 1.3.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.9(esbuild@0.14.54)(webpack@5.88.2)
+      watchpack: 2.4.0
+      webpack-cli: 5.1.4(webpack@5.88.2)
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
     dev: true
 
   /webworkify@1.5.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -573,6 +573,9 @@ devDependencies:
   postcss-loader:
     specifier: ^4.3.0
     version: 4.3.0(postcss@8.4.18)(webpack@5.88.2)
+  process:
+    specifier: ^0.11.10
+    version: 0.11.10
   raw-loader:
     specifier: ^4.0.2
     version: 4.0.2(webpack@5.88.2)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,7 +65,7 @@ function createEntry(entry) {
             rules: [
                 {
                     test: /\.stories\.[jt]sx?$/,
-                    loaders: [require.resolve('@storybook/source-loader')],
+                    use: [require.resolve('@storybook/source-loader')],
                 },
                 {
                     test: /\.[jt]sx?$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,6 @@ function createEntry(entry) {
         },
         output: {
             path: path.resolve(__dirname, 'frontend', 'dist'),
-            filename: '[name].js',
             chunkFilename: '[name].[contenthash].js',
             publicPath: process.env.JS_URL
                 ? `${process.env.JS_URL}${process.env.JS_URL.endsWith('/') ? '' : '/'}static/`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 /* global require, module, process, __dirname */
 const path = require('path')
+const webpack = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const HtmlWebpackHarddiskPlugin = require('html-webpack-harddisk-plugin')
 const AntdDayjsWebpackPlugin = require('antd-dayjs-webpack-plugin')
@@ -59,6 +60,7 @@ function createEntry(entry) {
                 types: path.resolve(__dirname, 'frontend', 'types'),
                 public: path.resolve(__dirname, 'frontend', 'public'),
                 cypress: path.resolve(__dirname, 'cypress'),
+                process: 'process/browser',
             },
         },
         module: {
@@ -204,7 +206,12 @@ function createEntry(entry) {
                       new HtmlWebpackHarddiskPlugin(),
                   ]
                 : entry === 'cypress'
-                ? [new HtmlWebpackHarddiskPlugin()]
+                ? [
+                      new HtmlWebpackHarddiskPlugin(),
+                      new webpack.ProvidePlugin({
+                          process: 'process/browser',
+                      }),
+                  ]
                 : []
         ),
     }


### PR DESCRIPTION
## Problem

Towards https://github.com/PostHog/posthog/pull/16605

`TipTap 2.0.0` requires `React 18` which requires `Storybook 7` which requires `Webpack 5`

## Changes

Upgrades Webpack to the latest version. As per the upgrade guide:
- Removed `filename: '[name].js'` as it was the default
- Replace `loaders` with `use`
- Add `process` package and plugin to [replace removed polyfill](https://stackoverflow.com/questions/65018431/webpack-5-uncaught-referenceerror-process-is-not-defined)

## How did you test this code?

- Ran it locally
- Tests still pass
