### PR TITLE
feat: Add projection on inserted_at

### DIFF
--- a/posthog/clickhouse/migrations/0048_add_inserted_at_projection.py
+++ b/posthog/clickhouse/migrations/0048_add_inserted_at_projection.py
@@ -1,0 +1,21 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+ADD_PROJECTION_SQL = """
+ALTER TABLE sharded_events
+ON CLUSTER '{cluster}'
+ADD PROJECTION events_inserted_at_projection (
+  SELECT * ORDER BY (team_id, inserted_at, event, cityHash64(distinct_id), cityHash64(uuid))
+);
+"""
+
+MATERIALIZE_PROJECTION_SQL = """
+ALTER TABLE sharded_events
+ON CLUSTER '{cluster}'
+MATERIALIZE PROJECTION events_inserted_at_projection;
+"""
+
+operations = [
+    run_sql_with_exceptions(ADD_PROJECTION_SQL.format(cluster=CLICKHOUSE_CLUSTER)),
+    run_sql_with_exceptions(MATERIALIZE_PROJECTION_SQL.format(cluster=CLICKHOUSE_CLUSTER)),
+]


### PR DESCRIPTION
## Problem

Since we added `inserted_at` batch exports are querying events based on `inserted_at`. However, we are forced to include `timestamp` in the query to better utilize the sort key. It would be better if we could use a sort key based on `inserted_at` to optimize performance. Moreover, due to the discrepancy between `inserted_at` and `timestamp` we are missing events that were historically loaded.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add a migration that creates a projection with `inserted_at` in the sort key.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
