### PR TITLE
fix: Don't log if we drop due to purposefully no consuming

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
@@ -100,7 +100,13 @@ export class ReplayEventsIngester {
         }
 
         if (event.replayIngestionConsumer !== 'v2') {
-            return drop('invalid_event_type')
+            eventDroppedCounter
+                .labels({
+                    event_type: 'session_recordings_replay_events',
+                    drop_cause: 'not_target_consumer',
+                })
+                .inc()
+            return
         }
 
         if (


### PR DESCRIPTION
## Problem

We're consuming again! But we're logging way too much.

## Changes

* Counts but doesn't log dropped events due to not being the target consumer

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
