### PR TITLE
fix: Replay next button

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerUpNext.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerUpNext.tsx
@@ -23,8 +23,8 @@ export function PlayerUpNext({ interrupted, clearInterrupted }: PlayerUpNextProp
 
     const goToRecording = (automatic: boolean): void => {
         reportNextRecordingTriggered(automatic)
-        router.actions.push(router.values.currentLocation.pathname, router.values.currentLocation.searchParams, {
-            ...router.values.currentLocation.hashParams,
+        router.actions.push(router.values.currentLocation.pathname, {
+            ...router.values.currentLocation.searchParams,
             sessionRecordingId: nextSessionRecording?.id,
         })
     }

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -185,7 +185,7 @@ export function RecordingsLists({
                                                 className={clsx(
                                                     'transition-all flex items-center',
                                                     !autoplayDirection && 'text-border text-sm',
-                                                    !!autoplayDirection && 'text-primary-highlight text-xs pl-px',
+                                                    !!autoplayDirection && 'text-white text-xs pl-px',
                                                     autoplayDirection === 'newer' && 'rotate-180'
                                                 )}
                                             >


### PR DESCRIPTION
## Problem

Regression since we moved to using search params for recordings

## Changes

* Fixes the issue to use search params instead of hash
* Fixes the button color for autoplay

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
