### PR TITLE
feat: Retry forever on PG activities

### DIFF
--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -269,6 +269,8 @@ class S3BatchExportWorkflow(PostHogWorkflow):
             start_to_close_timeout=dt.timedelta(minutes=20),
             schedule_to_close_timeout=dt.timedelta(minutes=5),
             retry_policy=RetryPolicy(
+                initial_interval=dt.timedelta(seconds=10),
+                maximum_interval=dt.timedelta(seconds=60),
                 maximum_attempts=0,
                 non_retryable_error_types=["NotNullViolation", "IntegrityError"],
             ),
@@ -311,7 +313,12 @@ class S3BatchExportWorkflow(PostHogWorkflow):
                 update_inputs,
                 start_to_close_timeout=dt.timedelta(minutes=20),
                 schedule_to_close_timeout=dt.timedelta(minutes=5),
-                retry_policy=RetryPolicy(maximum_attempts=0),
+                retry_policy=RetryPolicy(
+                    initial_interval=dt.timedelta(seconds=10),
+                    maximum_interval=dt.timedelta(seconds=60),
+                    maximum_attempts=0,
+                    non_retryable_error_types=["NotNullViolation", "IntegrityError"],
+                ),
             )
 
 

--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -269,7 +269,7 @@ class S3BatchExportWorkflow(PostHogWorkflow):
             start_to_close_timeout=dt.timedelta(minutes=20),
             schedule_to_close_timeout=dt.timedelta(minutes=5),
             retry_policy=RetryPolicy(
-                maximum_attempts=3,
+                maximum_attempts=0,
                 non_retryable_error_types=["NotNullViolation", "IntegrityError"],
             ),
         )
@@ -311,7 +311,7 @@ class S3BatchExportWorkflow(PostHogWorkflow):
                 update_inputs,
                 start_to_close_timeout=dt.timedelta(minutes=20),
                 schedule_to_close_timeout=dt.timedelta(minutes=5),
-                retry_policy=RetryPolicy(maximum_attempts=3),
+                retry_policy=RetryPolicy(maximum_attempts=0),
             )
 
 

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -289,7 +289,7 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
             start_to_close_timeout=dt.timedelta(minutes=20),
             schedule_to_close_timeout=dt.timedelta(minutes=5),
             retry_policy=RetryPolicy(
-                maximum_attempts=3,
+                maximum_attempts=0,
                 non_retryable_error_types=["NotNullViolation", "IntegrityError"],
             ),
         )
@@ -336,7 +336,7 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
                 update_inputs,
                 start_to_close_timeout=dt.timedelta(minutes=20),
                 schedule_to_close_timeout=dt.timedelta(minutes=5),
-                retry_policy=RetryPolicy(maximum_attempts=3),
+                retry_policy=RetryPolicy(maximum_attempts=0),
             )
 
 

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -289,6 +289,8 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
             start_to_close_timeout=dt.timedelta(minutes=20),
             schedule_to_close_timeout=dt.timedelta(minutes=5),
             retry_policy=RetryPolicy(
+                initial_interval=dt.timedelta(seconds=10),
+                maximum_interval=dt.timedelta(seconds=60),
                 maximum_attempts=0,
                 non_retryable_error_types=["NotNullViolation", "IntegrityError"],
             ),
@@ -336,7 +338,12 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
                 update_inputs,
                 start_to_close_timeout=dt.timedelta(minutes=20),
                 schedule_to_close_timeout=dt.timedelta(minutes=5),
-                retry_policy=RetryPolicy(maximum_attempts=0),
+                retry_policy=RetryPolicy(
+                    initial_interval=dt.timedelta(seconds=10),
+                    maximum_interval=dt.timedelta(seconds=60),
+                    maximum_attempts=0,
+                    non_retryable_error_types=["NotNullViolation", "IntegrityError"],
+                ),
             )
 
 


### PR DESCRIPTION
## Problem

Activities that hit Postgres can run out of retries, yet we control everything related to those activities. The only failures that can happen (with the exception of us introducing a bug) are transient. So, we can retry forever.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Set unbounded number of retries for `create_export_run` and `update_export_run` activities which hit Postgres. Since we are retrying forever, I'm also bumping the initial retry interval to 10 seconds, and adding a maximum interval of 1 minute (backoff coefficient is by default 2, so retries will be 10s -> 20s -> 40s -> 60s -> 60s -> ...).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
