### PR TITLE
test: fix pytest errors when running without ee directory

### DIFF
--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1316,7 +1316,6 @@ class TestCapture(BaseTest):
         default_kafka_producer_mock: MagicMock,
         session_recording_producer_factory_mock: MagicMock,
     ) -> None:
-
         with self.settings(
             KAFKA_HOSTS=["first.server:9092", "second.server:9092"],
             SESSION_RECORDING_KAFKA_HOSTS=["another-server:9092", "a-fourth.server:9092"],
@@ -1407,7 +1406,10 @@ class TestCapture(BaseTest):
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     @pytest.mark.ee
     def test_quota_limits_ignored_if_disabled(self, kafka_produce) -> None:
-        from ee.billing.quota_limiting import QuotaResource, replace_limited_team_tokens
+        try:
+            from ee.billing.quota_limiting import QuotaResource, replace_limited_team_tokens
+        except ImportError:
+            pytest.skip("ee module not available")
 
         replace_limited_team_tokens(QuotaResource.RECORDINGS, {self.team.api_token: timezone.now().timestamp() + 10000})
         replace_limited_team_tokens(QuotaResource.EVENTS, {self.team.api_token: timezone.now().timestamp() + 10000})
@@ -1417,7 +1419,10 @@ class TestCapture(BaseTest):
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     @pytest.mark.ee
     def test_quota_limits(self, kafka_produce) -> None:
-        from ee.billing.quota_limiting import QuotaResource, replace_limited_team_tokens
+        try:
+            from ee.billing.quota_limiting import QuotaResource, replace_limited_team_tokens
+        except ImportError:
+            pytest.skip("ee module not available")
 
         def _produce_events():
             kafka_produce.reset_mock()

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -170,7 +170,6 @@ class TestFeatureFlag(APIBaseTest):
     @freeze_time("2021-08-25T22:09:14.252Z")
     @patch("posthog.api.feature_flag.report_user_action")
     def test_create_feature_flag(self, mock_capture):
-
         response = self.client.post(
             f"/api/projects/{self.team.id}/feature_flags/",
             {"name": "Alpha feature", "key": "alpha-feature", "filters": {"groups": [{"rollout_percentage": 50}]}},
@@ -220,7 +219,6 @@ class TestFeatureFlag(APIBaseTest):
 
     @patch("posthog.api.feature_flag.report_user_action")
     def test_create_minimal_feature_flag(self, mock_capture):
-
         response = self.client.post(
             f"/api/projects/{self.team.id}/feature_flags/", {"key": "omega-feature"}, format="json"
         )
@@ -250,7 +248,6 @@ class TestFeatureFlag(APIBaseTest):
 
     @patch("posthog.api.feature_flag.report_user_action")
     def test_create_multivariate_feature_flag(self, mock_capture):
-
         response = self.client.post(
             f"/api/projects/{self.team.id}/feature_flags/",
             {
@@ -1946,7 +1943,6 @@ class TestFeatureFlag(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_creating_feature_flag_with_behavioral_cohort(self):
-
         cohort_valid_for_ff = Cohort.objects.create(
             team=self.team,
             groups=[{"properties": [{"key": "$some_prop", "value": "nomatchihope", "type": "person"}]}],
@@ -2025,7 +2021,6 @@ class TestFeatureFlag(APIBaseTest):
         )
 
     def test_creating_feature_flag_with_nested_behavioral_cohort(self):
-
         cohort_not_valid_for_ff = Cohort.objects.create(
             team=self.team,
             filters={
@@ -2351,7 +2346,6 @@ class TestFeatureFlag(APIBaseTest):
 class TestBlastRadius(ClickhouseTestMixin, APIBaseTest):
     @snapshot_clickhouse_queries
     def test_user_blast_radius(self):
-
         for i in range(10):
             _create_person(team_id=self.team.pk, distinct_ids=[f"person{i}"], properties={"group": f"{i}"})
 
@@ -2371,7 +2365,6 @@ class TestBlastRadius(ClickhouseTestMixin, APIBaseTest):
         self.assertDictContainsSubset({"users_affected": 4, "total_users": 10}, response_json)
 
     def test_user_blast_radius_with_zero_users(self):
-
         response = self.client.post(
             f"/api/projects/{self.team.id}/feature_flags/user_blast_radius",
             {
@@ -2388,7 +2381,6 @@ class TestBlastRadius(ClickhouseTestMixin, APIBaseTest):
         self.assertDictContainsSubset({"users_affected": 0, "total_users": 0}, response_json)
 
     def test_user_blast_radius_with_zero_selected_users(self):
-
         for i in range(5):
             _create_person(team_id=self.team.pk, distinct_ids=[f"person{i}"], properties={"group": f"{i}"})
 
@@ -2408,7 +2400,6 @@ class TestBlastRadius(ClickhouseTestMixin, APIBaseTest):
         self.assertDictContainsSubset({"users_affected": 0, "total_users": 5}, response_json)
 
     def test_user_blast_radius_with_all_selected_users(self):
-
         for i in range(5):
             _create_person(team_id=self.team.pk, distinct_ids=[f"person{i}"], properties={"group": f"{i}"})
 
@@ -2424,7 +2415,6 @@ class TestBlastRadius(ClickhouseTestMixin, APIBaseTest):
 
     @snapshot_clickhouse_queries
     def test_user_blast_radius_with_single_cohort(self):
-
         for i in range(10):
             _create_person(team_id=self.team.pk, distinct_ids=[f"person{i}"], properties={"group": f"{i}"})
 
@@ -2483,7 +2473,6 @@ class TestBlastRadius(ClickhouseTestMixin, APIBaseTest):
 
     @snapshot_clickhouse_queries
     def test_user_blast_radius_with_multiple_precalculated_cohorts(self):
-
         for i in range(10):
             _create_person(team_id=self.team.pk, distinct_ids=[f"person{i}"], properties={"group": f"{i}"})
 
@@ -2549,7 +2538,6 @@ class TestBlastRadius(ClickhouseTestMixin, APIBaseTest):
 
     @snapshot_clickhouse_queries
     def test_user_blast_radius_with_multiple_static_cohorts(self):
-
         for i in range(10):
             _create_person(team_id=self.team.pk, distinct_ids=[f"person{i}"], properties={"group": f"{i}"})
 
@@ -2858,6 +2846,8 @@ def slow_query(execute, sql, *args, **kwargs):
 
 @patch("posthog.models.feature_flag.flag_matching.postgres_healthcheck.is_connected", return_value=True)
 class TestResiliency(TransactionTestCase, QueryMatchingTest):
+    available_apps = ["posthog"]
+
     def setUp(self) -> None:
         return super().setUp()
 
@@ -2921,7 +2911,6 @@ class TestResiliency(TransactionTestCase, QueryMatchingTest):
 
         # now db is down
         with snapshot_postgres_queries_context(self), connection.execute_wrapper(QueryTimeoutWrapper()):
-
             with self.assertNumQueries(1):
                 all_flags, _, _, errors = get_all_feature_flags(team_id, "example_id", groups={"organization": "org:1"})
 
@@ -3270,7 +3259,6 @@ class TestResiliency(TransactionTestCase, QueryMatchingTest):
         with snapshot_postgres_queries_context(self), connection.execute_wrapper(slow_query), patch(
             "posthog.models.feature_flag.flag_matching.FLAG_MATCHING_QUERY_TIMEOUT_MS", 500
         ):
-
             with self.assertNumQueries(2):
                 all_flags, _, _, errors = get_all_feature_flags(team_id, "example_id", groups={"organization": "org:1"})
 

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -26,7 +26,11 @@ from posthog.test.base import (
     also_test_with_materialized_columns,
     flush_persons_and_events,
     snapshot_clickhouse_queries,
+    class_not_available,
 )
+import pytest
+
+LOAD_PERFORMANCE_EVENTS_RECENT_PAGEVIEWS = "ee.api.performance_events.load_performance_events_recent_pageviews"
 
 
 class TestQuery(ClickhouseTestMixin, APIBaseTest):
@@ -488,7 +492,10 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         )
         assert api_response.status_code == 200
 
-    @patch("ee.api.performance_events.load_performance_events_recent_pageviews")
+    @pytest.mark.skipif(
+        class_not_available(LOAD_PERFORMANCE_EVENTS_RECENT_PAGEVIEWS), reason="ee module is not available"
+    )
+    @patch(LOAD_PERFORMANCE_EVENTS_RECENT_PAGEVIEWS)
     def test_valid_recent_performance_pageviews_defaults_to_the_last_hour(self, patched_load_performance_events):
         frozen_now = "2020-01-10T12:14:00Z"
         one_hour_before = "2020-01-10T11:14:00Z"

--- a/posthog/management/commands/test/test_backfill_persons_and_groups_on_events.py
+++ b/posthog/management/commands/test/test_backfill_persons_and_groups_on_events.py
@@ -29,7 +29,7 @@ class TestBackfillPersonsAndGroupsOnEvents(BaseTest, ClickhouseTestMixin):
         super().tearDown()
 
     def recreate_database(self, create_tables=True):
-        sync_execute(f"DROP DATABASE {settings.CLICKHOUSE_DATABASE} SYNC")
+        sync_execute(f"DROP DATABASE IF EXISTS {settings.CLICKHOUSE_DATABASE} SYNC")
         sync_execute(f"CREATE DATABASE {settings.CLICKHOUSE_DATABASE}")
         if create_tables:
             create_clickhouse_tables(0)
@@ -52,8 +52,7 @@ class TestBackfillPersonsAndGroupsOnEvents(BaseTest, ClickhouseTestMixin):
         sync_execute(
             f"""
             INSERT INTO person_distinct_id2 (person_id, distinct_id, team_id)
-            VALUES
-                ('{str(person_id)}', 'some_distinct_id', 1)
+            VALUES ('{str(person_id)}', 'some_distinct_id', 1)
             """
         )
 

--- a/posthog/management/commands/test/test_sync_replicated_schema.py
+++ b/posthog/management/commands/test/test_sync_replicated_schema.py
@@ -14,7 +14,7 @@ class TestSyncReplicatedSchema(BaseTest, ClickhouseTestMixin):
         super().tearDown()
 
     def recreate_database(self, create_tables=True):
-        sync_execute(f"DROP DATABASE {settings.CLICKHOUSE_DATABASE} SYNC")
+        sync_execute(f"DROP DATABASE IF EXISTS {settings.CLICKHOUSE_DATABASE} SYNC")
         sync_execute(f"CREATE DATABASE {settings.CLICKHOUSE_DATABASE}")
         if create_tables:
             create_clickhouse_tables(0)

--- a/posthog/models/test/test_person_override_model.py
+++ b/posthog/models/test/test_person_override_model.py
@@ -9,392 +9,580 @@ from django.db.utils import DEFAULT_DB_ALIAS, ConnectionHandler, IntegrityError
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.models import Person, PersonOverride, PersonOverrideMapping, Team
+from posthog.test.base import TransactionTestCase
 
 
-@pytest.fixture
-def organization():
-    organization = create_organization(name="test")
+class TestPersonOverride(TransactionTestCase):
+    # This allows cleanup to run "TRUNCATE TABLE" with CASCADE option
+    available_apps = ["posthog"]
 
-    yield organization
+    @pytest.fixture(autouse=True)
+    def organization(self):
+        self.organization = create_organization(name="test")
 
-    organization.delete()
+        yield
 
+        self.organization.delete()
 
-@pytest.fixture
-def team(organization):
-    team = create_team(organization=organization)
+    @pytest.fixture(autouse=True)
+    def team(self, organization):
+        self.team = create_team(organization=self.organization)
 
-    yield team
+        yield
 
-    team.delete()
+        self.team.delete()
 
+    @pytest.fixture(autouse=True)
+    def people(self, team):
+        old_person_uuid = uuid4()
+        override_person_uuid = uuid4()
+        new_override_person_uuid = uuid4()
 
-@pytest.fixture
-def people(team):
-    old_person_uuid = uuid4()
-    override_person_uuid = uuid4()
-    new_override_person_uuid = uuid4()
+        self.p1 = Person.objects.create(uuid=old_person_uuid, team=self.team)
+        self.p2 = Person.objects.create(uuid=override_person_uuid, team=self.team)
+        self.p3 = Person.objects.create(uuid=new_override_person_uuid, team=self.team)
 
-    p1 = Person.objects.create(uuid=old_person_uuid, team=team)
-    p2 = Person.objects.create(uuid=override_person_uuid, team=team)
-    p3 = Person.objects.create(uuid=new_override_person_uuid, team=team)
+        yield
 
-    yield (p1, p2, p3)
+        self.p1.delete()
+        self.p2.delete()
+        self.p3.delete()
 
-    p1.delete()
-    p2.delete()
-    p3.delete()
+    @pytest.fixture(autouse=True)
+    def oldest_event(self):
+        self.oldest_event = dt.datetime.now(dt.timezone.utc)
 
+    def test_person_override_disallows_same_old_person_id(self):
+        """Test a new old_person_id cannot match an existing old_person_id.
 
-@pytest.fixture
-def oldest_event():
-    return dt.datetime.now(dt.timezone.utc)
-
-
-@pytest.mark.django_db(transaction=True)
-def test_person_override_disallows_same_old_person_id(team, oldest_event):
-    """Test a new old_person_id cannot match an existing old_person_id.
-
-    This is enforced by a UNIQUE constraint on (team_id, old_person_id)
-    """
-    old_person_id = uuid4()
-    override_person_id = uuid4()
-    new_override_person_id = uuid4()
-
-    old_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=old_person_id,
-    )
-    override_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=override_person_id,
-    )
-    person_override = PersonOverride.objects.create(
-        team=team,
-        old_person_id=old_mapping,
-        override_person_id=override_mapping,
-        oldest_event=oldest_event,
-        version=1,
-    )
-    person_override.save()
-
-    assert person_override.old_person_id == old_mapping
-    assert person_override.override_person_id == override_mapping
-
-    new_override_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=new_override_person_id,
-    )
-
-    with pytest.raises(IntegrityError):
-        PersonOverride.objects.create(
-            team=team,
-            old_person_id=old_mapping,
-            override_person_id=new_override_mapping,
-            oldest_event=oldest_event,
-            version=1,
-        ).save()
-
-
-@pytest.mark.django_db(transaction=True)
-def test_person_override_same_old_person_id_in_different_teams(organization, team, oldest_event):
-    """Test a new old_person_id can match an existing from a different team."""
-    old_person_id = uuid4()
-    override_person_id = uuid4()
-    new_team = Team.objects.create(
-        organization=organization,
-        api_token="a different token",
-    )
-
-    old_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=old_person_id,
-    )
-    override_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=override_person_id,
-    )
-
-    p1 = PersonOverride.objects.create(
-        team=team,
-        old_person_id=old_mapping,
-        override_person_id=override_mapping,
-        oldest_event=oldest_event,
-        version=1,
-    )
-    p1.save()
-
-    assert p1.old_person_id == old_mapping
-    assert p1.override_person_id == override_mapping
-
-    new_team_old_mapping = PersonOverrideMapping.objects.create(
-        team_id=new_team.id,
-        uuid=old_person_id,
-    )
-    new_team_override_mapping = PersonOverrideMapping.objects.create(
-        team_id=new_team.id,
-        uuid=override_person_id,
-    )
-
-    p2 = PersonOverride.objects.create(
-        team=new_team,
-        old_person_id=new_team_old_mapping,
-        override_person_id=new_team_override_mapping,
-        oldest_event=oldest_event,
-        version=1,
-    )
-    p2.save()
-
-    assert p1.old_person_id.uuid == p2.old_person_id.uuid
-    assert p1.override_person_id.uuid == p2.override_person_id.uuid
-    assert p1.old_person_id.id != p2.old_person_id.id
-    assert p1.override_person_id.id != p2.override_person_id.id
-    assert p1.team != p2.team
-
-
-@pytest.mark.django_db(transaction=True)
-def test_person_override_disallows_override_person_id_as_old_person_id(team, oldest_event):
-    """Test a new old_person_id cannot match an existing override_person_id.
-
-    We re-use the override_person_id from the first model created as the old_person_id
-    of the second model. We expect an exception on saving this second model.
-    """
-    old_person_id = uuid4()
-    override_person_id = uuid4()
-    new_override_person_id = uuid4()
-
-    old_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=old_person_id,
-    )
-    override_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=override_person_id,
-    )
-
-    person_override = PersonOverride.objects.create(
-        team=team,
-        old_person_id=old_mapping,
-        override_person_id=override_mapping,
-        oldest_event=oldest_event,
-        version=1,
-    )
-    person_override.save()
-
-    assert person_override.old_person_id == old_mapping
-    assert person_override.override_person_id == override_mapping
-
-    new_override_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=new_override_person_id,
-    )
-
-    with pytest.raises(IntegrityError):
-        PersonOverride.objects.create(
-            team=team,
-            old_person_id=override_mapping,
-            override_person_id=new_override_mapping,
-            oldest_event=oldest_event,
-            version=1,
-        ).save()
-
-
-@pytest.mark.django_db(transaction=True)
-def test_person_override_allows_override_person_id_as_old_person_id_in_different_teams(
-    team, organization, oldest_event
-):
-    """Test a new old_person_id can match an override in a different team."""
-    old_person_id = uuid4()
-    override_person_id = uuid4()
-    new_override_person_id = uuid4()
-    new_team = Team.objects.create(
-        organization=organization,
-        api_token="a much different token",
-    )
-
-    old_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=old_person_id,
-    )
-    override_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=override_person_id,
-    )
-
-    p1 = PersonOverride.objects.create(
-        team=team,
-        old_person_id=old_mapping,
-        override_person_id=override_mapping,
-        oldest_event=oldest_event,
-        version=1,
-    )
-    p1.save()
-
-    assert p1.old_person_id == old_mapping
-    assert p1.override_person_id == override_mapping
-
-    new_team_old_mapping = PersonOverrideMapping.objects.create(
-        team_id=new_team.id,
-        uuid=override_person_id,
-    )
-    new_team_override_mapping = PersonOverrideMapping.objects.create(
-        team_id=new_team.id,
-        uuid=new_override_person_id,
-    )
-    p2 = PersonOverride.objects.create(
-        team=new_team,
-        old_person_id=new_team_old_mapping,
-        override_person_id=new_team_override_mapping,
-        oldest_event=oldest_event,
-        version=1,
-    )
-    p2.save()
-
-    assert p1.override_person_id.uuid == p2.old_person_id.uuid
-    assert p2.override_person_id == new_team_override_mapping
-    assert p1.team != p2.team
-
-
-@pytest.mark.django_db(transaction=True)
-def test_person_override_disallows_old_person_id_as_override_person_id(team, oldest_event):
-    """Test a new override_person_id cannot match an existing old_person_id.
-
-    We re-use the old_person_id from the first model created as the override_person_id
-    of the second model. We expect an exception on saving this second model.
-    """
-    old_person_id = uuid4()
-    override_person_id = uuid4()
-    new_old_person_id = uuid4()
-
-    old_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=old_person_id,
-    )
-    old_mapping.save()
-
-    override_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=override_person_id,
-    )
-    override_mapping.save()
-
-    person_override = PersonOverride.objects.create(
-        team=team,
-        old_person_id=old_mapping,
-        override_person_id=override_mapping,
-        oldest_event=oldest_event,
-        version=1,
-    )
-    person_override.save()
-
-    assert person_override.old_person_id == old_mapping
-    assert person_override.override_person_id == override_mapping
-
-    new_old_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=new_old_person_id,
-    )
-    new_old_mapping.save()
-
-    with pytest.raises(IntegrityError):
-        p = PersonOverride.objects.create(
-            team=team,
-            old_person_id=new_old_mapping,
-            override_person_id=old_mapping,
-            oldest_event=oldest_event,
-            version=1,
-        )
-        p.save()
-
-
-@pytest.mark.django_db(transaction=True)
-def test_person_override_old_person_id_as_override_person_id_in_different_teams(organization, team, oldest_event):
-    """Test a new override_person_id can match an old in a different team."""
-    old_person_id = uuid4()
-    override_person_id = uuid4()
-    new_old_person_id = uuid4()
-    new_team = Team.objects.create(
-        organization=organization,
-        api_token="a significantly different token",
-    )
-
-    old_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=old_person_id,
-    )
-    override_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=override_person_id,
-    )
-
-    p1 = PersonOverride.objects.create(
-        team=team,
-        old_person_id=old_mapping,
-        override_person_id=override_mapping,
-        oldest_event=oldest_event,
-        version=1,
-    )
-    p1.save()
-
-    assert p1.old_person_id == old_mapping
-    assert p1.override_person_id == override_mapping
-
-    new_old_mapping = PersonOverrideMapping.objects.create(
-        team_id=new_team.id,
-        uuid=new_old_person_id,
-    )
-    new_override_mapping = PersonOverrideMapping.objects.create(
-        team_id=new_team.id,
-        uuid=old_mapping.uuid,
-    )
-
-    p2 = PersonOverride.objects.create(
-        team=new_team,
-        old_person_id=new_old_mapping,
-        override_person_id=new_override_mapping,
-        oldest_event=oldest_event,
-        version=1,
-    )
-    p2.save()
-
-    assert p1.old_person_id.uuid == p2.override_person_id.uuid
-    assert p1.old_person_id.team_id == p1.override_person_id.team_id
-    assert p2.old_person_id == new_old_mapping
-    assert p1.team != p2.team
-
-
-@pytest.mark.django_db(transaction=True)
-def test_person_override_allows_duplicate_override_person_id(team, oldest_event):
-    """Test duplicate override_person_ids with different old_person_ids are allowed."""
-    override_person_id = uuid4()
-    n_person_overrides = 2
-    created = []
-
-    override_mapping = PersonOverrideMapping.objects.create(
-        team_id=team.id,
-        uuid=override_person_id,
-    )
-
-    for _ in range(n_person_overrides):
+        This is enforced by a UNIQUE constraint on (team_id, old_person_id)
+        """
         old_person_id = uuid4()
+        override_person_id = uuid4()
+        new_override_person_id = uuid4()
+
         old_mapping = PersonOverrideMapping.objects.create(
-            team_id=team.id,
+            team_id=self.team.id,
             uuid=old_person_id,
         )
-
+        override_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=override_person_id,
+        )
         person_override = PersonOverride.objects.create(
-            team=team,
+            team=self.team,
             old_person_id=old_mapping,
             override_person_id=override_mapping,
-            oldest_event=oldest_event,
+            oldest_event=self.oldest_event,
             version=1,
         )
         person_override.save()
 
-        created.append(person_override)
+        assert person_override.old_person_id == old_mapping
+        assert person_override.override_person_id == override_mapping
 
-    assert all(p.override_person_id == override_mapping for p in created)
-    assert len(set(p.old_person_id.uuid for p in created)) == n_person_overrides
+        new_override_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=new_override_person_id,
+        )
+
+        with pytest.raises(IntegrityError):
+            PersonOverride.objects.create(
+                team=self.team,
+                old_person_id=old_mapping,
+                override_person_id=new_override_mapping,
+                oldest_event=self.oldest_event,
+                version=1,
+            ).save()
+
+    def test_person_override_same_old_person_id_in_different_teams(self):
+        """Test a new old_person_id can match an existing from a different team."""
+        old_person_id = uuid4()
+        override_person_id = uuid4()
+        new_team = Team.objects.create(
+            organization=self.organization,
+            api_token="a different token",
+        )
+
+        old_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=old_person_id,
+        )
+        override_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=override_person_id,
+        )
+
+        p1 = PersonOverride.objects.create(
+            team=self.team,
+            old_person_id=old_mapping,
+            override_person_id=override_mapping,
+            oldest_event=self.oldest_event,
+            version=1,
+        )
+        p1.save()
+
+        assert p1.old_person_id == old_mapping
+        assert p1.override_person_id == override_mapping
+
+        new_team_old_mapping = PersonOverrideMapping.objects.create(
+            team_id=new_team.id,
+            uuid=old_person_id,
+        )
+        new_team_override_mapping = PersonOverrideMapping.objects.create(
+            team_id=new_team.id,
+            uuid=override_person_id,
+        )
+
+        p2 = PersonOverride.objects.create(
+            team=new_team,
+            old_person_id=new_team_old_mapping,
+            override_person_id=new_team_override_mapping,
+            oldest_event=self.oldest_event,
+            version=1,
+        )
+        p2.save()
+
+        assert p1.old_person_id.uuid == p2.old_person_id.uuid
+        assert p1.override_person_id.uuid == p2.override_person_id.uuid
+        assert p1.old_person_id.id != p2.old_person_id.id
+        assert p1.override_person_id.id != p2.override_person_id.id
+        assert p1.team != p2.team
+
+    def test_person_override_disallows_override_person_id_as_old_person_id(self):
+        """Test a new old_person_id cannot match an existing override_person_id.
+
+        We re-use the override_person_id from the first model created as the old_person_id
+        of the second model. We expect an exception on saving this second model.
+        """
+        old_person_id = uuid4()
+        override_person_id = uuid4()
+        new_override_person_id = uuid4()
+
+        old_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=old_person_id,
+        )
+        override_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=override_person_id,
+        )
+
+        person_override = PersonOverride.objects.create(
+            team=self.team,
+            old_person_id=old_mapping,
+            override_person_id=override_mapping,
+            oldest_event=self.oldest_event,
+            version=1,
+        )
+        person_override.save()
+
+        assert person_override.old_person_id == old_mapping
+        assert person_override.override_person_id == override_mapping
+
+        new_override_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=new_override_person_id,
+        )
+
+        with pytest.raises(IntegrityError):
+            PersonOverride.objects.create(
+                team=self.team,
+                old_person_id=override_mapping,
+                override_person_id=new_override_mapping,
+                oldest_event=self.oldest_event,
+                version=1,
+            ).save()
+
+    def test_person_override_allows_override_person_id_as_old_person_id_in_different_teams(self):
+        """Test a new old_person_id can match an override in a different team."""
+        old_person_id = uuid4()
+        override_person_id = uuid4()
+        new_override_person_id = uuid4()
+        new_team = Team.objects.create(
+            organization=self.organization,
+            api_token="a much different token",
+        )
+
+        old_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=old_person_id,
+        )
+        override_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=override_person_id,
+        )
+
+        p1 = PersonOverride.objects.create(
+            team=self.team,
+            old_person_id=old_mapping,
+            override_person_id=override_mapping,
+            oldest_event=self.oldest_event,
+            version=1,
+        )
+        p1.save()
+
+        assert p1.old_person_id == old_mapping
+        assert p1.override_person_id == override_mapping
+
+        new_team_old_mapping = PersonOverrideMapping.objects.create(
+            team_id=new_team.id,
+            uuid=override_person_id,
+        )
+        new_team_override_mapping = PersonOverrideMapping.objects.create(
+            team_id=new_team.id,
+            uuid=new_override_person_id,
+        )
+        p2 = PersonOverride.objects.create(
+            team=new_team,
+            old_person_id=new_team_old_mapping,
+            override_person_id=new_team_override_mapping,
+            oldest_event=self.oldest_event,
+            version=1,
+        )
+        p2.save()
+
+        assert p1.override_person_id.uuid == p2.old_person_id.uuid
+        assert p2.override_person_id == new_team_override_mapping
+        assert p1.team != p2.team
+
+    def test_person_override_disallows_old_person_id_as_override_person_id(self):
+        """Test a new override_person_id cannot match an existing old_person_id.
+
+        We re-use the old_person_id from the first model created as the override_person_id
+        of the second model. We expect an exception on saving this second model.
+        """
+        old_person_id = uuid4()
+        override_person_id = uuid4()
+        new_old_person_id = uuid4()
+
+        old_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=old_person_id,
+        )
+        old_mapping.save()
+
+        override_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=override_person_id,
+        )
+        override_mapping.save()
+
+        person_override = PersonOverride.objects.create(
+            team=self.team,
+            old_person_id=old_mapping,
+            override_person_id=override_mapping,
+            oldest_event=self.oldest_event,
+            version=1,
+        )
+        person_override.save()
+
+        assert person_override.old_person_id == old_mapping
+        assert person_override.override_person_id == override_mapping
+
+        new_old_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=new_old_person_id,
+        )
+        new_old_mapping.save()
+
+        with pytest.raises(IntegrityError):
+            p = PersonOverride.objects.create(
+                team=self.team,
+                old_person_id=new_old_mapping,
+                override_person_id=old_mapping,
+                oldest_event=self.oldest_event,
+                version=1,
+            )
+            p.save()
+
+    def test_person_override_old_person_id_as_override_person_id_in_different_teams(self):
+        """Test a new override_person_id can match an old in a different team."""
+        old_person_id = uuid4()
+        override_person_id = uuid4()
+        new_old_person_id = uuid4()
+        new_team = Team.objects.create(
+            organization=self.organization,
+            api_token="a significantly different token",
+        )
+
+        old_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=old_person_id,
+        )
+        override_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=override_person_id,
+        )
+
+        p1 = PersonOverride.objects.create(
+            team=self.team,
+            old_person_id=old_mapping,
+            override_person_id=override_mapping,
+            oldest_event=self.oldest_event,
+            version=1,
+        )
+        p1.save()
+
+        assert p1.old_person_id == old_mapping
+        assert p1.override_person_id == override_mapping
+
+        new_old_mapping = PersonOverrideMapping.objects.create(
+            team_id=new_team.id,
+            uuid=new_old_person_id,
+        )
+        new_override_mapping = PersonOverrideMapping.objects.create(
+            team_id=new_team.id,
+            uuid=old_mapping.uuid,
+        )
+
+        p2 = PersonOverride.objects.create(
+            team=new_team,
+            old_person_id=new_old_mapping,
+            override_person_id=new_override_mapping,
+            oldest_event=self.oldest_event,
+            version=1,
+        )
+        p2.save()
+
+        assert p1.old_person_id.uuid == p2.override_person_id.uuid
+        assert p1.old_person_id.team_id == p1.override_person_id.team_id
+        assert p2.old_person_id == new_old_mapping
+        assert p1.team != p2.team
+
+    def test_person_override_allows_duplicate_override_person_id(self):
+        """Test duplicate override_person_ids with different old_person_ids are allowed."""
+        override_person_id = uuid4()
+        n_person_overrides = 2
+        created = []
+
+        override_mapping = PersonOverrideMapping.objects.create(
+            team_id=self.team.id,
+            uuid=override_person_id,
+        )
+
+        for _ in range(n_person_overrides):
+            old_person_id = uuid4()
+            old_mapping = PersonOverrideMapping.objects.create(
+                team_id=self.team.id,
+                uuid=old_person_id,
+            )
+
+            person_override = PersonOverride.objects.create(
+                team=self.team,
+                old_person_id=old_mapping,
+                override_person_id=override_mapping,
+                oldest_event=self.oldest_event,
+                version=1,
+            )
+            person_override.save()
+
+            created.append(person_override)
+
+        assert all(p.override_person_id == override_mapping for p in created)
+        assert len(set(p.old_person_id.uuid for p in created)) == n_person_overrides
+
+    """
+    Concurrency tests for person overrides table
+    Goal: verify that we don't end up in a situation with the same uuid is both
+    an old person id and an override person id
+    - there are two cases that we want to check for
+        - concurrent merges
+        - concurrent merge and person deletion
+    In both cases one of the transactions will wait on the lock,
+    so they can only complete in one order (which is tested below).
+    Note that to test the race condition scenario we need to:
+        1. create multiple concurrent transactions, such that we can verify
+        constraints are enforced at COMMIT time.
+        2. enable transactions for the Django test. This is more so we can see data
+        from the main Django PostgreSQL connection session in the other
+        concurrent transactions. Not 100% required but makes things a little
+        easier to write.
+    """
+
+    # def test_person_override_merge(self, people, team, oldest_event):
+    def test_person_override_merge(self):
+        """Verify our merge function work as expected."""
+        old_person, override_person, _ = self.p1, self.p2, self.p3
+
+        with create_connection() as merge_cursor:
+            merge_cursor.execute("BEGIN")
+            _merge_people(self.team, merge_cursor, old_person.uuid, override_person.uuid, self.oldest_event)
+            merge_cursor.execute("COMMIT")
+
+        assert [_[0] for _ in PersonOverrideMapping.objects.all().values_list("uuid")] == [
+            old_person.uuid,
+            override_person.uuid,
+        ]
+
+        old_person_id = PersonOverrideMapping.objects.filter(uuid=old_person.uuid).all()[0].id
+        override_person_id = PersonOverrideMapping.objects.filter(uuid=override_person.uuid).all()[0].id
+
+        assert list(PersonOverride.objects.all().values_list("old_person_id", "override_person_id")) == [
+            (old_person_id, override_person_id)
+        ]
+
+    # def test_person_override_allow_consecutive_merges(self, people, team, oldest_event):
+    def test_person_override_allow_consecutive_merges(self):
+        """Verify our merge function works as expected when called consecutively."""
+        old_person, override_person, new_override_person = self.p1, self.p2, self.p3
+
+        with create_connection() as first_cursor:
+            first_cursor.execute("BEGIN")
+            _merge_people(self.team, first_cursor, old_person.uuid, override_person.uuid, self.oldest_event)
+            first_cursor.execute("COMMIT")
+
+        with create_connection() as second_cursor:
+            second_cursor.execute("BEGIN")
+            _merge_people(self.team, second_cursor, override_person.uuid, new_override_person.uuid, self.oldest_event)
+            second_cursor.execute("COMMIT")
+
+        assert [_[0] for _ in PersonOverrideMapping.objects.all().values_list("uuid")] == [
+            old_person.uuid,
+            override_person.uuid,
+            new_override_person.uuid,
+        ]
+
+        old_person_id = PersonOverrideMapping.objects.filter(uuid=old_person.uuid).all()[0].id
+        override_person_id = PersonOverrideMapping.objects.filter(uuid=override_person.uuid).all()[0].id
+        new_override_person_id = PersonOverrideMapping.objects.filter(uuid=new_override_person.uuid).all()[0].id
+
+        mappings = list(PersonOverride.objects.all().values_list("old_person_id", "override_person_id"))
+
+        assert sorted(mappings) == sorted(
+            [
+                (override_person_id, new_override_person_id),
+                (old_person_id, new_override_person_id),
+            ]
+        ), f"{mappings=} {old_person_id=}, {override_person_id=}, {new_override_person_id=}"
+
+    # def test_person_override_disallows_concurrent_merge(self, people, team, oldest_event):
+    def test_person_override_disallows_concurrent_merge(self):
+        """Test concurrent merges.
+
+        Running two merges:
+        A: old_person -> override_person
+        B: override_person -> new_override_person
+
+        Both merges are run in their own transactions, but for this test the B merge will be
+        committed first, before A has had a chance to lock the tables.
+
+        Then A should raise an exception, as it now violates an integrity constraint (trying to
+        use override_person_id that already exists as old_person_id)
+        """
+        old_person, override_person, new_override_person = self.p1, self.p2, self.p3
+
+        with create_connection() as first_cursor, create_connection() as second_cursor:
+            # each transaction gets a "copy" of the DB state
+            first_cursor.execute("BEGIN")
+            second_cursor.execute("BEGIN")
+
+            # Try to do the merges
+            # We need to use threads here otherwise we will timeout waiting for a lock, as when we are running in a single thread
+            # we cannot proceed while waiting.
+            # Spawning threads allows the main thread to continue and commit the transactions to release the locks.
+            # This allows us to control the order in which the transactions are committed, so that we can assert their
+            # behavior consistently.
+
+            can_lock_event = Event()
+            done_t1_event = Event()
+            done_t2_event = Event()
+            t1 = Thread(
+                target=_merge_people,
+                args=(self.team, first_cursor, old_person.uuid, override_person.uuid, self.oldest_event),
+                kwargs={"can_lock_event": can_lock_event, "done_event": done_t1_event},
+            )
+            t2 = Thread(
+                target=_merge_people,
+                args=(self.team, second_cursor, override_person.uuid, new_override_person.uuid, self.oldest_event),
+                kwargs={"done_event": done_t2_event},
+            )
+            t1.start()
+            t2.start()
+
+            # The main thread can now enforce the order of completion for these transactions.
+            # We expect the one finishing first to suceed, and the one finishing second to fail
+            done_t2_event.wait(10)
+            second_cursor.execute("COMMIT")
+
+            with pytest.raises(IntegrityError):
+                can_lock_event.set()
+                done_t1_event.wait(10)
+                first_cursor.execute("COMMIT")
+
+        assert [_[0] for _ in PersonOverrideMapping.objects.all().values_list("uuid")] == [
+            override_person.uuid,
+            new_override_person.uuid,
+        ]
+
+        override_person_id = PersonOverrideMapping.objects.filter(uuid=override_person.uuid).all()[0].id
+        new_override_person_id = PersonOverrideMapping.objects.filter(uuid=new_override_person.uuid).all()[0].id
+
+        assert list(PersonOverride.objects.all().values_list("old_person_id", "override_person_id")) == [
+            (override_person_id, new_override_person_id)
+        ]
+
+    # def test_person_override_disallows_concurrent_merge_different_order(self, people, team, oldest_event):
+    def test_person_override_disallows_concurrent_merge_different_order(self):
+        """Test concurrent merges but in a valid consecutive order.
+
+        Running two merges:
+        A: old_person -> override_person
+        B: override_person -> new_override_person
+
+        Both merges are run in their own transactions, and in this test the A merge will be
+        committed first, before B has had a chance to lock the tables.
+
+        Then both should succeed as these merges are compatible: B will simply update
+        override_person to new_override_person when it is allowed to run.
+        This is just the concurrent version of the test scenario from test_person_override_allow_consecutive_merges.
+        """
+        old_person, override_person, new_override_person = self.p1, self.p2, self.p3
+
+        with create_connection() as first_cursor, create_connection() as second_cursor:
+            first_cursor.execute("BEGIN")
+            second_cursor.execute("BEGIN")
+
+            can_lock_event = Event()
+            done_t1_event = Event()
+            done_t2_event = Event()
+            t1 = Thread(
+                target=_merge_people,
+                args=(self.team, first_cursor, old_person.uuid, override_person.uuid, self.oldest_event),
+                kwargs={"done_event": done_t1_event},
+            )
+            t2 = Thread(
+                target=_merge_people,
+                args=(self.team, second_cursor, override_person.uuid, new_override_person.uuid, self.oldest_event),
+                kwargs={"can_lock_event": can_lock_event, "done_event": done_t2_event},
+            )
+            t1.start()
+            t2.start()
+
+            # The main thread can now enforce the order of completion for these transactions.
+            done_t1_event.wait(10)
+            first_cursor.execute("COMMIT")
+
+            can_lock_event.set()
+            done_t2_event.wait(10)
+            second_cursor.execute("COMMIT")
+
+        # The main difference from the previous thread is we now expect all 3 UUIDs to be there.
+        assert [_[0] for _ in PersonOverrideMapping.objects.all().values_list("uuid")] == [
+            old_person.uuid,
+            override_person.uuid,
+            new_override_person.uuid,
+        ]
+
+        old_person_id = PersonOverrideMapping.objects.filter(uuid=old_person.uuid).all()[0].id
+        override_person_id = PersonOverrideMapping.objects.filter(uuid=override_person.uuid).all()[0].id
+        new_override_person_id = PersonOverrideMapping.objects.filter(uuid=new_override_person.uuid).all()[0].id
+
+        # And the merge of old_person_id to be updated to new_override_person_id
+        assert list(PersonOverride.objects.all().values_list("old_person_id", "override_person_id", "version")) == [
+            (override_person_id, new_override_person_id, 1),
+            (old_person_id, new_override_person_id, 2),
+        ]
 
 
 @contextlib.contextmanager
