### PR TITLE
fix: constrain the scope of OR when querying multiple events for session listing

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -749,7 +749,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
   '
-  /* user_id:69 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:68 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -892,7 +892,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:71 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:70 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -1089,7 +1089,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter
   '
-  /* user_id:73 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:72 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -749,7 +749,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
   '
-  /* user_id:68 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:69 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -892,7 +892,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:70 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:71 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -1089,7 +1089,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter
   '
-  /* user_id:72 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:73 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
+++ b/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
@@ -135,6 +135,8 @@ join (
             )
             joining = "OR" if index > 0 else ""
             condition_sql += f"{joining} ({this_entity_condition_sql})"
+            # wrap in smooths to constrain the scope of the OR
+            condition_sql = f"( {condition_sql} )"
             params = {**params, **this_entity_filter_params}
 
         params = {**params, "event_names": list(event_names_to_filter)}

--- a/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
+++ b/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
@@ -134,7 +134,7 @@ join (
                 entity, prepend=f"event_matcher_{index}", team_id=self._team_id
             )
             joining = "OR" if index > 0 else ""
-            condition_sql += f"{joining} ({this_entity_condition_sql})"
+            condition_sql += f"{joining} {this_entity_condition_sql}"
             # wrap in smooths to constrain the scope of the OR
             condition_sql = f"( {condition_sql} )"
             params = {**params, **this_entity_filter_params}

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -25,10 +25,10 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2022-12-27 12:00:00'
        AND timestamp <= '2023-01-04 12:00:00'
-       AND (((event = 'custom-event'
-              AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))
-                   AND has(['test_action_filter-session-one'], "$session_id")
-                   AND has(['test_action_filter-window-id'], "$window_id")))))
+       AND ((((event = 'custom-event'
+               AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))
+                    AND has(['test_action_filter-session-one'], "$session_id")
+                    AND has(['test_action_filter-window-id'], "$window_id"))))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['custom-event'])) as e on s.session_id = e.`$session_id`
@@ -70,9 +70,9 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2022-12-27 12:00:00'
        AND timestamp <= '2023-01-04 12:00:00'
-       AND (((event = 'custom-event'
-              AND (has(['test_action_filter-session-one'], "$session_id")
-                   AND has(['test_action_filter-window-id'], "$window_id")))))
+       AND ((((event = 'custom-event'
+               AND (has(['test_action_filter-session-one'], "$session_id")
+                    AND has(['test_action_filter-window-id'], "$window_id"))))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['custom-event'])) as e on s.session_id = e.`$session_id`
@@ -114,10 +114,10 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2022-12-27 12:00:00'
        AND timestamp <= '2023-01-04 12:00:00'
-       AND (((event = 'custom-event'
-              AND (has(['test_action_filter-session-one'], "$session_id")
-                   AND has(['test_action_filter-window-id'], "$window_id"))))
-            AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+       AND ((((event = 'custom-event'
+               AND (has(['test_action_filter-session-one'], "$session_id")
+                    AND has(['test_action_filter-window-id'], "$window_id"))))
+             AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['custom-event'])) as e on s.session_id = e.`$session_id`
@@ -159,10 +159,10 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2022-12-27 12:00:00'
        AND timestamp <= '2023-01-04 12:00:00'
-       AND (((event = 'custom-event'
-              AND (has(['test_action_filter-session-one'], "$session_id")
-                   AND has(['test_action_filter-window-id'], "$window_id"))))
-            AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+       AND ((((event = 'custom-event'
+               AND (has(['test_action_filter-session-one'], "$session_id")
+                    AND has(['test_action_filter-window-id'], "$window_id"))))
+             AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['custom-event'])) as e on s.session_id = e.`$session_id`
@@ -213,8 +213,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-21 12:00:00'
        AND timestamp <= '2021-01-05 11:59:59'
-       AND (event = '$pageview')
-       OR (((event = 'custom-event')))
+       AND (((event = '$pageview'))
+            OR (((event = 'custom-event'))))
      GROUP BY `$session_id`,
               pdi.distinct_id
      HAVING argMax(is_deleted, version) = 0
@@ -258,7 +258,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND (1 = 1)
+       AND ((1 = 1))
      GROUP BY `$session_id`
      HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
@@ -298,8 +298,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND (1 = 1
-            AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+       AND ((1 = 1
+             AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))))
      GROUP BY `$session_id`
      HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
@@ -339,8 +339,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND (1 = 1
-            AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+       AND ((1 = 1
+             AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))))
      GROUP BY `$session_id`
      HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
@@ -380,7 +380,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND (1 = 1)
+       AND ((1 = 1))
      GROUP BY `$session_id`
      HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
@@ -420,8 +420,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND (1 = 1
-            AND (has(['Chrome'], "mat_$browser")))
+       AND ((1 = 1
+             AND (has(['Chrome'], "mat_$browser"))))
      GROUP BY `$session_id`
      HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
@@ -461,8 +461,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND (1 = 1
-            AND (has(['Firefox'], "mat_$browser")))
+       AND ((1 = 1
+             AND (has(['Firefox'], "mat_$browser"))))
      GROUP BY `$session_id`
      HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
@@ -988,7 +988,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview')
+       AND ((event = '$pageview'))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1030,7 +1030,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$autocapture')
+       AND ((event = '$autocapture'))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$autocapture'])) as e on s.session_id = e.`$session_id`
@@ -1072,7 +1072,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview')
+       AND ((event = '$pageview'))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1144,7 +1144,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview')
+       AND ((event = '$pageview'))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1187,7 +1187,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview')
+       AND ((event = '$pageview'))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1240,9 +1240,9 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview'
-            AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0)
-                 AND ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), 'bla'), 0)))
+       AND ((event = '$pageview'
+             AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0)
+                  AND ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), 'bla'), 0))))
      GROUP BY `$session_id`,
               pdi.distinct_id
      HAVING argMax(is_deleted, version) = 0
@@ -1285,8 +1285,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview'
-            AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Firefox'), 0)))
+       AND ((event = '$pageview'
+             AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Firefox'), 0))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1328,7 +1328,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview')
+       AND ((event = '$pageview'))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1370,7 +1370,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$autocapture')
+       AND ((event = '$autocapture'))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$autocapture'])) as e on s.session_id = e.`$session_id`
@@ -1461,8 +1461,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview'
-            AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+       AND ((event = '$pageview'
+             AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1504,8 +1504,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview'
-            AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+       AND ((event = '$pageview'
+             AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1547,8 +1547,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview'
-            AND (has(['Chrome'], "mat_$browser")))
+       AND ((event = '$pageview'
+             AND (has(['Chrome'], "mat_$browser"))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1590,8 +1590,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview'
-            AND (has(['Firefox'], "mat_$browser")))
+       AND ((event = '$pageview'
+             AND (has(['Firefox'], "mat_$browser"))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1633,7 +1633,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND (event = '$pageview')
+       AND ((event = '$pageview'))
        AND (has(['false'], replaceRegexpAll(JSONExtractRaw(e.properties, 'is_internal_user'), '^"|"$', '')))
      GROUP BY `$session_id`
      HAVING 1=1
@@ -1676,10 +1676,53 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND (event = '$pageview')
+       AND ((event = '$pageview'))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_event_filter_with_two_events_and_multiple_teams
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  join
+    (SELECT groupUniqArray(event) as event_names,
+            `$session_id`
+     FROM events e
+     WHERE team_id = 2
+       and notEmpty(`$session_id`)
+       AND timestamp >= '2021-01-13 12:00:00'
+       AND timestamp <= '2021-01-22 08:00:00'
+       AND (((event = '$pageview'))
+            OR (event = '$pageleave'))
+     GROUP BY `$session_id`
+     HAVING 1=1
+     AND hasAll(event_names, ['$pageview', '$pageleave'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
@@ -2189,7 +2232,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-08-13 12:00:00'
        AND timestamp <= '2021-08-22 08:00:00'
-       AND (event = '$pageview')
+       AND ((event = '$pageview'))
        AND (pdi.person_id IN
               (SELECT DISTINCT person_id
                FROM cohortpeople
@@ -2247,7 +2290,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-08-13 12:00:00'
        AND timestamp <= '2021-08-22 08:00:00'
-       AND (event = 'custom_event')
+       AND ((event = 'custom_event'))
        AND (pdi.person_id IN
               (SELECT DISTINCT person_id
                FROM cohortpeople
@@ -2296,8 +2339,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview')
-       OR (event = 'new-event')
+       AND (((event = '$pageview'))
+            OR (event = 'new-event'))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview', 'new-event'])) as e on s.session_id = e.`$session_id`
@@ -2339,8 +2382,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview')
-       OR (event = 'new-event2')
+       AND (((event = '$pageview'))
+            OR (event = 'new-event2'))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview', 'new-event2'])) as e on s.session_id = e.`$session_id`

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -25,10 +25,10 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2022-12-27 12:00:00'
        AND timestamp <= '2023-01-04 12:00:00'
-       AND ((((event = 'custom-event'
-               AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))
-                    AND has(['test_action_filter-session-one'], "$session_id")
-                    AND has(['test_action_filter-window-id'], "$window_id"))))))
+       AND (((event = 'custom-event'
+              AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))
+                   AND has(['test_action_filter-session-one'], "$session_id")
+                   AND has(['test_action_filter-window-id'], "$window_id")))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['custom-event'])) as e on s.session_id = e.`$session_id`
@@ -70,9 +70,9 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2022-12-27 12:00:00'
        AND timestamp <= '2023-01-04 12:00:00'
-       AND ((((event = 'custom-event'
-               AND (has(['test_action_filter-session-one'], "$session_id")
-                    AND has(['test_action_filter-window-id'], "$window_id"))))))
+       AND (((event = 'custom-event'
+              AND (has(['test_action_filter-session-one'], "$session_id")
+                   AND has(['test_action_filter-window-id'], "$window_id")))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['custom-event'])) as e on s.session_id = e.`$session_id`
@@ -114,10 +114,10 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2022-12-27 12:00:00'
        AND timestamp <= '2023-01-04 12:00:00'
-       AND ((((event = 'custom-event'
-               AND (has(['test_action_filter-session-one'], "$session_id")
-                    AND has(['test_action_filter-window-id'], "$window_id"))))
-             AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))))
+       AND (((event = 'custom-event'
+              AND (has(['test_action_filter-session-one'], "$session_id")
+                   AND has(['test_action_filter-window-id'], "$window_id"))))
+            AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['custom-event'])) as e on s.session_id = e.`$session_id`
@@ -159,10 +159,10 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2022-12-27 12:00:00'
        AND timestamp <= '2023-01-04 12:00:00'
-       AND ((((event = 'custom-event'
-               AND (has(['test_action_filter-session-one'], "$session_id")
-                    AND has(['test_action_filter-window-id'], "$window_id"))))
-             AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))))
+       AND (((event = 'custom-event'
+              AND (has(['test_action_filter-session-one'], "$session_id")
+                   AND has(['test_action_filter-window-id'], "$window_id"))))
+            AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['custom-event'])) as e on s.session_id = e.`$session_id`
@@ -213,8 +213,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-21 12:00:00'
        AND timestamp <= '2021-01-05 11:59:59'
-       AND (((event = '$pageview'))
-            OR (((event = 'custom-event'))))
+       AND ((event = '$pageview')
+            OR ((event = 'custom-event')))
      GROUP BY `$session_id`,
               pdi.distinct_id
      HAVING argMax(is_deleted, version) = 0
@@ -258,7 +258,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND ((1 = 1))
+       AND (1 = 1)
      GROUP BY `$session_id`
      HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
@@ -298,8 +298,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND ((1 = 1
-             AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))))
+       AND (1 = 1
+            AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
      GROUP BY `$session_id`
      HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
@@ -339,8 +339,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND ((1 = 1
-             AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))))
+       AND (1 = 1
+            AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
      GROUP BY `$session_id`
      HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
@@ -380,7 +380,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND ((1 = 1))
+       AND (1 = 1)
      GROUP BY `$session_id`
      HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
@@ -420,8 +420,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND ((1 = 1
-             AND (has(['Chrome'], "mat_$browser"))))
+       AND (1 = 1
+            AND (has(['Chrome'], "mat_$browser")))
      GROUP BY `$session_id`
      HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
@@ -461,8 +461,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND ((1 = 1
-             AND (has(['Firefox'], "mat_$browser"))))
+       AND (1 = 1
+            AND (has(['Firefox'], "mat_$browser")))
      GROUP BY `$session_id`
      HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
@@ -988,7 +988,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$pageview'))
+       AND (event = '$pageview')
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1030,7 +1030,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$autocapture'))
+       AND (event = '$autocapture')
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$autocapture'])) as e on s.session_id = e.`$session_id`
@@ -1072,7 +1072,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$pageview'))
+       AND (event = '$pageview')
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1144,7 +1144,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$pageview'))
+       AND (event = '$pageview')
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1187,7 +1187,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$pageview'))
+       AND (event = '$pageview')
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1240,9 +1240,9 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$pageview'
-             AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0)
-                  AND ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), 'bla'), 0))))
+       AND (event = '$pageview'
+            AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0)
+                 AND ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), 'bla'), 0)))
      GROUP BY `$session_id`,
               pdi.distinct_id
      HAVING argMax(is_deleted, version) = 0
@@ -1285,8 +1285,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$pageview'
-             AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Firefox'), 0))))
+       AND (event = '$pageview'
+            AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Firefox'), 0)))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1328,7 +1328,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$pageview'))
+       AND (event = '$pageview')
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1370,7 +1370,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$autocapture'))
+       AND (event = '$autocapture')
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$autocapture'])) as e on s.session_id = e.`$session_id`
@@ -1461,8 +1461,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$pageview'
-             AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))))
+       AND (event = '$pageview'
+            AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1504,8 +1504,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$pageview'
-             AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))))
+       AND (event = '$pageview'
+            AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1547,8 +1547,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$pageview'
-             AND (has(['Chrome'], "mat_$browser"))))
+       AND (event = '$pageview'
+            AND (has(['Chrome'], "mat_$browser")))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1590,8 +1590,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$pageview'
-             AND (has(['Firefox'], "mat_$browser"))))
+       AND (event = '$pageview'
+            AND (has(['Firefox'], "mat_$browser")))
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1633,7 +1633,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND ((event = '$pageview'))
+       AND (event = '$pageview')
        AND (has(['false'], replaceRegexpAll(JSONExtractRaw(e.properties, 'is_internal_user'), '^"|"$', '')))
      GROUP BY `$session_id`
      HAVING 1=1
@@ -1676,7 +1676,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND ((event = '$pageview'))
+       AND (event = '$pageview')
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
@@ -1718,8 +1718,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
-       AND (((event = '$pageview'))
-            OR (event = '$pageleave'))
+       AND ((event = '$pageview')
+            OR event = '$pageleave')
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview', '$pageleave'])) as e on s.session_id = e.`$session_id`
@@ -2232,7 +2232,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-08-13 12:00:00'
        AND timestamp <= '2021-08-22 08:00:00'
-       AND ((event = '$pageview'))
+       AND (event = '$pageview')
        AND (pdi.person_id IN
               (SELECT DISTINCT person_id
                FROM cohortpeople
@@ -2290,7 +2290,7 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2021-08-13 12:00:00'
        AND timestamp <= '2021-08-22 08:00:00'
-       AND ((event = 'custom_event'))
+       AND (event = 'custom_event')
        AND (pdi.person_id IN
               (SELECT DISTINCT person_id
                FROM cohortpeople
@@ -2339,8 +2339,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (((event = '$pageview'))
-            OR (event = 'new-event'))
+       AND ((event = '$pageview')
+            OR event = 'new-event')
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview', 'new-event'])) as e on s.session_id = e.`$session_id`
@@ -2382,8 +2382,8 @@
        and notEmpty(`$session_id`)
        AND timestamp >= '2020-12-24 12:00:00'
        AND timestamp <= '2021-01-02 01:46:23'
-       AND (((event = '$pageview'))
-            OR (event = 'new-event2'))
+       AND ((event = '$pageview')
+            OR event = 'new-event2')
      GROUP BY `$session_id`
      HAVING 1=1
      AND hasAll(event_names, ['$pageview', 'new-event2'])) as e on s.session_id = e.`$session_id`


### PR DESCRIPTION
See thread: https://posthog.slack.com/archives/C03PB072FMJ/p1690275675510189

A discussion with @benjackwhite about query performance sent me down a rabbit hole and I think means I've found a bug

```
SELECT groupUniqArray(event) as event_names,
            `$session_id`
     FROM events e
     WHERE team_id = 999
       and notEmpty(`$session_id`)
       AND timestamp >= '2020-12-24 12:00:00'
       AND timestamp <= '2021-01-02 01:46:23'
       AND (event = '$pageview')
       OR (event = 'new-event')
     GROUP BY `$session_id`
     HAVING 1=1
     AND hasAll(event_names, ['$pageview', 'new-event'])
```

here we say get all of the events where some filters

```
team_id = 999
       and notEmpty(`$session_id`)
       AND timestamp >= '2020-12-24 12:00:00'
       AND timestamp <= '2021-01-02 01:46:23'
       -- imagine these two aren't here
       --AND (event = '$pageview')
       --OR (event = 'new-event')
```

then group them by session id so we can check

```
HAVING 1=1
     AND hasAll(event_names, ['$pageview', 'new-event'])
```

That is indeed (potentially) slow because CH can skip data that isn't team 999, and skip data that isn't in the time range.
**But** then it has to load every event so it can group by session id and check the HAVING clause. HAVING applies after filtering not before.

So we cleverly add a filter on event.

```
team_id = 999
       and notEmpty(`$session_id`)
       AND timestamp >= '2020-12-24 12:00:00'
       AND timestamp <= '2021-01-02 01:46:23'
       AND (event = '$pageview')
       OR (event = 'new-event')
```

Now CH can skip any parts that aren't team 999, in that time range, and don't contain those events.

Because the table is created with

```
PARTITION BY toYYYYMM(timestamp)
ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))
```

Things in here directly affect how the data is stored on disk and that's used when filtering.

Spotted the bug... We're missing some smooths... ()

If you prepend `EXPLAIN SYNTAX` you see what ClickHouse generates from the provided query

```
WHERE
(
    (
        (1 = 1)
        AND
        (team_id = 999)
        AND
        notEmpty(`$session_id`)
        AND
        (timestamp >= '2021-01-13 12:00:00')
        AND
        (timestamp <= '2021-01-22 08:00:00')
        AND
        (event = '$pageview')
    )
    OR
        (event = '$pageleave')
)
```

So, we scan events table for rows with a set of filters that CH can use to reduce the amount of data it selects... **OR** every row that has `event = '$pageleave'`

That at least is in the index.

We then group by session id so we're not leaking data between teams. But we are loading tonnes more data than we need to

Instead, wrap any `x OR y` with smooths so we constrain the query