### PR TITLE
fix: remove cache-to: gha when using Depot

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -68,8 +68,6 @@ jobs:
               with:
                   project: x19jffd9zf # posthog
                   buildx-fallback: false # the fallback is so slow it's better to just fail
-                  cache-from: type=gha # always pull the layers from GHA
-                  cache-to: type=gha,mode=max # always push the layers to GHA
                   push: true
                   tags: posthog/posthog:latest,${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:master
                   platforms: linux/arm64,linux/amd64

--- a/.github/workflows/container-images-release-unstable.yml
+++ b/.github/workflows/container-images-release-unstable.yml
@@ -51,8 +51,6 @@ jobs:
               with:
                   project: x19jffd9zf # posthog
                   buildx-fallback: false # the fallback is so slow it's better to just fail
-                  cache-from: type=gha # always pull the layers from GHA
-                  cache-to: type=gha,mode=max # always push the layers to GHA
                   context: .
                   push: true
                   tags: posthog/posthog:${{ env.BRANCH_NAME }}-unstable


### PR DESCRIPTION
## Problem

`cache-to` and `cache-from` to GitHub Actions is unnecessary when using Depot, and the GitHub Actions Cache API keeps dying and taking the build host with it.

## Changes

This PR removes the remaining `cache-to` and `cache-from` from `depot/build-push-action` instances.

## How did you test this code?

N/A