### PR TITLE
feat: BatchExports updates now reflect in TemporalSchedule

### DIFF
--- a/posthog/api/test/batch_exports/test_update.py
+++ b/posthog/api/test/batch_exports/test_update.py
@@ -1,7 +1,12 @@
-from django.test.client import Client as HttpClient
-import pytest
+import datetime as dt
+import json
 
+import pytest
+from asgiref.sync import async_to_sync
+from django.conf import settings
+from django.test.client import Client as HttpClient
 from rest_framework import status
+
 from posthog.api.test.batch_exports.conftest import start_test_worker
 from posthog.api.test.batch_exports.operations import (
     create_batch_export_ok,
@@ -12,13 +17,20 @@ from posthog.api.test.batch_exports.operations import (
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
-
-
 from posthog.temporal.client import sync_connect
+from posthog.temporal.codec import EncryptionCodec
 
 pytestmark = [
     pytest.mark.django_db,
 ]
+
+
+@async_to_sync
+async def describe_schedule(temporal, schedule_id: str):
+    """Return the description of a Temporal Schedule with the given id."""
+    handle = temporal.get_schedule_handle(schedule_id)
+    temporal_schedule = await handle.describe()
+    return temporal_schedule
 
 
 def test_can_put_config(client: HttpClient):
@@ -54,28 +66,43 @@ def test_can_put_config(client: HttpClient):
             batch_export_data,
         )
 
-    # If we try to update without all fields, it should fail with a 400 error
-    new_batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "interval": "hour",
-    }
+        # If we try to update without all fields, it should fail with a 400 error
+        new_batch_export_data = {
+            "name": "my-production-s3-bucket-destination",
+            "interval": "hour",
+        }
+        response = put_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    response = put_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+        old_schedule = describe_schedule(temporal, batch_export["id"])
 
-    # We should be able to update if we specify all fields
-    new_batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "day",
-    }
+        # We should be able to update if we specify all fields
+        new_destination_data = {**destination_data}
+        new_destination_data["config"]["bucket_name"] = "my-new-production-s3-bucket"
+        new_destination_data["config"]["aws_secret_access_key"] = "new-secret"
+        new_batch_export_data = {
+            "name": "my-production-s3-bucket-destination",
+            "destination": new_destination_data,
+            "interval": "day",
+        }
 
-    response = put_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
-    assert response.status_code == status.HTTP_200_OK
+        response = put_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+        assert response.status_code == status.HTTP_200_OK
 
-    # get the batch export and validate e.g. that interval has been updated to day
-    batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
-    assert batch_export["interval"] == "day"
+        # get the batch export and validate e.g. that interval has been updated to day
+        batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
+        assert batch_export["interval"] == "day"
+
+        # validate the underlying temporal schedule has been updated
+        codec = EncryptionCodec(settings=settings)
+        new_schedule = describe_schedule(temporal, batch_export["id"])
+        assert old_schedule.schedule.spec.intervals[0].every != new_schedule.schedule.spec.intervals[0].every
+        assert new_schedule.schedule.spec.intervals[0].every == dt.timedelta(days=1)
+
+        decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
+        args = json.loads(decoded_payload[0].data)
+        assert args["bucket_name"] == "my-new-production-s3-bucket"
+        assert args["aws_secret_access_key"] == "new-secret"
 
 
 def test_can_patch_config(client: HttpClient):
@@ -110,29 +137,38 @@ def test_can_patch_config(client: HttpClient):
             team.pk,
             batch_export_data,
         )
+        old_schedule = describe_schedule(temporal, batch_export["id"])
 
-    # We should be able to update the destination config, excluding the aws
-    # credentials. The existing values should be preserved, e.g.
-    # batch_window_size = 3600
-    new_destination_data = {
-        "type": "S3",
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
+        # We should be able to update the destination config, excluding the aws
+        # credentials. The existing values should be preserved, e.g.
+        # batch_window_size = 3600
+        new_destination_data = {
+            "type": "S3",
+            "config": {
+                "bucket_name": "my-new-production-s3-bucket",
+                "region": "us-east-1",
+                "prefix": "posthog-events/",
+            },
+        }
 
-    new_batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": new_destination_data,
-    }
+        new_batch_export_data = {
+            "name": "my-production-s3-bucket-destination",
+            "destination": new_destination_data,
+        }
 
-    response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
-    assert response.status_code == status.HTTP_200_OK, response.json()
+        response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+        assert response.status_code == status.HTTP_200_OK, response.json()
 