@@ -536,210 +724,3 @@ def _merge_people(
 
     if done_event is not None:
         done_event.set()
-
-
-"""
-Concurrency tests for person overrides table
-Goal: verify that we don't end up in a situation with the same uuid is both
-an old person id and an override person id
-- there are two cases that we want to check for
-    - concurrent merges
-    - concurrent merge and person deletion
-In both cases one of the transactions will wait on the lock,
-so they can only complete in one order (which is tested below).
-Note that to test the race condition scenario we need to:
-    1. create multiple concurrent transactions, such that we can verify
-    constraints are enforced at COMMIT time.
-    2. enable transactions for the Django test. This is more so we can see data
-    from the main Django PostgreSQL connection session in the other
-    concurrent transactions. Not 100% required but makes things a little
-    easier to write.
-"""
-
-
-@pytest.mark.django_db(transaction=True)
-def test_person_override_merge(people, team, oldest_event):
-    """Verify our merge function work as expected."""
-    old_person, override_person, _ = people
-
-    with create_connection() as merge_cursor:
-        merge_cursor.execute("BEGIN")
-        _merge_people(team, merge_cursor, old_person.uuid, override_person.uuid, oldest_event)
-        merge_cursor.execute("COMMIT")
-
-    assert [_[0] for _ in PersonOverrideMapping.objects.all().values_list("uuid")] == [
-        old_person.uuid,
-        override_person.uuid,
-    ]
-
-    old_person_id = PersonOverrideMapping.objects.filter(uuid=old_person.uuid).all()[0].id
-    override_person_id = PersonOverrideMapping.objects.filter(uuid=override_person.uuid).all()[0].id
-
-    assert list(PersonOverride.objects.all().values_list("old_person_id", "override_person_id")) == [
-        (old_person_id, override_person_id)
-    ]
-
-
-@pytest.mark.django_db(transaction=True)
-def test_person_override_allow_consecutive_merges(people, team, oldest_event):
-    """Verify our merge function works as expected when called consecutively."""
-    old_person, override_person, new_override_person = people
-
-    with create_connection() as first_cursor:
-        first_cursor.execute("BEGIN")
-        _merge_people(team, first_cursor, old_person.uuid, override_person.uuid, oldest_event)
-        first_cursor.execute("COMMIT")
-
-    with create_connection() as second_cursor:
-        second_cursor.execute("BEGIN")
-        _merge_people(team, second_cursor, override_person.uuid, new_override_person.uuid, oldest_event)
-        second_cursor.execute("COMMIT")
-
-    assert [_[0] for _ in PersonOverrideMapping.objects.all().values_list("uuid")] == [
-        old_person.uuid,
-        override_person.uuid,
-        new_override_person.uuid,
-    ]
-
-    old_person_id = PersonOverrideMapping.objects.filter(uuid=old_person.uuid).all()[0].id
-    override_person_id = PersonOverrideMapping.objects.filter(uuid=override_person.uuid).all()[0].id
-    new_override_person_id = PersonOverrideMapping.objects.filter(uuid=new_override_person.uuid).all()[0].id
-
-    mappings = list(PersonOverride.objects.all().values_list("old_person_id", "override_person_id"))
-
-    assert sorted(mappings) == sorted(
-        [
-            (override_person_id, new_override_person_id),
-            (old_person_id, new_override_person_id),
-        ]
-    ), f"{mappings=} {old_person_id=}, {override_person_id=}, {new_override_person_id=}"
-
-
-@pytest.mark.django_db(transaction=True)
-def test_person_override_disallows_concurrent_merge(people, team, oldest_event):
-    """Test concurrent merges.
-
-    Running two merges:
-    A: old_person -> override_person
-    B: override_person -> new_override_person
-
-    Both merges are run in their own transactions, but for this test the B merge will be
-    committed first, before A has had a chance to lock the tables.
-
-    Then A should raise an exception, as it now violates an integrity constraint (trying to
-    use override_person_id that already exists as old_person_id)
-    """
-    old_person, override_person, new_override_person = people
-
-    with create_connection() as first_cursor, create_connection() as second_cursor:
-        # each transaction gets a "copy" of the DB state
-        first_cursor.execute("BEGIN")
-        second_cursor.execute("BEGIN")
-
-        # Try to do the merges
-        # We need to use threads here otherwise we will timeout waiting for a lock, as when we are running in a single thread
-        # we cannot proceed while waiting.
-        # Spawning threads allows the main thread to continue and commit the transactions to release the locks.
-        # This allows us to control the order in which the transactions are committed, so that we can assert their
-        # behavior consistently.
-
-        can_lock_event = Event()
-        done_t1_event = Event()
-        done_t2_event = Event()
-        t1 = Thread(
-            target=_merge_people,
-            args=(team, first_cursor, old_person.uuid, override_person.uuid, oldest_event),
-            kwargs={"can_lock_event": can_lock_event, "done_event": done_t1_event},
-        )
-        t2 = Thread(
-            target=_merge_people,
-            args=(team, second_cursor, override_person.uuid, new_override_person.uuid, oldest_event),
-            kwargs={"done_event": done_t2_event},
-        )
-        t1.start()
-        t2.start()
-
-        # The main thread can now enforce the order of completion for these transactions.
-        # We expect the one finishing first to suceed, and the one finishing second to fail
-        done_t2_event.wait(10)
-        second_cursor.execute("COMMIT")
-
-        with pytest.raises(IntegrityError):
-            can_lock_event.set()
-            done_t1_event.wait(10)
-            first_cursor.execute("COMMIT")
-
-    assert [_[0] for _ in PersonOverrideMapping.objects.all().values_list("uuid")] == [
-        override_person.uuid,
-        new_override_person.uuid,
-    ]
-
-    override_person_id = PersonOverrideMapping.objects.filter(uuid=override_person.uuid).all()[0].id
-    new_override_person_id = PersonOverrideMapping.objects.filter(uuid=new_override_person.uuid).all()[0].id
-
-    assert list(PersonOverride.objects.all().values_list("old_person_id", "override_person_id")) == [
-        (override_person_id, new_override_person_id)
-    ]
-
-
-@pytest.mark.django_db(transaction=True)
-def test_person_override_disallows_concurrent_merge_different_order(people, team, oldest_event):
-    """Test concurrent merges but in a valid consecutive order.
-
-    Running two merges:
-    A: old_person -> override_person
-    B: override_person -> new_override_person
-
-    Both merges are run in their own transactions, and in this test the A merge will be
-    committed first, before B has had a chance to lock the tables.
-
-    Then both should succeed as these merges are compatible: B will simply update
-    override_person to new_override_person when it is allowed to run.
-    This is just the concurrent version of the test scenario from test_person_override_allow_consecutive_merges.
-    """
-    old_person, override_person, new_override_person = people
-
-    with create_connection() as first_cursor, create_connection() as second_cursor:
-        first_cursor.execute("BEGIN")
-        second_cursor.execute("BEGIN")
-
-        can_lock_event = Event()
-        done_t1_event = Event()
-        done_t2_event = Event()
-        t1 = Thread(
-            target=_merge_people,
-            args=(team, first_cursor, old_person.uuid, override_person.uuid, oldest_event),
-            kwargs={"done_event": done_t1_event},
-        )
-        t2 = Thread(
-            target=_merge_people,
-            args=(team, second_cursor, override_person.uuid, new_override_person.uuid, oldest_event),
-            kwargs={"can_lock_event": can_lock_event, "done_event": done_t2_event},
-        )
-        t1.start()
-        t2.start()
-
-        # The main thread can now enforce the order of completion for these transactions.
-        done_t1_event.wait(10)
-        first_cursor.execute("COMMIT")
-
-        can_lock_event.set()
-        done_t2_event.wait(10)
-        second_cursor.execute("COMMIT")
-
-    # The main difference from the previous thread is we now expect all 3 UUIDs to be there.
-    assert [_[0] for _ in PersonOverrideMapping.objects.all().values_list("uuid")] == [
-        old_person.uuid,
-        override_person.uuid,
-        new_override_person.uuid,
-    ]
-
-    old_person_id = PersonOverrideMapping.objects.filter(uuid=old_person.uuid).all()[0].id
-    override_person_id = PersonOverrideMapping.objects.filter(uuid=override_person.uuid).all()[0].id
-    new_override_person_id = PersonOverrideMapping.objects.filter(uuid=new_override_person.uuid).all()[0].id
-
-    # And the merge of old_person_id to be updated to new_override_person_id
-    assert list(PersonOverride.objects.all().values_list("old_person_id", "override_person_id", "version")) == [
-        (override_person_id, new_override_person_id, 1),
-        (old_person_id, new_override_person_id, 2),
-    ]

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -97,7 +97,6 @@ class FuzzyInt(int):
 
 
 class ErrorResponsesMixin:
-
     ERROR_INVALID_CREDENTIALS = {
         "type": "validation_error",
         "code": "invalid_credentials",
@@ -158,7 +157,6 @@ class TestMixin:
             _setup_test_data(cls)
 
     def setUp(self):
-
         if get_instance_setting("PERSON_ON_EVENTS_ENABLED"):
             from posthog.models.team import util
 
@@ -168,7 +166,6 @@ class TestMixin:
             _setup_test_data(self)
 
     def tearDown(self):
-
         if len(persons_cache_tests) > 0:
             persons_cache_tests.clear()
             raise Exception(
@@ -232,7 +229,6 @@ class APIBaseTest(TestMixin, ErrorResponsesMixin, DRFTestCase):
     initial_cloud_mode: Optional[bool] = False
 
     def setUp(self):
-
         super().setUp()
 
         TEST_clear_cloud_cache(self.initial_cloud_mode)
@@ -912,3 +908,18 @@ def create_person_id_override_by_distinct_id(
         VALUES ({team_id}, '{person_id_from}', '{person_id_to}', {version})
     """
     )
+
+
+def class_not_available(class_name):
+    """
+    Returns True if the class is not available, False otherwise.
+
+    Example usage:
+    @pytest.mark.skipif(not_available("ee.pkg.someclass", reason="ee module is not available")
+    @patch("ee.pkg.someclass")
+    """
+    try:
+        __import__(class_name)
+        return False
+    except ImportError:
+        return True

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -29,7 +29,6 @@ from posthog.test.base import BaseTest, QueryMatchingTest, snapshot_postgres_que
 
 
 class TestFeatureFlagCohortExpansion(BaseTest):
-
     maxDiff = None
 
     def test_cohort_expansion(self):
@@ -2381,7 +2380,6 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
 
     @patch("posthog.models.feature_flag.flag_matching.postgres_healthcheck")
     def test_invalid_filters_dont_set_db_down(self, mock_database_healthcheck):
-
         cohort = Cohort.objects.create(
             team=self.team,
             filters={
@@ -2627,7 +2625,6 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
 
 
 class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
-
     person: Person
 
     @classmethod
@@ -2671,7 +2668,6 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
         )
 
     def test_setting_overrides(self):
-
         set_feature_flag_hash_key_overrides(
             team_id=self.team.pk, distinct_ids=self.person.distinct_ids, hash_key_override="other_id"
         )
@@ -2685,7 +2681,6 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
             self.assertEqual({var[0] for var in res}, {"other_id"})
 
     def test_retrieving_hash_key_overrides(self):
-
         set_feature_flag_hash_key_overrides(
             team_id=self.team.pk, distinct_ids=self.person.distinct_ids, hash_key_override="other_id"
         )
@@ -2695,7 +2690,6 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
         self.assertEqual(hash_keys, {"beta-feature": "other_id", "multivariate-flag": "other_id"})
 
     def test_hash_key_overrides_for_multiple_ids_when_people_are_not_merged(self):
-
         Person.objects.create(
             team=self.team, distinct_ids=["1"], properties={"email": "beuk@posthog.com", "team": "posthog"}
         )
@@ -2712,7 +2706,6 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
         self.assertEqual(hash_keys, {"beta-feature": "other_id1", "multivariate-flag": "other_id1"})
 
     def test_setting_overrides_doesnt_balk_with_existing_overrides(self):
-
         all_feature_flags = list(FeatureFlag.objects.filter(team_id=self.team.pk))
 
         # existing overrides
@@ -2740,7 +2733,6 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
             self.assertEqual({var[0] for var in res}, {hash_key})
 
     def test_setting_overrides_when_persons_dont_exist(self):
-
         set_feature_flag_hash_key_overrides(
             team_id=self.team.pk, distinct_ids=["1", "2", "3", "4"], hash_key_override="other_id"
         )
@@ -2786,6 +2778,8 @@ class TestFeatureFlagHashKeyOverrides(BaseTest, QueryMatchingTest):
 
 
 class TestHashKeyOverridesRaceConditions(TransactionTestCase, QueryMatchingTest):
+    available_apps = ["posthog"]
+
     def setUp(self) -> None:
         postgres_healthcheck.set_connection(True)
         return super().setUp()

--- a/posthog/test/test_latest_migrations.py
+++ b/posthog/test/test_latest_migrations.py
@@ -2,6 +2,7 @@ import glob
 import os
 import pathlib
 from unittest import TestCase
+import pytest
 
 
 class TestLatestMigrations(TestCase):
@@ -21,11 +22,15 @@ class TestLatestMigrations(TestCase):
     def test_ee_migrations_is_in_sync_with_latest(self):
         latest_manifest_migration = self._get_latest_migration_from_manifest("ee")
         latest_migration_file = self._get_newest_migration_file(f"{pathlib.Path().resolve()}/ee/migrations/*")
+        if not latest_migration_file:
+            pytest.skip("ee migrations not found")
         self.assertEqual(latest_manifest_migration, latest_migration_file)
 
     @staticmethod
     def _get_newest_migration_file(path: str) -> str:
         migrations = [file for file in glob.glob(path) if file.endswith(".py") and not file.endswith("__init__.py")]
+        if not migrations:
+            return None
         latest_file = max(sorted(migrations))
         return os.path.basename(latest_file).replace(".py", "")
 


### PR DESCRIPTION
## Problem

Fix errors reported by pytest after deleting ee directory. 
(Part of work on https://github.com/PostHog/posthog/issues/16397)

This PR was based on a branch where ee dir has already been deleted for testing purposes. 

## Changes

Errors in teardown due to running TRUNCATE TABLE on a table with foreign key constraints were solved by setting     available_apps = ["posthog"] in TransactionTestCase.  This allows teardown logic to use TRUNCATE ... CASCADE.

Tests which used @pytest.mark.django_db(transaction=True) were migrated into a TransactionTestCase in order to do this. 

Errors caused by ee module not being available were solved by skipping the test if ImportError is thrown when importing from ee.*

Errors caused by attempting to drop posthog_test when it was not available were solved by adding "IF EXISTS" to the "DROP DATABASE" statement.  

## How did you test this code?

By running pytest and verifying that all errors were resolved.  (Failures still remain)  Log is attached.  Summary:
=========== 67 failed, 2555 passed, 27 skipped in 1698.93s (0:28:18) ===========

[20230720-180425-pytest.log](https://github.com/PostHog/posthog/files/12113268/20230720-180425-pytest.log)

