### PR TITLE
fix: Don't verify SSL cert on sync request

### DIFF
--- a/posthog/temporal/workflows/clickhouse.py
+++ b/posthog/temporal/workflows/clickhouse.py
@@ -235,7 +235,9 @@ class ClickHouseClient:
             request_data = query.encode("utf-8")
 
         with requests.Session() as s:
-            response = s.post(url=self.url, params=params, headers=self.headers, data=request_data, stream=True)
+            response = s.post(
+                url=self.url, params=params, headers=self.headers, data=request_data, stream=True, verify=False
+            )
             self.check_response(response, query)
             yield response
 


### PR DESCRIPTION
## Problem

We are not verifying the SSL cert (yet), but we haven't disabled it in the new sync query.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Set `verify=False`.

TODO: Figure out why SSL verification is failing, but for now let's get this running again.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