-    # get the batch export and validate e.g. that batch_window_size and interval
-    # has been preserved
-    batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
-    assert batch_export["interval"] == "hour"
-    assert batch_export["destination"]["config"]["batch_window_size"] == 3600
+        # get the batch export and validate e.g. that batch_window_size and interval
+        # has been preserved
+        batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
+        assert batch_export["interval"] == "hour"
+        assert batch_export["destination"]["config"]["batch_window_size"] == 3600
+
+        # validate the underlying temporal schedule has been updated
+        codec = EncryptionCodec(settings=settings)
+        new_schedule = describe_schedule(temporal, batch_export["id"])
+        assert old_schedule.schedule.spec.intervals[0].every == new_schedule.schedule.spec.intervals[0].every
+        decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
+        args = json.loads(decoded_payload[0].data)
+        assert args["bucket_name"] == "my-new-production-s3-bucket"

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -17,6 +17,7 @@ from posthog.batch_exports.service import (
     pause_batch_export,
     reset_batch_export_run,
     unpause_batch_export,
+    update_batch_export,
 )
 from posthog.models import (
     BatchExport,
@@ -198,17 +199,19 @@ class BatchExportSerializer(serializers.ModelSerializer):
     def update(self, instance: BatchExport, validated_data: dict) -> BatchExport:
         """Update a BatchExport."""
         destination_data = validated_data.pop("destination", None)
+        interval = validated_data.get("interval", None)
+        name = validated_data.get("name", None)
+        start_at = validated_data.get("start_at", None)
+        end_at = validated_data.get("end_at", None)
 
-        if destination_data:
-            instance.destination.type = destination_data.get("type", instance.destination.type)
-            instance.destination.config = {**instance.destination.config, **destination_data.get("config", {})}
-            instance.destination.save()
-
-        instance.name = validated_data.get("name", instance.name)
-        instance.interval = validated_data.get("interval", instance.interval)
-        instance.save()
-
-        return instance
+        return update_batch_export(
+            batch_export=instance,
+            interval=interval,
+            name=name,
+            destination_data=destination_data,
+            start_at=start_at,
+            end_at=end_at,
+        )
 
 
 class BatchExportViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -13,6 +13,8 @@ from temporalio.client import (
     ScheduleOverlapPolicy,
     ScheduleSpec,
     ScheduleState,
+    ScheduleUpdate,
+    ScheduleUpdateInput,
 )
 
 from posthog import settings
@@ -250,6 +252,78 @@ def update_batch_export_run_status(run_id: UUID, status: str, latest_error: str 
     updated = BatchExportRun.objects.filter(id=run_id).update(status=status, latest_error=latest_error)
     if not updated:
         raise ValueError(f"BatchExportRun with id {run_id} not found.")
+
+
+def update_batch_export(
+    batch_export: BatchExport,
+    interval: str | None,
+    name: str | None,
+    destination_data: dict | None = None,
+    start_at: dt.datetime | None = None,
+    end_at: dt.datetime | None = None,
+):
+    if destination_data:
+        batch_export.destination.config = {**batch_export.destination.config, **destination_data.get("config", {})}
+
+    batch_export.name = name or batch_export.name
+
+    if interval is None:
+        interval = batch_export.interval
+
+    if interval == "hour":
+        time_delta_from_interval = dt.timedelta(hours=1)
+    elif interval == "day":
+        time_delta_from_interval = dt.timedelta(days=1)
+    else:
+        raise ValueError(f"Unsupported interval '{interval}'")
+
+    batch_export.interval = interval or batch_export.interval
+
+    workflow, workflow_inputs = DESTINATION_WORKFLOWS[batch_export.destination.type]
+    state = ScheduleState(
+        note=f"Schedule updated for BatchExport {batch_export.id} to Destination {batch_export.destination.id} in Team {batch_export.team.id}.",
+        paused=batch_export.paused,
+    )
+
+    temporal = sync_connect()
+    new_schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            workflow,
+            asdict(
+                workflow_inputs(
+                    team_id=batch_export.team.id,
+                    batch_export_id=str(batch_export.id),
+                    **batch_export.destination.config,
+                )
+            ),
+            id=str(batch_export.id),
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+        ),
+        spec=ScheduleSpec(
+            start_at=start_at,
+            end_at=end_at,
+            intervals=[ScheduleIntervalSpec(every=time_delta_from_interval)],
+        ),
+        state=state,
+    )
+
+    update_schedule(temporal, schedule_id=str(batch_export.id), schedule=new_schedule)
+
+    batch_export.save()
+    return batch_export
+
+
+@async_to_sync
+async def update_schedule(temporal: Client, schedule_id: str, schedule: Schedule) -> None:
+    """Update a Temporal Schedule."""
+    handle = temporal.get_schedule_handle(schedule_id)
+
+    async def updater(_: ScheduleUpdateInput) -> ScheduleUpdate:
+        return ScheduleUpdate(schedule=schedule)
+
+    return await handle.update(
+        updater=updater,
+    )
 
 
 def create_batch_export(

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -263,6 +263,7 @@ def update_batch_export(
     end_at: dt.datetime | None = None,
 ):
     if destination_data:
+        batch_export.destination.type = destination_data.get("type", batch_export.destination.type)
         batch_export.destination.config = {**batch_export.destination.config, **destination_data.get("config", {})}
 
     batch_export.name = name or batch_export.name
@@ -310,6 +311,7 @@ def update_batch_export(
     update_schedule(temporal, schedule_id=str(batch_export.id), schedule=new_schedule)
 
     batch_export.save()
+    batch_export.destination.save()
     return batch_export
 
 


### PR DESCRIPTION
## Problem

When updating BatchExports we are not reflecting the changes in the underlying Temporal Schedule. This means that, effectively, we are not updating the export.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Call `ScheduleHandle.update` with a new Schedule that reflects the updates.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Update `test_update.py` unit tests to also assert the underlying Temporal Schedule has changed.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
