### PR TITLE
fix(experiments): Make sure secondary experiments edit doesn't add ex…

### DIFF
--- a/frontend/src/scenes/experiments/secondaryMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/secondaryMetricsLogic.ts
@@ -31,15 +31,20 @@ export interface SecondaryMetricForm {
     filters: Partial<FilterType>
 }
 
-const defaultFormValuesGenerator: (aggregationType?: number) => SecondaryMetricForm = (aggregationType) => {
+const defaultFormValuesGenerator: (
+    aggregationType?: number,
+    disableAddEventToDefault?: boolean
+) => SecondaryMetricForm = (aggregationType, disableAddEventToDefault) => {
     const groupAggregation =
         aggregationType !== undefined ? { math: 'unique_group', math_group_type_index: aggregationType } : {}
+
+    const eventAddition = disableAddEventToDefault ? {} : { events: [{ ...getDefaultEvent(), ...groupAggregation }] }
 
     return {
         name: '',
         filters: {
             insight: InsightType.TRENDS,
-            events: [{ ...getDefaultEvent(), ...groupAggregation }],
+            ...eventAddition,
         },
     }
 }
@@ -150,7 +155,10 @@ export const secondaryMetricsLogic = kea<secondaryMetricsLogicType>([
                     insight: InsightType.TRENDS,
                     date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DD'),
                     date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
-                    ...defaultFormValuesGenerator(props.defaultAggregationType).filters,
+                    ...defaultFormValuesGenerator(
+                        props.defaultAggregationType,
+                        (filters?.actions?.length || 0) + (filters?.events?.length || 0) > 0
+                    ).filters,
                     ...filters,
                 })
             }


### PR DESCRIPTION
…tras

when editing a secondary experiment with an action metric, an erroneus "pageview" would be added, because the default wasn't checking whether there's already an event/action in place. Fixes that.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
