### PR TITLE
fix: Retry on ValueError raised by Snowflake

### DIFF
--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -237,7 +237,15 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs):
                         # Mostly to appease mypy, as this query should always return a tuple.
                         raise TypeError(f"Expected tuple from Snowflake COPY INTO query but got: '{type(result)}'")
 
-                    file_name, status = result[0:2]
+                    if len(result) < 2:
+                        raise SnowflakeFileNotLoadedError(
+                            inputs.table_name,
+                            "NO STATUS",
+                            0,
+                            result[1] if len(result) == 1 else "NO ERROR MESSAGE",
+                        )
+
+                    _, status = result[0:2]
 
                     if status != "LOADED":
                         errors_seen, first_error = result[5:7]


### PR DESCRIPTION
## Problem

The output of the `COPY` Snowflake query sometimes returns one value. This causes a `ValueError` we don't retry on. Let's raise a `SnowflakeFileNotLoadedError` which will trigger a retry instead.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Attempt to pass the only value returned as an error message, just to see what's there.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
