### PR TITLE
feat: Replace ChClient with own implementation to support query streaming

### DIFF
--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -415,8 +415,7 @@
          'random'
   FROM flags_to_override,
        target_person_ids
-  WHERE
-    EXISTS
+  WHERE EXISTS
       (SELECT 1
        FROM posthog_person
        WHERE id = person_id

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -48,9 +48,10 @@
      FROM
        (SELECT aggregation_target,
                steps,
-               max(steps) over (PARTITION BY aggregation_target, prop) as max_steps,
-               step_1_conversion_time ,
-               prop
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time ,
+                               prop
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -59,14 +60,13 @@
                      AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
                   prop
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
-                                   prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       prop
               FROM
                 (SELECT *,
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
@@ -128,7 +128,7 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time
+                               step_1_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -136,13 +136,11 @@
                   if(isNotNull(latest_1)
                      AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -197,7 +195,7 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time
+                               step_1_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -205,13 +203,11 @@
                   if(isNotNull(latest_1)
                      AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,

--- a/posthog/api/test/__snapshots__/test_insight_funnels.ambr
+++ b/posthog/api/test/__snapshots__/test_insight_funnels.ambr
@@ -11,8 +11,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -25,35 +25,29 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        latest_1,
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         step_2,
-                                         min(latest_2) over (PARTITION by aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             step_2,
+                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -136,8 +130,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -150,16 +144,14 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
-                                   step_2,
-                                   min(latest_2) over (PARTITION by aggregation_target
-                                                       ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
+                                                                       step_2,
+                                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                                           ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -239,8 +231,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   arraySort([latest_0,latest_1,latest_2]) as event_times,
@@ -251,16 +243,14 @@
                   if(isNotNull(conversion_times[3])
                      AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                   step_2,
-                                   min(latest_2) over (PARTITION by aggregation_target
-                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                       step_2,
+                                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -296,16 +286,14 @@
                             if(isNotNull(conversion_times[3])
                                AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                   step_2,
-                                   min(latest_2) over (PARTITION by aggregation_target
-                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                       step_2,
+                                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -341,16 +329,14 @@
                             if(isNotNull(conversion_times[3])
                                AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                   step_2,
-                                   min(latest_2) over (PARTITION by aggregation_target
-                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                       step_2,
+                                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,

--- a/posthog/api/test/__snapshots__/test_persons_trends.ambr
+++ b/posthog/api/test/__snapshots__/test_persons_trends.ambr
@@ -3,10 +3,9 @@
   /* user_id:0 request:_snapshot_ */
   SELECT person_id AS actor_id,
          count() AS actor_value ,
-         groupUniqArray(100)((timestamp,
-                              uuid,
-                              $session_id,
-                              $window_id)) as matching_events
+         groupUniqArray(100)((timestamp, uuid,
+                                         $session_id,
+                                         $window_id)) as matching_events
   FROM
     (SELECT e.timestamp as timestamp,
             e."properties" as "properties",
@@ -51,10 +50,9 @@
   /* user_id:0 request:_snapshot_ */
   SELECT person_id AS actor_id,
          count() AS actor_value ,
-         groupUniqArray(100)((timestamp,
-                              uuid,
-                              $session_id,
-                              $window_id)) as matching_events
+         groupUniqArray(100)((timestamp, uuid,
+                                         $session_id,
+                                         $window_id)) as matching_events
   FROM
     (SELECT e.timestamp as timestamp,
             e."properties" as "properties",
@@ -109,10 +107,9 @@
   /* user_id:0 request:_snapshot_ */
   SELECT person_id AS actor_id,
          count() AS actor_value ,
-         groupUniqArray(100)((timestamp,
-                              uuid,
-                              $session_id,
-                              $window_id)) as matching_events
+         groupUniqArray(100)((timestamp, uuid,
+                                         $session_id,
+                                         $window_id)) as matching_events
   FROM
     (SELECT e.timestamp as timestamp,
             e."properties" as "properties",

--- a/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
@@ -1,10 +1,9 @@
 # name: TestAppMetricsErrorDetailsQuery.test_error_details_query
   '
   
-  SELECT timestamp,
-         error_uuid,
-         error_type,
-         error_details
+  SELECT timestamp, error_uuid,
+                    error_type,
+                    error_details
   FROM app_metrics
   WHERE team_id = 2
     AND plugin_config_id = 3
@@ -17,10 +16,9 @@
 # name: TestAppMetricsErrorDetailsQuery.test_error_details_query_filter_by_job_id
   '
   
-  SELECT timestamp,
-         error_uuid,
-         error_type,
-         error_details
+  SELECT timestamp, error_uuid,
+                    error_type,
+                    error_details
   FROM app_metrics
   WHERE team_id = 2
     AND plugin_config_id = 3
@@ -34,10 +32,9 @@
 # name: TestAppMetricsErrorDetailsQuery.test_ignores_unrelated_data
   '
   
-  SELECT timestamp,
-         error_uuid,
-         error_type,
-         error_details
+  SELECT timestamp, error_uuid,
+                    error_type,
+                    error_details
   FROM app_metrics
   WHERE team_id = 2
     AND plugin_config_id = 3

--- a/posthog/queries/funnels/test/__snapshots__/test_breakdowns_by_current_url.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_breakdowns_by_current_url.ambr
@@ -35,9 +35,10 @@
      FROM
        (SELECT aggregation_target,
                steps,
-               max(steps) over (PARTITION BY aggregation_target, prop) as max_steps,
-               step_1_conversion_time ,
-               prop
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time ,
+                               prop
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -46,14 +47,13 @@
                      AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
                   prop
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
-                                   if(has([['https://example.com/home'], ['https://example.com'], ['/']], prop), prop, ['Other']) as prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([['https://example.com/home'], ['https://example.com'], ['/']], prop), prop, ['Other']) as prop
               FROM
                 (SELECT *,
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
@@ -129,9 +129,10 @@
      FROM
        (SELECT aggregation_target,
                steps,
-               max(steps) over (PARTITION BY aggregation_target, prop) as max_steps,
-               step_1_conversion_time ,
-               prop
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time ,
+                               prop
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -140,14 +141,13 @@
                      AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
                   prop
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
-                                   if(has([['/'], ['/home']], prop), prop, ['Other']) as prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([['/'], ['/home']], prop), prop, ['Other']) as prop
               FROM
                 (SELECT *,
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -19,8 +19,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -33,35 +33,29 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 15 SECOND, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        latest_1,
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         step_2,
-                                         min(latest_2) over (PARTITION by aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             step_2,
+                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -108,8 +102,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -122,35 +116,29 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 15 SECOND, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        latest_1,
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         step_2,
-                                         min(latest_2) over (PARTITION by aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             step_2,
+                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -221,8 +209,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -235,35 +223,29 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        latest_1,
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         step_2,
-                                         min(latest_2) over (PARTITION by aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             step_2,
+                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
                               if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) as aggregation_target,
@@ -315,7 +297,7 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time
+                               step_1_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -323,13 +305,11 @@
                   if(isNotNull(latest_1)
                      AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -412,7 +392,7 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time
+                               step_1_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -420,13 +400,11 @@
                   if(isNotNull(latest_1)
                      AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -488,8 +466,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -502,35 +480,29 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        latest_1,
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         step_2,
-                                         min(latest_2) over (PARTITION by aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             step_2,
+                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -597,8 +569,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -611,35 +583,29 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        latest_1,
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         step_2,
-                                         min(latest_2) over (PARTITION by aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             step_2,
+                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -710,8 +676,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -724,35 +690,29 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        latest_1,
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         step_2,
-                                         min(latest_2) over (PARTITION by aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             step_2,
+                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -823,8 +783,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -837,35 +797,29 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        latest_1,
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         step_2,
-                                         min(latest_2) over (PARTITION by aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             step_2,
+                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -946,7 +900,7 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time
+                               step_1_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -954,13 +908,11 @@
                   if(isNotNull(latest_1)
                      AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -1016,7 +968,7 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time
+                               step_1_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -1024,13 +976,11 @@
                   if(isNotNull(latest_1)
                      AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -1094,9 +1044,10 @@
      FROM
        (SELECT aggregation_target,
                steps,
-               max(steps) over (PARTITION BY aggregation_target, prop) as max_steps,
-               step_1_conversion_time ,
-               prop
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time ,
+                               prop
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -1105,14 +1056,13 @@
                      AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
                   prop
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
-                                   if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
               FROM
                 (SELECT *,
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
@@ -1186,9 +1136,10 @@
      FROM
        (SELECT aggregation_target,
                steps,
-               max(steps) over (PARTITION BY aggregation_target, prop) as max_steps,
-               step_1_conversion_time ,
-               prop
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time ,
+                               prop
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -1197,14 +1148,13 @@
                      AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
                   prop
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
-                                   if(has([['Safari'], ['Mac']], prop), prop, ['Other']) as prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([['Safari'], ['Mac']], prop), prop, ['Other']) as prop
               FROM
                 (SELECT *,
                         prop
@@ -1281,9 +1231,10 @@
      FROM
        (SELECT aggregation_target,
                steps,
-               max(steps) over (PARTITION BY aggregation_target, prop) as max_steps,
-               step_1_conversion_time ,
-               prop
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time ,
+                               prop
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -1292,14 +1243,13 @@
                      AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
                   prop
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
-                                   if(has([['', ''], ['alakazam', ''], ['Safari', 'xyz'], ['Mac', ''], ['Chrome', 'xyz'], ['0', '0'], ['', 'no-mac']], prop), prop, ['Other']) as prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([['', ''], ['alakazam', ''], ['Safari', 'xyz'], ['Mac', ''], ['Chrome', 'xyz'], ['0', '0'], ['', 'no-mac']], prop), prop, ['Other']) as prop
               FROM
                 (SELECT *,
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['','']) as prop

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_persons.ambr
@@ -18,21 +18,21 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time,
-               ("latest_0",
-                "uuid_0",
-                "$session_id_0",
-                "$window_id_0") as step_0_matching_event,
-               ("latest_1",
-                "uuid_1",
-                "$session_id_1",
-                "$window_id_1") as step_1_matching_event,
-               ("latest_2",
-                "uuid_2",
-                "$session_id_2",
-                "$window_id_2") as step_2_matching_event,
-               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+                               step_1_conversion_time,
+                               step_2_conversion_time,
+                               ("latest_0",
+                                "uuid_0",
+                                "$session_id_0",
+                                "$window_id_0") as step_0_matching_event,
+                               ("latest_1",
+                                "uuid_1",
+                                "$session_id_1",
+                                "$window_id_1") as step_1_matching_event,
+                               ("latest_2",
+                                "uuid_2",
+                                "$session_id_2",
+                                "$window_id_2") as step_2_matching_event,
+                               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -58,71 +58,65 @@
                    "$window_id_2") as step_2_matching_event,
                   if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     "uuid_0",
-                     "$session_id_0",
-                     "$window_id_0",
-                     step_1,
-                     latest_1,
-                     "uuid_1",
-                     "$session_id_1",
-                     "$window_id_1",
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                   last_value("uuid_2") over (PARTITION by aggregation_target
-                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                        last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                    last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    "uuid_0",
+                                                    "$session_id_0",
+                                                    "$window_id_0",
+                                                    step_1,
+                                                    latest_1,
+                                                    "uuid_1",
+                                                    "$session_id_1",
+                                                    "$window_id_1",
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                       last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                 last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                  last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        "uuid_0",
-                        "$session_id_0",
-                        "$window_id_0",
-                        step_1,
-                        latest_1,
-                        "uuid_1",
-                        "$session_id_1",
-                        "$window_id_1",
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2,
-                        if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
-                        if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
-                        if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       "uuid_0",
+                                                       "$session_id_0",
+                                                       "$window_id_0",
+                                                       step_1,
+                                                       latest_1,
+                                                       "uuid_1",
+                                                       "$session_id_1",
+                                                       "$window_id_1",
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2,
+                                                       if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
+                                                       if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
+                                                       if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           "uuid_0",
-                           "$session_id_0",
-                           "$window_id_0",
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         last_value("uuid_1") over (PARTITION by aggregation_target
-                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
-                                                              last_value("$session_id_1") over (PARTITION by aggregation_target
-                                                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
-                                                                                          last_value("$window_id_1") over (PARTITION by aggregation_target
-                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
-                                                                                                                     step_2,
-                                                                                                                     min(latest_2) over (PARTITION by aggregation_target
-                                                                                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                                                                                                                   last_value("uuid_2") over (PARTITION by aggregation_target
-                                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                                                                                                                        last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                                                                                                                    last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          "uuid_0",
+                                                          "$session_id_0",
+                                                          "$window_id_0",
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                                                       last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                                                        last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                                                        step_2,
+                                                                                                                                                                        min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                                                           last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                                                     last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                                                      last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -198,21 +192,21 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time,
-               ("latest_0",
-                "uuid_0",
-                "$session_id_0",
-                "$window_id_0") as step_0_matching_event,
-               ("latest_1",
-                "uuid_1",
-                "$session_id_1",
-                "$window_id_1") as step_1_matching_event,
-               ("latest_2",
-                "uuid_2",
-                "$session_id_2",
-                "$window_id_2") as step_2_matching_event,
-               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+                               step_1_conversion_time,
+                               step_2_conversion_time,
+                               ("latest_0",
+                                "uuid_0",
+                                "$session_id_0",
+                                "$window_id_0") as step_0_matching_event,
+                               ("latest_1",
+                                "uuid_1",
+                                "$session_id_1",
+                                "$window_id_1") as step_1_matching_event,
+                               ("latest_2",
+                                "uuid_2",
+                                "$session_id_2",
+                                "$window_id_2") as step_2_matching_event,
+                               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -238,71 +232,65 @@
                    "$window_id_2") as step_2_matching_event,
                   if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     "uuid_0",
-                     "$session_id_0",
-                     "$window_id_0",
-                     step_1,
-                     latest_1,
-                     "uuid_1",
-                     "$session_id_1",
-                     "$window_id_1",
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                   last_value("uuid_2") over (PARTITION by aggregation_target
-                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                        last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                    last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    "uuid_0",
+                                                    "$session_id_0",
+                                                    "$window_id_0",
+                                                    step_1,
+                                                    latest_1,
+                                                    "uuid_1",
+                                                    "$session_id_1",
+                                                    "$window_id_1",
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                       last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                 last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                  last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        "uuid_0",
-                        "$session_id_0",
-                        "$window_id_0",
-                        step_1,
-                        latest_1,
-                        "uuid_1",
-                        "$session_id_1",
-                        "$window_id_1",
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2,
-                        if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
-                        if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
-                        if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       "uuid_0",
+                                                       "$session_id_0",
+                                                       "$window_id_0",
+                                                       step_1,
+                                                       latest_1,
+                                                       "uuid_1",
+                                                       "$session_id_1",
+                                                       "$window_id_1",
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2,
+                                                       if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
+                                                       if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
+                                                       if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           "uuid_0",
-                           "$session_id_0",
-                           "$window_id_0",
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         last_value("uuid_1") over (PARTITION by aggregation_target
-                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
-                                                              last_value("$session_id_1") over (PARTITION by aggregation_target
-                                                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
-                                                                                          last_value("$window_id_1") over (PARTITION by aggregation_target
-                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
-                                                                                                                     step_2,
-                                                                                                                     min(latest_2) over (PARTITION by aggregation_target
-                                                                                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                                                                                                                   last_value("uuid_2") over (PARTITION by aggregation_target
-                                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                                                                                                                        last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                                                                                                                    last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          "uuid_0",
+                                                          "$session_id_0",
+                                                          "$window_id_0",
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                                                       last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                                                        last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                                                        step_2,
+                                                                                                                                                                        min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                                                           last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                                                     last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                                                      last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -378,21 +366,21 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time,
-               ("latest_0",
-                "uuid_0",
-                "$session_id_0",
-                "$window_id_0") as step_0_matching_event,
-               ("latest_1",
-                "uuid_1",
-                "$session_id_1",
-                "$window_id_1") as step_1_matching_event,
-               ("latest_2",
-                "uuid_2",
-                "$session_id_2",
-                "$window_id_2") as step_2_matching_event,
-               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+                               step_1_conversion_time,
+                               step_2_conversion_time,
+                               ("latest_0",
+                                "uuid_0",
+                                "$session_id_0",
+                                "$window_id_0") as step_0_matching_event,
+                               ("latest_1",
+                                "uuid_1",
+                                "$session_id_1",
+                                "$window_id_1") as step_1_matching_event,
+                               ("latest_2",
+                                "uuid_2",
+                                "$session_id_2",
+                                "$window_id_2") as step_2_matching_event,
+                               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -418,71 +406,65 @@
                    "$window_id_2") as step_2_matching_event,
                   if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     "uuid_0",
-                     "$session_id_0",
-                     "$window_id_0",
-                     step_1,
-                     latest_1,
-                     "uuid_1",
-                     "$session_id_1",
-                     "$window_id_1",
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                   last_value("uuid_2") over (PARTITION by aggregation_target
-                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                        last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                    last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    "uuid_0",
+                                                    "$session_id_0",
+                                                    "$window_id_0",
+                                                    step_1,
+                                                    latest_1,
+                                                    "uuid_1",
+                                                    "$session_id_1",
+                                                    "$window_id_1",
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                       last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                 last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                  last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        "uuid_0",
-                        "$session_id_0",
-                        "$window_id_0",
-                        step_1,
-                        latest_1,
-                        "uuid_1",
-                        "$session_id_1",
-                        "$window_id_1",
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2,
-                        if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
-                        if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
-                        if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       "uuid_0",
+                                                       "$session_id_0",
+                                                       "$window_id_0",
+                                                       step_1,
+                                                       latest_1,
+                                                       "uuid_1",
+                                                       "$session_id_1",
+                                                       "$window_id_1",
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2,
+                                                       if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
+                                                       if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
+                                                       if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           "uuid_0",
-                           "$session_id_0",
-                           "$window_id_0",
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         last_value("uuid_1") over (PARTITION by aggregation_target
-                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
-                                                              last_value("$session_id_1") over (PARTITION by aggregation_target
-                                                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
-                                                                                          last_value("$window_id_1") over (PARTITION by aggregation_target
-                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
-                                                                                                                     step_2,
-                                                                                                                     min(latest_2) over (PARTITION by aggregation_target
-                                                                                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                                                                                                                   last_value("uuid_2") over (PARTITION by aggregation_target
-                                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                                                                                                                        last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                                                                                                                    last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          "uuid_0",
+                                                          "$session_id_0",
+                                                          "$window_id_0",
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                                                       last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                                                        last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                                                        step_2,
+                                                                                                                                                                        min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                                                           last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                                                     last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                                                      last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -33,9 +33,10 @@
      FROM
        (SELECT aggregation_target,
                steps,
-               max(steps) over (PARTITION BY aggregation_target, prop) as max_steps,
-               step_1_conversion_time,
-               prop
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time,
+                               prop
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -43,14 +44,13 @@
                   if(isNotNull(latest_1)
                      AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1 ,
-                                   if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1 ,
+                                                                       if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
               FROM
                 (SELECT *,
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
@@ -122,9 +122,10 @@
      FROM
        (SELECT aggregation_target,
                steps,
-               max(steps) over (PARTITION BY aggregation_target, prop) as max_steps,
-               step_1_conversion_time,
-               prop
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time,
+                               prop
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -132,14 +133,13 @@
                   if(isNotNull(latest_1)
                      AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1 ,
-                                   if(has([['Safari'], ['Mac']], prop), prop, ['Other']) as prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1 ,
+                                                                       if(has([['Safari'], ['Mac']], prop), prop, ['Other']) as prop
               FROM
                 (SELECT *,
                         prop
@@ -214,9 +214,10 @@
      FROM
        (SELECT aggregation_target,
                steps,
-               max(steps) over (PARTITION BY aggregation_target, prop) as max_steps,
-               step_1_conversion_time,
-               prop
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time,
+                               prop
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -224,14 +225,13 @@
                   if(isNotNull(latest_1)
                      AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1 ,
-                                   if(has([['', ''], ['alakazam', ''], ['Safari', 'xyz'], ['Mac', ''], ['Chrome', 'xyz'], ['0', '0'], ['', 'no-mac']], prop), prop, ['Other']) as prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1 ,
+                                                                       if(has([['', ''], ['alakazam', ''], ['Safari', 'xyz'], ['Mac', ''], ['Chrome', 'xyz'], ['0', '0'], ['', 'no-mac']], prop), prop, ['Other']) as prop
               FROM
                 (SELECT *,
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['','']) as prop

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
@@ -18,21 +18,21 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time ,
-               ("latest_0",
-                "uuid_0",
-                "$session_id_0",
-                "$window_id_0") as step_0_matching_event,
-               ("latest_1",
-                "uuid_1",
-                "$session_id_1",
-                "$window_id_1") as step_1_matching_event,
-               ("latest_2",
-                "uuid_2",
-                "$session_id_2",
-                "$window_id_2") as step_2_matching_event,
-               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+                               step_1_conversion_time,
+                               step_2_conversion_time ,
+                               ("latest_0",
+                                "uuid_0",
+                                "$session_id_0",
+                                "$window_id_0") as step_0_matching_event,
+                               ("latest_1",
+                                "uuid_1",
+                                "$session_id_1",
+                                "$window_id_1") as step_1_matching_event,
+                               ("latest_2",
+                                "uuid_2",
+                                "$session_id_2",
+                                "$window_id_2") as step_2_matching_event,
+                               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -58,31 +58,29 @@
                    "$window_id_2") as step_2_matching_event,
                   if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     "uuid_0",
-                     "$session_id_0",
-                     "$window_id_0",
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
-                                   min("uuid_1") over (PARTITION by aggregation_target
-                                                       ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "uuid_1",
-                                                 min("$session_id_1") over (PARTITION by aggregation_target
-                                                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$session_id_1",
-                                                                      min("$window_id_1") over (PARTITION by aggregation_target
-                                                                                                ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$window_id_1",
-                                                                                          step_2,
-                                                                                          min(latest_2) over (PARTITION by aggregation_target
-                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2,
-                                                                                                        min("uuid_2") over (PARTITION by aggregation_target
-                                                                                                                            ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "uuid_2",
-                                                                                                                      min("$session_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$session_id_2",
-                                                                                                                                           min("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    "uuid_0",
+                                                    "$session_id_0",
+                                                    "$window_id_0",
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
+                                                                       min("uuid_1") over (PARTITION by aggregation_target
+                                                                                           ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "uuid_1",
+                                                                                          min("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$session_id_1",
+                                                                                                                    min("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$window_id_1",
+                                                                                                                                             step_2,
+                                                                                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2,
+                                                                                                                                                                min("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "uuid_2",
+                                                                                                                                                                                   min("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                             min("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -155,21 +153,21 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time ,
-               ("latest_0",
-                "uuid_0",
-                "$session_id_0",
-                "$window_id_0") as step_0_matching_event,
-               ("latest_1",
-                "uuid_1",
-                "$session_id_1",
-                "$window_id_1") as step_1_matching_event,
-               ("latest_2",
-                "uuid_2",
-                "$session_id_2",
-                "$window_id_2") as step_2_matching_event,
-               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+                               step_1_conversion_time,
+                               step_2_conversion_time ,
+                               ("latest_0",
+                                "uuid_0",
+                                "$session_id_0",
+                                "$window_id_0") as step_0_matching_event,
+                               ("latest_1",
+                                "uuid_1",
+                                "$session_id_1",
+                                "$window_id_1") as step_1_matching_event,
+                               ("latest_2",
+                                "uuid_2",
+                                "$session_id_2",
+                                "$window_id_2") as step_2_matching_event,
+                               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -195,31 +193,29 @@
                    "$window_id_2") as step_2_matching_event,
                   if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     "uuid_0",
-                     "$session_id_0",
-                     "$window_id_0",
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
-                                   min("uuid_1") over (PARTITION by aggregation_target
-                                                       ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "uuid_1",
-                                                 min("$session_id_1") over (PARTITION by aggregation_target
-                                                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$session_id_1",
-                                                                      min("$window_id_1") over (PARTITION by aggregation_target
-                                                                                                ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$window_id_1",
-                                                                                          step_2,
-                                                                                          min(latest_2) over (PARTITION by aggregation_target
-                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2,
-                                                                                                        min("uuid_2") over (PARTITION by aggregation_target
-                                                                                                                            ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "uuid_2",
-                                                                                                                      min("$session_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$session_id_2",
-                                                                                                                                           min("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    "uuid_0",
+                                                    "$session_id_0",
+                                                    "$window_id_0",
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
+                                                                       min("uuid_1") over (PARTITION by aggregation_target
+                                                                                           ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "uuid_1",
+                                                                                          min("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$session_id_1",
+                                                                                                                    min("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$window_id_1",
+                                                                                                                                             step_2,
+                                                                                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2,
+                                                                                                                                                                min("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "uuid_2",
+                                                                                                                                                                                   min("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                             min("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -292,21 +288,21 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time ,
-               ("latest_0",
-                "uuid_0",
-                "$session_id_0",
-                "$window_id_0") as step_0_matching_event,
-               ("latest_1",
-                "uuid_1",
-                "$session_id_1",
-                "$window_id_1") as step_1_matching_event,
-               ("latest_2",
-                "uuid_2",
-                "$session_id_2",
-                "$window_id_2") as step_2_matching_event,
-               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+                               step_1_conversion_time,
+                               step_2_conversion_time ,
+                               ("latest_0",
+                                "uuid_0",
+                                "$session_id_0",
+                                "$window_id_0") as step_0_matching_event,
+                               ("latest_1",
+                                "uuid_1",
+                                "$session_id_1",
+                                "$window_id_1") as step_1_matching_event,
+                               ("latest_2",
+                                "uuid_2",
+                                "$session_id_2",
+                                "$window_id_2") as step_2_matching_event,
+                               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -332,31 +328,29 @@
                    "$window_id_2") as step_2_matching_event,
                   if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     "uuid_0",
-                     "$session_id_0",
-                     "$window_id_0",
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
-                                   min("uuid_1") over (PARTITION by aggregation_target
-                                                       ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "uuid_1",
-                                                 min("$session_id_1") over (PARTITION by aggregation_target
-                                                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$session_id_1",
-                                                                      min("$window_id_1") over (PARTITION by aggregation_target
-                                                                                                ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$window_id_1",
-                                                                                          step_2,
-                                                                                          min(latest_2) over (PARTITION by aggregation_target
-                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2,
-                                                                                                        min("uuid_2") over (PARTITION by aggregation_target
-                                                                                                                            ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "uuid_2",
-                                                                                                                      min("$session_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$session_id_2",
-                                                                                                                                           min("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    "uuid_0",
+                                                    "$session_id_0",
+                                                    "$window_id_0",
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
+                                                                       min("uuid_1") over (PARTITION by aggregation_target
+                                                                                           ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "uuid_1",
+                                                                                          min("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$session_id_1",
+                                                                                                                    min("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$window_id_1",
+                                                                                                                                             step_2,
+                                                                                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2,
+                                                                                                                                                                min("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "uuid_2",
+                                                                                                                                                                                   min("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                             min("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
@@ -11,8 +11,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -25,35 +25,29 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        latest_1,
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         step_2,
-                                         min(latest_2) over (PARTITION by aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             step_2,
+                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -136,8 +130,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -150,35 +144,29 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        latest_1,
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         step_2,
-                                         min(latest_2) over (PARTITION by aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             step_2,
+                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -261,8 +249,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -275,35 +263,29 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        latest_1,
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         step_2,
-                                         min(latest_2) over (PARTITION by aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             step_2,
+                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -386,8 +368,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   if(latest_0 <= latest_1
@@ -400,16 +382,14 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
-                                   step_2,
-                                   min(latest_2) over (PARTITION by aggregation_target
-                                                       ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
+                                                                       step_2,
+                                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                                           ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -489,8 +469,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   arraySort([latest_0,latest_1,latest_2]) as event_times,
@@ -501,16 +481,14 @@
                   if(isNotNull(conversion_times[3])
                      AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                   step_2,
-                                   min(latest_2) over (PARTITION by aggregation_target
-                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                       step_2,
+                                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -546,16 +524,14 @@
                             if(isNotNull(conversion_times[3])
                                AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                   step_2,
-                                   min(latest_2) over (PARTITION by aggregation_target
-                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                       step_2,
+                                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -591,16 +567,14 @@
                             if(isNotNull(conversion_times[3])
                                AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                   step_2,
-                                   min(latest_2) over (PARTITION by aggregation_target
-                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                       step_2,
+                                                                       min(latest_2) over (PARTITION by aggregation_target
+                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_trends.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_trends.ambr
@@ -25,35 +25,29 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        latest_1,
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         step_2,
-                                         min(latest_2) over (PARTITION by aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             step_2,
+                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -116,35 +110,29 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        latest_1,
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         step_2,
-                                         min(latest_2) over (PARTITION by aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             step_2,
+                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -207,35 +195,29 @@
                   if(isNotNull(latest_2)
                      AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     min(latest_2) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    min(latest_2) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        latest_1,
-                        step_2,
-                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       latest_1,
+                                                       step_2,
+                                                       if(latest_2 < latest_1, NULL, latest_2) as latest_2
                  FROM
-                   (SELECT aggregation_target,
-                           timestamp,
-                           step_0,
-                           latest_0,
-                           step_1,
-                           min(latest_1) over (PARTITION by aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                         step_2,
-                                         min(latest_2) over (PARTITION by aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                   (SELECT aggregation_target, timestamp, step_0,
+                                                          latest_0,
+                                                          step_1,
+                                                          min(latest_1) over (PARTITION by aggregation_target
+                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                             step_2,
+                                                                             min(latest_2) over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
                               pdi.person_id as aggregation_target,
@@ -291,35 +273,29 @@
                if(isNotNull(latest_2)
                   AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
         FROM
-          (SELECT aggregation_target,
-                  timestamp,
-                  step_0,
-                  latest_0,
-                  step_1,
-                  latest_1,
-                  step_2,
-                  min(latest_2) over (PARTITION by aggregation_target
-                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+          (SELECT aggregation_target, timestamp, step_0,
+                                                 latest_0,
+                                                 step_1,
+                                                 latest_1,
+                                                 step_2,
+                                                 min(latest_2) over (PARTITION by aggregation_target
+                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     latest_1,
-                     step_2,
-                     if(latest_2 < latest_1, NULL, latest_2) as latest_2
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    latest_1,
+                                                    step_2,
+                                                    if(latest_2 < latest_1, NULL, latest_2) as latest_2
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        step_1,
-                        min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                      step_2,
-                                      min(latest_2) over (PARTITION by aggregation_target
-                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       step_1,
+                                                       min(latest_1) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                          step_2,
+                                                                          min(latest_2) over (PARTITION by aggregation_target
+                                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                  FROM
                    (SELECT e.timestamp as timestamp,
                            pdi.person_id as aggregation_target,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
@@ -36,71 +36,65 @@
                 "$window_id_2") as step_2_matching_event,
                if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
         FROM
-          (SELECT aggregation_target,
-                  timestamp,
-                  step_0,
-                  latest_0,
-                  "uuid_0",
-                  "$session_id_0",
-                  "$window_id_0",
-                  step_1,
-                  latest_1,
-                  "uuid_1",
-                  "$session_id_1",
-                  "$window_id_1",
-                  step_2,
-                  min(latest_2) over (PARTITION by aggregation_target
-                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                last_value("uuid_2") over (PARTITION by aggregation_target
-                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                     last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                 last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+          (SELECT aggregation_target, timestamp, step_0,
+                                                 latest_0,
+                                                 "uuid_0",
+                                                 "$session_id_0",
+                                                 "$window_id_0",
+                                                 step_1,
+                                                 latest_1,
+                                                 "uuid_1",
+                                                 "$session_id_1",
+                                                 "$window_id_1",
+                                                 step_2,
+                                                 min(latest_2) over (PARTITION by aggregation_target
+                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                    last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                              last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                               last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     "uuid_0",
-                     "$session_id_0",
-                     "$window_id_0",
-                     step_1,
-                     latest_1,
-                     "uuid_1",
-                     "$session_id_1",
-                     "$window_id_1",
-                     step_2,
-                     if(latest_2 < latest_1, NULL, latest_2) as latest_2,
-                     if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
-                     if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
-                     if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    "uuid_0",
+                                                    "$session_id_0",
+                                                    "$window_id_0",
+                                                    step_1,
+                                                    latest_1,
+                                                    "uuid_1",
+                                                    "$session_id_1",
+                                                    "$window_id_1",
+                                                    step_2,
+                                                    if(latest_2 < latest_1, NULL, latest_2) as latest_2,
+                                                    if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
+                                                    if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
+                                                    if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        "uuid_0",
-                        "$session_id_0",
-                        "$window_id_0",
-                        step_1,
-                        min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                      last_value("uuid_1") over (PARTITION by aggregation_target
-                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
-                                                           last_value("$session_id_1") over (PARTITION by aggregation_target
-                                                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
-                                                                                       last_value("$window_id_1") over (PARTITION by aggregation_target
-                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
-                                                                                                                  step_2,
-                                                                                                                  min(latest_2) over (PARTITION by aggregation_target
-                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                                                                                                                last_value("uuid_2") over (PARTITION by aggregation_target
-                                                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                                                                                                                     last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                                                                                                                 last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       "uuid_0",
+                                                       "$session_id_0",
+                                                       "$window_id_0",
+                                                       step_1,
+                                                       min(latest_1) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                          last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                                                    last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                                                     last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                                                     step_2,
+                                                                                                                                                                     min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                                                        last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                                                  last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                                                   last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                  FROM
                    (SELECT e.timestamp as timestamp,
                            pdi.person_id as aggregation_target,
@@ -194,71 +188,65 @@
                 "$window_id_2") as step_2_matching_event,
                if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
         FROM
-          (SELECT aggregation_target,
-                  timestamp,
-                  step_0,
-                  latest_0,
-                  "uuid_0",
-                  "$session_id_0",
-                  "$window_id_0",
-                  step_1,
-                  latest_1,
-                  "uuid_1",
-                  "$session_id_1",
-                  "$window_id_1",
-                  step_2,
-                  min(latest_2) over (PARTITION by aggregation_target
-                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                last_value("uuid_2") over (PARTITION by aggregation_target
-                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                     last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                 last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+          (SELECT aggregation_target, timestamp, step_0,
+                                                 latest_0,
+                                                 "uuid_0",
+                                                 "$session_id_0",
+                                                 "$window_id_0",
+                                                 step_1,
+                                                 latest_1,
+                                                 "uuid_1",
+                                                 "$session_id_1",
+                                                 "$window_id_1",
+                                                 step_2,
+                                                 min(latest_2) over (PARTITION by aggregation_target
+                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                    last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                              last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                               last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     "uuid_0",
-                     "$session_id_0",
-                     "$window_id_0",
-                     step_1,
-                     latest_1,
-                     "uuid_1",
-                     "$session_id_1",
-                     "$window_id_1",
-                     step_2,
-                     if(latest_2 < latest_1, NULL, latest_2) as latest_2,
-                     if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
-                     if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
-                     if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    "uuid_0",
+                                                    "$session_id_0",
+                                                    "$window_id_0",
+                                                    step_1,
+                                                    latest_1,
+                                                    "uuid_1",
+                                                    "$session_id_1",
+                                                    "$window_id_1",
+                                                    step_2,
+                                                    if(latest_2 < latest_1, NULL, latest_2) as latest_2,
+                                                    if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
+                                                    if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
+                                                    if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        "uuid_0",
-                        "$session_id_0",
-                        "$window_id_0",
-                        step_1,
-                        min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                      last_value("uuid_1") over (PARTITION by aggregation_target
-                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
-                                                           last_value("$session_id_1") over (PARTITION by aggregation_target
-                                                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
-                                                                                       last_value("$window_id_1") over (PARTITION by aggregation_target
-                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
-                                                                                                                  step_2,
-                                                                                                                  min(latest_2) over (PARTITION by aggregation_target
-                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                                                                                                                last_value("uuid_2") over (PARTITION by aggregation_target
-                                                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                                                                                                                     last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                                                                                                                 last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       "uuid_0",
+                                                       "$session_id_0",
+                                                       "$window_id_0",
+                                                       step_1,
+                                                       min(latest_1) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                          last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                                                    last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                                                     last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                                                     step_2,
+                                                                                                                                                                     min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                                                        last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                                                  last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                                                   last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                  FROM
                    (SELECT e.timestamp as timestamp,
                            pdi.person_id as aggregation_target,
@@ -353,71 +341,65 @@
                 "$window_id_2") as step_2_matching_event,
                if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
         FROM
-          (SELECT aggregation_target,
-                  timestamp,
-                  step_0,
-                  latest_0,
-                  "uuid_0",
-                  "$session_id_0",
-                  "$window_id_0",
-                  step_1,
-                  latest_1,
-                  "uuid_1",
-                  "$session_id_1",
-                  "$window_id_1",
-                  step_2,
-                  min(latest_2) over (PARTITION by aggregation_target
-                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                last_value("uuid_2") over (PARTITION by aggregation_target
-                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                     last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                 last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+          (SELECT aggregation_target, timestamp, step_0,
+                                                 latest_0,
+                                                 "uuid_0",
+                                                 "$session_id_0",
+                                                 "$window_id_0",
+                                                 step_1,
+                                                 latest_1,
+                                                 "uuid_1",
+                                                 "$session_id_1",
+                                                 "$window_id_1",
+                                                 step_2,
+                                                 min(latest_2) over (PARTITION by aggregation_target
+                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                    last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                              last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                               last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     "uuid_0",
-                     "$session_id_0",
-                     "$window_id_0",
-                     step_1,
-                     latest_1,
-                     "uuid_1",
-                     "$session_id_1",
-                     "$window_id_1",
-                     step_2,
-                     if(latest_2 < latest_1, NULL, latest_2) as latest_2,
-                     if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
-                     if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
-                     if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    "uuid_0",
+                                                    "$session_id_0",
+                                                    "$window_id_0",
+                                                    step_1,
+                                                    latest_1,
+                                                    "uuid_1",
+                                                    "$session_id_1",
+                                                    "$window_id_1",
+                                                    step_2,
+                                                    if(latest_2 < latest_1, NULL, latest_2) as latest_2,
+                                                    if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
+                                                    if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
+                                                    if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
               FROM
-                (SELECT aggregation_target,
-                        timestamp,
-                        step_0,
-                        latest_0,
-                        "uuid_0",
-                        "$session_id_0",
-                        "$window_id_0",
-                        step_1,
-                        min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                      last_value("uuid_1") over (PARTITION by aggregation_target
-                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
-                                                           last_value("$session_id_1") over (PARTITION by aggregation_target
-                                                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
-                                                                                       last_value("$window_id_1") over (PARTITION by aggregation_target
-                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
-                                                                                                                  step_2,
-                                                                                                                  min(latest_2) over (PARTITION by aggregation_target
-                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                                                                                                                last_value("uuid_2") over (PARTITION by aggregation_target
-                                                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                                                                                                                     last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                                                                                                                 last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+                (SELECT aggregation_target, timestamp, step_0,
+                                                       latest_0,
+                                                       "uuid_0",
+                                                       "$session_id_0",
+                                                       "$window_id_0",
+                                                       step_1,
+                                                       min(latest_1) over (PARTITION by aggregation_target
+                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                          last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                                                    last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                                                     last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                                                     step_2,
+                                                                                                                                                                     min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                                                        last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                                                  last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                                                   last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                  FROM
                    (SELECT e.timestamp as timestamp,
                            pdi.person_id as aggregation_target,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -51,9 +51,10 @@
      FROM
        (SELECT aggregation_target,
                steps,
-               max(steps) over (PARTITION BY aggregation_target, prop) as max_steps,
-               step_1_conversion_time,
-               prop
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time,
+                               prop
         FROM
           (SELECT *,
                   arraySort([latest_0,latest_1]) as event_times,
@@ -62,14 +63,13 @@
                   if(isNotNull(conversion_times[2])
                      AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
-                                   if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
               FROM
                 (SELECT *,
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
@@ -107,14 +107,13 @@
                             if(isNotNull(conversion_times[2])
                                AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
-                                   if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
               FROM
                 (SELECT *,
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
@@ -205,9 +204,10 @@
      FROM
        (SELECT aggregation_target,
                steps,
-               max(steps) over (PARTITION BY aggregation_target, prop) as max_steps,
-               step_1_conversion_time,
-               prop
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time,
+                               prop
         FROM
           (SELECT *,
                   arraySort([latest_0,latest_1]) as event_times,
@@ -216,14 +216,13 @@
                   if(isNotNull(conversion_times[2])
                      AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
-                                   if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
               FROM
                 (SELECT *,
                         prop
@@ -265,14 +264,13 @@
                             if(isNotNull(conversion_times[2])
                                AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
-                                   if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
               FROM
                 (SELECT *,
                         prop
@@ -367,9 +365,10 @@
      FROM
        (SELECT aggregation_target,
                steps,
-               max(steps) over (PARTITION BY aggregation_target, prop) as max_steps,
-               step_1_conversion_time,
-               prop
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time,
+                               prop
         FROM
           (SELECT *,
                   arraySort([latest_0,latest_1]) as event_times,
@@ -378,14 +377,13 @@
                   if(isNotNull(conversion_times[2])
                      AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
-                                   if(has([['', ''], ['alakazam', ''], ['Safari', 'xyz'], ['Mac', ''], ['Chrome', 'xyz'], ['0', '0'], ['', 'no-mac']], prop), prop, ['Other']) as prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([['', ''], ['alakazam', ''], ['Safari', 'xyz'], ['Mac', ''], ['Chrome', 'xyz'], ['0', '0'], ['', 'no-mac']], prop), prop, ['Other']) as prop
               FROM
                 (SELECT *,
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['','']) as prop
@@ -422,14 +420,13 @@
                             if(isNotNull(conversion_times[2])
                                AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target, prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
-                                   if(has([['', ''], ['alakazam', ''], ['Safari', 'xyz'], ['Mac', ''], ['Chrome', 'xyz'], ['0', '0'], ['', 'no-mac']], prop), prop, ['Other']) as prop
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([['', ''], ['alakazam', ''], ['Safari', 'xyz'], ['Mac', ''], ['Chrome', 'xyz'], ['0', '0'], ['', 'no-mac']], prop), prop, ['Other']) as prop
               FROM
                 (SELECT *,
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['','']) as prop

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
@@ -14,8 +14,8 @@
        (SELECT aggregation_target,
                steps,
                max(steps) over (PARTITION BY aggregation_target) as max_steps,
-               step_1_conversion_time,
-               step_2_conversion_time
+                               step_1_conversion_time,
+                               step_2_conversion_time
         FROM
           (SELECT *,
                   arraySort([latest_0,latest_1,latest_2]) as event_times,
@@ -26,31 +26,29 @@
                   if(isNotNull(conversion_times[3])
                      AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     "uuid_0",
-                     "$session_id_0",
-                     "$window_id_0",
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                   last_value("uuid_1") over (PARTITION by aggregation_target
-                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
-                                                        last_value("$session_id_1") over (PARTITION by aggregation_target
-                                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
-                                                                                    last_value("$window_id_1") over (PARTITION by aggregation_target
-                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
-                                                                                                               step_2,
-                                                                                                               min(latest_2) over (PARTITION by aggregation_target
-                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                                                                                                             last_value("uuid_2") over (PARTITION by aggregation_target
-                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                                                                                                                  last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                                                                                                              last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    "uuid_0",
+                                                    "$session_id_0",
+                                                    "$window_id_0",
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                       last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                                                 last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                                                  last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                                                  step_2,
+                                                                                                                                                                  min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                                                     last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                                               last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                                                last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -96,31 +94,29 @@
                             if(isNotNull(conversion_times[3])
                                AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     "uuid_0",
-                     "$session_id_0",
-                     "$window_id_0",
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                   last_value("uuid_1") over (PARTITION by aggregation_target
-                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
-                                                        last_value("$session_id_1") over (PARTITION by aggregation_target
-                                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
-                                                                                    last_value("$window_id_1") over (PARTITION by aggregation_target
-                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
-                                                                                                               step_2,
-                                                                                                               min(latest_2) over (PARTITION by aggregation_target
-                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                                                                                                             last_value("uuid_2") over (PARTITION by aggregation_target
-                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                                                                                                                  last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                                                                                                              last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    "uuid_0",
+                                                    "$session_id_0",
+                                                    "$window_id_0",
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                       last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                                                 last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                                                  last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                                                  step_2,
+                                                                                                                                                                  min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                                                     last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                                               last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                                                last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,
@@ -166,31 +162,29 @@
                             if(isNotNull(conversion_times[3])
                                AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
            FROM
-             (SELECT aggregation_target,
-                     timestamp,
-                     step_0,
-                     latest_0,
-                     "uuid_0",
-                     "$session_id_0",
-                     "$window_id_0",
-                     step_1,
-                     min(latest_1) over (PARTITION by aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
-                                   last_value("uuid_1") over (PARTITION by aggregation_target
-                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
-                                                        last_value("$session_id_1") over (PARTITION by aggregation_target
-                                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
-                                                                                    last_value("$window_id_1") over (PARTITION by aggregation_target
-                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
-                                                                                                               step_2,
-                                                                                                               min(latest_2) over (PARTITION by aggregation_target
-                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
-                                                                                                                             last_value("uuid_2") over (PARTITION by aggregation_target
-                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
-                                                                                                                                                  last_value("$session_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
-                                                                                                                                                                              last_value("$window_id_2") over (PARTITION by aggregation_target
-                                                                                                                                                                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    "uuid_0",
+                                                    "$session_id_0",
+                                                    "$window_id_0",
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                                       last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                                                 last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                                                  last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                                                  step_2,
+                                                                                                                                                                  min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                                                     last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                                               last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                                                last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
                         pdi.person_id as aggregation_target,

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list.ambr
@@ -20,11 +20,9 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id ,
-            events.properties as properties
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id ,
+                                events.properties as properties
      FROM events
      WHERE team_id = 2
        AND timestamp >= '2021-01-13 12:00:00'
@@ -82,11 +80,9 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id ,
-            events.properties as properties
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id ,
+                                events.properties as properties
      FROM events
      WHERE team_id = 2
        AND timestamp >= '2021-01-13 12:00:00'
@@ -144,11 +140,9 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id ,
-            events.mat_$browser as mat_$browser
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id ,
+                                events.mat_$browser as mat_$browser
      FROM events
      WHERE team_id = 2
        AND timestamp >= '2021-01-13 12:00:00'
@@ -206,11 +200,9 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id ,
-            events.mat_$browser as mat_$browser
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id ,
+                                events.mat_$browser as mat_$browser
      FROM events
      WHERE team_id = 2
        AND timestamp >= '2021-01-13 12:00:00'
@@ -266,10 +258,8 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id
      FROM events
      WHERE team_id = 2
        AND event IN ['$pageview']
@@ -326,10 +316,8 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id
      FROM events
      WHERE team_id = 2
        AND event IN ['$autocapture']
@@ -465,11 +453,9 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id ,
-            events.properties as properties
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id ,
+                                events.properties as properties
      FROM events
      WHERE team_id = 2
        AND event IN ['$pageview']
@@ -542,11 +528,9 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id ,
-            events.properties as properties
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id ,
+                                events.properties as properties
      FROM events
      WHERE team_id = 2
        AND event IN ['$pageview']
@@ -607,11 +591,9 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id ,
-            events.mat_$browser as mat_$browser
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id ,
+                                events.mat_$browser as mat_$browser
      FROM events
      WHERE team_id = 2
        AND event IN ['$pageview']
@@ -684,11 +666,9 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id ,
-            events.mat_$browser as mat_$browser
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id ,
+                                events.mat_$browser as mat_$browser
      FROM events
      WHERE team_id = 2
        AND event IN ['$pageview']
@@ -745,10 +725,8 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id
      FROM events
      WHERE team_id = 2
        AND event IN ['$pageview']
@@ -805,10 +783,8 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id
      FROM events
      WHERE team_id = 2
        AND event IN ['$autocapture']
@@ -922,11 +898,9 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id ,
-            events.properties as properties
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id ,
+                                events.properties as properties
      FROM events
      WHERE team_id = 2
        AND event IN ['$pageview']
@@ -985,11 +959,9 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id ,
-            events.properties as properties
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id ,
+                                events.properties as properties
      FROM events
      WHERE team_id = 2
        AND event IN ['$pageview']
@@ -1048,11 +1020,9 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id ,
-            events.mat_$browser as mat_$browser
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id ,
+                                events.mat_$browser as mat_$browser
      FROM events
      WHERE team_id = 2
        AND event IN ['$pageview']
@@ -1111,11 +1081,9 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id ,
-            events.mat_$browser as mat_$browser
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id ,
+                                events.mat_$browser as mat_$browser
      FROM events
      WHERE team_id = 2
        AND event IN ['$pageview']
@@ -1177,10 +1145,8 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id
      FROM events
      WHERE team_id = 2
        AND event IN ['$pageview', 'new-event']
@@ -1243,10 +1209,8 @@
     (SELECT uuid,
             distinct_id,
             event,
-            team_id,
-            timestamp,
-            $session_id as session_id,
-            $window_id as window_id
+            team_id, timestamp, $session_id as session_id,
+                                $window_id as window_id
      FROM events
      WHERE team_id = 2
        AND event IN ['$pageview', 'new-event2']
@@ -1300,22 +1264,19 @@
   FROM
     (SELECT session_id,
             distinct_id ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_0 = 1) AS matching_events_0 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_0 = 1) AS matching_events_0 ,
             sum(event_match_0) AS matches_0
      FROM
        (SELECT uuid,
                distinct_id,
                event,
-               team_id,
-               timestamp,
-               $session_id as session_id,
-               $window_id as window_id ,
-               events.properties as properties ,
-               if(1 = 1
-                  AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))), 1, 0) as event_match_0
+               team_id, timestamp, $session_id as session_id,
+                                   $window_id as window_id ,
+                                   events.properties as properties ,
+                                   if(1 = 1
+                                      AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))), 1, 0) as event_match_0
         FROM events
         WHERE team_id = 2
           AND timestamp >= '2021-01-13 12:00:00'
@@ -1365,22 +1326,19 @@
   FROM
     (SELECT session_id,
             distinct_id ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_0 = 1) AS matching_events_0 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_0 = 1) AS matching_events_0 ,
             sum(event_match_0) AS matches_0
      FROM
        (SELECT uuid,
                distinct_id,
                event,
-               team_id,
-               timestamp,
-               $session_id as session_id,
-               $window_id as window_id ,
-               events.properties as properties ,
-               if(1 = 1
-                  AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))), 1, 0) as event_match_0
+               team_id, timestamp, $session_id as session_id,
+                                   $window_id as window_id ,
+                                   events.properties as properties ,
+                                   if(1 = 1
+                                      AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))), 1, 0) as event_match_0
         FROM events
         WHERE team_id = 2
           AND timestamp >= '2021-01-13 12:00:00'
@@ -1430,22 +1388,19 @@
   FROM
     (SELECT session_id,
             distinct_id ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_0 = 1) AS matching_events_0 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_0 = 1) AS matching_events_0 ,
             sum(event_match_0) AS matches_0
      FROM
        (SELECT uuid,
                distinct_id,
                event,
-               team_id,
-               timestamp,
-               $session_id as session_id,
-               $window_id as window_id ,
-               events.mat_$browser as mat_$browser ,
-                           if(1 = 1
-                              AND (has(['Chrome'], "mat_$browser")), 1, 0) as event_match_0
+               team_id, timestamp, $session_id as session_id,
+                                   $window_id as window_id ,
+                                   events.mat_$browser as mat_$browser ,
+                                               if(1 = 1
+                                                  AND (has(['Chrome'], "mat_$browser")), 1, 0) as event_match_0
         FROM events
         WHERE team_id = 2
           AND timestamp >= '2021-01-13 12:00:00'
@@ -1495,22 +1450,19 @@
   FROM
     (SELECT session_id,
             distinct_id ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_0 = 1) AS matching_events_0 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_0 = 1) AS matching_events_0 ,
             sum(event_match_0) AS matches_0
      FROM
        (SELECT uuid,
                distinct_id,
                event,
-               team_id,
-               timestamp,
-               $session_id as session_id,
-               $window_id as window_id ,
-               events.mat_$browser as mat_$browser ,
-                           if(1 = 1
-                              AND (has(['Firefox'], "mat_$browser")), 1, 0) as event_match_0
+               team_id, timestamp, $session_id as session_id,
+                                   $window_id as window_id ,
+                                   events.mat_$browser as mat_$browser ,
+                                               if(1 = 1
+                                                  AND (has(['Firefox'], "mat_$browser")), 1, 0) as event_match_0
         FROM events
         WHERE team_id = 2
           AND timestamp >= '2021-01-13 12:00:00'
@@ -1560,20 +1512,17 @@
   FROM
     (SELECT session_id,
             distinct_id ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_0 = 1) AS matching_events_0 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_0 = 1) AS matching_events_0 ,
             sum(event_match_0) AS matches_0
      FROM
        (SELECT uuid,
                distinct_id,
                event,
-               team_id,
-               timestamp,
-               $session_id as session_id,
-               $window_id as window_id ,
-               if(event = '$pageview', 1, 0) as event_match_0
+               team_id, timestamp, $session_id as session_id,
+                                   $window_id as window_id ,
+                                   if(event = '$pageview', 1, 0) as event_match_0
         FROM events
         WHERE team_id = 2
           AND event IN ['$pageview']
@@ -1624,20 +1573,17 @@
   FROM
     (SELECT session_id,
             distinct_id ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_0 = 1) AS matching_events_0 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_0 = 1) AS matching_events_0 ,
             sum(event_match_0) AS matches_0
      FROM
        (SELECT uuid,
                distinct_id,
                event,
-               team_id,
-               timestamp,
-               $session_id as session_id,
-               $window_id as window_id ,
-               if(event = '$autocapture', 1, 0) as event_match_0
+               team_id, timestamp, $session_id as session_id,
+                                   $window_id as window_id ,
+                                   if(event = '$autocapture', 1, 0) as event_match_0
         FROM events
         WHERE team_id = 2
           AND event IN ['$autocapture']
@@ -1763,20 +1709,17 @@
   FROM
     (SELECT session_id,
             distinct_id ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_0 = 1) AS matching_events_0 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_0 = 1) AS matching_events_0 ,
             sum(event_match_0) AS matches_0
      FROM
        (SELECT uuid,
                distinct_id,
                event,
-               team_id,
-               timestamp,
-               $session_id as session_id,
-               $window_id as window_id ,
-               if(event = '$pageview', 1, 0) as event_match_0
+               team_id, timestamp, $session_id as session_id,
+                                   $window_id as window_id ,
+                                   if(event = '$pageview', 1, 0) as event_match_0
         FROM events
         WHERE team_id = 2
           AND event IN ['$pageview']
@@ -1827,20 +1770,17 @@
   FROM
     (SELECT session_id,
             distinct_id ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_0 = 1) AS matching_events_0 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_0 = 1) AS matching_events_0 ,
             sum(event_match_0) AS matches_0
      FROM
        (SELECT uuid,
                distinct_id,
                event,
-               team_id,
-               timestamp,
-               $session_id as session_id,
-               $window_id as window_id ,
-               if(event = '$autocapture', 1, 0) as event_match_0
+               team_id, timestamp, $session_id as session_id,
+                                   $window_id as window_id ,
+                                   if(event = '$autocapture', 1, 0) as event_match_0
         FROM events
         WHERE team_id = 2
           AND event IN ['$autocapture']
@@ -1946,22 +1886,19 @@
   FROM
     (SELECT session_id,
             distinct_id ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_0 = 1) AS matching_events_0 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_0 = 1) AS matching_events_0 ,
             sum(event_match_0) AS matches_0
      FROM
        (SELECT uuid,
                distinct_id,
                event,
-               team_id,
-               timestamp,
-               $session_id as session_id,
-               $window_id as window_id ,
-               events.properties as properties ,
-               if(event = '$pageview'
-                  AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))), 1, 0) as event_match_0
+               team_id, timestamp, $session_id as session_id,
+                                   $window_id as window_id ,
+                                   events.properties as properties ,
+                                   if(event = '$pageview'
+                                      AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))), 1, 0) as event_match_0
         FROM events
         WHERE team_id = 2
           AND event IN ['$pageview']
@@ -2012,22 +1949,19 @@
   FROM
     (SELECT session_id,
             distinct_id ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_0 = 1) AS matching_events_0 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_0 = 1) AS matching_events_0 ,
             sum(event_match_0) AS matches_0
      FROM
        (SELECT uuid,
                distinct_id,
                event,
-               team_id,
-               timestamp,
-               $session_id as session_id,
-               $window_id as window_id ,
-               events.properties as properties ,
-               if(event = '$pageview'
-                  AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))), 1, 0) as event_match_0
+               team_id, timestamp, $session_id as session_id,
+                                   $window_id as window_id ,
+                                   events.properties as properties ,
+                                   if(event = '$pageview'
+                                      AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))), 1, 0) as event_match_0
         FROM events
         WHERE team_id = 2
           AND event IN ['$pageview']
@@ -2078,22 +2012,19 @@
   FROM
     (SELECT session_id,
             distinct_id ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_0 = 1) AS matching_events_0 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_0 = 1) AS matching_events_0 ,
             sum(event_match_0) AS matches_0
      FROM
        (SELECT uuid,
                distinct_id,
                event,
-               team_id,
-               timestamp,
-               $session_id as session_id,
-               $window_id as window_id ,
-               events.mat_$browser as mat_$browser ,
-                           if(event = '$pageview'
-                              AND (has(['Chrome'], "mat_$browser")), 1, 0) as event_match_0
+               team_id, timestamp, $session_id as session_id,
+                                   $window_id as window_id ,
+                                   events.mat_$browser as mat_$browser ,
+                                               if(event = '$pageview'
+                                                  AND (has(['Chrome'], "mat_$browser")), 1, 0) as event_match_0
         FROM events
         WHERE team_id = 2
           AND event IN ['$pageview']
@@ -2144,22 +2075,19 @@
   FROM
     (SELECT session_id,
             distinct_id ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_0 = 1) AS matching_events_0 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_0 = 1) AS matching_events_0 ,
             sum(event_match_0) AS matches_0
      FROM
        (SELECT uuid,
                distinct_id,
                event,
-               team_id,
-               timestamp,
-               $session_id as session_id,
-               $window_id as window_id ,
-               events.mat_$browser as mat_$browser ,
-                           if(event = '$pageview'
-                              AND (has(['Firefox'], "mat_$browser")), 1, 0) as event_match_0
+               team_id, timestamp, $session_id as session_id,
+                                   $window_id as window_id ,
+                                   events.mat_$browser as mat_$browser ,
+                                               if(event = '$pageview'
+                                                  AND (has(['Firefox'], "mat_$browser")), 1, 0) as event_match_0
         FROM events
         WHERE team_id = 2
           AND event IN ['$pageview']
@@ -2212,26 +2140,22 @@
   FROM
     (SELECT session_id,
             distinct_id ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_0 = 1) AS matching_events_0 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_0 = 1) AS matching_events_0 ,
             sum(event_match_0) AS matches_0 ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_1 = 1) AS matching_events_1 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_1 = 1) AS matching_events_1 ,
             sum(event_match_1) AS matches_1
      FROM
        (SELECT uuid,
                distinct_id,
                event,
-               team_id,
-               timestamp,
-               $session_id as session_id,
-               $window_id as window_id ,
-               if(event = '$pageview', 1, 0) as event_match_0 ,
-               if(event = 'new-event', 1, 0) as event_match_1
+               team_id, timestamp, $session_id as session_id,
+                                   $window_id as window_id ,
+                                   if(event = '$pageview', 1, 0) as event_match_0 ,
+                                   if(event = 'new-event', 1, 0) as event_match_1
         FROM events
         WHERE team_id = 2
           AND event IN ['$pageview', 'new-event']
@@ -2285,26 +2209,22 @@
   FROM
     (SELECT session_id,
             distinct_id ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_0 = 1) AS matching_events_0 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_0 = 1) AS matching_events_0 ,
             sum(event_match_0) AS matches_0 ,
-            groupUniqArrayIf(100)((timestamp,
-                                   uuid,
-                                   session_id,
-                                   window_id), event_match_1 = 1) AS matching_events_1 ,
+            groupUniqArrayIf(100)((timestamp, uuid,
+                                              session_id,
+                                              window_id), event_match_1 = 1) AS matching_events_1 ,
             sum(event_match_1) AS matches_1
      FROM
        (SELECT uuid,
                distinct_id,
                event,
-               team_id,
-               timestamp,
-               $session_id as session_id,
-               $window_id as window_id ,
-               if(event = '$pageview', 1, 0) as event_match_0 ,
-               if(event = 'new-event2', 1, 0) as event_match_1
+               team_id, timestamp, $session_id as session_id,
+                                   $window_id as window_id ,
+                                   if(event = '$pageview', 1, 0) as event_match_0 ,
+                                   if(event = 'new-event2', 1, 0) as event_match_1
         FROM events
         WHERE team_id = 2
           AND event IN ['$pageview', 'new-event2']

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -613,7 +613,7 @@
                     day_start
            UNION ALL SELECT counts AS total,
                             timestamp AS day_start,
-                                         breakdown_value
+                            breakdown_value
            FROM
              (SELECT d.timestamp,
                      COUNT(DISTINCT person_id) counts,
@@ -661,9 +661,8 @@
                                  GROUP BY id
                                  HAVING max(is_deleted) = 0
                                  AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))))))
-                 GROUP BY timestamp,
-                          person_id,
-                          breakdown_value) e
+                 GROUP BY timestamp, person_id,
+                                     breakdown_value) e
               WHERE e.timestamp <= d.timestamp
                 AND e.timestamp > d.timestamp - INTERVAL 6 DAY
               GROUP BY d.timestamp,
@@ -1309,7 +1308,7 @@
                     day_start
            UNION ALL SELECT counts AS total,
                             timestamp AS day_start,
-                                         breakdown_value
+                            breakdown_value
            FROM
              (SELECT d.timestamp,
                      COUNT(DISTINCT person_id) counts,
@@ -1350,9 +1349,8 @@
                    AND event = 'sign up'
                    AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-28 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
-                 GROUP BY timestamp,
-                          person_id,
-                          breakdown_value) e
+                 GROUP BY timestamp, person_id,
+                                     breakdown_value) e
               WHERE e.timestamp <= d.timestamp
                 AND e.timestamp > d.timestamp - INTERVAL 29 DAY
               GROUP BY d.timestamp,
@@ -1424,7 +1422,7 @@
                     day_start
            UNION ALL SELECT counts AS total,
                             timestamp AS day_start,
-                                         breakdown_value
+                            breakdown_value
            FROM
              (SELECT d.timestamp,
                      COUNT(DISTINCT person_id) counts,
@@ -1454,9 +1452,8 @@
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
                    AND notEmpty(e.person_id)
                    AND notEmpty(e.person_id)
-                 GROUP BY timestamp,
-                          person_id,
-                          breakdown_value) e
+                 GROUP BY timestamp, person_id,
+                                     breakdown_value) e
               WHERE e.timestamp <= d.timestamp
                 AND e.timestamp > d.timestamp - INTERVAL 29 DAY
               GROUP BY d.timestamp,
@@ -2249,8 +2246,7 @@
                 AND event = 'sign up'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'UTC')
                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -2507,8 +2503,7 @@
                 AND event = 'sign up'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'America/Phoenix')
                 AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 23:59:59', 'America/Phoenix')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -2765,8 +2760,7 @@
                 AND event = 'sign up'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'Asia/Tokyo')
                 AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 23:59:59', 'Asia/Tokyo')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -3812,8 +3806,7 @@
                 AND event = 'sign up'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-24 00:00:00', 'UTC')
                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 29 DAY
            GROUP BY d.timestamp
@@ -3855,8 +3848,7 @@
                 AND event = 'sign up'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-17 00:00:00', 'UTC')
                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -4037,9 +4029,7 @@
                      min(timestamp) as timestamp,
                      breakdown_value
               FROM
-                (SELECT pdi.person_id as person_id,
-                        timestamp,
-                        replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') as breakdown_value
+                (SELECT pdi.person_id as person_id, timestamp, replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') as breakdown_value
                  FROM events e
                  INNER JOIN
                    (SELECT distinct_id,
@@ -4125,9 +4115,7 @@
                      min(timestamp) as timestamp,
                      breakdown_value
               FROM
-                (SELECT if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) as person_id,
-                        timestamp,
-                        replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') as breakdown_value
+                (SELECT if(notEmpty(overrides.person_id), overrides.person_id, e.person_id) as person_id, timestamp, replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') as breakdown_value
                  FROM events e
                  LEFT OUTER JOIN
                    (SELECT argMax(override_person_id, version) as person_id,
@@ -5082,8 +5070,7 @@
                 AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-19 23:59:59', 'UTC')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -5132,8 +5119,7 @@
                 AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'America/Phoenix')
                 AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-19 23:59:59', 'America/Phoenix')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -5182,8 +5168,7 @@
                 AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'Asia/Tokyo')
                 AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-19 23:59:59', 'Asia/Tokyo')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -5244,8 +5229,7 @@
                 AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-25 00:00:00', 'UTC')
                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -5306,8 +5290,7 @@
                 AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-25 00:00:00', 'UTC')
                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -5356,8 +5339,7 @@
                 AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-02 06:00:00', 'UTC')
                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-09 17:00:00', 'UTC')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -5406,8 +5388,7 @@
                 AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-24 00:00:00', 'UTC')
                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-29 23:59:59', 'UTC')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -5456,8 +5437,7 @@
                 AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-24 00:00:00', 'America/Phoenix')
                 AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-02-29 23:59:59', 'America/Phoenix')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -5506,8 +5486,7 @@
                 AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-24 00:00:00', 'Asia/Tokyo')
                 AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-02-29 23:59:59', 'Asia/Tokyo')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -5556,8 +5535,7 @@
                 AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'UTC')
                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-18 23:59:59', 'UTC')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -5606,8 +5584,7 @@
                 AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'America/Phoenix')
                 AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-18 23:59:59', 'America/Phoenix')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp
@@ -5656,8 +5633,7 @@
                 AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'Asia/Tokyo')
                 AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-18 23:59:59', 'Asia/Tokyo')
-              GROUP BY timestamp,
-                       actor_id) e
+              GROUP BY timestamp, actor_id) e
            WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY
              AND e.timestamp > d.timestamp - INTERVAL 6 DAY
            GROUP BY d.timestamp

--- a/posthog/queries/trends/test/__snapshots__/test_person.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_person.ambr
@@ -3,10 +3,9 @@
   
   SELECT $group_0 AS actor_id,
          count() AS actor_value ,
-         groupUniqArray(100)((timestamp,
-                              uuid,
-                              $session_id,
-                              $window_id)) as matching_events
+         groupUniqArray(100)((timestamp, uuid,
+                                         $session_id,
+                                         $window_id)) as matching_events
   FROM
     (SELECT e.timestamp as timestamp,
             e."$group_0" as "$group_0",

--- a/posthog/temporal/tests/batch_exports/test_batch_exports.py
+++ b/posthog/temporal/tests/batch_exports/test_batch_exports.py
@@ -22,6 +22,7 @@ EventValues = TypedDict(
         "event": str,
         "_timestamp": str,
         "timestamp": str,
+        "inserted_at": str,
         "created_at": str,
         "distinct_id": str,
         "person_id": str,
@@ -42,6 +43,7 @@ async def insert_events(ch_client: ClickHouseClient, events: list[EventValues]):
             event,
             timestamp,
             _timestamp,
+            inserted_at,
             person_id,
             team_id,
             properties,
@@ -59,6 +61,7 @@ async def insert_events(ch_client: ClickHouseClient, events: list[EventValues]):
                 event["event"],
                 event["timestamp"],
                 event["_timestamp"],
+                event["inserted_at"],
                 event["person_id"],
                 event["team_id"],
                 json.dumps(event["properties"]) if isinstance(event["properties"], dict) else event["properties"],
@@ -105,6 +108,7 @@ async def test_get_rows_count(client):
             "event": "test",
             "_timestamp": "2023-04-20 14:30:00",
             "timestamp": f"2023-04-20 14:30:00.{i:06d}",
+            "inserted_at": f"2023-04-20 14:30:00.{i:06d}",
             "created_at": "2023-04-20 14:30:00.000000",
             "distinct_id": str(uuid4()),
             "person_id": str(uuid4()),
@@ -139,6 +143,7 @@ async def test_get_results_iterator(client):
             "event": f"test-{i}",
             "_timestamp": "2023-04-20 14:30:00",
             "timestamp": f"2023-04-20 14:30:00.{i:06d}",
+            "inserted_at": f"2023-04-20 14:30:00.{i:06d}",
             "created_at": "2023-04-20 14:30:00.000000",
             "distinct_id": str(uuid4()),
             "person_id": str(uuid4()),
@@ -154,8 +159,8 @@ async def test_get_results_iterator(client):
         events=events,
     )
 
-    aiter = get_results_iterator(client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00")
-    rows = [row async for row in aiter]
+    iter_ = get_results_iterator(client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00")
+    rows = [row for row in iter_]
 
     all_expected = sorted(events, key=operator.itemgetter("event"))
     all_result = sorted(rows, key=operator.itemgetter("event"))

--- a/posthog/temporal/tests/batch_exports/test_batch_exports.py
+++ b/posthog/temporal/tests/batch_exports/test_batch_exports.py
@@ -1,0 +1,164 @@
+import json
+import operator
+from random import randint
+from typing import TypedDict
+from uuid import uuid4
+
+import aiohttp
+import pytest
+from django.conf import settings
+
+from posthog.temporal.workflows.batch_exports import (
+    get_results_iterator,
+    get_rows_count,
+)
+from posthog.temporal.workflows.clickhouse import ClickHouseClient
+
+EventValues = TypedDict(
+    "EventValues",
+    {
+        "uuid": str,
+        "event": str,
+        "_timestamp": str,
+        "timestamp": str,
+        "created_at": str,
+        "distinct_id": str,
+        "person_id": str,
+        "person_properties": dict | None,
+        "team_id": int,
+        "properties": dict | None,
+        "elements_chain": str,
+    },
+)
+
+
+async def insert_events(client: ClickHouseClient, events: list[EventValues]):
+    """Insert some events into the sharded_events table."""
+    await client.execute_query(
+        f"""
+        INSERT INTO `sharded_events` (
+            uuid,
+            event,
+            timestamp,
+            _timestamp,
+            person_id,
+            team_id,
+            properties,
+            elements_chain,
+
+            distinct_id,
+            created_at,
+            person_properties
+        )
+        VALUES
+        """,
+        *[
+            (
+                event["uuid"],
+                event["event"],
+                event["timestamp"],
+                event["_timestamp"],
+                event["person_id"],
+                event["team_id"],
+                json.dumps(event["properties"]) if isinstance(event["properties"], dict) else event["properties"],
+                event["elements_chain"],
+                event["distinct_id"],
+                event["created_at"],
+                json.dumps(event["person_properties"])
+                if isinstance(event["person_properties"], dict)
+                else event["person_properties"],
+            )
+            for event in events
+        ],
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_get_rows_count():
+    """Test the count of rows returned by get_rows_count."""
+    team_id = randint(1, 1000000)
+
+    events: list[EventValues] = [
+        {
+            "uuid": str(uuid4()),
+            "event": "test",
+            "_timestamp": "2023-04-20 14:30:00",
+            "timestamp": f"2023-04-20 14:30:00.{i:06d}",
+            "created_at": "2023-04-20 14:30:00.000000",
+            "distinct_id": str(uuid4()),
+            "person_id": str(uuid4()),
+            "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "team_id": team_id,
+            "properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "elements_chain": "this that and the other",
+        }
+        # NOTE: we have to do a lot here, otherwise we do not trigger a
+        # multipart upload, and the minimum part chunk size is 5MB.
+        for i in range(10000)
+    ]
+    async with aiohttp.ClientSession() as session:
+        client = ClickHouseClient(
+            session=session,
+            url=settings.CLICKHOUSE_HTTP_URL,
+            user=settings.CLICKHOUSE_USER,
+            password=settings.CLICKHOUSE_PASSWORD,
+            database=settings.CLICKHOUSE_DATABASE,
+        )
+        await insert_events(
+            client=client,
+            events=events,
+        )
+
+        row_count = await get_rows_count(client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00")
+
+    assert row_count == 10000
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_get_results_iterator():
+    """Test the rows returned by get_results_iterator."""
+    team_id = randint(1, 1000000)
+
+    events: list[EventValues] = [
+        {
+            "uuid": str(uuid4()),
+            "event": f"test-{i}",
+            "_timestamp": "2023-04-20 14:30:00",
+            "timestamp": f"2023-04-20 14:30:00.{i:06d}",
+            "created_at": "2023-04-20 14:30:00.000000",
+            "distinct_id": str(uuid4()),
+            "person_id": str(uuid4()),
+            "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "team_id": team_id,
+            "properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "elements_chain": "this that and the other",
+        }
+        for i in range(10000)
+    ]
+    async with aiohttp.ClientSession() as session:
+        client = ClickHouseClient(
+            session=session,
+            url=settings.CLICKHOUSE_HTTP_URL,
+            user=settings.CLICKHOUSE_USER,
+            password=settings.CLICKHOUSE_PASSWORD,
+            database=settings.CLICKHOUSE_DATABASE,
+        )
+        await insert_events(
+            client=client,
+            events=events,
+        )
+
+        aiter = get_results_iterator(client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00")
+        rows = [row async for row in aiter]
+
+    all_expected = sorted(events, key=operator.itemgetter("event"))
+    all_result = sorted(rows, key=operator.itemgetter("event"))
+
+    assert len(all_expected) == len(all_result)
+
+    for expected, result in zip(all_expected, all_result):
+        for key, value in result.items():
+            # Some keys will be missing from result, so let's only check the ones we have.
+            assert value == expected[key], f"{key} value in {result} didn't match value in {expected}"

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -533,7 +533,7 @@ async def test_s3_export_workflow_with_minio_bucket_and_a_lot_of_data(client: Ht
     run = runs[0]
     assert run.status == "Completed"
 
-    assert_events_in_s3(s3_client, bucket_name, prefix, events)
+    assert_events_in_s3(s3_client, bucket_name, prefix.format(year=2023, month="04", day="25"), events)
 
 
 @pytest.mark.django_db
@@ -848,10 +848,10 @@ async def test_s3_export_workflow_continues_on_json_decode_error(client: HttpCli
     )
     error_raised = False
 
-    async def fake_get_results_iterator(*args, **kwargs):
+    def fake_get_results_iterator(*args, **kwargs):
         nonlocal error_raised
 
-        async for result in get_results_iterator(*args, **kwargs):
+        for result in get_results_iterator(*args, **kwargs):
             if error_raised is False:
                 error_raised = True
                 raise json.JSONDecodeError("Test error", "A ClickHouse error message\n", 0)
@@ -990,8 +990,8 @@ async def test_s3_export_workflow_continues_on_multiple_json_decode_error(client
     def should_fail(event):
         return bool(int(event["event"]) % 2)
 
-    async def fake_get_results_iterator(*args, **kwargs):
-        async for result in get_results_iterator(*args, **kwargs):
+    def fake_get_results_iterator(*args, **kwargs):
+        for result in get_results_iterator(*args, **kwargs):
             if result["event"] not in failed_events and should_fail(result):
                 # Will raise an exception every other row.
                 failed_events.add(result["event"])  # Otherwise we infinite loop

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -658,7 +658,7 @@ async def test_s3_export_workflow_with_minio_bucket_and_custom_key_prefix(client
 
     We will be asserting that exported events land in the appropiate S3 key according to the prefix.
     """
-    ch_client = ChClient(
+    ch_client = ClickHouseClient(
         url=settings.CLICKHOUSE_HTTP_URL,
         user=settings.CLICKHOUSE_USER,
         password=settings.CLICKHOUSE_PASSWORD,

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -524,7 +524,7 @@ async def test_s3_export_workflow_with_minio_bucket_and_a_lot_of_data(client: Ht
                     id=workflow_id,
                     task_queue=settings.TEMPORAL_TASK_QUEUE,
                     retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=dt.timedelta(seconds=60),
+                    execution_timeout=dt.timedelta(seconds=120),
                 )
 
     runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -442,7 +442,7 @@ async def test_s3_export_workflow_defaults_to_timestamp_on_null_inserted_at(clie
     In this scenario we assert that when inserted_at is NULL, we default to _timestamp.
     This scenario is relevant values inserted before the migration happened.
     """
-    ch_client = ChClient(
+    ch_client = ClickHouseClient(
         url=settings.CLICKHOUSE_HTTP_URL,
         user=settings.CLICKHOUSE_USER,
         password=settings.CLICKHOUSE_PASSWORD,

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -322,10 +322,10 @@ async def test_insert_into_s3_activity_puts_data_into_s3(bucket_name, s3_client,
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_s3_export_workflow_with_minio_bucket(client: HttpClient, s3_client, bucket_name):
-    """
-    Test that the whole workflow not just the activity works. It should update
-    the batch export run status to completed, as well as updating the record
-    count.
+    """Test the full S3 workflow targetting a MinIO bucket.
+
+    The workflow should update the batch export run status to completed and produce the expected
+    records to the MinIO bucket.
     """
     ch_client = ClickHouseClient(
         url=settings.CLICKHOUSE_HTTP_URL,
@@ -423,6 +423,108 @@ async def test_s3_export_workflow_with_minio_bucket(client: HttpClient, s3_clien
                     task_queue=settings.TEMPORAL_TASK_QUEUE,
                     retry_policy=RetryPolicy(maximum_attempts=1),
                     execution_timeout=dt.timedelta(seconds=10),
+                )
+
+    runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)
+    assert len(runs) == 1
+
+    run = runs[0]
+    assert run.status == "Completed"
+
+    assert_events_in_s3(s3_client, bucket_name, prefix, events)
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_s3_export_workflow_with_minio_bucket_and_a_lot_of_data(client: HttpClient, s3_client, bucket_name):
+    """Test the full S3 workflow targetting a MinIO bucket.
+
+    The workflow should update the batch export run status to completed and produce the expected
+    records to the MinIO bucket.
+    """
+    ch_client = ClickHouseClient(
+        url=settings.CLICKHOUSE_HTTP_URL,
+        user=settings.CLICKHOUSE_USER,
+        password=settings.CLICKHOUSE_PASSWORD,
+        database=settings.CLICKHOUSE_DATABASE,
+    )
+
+    prefix = f"posthog-events-{str(uuid4())}-{{year}}-{{month}}-{{day}}"
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": bucket_name,
+            "region": "us-east-1",
+            "prefix": prefix,
+            "batch_window_size": 3600,
+            "aws_access_key_id": "object_storage_root_user",
+            "aws_secret_access_key": "object_storage_root_password",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    organization = await acreate_organization("test")
+    team = await acreate_team(organization=organization)
+    batch_export = await acreate_batch_export(
+        team_id=team.pk,
+        name=batch_export_data["name"],
+        destination_data=batch_export_data["destination"],
+        interval=batch_export_data["interval"],
+    )
+
+    events: list[EventValues] = [
+        {
+            "uuid": str(uuid4()),
+            "event": f"test-{i}",
+            "timestamp": f"2023-04-25 13:30:00.{i:06}",
+            "created_at": "2023-04-25 13:30:00.000000",
+            "inserted_at": f"2023-04-25 13:30:00.{i:06}",
+            "_timestamp": "2023-04-25 13:30:00",
+            "person_id": str(uuid4()),
+            "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "team_id": team.pk,
+            "properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "distinct_id": str(uuid4()),
+            "elements_chain": "this is a comman, separated, list, of css selectors(?)",
+        }
+        for i in range(1000000)
+    ]
+
+    # Insert some data into the `sharded_events` table.
+    await insert_events(
+        client=ch_client,
+        events=events,
+    )
+
+    workflow_id = str(uuid4())
+    inputs = S3BatchExportInputs(
+        team_id=team.pk,
+        batch_export_id=str(batch_export.id),
+        data_interval_end="2023-04-25 14:30:00.000000",
+        **batch_export.destination.config,
+    )
+
+    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+        async with Worker(
+            activity_environment.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[S3BatchExportWorkflow],
+            activities=[create_export_run, insert_into_s3_activity, update_export_run_status],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            with mock.patch("posthog.temporal.workflows.s3_batch_export.boto3.client", side_effect=create_test_client):
+                await activity_environment.client.execute_workflow(
+                    S3BatchExportWorkflow.run,
+                    inputs,
+                    id=workflow_id,
+                    task_queue=settings.TEMPORAL_TASK_QUEUE,
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                    execution_timeout=dt.timedelta(seconds=60),
                 )
 
     runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -1,0 +1,27 @@
+import datetime as dt
+import uuid
+
+import pytest
+
+from posthog.temporal.workflows.clickhouse import encode_clickhouse_data
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        (uuid.UUID("c4c5547d-8782-4017-8eca-3ea19f4d528e"), b"'c4c5547d-8782-4017-8eca-3ea19f4d528e'"),
+        ("test-string", b"'test-string'"),
+        (("a", 1, ("b", 2)), b"('a',1,('b',2))"),
+        (["a", 1, ["b", 2]], b"['a',1,['b',2]]"),
+        (dt.datetime(2023, 7, 14, 0, 0, 0, tzinfo=dt.timezone.utc), b"toDateTime('2023-07-14 00:00:00', 'UTC')"),
+        (dt.datetime(2023, 7, 14, 0, 0, 0), b"toDateTime('2023-07-14 00:00:00')"),
+        (
+            dt.datetime(2023, 7, 14, 0, 0, 0, 5555, tzinfo=dt.timezone.utc),
+            b"toDateTime64('2023-07-14 00:00:00.005555', 6, 'UTC')",
+        ),
+    ],
+)
+def test_encode_clickhouse_data(data, expected):
+    """Test data is encoded as expected."""
+    result = encode_clickhouse_data(data)
+    assert result == expected

--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -85,7 +85,9 @@ def get_results_iterator(
                 "distinct_id": record.get("distinct_id").decode(),
                 "person_id": record.get("person_id").decode(),
                 "event": record.get("event").decode(),
-                "inserted_at": record.get("inserted_at").strftime("%Y-%m-%d %H:%M:%S.%f"),
+                "inserted_at": record.get("inserted_at").strftime("%Y-%m-%d %H:%M:%S.%f")
+                if record.get("inserted_at")
+                else None,
                 "created_at": record.get("created_at").strftime("%Y-%m-%d %H:%M:%S.%f"),
                 "timestamp": record.get("timestamp").strftime("%Y-%m-%d %H:%M:%S.%f"),
                 "properties": json.loads(properties) if properties else None,

--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -150,8 +150,8 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
         with tempfile.NamedTemporaryFile() as local_results_file:
             while True:
                 try:
-                    result = await results_iterator.__anext__()
-                except StopAsyncIteration:
+                    result = results_iterator.__next__()
+                except StopIteration:
                     break
                 except json.JSONDecodeError:
                     # This is raised by aiochclient as we try to decode an error message from ClickHouse.

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -234,23 +234,23 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs):
                 )
                 results = cursor.fetchall()
 
-                for result in results:
-                    if not isinstance(result, tuple):
+                for query_result in results:
+                    if not isinstance(query_result, tuple):
                         # Mostly to appease mypy, as this query should always return a tuple.
                         raise TypeError(f"Expected tuple from Snowflake COPY INTO query but got: '{type(result)}'")
 
-                    if len(result) < 2:
+                    if len(query_result) < 2:
                         raise SnowflakeFileNotLoadedError(
                             inputs.table_name,
                             "NO STATUS",
                             0,
-                            result[1] if len(result) == 1 else "NO ERROR MESSAGE",
+                            query_result[1] if len(query_result) == 1 else "NO ERROR MESSAGE",
                         )
 
-                    _, status = result[0:2]
+                    _, status = query_result[0:2]
 
                     if status != "LOADED":
-                        errors_seen, first_error = result[5:7]
+                        errors_seen, first_error = query_result[5:7]
                         raise SnowflakeFileNotLoadedError(
                             inputs.table_name,
                             status or "NO STATUS",

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -166,9 +166,9 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs):
             try:
                 while True:
                     try:
-                        result = await results_iterator.__anext__()
+                        result = results_iterator.__next__()
 
-                    except StopAsyncIteration:
+                    except StopIteration:
                         break
 
                     except json.JSONDecodeError:

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -345,8 +345,7 @@
          'example_id'
   FROM flags_to_override,
        target_person_ids
-  WHERE
-    EXISTS
+  WHERE EXISTS
       (SELECT 1
        FROM posthog_person
        WHERE id = person_id
@@ -395,8 +394,7 @@
          'example_id'
   FROM flags_to_override,
        target_person_ids
-  WHERE
-    EXISTS
+  WHERE EXISTS
       (SELECT 1
        FROM posthog_person
        WHERE id = person_id
@@ -511,8 +509,7 @@
          'example_id'
   FROM flags_to_override,
        target_person_ids
-  WHERE
-    EXISTS
+  WHERE EXISTS
       (SELECT 1
        FROM posthog_person
        WHERE id = person_id
@@ -561,8 +558,7 @@
          'example_id'
   FROM flags_to_override,
        target_person_ids
-  WHERE
-    EXISTS
+  WHERE EXISTS
       (SELECT 1
        FROM posthog_person
        WHERE id = person_id

--- a/requirements.in
+++ b/requirements.in
@@ -54,6 +54,7 @@ Pillow==9.2.0
 posthoganalytics==3.0.1
 prance==0.22.2.22.0
 psycopg2-binary==2.8.6
+pyarrow==12.0.1
 pydantic==1.10.4
 pyjwt==2.4.0
 python-dateutil>=2.8.2

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@
 # - `pip-compile --rebuild requirements.in`
 # - `pip-compile --rebuild requirements-dev.in`
 #
-aiochclient[aiohttp]>=2.4.0
+aiohttp>=3.8.4
 antlr4-python3-runtime==4.13.0
 amqp==2.6.0
 boto3==1.26.66

--- a/requirements.txt
+++ b/requirements.txt
@@ -245,7 +245,9 @@ multidict==6.0.2
 mypy-boto3-s3==1.26.127
     # via boto3-stubs
 numpy==1.23.3
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   pyarrow
 oauthlib==3.1.0
     # via
     #   requests-oauthlib
@@ -283,6 +285,8 @@ psycopg2-binary==2.8.6
     # via -r requirements.in
 ptyprocess==0.6.0
     # via pexpect
+pyarrow==12.0.1
+    # via -r requirements.in
 pycparser==2.20
     # via cffi
 pycryptodomex==3.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,9 @@
 #
 #    pip-compile requirements.in
 #
-aiochclient[aiohttp]==2.4.0
-    # via -r requirements.in
 aiohttp==3.8.4
     # via
-    #   aiochclient
+    #   -r requirements.in
     #   geoip2
     #   openai
 aiosignal==1.2.0
@@ -395,7 +393,6 @@ sortedcontainers==2.4.0
 sqlparse==0.4.4
     # via
     #   -r requirements.in
-    #   aiochclient
     #   django
 statshog==1.0.6
     # via -r requirements.in


### PR DESCRIPTION
## Problem

The biggest time waster in BatchExports is the innefficiency of the JSONEachRow format: it takes ClickHouse 25 to 30 minutes to stream 800k rows in JSONEachRow format, for a total of 5GBs. The same 800k rows can be streamed in 300MB of Apache Arrow an file in less than a minute.

BatchExports should not be using JSON until it's absolutely necessary, but instead stream results first in the most efficient format.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

1. Implement our own ClickHouse async Client and remove aiochclient as a dependency.
  a. This is because aiochclient doesn't support other formats besides JSON or each row.
2. Stream results in Apache Arrow format.
  a. For now, we are converting them back to JSON as soon as we get them to minimize the footprint of the changes.
3. (TODO) Add support for more output formats.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Existing and new unit tests updated and passing.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
