### PR TITLE
feat: Allow passing Snowflake role input

### DIFF
--- a/frontend/src/scenes/exports/CreateExport.tsx
+++ b/frontend/src/scenes/exports/CreateExport.tsx
@@ -292,12 +292,14 @@ export function CreateSnowflakeExport({ startAt, endAt }: ExportCommonProps): JS
     const schemaRef = useRef<HTMLInputElement>(null)
     const tableNameRef = useRef<HTMLInputElement>(null)
     const intervalRef = useRef<'hour' | 'day' | null>(null)
+    const roleRef = useRef<HTMLInputElement>(null)
 
     const { createExport, loading, error } = useCreateExport()
 
     const handleCreateExport = useCallback(() => {
         if (
             !nameRef.current ||
+            !roleRef.current ||
             !userRef.current ||
             !passwordRef.current ||
             !accountRef.current ||
@@ -319,6 +321,7 @@ export function CreateSnowflakeExport({ startAt, endAt }: ExportCommonProps): JS
         const schema = schemaRef.current?.value ?? ''
         const tableName = tableNameRef.current?.value ?? ''
         const interval = intervalRef.current
+        const role = roleRef.current?.value ?? null
 
         const exportData = {
             name,
@@ -331,6 +334,7 @@ export function CreateSnowflakeExport({ startAt, endAt }: ExportCommonProps): JS
                     database,
                     warehouse,
                     schema,
+                    role,
                     table_name: tableName,
                 },
             },

--- a/frontend/src/scenes/exports/api.ts
+++ b/frontend/src/scenes/exports/api.ts
@@ -93,6 +93,7 @@ type SnowflakeDestination = {
         password: string
         schema: string
         table_name: string
+        role: string | null
     }
 }
 
@@ -177,6 +178,30 @@ export const useDeleteExport = (
     }, [teamId, exportId])
 
     return { deleteExport, ...state }
+}
+
+export const useUpdateExport = (): {
+    loading: boolean
+    error: Error | null
+    updateExport: (teamId: number, exportId: string, exportData: BatchExportData) => Promise<void>
+} => {
+    const [state, setState] = useState<{ loading: boolean; error: Error | null }>({ loading: false, error: null })
+
+    const updateExport = useCallback((teamId: number, exportId: string, exportData: BatchExportData) => {
+        setState({ loading: true, error: null })
+        return api.createResponse(`/api/projects/${teamId}/batch_exports/${exportId}`, exportData).then((response) => {
+            if (response.ok) {
+                setState({ loading: false, error: null })
+            } else {
+                // TODO: parse the error response.
+                const error = new Error(response.statusText)
+                setState({ loading: false, error: error })
+                throw error
+            }
+        })
+    }, [])
+
+    return { updateExport, ...state }
 }
 
 export const useExportAction = (

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -69,6 +69,7 @@ class SnowflakeBatchExportInputs:
     schema: str
     table_name: str = "events"
     data_interval_end: str | None = None
+    role: str | None = None
 
 
 DESTINATION_WORKFLOWS = {

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -60,6 +60,7 @@ class SnowflakeInsertInputs:
     table_name: str
     data_interval_start: str
     data_interval_end: str
+    role: str | None = None
 
 
 def put_file_to_snowflake_table(cursor: SnowflakeCursor, file_name: str, table_name: str):
@@ -125,6 +126,7 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs):
             warehouse=inputs.warehouse,
             database=inputs.database,
             schema=inputs.schema,
+            role=inputs.role,
         )
 
         try:
@@ -316,6 +318,7 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
             table_name=inputs.table_name,
             data_interval_start=data_interval_start.isoformat(),
             data_interval_end=data_interval_end.isoformat(),
+            role=inputs.role,
         )
         try:
             await workflow.execute_activity(


### PR DESCRIPTION
## Problem

I don't know why we didn't have this already, but we are not taking a role parameter even though the Snowflake export app did. The Python Snowflake connector takes basically the same arguments as the Javascript one, so this should have been a 1:1 mapping.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add role parameter for Snowflake connector. [The role can be None](https://github.com/snowflakedb/snowflake-connector-python/blob/85df67cf4a29d545a026c0ea6a25aec5d9ce0245/src/snowflake/connector/connection.py#L140C1-L140C52) so we just pass it without any validation.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
