### PR TITLE
fix: Stop the drain check to see if that is the issue

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
@@ -155,6 +155,7 @@ export class SessionManager {
         })
     }
 
+    // eslint-disable-next-line @typescript-eslint/require-await
     public async add(message: IncomingRecordingMessage): Promise<void> {
         if (this.destroying) {
             return
@@ -188,7 +189,8 @@ export class SessionManager {
             // NOTE: If write returns false we are supposed to wait for drain
             if (!this.buffer.fileStream.write(content)) {
                 writeStreamBlocked.inc()
-                await new Promise((r) => this.buffer.fileStream.once('drain', r))
+                // NOTE: We aren't doing this yet as it doesn't seem to work
+                // await new Promise((r) => this.buffer.fileStream.once('drain', r))
             }
         } catch (error) {
             this.captureException(error, { message })

--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/session-manager.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/session-manager.test.ts
@@ -331,11 +331,11 @@ describe('session-manager', () => {
         }
     })
 
-    it('waits for the drain if write returns false', async () => {
-        await sessionManager.add(createIncomingRecordingMessage())
-        ;(sessionManager.buffer.fileStream.write as jest.Mock).mockReturnValueOnce(false)
-        await sessionManager.add(createIncomingRecordingMessage())
+    // it('waits for the drain if write returns false', async () => {
+    //     await sessionManager.add(createIncomingRecordingMessage())
+    //     ;(sessionManager.buffer.fileStream.write as jest.Mock).mockReturnValueOnce(false)
+    //     await sessionManager.add(createIncomingRecordingMessage())
 
-        expect(sessionManager.buffer.fileStream.once).toHaveBeenCalledWith('drain', expect.any(Function))
-    })
+    //     expect(sessionManager.buffer.fileStream.once).toHaveBeenCalledWith('drain', expect.any(Function))
+    // })
 })


### PR DESCRIPTION
## Problem

The write backpressure handling seems to basically kill the service.

## Changes

* For now we just comment it out to see if it is definitely the issue and track that we _would_ have blocked.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
