### PR TITLE
revert(insights): fix test account filter changes

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -329,7 +329,7 @@ export const insightLogic = kea<insightLogicType>([
         filters: [
             () => props.cachedInsight?.filters || ({} as Partial<FilterType>),
             {
-                setFilters: (_, { filters }) => cleanFilters(filters),
+                setFilters: (state, { filters }) => cleanFilters(filters, state),
                 setInsight: (state, { insight: { filters }, options: { overrideFilter } }) =>
                     overrideFilter ? cleanFilters(filters || {}) : state,
                 loadInsightSuccess: (state, { insight }) =>

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -189,7 +189,9 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                     values.insightLogicRef?.logic.actions.setInsight(
                         {
                             ...createEmptyInsight('new', teamFilterTestAccounts),
-                            ...(filters ? { filters: cleanFilters(filters || {}, teamFilterTestAccounts) } : {}),
+                            ...(filters
+                                ? { filters: cleanFilters(filters || {}, undefined, teamFilterTestAccounts) }
+                                : {}),
                             ...(dashboard ? { dashboards: [dashboard] } : {}),
                             ...(q ? { query: JSON.parse(q) } : {}),
                         },

--- a/frontend/src/scenes/insights/utils/cleanFilters.test.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.test.ts
@@ -11,19 +11,28 @@ import {
 import { NON_VALUES_ON_SERIES_DISPLAY_TYPES, ShownAsValue } from 'lib/constants'
 
 describe('cleanFilters', () => {
-    it('removes shownas from trends insights', () => {
-        expect(cleanFilters({ insight: InsightType.TRENDS, shown_as: ShownAsValue.STICKINESS })).toEqual(
-            expect.objectContaining({ insight: InsightType.TRENDS, shown_as: undefined })
-        )
+    it('removes shownas if moving from stickiness to trends', () => {
+        expect(
+            cleanFilters(
+                { insight: InsightType.TRENDS, shown_as: ShownAsValue.STICKINESS },
+                { insight: InsightType.STICKINESS, shown_as: ShownAsValue.STICKINESS }
+            )
+        ).toEqual(expect.objectContaining({ insight: InsightType.TRENDS, shown_as: undefined }))
     })
 
-    it('removes breakdown when it also has breakdowns', () => {
-        const cleanedFilters = cleanFilters({
-            breakdown: '$browser',
-            breakdowns: [{ property: '$browser', type: 'event' }],
-            insight: InsightType.FUNNELS,
-            funnel_viz_type: FunnelVizType.Steps,
-        } as FunnelsFilterType)
+    it('removes breakdown when adding breakdowns', () => {
+        const cleanedFilters = cleanFilters(
+            {
+                breakdowns: [{ property: '$browser', type: 'event' }],
+                insight: InsightType.FUNNELS,
+                funnel_viz_type: FunnelVizType.Steps,
+            } as FunnelsFilterType,
+            {
+                breakdown: '$browser',
+                insight: InsightType.FUNNELS,
+                funnel_viz_type: FunnelVizType.Steps,
+            } as FunnelsFilterType
+        )
 
         expect(cleanedFilters).toHaveProperty('breakdown', undefined)
 
@@ -32,81 +41,108 @@ describe('cleanFilters', () => {
         )
     })
 
-    it('allows breakdown_type with breakdown', () => {
-        const cleanedFilters = cleanFilters({
-            breakdown: '$thing',
-            breakdown_type: 'event',
-            insight: InsightType.FUNNELS,
-            funnel_viz_type: FunnelVizType.Steps,
-        } as FunnelsFilterType)
+    it('adds breakdown_type when adding breakdown', () => {
+        const cleanedFilters = cleanFilters(
+            {
+                breakdown: '$thing',
+                breakdown_type: 'event',
+                insight: InsightType.FUNNELS,
+                funnel_viz_type: FunnelVizType.Steps,
+            } as FunnelsFilterType,
+            { insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps } as FunnelsFilterType
+        )
 
         expect(cleanedFilters).toHaveProperty('breakdown', '$thing')
         expect(cleanedFilters).toHaveProperty('breakdown_type', 'event')
     })
 
-    it('allows breakdown_type when adding breakdowns', () => {
-        const cleanedFilters = cleanFilters({
-            breakdowns: [{ property: '$browser', type: 'event' }],
-            breakdown_type: 'event',
-            insight: InsightType.FUNNELS,
-            funnel_viz_type: FunnelVizType.Steps,
-        } as FunnelsFilterType)
+    it('adds breakdown_type when adding breakdowns', () => {
+        const cleanedFilters = cleanFilters(
+            {
+                breakdowns: [{ property: '$browser', type: 'event' }],
+                breakdown_type: 'event',
+                insight: InsightType.FUNNELS,
+                funnel_viz_type: FunnelVizType.Steps,
+            } as FunnelsFilterType,
+            { insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps } as FunnelsFilterType
+        )
 
         expect(cleanedFilters).toHaveProperty('breakdowns', [{ property: '$browser', type: 'event' }])
         expect(cleanedFilters).toHaveProperty('breakdown_type', 'event')
     })
 
     it('defaults to normalizing URL for breakdowns by $current_url', () => {
-        const cleanedFilters = cleanFilters({
-            breakdowns: [{ property: '$current_url', type: 'event' }],
-            breakdown_type: 'event',
-        } as TrendsFilterType)
+        const cleanedFilters = cleanFilters(
+            {
+                breakdowns: [{ property: '$current_url', type: 'event' }],
+                breakdown_type: 'event',
+            } as TrendsFilterType,
+            { insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps } as FunnelsFilterType
+        )
 
         expect(cleanedFilters).toHaveProperty('breakdown_normalize_url', true)
     })
 
     it('defaults to normalizing URL for breakdown by $current_url', () => {
-        const cleanedFilters = cleanFilters({
-            breakdown: '$current_url',
-            breakdown_type: 'event',
-        } as TrendsFilterType)
+        const cleanedFilters = cleanFilters(
+            {
+                breakdown: '$current_url',
+                breakdown_type: 'event',
+            } as TrendsFilterType,
+            { insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps } as FunnelsFilterType
+        )
 
         expect(cleanedFilters).toHaveProperty('breakdown_normalize_url', true)
     })
 
     it('defaults to normalizing URL for breakdowns by $pathname', () => {
-        const cleanedFilters = cleanFilters({
-            breakdowns: [{ property: '$pathname', type: 'event' }],
-            breakdown_type: 'event',
-        } as TrendsFilterType)
+        const cleanedFilters = cleanFilters(
+            {
+                breakdowns: [{ property: '$pathname', type: 'event' }],
+                breakdown_type: 'event',
+            } as TrendsFilterType,
+            { insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps } as FunnelsFilterType
+        )
 
         expect(cleanedFilters).toHaveProperty('breakdown_normalize_url', true)
     })
 
     it('defaults to normalizing URL for breakdown by $pathname', () => {
-        const cleanedFilters = cleanFilters({
-            breakdown: '$pathname',
-            breakdown_type: 'event',
-        } as TrendsFilterType)
+        const cleanedFilters = cleanFilters(
+            {
+                breakdown: '$pathname',
+                breakdown_type: 'event',
+            } as TrendsFilterType,
+            { insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps } as FunnelsFilterType
+        )
 
         expect(cleanedFilters).toHaveProperty('breakdown_normalize_url', true)
     })
 
     it('can set normalizing URL for breakdown to false', () => {
-        const cleanedFilters = cleanFilters({
-            breakdown: '$current_url',
-            breakdown_type: 'event',
-            breakdown_normalize_url: false,
-        } as TrendsFilterType)
+        const cleanedFilters = cleanFilters(
+            {
+                breakdown: '$current_url',
+                breakdown_type: 'event',
+                breakdown_normalize_url: false,
+            } as TrendsFilterType,
+            { insight: InsightType.FUNNELS, funnel_viz_type: FunnelVizType.Steps } as FunnelsFilterType
+        )
 
         expect(cleanedFilters).toHaveProperty('breakdown_normalize_url', false)
     })
 
     it('removes normalizing URL for breakdown by other properties', () => {
-        const cleanedFilters = cleanFilters({
-            breakdowns: [{ property: '$pageview', type: 'event' }],
-            breakdown_type: 'event',
-        } as TrendsFilterType)
+        const cleanedFilters = cleanFilters(
+            {
+                breakdowns: [{ property: '$pageview', type: 'event' }],
+                breakdown_type: 'event',
+            } as TrendsFilterType,
+            {
+                breakdowns: [{ property: '$pathname', type: 'event', normalize_url: true }],
+                breakdown_type: 'event',
+            } as TrendsFilterType
+        )
 
         expect(cleanedFilters).toHaveProperty('breakdown_normalize_url', undefined)
     })
@@ -141,11 +177,19 @@ describe('cleanFilters', () => {
     })
 
     it('removes empty breakdowns array', () => {
-        const cleanedFilters = cleanFilters({
-            breakdowns: [],
-            insight: InsightType.FUNNELS,
-            funnel_viz_type: FunnelVizType.Steps,
-        } as FunnelsFilterType)
+        const cleanedFilters = cleanFilters(
+            {
+                breakdowns: [],
+                insight: InsightType.FUNNELS,
+                funnel_viz_type: FunnelVizType.Steps,
+            } as FunnelsFilterType,
+            {
+                breakdowns: [{ property: 'something', type: 'event' }],
+                breakdown_type: 'event',
+                insight: InsightType.FUNNELS,
+                funnel_viz_type: FunnelVizType.Steps,
+            } as FunnelsFilterType
+        )
 
         expect(cleanedFilters).toHaveProperty('breakdowns', undefined)
         expect(cleanedFilters).toHaveProperty('breakdown', undefined)
@@ -153,14 +197,22 @@ describe('cleanFilters', () => {
     })
 
     it('does not include breakdown properties if funnel is not type steps', () => {
-        const cleanedFilters = cleanFilters({
-            breakdowns: [{ property: 'any', type: 'event' }],
-            breakdown: 'something',
-            breakdown_type: 'event',
-            breakdown_group_type_index: 1,
-            insight: InsightType.FUNNELS,
-            funnel_viz_type: FunnelVizType.Trends,
-        } as FunnelsFilterType)
+        const cleanedFilters = cleanFilters(
+            {
+                breakdowns: [{ property: 'any', type: 'event' }],
+                breakdown: 'something',
+                breakdown_type: 'event',
+                breakdown_group_type_index: 1,
+                insight: InsightType.FUNNELS,
+                funnel_viz_type: FunnelVizType.Trends,
+            } as FunnelsFilterType,
+            {
+                breakdowns: [{ property: 'something', type: 'event' }],
+                breakdown_type: 'event',
+                insight: InsightType.FUNNELS,
+                funnel_viz_type: FunnelVizType.Steps,
+            } as FunnelsFilterType
+        )
 
         expect(cleanedFilters).toHaveProperty('breakdowns', undefined)
         expect(cleanedFilters).toHaveProperty('breakdown', undefined)
@@ -168,12 +220,20 @@ describe('cleanFilters', () => {
         expect(cleanedFilters).toHaveProperty('breakdown_group_type_index', undefined)
     })
 
-    it('keeps single property filters for trends', () => {
-        const cleanedFilters = cleanFilters({
-            breakdown: 'one thing',
-            breakdown_type: 'event',
-            insight: InsightType.TRENDS,
-        })
+    it('keeps single property filters switching to trends', () => {
+        const cleanedFilters = cleanFilters(
+            {
+                breakdown: 'one thing',
+                breakdown_type: 'event',
+                insight: InsightType.TRENDS,
+            },
+            {
+                breakdown: 'one thing',
+                breakdown_type: 'event',
+                insight: InsightType.FUNNELS,
+                funnel_viz_type: FunnelVizType.Steps,
+            } as FunnelsFilterType
+        )
 
         expect(cleanedFilters).toHaveProperty('breakdowns', undefined)
         expect(cleanedFilters).toHaveProperty('breakdown', 'one thing')
@@ -181,13 +241,20 @@ describe('cleanFilters', () => {
         expect(cleanedFilters).toHaveProperty('breakdown_group_type_index', undefined)
     })
 
-    it('keeps single property filters for funnels', () => {
-        const cleanedFilters = cleanFilters({
-            breakdown: 'one thing',
-            breakdown_type: 'event',
-            insight: InsightType.FUNNELS,
-            funnel_viz_type: FunnelVizType.Steps,
-        } as FunnelsFilterType)
+    it('keeps single property filters when switching to funnels', () => {
+        const cleanedFilters = cleanFilters(
+            {
+                breakdown: 'one thing',
+                breakdown_type: 'event',
+                insight: InsightType.FUNNELS,
+                funnel_viz_type: FunnelVizType.Steps,
+            } as FunnelsFilterType,
+            {
+                breakdown: 'one thing',
+                breakdown_type: 'event',
+                insight: InsightType.TRENDS,
+            }
+        )
 
         expect(cleanedFilters).toHaveProperty('breakdowns', undefined)
         expect(cleanedFilters).toHaveProperty('breakdown', 'one thing')
@@ -195,15 +262,26 @@ describe('cleanFilters', () => {
         expect(cleanedFilters).toHaveProperty('breakdown_group_type_index', undefined)
     })
 
-    it('keeps the first multi property filter for trends', () => {
-        const cleanedFilters = cleanFilters({
-            breakdowns: [
-                { property: 'one thing', type: 'event' },
-                { property: 'two thing', type: 'event' },
-            ],
-            breakdown_type: 'event',
-            insight: InsightType.TRENDS,
-        })
+    it('keeps the first multi property filter when switching to trends', () => {
+        const cleanedFilters = cleanFilters(
+            {
+                breakdowns: [
+                    { property: 'one thing', type: 'event' },
+                    { property: 'two thing', type: 'event' },
+                ],
+                breakdown_type: 'event',
+                insight: InsightType.TRENDS,
+            },
+            {
+                breakdowns: [
+                    { property: 'one thing', type: 'event' },
+                    { property: 'two thing', type: 'event' },
+                ],
+                breakdown_type: 'event',
+                insight: InsightType.FUNNELS,
+                funnel_viz_type: FunnelVizType.Steps,
+            }
+        )
 
         expect(cleanedFilters).toHaveProperty('breakdowns', undefined)
         expect(cleanedFilters).toHaveProperty('breakdown', 'one thing')
@@ -212,38 +290,53 @@ describe('cleanFilters', () => {
     })
 
     it('reads "smoothing_intervals" and "interval" from URL when viewing and corrects bad pairings', () => {
-        const cleanedFilters = cleanFilters({
-            interval: 'day',
-            smoothing_intervals: 4,
-        })
+        const cleanedFilters = cleanFilters(
+            {
+                interval: 'day',
+                smoothing_intervals: 4,
+            },
+            {
+                interval: 'day',
+                smoothing_intervals: 3,
+            }
+        )
 
         expect(cleanedFilters).toHaveProperty('smoothing_intervals', 1)
     })
 
     it('can add funnel step reference', () => {
-        const cleanedFilters = cleanFilters({
-            funnel_step_reference: FunnelStepReference.previous,
-            insight: InsightType.FUNNELS,
-        })
+        const cleanedFilters = cleanFilters(
+            {
+                funnel_step_reference: FunnelStepReference.previous,
+                insight: InsightType.FUNNELS,
+            },
+            {}
+        )
 
         expect(cleanedFilters).toHaveProperty('funnel_step_reference', FunnelStepReference.previous)
     })
 
     it('removes the interval from funnels', () => {
-        const cleanedFilters = cleanFilters({
-            insight: InsightType.FUNNELS,
-            interval: 'hour',
-        })
+        const cleanedFilters = cleanFilters(
+            {
+                insight: InsightType.FUNNELS,
+                interval: 'hour',
+            },
+            {}
+        )
 
         expect(cleanedFilters).toHaveProperty('interval', undefined)
     })
 
     it('keeps the interval for trends funnels', () => {
-        const cleanedFilters = cleanFilters({
-            insight: InsightType.FUNNELS,
-            funnel_viz_type: FunnelVizType.Trends,
-            interval: 'hour',
-        })
+        const cleanedFilters = cleanFilters(
+            {
+                insight: InsightType.FUNNELS,
+                funnel_viz_type: FunnelVizType.Trends,
+                interval: 'hour',
+            },
+            {}
+        )
 
         expect(cleanedFilters).toHaveProperty('interval', 'hour')
     })
@@ -251,49 +344,64 @@ describe('cleanFilters', () => {
     describe('show_values_on_series', () => {
         ;[InsightType.TRENDS, InsightType.LIFECYCLE, InsightType.STICKINESS].forEach((insight) => {
             it(`keeps show values on series for ${insight}`, () => {
-                const cleanedFilters = cleanFilters({
-                    insight,
-                    show_values_on_series: true,
-                })
+                const cleanedFilters = cleanFilters(
+                    {
+                        insight,
+                        show_values_on_series: true,
+                    },
+                    {}
+                )
 
                 expect(cleanedFilters).toHaveProperty('show_values_on_series', true)
             })
         })
         NON_VALUES_ON_SERIES_DISPLAY_TYPES.forEach((display) => {
             it(`removes show values on series for ${display}`, () => {
-                const cleanedFilters = cleanFilters({
-                    insight: InsightType.TRENDS,
-                    display,
-                    show_values_on_series: true,
-                })
+                const cleanedFilters = cleanFilters(
+                    {
+                        insight: InsightType.TRENDS,
+                        display,
+                        show_values_on_series: true,
+                    },
+                    {}
+                )
 
                 expect(cleanedFilters).not.toHaveProperty('show_values_on_series')
             })
         })
         ;[(InsightType.PATHS, InsightType.FUNNELS, InsightType.RETENTION)].forEach((insight) => {
             it(`removes show values on series for ${insight}`, () => {
-                const cleanedFilters = cleanFilters({
-                    insight,
-                    show_values_on_series: true,
-                })
+                const cleanedFilters = cleanFilters(
+                    {
+                        insight,
+                        show_values_on_series: true,
+                    },
+                    {}
+                )
 
                 expect(cleanedFilters).not.toHaveProperty('show_values_on_series')
             })
         })
         it('sets show values on series for piecharts if it is undefined', () => {
-            const cleanedFilters = cleanFilters({
-                insight: InsightType.TRENDS,
-                display: ChartDisplayType.ActionsPie,
-            })
+            const cleanedFilters = cleanFilters(
+                {
+                    insight: InsightType.TRENDS,
+                    display: ChartDisplayType.ActionsPie,
+                },
+                {}
+            )
 
             expect(cleanedFilters).toHaveProperty('show_values_on_series', true)
         })
         it('can set show values on series for piecharts to false', () => {
-            const cleanedFilters = cleanFilters({
-                insight: InsightType.TRENDS,
-                display: ChartDisplayType.ActionsPie,
-                show_values_on_series: false,
-            })
+            const cleanedFilters = cleanFilters(
+                {
+                    insight: InsightType.TRENDS,
+                    display: ChartDisplayType.ActionsPie,
+                    show_values_on_series: false,
+                },
+                {}
+            )
 
             expect(cleanedFilters).toHaveProperty('show_values_on_series', false)
         })

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -146,33 +146,27 @@ const isNewInsight = (filters: Partial<AnyFilterType>): boolean => {
     return true
 }
 
-export const setTestAccountFilterForNewInsight = (
-    filter: Partial<AnyFilterType>,
-    test_account_filters_default_checked?: boolean
-): void => {
-    if (localStorage.getItem('default_filter_test_accounts') !== null) {
-        // use current user default
-        filter.filter_test_accounts = localStorage.getItem('default_filter_test_accounts') === 'true'
-    } else if (!filter.filter_test_accounts && test_account_filters_default_checked !== undefined) {
-        // overwrite with team default, only if not set
-        filter.filter_test_accounts = test_account_filters_default_checked
-    }
-}
-
 export function cleanFilters(
     filters: Partial<AnyFilterType>,
-    test_account_filters_default_checked?: boolean
+    // @ts-expect-error
+    oldFilters?: Partial<AnyFilterType>,
+    teamFilterTestAccounts?: boolean
 ): Partial<FilterType> {
     const commonFilters: Partial<CommonFiltersType> = {
         ...(filters.sampling_factor ? { sampling_factor: filters.sampling_factor } : {}),
         ...(filters.filter_test_accounts ? { filter_test_accounts: filters.filter_test_accounts } : {}),
         ...(filters.properties ? { properties: filters.properties } : {}),
-        ...(filters.filter_test_accounts ? { filter_test_accounts: filters.filter_test_accounts } : {}),
     }
 
     // set test account filter default for new insights from team and local storage settings
     if (isNewInsight(filters)) {
-        setTestAccountFilterForNewInsight(commonFilters, test_account_filters_default_checked)
+        if (localStorage.getItem('default_filter_test_accounts') !== null) {
+            // use current user default
+            commonFilters.filter_test_accounts = localStorage.getItem('default_filter_test_accounts') === 'true'
+        } else if (!filters.filter_test_accounts && teamFilterTestAccounts !== undefined) {
+            // overwrite with team default, only if not set
+            commonFilters.filter_test_accounts = teamFilterTestAccounts
+        }
     }
 
     if (isRetentionFilter(filters)) {

--- a/frontend/src/scenes/insights/utils/compareFilters.ts
+++ b/frontend/src/scenes/insights/utils/compareFilters.ts
@@ -4,48 +4,23 @@ import { objectCleanWithEmpty, objectsEqual } from 'lib/utils'
 import { cleanFilters } from './cleanFilters'
 
 /** clean filters so that we can check for semantic equality with a deep equality check */
-const clean = (
-    f: Partial<AnyFilterType>,
-    test_account_filters_default_checked: boolean | undefined
-): Partial<AnyFilterType> => {
+const clean = (f: Partial<AnyFilterType>): Partial<AnyFilterType> => {
     // remove undefined values, empty array and empty objects
-    const cleanedFilters = objectCleanWithEmpty(cleanFilters(f, test_account_filters_default_checked))
+    const cleanedFilters = objectCleanWithEmpty(cleanFilters(f))
 
-    // do we need an order property on events or actions?
-    const needsOrder = (cleanedFilters.events || []).length + (cleanedFilters.actions || []).length > 1
-
-    cleanedFilters.events?.forEach((e) => {
+    cleanedFilters.events = cleanedFilters.events?.map((e) => {
         // event math `total` is the default
         if (e.math === 'total') {
             delete e.math
         }
-
-        // delete unnecessary event order
-        if (!needsOrder) {
-            delete e.order
-        }
+        return e
     })
-
-    cleanedFilters.actions?.forEach((a) => {
-        // delete unnecessary action order
-        if (!needsOrder) {
-            delete a.order
-        }
-    })
-
-    // used only for persons endpoint
-    delete f.entity_type
-
     return cleanedFilters
 }
 
 /** compares to filter objects for semantical equality */
-export function compareFilters(
-    a: Partial<AnyFilterType>,
-    b: Partial<AnyFilterType>,
-    test_account_filters_default_checked: boolean | undefined
-): boolean {
+export function compareFilters(a: Partial<AnyFilterType>, b: Partial<AnyFilterType>): boolean {
     // this is not optimized for speed and does not work for many cases yet
     // e.g. falsy values are not treated the same as undefined values, unset filters are not handled, ordering of series isn't checked
-    return objectsEqual(clean(a, test_account_filters_default_checked), clean(b, test_account_filters_default_checked))
+    return objectsEqual(clean(a), clean(b))
 }


### PR DESCRIPTION
Reverts PostHog/posthog#16690 due to an issue where saving a new insight results in this alert:

<img width="280" alt="Screenshot 2023-07-24 at 15 34 42" src="https://github.com/PostHog/posthog/assets/4550621/3ae4add7-7a37-4d9a-abc0-b8e756805f13">

TODOs:
- re-merge this with a fix
- find out why end-to-end tests didn't catch this (possibly the alert is being auto-accepted in tests)