### PR TITLE
feat: Add basic search attributes to scheduled batch exports 

### DIFF
--- a/bin/check_temporal_up
+++ b/bin/check_temporal_up
@@ -6,18 +6,29 @@ set -e
 SECONDS=0
 TIMEOUT=180
 
+# Check that the add-search-attributes container finished.
+until [ "`docker inspect -f {{.State.Status}} posthog_temporal-add-search-attributes_1`"=="exited" ]; do
+    if [ $SECONDS -ge $TIMEOUT ]; then
+        echo "Timed out waiting for temporal-add-search-attributes"
+        exit 1
+    fi
+
+    sleep 1;
+done;
+
 # Check Temporal by just checking that the port is open
 while true; do
     if nc -z localhost 7233; then
         echo "Temporal is up!"
         exit 0
     fi
-    
+
+
     if [ $SECONDS -ge $TIMEOUT ]; then
         echo "Timed out waiting for Temporal to be ready"
         exit 1
     fi
-    
+
     echo "Waiting for Temporal to be ready"
     sleep 1
 done

--- a/bin/temporal-add-search-attributes
+++ b/bin/temporal-add-search-attributes
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+until temporal operator search-attribute list --namespace ${TEMPORAL_NAMESPACE:-default}
+do
+    echo "Waiting for namespace cache to refresh..."
+    sleep 1
+done
+echo "Namespace cache refreshed."
+
+echo "Adding search attributes."
+temporal operator search-attribute create -y --namespace ${TEMPORAL_NAMESPACE:-default} \
+        --name DestinationType --type Text \
+        --name TeamId --type Int

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -172,6 +172,18 @@ services:
         image: temporalio/admin-tools:1.20.0
         stdin_open: true
         tty: true
+    temporal-add-search-attributes:
+        depends_on:
+            - temporal
+        environment:
+            - TEMPORAL_CLI_ADDRESS=temporal:7233
+        image: temporalio/admin-tools:1.20.0
+        stdin_open: true
+        tty: true
+        entrypoint: /bin/bash
+        command: ./temporal-add-search-attributes
+        volumes:
+            - ./bin/temporal-add-search-attributes:/etc/temporal/temporal-add-search-attributes
     temporal-ui:
         depends_on:
             - temporal

--- a/docker-compose.dev-full.yml
+++ b/docker-compose.dev-full.yml
@@ -123,6 +123,18 @@ services:
             service: temporal
         ports:
             - 7233:7233
+    temporal-add-search-attributes:
+        depends_on:
+            - temporal
+        environment:
+            - TEMPORAL_CLI_ADDRESS=temporal:7233
+        image: temporalio/admin-tools:1.20.0
+        stdin_open: true
+        tty: true
+        entrypoint: /bin/bash
+        command: ./temporal-add-search-attributes
+        volumes:
+            - ./bin/temporal-add-search-attributes:/etc/temporal/temporal-add-search-attributes
     temporal-admin-tools:
         extends:
             file: docker-compose.base.yml

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -88,6 +88,10 @@ services:
         extends:
             file: docker-compose.base.yml
             service: temporal-admin-tools
+    temporal-add-search-attributes:
+        extends:
+            file: docker-compose.base.yml
+            service: temporal-add-search-attributes
     temporal-ui:
         extends:
             file: docker-compose.base.yml

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -125,6 +125,12 @@ services:
         extends:
             file: docker-compose.base.yml
             service: temporal-admin-tools
+    temporal-add-search-attributes:
+        extends:
+            file: docker-compose.base.yml
+            service: temporal-add-search-attributes
+        volumes:
+            - ./posthog/bin/temporal-add-search-attributes:/etc/temporal/temporal-add-search-attributes
     temporal-ui:
         extends:
             file: docker-compose.base.yml


### PR DESCRIPTION
## Problem

Search attributes are valuable to be able to filter Workflows. For example, right now is very awkward to get a list of all workflows for a team: You need to query PG to get the export id, then use that export id to find the schedule, then find all workflows scheduled by that schedule. With a `TeamId` search attribute we could just query by the team id and that's it.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* BatchExports are now created with `TeamId` and `DestinationType` Search Attributes. We may add more in the future.
* Added a script to create these search attributes in dev and hobby. They have already been created in external temporal.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

The normal unit tests should fail if the search attributes are not created properly.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
