### PR TITLE
revert(dev): Enable React strict mode

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,5 @@
 import '~/styles'
 
-import { StrictMode } from 'react'
 import ReactDOM from 'react-dom'
 import { getContext } from 'kea'
 
@@ -30,13 +29,11 @@ function renderApp(): void {
     const root = document.getElementById('root')
     if (root) {
         ReactDOM.render(
-            <StrictMode>
-                <ErrorBoundary>
-                    <PostHogProvider client={posthog}>
-                        <App />
-                    </PostHogProvider>
-                </ErrorBoundary>
-            </StrictMode>,
+            <ErrorBoundary>
+                <PostHogProvider client={posthog}>
+                    <App />
+                </PostHogProvider>
+            </ErrorBoundary>,
             root
         )
     } else {


### PR DESCRIPTION
Reverts PostHog/posthog#16729. Apparently React strict mode [doesn't work with Kea](https://posthog.slack.com/archives/C0113360FFV/p1690281813136649). This is really tricky to resolve so reverting.