### PR TITLE
feat(hogql): add clickhouse geohash functions

### DIFF
--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -465,6 +465,9 @@ HOGQL_CLICKHOUSE_FUNCTIONS: Dict[str, HogQLFunctionMeta] = {
     "greatCircleAngle": HogQLFunctionMeta("greatCircleAngle", 4, 4),
     "pointInEllipses": HogQLFunctionMeta("pointInEllipses", 6, None),
     "pointInPolygon": HogQLFunctionMeta("pointInPolygon", 2, None),
+    "geohashEncode": HogQLFunctionMeta("geohashEncode", 2, 3),
+    "geohashDecode": HogQLFunctionMeta("geohashDecode", 1, 1),
+    "geohashesInBox": HogQLFunctionMeta("geohashesInBox", 5, 5),
     # nullable
     "isNull": HogQLFunctionMeta("isNull", 1, 1),
     "isNotNull": HogQLFunctionMeta("isNotNull", 1, 1),


### PR DESCRIPTION
## Problem

Adds a few missing functions

## Changes

Makes the following queries possible:

```sql
     with properties.$geoip_latitude as latitude,
          properties.$geoip_longitude as longitude
   select geohashEncode(latitude, longitude, 12) as geohash,
          count()
     from events
    where latitude is not null and longitude is not null
 group by latitude, longitude
 order by count() desc
    limit 100
```

Those can in turn be used to show clustered dots on a map, if we ever decide to implement a map view.

## How did you test this code?

Ran it locally in the SQL insight editor.