### PR TITLE
fix: Segmenter calculation of inactive segments

### DIFF
--- a/frontend/src/scenes/session-recordings/player/utils/segmenter.ts
+++ b/frontend/src/scenes/session-recordings/player/utils/segmenter.ts
@@ -63,7 +63,7 @@ export const createSegments = (snapshots: RecordingSnapshot[], start?: Dayjs, en
             isNewSegment = true
         }
 
-        // 5. If windowId changes we create a new segment
+        // 4. If windowId changes we create a new segment
         if (activeSegment?.windowId !== snapshot.windowId && eventIsActive) {
             isNewSegment = true
         }

--- a/frontend/src/scenes/session-recordings/player/utils/segmenter.ts
+++ b/frontend/src/scenes/session-recordings/player/utils/segmenter.ts
@@ -48,7 +48,6 @@ export const createSegments = (snapshots: RecordingSnapshot[], start?: Dayjs, en
 
     snapshots.forEach((snapshot, index) => {
         const eventIsActive = isActiveEvent(snapshot) || index === 0
-        lastActiveEventTimestamp = eventIsActive ? snapshot.timestamp : lastActiveEventTimestamp
 
         // When do we create a new segment?
         // 1. If we don't have one yet
@@ -64,10 +63,13 @@ export const createSegments = (snapshots: RecordingSnapshot[], start?: Dayjs, en
             isNewSegment = true
         }
 
-        // 4. If windowId changes we create a new segment
+        // 5. If windowId changes we create a new segment
         if (activeSegment?.windowId !== snapshot.windowId && eventIsActive) {
             isNewSegment = true
         }
+
+        // NOTE: We have to make sure that we set this _after_ we use it
+        lastActiveEventTimestamp = eventIsActive ? snapshot.timestamp : lastActiveEventTimestamp
 
         if (isNewSegment) {
             if (activeSegment) {

--- a/plugin-server/src/main/ingestion-queues/session-recording/snapshot-segmenter.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/snapshot-segmenter.ts
@@ -38,7 +38,6 @@ const createSegments = (snapshots: RRWebEvent[]): RecordingSegment[] => {
 
     snapshots.forEach((snapshot) => {
         const eventIsActive = isActiveEvent(snapshot)
-        lastActiveEventTimestamp = eventIsActive ? snapshot.timestamp : lastActiveEventTimestamp
 
         // When do we create a new segment?
         // 1. If we don't have one yet
@@ -53,6 +52,9 @@ const createSegments = (snapshots: RRWebEvent[]): RecordingSegment[] => {
         if (activeSegment?.isActive && lastActiveEventTimestamp + ACTIVITY_THRESHOLD_MS < snapshot.timestamp) {
             isNewSegment = true
         }
+
+        // NOTE: We have to make sure that we set this _after_ we use it
+        lastActiveEventTimestamp = eventIsActive ? snapshot.timestamp : lastActiveEventTimestamp
 
         if (isNewSegment) {
             if (activeSegment) {


### PR DESCRIPTION
## Problem

Not sure how or when this broke but we were calculating inactive period all wrong.

## Changes

* Fixed to set the lastactivetime _after_ we use it rather than before.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
