### PR TITLE
feat: Reduce the amount of network requests in "auto" mode

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -490,6 +490,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                         }
 
                         const responseStatus = item.data.response_status || 200
+                        const responseTime = item.data.duration || 0
 
                         if (
                             miniFiltersByKey['performance-all']?.enabled ||
@@ -505,8 +506,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                             include = true
                         }
                         if (
-                            (miniFiltersByKey['performance-fetch']?.enabled ||
-                                miniFiltersByKey['all-automatic']?.enabled) &&
+                            miniFiltersByKey['performance-fetch']?.enabled &&
                             item.data.entry_type === 'resource' &&
                             ['fetch', 'xmlhttprequest'].includes(item.data.initiator_type || '')
                         ) {
@@ -556,6 +556,10 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                             (miniFiltersByKey['all-errors']?.enabled || miniFiltersByKey['all-automatic']?.enabled) &&
                             responseStatus >= 400
                         ) {
+                            include = true
+                        }
+
+                        if (miniFiltersByKey['all-automatic']?.enabled && responseTime >= 1000) {
                             include = true
                         }
 


### PR DESCRIPTION
## Problem

I keep noticing that the "auto" tab is very noisy if you have network events. 

## Changes

* Only show page load network events or network events longer than 1 second or with an error status

|Before|After|
|----|----|
| <img width="417" alt="Screenshot 2023-07-21 at 12 40 54" src="https://github.com/PostHog/posthog/assets/2536520/d8c8229b-3214-4c81-988e-22d3d9372c00"> | <img width="397" alt="Screenshot 2023-07-21 at 12 40 15" src="https://github.com/PostHog/posthog/assets/2536520/0556b3e0-ec5f-499c-9bf8-94d6e9f2ca74"> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 