### PR TITLE
fix: Improvements to S3 flushing.

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
@@ -11,6 +11,7 @@ import { BatchConsumer, startBatchConsumer } from '../../../kafka/batch-consumer
 import { createRdConnectionConfigFromEnvVars } from '../../../kafka/config'
 import { PipelineEvent, PluginsServerConfig, RawEventMessage, RedisPool, TeamId } from '../../../types'
 import { BackgroundRefresher } from '../../../utils/background-refresher'
+import { timeoutGuard } from '../../../utils/db/utils'
 import { status } from '../../../utils/status'
 import { fetchTeamTokensWithRecordings } from '../../../worker/ingestion/team-manager'
 import { ObjectStorage } from '../../services/object_storage'
@@ -278,6 +279,9 @@ export class SessionRecordingIngesterV2 {
         }
 
         await this.replayEventsIngester.consumeBatch(recordingMessages)
+        const timeout = timeoutGuard(`Flushing sessions timed out`, {}, 120 * 1000)
+        await this.flushAllReadySessions(true)
+        clearTimeout(timeout)
 
         transaction.finish()
     }
@@ -401,20 +405,30 @@ export class SessionRecordingIngesterV2 {
         })
 
         // We trigger the flushes from this level to reduce the number of running timers
-        this.flushInterval = setInterval(() => {
+        this.flushInterval = setInterval(async () => {
             status.info('🚽', `blob_ingester_session_manager flushInterval fired`)
 
-            for (const [key, sessionManager] of Object.entries(this.sessions)) {
-                // in practice, we will always have a values for latestKafkaMessageTimestamp,
-                const referenceTime = this.partitionNow[sessionManager.partition]
-                if (!referenceTime) {
-                    status.warn('🤔', 'blob_ingester_consumer - no referenceTime for partition', {
-                        partition: sessionManager.partition,
-                    })
-                    continue
-                }
+            await this.flushAllReadySessions(false)
 
-                void sessionManager.flushIfSessionBufferIsOld(referenceTime).catch((err) => {
+            status.info('🚽', `blob_ingester_session_manager flushInterval completed`)
+        }, flushIntervalTimeoutMs)
+    }
+
+    private async flushAllReadySessions(wait: boolean): Promise<void> {
+        const promises: Promise<void>[] = []
+        for (const [key, sessionManager] of Object.entries(this.sessions)) {
+            // in practice, we will always have a values for latestKafkaMessageTimestamp,
+            const referenceTime = this.partitionNow[sessionManager.partition]
+            if (!referenceTime) {
+                status.warn('🤔', 'blob_ingester_consumer - no referenceTime for partition', {
+                    partition: sessionManager.partition,
+                })
+                continue
+            }
+
+            const flushPromise = sessionManager
+                .flushIfSessionBufferIsOld(referenceTime)
+                .catch((err) => {
                     status.error(
                         '🚽',
                         'blob_ingester_consumer - failed trying to flush on idle session: ' + sessionManager.sessionId,
@@ -424,22 +438,25 @@ export class SessionRecordingIngesterV2 {
                         }
                     )
                     captureException(err, { tags: { session_id: sessionManager.sessionId } })
-                    throw err
+                })
+                .finally(() => {
+                    // If the SessionManager is done (flushed and with no more queued events) then we remove it to free up memory
+                    if (sessionManager.isEmpty) {
+                        void this.destroySessions([[key, sessionManager]])
+                    }
                 })
 
-                // If the SessionManager is done (flushed and with no more queued events) then we remove it to free up memory
-                if (sessionManager.isEmpty) {
-                    void this.destroySessions([[key, sessionManager]])
-                }
-            }
+            promises.push(flushPromise)
+        }
 
-            gaugeSessionsHandled.set(Object.keys(this.sessions).length)
-            gaugeRealtimeSessions.set(
-                Object.values(this.sessions).reduce((acc, sessionManager) => acc + (sessionManager.realtime ? 1 : 0), 0)
-            )
+        if (wait) {
+            await Promise.allSettled(promises)
+        }
 
-            status.info('🚽', `blob_ingester_session_manager flushInterval completed`)
-        }, flushIntervalTimeoutMs)
+        gaugeSessionsHandled.set(Object.keys(this.sessions).length)
+        gaugeRealtimeSessions.set(
+            Object.values(this.sessions).reduce((acc, sessionManager) => acc + (sessionManager.realtime ? 1 : 0), 0)
+        )
     }
 
     public async stop(): Promise<void> {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
@@ -29,7 +29,7 @@ require('@sentry/tracing')
 
 const groupId = 'session-recordings-blob'
 const sessionTimeout = 30000
-const flushIntervalTimeoutMs = 30000
+// const flushIntervalTimeoutMs = 30000
 
 const gaugeSessionsHandled = new Gauge({
     name: 'recording_blob_ingestion_session_manager_count',
@@ -404,17 +404,17 @@ export class SessionRecordingIngesterV2 {
             await this.stop()
         })
 
-        // We trigger the flushes from this level to reduce the number of running timers
-        this.flushInterval = setInterval(async () => {
-            status.info('🚽', `blob_ingester_session_manager flushInterval fired`)
+        // // We trigger the flushes from this level to reduce the number of running timers
+        // this.flushInterval = setInterval(async () => {
+        //     status.info('🚽', `blob_ingester_session_manager flushInterval fired`)
 
-            await this.flushAllReadySessions(false)
+        //     await this.flushAllReadySessions(false)
 
-            status.info('🚽', `blob_ingester_session_manager flushInterval completed`)
-        }, flushIntervalTimeoutMs)
+        //     status.info('🚽', `blob_ingester_session_manager flushInterval completed`)
+        // }, flushIntervalTimeoutMs)
     }
 
-    private async flushAllReadySessions(wait: boolean): Promise<void> {
+    async flushAllReadySessions(wait: boolean): Promise<void> {
         const promises: Promise<void>[] = []
         for (const [key, sessionManager] of Object.entries(this.sessions)) {
             // in practice, we will always have a values for latestKafkaMessageTimestamp,

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
@@ -134,7 +134,8 @@ describe('ingester', () => {
         const event = createIncomingRecordingMessage()
         await ingester.consume(event)
         expect(ingester.sessions['1-session_id_1']).toBeDefined()
-        await ingester.sessions['1-session_id_1']?.flush('buffer_age')
+        ingester.sessions['1-session_id_1'].buffer.createdAt = 0 // Force the flush
+        await ingester.flushAllReadySessions(true)
 
         jest.runOnlyPendingTimers() // flush timer
 


### PR DESCRIPTION
## Problem

It seems that some flushes are getting stuck. This leads to a runaway situation where the pods get overwhelmed in mempory.

## Changes

* Swap to flush as part of the consume flow. This will likely be slow but I want to "break" it this way and see if we can work back towards an efficient flow.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
