### PR TITLE
fix: use latest pnpm version (plugin-server)

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -4,7 +4,7 @@
     "description": "PostHog Plugin Server",
     "types": "dist/index.d.ts",
     "main": "dist/index.js",
-    "packageManager": "pnpm@8.3.1",
+    "packageManager": "pnpm@8.6.0",
     "scripts": {
         "test": "jest --runInBand --forceExit",
         "functional_tests": "jest --config ./jest.config.functional.js",

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 patchedDependencies:
   pg@8.10.0:


### PR DESCRIPTION
## Problem

Setup the product for the first time is broken. Running `pnpm i --dir plugin-server` is upgrading the lockfile version to v6.1 which breaks the build of the plugin-server

## Changes

This PR upgrades pnpm to the latest version, compatible with lockfile version 6.1

## How did you test this code?

The build now works without issues in the lock file. Also this verification now passes :)

<img width="404" alt="Screenshot 2023-07-22 at 17 42 41" src="https://github.com/PostHog/posthog/assets/326949/746e4852-836a-48fc-bf23-ab715d180da4">

