### PR TITLE
fix: Check for events_summary

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v1.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v1.ts
@@ -281,13 +281,13 @@ const eachMessage =
                         const properties = event.properties || {}
                         const shouldCreateReplayEvents = (properties['$snapshot_consumer'] ?? 'v1') === 'v1'
 
-                        if (shouldCreateReplayEvents && properties.$snapshot_data?.events_summary.length) {
+                        if (shouldCreateReplayEvents && properties.$snapshot_data?.events_summary?.length) {
                             replayRecord = createSessionReplayEvent(
                                 messagePayload.uuid,
                                 team.id,
                                 messagePayload.distinct_id,
                                 properties['$session_id'],
-                                properties.$snapshot_data?.events_summary || []
+                                properties.$snapshot_data.events_summary || []
                             )
                         }
                         // the replay record timestamp has to be valid and be within a reasonable diff from now

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v1.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v1.ts
@@ -280,14 +280,15 @@ const eachMessage =
                     try {
                         const properties = event.properties || {}
                         const shouldCreateReplayEvents = (properties['$snapshot_consumer'] ?? 'v1') === 'v1'
+                        const eventsSummary: any[] = properties.$snapshot_data?.events_summary || []
 
-                        if (shouldCreateReplayEvents && properties.$snapshot_data?.events_summary?.length) {
+                        if (shouldCreateReplayEvents && eventsSummary.length) {
                             replayRecord = createSessionReplayEvent(
                                 messagePayload.uuid,
                                 team.id,
                                 messagePayload.distinct_id,
                                 properties['$session_id'],
-                                properties.$snapshot_data.events_summary || []
+                                eventsSummary
                             )
                         }
                         // the replay record timestamp has to be valid and be within a reasonable diff from now


### PR DESCRIPTION
## Problem

[Related issue](https://posthog.sentry.io/issues/4330255923/?query=is%3Aunresolved+PLUGIN_SERVER_MODE%3Arecordings-ingestion&referrer=issue-stream&statsPeriod=14d&stream_index=0)

## Changes

* Make sure we are handling if the events_summary is null (primarily happening in a chunked message)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
