### PR TITLE
fix(decide): Use read replica for site apps

### DIFF
--- a/posthog/api/test/__snapshots__/test_session_recordings_version_three.ambr
+++ b/posthog/api/test/__snapshots__/test_session_recordings_version_three.ambr
@@ -1081,7 +1081,8 @@
          "posthog_person"."version"
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
-  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
+  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user',
+                                                      'user2',
                                                       'user3')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '

--- a/posthog/api/test/__snapshots__/test_session_recordings_version_three.ambr
+++ b/posthog/api/test/__snapshots__/test_session_recordings_version_three.ambr
@@ -1081,8 +1081,7 @@
          "posthog_person"."version"
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
-  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user',
-                                                      'user2',
+  WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
                                                       'user3')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -2920,6 +2920,33 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             self.assertEqual(response.json()["featureFlags"], {"groups-flag": True, "default-no-prop-group-flag": True})
             self.assertFalse(response.json()["errorsWhileComputingFlags"])
 
+    @patch("posthog.models.feature_flag.flag_matching.postgres_healthcheck.is_connected", return_value=True)
+    def test_site_apps_in_decide_use_replica(self, mock_is_connected):
+        org, team, user = self.setup_user_and_team_in_db("default")
+        self.organization, self.team, self.user = org, team, user
+
+        plugin = Plugin.objects.create(organization=self.team.organization, name="My Plugin", plugin_type="source")
+        PluginSourceFile.objects.create(
+            plugin=plugin,
+            filename="site.ts",
+            source="export function inject (){}",
+            transpiled="function inject(){}",
+            status=PluginSourceFile.Status.TRANSPILED,
+        )
+        PluginConfig.objects.create(
+            plugin=plugin, enabled=True, order=1, team=self.team, config={}, web_token="tokentoken"
+        )
+        sync_team_inject_web_apps(self.team)
+
+        # update caches
+        self._post_decide(api_version=3)
+
+        with self.assertNumQueries(2, using="replica"), self.assertNumQueries(0, using="default"):
+            response = self._post_decide(api_version=3)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            injected = response.json()["siteApps"]
+            self.assertEqual(len(injected), 1)
+
 
 class TestDecideMetricLabel(TestCase):
     def test_simple_team_ids(self):

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -2233,7 +2233,7 @@ class TestDatabaseCheckForDecide(BaseTest, QueryMatchingTest):
 
         with connection.execute_wrapper(QueryTimeoutWrapper()), snapshot_postgres_queries_context(
             self
-        ), self.assertNumQueries(4):
+        ), self.assertNumQueries(1):
             response = self._post_decide(api_version=3, origin="https://random.example.com").json()
             response = self._post_decide(api_version=3, origin="https://random.example.com").json()
             response = self._post_decide(api_version=3, origin="https://random.example.com").json()

--- a/posthog/plugins/site.py
+++ b/posthog/plugins/site.py
@@ -42,11 +42,12 @@ def get_transpiled_site_source(id: int, token: str) -> Optional[WebJsSource]:
     return WebJsSource(*(list(response)))  # type: ignore
 
 
-def get_decide_site_apps(team: "Team") -> List[dict]:
+def get_decide_site_apps(team: "Team", using_database: str = "default") -> List[dict]:
     from posthog.models import PluginConfig, PluginSourceFile
 
     sources = (
-        PluginConfig.objects.filter(
+        PluginConfig.objects.using(using_database)
+        .filter(
             team=team,
             enabled=True,
             plugin__pluginsourcefile__filename="site.ts",

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -598,6 +598,7 @@ async def test_s3_export_workflow_with_minio_bucket_and_custom_key_prefix(client
             "event": "test",
             "timestamp": "2023-04-25 13:30:00.000000",
             "created_at": "2023-04-25 13:30:00.000000",
+            "inserted_at": "2023-04-25 13:31:00.000000",
             "_timestamp": "2023-04-25 13:30:00",
             "person_id": str(uuid4()),
             "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},


### PR DESCRIPTION
## Problem

Noticed during debugging that while we moved flag matching to the read replica, I forgot about site apps!

This has potential to destroy regular decide calls, since hanging in site app call is no different from hanging in feature flag call 🤷 🤦‍♂️ .
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
