### PR TITLE
chore(ingestion): fix backfills with anon IDs

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -19,6 +19,7 @@ const MAX_FAILED_PERSON_MERGE_ATTEMPTS = 3
 // that we can safely assume stem from a bug or mistake
 const CASE_INSENSITIVE_ILLEGAL_IDS = new Set([
     'anonymous',
+    'backend',
     'guest',
     'distinctid',
     'distinct_id',

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -98,6 +98,7 @@ LIKELY_ANONYMOUS_IDS = {
     "anon_id",
     "anonymous",
     "anonymous_id",
+    "backend",
     "distinct_id",
     "distinctid",
     "email",


### PR DESCRIPTION
## Problem

Messages sent with `distinct_id:backend` should not benefit from our locality guarantees, to avoid overwhelming a single partition 

## Changes

- Add to capture's `LIKELY_ANONYMOUS_IDS` to remove the locality constraint
- Add to `CASE_INSENSITIVE_ILLEGAL_IDS` to forbid merges to that ID
- Change the capture logic to override the partition key for `LIKELY_ANONYMOUS_IDS`, even during backfills

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
