### PR TITLE
chore(plugin-server): capture event uuid in timestamp parsing warnings

### DIFF
--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -69,7 +69,7 @@ const WARNING_TYPE_RENDERER = {
     },
     ignored_invalid_timestamp: function Render(warning: IngestionWarning): JSX.Element {
         const details = warning.details as {
-            uuid: string
+            eventUuid: string
             field: string
             value: string
             reason: string
@@ -78,7 +78,7 @@ const WARNING_TYPE_RENDERER = {
             <>
                 Used server timestamp when ingesting event due to invalid input:
                 <ul>
-                    {details.uuid ? <li>Event UUID: {details.uuid}</li> : ''}
+                    {details.eventUuid ? <li>Event UUID: {details.eventUuid}</li> : ''}
                     {details.field ? <li>Invalid field: {details.field}</li> : ''}
                     {details.value ? <li>Invalid value: {details.value}</li> : ''}
                     {details.reason ? <li>Error: {details.reason}</li> : ''}
@@ -88,7 +88,7 @@ const WARNING_TYPE_RENDERER = {
     },
     event_timestamp_in_future: function Render(warning: IngestionWarning): JSX.Element {
         const details = warning.details as {
-            uuid: string
+            eventUuid: string
             timestamp: string
             sentAt: string
             offset: string
@@ -100,7 +100,7 @@ const WARNING_TYPE_RENDERER = {
                 The event timestamp computed too far in the future, so the capture time was used instead. Event values:
                 <ul>
                     <li>Computed timestamp: {details.result}</li>
-                    {details.uuid ? <li>Event UUID: {details.uuid}</li> : ''}
+                    {details.eventUuid ? <li>Event UUID: {details.eventUuid}</li> : ''}
                     {details.timestamp ? <li>Client provided timestamp: {details.timestamp}</li> : ''}
                     {details.sentAt ? <li>Client provided sent_at: {details.sentAt}</li> : ''}
                     {details.offset ? <li>Client provided time offset: {details.offset}</li> : ''}

--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -69,19 +69,26 @@ const WARNING_TYPE_RENDERER = {
     },
     ignored_invalid_timestamp: function Render(warning: IngestionWarning): JSX.Element {
         const details = warning.details as {
+            uuid: string
             field: string
             value: string
             reason: string
         }
         return (
             <>
-                Used server timestamp when ingesting event due to invalid value <code>{details.value}</code> in field{' '}
-                <code>{details.field}</code>: {details.reason}
+                Used server timestamp when ingesting event due to invalid input:
+                <ul>
+                    {details.uuid ? <li>Event UUID: {details.uuid}</li> : ''}
+                    {details.field ? <li>Invalid field: {details.field}</li> : ''}
+                    {details.value ? <li>Invalid value: {details.value}</li> : ''}
+                    {details.reason ? <li>Error: {details.reason}</li> : ''}
+                </ul>
             </>
         )
     },
     event_timestamp_in_future: function Render(warning: IngestionWarning): JSX.Element {
         const details = warning.details as {
+            uuid: string
             timestamp: string
             sentAt: string
             offset: string
@@ -93,6 +100,7 @@ const WARNING_TYPE_RENDERER = {
                 The event timestamp computed too far in the future, so the capture time was used instead. Event values:
                 <ul>
                     <li>Computed timestamp: {details.result}</li>
+                    {details.uuid ? <li>Event UUID: {details.uuid}</li> : ''}
                     {details.timestamp ? <li>Client provided timestamp: {details.timestamp}</li> : ''}
                     {details.sentAt ? <li>Client provided sent_at: {details.sentAt}</li> : ''}
                     {details.offset ? <li>Client provided time offset: {details.offset}</li> : ''}

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -16,7 +16,7 @@ export function parseEventTimestamp(data: PluginEvent, callback?: IngestionWarni
         sentAt = DateTime.fromISO(data['sent_at']).toUTC()
         if (!sentAt.isValid) {
             callback?.('ignored_invalid_timestamp', {
-                uuid: data['uuid'] ?? '',
+                eventUuid: data['uuid'] ?? '',
                 field: 'sent_at',
                 value: data['sent_at'],
                 reason: sentAt.invalidExplanation || 'unknown error',
@@ -28,7 +28,7 @@ export function parseEventTimestamp(data: PluginEvent, callback?: IngestionWarni
     const parsedTs = handleTimestamp(data, now, sentAt, data.team_id, callback)
     if (!parsedTs.isValid) {
         callback?.('ignored_invalid_timestamp', {
-            uuid: data['uuid'] ?? '',
+            eventUuid: data['uuid'] ?? '',
             field: 'timestamp',
             value: data['timestamp'] ?? '',
             reason: parsedTs.invalidExplanation || 'unknown error',
@@ -95,7 +95,6 @@ function handleTimestamp(
     // We will also 'fix' the date to be now()
     if (nowDiff > FutureEventHoursCutoffMillis) {
         callback?.('event_timestamp_in_future', {
-            uuid: data['uuid'] ?? '',
             timestamp: data['timestamp'] ?? '',
             sentAt: data['sent_at'] ?? '',
             offset: data['offset'] ?? '',

--- a/plugin-server/src/worker/ingestion/timestamps.ts
+++ b/plugin-server/src/worker/ingestion/timestamps.ts
@@ -16,6 +16,7 @@ export function parseEventTimestamp(data: PluginEvent, callback?: IngestionWarni
         sentAt = DateTime.fromISO(data['sent_at']).toUTC()
         if (!sentAt.isValid) {
             callback?.('ignored_invalid_timestamp', {
+                uuid: data['uuid'] ?? '',
                 field: 'sent_at',
                 value: data['sent_at'],
                 reason: sentAt.invalidExplanation || 'unknown error',
@@ -27,6 +28,7 @@ export function parseEventTimestamp(data: PluginEvent, callback?: IngestionWarni
     const parsedTs = handleTimestamp(data, now, sentAt, data.team_id, callback)
     if (!parsedTs.isValid) {
         callback?.('ignored_invalid_timestamp', {
+            uuid: data['uuid'] ?? '',
             field: 'timestamp',
             value: data['timestamp'] ?? '',
             reason: parsedTs.invalidExplanation || 'unknown error',
@@ -93,6 +95,7 @@ function handleTimestamp(
     // We will also 'fix' the date to be now()
     if (nowDiff > FutureEventHoursCutoffMillis) {
         callback?.('event_timestamp_in_future', {
+            uuid: data['uuid'] ?? '',
             timestamp: data['timestamp'] ?? '',
             sentAt: data['sent_at'] ?? '',
             offset: data['offset'] ?? '',

--- a/plugin-server/tests/worker/ingestion/timestamps.test.ts
+++ b/plugin-server/tests/worker/ingestion/timestamps.test.ts
@@ -1,5 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
+import { UUIDT } from '../../../src/utils/utils'
 import { parseDate, parseEventTimestamp } from '../../../src/worker/ingestion/timestamps'
 
 describe('parseDate()', () => {
@@ -55,6 +56,7 @@ describe('parseEventTimestamp()', () => {
             timestamp: '2021-10-31T00:44:00.000Z',
             sent_at: 'invalid',
             now: '2021-10-30T01:44:00.000Z',
+            uuid: new UUIDT(),
         } as any as PluginEvent
 
         const callbackMock = jest.fn()
@@ -66,6 +68,7 @@ describe('parseEventTimestamp()', () => {
                     field: 'sent_at',
                     reason: 'the input "invalid" can\'t be parsed as ISO 8601',
                     value: 'invalid',
+                    eventUuid: event.uuid,
                 },
             ],
         ])
@@ -132,6 +135,7 @@ describe('parseEventTimestamp()', () => {
             team_id: 123,
             timestamp: 'notISO',
             now: '2020-01-01T12:00:05.200Z',
+            uuid: new UUIDT(),
         } as any as PluginEvent
 
         const callbackMock = jest.fn()
@@ -143,6 +147,7 @@ describe('parseEventTimestamp()', () => {
                     field: 'timestamp',
                     reason: 'the input "notISO" can\'t be parsed as ISO 8601',
                     value: 'notISO',
+                    eventUuid: event.uuid,
                 },
             ],
         ])


### PR DESCRIPTION
## Problem

`event_timestamp_in_future` is most probably caused by one misbehaving user-agent, but we cannot pinpoint which one.

## Changes

- collect the event uuid so that we can check what browser sends these

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
