### PR TITLE
fix: Change redis key to reset the high water marker

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/offset-high-water-marker.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/offset-high-water-marker.ts
@@ -27,7 +27,7 @@ export class OffsetHighWaterMarker {
     // We don't need to load them more than once per TP as this consumer is the only thing writing to it
     private topicPartitionWaterMarks: Record<string, Promise<OffsetHighWaterMarks> | undefined> = {}
 
-    constructor(private redisPool: RedisPool, private keyPrefix = '@posthog/replay/partition-high-water-marks') {}
+    constructor(private redisPool: RedisPool, private keyPrefix = '@posthog/replay/high-water-marks') {}
 
     private async run<T>(description: string, fn: (client: Redis) => Promise<T>): Promise<T> {
         const client = await this.redisPool.acquire()


### PR DESCRIPTION
## Problem

I _think_ that the bug we had around the offset manager may have left some partitions in a super blocked state so changing the key to essentially reset things

## Changes

* As above

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
