### PR TITLE
fix: Limited checking for SITE_URL reachability

### DIFF
--- a/posthog/tasks/exports/exporter_utils.py
+++ b/posthog/tasks/exports/exporter_utils.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from typing import Optional
+
+import requests
+import structlog
+
+from posthog import settings
+
+logger = structlog.get_logger(__name__)
+
+
+_site_reachable = None
+_site_reachable_checked_at: Optional[datetime] = None
+
+
+def is_site_url_reachable() -> bool:
+    """
+    Attempt to GET the SITE_ URL and log an error if it's not reachable
+    or if the HTTP status code indicates an error
+    """
+
+    global _site_reachable
+    global _site_reachable_checked_at
+
+    if not settings.SITE_URL:
+        return False
+
+    if _site_reachable_checked_at and _site_reachable_checked_at > datetime.now() - datetime.timedelta(minutes=1):
+        _site_reachable_checked_at = None
+
+    if _site_reachable_checked_at is None:
+        _site_reachable_checked_at = datetime.now()
+
+        try:
+            response = requests.get(settings.SITE_URL, timeout=5)
+            _site_reachable = response.status_code < 400
+        except Exception:
+            _site_reachable = False
+
+    return _site_reachable
+
+
+def log_error_if_site_url_not_reachable() -> None:
+    if not settings.SITE_URL:
+        logger.error("site_url_not_set")
+    elif not is_site_url_reachable():
+        logger.error("site_url_not_reachable", site_url=settings.SITE_URL)

--- a/posthog/tasks/exports/exporter_utils.py
+++ b/posthog/tasks/exports/exporter_utils.py
@@ -43,7 +43,7 @@ def is_site_url_reachable() -> bool:
             _site_reachable_exception = e
             _site_reachable = False
 
-    return _site_reachable
+    return _site_reachable or False
 
 
 def log_error_if_site_url_not_reachable() -> None:

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -3,7 +3,6 @@ import os
 import uuid
 from datetime import timedelta
 from typing import Literal, Optional
-import requests
 
 import structlog
 from django.conf import settings
@@ -22,6 +21,7 @@ from posthog.caching.fetch_from_cache import synchronously_update_cache
 from posthog.logging.timing import timed
 from posthog.metrics import LABEL_TEAM_ID
 from posthog.models.exported_asset import ExportedAsset, get_public_access_token, save_content
+from posthog.tasks.exports.exporter_utils import log_error_if_site_url_not_reachable
 from posthog.utils import absolute_uri
 
 logger = structlog.get_logger(__name__)
@@ -126,8 +126,7 @@ def _export_to_png(exported_asset: ExportedAsset) -> None:
         if image_path and os.path.exists(image_path):
             os.remove(image_path)
 
-        if settings.SITE_URL:
-            log_error_if_url_not_reachable(settings.SITE_URL)
+        log_error_if_site_url_not_reachable()
 
         raise err
 
@@ -203,23 +202,3 @@ def export_image(exported_asset: ExportedAsset) -> None:
             logger.error("image_exporter.failed", exception=e, exc_info=True)
             IMAGE_EXPORT_FAILED_COUNTER.labels(team_id=team_id).inc()
             raise e
-
-
-def log_error_if_url_not_reachable(url: str) -> None:
-    """
-    Attempt to GET a URL and log an error if it's not reachable
-    or if the HTTP status code indicates an error
-    """
-
-    try:
-        if not url:
-            raise Exception("No url provided to log_error_if_url_not_reachable")
-
-        # try to request the url
-        response = requests.get(url, timeout=5)
-
-        # if the status code is an error, log it
-        if response.status_code >= 400:
-            logger.error("get_url_error_status", url=url, status_code=response.status_code)
-    except Exception as e:
-        logger.error("get_url_exception", exception=e, url=url)

--- a/posthog/tasks/exports/test/test_export_utils.py
+++ b/posthog/tasks/exports/test/test_export_utils.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch
+
+import pytest
+from requests import RequestException
+
+from posthog.tasks.exports import exporter_utils
+from posthog.test.base import APIBaseTest
+
+TEST_PREFIX = "Test-Exports"
+
+
+class TestSiteURLReachability(APIBaseTest):
+    @patch("posthog.tasks.exports.exporter_utils.logger")
+    def test_url_not_reachable_exception(self, logger_mock):
+        test_url = "http://some-bad-url.test"
+        with self.settings(SITE_URL=test_url):
+            try:
+                exporter_utils.log_error_if_site_url_not_reachable()
+            except Exception as e:
+                raise pytest.fail(f"Should not have raised exception: {e}")
+
+            assert logger_mock.error.call_count == 1
+            assert logger_mock.error.call_args[0][0] == "site_url_not_reachable"
+            assert logger_mock.error.call_args[1]["site_url"] == test_url
+            assert isinstance(logger_mock.error.call_args[1]["exception"], RequestException)
+
+    @patch("posthog.tasks.exports.exporter_utils.logger")
+    def test_url_not_reachable_error_status(self, logger_mock):
+        test_url = "http://some-status-bad-url.test"
+        with self.settings(SITE_URL=test_url):
+            with patch("requests.get") as mock_request:
+                mock_request.return_value.status_code = 500
+                try:
+                    exporter_utils.log_error_if_site_url_not_reachable()
+                except Exception as e:
+                    raise pytest.fail(f"Should not have raised exception: {e}")
+
+                assert logger_mock.error.call_count == 1
+                assert logger_mock.error.call_args[0][0] == "site_url_not_reachable"
+                assert logger_mock.error.call_args[1]["site_url"] == test_url
+                assert str(logger_mock.error.call_args[1]["exception"]) == "HTTP status code: 500"
+
+    @patch("posthog.tasks.exports.exporter_utils.logger")
+    def test_url_reachable_success(self, logger_mock):
+        test_url = "http://some-good-url.test"
+        with self.settings(SITE_URL=test_url):
+            with patch("requests.get") as mock_request:
+                mock_request.return_value.status_code = 200
+                try:
+                    exporter_utils.log_error_if_site_url_not_reachable()
+                except Exception as e:
+                    raise pytest.fail(f"Should not have raised exception: {e}")
+
+                assert logger_mock.error.call_count == 0


### PR DESCRIPTION
## Problem

Community contribution added some better logging if the SITE_URL was unreachable during an image export. It had the potential in extreme circumstances to cause a request flood so this is a follow up.

## Changes

* Only checks at a max rate and caches the response (would allow it to be used elsewhere in the future as well)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
