### PR TITLE
revert: "feat(decide): Add a python-level signal timeout for database writes"

### DIFF
--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -2,7 +2,6 @@ import hashlib
 from dataclasses import dataclass
 from enum import Enum
 import time
-from django.conf import settings
 import structlog
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -23,7 +22,7 @@ from posthog.models.person import Person, PersonDistinctId
 from posthog.models.property import GroupTypeIndex, GroupTypeName
 from posthog.models.property.property import Property
 from posthog.models.cohort import Cohort
-from posthog.models.utils import TimeoutException, execute_with_timeout, python_signal_timeout
+from posthog.models.utils import execute_with_timeout
 from posthog.queries.base import match_property, properties_to_Q
 from posthog.database_healthcheck import postgres_healthcheck, DATABASE_FOR_FLAG_MATCHING
 from posthog.utils import label_for_team_id_to_track
@@ -658,13 +657,14 @@ def get_all_feature_flags(
                 # and the hash_key_override, and add overrides for all these personIDs.
                 # On merge, if a person is deleted, it is fine because the below line in plugin-server will take care of it.
                 # https://github.com/PostHog/posthog/blob/master/plugin-server/src/worker/ingestion/person-state.ts#L696 (addFeatureFlagHashKeysForMergedPerson)
-                with python_signal_timeout(2, enable=settings.DECIDE_SIGNAL_TIMEOUT):
-                    writing_hash_key_override = set_feature_flag_hash_key_overrides(
-                        team_id, [distinct_id, hash_key_override], hash_key_override
-                    )
-                    FLAG_HASH_KEY_WRITES_COUNTER.labels(
-                        team_id=label_for_team_id_to_track(team_id), successful_write=writing_hash_key_override
-                    ).inc()
+
+                writing_hash_key_override = set_feature_flag_hash_key_overrides(
+                    team_id, [distinct_id, hash_key_override], hash_key_override
+                )
+                team_id_label = label_for_team_id_to_track(team_id)
+                FLAG_HASH_KEY_WRITES_COUNTER.labels(
+                    team_id=team_id_label, successful_write=writing_hash_key_override
+                ).inc()
             except Exception as e:
                 # If the database is in read-only mode, we can't handle experience continuity flags,
                 # since the set_feature_flag_hash_key_overrides call will fail.
@@ -795,7 +795,5 @@ def parse_exception_for_error_message(err: Exception):
             reason = "healthcheck_failed"
         elif "query_wait_timeout" in str(err):
             reason = "query_wait_timeout"
-    elif isinstance(err, TimeoutException):
-        reason = "python_timeout"
 
     return reason

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -24,7 +24,7 @@ AXES_META_PRECEDENCE_ORDER = ["HTTP_X_FORWARDED_FOR", "REMOTE_ADDR"]
 DECIDE_RATE_LIMIT_ENABLED = get_from_env("DECIDE_RATE_LIMIT_ENABLED", False, type_cast=str_to_bool)
 DECIDE_BUCKET_CAPACITY = get_from_env("DECIDE_BUCKET_CAPACITY", type_cast=int, default=500)
 DECIDE_BUCKET_REPLENISH_RATE = get_from_env("DECIDE_BUCKET_REPLENISH_RATE", type_cast=float, default=10.0)
-DECIDE_SIGNAL_TIMEOUT = get_from_env("DECIDE_SIGNAL_TIMEOUT", type_cast=str_to_bool, default=False)
+
 # Decide billing analytics
 
 DECIDE_BILLING_SAMPLING_RATE = get_from_env("DECIDE_BILLING_SAMPLING_RATE", 0.1, type_cast=float)


### PR DESCRIPTION
Reverts PostHog/posthog#16668

Locally, when I'm running the app I'm on the main thread, but in dev/production gunicorn runs the app in threads, which means signals wouldn't work, since these can only be handled by the main thread.

Now that we have analytics for this code path though, it's small enough that spawning a new thread is fine, will go that route for writes.