### PR TITLE
chore(dev): Enable React strict mode

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,5 +1,6 @@
 import '~/styles'
 
+import { StrictMode } from 'react'
 import ReactDOM from 'react-dom'
 import { getContext } from 'kea'
 
@@ -29,11 +30,13 @@ function renderApp(): void {
     const root = document.getElementById('root')
     if (root) {
         ReactDOM.render(
-            <ErrorBoundary>
-                <PostHogProvider client={posthog}>
-                    <App />
-                </PostHogProvider>
-            </ErrorBoundary>,
+            <StrictMode>
+                <ErrorBoundary>
+                    <PostHogProvider client={posthog}>
+                        <App />
+                    </PostHogProvider>
+                </ErrorBoundary>
+            </StrictMode>,
             root
         )
     } else {


### PR DESCRIPTION
## Changes

Enabling React strict mode (development-only), which has the potential of highlighting issues arising from components being non-pure functions. Didn't notice a problem from clicking around, which is good, but this is a standard measure these days.