### PR TITLE
feat: Add logging to image_exporter to report lack of connectivity to web server

### DIFF
--- a/posthog/tasks/exports/test/test_image_exporter.py
+++ b/posthog/tasks/exports/test/test_image_exporter.py
@@ -2,6 +2,8 @@ from unittest.mock import mock_open, patch
 
 from boto3 import resource
 from botocore.client import Config
+import pytest
+from requests import RequestException
 
 from posthog.models import ExportedAsset, Insight
 from posthog.settings import (
@@ -81,3 +83,50 @@ class TestImageExporter(APIBaseTest):
             assert self.exported_asset.content_location is None
 
             assert self.exported_asset.content == b"image_data"
+
+    def test_url_not_reachable_exception(self, mock_absolute_uri, *args):
+        with self.assertLogs(level="ERROR") as log:
+            test_url = "http://some-bad-url.test"
+            try:
+                image_exporter.log_error_if_url_not_reachable(test_url)
+            except Exception as e:
+                raise pytest.fail(f"Should not have raised exception: {e}")
+
+            logged_warning = log.records[0].__dict__
+            self.assertEqual(logged_warning["levelname"], "ERROR")
+            msg = logged_warning["msg"]
+
+            self.assertDictContainsSubset(
+                {
+                    "url": test_url,
+                    "event": "get_url_exception",
+                    "logger": "posthog.tasks.exports.image_exporter",
+                },
+                msg,
+            )
+            self.assertIsInstance(msg["exception"], RequestException)
+
+    def test_url_not_reachable_error_status(self, *args):
+        test_url = "http://google.com"
+
+        with self.assertLogs(level="ERROR") as log, patch("requests.get") as mock_request:
+            mock_request.return_value.status_code = 500
+            try:
+                image_exporter.log_error_if_url_not_reachable(test_url)
+            except Exception as e:
+                raise pytest.fail(f"Should not have raised exception: {e}")
+
+            logged_warning = log.records[0].__dict__
+            self.assertEqual(logged_warning["levelname"], "ERROR")
+
+            msg = logged_warning["msg"]
+
+            self.assertDictContainsSubset(
+                {
+                    "url": test_url,
+                    "status_code": 500,
+                    "event": "get_url_error_status",
+                    "logger": "posthog.tasks.exports.image_exporter",
+                },
+                msg,
+            )


### PR DESCRIPTION
## Problem

If export to .png fails due to lack of connectivity to the web server, it can be unclear what is happening.  

## Changes

In the exception handler for _export_to_png, attempt to fetch SITE_URL and log a helpful message to the log

## How did you test this code?

Added unit tests for the new function log_error_if_url_not_reachable