### PR TITLE
fix(exports): fix events query export context

### DIFF
--- a/frontend/src/queries/query.test.ts
+++ b/frontend/src/queries/query.test.ts
@@ -2,7 +2,6 @@ import { query, queryExportContext } from '~/queries/query'
 import { EventsQuery, HogQLQuery, NodeKind } from '~/queries/schema'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 import { initKeaTests } from '~/test/init'
-import { MOCK_TEAM_ID } from 'lib/api.mock'
 import posthog from 'posthog-js'
 import { useMocks } from '~/mocks/jest'
 
@@ -48,8 +47,7 @@ describe('query', () => {
         }
         const actual = queryExportContext(q, {}, false)
         expect(actual).toEqual({
-            body: {
-                after: expect.any(String),
+            source: {
                 kind: 'EventsQuery',
                 limit: 100,
                 properties: [
@@ -69,8 +67,7 @@ describe('query', () => {
                     'timestamp',
                 ],
             },
-            method: 'POST',
-            path: `/api/projects/${MOCK_TEAM_ID}/query`,
+            max_limit: 10000,
         })
     })
 

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -45,8 +45,10 @@ export function queryExportContext<N extends DataNode = DataNode>(
             path: api.queryURL(),
             method: 'POST',
             body: {
-                ...query,
-                after: now().subtract(EVENTS_DAYS_FIRST_FETCH, 'day').toISOString(),
+                query: {
+                    ...query,
+                    after: now().subtract(EVENTS_DAYS_FIRST_FETCH, 'day').toISOString(),
+                },
             },
         }
     } else if (isHogQLQuery(query)) {

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -13,7 +13,7 @@ import {
 } from './utils'
 import api, { ApiMethodOptions } from 'lib/api'
 import { getCurrentTeamId } from 'lib/utils/logics'
-import { AnyPartialFilterType, OnlineExportContext } from '~/types'
+import { AnyPartialFilterType, OnlineExportContext, QueryExportContext } from '~/types'
 import {
     filterTrendsClientSideParams,
     isFunnelsFilter,
@@ -28,28 +28,22 @@ import { queryNodeToFilter } from './nodes/InsightQuery/utils/queryNodeToFilter'
 import { now } from 'lib/dayjs'
 import { currentSessionId } from 'lib/internalMetrics'
 
-const EVENTS_DAYS_FIRST_FETCH = 5
+const EXPORT_MAX_LIMIT = 10000
 
 //get export context for a given query
 export function queryExportContext<N extends DataNode = DataNode>(
     query: N,
     methodOptions?: ApiMethodOptions,
     refresh?: boolean
-): OnlineExportContext {
+): OnlineExportContext | QueryExportContext {
     if (isInsightVizNode(query)) {
         return queryExportContext(query.source, methodOptions, refresh)
     } else if (isDataTableNode(query)) {
         return queryExportContext(query.source, methodOptions, refresh)
     } else if (isEventsQuery(query)) {
         return {
-            path: api.queryURL(),
-            method: 'POST',
-            body: {
-                query: {
-                    ...query,
-                    after: now().subtract(EVENTS_DAYS_FIRST_FETCH, 'day').toISOString(),
-                },
-            },
+            source: query,
+            max_limit: EXPORT_MAX_LIMIT,
         }
     } else if (isHogQLQuery(query)) {
         return { path: api.queryURL(), method: 'POST', body: query }


### PR DESCRIPTION
## Problem

See https://posthoghelp.zendesk.com/agent/tickets/4563 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/6993)

## Changes

This PR brings event table exports in line with what data table does https://github.com/PostHog/posthog/blob/8f3ae7515de1740ff2f5f2799ae3862032207a21/frontend/src/queries/nodes/DataTable/DataTableExport.tsx#L13-L40, fixing the issue above. See first commit for an alternative.

## How did you test this code?

Tested 
- exporting an events query insight as csv works
- exporting an events query insight as png works
- exporting an events query data table works