### PR TITLE
fix: call italic from toggle

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
@@ -51,7 +51,7 @@ const TEXT_CONTROLS: SlashCommandsItem[] = [
     },
     {
         title: 'I',
-        command: (chain) => chain.toggleBold(),
+        command: (chain) => chain.toggleItalic(),
     },
 ]
 


### PR DESCRIPTION
## Problem

We're calling bold instead of italics from the slash commands

## Changes

Call italics

## How did you test this code?

Manually