### PR TITLE
fix(insights): fix test account filter changes

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -79,7 +79,7 @@ export const experimentLogic = kea<experimentLogicType>([
     key((props) => props.experimentId || 'new'),
     path((key) => ['scenes', 'experiment', 'experimentLogic', key]),
     connect(() => ({
-        values: [teamLogic, ['currentTeamId'], groupsModel, ['aggregationLabel', 'groupTypes']],
+        values: [teamLogic, ['currentTeamId', 'currentTeam'], groupsModel, ['aggregationLabel', 'groupTypes']],
         actions: [
             experimentsLogic,
             ['updateExperiments', 'addToExperiments'],
@@ -327,15 +327,18 @@ export const experimentLogic = kea<experimentLogicType>([
             let newInsightFilters
             const aggregationGroupTypeIndex = values.experiment.parameters?.aggregation_group_type_index
             if (filters?.insight === InsightType.FUNNELS) {
-                newInsightFilters = cleanFilters({
-                    insight: InsightType.FUNNELS,
-                    funnel_viz_type: FunnelVizType.Steps,
-                    date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
-                    date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
-                    layout: FunnelLayout.horizontal,
-                    aggregation_group_type_index: aggregationGroupTypeIndex,
-                    ...filters,
-                })
+                newInsightFilters = cleanFilters(
+                    {
+                        insight: InsightType.FUNNELS,
+                        funnel_viz_type: FunnelVizType.Steps,
+                        date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
+                        date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
+                        layout: FunnelLayout.horizontal,
+                        aggregation_group_type_index: aggregationGroupTypeIndex,
+                        ...filters,
+                    },
+                    values.currentTeam?.test_account_filters_default_checked
+                )
             } else {
                 const groupAggregation =
                     aggregationGroupTypeIndex !== undefined
@@ -345,13 +348,16 @@ export const experimentLogic = kea<experimentLogicType>([
                     filters?.actions || filters?.events
                         ? {}
                         : { events: [{ ...getDefaultEvent(), ...groupAggregation }] }
-                newInsightFilters = cleanFilters({
-                    insight: InsightType.TRENDS,
-                    date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
-                    date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
-                    ...eventAddition,
-                    ...filters,
-                })
+                newInsightFilters = cleanFilters(
+                    {
+                        insight: InsightType.TRENDS,
+                        date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
+                        date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
+                        ...eventAddition,
+                        ...filters,
+                    },
+                    values.currentTeam?.test_account_filters_default_checked
+                )
             }
 
             actions.updateQuerySource(filtersToQueryNode(newInsightFilters))
@@ -361,12 +367,15 @@ export const experimentLogic = kea<experimentLogicType>([
             actions.setExperiment({ filters: queryNodeToFilter((query as InsightVizNode).source) })
         },
         setExperimentExposureInsight: async ({ filters }) => {
-            const newInsightFilters = cleanFilters({
-                insight: InsightType.TRENDS,
-                date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
-                date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
-                ...filters,
-            })
+            const newInsightFilters = cleanFilters(
+                {
+                    insight: InsightType.TRENDS,
+                    date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
+                    date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
+                    ...filters,
+                },
+                values.currentTeam?.test_account_filters_default_checked
+            )
 
             actions.updateExposureQuerySource(filtersToQueryNode(newInsightFilters))
         },

--- a/frontend/src/scenes/experiments/secondaryMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/secondaryMetricsLogic.ts
@@ -50,7 +50,7 @@ export const secondaryMetricsLogic = kea<secondaryMetricsLogicType>([
     path((key) => ['scenes', 'experiment', 'secondaryMetricsLogic', key]),
     connect({
         logic: [insightLogic({ dashboardItemId: SECONDARY_METRIC_INSIGHT_ID, syncWithUrl: false })],
-        values: [teamLogic, ['currentTeamId']],
+        values: [teamLogic, ['currentTeamId', 'currentTeam']],
         actions: [
             insightDataLogic({ dashboardItemId: SECONDARY_METRIC_INSIGHT_ID }),
             ['setQuery'],
@@ -136,23 +136,29 @@ export const secondaryMetricsLogic = kea<secondaryMetricsLogicType>([
         setPreviewInsight: async ({ filters }) => {
             let newInsightFilters
             if (filters?.insight === InsightType.FUNNELS) {
-                newInsightFilters = cleanFilters({
-                    insight: InsightType.FUNNELS,
-                    funnel_viz_type: FunnelVizType.Steps,
-                    date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DD'),
-                    date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
-                    layout: FunnelLayout.horizontal,
-                    aggregation_group_type_index: props.defaultAggregationType,
-                    ...filters,
-                })
+                newInsightFilters = cleanFilters(
+                    {
+                        insight: InsightType.FUNNELS,
+                        funnel_viz_type: FunnelVizType.Steps,
+                        date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DD'),
+                        date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
+                        layout: FunnelLayout.horizontal,
+                        aggregation_group_type_index: props.defaultAggregationType,
+                        ...filters,
+                    },
+                    values.currentTeam?.test_account_filters_default_checked
+                )
             } else {
-                newInsightFilters = cleanFilters({
-                    insight: InsightType.TRENDS,
-                    date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DD'),
-                    date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
-                    ...defaultFormValuesGenerator(props.defaultAggregationType).filters,
-                    ...filters,
-                })
+                newInsightFilters = cleanFilters(
+                    {
+                        insight: InsightType.TRENDS,
+                        date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DD'),
+                        date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
+                        ...defaultFormValuesGenerator(props.defaultAggregationType).filters,
+                        ...filters,
+                    },
+                    values.currentTeam?.test_account_filters_default_checked
+                )
             }
 
             actions.updateQuerySource(filtersToQueryNode(newInsightFilters))

--- a/frontend/src/scenes/funnels/FunnelLineGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelLineGraph.tsx
@@ -11,6 +11,7 @@ import { funnelDataLogic } from './funnelDataLogic'
 import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { isInsightQueryNode } from '~/queries/utils'
 import { TrendsFilter } from '~/queries/schema'
+import { teamLogic } from 'scenes/teamLogic'
 
 export function FunnelLineGraph({
     inSharedMode,
@@ -19,6 +20,8 @@ export function FunnelLineGraph({
     const { insightProps } = useValues(insightLogic)
     const { steps, aggregationTargetLabel, incompletenessOffsetFromEnd, interval, querySource, insightData } =
         useValues(funnelDataLogic(insightProps))
+
+    const { currentTeam } = useValues(teamLogic)
 
     if (!isInsightQueryNode(querySource)) {
         return null
@@ -72,6 +75,7 @@ export function FunnelLineGraph({
                               date_from: day ?? '',
                               date_to: day ?? '',
                               filters,
+                              test_account_filters_default_checked: currentTeam?.test_account_filters_default_checked,
                           }
 
                           const url = buildPeopleUrl(props)

--- a/frontend/src/scenes/funnels/FunnelStepMore.tsx
+++ b/frontend/src/scenes/funnels/FunnelStepMore.tsx
@@ -7,6 +7,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { funnelDataLogic } from './funnelDataLogic'
 import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
+import { teamLogic } from 'scenes/teamLogic'
 
 type FunnelStepMoreProps = {
     stepIndex: number
@@ -15,8 +16,10 @@ type FunnelStepMoreProps = {
 export function FunnelStepMore({ stepIndex }: FunnelStepMoreProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { querySource } = useValues(funnelDataLogic(insightProps))
+    const { currentTeam } = useValues(teamLogic)
+
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const filterProps = cleanFilters(queryNodeToFilter(querySource!))
+    const filterProps = cleanFilters(queryNodeToFilter(querySource!), currentTeam?.test_account_filters_default_checked)
 
     const aggregationGroupTypeIndex = querySource?.aggregation_group_type_index
 

--- a/frontend/src/scenes/funnels/funnelCorrelationLogic.ts
+++ b/frontend/src/scenes/funnels/funnelCorrelationLogic.ts
@@ -130,10 +130,10 @@ export const funnelCorrelationLogic = kea<funnelCorrelationLogicType>([
     }),
     selectors({
         apiParams: [
-            (s) => [s.querySource],
-            (querySource) => {
+            (s) => [s.querySource, s.currentTeam],
+            (querySource, currentTeam) => {
                 const cleanedParams: Partial<FunnelsFilterType> = querySource
-                    ? cleanFilters(queryNodeToFilter(querySource))
+                    ? cleanFilters(queryNodeToFilter(querySource), currentTeam?.test_account_filters_default_checked)
                     : {}
                 return cleanedParams
             },

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -8,7 +8,7 @@ import { insightLogic } from './insightLogic'
 import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { filtersToQueryNode } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import { isInsightVizNode } from '~/queries/utils'
-import { cleanFilters } from './utils/cleanFilters'
+import { cleanFilters, setTestAccountFilterForNewInsight } from './utils/cleanFilters'
 import { insightTypeToDefaultQuery, nodeKindToDefaultQuery } from '~/queries/nodes/InsightQuery/defaults'
 import { dataNodeLogic, DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
@@ -115,13 +115,16 @@ export const insightDataLogic = kea<insightDataLogicType>([
                     return !objectsEqual(query, insight.query)
                 } else {
                     const currentFilters = queryNodeToFilter((query as InsightVizNode).source)
-                    const savedFilters =
-                        savedInsight.filters ||
-                        queryNodeToFilter(insightTypeToDefaultQuery[currentFilters.insight || InsightType.TRENDS])
 
-                    // TODO: Ignore filter_test_accounts for now, but should compare against default
-                    delete currentFilters.filter_test_accounts
-                    delete savedFilters.filter_test_accounts
+                    let savedFilters: Partial<FilterType>
+                    if (savedInsight.filters) {
+                        savedFilters = savedInsight.filters
+                    } else {
+                        savedFilters = queryNodeToFilter(
+                            insightTypeToDefaultQuery[currentFilters.insight || InsightType.TRENDS]
+                        )
+                        setTestAccountFilterForNewInsight(savedFilters)
+                    }
 
                     return !compareFilters(currentFilters, savedFilters)
                 }

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -329,7 +329,7 @@ export const insightLogic = kea<insightLogicType>([
         filters: [
             () => props.cachedInsight?.filters || ({} as Partial<FilterType>),
             {
-                setFilters: (state, { filters }) => cleanFilters(filters, state),
+                setFilters: (_, { filters }) => cleanFilters(filters),
                 setInsight: (state, { insight: { filters }, options: { overrideFilter } }) =>
                     overrideFilter ? cleanFilters(filters || {}) : state,
                 loadInsightSuccess: (state, { insight }) =>

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -59,7 +59,8 @@ export const UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES = 3
 function emptyFilters(filters: Partial<FilterType> | undefined): boolean {
     return (
         !filters ||
-        (Object.keys(filters).length < 2 && JSON.stringify(cleanFilters(filters)) === JSON.stringify(cleanFilters({})))
+        (Object.keys(filters).length < 2 &&
+            JSON.stringify(cleanFilters(filters, false)) === JSON.stringify(cleanFilters({}, false)))
     )
 }
 

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -193,6 +193,10 @@ export const insightLogic = kea<insightLogicType>([
                     const updatedInsight: InsightModel = {
                         ...response,
                         result: response.result || values.insight.result,
+                        filters: cleanFilters(
+                            response.filters || {},
+                            values.currentTeam?.test_account_filters_default_checked
+                        ),
                     }
                     callback?.(updatedInsight)
 
@@ -352,10 +356,7 @@ export const insightLogic = kea<insightLogicType>([
                 setInsight: (state, { insight, options: { fromPersistentApi } }) =>
                     fromPersistentApi ? { ...insight, filters: cleanFilters(insight.filters || {}) } : state,
                 loadInsightSuccess: (_, { insight }) => insight,
-                updateInsightSuccess: (_, { insight }) => ({
-                    ...insight,
-                    filters: cleanFilters(insight.filters || {}),
-                }),
+                updateInsightSuccess: (_, { insight }) => insight,
             },
         ],
         insightLoading: [

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -156,7 +156,15 @@ export const insightLogic = kea<insightLogicType>([
                         )}&include_query_insights=true`
                     )
                     if (response?.results?.[0]) {
-                        return response.results[0]
+                        let insight = response.results[0]
+                        insight = {
+                            ...insight,
+                            filters: cleanFilters(
+                                insight.filters || {},
+                                values.currentTeam?.test_account_filters_default_checked
+                            ),
+                        }
+                        return insight
                     }
                     throw new Error(`Insight "${shortId}" not found`)
                 },
@@ -343,7 +351,7 @@ export const insightLogic = kea<insightLogicType>([
             {
                 setInsight: (state, { insight, options: { fromPersistentApi } }) =>
                     fromPersistentApi ? { ...insight, filters: cleanFilters(insight.filters || {}) } : state,
-                loadInsightSuccess: (_, { insight }) => ({ ...insight, filters: cleanFilters(insight.filters || {}) }),
+                loadInsightSuccess: (_, { insight }) => insight,
                 updateInsightSuccess: (_, { insight }) => ({
                     ...insight,
                     filters: cleanFilters(insight.filters || {}),

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -49,7 +49,6 @@ import { queryExportContext } from '~/queries/query'
 import { tagsModel } from '~/models/tagsModel'
 import { isInsightVizNode } from '~/queries/utils'
 import { userLogic } from 'scenes/userLogic'
-import { globalInsightLogic } from './globalInsightLogic'
 import { transformLegacyHiddenLegendKeys } from 'scenes/funnels/funnelUtils'
 import { summarizeInsight } from 'scenes/insights/summarizeInsight'
 
@@ -92,10 +91,8 @@ export const insightLogic = kea<insightLogicType>([
             ['mathDefinitions'],
             userLogic,
             ['user'],
-            globalInsightLogic,
-            ['globalInsightFilters'],
         ],
-        actions: [tagsModel, ['loadTags'], globalInsightLogic, ['setGlobalInsightFilters']],
+        actions: [tagsModel, ['loadTags']],
         logic: [eventUsageLogic, dashboardsModel, promptLogic({ key: `save-as-insight` })],
     }),
 
@@ -105,7 +102,6 @@ export const insightLogic = kea<insightLogicType>([
             insightMode,
             clearInsightQuery,
         }),
-        setFiltersMerge: (filters: Partial<FilterType>) => ({ filters }),
         reportInsightViewedForRecentInsights: () => true,
         reportInsightViewed: (
             insightModel: Partial<InsightModel>,
@@ -340,7 +336,7 @@ export const insightLogic = kea<insightLogicType>([
         filters: [
             () => props.cachedInsight?.filters || ({} as Partial<FilterType>),
             {
-                setFilters: (_, { filters }) => cleanFilters(filters),
+                setFilters: (_, { filters }) => filters,
                 setInsight: (state, { insight, options: { overrideFilter } }) =>
                     overrideFilter ? insight.filters || ({} as Partial<FilterType>) : state,
                 loadInsightSuccess: (state, { insight }) =>
@@ -557,12 +553,6 @@ export const insightLogic = kea<insightLogicType>([
         ],
     }),
     listeners(({ actions, selectors, values }) => ({
-        setFiltersMerge: ({ filters }) => {
-            actions.setFilters({ ...values.filters, ...filters })
-        },
-        setGlobalInsightFilters: ({ globalInsightFilters }) => {
-            actions.setFilters({ ...values.filters, ...globalInsightFilters })
-        },
         setFilters: async ({ filters }, _, __, previousState) => {
             const previousFilters = selectors.filters(previousState)
             if (objectsEqual(previousFilters, filters)) {

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -189,9 +189,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                     values.insightLogicRef?.logic.actions.setInsight(
                         {
                             ...createEmptyInsight('new', teamFilterTestAccounts),
-                            ...(filters
-                                ? { filters: cleanFilters(filters || {}, undefined, teamFilterTestAccounts) }
-                                : {}),
+                            ...(filters ? { filters: cleanFilters(filters || {}) } : {}),
                             ...(dashboard ? { dashboards: [dashboard] } : {}),
                             ...(q ? { query: JSON.parse(q) } : {}),
                         },

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -189,7 +189,14 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                     values.insightLogicRef?.logic.actions.setInsight(
                         {
                             ...createEmptyInsight('new', teamFilterTestAccounts),
-                            ...(filters ? { filters: cleanFilters(filters || {}) } : {}),
+                            ...(filters
+                                ? {
+                                      filters: cleanFilters(
+                                          filters || {},
+                                          values.currentTeam?.test_account_filters_default_checked
+                                      ),
+                                  }
+                                : {}),
                             ...(dashboard ? { dashboards: [dashboard] } : {}),
                             ...(q ? { query: JSON.parse(q) } : {}),
                         },

--- a/frontend/src/scenes/insights/utils/cleanFilters.test.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.test.ts
@@ -11,28 +11,19 @@ import {
 import { NON_VALUES_ON_SERIES_DISPLAY_TYPES, ShownAsValue } from 'lib/constants'
 
 describe('cleanFilters', () => {
-    it('removes shownas if moving from stickiness to trends', () => {
-        expect(
-            cleanFilters(
-                { insight: InsightType.TRENDS, shown_as: ShownAsValue.STICKINESS },
-                { insight: InsightType.STICKINESS, shown_as: ShownAsValue.STICKINESS }
-            )
-        ).toEqual(expect.objectContaining({ insight: InsightType.TRENDS, shown_as: undefined }))
+    it('removes shownas from trends insights', () => {
+        expect(cleanFilters({ insight: InsightType.TRENDS, shown_as: ShownAsValue.STICKINESS })).toEqual(
+            expect.objectContaining({ insight: InsightType.TRENDS, shown_as: undefined })
+        )
     })
 
-    it('removes breakdown when adding breakdowns', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                breakdowns: [{ property: '$browser', type: 'event' }],
-                insight: InsightType.FUNNELS,
-                funnel_viz_type: FunnelVizType.Steps,
-            } as FunnelsFilterType,
-            {
-                breakdown: '$browser',
-                insight: InsightType.FUNNELS,
-                funnel_viz_type: FunnelVizType.Steps,
-            } as FunnelsFilterType
-        )
+    it('removes breakdown when it also has breakdowns', () => {
+        const cleanedFilters = cleanFilters({
+            breakdown: '$browser',
+            breakdowns: [{ property: '$browser', type: 'event' }],
+            insight: InsightType.FUNNELS,
+            funnel_viz_type: FunnelVizType.Steps,
+        } as FunnelsFilterType)
 
         expect(cleanedFilters).toHaveProperty('breakdown', undefined)
 
@@ -41,108 +32,81 @@ describe('cleanFilters', () => {
         )
     })
 
-    it('adds breakdown_type when adding breakdown', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                breakdown: '$thing',
-                breakdown_type: 'event',
-                insight: InsightType.FUNNELS,
-                funnel_viz_type: FunnelVizType.Steps,
-            } as FunnelsFilterType,
-            { insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps } as FunnelsFilterType
-        )
+    it('allows breakdown_type with breakdown', () => {
+        const cleanedFilters = cleanFilters({
+            breakdown: '$thing',
+            breakdown_type: 'event',
+            insight: InsightType.FUNNELS,
+            funnel_viz_type: FunnelVizType.Steps,
+        } as FunnelsFilterType)
 
         expect(cleanedFilters).toHaveProperty('breakdown', '$thing')
         expect(cleanedFilters).toHaveProperty('breakdown_type', 'event')
     })
 
-    it('adds breakdown_type when adding breakdowns', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                breakdowns: [{ property: '$browser', type: 'event' }],
-                breakdown_type: 'event',
-                insight: InsightType.FUNNELS,
-                funnel_viz_type: FunnelVizType.Steps,
-            } as FunnelsFilterType,
-            { insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps } as FunnelsFilterType
-        )
+    it('allows breakdown_type when adding breakdowns', () => {
+        const cleanedFilters = cleanFilters({
+            breakdowns: [{ property: '$browser', type: 'event' }],
+            breakdown_type: 'event',
+            insight: InsightType.FUNNELS,
+            funnel_viz_type: FunnelVizType.Steps,
+        } as FunnelsFilterType)
 
         expect(cleanedFilters).toHaveProperty('breakdowns', [{ property: '$browser', type: 'event' }])
         expect(cleanedFilters).toHaveProperty('breakdown_type', 'event')
     })
 
     it('defaults to normalizing URL for breakdowns by $current_url', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                breakdowns: [{ property: '$current_url', type: 'event' }],
-                breakdown_type: 'event',
-            } as TrendsFilterType,
-            { insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps } as FunnelsFilterType
-        )
+        const cleanedFilters = cleanFilters({
+            breakdowns: [{ property: '$current_url', type: 'event' }],
+            breakdown_type: 'event',
+        } as TrendsFilterType)
 
         expect(cleanedFilters).toHaveProperty('breakdown_normalize_url', true)
     })
 
     it('defaults to normalizing URL for breakdown by $current_url', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                breakdown: '$current_url',
-                breakdown_type: 'event',
-            } as TrendsFilterType,
-            { insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps } as FunnelsFilterType
-        )
+        const cleanedFilters = cleanFilters({
+            breakdown: '$current_url',
+            breakdown_type: 'event',
+        } as TrendsFilterType)
 
         expect(cleanedFilters).toHaveProperty('breakdown_normalize_url', true)
     })
 
     it('defaults to normalizing URL for breakdowns by $pathname', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                breakdowns: [{ property: '$pathname', type: 'event' }],
-                breakdown_type: 'event',
-            } as TrendsFilterType,
-            { insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps } as FunnelsFilterType
-        )
+        const cleanedFilters = cleanFilters({
+            breakdowns: [{ property: '$pathname', type: 'event' }],
+            breakdown_type: 'event',
+        } as TrendsFilterType)
 
         expect(cleanedFilters).toHaveProperty('breakdown_normalize_url', true)
     })
 
     it('defaults to normalizing URL for breakdown by $pathname', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                breakdown: '$pathname',
-                breakdown_type: 'event',
-            } as TrendsFilterType,
-            { insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps } as FunnelsFilterType
-        )
+        const cleanedFilters = cleanFilters({
+            breakdown: '$pathname',
+            breakdown_type: 'event',
+        } as TrendsFilterType)
 
         expect(cleanedFilters).toHaveProperty('breakdown_normalize_url', true)
     })
 
     it('can set normalizing URL for breakdown to false', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                breakdown: '$current_url',
-                breakdown_type: 'event',
-                breakdown_normalize_url: false,
-            } as TrendsFilterType,
-            { insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps } as FunnelsFilterType
-        )
+        const cleanedFilters = cleanFilters({
+            breakdown: '$current_url',
+            breakdown_type: 'event',
+            breakdown_normalize_url: false,
+        } as TrendsFilterType)
 
         expect(cleanedFilters).toHaveProperty('breakdown_normalize_url', false)
     })
 
     it('removes normalizing URL for breakdown by other properties', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                breakdowns: [{ property: '$pageview', type: 'event' }],
-                breakdown_type: 'event',
-            } as TrendsFilterType,
-            {
-                breakdowns: [{ property: '$pathname', type: 'event', normalize_url: true }],
-                breakdown_type: 'event',
-            } as TrendsFilterType
-        )
+        const cleanedFilters = cleanFilters({
+            breakdowns: [{ property: '$pageview', type: 'event' }],
+            breakdown_type: 'event',
+        } as TrendsFilterType)
 
         expect(cleanedFilters).toHaveProperty('breakdown_normalize_url', undefined)
     })
@@ -177,19 +141,11 @@ describe('cleanFilters', () => {
     })
 
     it('removes empty breakdowns array', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                breakdowns: [],
-                insight: InsightType.FUNNELS,
-                funnel_viz_type: FunnelVizType.Steps,
-            } as FunnelsFilterType,
-            {
-                breakdowns: [{ property: 'something', type: 'event' }],
-                breakdown_type: 'event',
-                insight: InsightType.FUNNELS,
-                funnel_viz_type: FunnelVizType.Steps,
-            } as FunnelsFilterType
-        )
+        const cleanedFilters = cleanFilters({
+            breakdowns: [],
+            insight: InsightType.FUNNELS,
+            funnel_viz_type: FunnelVizType.Steps,
+        } as FunnelsFilterType)
 
         expect(cleanedFilters).toHaveProperty('breakdowns', undefined)
         expect(cleanedFilters).toHaveProperty('breakdown', undefined)
@@ -197,22 +153,14 @@ describe('cleanFilters', () => {
     })
 
     it('does not include breakdown properties if funnel is not type steps', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                breakdowns: [{ property: 'any', type: 'event' }],
-                breakdown: 'something',
-                breakdown_type: 'event',
-                breakdown_group_type_index: 1,
-                insight: InsightType.FUNNELS,
-                funnel_viz_type: FunnelVizType.Trends,
-            } as FunnelsFilterType,
-            {
-                breakdowns: [{ property: 'something', type: 'event' }],
-                breakdown_type: 'event',
-                insight: InsightType.FUNNELS,
-                funnel_viz_type: FunnelVizType.Steps,
-            } as FunnelsFilterType
-        )
+        const cleanedFilters = cleanFilters({
+            breakdowns: [{ property: 'any', type: 'event' }],
+            breakdown: 'something',
+            breakdown_type: 'event',
+            breakdown_group_type_index: 1,
+            insight: InsightType.FUNNELS,
+            funnel_viz_type: FunnelVizType.Trends,
+        } as FunnelsFilterType)
 
         expect(cleanedFilters).toHaveProperty('breakdowns', undefined)
         expect(cleanedFilters).toHaveProperty('breakdown', undefined)
@@ -220,20 +168,12 @@ describe('cleanFilters', () => {
         expect(cleanedFilters).toHaveProperty('breakdown_group_type_index', undefined)
     })
 
-    it('keeps single property filters switching to trends', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                breakdown: 'one thing',
-                breakdown_type: 'event',
-                insight: InsightType.TRENDS,
-            },
-            {
-                breakdown: 'one thing',
-                breakdown_type: 'event',
-                insight: InsightType.FUNNELS,
-                funnel_viz_type: FunnelVizType.Steps,
-            } as FunnelsFilterType
-        )
+    it('keeps single property filters for trends', () => {
+        const cleanedFilters = cleanFilters({
+            breakdown: 'one thing',
+            breakdown_type: 'event',
+            insight: InsightType.TRENDS,
+        })
 
         expect(cleanedFilters).toHaveProperty('breakdowns', undefined)
         expect(cleanedFilters).toHaveProperty('breakdown', 'one thing')
@@ -241,20 +181,13 @@ describe('cleanFilters', () => {
         expect(cleanedFilters).toHaveProperty('breakdown_group_type_index', undefined)
     })
 
-    it('keeps single property filters when switching to funnels', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                breakdown: 'one thing',
-                breakdown_type: 'event',
-                insight: InsightType.FUNNELS,
-                funnel_viz_type: FunnelVizType.Steps,
-            } as FunnelsFilterType,
-            {
-                breakdown: 'one thing',
-                breakdown_type: 'event',
-                insight: InsightType.TRENDS,
-            }
-        )
+    it('keeps single property filters for funnels', () => {
+        const cleanedFilters = cleanFilters({
+            breakdown: 'one thing',
+            breakdown_type: 'event',
+            insight: InsightType.FUNNELS,
+            funnel_viz_type: FunnelVizType.Steps,
+        } as FunnelsFilterType)
 
         expect(cleanedFilters).toHaveProperty('breakdowns', undefined)
         expect(cleanedFilters).toHaveProperty('breakdown', 'one thing')
@@ -262,26 +195,15 @@ describe('cleanFilters', () => {
         expect(cleanedFilters).toHaveProperty('breakdown_group_type_index', undefined)
     })
 
-    it('keeps the first multi property filter when switching to trends', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                breakdowns: [
-                    { property: 'one thing', type: 'event' },
-                    { property: 'two thing', type: 'event' },
-                ],
-                breakdown_type: 'event',
-                insight: InsightType.TRENDS,
-            },
-            {
-                breakdowns: [
-                    { property: 'one thing', type: 'event' },
-                    { property: 'two thing', type: 'event' },
-                ],
-                breakdown_type: 'event',
-                insight: InsightType.FUNNELS,
-                funnel_viz_type: FunnelVizType.Steps,
-            }
-        )
+    it('keeps the first multi property filter for trends', () => {
+        const cleanedFilters = cleanFilters({
+            breakdowns: [
+                { property: 'one thing', type: 'event' },
+                { property: 'two thing', type: 'event' },
+            ],
+            breakdown_type: 'event',
+            insight: InsightType.TRENDS,
+        })
 
         expect(cleanedFilters).toHaveProperty('breakdowns', undefined)
         expect(cleanedFilters).toHaveProperty('breakdown', 'one thing')
@@ -290,53 +212,38 @@ describe('cleanFilters', () => {
     })
 
     it('reads "smoothing_intervals" and "interval" from URL when viewing and corrects bad pairings', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                interval: 'day',
-                smoothing_intervals: 4,
-            },
-            {
-                interval: 'day',
-                smoothing_intervals: 3,
-            }
-        )
+        const cleanedFilters = cleanFilters({
+            interval: 'day',
+            smoothing_intervals: 4,
+        })
 
         expect(cleanedFilters).toHaveProperty('smoothing_intervals', 1)
     })
 
     it('can add funnel step reference', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                funnel_step_reference: FunnelStepReference.previous,
-                insight: InsightType.FUNNELS,
-            },
-            {}
-        )
+        const cleanedFilters = cleanFilters({
+            funnel_step_reference: FunnelStepReference.previous,
+            insight: InsightType.FUNNELS,
+        })
 
         expect(cleanedFilters).toHaveProperty('funnel_step_reference', FunnelStepReference.previous)
     })
 
     it('removes the interval from funnels', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                insight: InsightType.FUNNELS,
-                interval: 'hour',
-            },
-            {}
-        )
+        const cleanedFilters = cleanFilters({
+            insight: InsightType.FUNNELS,
+            interval: 'hour',
+        })
 
         expect(cleanedFilters).toHaveProperty('interval', undefined)
     })
 
     it('keeps the interval for trends funnels', () => {
-        const cleanedFilters = cleanFilters(
-            {
-                insight: InsightType.FUNNELS,
-                funnel_viz_type: FunnelVizType.Trends,
-                interval: 'hour',
-            },
-            {}
-        )
+        const cleanedFilters = cleanFilters({
+            insight: InsightType.FUNNELS,
+            funnel_viz_type: FunnelVizType.Trends,
+            interval: 'hour',
+        })
 
         expect(cleanedFilters).toHaveProperty('interval', 'hour')
     })
@@ -344,64 +251,49 @@ describe('cleanFilters', () => {
     describe('show_values_on_series', () => {
         ;[InsightType.TRENDS, InsightType.LIFECYCLE, InsightType.STICKINESS].forEach((insight) => {
             it(`keeps show values on series for ${insight}`, () => {
-                const cleanedFilters = cleanFilters(
-                    {
-                        insight,
-                        show_values_on_series: true,
-                    },
-                    {}
-                )
+                const cleanedFilters = cleanFilters({
+                    insight,
+                    show_values_on_series: true,
+                })
 
                 expect(cleanedFilters).toHaveProperty('show_values_on_series', true)
             })
         })
         NON_VALUES_ON_SERIES_DISPLAY_TYPES.forEach((display) => {
             it(`removes show values on series for ${display}`, () => {
-                const cleanedFilters = cleanFilters(
-                    {
-                        insight: InsightType.TRENDS,
-                        display,
-                        show_values_on_series: true,
-                    },
-                    {}
-                )
+                const cleanedFilters = cleanFilters({
+                    insight: InsightType.TRENDS,
+                    display,
+                    show_values_on_series: true,
+                })
 
                 expect(cleanedFilters).not.toHaveProperty('show_values_on_series')
             })
         })
         ;[(InsightType.PATHS, InsightType.FUNNELS, InsightType.RETENTION)].forEach((insight) => {
             it(`removes show values on series for ${insight}`, () => {
-                const cleanedFilters = cleanFilters(
-                    {
-                        insight,
-                        show_values_on_series: true,
-                    },
-                    {}
-                )
+                const cleanedFilters = cleanFilters({
+                    insight,
+                    show_values_on_series: true,
+                })
 
                 expect(cleanedFilters).not.toHaveProperty('show_values_on_series')
             })
         })
         it('sets show values on series for piecharts if it is undefined', () => {
-            const cleanedFilters = cleanFilters(
-                {
-                    insight: InsightType.TRENDS,
-                    display: ChartDisplayType.ActionsPie,
-                },
-                {}
-            )
+            const cleanedFilters = cleanFilters({
+                insight: InsightType.TRENDS,
+                display: ChartDisplayType.ActionsPie,
+            })
 
             expect(cleanedFilters).toHaveProperty('show_values_on_series', true)
         })
         it('can set show values on series for piecharts to false', () => {
-            const cleanedFilters = cleanFilters(
-                {
-                    insight: InsightType.TRENDS,
-                    display: ChartDisplayType.ActionsPie,
-                    show_values_on_series: false,
-                },
-                {}
-            )
+            const cleanedFilters = cleanFilters({
+                insight: InsightType.TRENDS,
+                display: ChartDisplayType.ActionsPie,
+                show_values_on_series: false,
+            })
 
             expect(cleanedFilters).toHaveProperty('show_values_on_series', false)
         })

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -31,6 +31,7 @@ import {
     isTrendsFilter,
 } from 'scenes/insights/sharedUtils'
 import { isURLNormalizeable } from 'scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils'
+import { teamLogic } from 'scenes/teamLogic'
 
 export function getDefaultEvent(): Entity {
     const event = getDefaultEventName()
@@ -146,27 +147,28 @@ const isNewInsight = (filters: Partial<AnyFilterType>): boolean => {
     return true
 }
 
-export function cleanFilters(
-    filters: Partial<AnyFilterType>,
-    // @ts-expect-error
-    oldFilters?: Partial<AnyFilterType>,
-    teamFilterTestAccounts?: boolean
-): Partial<FilterType> {
+export const setTestAccountFilterForNewInsight = (filter: Partial<AnyFilterType>): void => {
+    const teamFilterTestAccounts = teamLogic.findMounted()?.values.currentTeam?.test_account_filters_default_checked
+    if (localStorage.getItem('default_filter_test_accounts') !== null) {
+        // use current user default
+        filter.filter_test_accounts = localStorage.getItem('default_filter_test_accounts') === 'true'
+    } else if (!filter.filter_test_accounts && teamFilterTestAccounts !== undefined) {
+        // overwrite with team default, only if not set
+        filter.filter_test_accounts = teamFilterTestAccounts
+    }
+}
+
+export function cleanFilters(filters: Partial<AnyFilterType>): Partial<FilterType> {
     const commonFilters: Partial<CommonFiltersType> = {
         ...(filters.sampling_factor ? { sampling_factor: filters.sampling_factor } : {}),
         ...(filters.filter_test_accounts ? { filter_test_accounts: filters.filter_test_accounts } : {}),
         ...(filters.properties ? { properties: filters.properties } : {}),
+        ...(filters.filter_test_accounts ? { filter_test_accounts: filters.filter_test_accounts } : {}),
     }
 
     // set test account filter default for new insights from team and local storage settings
     if (isNewInsight(filters)) {
-        if (localStorage.getItem('default_filter_test_accounts') !== null) {
-            // use current user default
-            commonFilters.filter_test_accounts = localStorage.getItem('default_filter_test_accounts') === 'true'
-        } else if (!filters.filter_test_accounts && teamFilterTestAccounts !== undefined) {
-            // overwrite with team default, only if not set
-            commonFilters.filter_test_accounts = teamFilterTestAccounts
-        }
+        setTestAccountFilterForNewInsight(commonFilters)
     }
 
     if (isRetentionFilter(filters)) {

--- a/frontend/src/scenes/insights/utils/compareFilters.ts
+++ b/frontend/src/scenes/insights/utils/compareFilters.ts
@@ -4,9 +4,12 @@ import { objectCleanWithEmpty, objectsEqual } from 'lib/utils'
 import { cleanFilters } from './cleanFilters'
 
 /** clean filters so that we can check for semantic equality with a deep equality check */
-const clean = (f: Partial<AnyFilterType>): Partial<AnyFilterType> => {
+const clean = (
+    f: Partial<AnyFilterType>,
+    test_account_filters_default_checked: boolean | undefined
+): Partial<AnyFilterType> => {
     // remove undefined values, empty array and empty objects
-    const cleanedFilters = objectCleanWithEmpty(cleanFilters(f))
+    const cleanedFilters = objectCleanWithEmpty(cleanFilters(f, test_account_filters_default_checked))
 
     cleanedFilters.events = cleanedFilters.events?.map((e) => {
         // event math `total` is the default
@@ -19,8 +22,12 @@ const clean = (f: Partial<AnyFilterType>): Partial<AnyFilterType> => {
 }
 
 /** compares to filter objects for semantical equality */
-export function compareFilters(a: Partial<AnyFilterType>, b: Partial<AnyFilterType>): boolean {
+export function compareFilters(
+    a: Partial<AnyFilterType>,
+    b: Partial<AnyFilterType>,
+    test_account_filters_default_checked: boolean | undefined
+): boolean {
     // this is not optimized for speed and does not work for many cases yet
     // e.g. falsy values are not treated the same as undefined values, unset filters are not handled, ordering of series isn't checked
-    return objectsEqual(clean(a), clean(b))
+    return objectsEqual(clean(a, test_account_filters_default_checked), clean(b, test_account_filters_default_checked))
 }

--- a/frontend/src/scenes/paths/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.ts
@@ -13,6 +13,7 @@ import { router } from 'kea-router'
 import { urls } from 'scenes/urls'
 import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { InsightQueryNode } from '~/queries/schema'
+import { teamLogic } from 'scenes/teamLogic'
 
 export const DEFAULT_STEP_LIMIT = 5
 
@@ -41,6 +42,8 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
                 'pathsFilter',
                 'dateRange',
             ],
+            teamLogic,
+            ['currentTeam'],
         ],
         actions: [insightVizDataLogic(props), ['updateInsightFilter']],
     })),
@@ -106,11 +109,14 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
                 path_end_key,
                 path_dropoff_key,
             }
-            const personsUrl = buildPeopleUrl({
-                date_from: '',
-                date_to: '',
-                filters,
-            })
+            const personsUrl = buildPeopleUrl(
+                {
+                    date_from: '',
+                    date_to: '',
+                    filters,
+                },
+                values.currentTeam?.test_account_filters_default_checked
+            )
             if (personsUrl) {
                 openPersonsModal({
                     url: personsUrl,

--- a/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
+++ b/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
@@ -128,6 +128,7 @@ export interface PeopleParamType {
 export interface PeopleUrlBuilderParams extends PeopleParamType {
     filters: Partial<FilterType>
     funnelStep?: number
+    test_account_filters_default_checked: boolean | undefined
 }
 
 export function parsePeopleParams(peopleParams: PeopleParamType, filters: Partial<FilterType>): string {
@@ -172,9 +173,10 @@ export const buildPeopleUrl = ({
     date_to,
     breakdown_value,
     funnelStep,
+    test_account_filters_default_checked,
 }: PeopleUrlBuilderParams): string | undefined => {
     if (isFunnelsFilter(filters) && filters.funnel_correlation_person_entity) {
-        const cleanedParams = cleanFilters(filters)
+        const cleanedParams = cleanFilters(filters, test_account_filters_default_checked)
         return `api/person/funnel/correlation/?${cleanedParams}`
     } else if (isStickinessFilter(filters)) {
         const filterParams = parsePeopleParams({ action, date_from, date_to, breakdown_value }, filters)
@@ -193,11 +195,11 @@ export const buildPeopleUrl = ({
                 ...(breakdown_value !== undefined && { funnel_step_breakdown: breakdown_value }),
             }
         }
-        const cleanedParams = cleanFilters(params)
+        const cleanedParams = cleanFilters(params, test_account_filters_default_checked)
         const funnelParams = toParams(cleanedParams)
         return `api/person/funnel/?${funnelParams}`
     } else if (isPathsFilter(filters)) {
-        const cleanedParams = cleanFilters(filters)
+        const cleanedParams = cleanFilters(filters, test_account_filters_default_checked)
         const pathParams = toParams(cleanedParams)
 
         return `api/person/path/?${pathParams}`

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -12,6 +12,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { fromParamsGivenUrl, isGroupType } from 'lib/utils'
 import { groupsModel } from '~/models/groupsModel'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
+import { teamLogic } from 'scenes/teamLogic'
 
 export interface PersonModalLogicProps {
     url: string
@@ -38,7 +39,7 @@ export const personsModalLogic = kea<personsModalLogicType>([
         setIsCohortModalOpen: (isOpen: boolean) => ({ isOpen }),
     }),
     connect({
-        values: [groupsModel, ['groupTypes', 'aggregationLabel']],
+        values: [groupsModel, ['groupTypes', 'aggregationLabel'], teamLogic, ['currentTeam']],
         actions: [eventUsageLogic, ['reportCohortCreatedFromPersonsModal', 'reportPersonsModalViewed']],
     }),
 
@@ -144,8 +145,8 @@ export const personsModalLogic = kea<personsModalLogicType>([
             },
         ],
         propertiesTimelineFilterFromUrl: [
-            (_, p) => [p.url],
-            (url): PropertiesTimelineFilterType => {
+            (s, p) => [p.url, s.currentTeam],
+            (url, currentTeam): PropertiesTimelineFilterType => {
                 // PersonsModal only gets an persons URL and not its underlying filters, so we need to extract those
                 const params = new URLSearchParams(url.split('?')[1])
                 const eventsString = params.get('events')
@@ -166,7 +167,7 @@ export const personsModalLogic = kea<personsModalLogicType>([
                     breakdown: params.get('breakdown') || undefined,
                     breakdown_type: (params.get('breakdown_type') || undefined) as BreakdownType | undefined,
                 }
-                return cleanFilters(filter)
+                return cleanFilters(filter, currentTeam?.test_account_filters_default_checked)
             },
         ],
     }),


### PR DESCRIPTION
## Problem

It's not possible to change the test account filter on an existing insight.

## Changes

This PR:
- Removes a hack that excluded `filter_test_accounts` from the comparision in the `queryChanged` selector. Previously this hack was necessary for comparing the filters set from `insightSceneLogic` to default filters for the respective query kind, so that the "confirm leaving the insight" alert wouldn't appear for the default insights.
- This is enabled by using new function `setTestAccountFilterForNewInsight` that also sets the default test account filters for the default insights the `queryChanged` selector is comparing against.
- Uses `teamLogic.findMounted()` instead of passing the value for the team to `cleanFilters`, so that ideally all instances of `cleanFilters` do the same thing.
- Removes the `oldFilters` argument from `cleanFilters`, as it was apparently unused.

DO NOT MERGE, currently this is broken for "SQL insights" for yet unknown reasons

## How did you test this code?

Manual testing