### PR TITLE
feat: sub queries not joins

### DIFF
--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -27,15 +27,14 @@ import { urls } from 'scenes/urls'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
 import { GroupAnalytics } from 'scenes/project/Settings/GroupAnalytics'
-import { IconInfo } from 'lib/lemon-ui/icons'
 import { PersonDisplayNameProperties } from './PersonDisplayNameProperties'
-import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { SlackIntegration } from './SlackIntegration'
 import { LemonButton, LemonDivider, LemonInput } from '@posthog/lemon-ui'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
 import { IngestionInfo } from './IngestionInfo'
 import { ExtraTeamSettings } from './ExtraTeamSettings'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 
 export const scene: SceneExport = {
     component: ProjectSettings,
@@ -117,10 +116,7 @@ export function ProjectSettings(): JSX.Element {
                 </div>
                 <LemonDivider className="my-6" />
                 <h2 className="subtitle" id="internal-users-filtering">
-                    Filter out internal and test users{' '}
-                    <Tooltip title='Events will still be ingested and saved, but they will be excluded from any queries where the "Filter out internal and test users" toggle is set.'>
-                        <IconInfo style={{ fontSize: '1em', color: 'var(--muted-alt)', marginTop: 4, marginLeft: 5 }} />
-                    </Tooltip>
+                    Filter out internal and test users
                 </h2>
                 <p>
                     Increase the quality of your analytics results by filtering out events from internal sources, such
@@ -130,17 +126,31 @@ export function ProjectSettings(): JSX.Element {
                     </strong>{' '}
                     So, if you apply a cohort, it means you will only match users in that cohort.
                 </p>
-                <strong>Example filters</strong>
-                <ul className="list-disc pl-4 mb-2">
-                    <li>
-                        "<strong>Email</strong> does not contain <strong>yourcompany.com</strong>" to exclude all events
-                        from your company's team members.
-                    </li>
-                    <li>
-                        "<strong>Host</strong> does not contain <strong>localhost</strong>" to exclude all events from
-                        local development environments.
-                    </li>
-                </ul>
+                <LemonBanner type="info">
+                    Events and recordings will still be ingested and saved, but they will be excluded from any queries
+                    where the "Filter out internal and test users" toggle is set. You can learn how to{' '}
+                    <Link to="https://posthog.com/tutorials/fewer-unwanted-events" target="_blank">
+                        capture fewer events
+                    </Link>{' '}
+                    or how to{' '}
+                    <Link to="https://posthog.com/tutorials/limit-session-recordings" target="_blank">
+                        capture fewer recordings
+                    </Link>{' '}
+                    in our docs.
+                </LemonBanner>
+                <div className={'mt-4'}>
+                    <strong>Example filters</strong>
+                    <ul className="list-disc pl-4 mb-2">
+                        <li>
+                            "<strong>Email</strong> does not contain <strong>yourcompany.com</strong>" to exclude all
+                            events from your company's team members.
+                        </li>
+                        <li>
+                            "<strong>Host</strong> does not contain <strong>localhost</strong>" to exclude all events
+                            from local development environments.
+                        </li>
+                    </ul>
+                </div>
                 <TestAccountFiltersConfig />
                 <LemonDivider className="my-6" />
                 <CorrelationConfig />

--- a/frontend/src/scenes/session-recordings/filters/SessionRecordingsFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/SessionRecordingsFilters.tsx
@@ -251,10 +251,14 @@ export function SessionRecordingsFilters({
             />
 
             <FlaggedFeature flag={FEATURE_FLAGS.SESSION_RECORDING_TEST_ACCOUNTS_FILTER} match={true}>
-                <TestAccountFilter
-                    filters={filters}
-                    onChange={(testFilters) => setFilters({ filter_test_accounts: testFilters.filter_test_accounts })}
-                />
+                <div className={'pt-2'}>
+                    <TestAccountFilter
+                        filters={filters}
+                        onChange={(testFilters) =>
+                            setFilters({ filter_test_accounts: testFilters.filter_test_accounts })
+                        }
+                    />
+                </div>
             </FlaggedFeature>
 
             <div className={'flex flex-col py-1 px-2 '}>

--- a/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
+++ b/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
@@ -167,7 +167,11 @@ class SessionIdEventsQuery(SessionRecordingList):
         persons_sub_query = ""
         if persons_select:
             # we want to join as infrequently as possible so only join if there are filters that expect it
-            if "person_props" in prop_query or "pdi.person_id":
+            if (
+                "person_props" in prop_query
+                or "pdi.person_id" in prop_query
+                or "person_props" in event_filters.where_conditions
+            ):
                 persons_join = f"JOIN ({persons_select}) as pdi on pdi.distinct_id = e.distinct_id"
             else:
                 persons_sub_query = (

--- a/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
+++ b/posthog/queries/session_recordings/session_recording_list_from_replay_summary.py
@@ -73,7 +73,7 @@ class SessionIdEventsQuery(SessionRecordingList):
             {event_filter_having_events_select}
             `$session_id`
         FROM events e
-        -- sometimes we have to join on persons so we can access person_props in filters
+        -- sometimes we have to join on persons so we can access e.g. person_props in filters
         {persons_join}
         PREWHERE
             team_id = %(team_id)s

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -17,26 +17,28 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2022-12-14 00:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2022-12-27 12:00:00'
-       AND timestamp <= '2023-01-04 12:00:00'
-       AND (((event = 'custom-event'
-              AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))
-                   AND has(['test_action_filter-session-one'], "$session_id")
-                   AND has(['test_action_filter-window-id'], "$window_id")))))
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['custom-event'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2022-12-14 00:00:00'
     AND s.min_first_timestamp >= '2022-12-28 00:00:00'
     AND s.max_last_timestamp <= '2023-01-04 00:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2022-12-14 00:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2022-12-27 12:00:00'
+            AND timestamp <= '2023-01-04 12:00:00'
+            AND (((event = 'custom-event'
+                   AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))
+                        AND has(['test_action_filter-session-one'], "$session_id")
+                        AND has(['test_action_filter-window-id'], "$window_id")))))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -63,25 +65,27 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2022-12-14 00:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2022-12-27 12:00:00'
-       AND timestamp <= '2023-01-04 12:00:00'
-       AND (((event = 'custom-event'
-              AND (has(['test_action_filter-session-one'], "$session_id")
-                   AND has(['test_action_filter-window-id'], "$window_id")))))
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['custom-event'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2022-12-14 00:00:00'
     AND s.min_first_timestamp >= '2022-12-28 00:00:00'
     AND s.max_last_timestamp <= '2023-01-04 00:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2022-12-14 00:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2022-12-27 12:00:00'
+            AND timestamp <= '2023-01-04 12:00:00'
+            AND (((event = 'custom-event'
+                   AND (has(['test_action_filter-session-one'], "$session_id")
+                        AND has(['test_action_filter-window-id'], "$window_id")))))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -108,26 +112,28 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2022-12-14 00:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2022-12-27 12:00:00'
-       AND timestamp <= '2023-01-04 12:00:00'
-       AND (((event = 'custom-event'
-              AND (has(['test_action_filter-session-one'], "$session_id")
-                   AND has(['test_action_filter-window-id'], "$window_id"))))
-            AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['custom-event'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2022-12-14 00:00:00'
     AND s.min_first_timestamp >= '2022-12-28 00:00:00'
     AND s.max_last_timestamp <= '2023-01-04 00:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2022-12-14 00:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2022-12-27 12:00:00'
+            AND timestamp <= '2023-01-04 12:00:00'
+            AND (((event = 'custom-event'
+                   AND (has(['test_action_filter-session-one'], "$session_id")
+                        AND has(['test_action_filter-window-id'], "$window_id"))))
+                 AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -154,26 +160,28 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2022-12-14 00:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2022-12-27 12:00:00'
-       AND timestamp <= '2023-01-04 12:00:00'
-       AND (((event = 'custom-event'
-              AND (has(['test_action_filter-session-one'], "$session_id")
-                   AND has(['test_action_filter-window-id'], "$window_id"))))
-            AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['custom-event'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2022-12-14 00:00:00'
     AND s.min_first_timestamp >= '2022-12-28 00:00:00'
     AND s.max_last_timestamp <= '2023-01-04 00:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2022-12-14 00:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2022-12-27 12:00:00'
+            AND timestamp <= '2023-01-04 12:00:00'
+            AND (((event = 'custom-event'
+                   AND (has(['test_action_filter-session-one'], "$session_id")
+                        AND has(['test_action_filter-window-id'], "$window_id"))))
+                 AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -200,52 +208,56 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e
-     JOIN
-       (SELECT distinct_id,
-               argMax(person_id, version) as person_id
-        FROM person_distinct_id2 as pdi
-        INNER JOIN
-          (SELECT id
-           FROM person
-           WHERE team_id = 2
-           GROUP BY id
-           HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-        WHERE team_id = 2
-        GROUP BY distinct_id
-        HAVING argMax(is_deleted, version) = 0
-        and person_id = '00000000-0000-0000-0000-000000000000') as pdi on pdi.distinct_id = e.distinct_id PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-21 12:00:00'
-       AND timestamp <= '2021-01-05 11:59:59'
-       AND ((event = '$pageview')
-            OR ((event = 'custom-event')))
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview', 'custom-event'])) as e on s.session_id = e.`$session_id`
-  JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2 as pdi
-     INNER JOIN
-       (SELECT id
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0
-     and person_id = '00000000-0000-0000-0000-000000000000') as pdi on pdi.distinct_id = s.distinct_id
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-22 00:00:00'
     AND s.max_last_timestamp <= '2021-01-04 23:59:59'
+    AND s.distinct_id in
+      (select distinct_id
+       from
+         (SELECT distinct_id,
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2 as pdi
+          INNER JOIN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+             GROUP BY id
+             HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0
+          and person_id = '00000000-0000-0000-0000-000000000000') as session_persons_sub_query)
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e
+          JOIN
+            (SELECT distinct_id,
+                    argMax(person_id, version) as person_id
+             FROM person_distinct_id2 as pdi
+             INNER JOIN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                GROUP BY id
+                HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+             WHERE team_id = 2
+             GROUP BY distinct_id
+             HAVING argMax(is_deleted, version) = 0
+             and person_id = '00000000-0000-0000-0000-000000000000') as pdi on pdi.distinct_id = e.distinct_id PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-21 12:00:00'
+            AND timestamp <= '2021-01-05 11:59:59'
+            AND ((event = '$pageview')
+                 OR ((event = 'custom-event')))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview', 'custom-event'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   AND duration > 60
@@ -273,21 +285,23 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-31 20:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 08:00:00'
-       AND (1 = 1)
-     GROUP BY `$session_id`
-     HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
     AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (1 = 1)
+          GROUP BY `$session_id`
+          HAVING 1=1) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -314,22 +328,24 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-31 20:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 08:00:00'
-       AND (1 = 1
-            AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
-     GROUP BY `$session_id`
-     HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
     AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (1 = 1
+                 AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+          GROUP BY `$session_id`
+          HAVING 1=1) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -356,22 +372,24 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-31 20:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 08:00:00'
-       AND (1 = 1
-            AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
-     GROUP BY `$session_id`
-     HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
     AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (1 = 1
+                 AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+          GROUP BY `$session_id`
+          HAVING 1=1) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -398,21 +416,23 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-31 20:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 08:00:00'
-       AND (1 = 1)
-     GROUP BY `$session_id`
-     HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
     AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (1 = 1)
+          GROUP BY `$session_id`
+          HAVING 1=1) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -439,22 +459,24 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-31 20:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 08:00:00'
-       AND (1 = 1
-            AND (has(['Chrome'], "mat_$browser")))
-     GROUP BY `$session_id`
-     HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
     AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (1 = 1
+                 AND (has(['Chrome'], "mat_$browser")))
+          GROUP BY `$session_id`
+          HAVING 1=1) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -481,22 +503,24 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-31 20:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 08:00:00'
-       AND (1 = 1
-            AND (has(['Firefox'], "mat_$browser")))
-     GROUP BY `$session_id`
-     HAVING 1=1) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
     AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (1 = 1
+                 AND (has(['Firefox'], "mat_$browser")))
+          GROUP BY `$session_id`
+          HAVING 1=1) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1008,23 +1032,25 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview')
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1051,23 +1077,25 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$autocapture')
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$autocapture'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND (event = '$autocapture')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$autocapture'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1094,23 +1122,25 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview')
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1167,23 +1197,25 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview')
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   AND duration > 60
@@ -1211,23 +1243,25 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview')
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   AND active_seconds > 60
@@ -1255,55 +1289,59 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e
-     JOIN
-       (SELECT distinct_id,
-               argMax(person_id, version) as person_id ,
-               argMax(person_props, version) as person_props
-        FROM person_distinct_id2 as pdi
-        INNER JOIN
-          (SELECT id,
-                  argMax(properties, version) as person_props
-           FROM person
-           WHERE team_id = 2
-           GROUP BY id
-           HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-        WHERE team_id = 2
-        GROUP BY distinct_id
-        HAVING argMax(is_deleted, version) = 0) as pdi on pdi.distinct_id = e.distinct_id PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview'
-            AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0)
-                 AND ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), 'bla'), 0)))
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
-  JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id ,
-            argMax(person_props, version) as person_props
-     FROM person_distinct_id2 as pdi
-     INNER JOIN
-       (SELECT id,
-               argMax(properties, version) as person_props
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi on pdi.distinct_id = s.distinct_id
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.distinct_id in
+      (select distinct_id
+       from
+         (SELECT distinct_id,
+                 argMax(person_id, version) as person_id ,
+                 argMax(person_props, version) as person_props
+          FROM person_distinct_id2 as pdi
+          INNER JOIN
+            (SELECT id,
+                    argMax(properties, version) as person_props
+             FROM person
+             WHERE team_id = 2
+             GROUP BY id
+             HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0) as session_persons_sub_query)
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e
+          JOIN
+            (SELECT distinct_id,
+                    argMax(person_id, version) as person_id ,
+                    argMax(person_props, version) as person_props
+             FROM person_distinct_id2 as pdi
+             INNER JOIN
+               (SELECT id,
+                       argMax(properties, version) as person_props
+                FROM person
+                WHERE team_id = 2
+                GROUP BY id
+                HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+             WHERE team_id = 2
+             GROUP BY distinct_id
+             HAVING argMax(is_deleted, version) = 0) as pdi on pdi.distinct_id = e.distinct_id PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND (event = '$pageview'
+                 AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0)
+                      AND ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), 'bla'), 0)))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1330,24 +1368,26 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview'
-            AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Firefox'), 0)))
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND (event = '$pageview'
+                 AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Firefox'), 0)))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1374,23 +1414,25 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview')
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1417,23 +1459,25 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$autocapture')
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$autocapture'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND (event = '$autocapture')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$autocapture'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1460,29 +1504,31 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2 as pdi
-     INNER JOIN
-       (SELECT id
-        FROM person
-        WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2
-               AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))) )
-        GROUP BY id
-        HAVING max(is_deleted) = 0
-        AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))) person ON person.id = pdi.person_id
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi on pdi.distinct_id = s.distinct_id
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.distinct_id in
+      (select distinct_id
+       from
+         (SELECT distinct_id,
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2 as pdi
+          INNER JOIN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND id IN
+                 (SELECT id
+                  FROM person
+                  WHERE team_id = 2
+                    AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))) )
+             GROUP BY id
+             HAVING max(is_deleted) = 0
+             AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))) person ON person.id = pdi.person_id
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0) as session_persons_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1509,24 +1555,26 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview'
-            AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND (event = '$pageview'
+                 AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1553,24 +1601,26 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview'
-            AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND (event = '$pageview'
+                 AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1597,24 +1647,26 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview'
-            AND (has(['Chrome'], "mat_$browser")))
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND (event = '$pageview'
+                 AND (has(['Chrome'], "mat_$browser")))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1641,24 +1693,26 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND (event = '$pageview'
-            AND (has(['Firefox'], "mat_$browser")))
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND (event = '$pageview'
+                 AND (has(['Firefox'], "mat_$browser")))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1685,24 +1739,26 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-31 20:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 08:00:00'
-       AND (event = '$pageview')
-       AND (has(['false'], replaceRegexpAll(JSONExtractRaw(e.properties, 'is_internal_user'), '^"|"$', '')))
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
     AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (event = '$pageview')
+            AND (has(['false'], replaceRegexpAll(JSONExtractRaw(e.properties, 'is_internal_user'), '^"|"$', '')))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1729,23 +1785,25 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-31 20:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 08:00:00'
-       AND (event = '$pageview')
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
     AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1772,24 +1830,26 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-31 20:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 08:00:00'
-       AND ((event = '$pageview')
-            OR event = '$pageleave')
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview', '$pageleave'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
     AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND ((event = '$pageview')
+                 OR event = '$pageleave')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview', '$pageleave'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -2209,29 +2269,31 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2 as pdi
-     INNER JOIN
-       (SELECT id
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-     WHERE team_id = 2
-       AND (pdi.person_id IN
-              (SELECT DISTINCT person_id
-               FROM cohortpeople
-               WHERE team_id = 2
-                 AND cohort_id = 2
-                 AND version = 0 ))
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi on pdi.distinct_id = s.distinct_id
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2021-07-31 20:00:00'
     AND s.min_first_timestamp >= '2021-08-14 00:00:00'
     AND s.max_last_timestamp <= '2021-08-21 20:00:00'
+    AND s.distinct_id in
+      (select distinct_id
+       from
+         (SELECT distinct_id,
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2 as pdi
+          INNER JOIN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+             GROUP BY id
+             HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+          WHERE team_id = 2
+            AND (pdi.person_id IN
+                   (SELECT DISTINCT person_id
+                    FROM cohortpeople
+                    WHERE team_id = 2
+                      AND cohort_id = 2
+                      AND version = 0 ))
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0) as session_persons_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -2278,67 +2340,71 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e
-     JOIN
-       (SELECT distinct_id,
-               argMax(person_id, version) as person_id
-        FROM person_distinct_id2 as pdi
-        INNER JOIN
-          (SELECT id
-           FROM person
-           WHERE team_id = 2
-           GROUP BY id
-           HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-        WHERE team_id = 2
-          AND (pdi.person_id IN
-                 (SELECT DISTINCT person_id
-                  FROM cohortpeople
-                  WHERE team_id = 2
-                    AND cohort_id = 2
-                    AND version = 0 ))
-        GROUP BY distinct_id
-        HAVING argMax(is_deleted, version) = 0) as pdi on pdi.distinct_id = e.distinct_id PREWHERE team_id = 2
-     AND e.timestamp >= '2021-07-31 20:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2021-08-13 12:00:00'
-       AND timestamp <= '2021-08-22 08:00:00'
-       AND (event = '$pageview')
-       AND (pdi.person_id IN
-              (SELECT DISTINCT person_id
-               FROM cohortpeople
-               WHERE team_id = 2
-                 AND cohort_id = 2
-                 AND version = 0 ))
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview'])) as e on s.session_id = e.`$session_id`
-  JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2 as pdi
-     INNER JOIN
-       (SELECT id
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-     WHERE team_id = 2
-       AND (pdi.person_id IN
-              (SELECT DISTINCT person_id
-               FROM cohortpeople
-               WHERE team_id = 2
-                 AND cohort_id = 2
-                 AND version = 0 ))
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi on pdi.distinct_id = s.distinct_id
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2021-07-31 20:00:00'
     AND s.min_first_timestamp >= '2021-08-14 00:00:00'
     AND s.max_last_timestamp <= '2021-08-21 20:00:00'
+    AND s.distinct_id in
+      (select distinct_id
+       from
+         (SELECT distinct_id,
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2 as pdi
+          INNER JOIN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+             GROUP BY id
+             HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+          WHERE team_id = 2
+            AND (pdi.person_id IN
+                   (SELECT DISTINCT person_id
+                    FROM cohortpeople
+                    WHERE team_id = 2
+                      AND cohort_id = 2
+                      AND version = 0 ))
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0) as session_persons_sub_query)
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e
+          JOIN
+            (SELECT distinct_id,
+                    argMax(person_id, version) as person_id
+             FROM person_distinct_id2 as pdi
+             INNER JOIN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                GROUP BY id
+                HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+             WHERE team_id = 2
+               AND (pdi.person_id IN
+                      (SELECT DISTINCT person_id
+                       FROM cohortpeople
+                       WHERE team_id = 2
+                         AND cohort_id = 2
+                         AND version = 0 ))
+             GROUP BY distinct_id
+             HAVING argMax(is_deleted, version) = 0) as pdi on pdi.distinct_id = e.distinct_id PREWHERE team_id = 2
+          AND e.timestamp >= '2021-07-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-08-13 12:00:00'
+            AND timestamp <= '2021-08-22 08:00:00'
+            AND (event = '$pageview')
+            AND (pdi.person_id IN
+                   (SELECT DISTINCT person_id
+                    FROM cohortpeople
+                    WHERE team_id = 2
+                      AND cohort_id = 2
+                      AND version = 0 ))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -2365,67 +2431,71 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e
-     JOIN
-       (SELECT distinct_id,
-               argMax(person_id, version) as person_id
-        FROM person_distinct_id2 as pdi
-        INNER JOIN
-          (SELECT id
-           FROM person
-           WHERE team_id = 2
-           GROUP BY id
-           HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-        WHERE team_id = 2
-          AND (pdi.person_id IN
-                 (SELECT DISTINCT person_id
-                  FROM cohortpeople
-                  WHERE team_id = 2
-                    AND cohort_id = 2
-                    AND version = 0 ))
-        GROUP BY distinct_id
-        HAVING argMax(is_deleted, version) = 0) as pdi on pdi.distinct_id = e.distinct_id PREWHERE team_id = 2
-     AND e.timestamp >= '2021-07-31 20:00:00'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2021-08-13 12:00:00'
-       AND timestamp <= '2021-08-22 08:00:00'
-       AND (event = 'custom_event')
-       AND (pdi.person_id IN
-              (SELECT DISTINCT person_id
-               FROM cohortpeople
-               WHERE team_id = 2
-                 AND cohort_id = 2
-                 AND version = 0 ))
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['custom_event'])) as e on s.session_id = e.`$session_id`
-  JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2 as pdi
-     INNER JOIN
-       (SELECT id
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-     WHERE team_id = 2
-       AND (pdi.person_id IN
-              (SELECT DISTINCT person_id
-               FROM cohortpeople
-               WHERE team_id = 2
-                 AND cohort_id = 2
-                 AND version = 0 ))
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi on pdi.distinct_id = s.distinct_id
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2021-07-31 20:00:00'
     AND s.min_first_timestamp >= '2021-08-14 00:00:00'
     AND s.max_last_timestamp <= '2021-08-21 20:00:00'
+    AND s.distinct_id in
+      (select distinct_id
+       from
+         (SELECT distinct_id,
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2 as pdi
+          INNER JOIN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+             GROUP BY id
+             HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+          WHERE team_id = 2
+            AND (pdi.person_id IN
+                   (SELECT DISTINCT person_id
+                    FROM cohortpeople
+                    WHERE team_id = 2
+                      AND cohort_id = 2
+                      AND version = 0 ))
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0) as session_persons_sub_query)
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e
+          JOIN
+            (SELECT distinct_id,
+                    argMax(person_id, version) as person_id
+             FROM person_distinct_id2 as pdi
+             INNER JOIN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                GROUP BY id
+                HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+             WHERE team_id = 2
+               AND (pdi.person_id IN
+                      (SELECT DISTINCT person_id
+                       FROM cohortpeople
+                       WHERE team_id = 2
+                         AND cohort_id = 2
+                         AND version = 0 ))
+             GROUP BY distinct_id
+             HAVING argMax(is_deleted, version) = 0) as pdi on pdi.distinct_id = e.distinct_id PREWHERE team_id = 2
+          AND e.timestamp >= '2021-07-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-08-13 12:00:00'
+            AND timestamp <= '2021-08-22 08:00:00'
+            AND (event = 'custom_event')
+            AND (pdi.person_id IN
+                   (SELECT DISTINCT person_id
+                    FROM cohortpeople
+                    WHERE team_id = 2
+                      AND cohort_id = 2
+                      AND version = 0 ))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['custom_event'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -2452,24 +2522,26 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$pageview')
-            OR event = 'new-event')
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview', 'new-event'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND ((event = '$pageview')
+                 OR event = 'new-event')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview', 'new-event'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -2496,24 +2568,26 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT groupUniqArray(event) as event_names,
-            `$session_id`
-     FROM events e PREWHERE team_id = 2
-     AND e.timestamp >= '2020-12-11 13:46:23'
-     AND e.timestamp <= now()
-     WHERE notEmpty(`$session_id`)
-       AND timestamp >= '2020-12-24 12:00:00'
-       AND timestamp <= '2021-01-02 01:46:23'
-       AND ((event = '$pageview')
-            OR event = 'new-event2')
-     GROUP BY `$session_id`
-     HAVING 1=1
-     AND hasAll(event_names, ['$pageview', 'new-event2'])) as e on s.session_id = e.`$session_id`
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-11 13:46:23'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2020-12-24 12:00:00'
+            AND timestamp <= '2021-01-02 01:46:23'
+            AND ((event = '$pageview')
+                 OR event = 'new-event2')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview', 'new-event2'])) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -2540,24 +2614,26 @@
          sum(s.console_warn_count) as console_warn_count,
          sum(s.console_error_count) as console_error_count
   FROM session_replay_events s
-  JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2 as pdi
-     INNER JOIN
-       (SELECT id
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0
-     and person_id = '00000000-0000-0000-0000-000000000000') as pdi on pdi.distinct_id = s.distinct_id
   WHERE s.team_id = 2
     AND s.min_first_timestamp >= '2020-12-11 13:46:23'
     AND s.min_first_timestamp >= '2020-12-25 00:00:00'
     AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.distinct_id in
+      (select distinct_id
+       from
+         (SELECT distinct_id,
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2 as pdi
+          INNER JOIN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+             GROUP BY id
+             HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0
+          and person_id = '00000000-0000-0000-0000-000000000000') as session_persons_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC

--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -233,21 +233,7 @@
        from
          (SELECT groupUniqArray(event) as event_names,
                  `$session_id`
-          FROM events e
-          JOIN
-            (SELECT distinct_id,
-                    argMax(person_id, version) as person_id
-             FROM person_distinct_id2 as pdi
-             INNER JOIN
-               (SELECT id
-                FROM person
-                WHERE team_id = 2
-                GROUP BY id
-                HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
-             WHERE team_id = 2
-             GROUP BY distinct_id
-             HAVING argMax(is_deleted, version) = 0
-             and person_id = '00000000-0000-0000-0000-000000000000') as pdi on pdi.distinct_id = e.distinct_id PREWHERE team_id = 2
+          FROM events e PREWHERE team_id = 2
           AND e.timestamp >= '2020-12-11 13:46:23'
           AND e.timestamp <= now()
           WHERE notEmpty(`$session_id`)
@@ -255,6 +241,22 @@
             AND timestamp <= '2021-01-05 11:59:59'
             AND ((event = '$pageview')
                  OR ((event = 'custom-event')))
+            AND e.distinct_id in
+              (select distinct_id
+               from
+                 (SELECT distinct_id,
+                         argMax(person_id, version) as person_id
+                  FROM person_distinct_id2 as pdi
+                  INNER JOIN
+                    (SELECT id
+                     FROM person
+                     WHERE team_id = 2
+                     GROUP BY id
+                     HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                  WHERE team_id = 2
+                  GROUP BY distinct_id
+                  HAVING argMax(is_deleted, version) = 0
+                  and person_id = '00000000-0000-0000-0000-000000000000') as events_persons_sub_query)
           GROUP BY `$session_id`
           HAVING 1=1
           AND hasAll(event_names, ['$pageview', 'custom-event'])) as session_events_sub_query)


### PR DESCRIPTION
## Problem

using @neilkakkar's brain and house watch we can assert it's quicker to use a subquery than a join when listing session replays

![Screenshot 2023-07-26 at 13 11 37](https://github.com/PostHog/posthog/assets/984817/9e47b772-8702-4c7e-a616-a86ea3f271f5)

We do have to join sometimes (without further changes) since events filters can reference person properties and assume the join has happened

## Changes

Join as infrequently as possible

And as a little messy making the PR do more than one thing

Adds some text to the settings for internal account filtering because its caught people out on support before now where they think this means they won't ingest data

![Screenshot 2023-07-26 at 16 05 08](https://github.com/PostHog/posthog/assets/984817/a5694bf6-4764-425d-8de8-f236fc1fe852)

## How did you test this code?

developer tests