### PR TITLE
fix: Session high watermarks logic

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
@@ -40,7 +40,7 @@ export class SessionOffsetHighWaterMark {
         }
     }
 
-    public async getWatermarks(tp: TopicPartition): Promise<SessionOffsetHighWaterMarks> {
+    public async getWaterMarks(tp: TopicPartition): Promise<SessionOffsetHighWaterMarks> {
         const key = offsetHighWaterMarkKey(this.keyPrefix, tp)
 
         // If we already have a watermark promise then we return it (i.e. we don't want to load the watermarks twice)
@@ -87,7 +87,7 @@ export class SessionOffsetHighWaterMark {
                 })
             }).then(async () => {
                 // NOTE: We do this in a secondary promise to release the previous redis client
-                const watermarks = await this.getWatermarks(tp)
+                const watermarks = await this.getWaterMarks(tp)
                 watermarks[sessionId] = offset
                 this.watermarks[key] = Promise.resolve(watermarks)
             })
@@ -122,7 +122,7 @@ export class SessionOffsetHighWaterMark {
                     ...tp,
                     offset,
                 })
-                const watermarks = await this.getWatermarks(tp)
+                const watermarks = await this.getWaterMarks(tp)
                 // remove each key in currentHighWaterMarks that has an offset less than or equal to the offset we just committed
                 Object.entries(watermarks).forEach(([sessionId, value]) => {
                     if (value && value <= offset) {
@@ -156,7 +156,7 @@ export class SessionOffsetHighWaterMark {
      * so that callers are safe to drop messages
      */
     public async isBelowHighWaterMark(tp: TopicPartition, sessionId: string, offset: number): Promise<boolean> {
-        const highWaterMarks = await this.getWatermarks(tp)
+        const highWaterMarks = await this.getWaterMarks(tp)
 
         return offset <= (highWaterMarks[sessionId] ?? -1)
     }

--- a/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.ts
@@ -6,9 +6,11 @@ import { RedisPool } from '../../../../types'
 import { timeoutGuard } from '../../../../utils/db/utils'
 import { status } from '../../../../utils/status'
 
-const offsetHighWaterMarkKey = (prefix: string, tp: TopicPartition) => {
+export const offsetHighWaterMarkKey = (prefix: string, tp: TopicPartition) => {
     return `${prefix}/${tp.topic}/${tp.partition}`
 }
+
+export type SessionOffsetHighWaterMarks = Record<string, number | undefined>
 
 /**
  * If a file is written to S3 we need to know the offset of the last message in that file so that we can
@@ -21,47 +23,57 @@ const offsetHighWaterMarkKey = (prefix: string, tp: TopicPartition) => {
  * so that we don't re-process those messages.
  */
 export class SessionOffsetHighWaterMark {
-    private topicPartitionWaterMarks: Record<string, Record<string, number>> = {}
+    // Watermarks are held in memory and synced back to redis on commit
+    // We don't need to load them more than once per TP as this consumer is the only thing writing to it
+    private watermarks: Record<string, Promise<SessionOffsetHighWaterMarks> | undefined> = {}
 
-    getWatermarkFor(tp: TopicPartition): Record<string, number> {
-        const key = `${tp.topic}-${tp.partition}`
-        if (!this.topicPartitionWaterMarks[key]) {
-            this.topicPartitionWaterMarks[key] = {}
-        }
-        return this.topicPartitionWaterMarks[key]
-    }
-
-    private setWaterMarkFor(tp: TopicPartition, sessionId: string, offset: number) {
-        const key = `${tp.topic}-${tp.partition}`
-        if (!this.topicPartitionWaterMarks[key]) {
-            this.topicPartitionWaterMarks[key] = {}
-        }
-        this.topicPartitionWaterMarks[key][sessionId] = offset
-    }
-
-    private getAllPromise: Promise<Record<string, number> | null> | null = null
     constructor(private redisPool: RedisPool, private keyPrefix = '@posthog/replay/partition-high-water-marks') {}
 
-    private async run<T>(description: string, fn: (client: Redis) => Promise<T>): Promise<T | null> {
+    private async run<T>(description: string, fn: (client: Redis) => Promise<T>): Promise<T> {
         const client = await this.redisPool.acquire()
         const timeout = timeoutGuard(`${description} delayed. Waiting over 30 seconds.`)
         try {
             return await fn(client)
-        } catch (error) {
-            if (error instanceof SyntaxError) {
-                // invalid JSON
-                return null
-            } else {
-                throw error
-            }
         } finally {
             clearTimeout(timeout)
             await this.redisPool.release(client)
         }
     }
 
+    public async getWatermarks(tp: TopicPartition): Promise<SessionOffsetHighWaterMarks> {
+        const key = offsetHighWaterMarkKey(this.keyPrefix, tp)
+
+        // If we already have a watermark promise then we return it (i.e. we don't want to load the watermarks twice)
+        if (!this.watermarks[key]) {
+            this.watermarks[key] = this.run(`read all offset high-water mark for ${key} `, (client) =>
+                client.zrange(key, 0, -1, 'WITHSCORES')
+            ).then((redisValue) => {
+                // NOTE: We do this in a secondary promise to release the previous redis client
+
+                // redisValue is an array of [sessionId, offset, sessionId, offset, ...]
+                // we want to convert it to an object of { sessionId: offset, sessionId: offset, ... }
+                const highWaterMarks = redisValue.reduce(
+                    (acc: SessionOffsetHighWaterMarks, value: string, index: number) => {
+                        if (index % 2 === 0) {
+                            acc[value] = parseInt(redisValue[index + 1])
+                        }
+                        return acc
+                    },
+                    {}
+                )
+
+                this.watermarks[key] = Promise.resolve(highWaterMarks)
+
+                return highWaterMarks
+            })
+        }
+
+        return this.watermarks[key]!
+    }
+
     public async add(tp: TopicPartition, sessionId: string, offset: number): Promise<void> {
         const key = offsetHighWaterMarkKey(this.keyPrefix, tp)
+
         try {
             await this.run(`write offset high-water mark ${key} `, async (client) => {
                 const returnCountOfUpdatedAndAddedElements = 'CH'
@@ -73,7 +85,11 @@ export class SessionOffsetHighWaterMark {
                     offset,
                     updatedCount,
                 })
-                this.setWaterMarkFor(tp, sessionId, offset)
+            }).then(async () => {
+                // NOTE: We do this in a secondary promise to release the previous redis client
+                const watermarks = await this.getWatermarks(tp)
+                watermarks[sessionId] = offset
+                this.watermarks[key] = Promise.resolve(watermarks)
             })
         } catch (error) {
             status.error('🧨', 'WrittenOffsetCache failed to add high-water mark for partition', {
@@ -96,52 +112,7 @@ export class SessionOffsetHighWaterMark {
         }
     }
 
-    public async getAll(tp: TopicPartition): Promise<Record<string, number> | null> {
-        const key = offsetHighWaterMarkKey(this.keyPrefix, tp)
-        try {
-            // this might be called multiple times, particularly around rebalances, so, hold one promise for the getAll which multiple callers can await
-            if (this.getAllPromise === null) {
-                this.getAllPromise = this.run(`read all offset high-water mark for ${key} `, async (client) => {
-                    const redisValue = await client.zrange(key, 0, -1, 'WITHSCORES')
-                    // redisValue is an array of [sessionId, offset, sessionId, offset, ...]
-                    // we want to convert it to an object of { sessionId: offset, sessionId: offset, ... }
-                    const highWaterMarks = redisValue.reduce(
-                        (acc: Record<string, number>, value: string, index: number) => {
-                            if (index % 2 === 0) {
-                                acc[value] = parseInt(redisValue[index + 1])
-                            }
-                            return acc
-                        },
-                        {}
-                    )
-
-                    this.topicPartitionWaterMarks[`${tp.topic}-${tp.partition}`] = highWaterMarks
-
-                    return highWaterMarks
-                })
-            }
-            return await this.getAllPromise
-        } catch (error) {
-            status.error('🧨', 'WrittenOffsetCache failed to read high-water marks for partition', {
-                error: error.message,
-                key,
-                ...tp,
-            })
-            captureException(error, {
-                extra: {
-                    key,
-                },
-                tags: {
-                    ...tp,
-                },
-            })
-            return null
-        } finally {
-            this.getAllPromise = null
-        }
-    }
-
-    public async onCommit(tp: TopicPartition, offset: number): Promise<Record<string, number> | null> {
+    public async onCommit(tp: TopicPartition, offset: number): Promise<void> {
         const key = offsetHighWaterMarkKey(this.keyPrefix, tp)
         try {
             return await this.run(`commit all below offset high-water mark for ${key} `, async (client) => {
@@ -151,15 +122,15 @@ export class SessionOffsetHighWaterMark {
                     ...tp,
                     offset,
                 })
-                const currentHighWaterMarks = this.getWatermarkFor(tp)
+                const watermarks = await this.getWatermarks(tp)
                 // remove each key in currentHighWaterMarks that has an offset less than or equal to the offset we just committed
-                Object.keys(currentHighWaterMarks).forEach((sessionId) => {
-                    if (currentHighWaterMarks[sessionId] <= offset) {
-                        delete currentHighWaterMarks[sessionId]
+                Object.entries(watermarks).forEach(([sessionId, value]) => {
+                    if (value && value <= offset) {
+                        delete watermarks[sessionId]
                     }
                 })
 
-                return currentHighWaterMarks
+                this.watermarks[key] = Promise.resolve(watermarks)
             })
         } catch (error) {
             status.error('🧨', 'WrittenOffsetCache failed to commit high-water mark for partition', {
@@ -175,7 +146,6 @@ export class SessionOffsetHighWaterMark {
                     ...tp,
                 },
             })
-            return null
         }
     }
 
@@ -186,47 +156,12 @@ export class SessionOffsetHighWaterMark {
      * so that callers are safe to drop messages
      */
     public async isBelowHighWaterMark(tp: TopicPartition, sessionId: string, offset: number): Promise<boolean> {
-        if (!this.topicPartitionWaterMarks[tp.partition]) {
-            const highWaterMarks = await this.getAll(tp)
-            if (highWaterMarks) {
-                this.topicPartitionWaterMarks[tp.partition] = highWaterMarks
-            }
-        }
-        return offset <= this.topicPartitionWaterMarks[tp.partition]?.[sessionId]
+        const highWaterMarks = await this.getWatermarks(tp)
+
+        return offset <= (highWaterMarks[sessionId] ?? -1)
     }
 
     public revoke(tp: TopicPartition) {
-        delete this.topicPartitionWaterMarks[`${tp.topic}-${tp.partition}`]
-    }
-}
-
-/**
- * To test if the offset high-water mark functionality is introducing playback errors
- * here's a version that does nothing that can be swapped in
- */
-export class NullSessionOffsetHighWaterMark extends SessionOffsetHighWaterMark {
-    getWatermarkFor(_tp: TopicPartition): Record<string, number> {
-        return {}
-    }
-
-    async add(_tp: TopicPartition, _sessionId: string, _offset: number): Promise<void> {
-        return Promise.resolve()
-    }
-
-    async getAll(_tp: TopicPartition): Promise<Record<string, number> | null> {
-        return Promise.resolve(null)
-    }
-
-    async onCommit(_tp: TopicPartition, _offset: number): Promise<Record<string, number> | null> {
-        return Promise.resolve(null)
-    }
-
-    async isBelowHighWaterMark(_tp: TopicPartition, _sessionId: string, _offset: number): Promise<boolean> {
-        // always return false so that we never drop messages
-        return Promise.resolve(false)
-    }
-
-    revoke(_tp: TopicPartition) {
-        return
+        delete this.watermarks[offsetHighWaterMarkKey(this.keyPrefix, tp)]
     }
 }

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.test.ts
@@ -1,8 +1,9 @@
 import { TopicPartition } from 'kafkajs'
+
 import {
+    offsetHighWaterMarkKey,
     SessionOffsetHighWaterMark,
     SessionOffsetHighWaterMarks,
-    offsetHighWaterMarkKey,
 } from '../../../../../src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark'
 import { Hub } from '../../../../../src/types'
 import { createHub } from '../../../../../src/utils/db/hub'
@@ -50,7 +51,7 @@ describe('session offset high-water mark', () => {
     })
 
     const expectMemoryAndRedisToEqual = async (tp: TopicPartition, toEqual: any) => {
-        expect(await sessionOffsetHighWaterMark.getWatermarks(tp)).toEqual(toEqual)
+        expect(await sessionOffsetHighWaterMark.getWaterMarks(tp)).toEqual(toEqual)
         expect(await getWaterMarksFromRedis(tp)).toEqual(toEqual)
     }
 
@@ -72,8 +73,8 @@ describe('session offset high-water mark', () => {
 
         it('can get multiple watermarks without clashes', async () => {
             const results = await Promise.all([
-                sessionOffsetHighWaterMark.getWatermarks({ topic: 'topic', partition: 1 }),
-                sessionOffsetHighWaterMark.getWatermarks({ topic: 'topic', partition: 2 }),
+                sessionOffsetHighWaterMark.getWaterMarks({ topic: 'topic', partition: 1 }),
+                sessionOffsetHighWaterMark.getWaterMarks({ topic: 'topic', partition: 2 }),
             ])
 
             expect(results).toEqual([{}, {}])
@@ -106,7 +107,7 @@ describe('session offset high-water mark', () => {
     describe('with existing high-water marks', () => {
         beforeEach(async () => {
             // works even before anything is written to redis
-            expect(await sessionOffsetHighWaterMark.getWatermarks({ topic: 'topic', partition: 1 })).toStrictEqual({})
+            expect(await sessionOffsetHighWaterMark.getWaterMarks({ topic: 'topic', partition: 1 })).toStrictEqual({})
 
             await sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 1 }, 'some-session', 123)
             await sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 1 }, 'another-session', 12)

--- a/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark.test.ts
@@ -1,23 +1,43 @@
-import { SessionOffsetHighWaterMark } from '../../../../../src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark'
+import { TopicPartition } from 'kafkajs'
+import {
+    SessionOffsetHighWaterMark,
+    SessionOffsetHighWaterMarks,
+    offsetHighWaterMarkKey,
+} from '../../../../../src/main/ingestion-queues/session-recording/blob-ingester/session-offset-high-water-mark'
 import { Hub } from '../../../../../src/types'
 import { createHub } from '../../../../../src/utils/db/hub'
 
-async function deleteKeysWithPrefix(hub: Hub, keyPrefix: string) {
-    const redisClient = await hub.redisPool.acquire()
-    const keys = await redisClient.keys(`${keyPrefix}*`)
-    const pipeline = redisClient.pipeline()
-    keys.forEach(function (key) {
-        pipeline.del(key)
-    })
-    await pipeline.exec()
-    await hub.redisPool.release(redisClient)
-}
-
 describe('session offset high-water mark', () => {
+    jest.setTimeout(1000)
     let hub: Hub
     let closeHub: () => Promise<void>
     const keyPrefix = 'test-high-water-mark'
     let sessionOffsetHighWaterMark: SessionOffsetHighWaterMark
+
+    async function deletePrefixedKeys() {
+        const redisClient = await hub.redisPool.acquire()
+        const keys = await redisClient.keys(`${keyPrefix}*`)
+        const pipeline = redisClient.pipeline()
+        keys.forEach(function (key) {
+            pipeline.del(key)
+        })
+        await pipeline.exec()
+        await hub.redisPool.release(redisClient)
+    }
+
+    async function getWaterMarksFromRedis(tp: TopicPartition) {
+        const client = await hub.redisPool.acquire()
+        const key = offsetHighWaterMarkKey(keyPrefix, tp)
+        const redisValue = await client.zrange(key, 0, -1, 'WITHSCORES')
+        await hub.redisPool.release(client)
+
+        return redisValue.reduce((acc: SessionOffsetHighWaterMarks, value: string, index: number) => {
+            if (index % 2 === 0) {
+                acc[value] = parseInt(redisValue[index + 1])
+            }
+            return acc
+        }, {})
+    }
 
     beforeEach(async () => {
         ;[hub, closeHub] = await createHub()
@@ -25,29 +45,68 @@ describe('session offset high-water mark', () => {
     })
 
     afterEach(async () => {
-        await deleteKeysWithPrefix(hub, keyPrefix)
+        await deletePrefixedKeys()
         await closeHub()
     })
 
+    const expectMemoryAndRedisToEqual = async (tp: TopicPartition, toEqual: any) => {
+        expect(await sessionOffsetHighWaterMark.getWatermarks(tp)).toEqual(toEqual)
+        expect(await getWaterMarksFromRedis(tp)).toEqual(toEqual)
+    }
+
     describe('with no existing high-water marks', () => {
         it('can remove all high-water marks based on a given offset', async () => {
-            const inMemoryResults = await sessionOffsetHighWaterMark.onCommit({ topic: 'topic', partition: 1 }, 12)
-            expect(inMemoryResults).toEqual({})
-            expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 1 })).toEqual({})
+            await sessionOffsetHighWaterMark.onCommit({ topic: 'topic', partition: 1 }, 12)
+            await expectMemoryAndRedisToEqual({ topic: 'topic', partition: 1 }, {})
         })
 
         it('can add a high-water mark', async () => {
             await sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 1 }, 'some-session', 123)
-            expect(sessionOffsetHighWaterMark.getWatermarkFor({ topic: 'topic', partition: 1 })).toEqual({
-                'some-session': 123,
-            })
+            await expectMemoryAndRedisToEqual(
+                { topic: 'topic', partition: 1 },
+                {
+                    'some-session': 123,
+                }
+            )
+        })
+
+        it('can get multiple watermarks without clashes', async () => {
+            const results = await Promise.all([
+                sessionOffsetHighWaterMark.getWatermarks({ topic: 'topic', partition: 1 }),
+                sessionOffsetHighWaterMark.getWatermarks({ topic: 'topic', partition: 2 }),
+            ])
+
+            expect(results).toEqual([{}, {}])
+        })
+
+        it('can add multiple high-water marks in parallel', async () => {
+            await Promise.all([
+                sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 1 }, 'some-session', 10),
+                sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 1 }, 'some-session2', 20),
+                sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 2 }, 'some-session3', 30),
+            ])
+
+            await expectMemoryAndRedisToEqual(
+                { topic: 'topic', partition: 1 },
+                {
+                    'some-session': 10,
+                    'some-session2': 20,
+                }
+            )
+
+            await expectMemoryAndRedisToEqual(
+                { topic: 'topic', partition: 2 },
+                {
+                    'some-session3': 30,
+                }
+            )
         })
     })
 
     describe('with existing high-water marks', () => {
         beforeEach(async () => {
             // works even before anything is written to redis
-            expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 1 })).toStrictEqual({})
+            expect(await sessionOffsetHighWaterMark.getWatermarks({ topic: 'topic', partition: 1 })).toStrictEqual({})
 
             await sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 1 }, 'some-session', 123)
             await sessionOffsetHighWaterMark.add({ topic: 'topic', partition: 1 }, 'another-session', 12)
@@ -55,28 +114,33 @@ describe('session offset high-water mark', () => {
         })
 
         it('can get high-water marks for all sessions for a partition', async () => {
-            expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 1 })).toEqual({
-                'some-session': 123,
-                'another-session': 12,
-            })
+            await expectMemoryAndRedisToEqual(
+                { topic: 'topic', partition: 1 },
+                {
+                    'some-session': 123,
+                    'another-session': 12,
+                }
+            )
         })
 
         it('can remove all high-water marks based on a given offset', async () => {
-            const inMemoryResults = await sessionOffsetHighWaterMark.onCommit({ topic: 'topic', partition: 1 }, 12)
-            // the commit updates the in-memory cache
-            expect(inMemoryResults).toEqual({
-                'some-session': 123,
-            })
+            await sessionOffsetHighWaterMark.onCommit({ topic: 'topic', partition: 1 }, 12)
 
             // the commit updates redis
             // removes all high-water marks that are <= 12
-            expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 1 })).toEqual({
-                'some-session': 123,
-            })
+            await expectMemoryAndRedisToEqual(
+                { topic: 'topic', partition: 1 },
+                {
+                    'some-session': 123,
+                }
+            )
             // does not affect other partitions
-            expect(await sessionOffsetHighWaterMark.getAll({ topic: 'topic', partition: 2 })).toEqual({
-                'a-third-session': 1,
-            })
+            await expectMemoryAndRedisToEqual(
+                { topic: 'topic', partition: 2 },
+                {
+                    'a-third-session': 1,
+                }
+            )
         })
 
         it('can check if an offset is below the high-water mark', async () => {


### PR DESCRIPTION
## Problem

I believe there were some bugs around the highwatermarker:
1. We were using a shared promise but that was per TP combination which means if two ran in parallel for different TPs they resolved to the same value 🙈
2. We had some loose typing which meant we may have been modifying values that weren't actually there.

## Changes

* Bit of a rework to change everything to be promises, so that each topicPartition has its own promise associated with it
* This should fix issues todo with multiple parallel calls affecting each other.


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
