### PR TITLE
fix: Remove references to community Slack

### DIFF
--- a/frontend/src/mocks/fixtures/_billing_v2.json
+++ b/frontend/src/mocks/fixtures/_billing_v2.json
@@ -359,16 +359,16 @@
         },
         {
             "key": "community_support",
-            "name": "Slack (community)",
-            "description": "Get help from the PostHog community in our PostHog Users Slack group.",
+            "name": "Community forum",
+            "description": "Get help from the PostHog community in our public forum.",
             "unit": null,
             "limit": null,
             "note": null
         },
         {
             "key": "dedicated_support",
-            "name": "Slack (dedicated channel)",
-            "description": "Get help firectly from our support team in a dedicated Slack channel shared between you and the PostHog team.",
+            "name": "Dedicated Slack channel",
+            "description": "Get help in a dedicated Slack channel shared between you and the PostHog team.",
             "unit": null,
             "limit": null,
             "note": "$2k/month spend or above"
@@ -1302,8 +1302,8 @@
                             "features": [
                                 {
                                     "key": "community_support",
-                                    "name": "Slack (community)",
-                                    "description": "Get help from the PostHog community in our PostHog Users Slack group.",
+                                    "name": "Community forum",
+                                    "description": "Get help from the PostHog community in our public forum.",
                                     "unit": null,
                                     "limit": null,
                                     "note": null,
@@ -1810,8 +1810,8 @@
                             "features": [
                                 {
                                     "key": "community_support",
-                                    "name": "Slack (community)",
-                                    "description": "Get help from the PostHog community in our PostHog Users Slack group.",
+                                    "name": "Community forum",
+                                    "description": "Get help from the PostHog community in our public forum.",
                                     "unit": null,
                                     "limit": null,
                                     "note": null,
@@ -1819,8 +1819,8 @@
                                 },
                                 {
                                     "key": "dedicated_support",
-                                    "name": "Slack (dedicated channel)",
-                                    "description": "Get help firectly from our support team in a dedicated Slack channel shared between you and the PostHog team.",
+                                    "name": "Dedicated Slack channel",
+                                    "description": "Get help in a dedicated Slack channel shared between you and the PostHog team.",
                                     "unit": null,
                                     "limit": null,
                                     "note": "$2k/month spend or above",
@@ -2363,8 +2363,8 @@
                             "features": [
                                 {
                                     "key": "community_support",
-                                    "name": "Slack (community)",
-                                    "description": "Get help from the PostHog community in our PostHog Users Slack group.",
+                                    "name": "Community forum",
+                                    "description": "Get help from the PostHog community in our public forum.",
                                     "unit": null,
                                     "limit": null,
                                     "note": null,
@@ -2372,8 +2372,8 @@
                                 },
                                 {
                                     "key": "dedicated_support",
-                                    "name": "Slack (dedicated channel)",
-                                    "description": "Get help firectly from our support team in a dedicated Slack channel shared between you and the PostHog team.",
+                                    "name": "Dedicated Slack channel",
+                                    "description": "Get help in a dedicated Slack channel shared between you and the PostHog team.",
                                     "unit": null,
                                     "limit": null,
                                     "note": "$2k/month spend or above",

--- a/frontend/src/mocks/fixtures/_billing_v2_with_discount.json
+++ b/frontend/src/mocks/fixtures/_billing_v2_with_discount.json
@@ -335,16 +335,16 @@
         },
         {
             "key": "community_support",
-            "name": "Slack (community)",
-            "description": "Get help from the PostHog community in our PostHog Users Slack group.",
+            "name": "Community forum",
+            "description": "Get help from the PostHog community in our public forums.",
             "unit": null,
             "limit": null,
             "note": null
         },
         {
             "key": "dedicated_support",
-            "name": "Slack (dedicated channel)",
-            "description": "Get help firectly from our support team in a dedicated Slack channel shared between you and the PostHog team.",
+            "name": "Dedicated Slack channel",
+            "description": "Get help directly in a dedicated Slack channel shared between you and the PostHog team.",
             "unit": null,
             "limit": null,
             "note": "$2k/month spend or above"
@@ -1025,8 +1025,8 @@
                         },
                         {
                             "key": "community_support",
-                            "name": "Slack (community)",
-                            "description": "Get help from the PostHog community in our PostHog Users Slack group.",
+                            "name": "Community forum",
+                            "description": "Get help from the PostHog community in our public forum.",
                             "unit": null,
                             "limit": null,
                             "note": null
@@ -1129,16 +1129,16 @@
                         },
                         {
                             "key": "community_support",
-                            "name": "Slack (community)",
-                            "description": "Get help from the PostHog community in our PostHog Users Slack group.",
+                            "name": "Community forum",
+                            "description": "Get help from the PostHog community in our public forum.",
                             "unit": null,
                             "limit": null,
                             "note": null
                         },
                         {
                             "key": "dedicated_support",
-                            "name": "Slack (dedicated channel)",
-                            "description": "Get help firectly from our support team in a dedicated Slack channel shared between you and the PostHog team.",
+                            "name": "Dedicated Slack channel",
+                            "description": "Get help in a dedicated Slack channel shared between you and the PostHog team.",
                             "unit": null,
                             "limit": null,
                             "note": "$2k/month spend or above"
@@ -1446,8 +1446,8 @@
                             "features": [
                                 {
                                     "key": "community_support",
-                                    "name": "Slack (community)",
-                                    "description": "Get help from the PostHog community in our PostHog Users Slack group.",
+                                    "name": "Community forum",
+                                    "description": "Get help from the PostHog community in our public forum.",
                                     "unit": null,
                                     "limit": null,
                                     "note": null,
@@ -1954,8 +1954,8 @@
                             "features": [
                                 {
                                     "key": "community_support",
-                                    "name": "Slack (community)",
-                                    "description": "Get help from the PostHog community in our PostHog Users Slack group.",
+                                    "name": "Community forum",
+                                    "description": "Get help from the PostHog community in our public forum.",
                                     "unit": null,
                                     "limit": null,
                                     "note": null,
@@ -1963,8 +1963,8 @@
                                 },
                                 {
                                     "key": "dedicated_support",
-                                    "name": "Slack (dedicated channel)",
-                                    "description": "Get help firectly from our support team in a dedicated Slack channel shared between you and the PostHog team.",
+                                    "name": "Dedicated Slack channel",
+                                    "description": "Get help in a dedicated Slack channel shared between you and the PostHog team.",
                                     "unit": null,
                                     "limit": null,
                                     "note": "$2k/month spend or above",
@@ -2507,8 +2507,8 @@
                             "features": [
                                 {
                                     "key": "community_support",
-                                    "name": "Slack (community)",
-                                    "description": "Get help from the PostHog community in our PostHog Users Slack group.",
+                                    "name": "Community forum",
+                                    "description": "Get help from the PostHog community in our public forum.",
                                     "unit": null,
                                     "limit": null,
                                     "note": null,
@@ -2516,8 +2516,8 @@
                                 },
                                 {
                                     "key": "dedicated_support",
-                                    "name": "Slack (dedicated channel)",
-                                    "description": "Get help firectly from our support team in a dedicated Slack channel shared between you and the PostHog team.",
+                                    "name": "Dedicated Slack channel",
+                                    "description": "Get help in a dedicated Slack channel shared between you and the PostHog team.",
                                     "unit": null,
                                     "limit": null,
                                     "note": "$2k/month spend or above",


### PR DESCRIPTION
## Problem

We're moving community Slack to community forums. 

Builds on https://github.com/PostHog/posthog/pull/16655

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
