### PR TITLE
chore(debug): Lemonize CH queries modal

### DIFF
--- a/frontend/src/lib/components/CodeSnippet/CodeSnippet.scss
+++ b/frontend/src/lib/components/CodeSnippet/CodeSnippet.scss
@@ -18,10 +18,6 @@
             }
         }
     }
-    button,
-    svg {
-        color: #fff;
-    }
 }
 
 .posthog-3000 .CodeSnippet pre {

--- a/frontend/src/lib/components/CodeSnippet/CodeSnippet.tsx
+++ b/frontend/src/lib/components/CodeSnippet/CodeSnippet.tsx
@@ -22,7 +22,7 @@ import { copyToClipboard } from 'lib/utils'
 import { Popconfirm } from 'antd'
 import { PopconfirmProps } from 'antd/lib/popconfirm'
 import './CodeSnippet.scss'
-import { IconCopy } from 'lib/lemon-ui/icons'
+import { IconCopy, IconUnfoldLess, IconUnfoldMore } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { useValues } from 'kea'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -138,7 +138,14 @@ export function CodeSnippet({
                 {displayedText}
             </SyntaxHighlighter>
             {indexOfLimitNewline !== -1 && (
-                <LemonButton onClick={() => setExpanded(!expanded)} fullWidth center size="small" type="secondary">
+                <LemonButton
+                    onClick={() => setExpanded(!expanded)}
+                    fullWidth
+                    center
+                    size="small"
+                    type="secondary"
+                    icon={expanded ? <IconUnfoldLess /> : <IconUnfoldMore />}
+                >
                     {expanded ? 'Collapse' : 'Expand'} snippet
                 </LemonButton>
             )}

--- a/frontend/src/lib/components/CodeSnippet/index.ts
+++ b/frontend/src/lib/components/CodeSnippet/index.ts
@@ -1,0 +1,1 @@
+export { CodeSnippet, Language } from './CodeSnippet'

--- a/frontend/src/lib/components/CodeSnippet/index.tsx
+++ b/frontend/src/lib/components/CodeSnippet/index.tsx
@@ -84,8 +84,9 @@ export interface CodeSnippetProps {
     wrap?: boolean
     actions?: Action[]
     style?: React.CSSProperties
-    copyDescription?: string
-    hideCopyButton?: boolean
+    /** What is being copied. @example 'link' */
+    thing?: string
+    allowCopy?: boolean
 }
 
 export function CodeSnippet({
@@ -94,8 +95,8 @@ export function CodeSnippet({
     wrap = false,
     style,
     actions,
-    copyDescription = 'code snippet',
-    hideCopyButton = false,
+    thing = 'snippet',
+    allowCopy: hideCopyButton = false,
 }: CodeSnippetProps): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
 
@@ -118,7 +119,7 @@ export function CodeSnippet({
                         data-attr="copy-code-button"
                         icon={<IconCopy />}
                         onClick={async () => {
-                            children && (await copyToClipboard(children, copyDescription))
+                            children && (await copyToClipboard(children, thing))
                         }}
                     />
                 )}

--- a/frontend/src/lib/components/CodeSnippet/index.tsx
+++ b/frontend/src/lib/components/CodeSnippet/index.tsx
@@ -96,7 +96,7 @@ export function CodeSnippet({
     style,
     actions,
     thing = 'snippet',
-    allowCopy: hideCopyButton = false,
+    allowCopy = false,
 }: CodeSnippetProps): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
 
@@ -114,7 +114,7 @@ export function CodeSnippet({
                             </Popconfirm>
                         )
                     )}
-                {!hideCopyButton && (
+                {!allowCopy && (
                     <LemonButton
                         data-attr="copy-code-button"
                         icon={<IconCopy />}

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -41,7 +41,7 @@ function QueryCol({ item }: { item: Query }): JSX.Element {
     return (
         <>
             <CodeSnippet
-                hideCopyButton={!expanded}
+                allowCopy={!expanded}
                 language={Language.SQL}
                 thing="query"
                 style={{ maxWidth: 600, fontSize: 12 }}

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -100,7 +100,13 @@ function DebugCHQueries(): JSX.Element {
                             </LemonButton>
                         ))}
                     </div>
-                    <LemonButton icon={<IconRefresh />} onClick={() => loadQueries()} size="small" type="secondary">
+                    <LemonButton
+                        icon={<IconRefresh />}
+                        disabledReason={queriesLoading ? 'Loading…' : null}
+                        onClick={() => loadQueries()}
+                        size="small"
+                        type="secondary"
+                    >
                         Refresh
                     </LemonButton>
                 </div>

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -15,46 +15,6 @@ interface Query {
     path: string
 }
 
-function nthChar(string: string, character: string, n: number): number {
-    let count = 0,
-        i = 0
-    while (count < n && (i = string.indexOf(character, i) + 1)) {
-        count++
-    }
-    if (count == n) {
-        return i - 1
-    }
-    return -1
-}
-
-function QueryCol({ item }: { item: Query }): JSX.Element {
-    const [expanded, setExpanded] = useState(false as boolean)
-
-    const has5lines = nthChar(item.query, '\n', 5)
-    if (has5lines === -1) {
-        return (
-            <CodeSnippet language={Language.SQL} thing="query" style={{ maxWidth: 600, fontSize: 12 }}>
-                {item.query}
-            </CodeSnippet>
-        )
-    }
-    return (
-        <>
-            <CodeSnippet
-                allowCopy={!expanded}
-                language={Language.SQL}
-                thing="query"
-                style={{ maxWidth: 600, fontSize: 12 }}
-            >
-                {expanded ? item.query : item.query.slice(0, has5lines)}
-            </CodeSnippet>
-            <LemonButton size="small" onClick={() => setExpanded(!expanded)}>
-                {expanded ? 'Show less' : 'Show more'}
-            </LemonButton>
-        </>
-    )
-}
-
 function ModalContent({ origResult }: { origResult: Query[] }): JSX.Element {
     const [pathFilter, setPathFilter] = useState(null as string | null)
 
@@ -92,7 +52,14 @@ function ModalContent({ origResult }: { origResult: Query[] }): JSX.Element {
                             return (
                                 <>
                                     {item.exception}
-                                    <QueryCol item={item} />
+                                    <CodeSnippet
+                                        language={Language.SQL}
+                                        thing="query"
+                                        maxLinesWithoutExpansion={5}
+                                        style={{ maxWidth: 600, fontSize: 12 }}
+                                    >
+                                        {item.query}
+                                    </CodeSnippet>
                                 </>
                             )
                         },

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -20,7 +20,8 @@ export async function debugCHQueries(): Promise<void> {
 }
 
 export interface Query {
-    timestamp: number
+    /** @example '2023-07-27T10:06:11' */
+    timestamp: string
     query: string
     exception: string
     type: number
@@ -111,7 +112,7 @@ function DebugCHQueries(): JSX.Element {
                         title: 'Timestamp',
                         render: (_, item) => (
                             <span className="font-mono whitespace-pre">
-                                {dayjs(item.timestamp).format().replace('T', '\n')}
+                                {dayjs.tz(item.timestamp, 'UTC').tz().format().replace('T', '\n')}
                             </span>
                         ),
                         width: 160,
@@ -139,10 +140,11 @@ function DebugCHQueries(): JSX.Element {
                         },
                     },
                     {
-                        title: 'Execution duration',
+                        title: 'Duration',
                         render: function exec(_, item) {
                             return <>{Math.round((item.execution_time + Number.EPSILON) * 100) / 100} ms</>
                         },
+                        align: 'right',
                     },
                 ]}
                 dataSource={filteredQueries}

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -33,7 +33,7 @@ function QueryCol({ item }: { item: Query }): JSX.Element {
     const has5lines = nthChar(item.query, '\n', 5)
     if (has5lines === -1) {
         return (
-            <CodeSnippet language={Language.SQL} copyDescription="Copy query" style={{ maxWidth: 600, fontSize: 12 }}>
+            <CodeSnippet language={Language.SQL} thing="query" style={{ maxWidth: 600, fontSize: 12 }}>
                 {item.query}
             </CodeSnippet>
         )
@@ -43,7 +43,7 @@ function QueryCol({ item }: { item: Query }): JSX.Element {
             <CodeSnippet
                 hideCopyButton={!expanded}
                 language={Language.SQL}
-                copyDescription="Copy query"
+                thing="query"
                 style={{ maxWidth: 600, fontSize: 12 }}
             >
                 {expanded ? item.query : item.query.slice(0, has5lines)}

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -1,12 +1,25 @@
-import { useState } from 'react'
-import { Modal } from 'antd'
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
 import { CodeSnippet, Language } from '../CodeSnippet'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { actions, afterMount, kea, reducers, selectors, useActions, useValues, path } from 'kea'
+import { loaders } from 'kea-loaders'
+import type { debugCHQueriesLogicType } from './DebugCHQueriesType'
+import { IconRefresh } from 'lib/lemon-ui/icons'
 
-interface Query {
+export async function debugCHQueries(): Promise<void> {
+    LemonDialog.open({
+        title: 'ClickHouse queries recently executed for this user',
+        content: <DebugCHQueries />,
+        primaryButton: null,
+        width: 1200,
+    })
+}
+
+export interface Query {
     timestamp: number
     query: string
     exception: string
@@ -15,82 +28,129 @@ interface Query {
     path: string
 }
 
-function ModalContent({ origResult }: { origResult: Query[] }): JSX.Element {
-    const [pathFilter, setPathFilter] = useState(null as string | null)
+const debugCHQueriesLogic = kea<debugCHQueriesLogicType>([
+    path(['lib', 'components', 'CommandPalette', 'DebugCHQueries']),
+    actions({
+        setPathFilter: (path: string | null) => ({ path }),
+    }),
+    reducers({
+        pathFilter: [
+            null as string | null,
+            {
+                setPathFilter: (_, { path }) => path,
+            },
+        ],
+    }),
+    loaders({
+        queries: [
+            [] as Query[],
+            {
+                loadQueries: async () => {
+                    return await api.get('api/debug_ch_queries/')
+                },
+            },
+        ],
+    }),
+    selectors({
+        paths: [
+            (s) => [s.queries],
+            (queries: Query[]) => {
+                return queries
+                    ? Object.entries(
+                          queries
+                              .map((result) => result.path)
+                              .reduce((acc, val) => {
+                                  acc[val] = acc[val] === undefined ? 1 : (acc[val] += 1)
+                                  return acc
+                              }, {})
+                      ).sort((a: any, b: any) => b[1] - a[1])
+                    : null
+            },
+        ],
+        filteredQueries: [
+            (s) => [s.queries, s.pathFilter],
+            (queries: Query[], pathFilter: string | null) => {
+                return pathFilter && queries ? queries.filter((item) => item.path === pathFilter) : queries
+            },
+        ],
+    }),
+    afterMount(({ actions }) => {
+        actions.loadQueries()
+    }),
+])
 
-    const paths = Object.entries(
-        origResult
-            .map((result) => result.path)
-            .reduce((acc, val) => {
-                acc[val] = acc[val] === undefined ? 1 : (acc[val] += 1)
-                return acc
-            }, {})
-    ).sort((a: any, b: any) => b[1] - a[1])
-
-    const results = pathFilter ? origResult.filter((item) => item.path === pathFilter) : origResult
+function DebugCHQueries(): JSX.Element {
+    const { queriesLoading, filteredQueries, pathFilter, paths } = useValues(debugCHQueriesLogic)
+    const { setPathFilter, loadQueries } = useActions(debugCHQueriesLogic)
 
     return (
         <>
-            {paths.map(([path, count]) => (
-                <LemonButton
-                    key={path}
-                    type={pathFilter === path ? 'primary' : 'tertiary'}
-                    size="small"
-                    onClick={() => (pathFilter === path ? setPathFilter(null) : setPathFilter(path))}
-                >
-                    {path} ({count})
-                </LemonButton>
-            ))}
-            {pathFilter && <LemonButton onClick={() => setPathFilter(null)}>Remove path filter</LemonButton>}
+            {!!paths?.length && (
+                <div className="flex gap-4 items-end justify-between mb-4">
+                    <div className="flex flex-wrap gap-2">
+                        {paths.map(([path, count]) => (
+                            <LemonButton
+                                key={path}
+                                type={pathFilter === path ? 'primary' : 'tertiary'}
+                                size="small"
+                                onClick={() => (pathFilter === path ? setPathFilter(null) : setPathFilter(path))}
+                            >
+                                {path} ({count})
+                            </LemonButton>
+                        ))}
+                    </div>
+                    <LemonButton icon={<IconRefresh />} onClick={() => loadQueries()} size="small" type="secondary">
+                        Refresh
+                    </LemonButton>
+                </div>
+            )}
 
             <LemonTable
                 columns={[
-                    { title: 'Timestamp', render: (_, item) => dayjs(item.timestamp).format() },
+                    {
+                        title: 'Timestamp',
+                        render: (_, item) => (
+                            <span className="font-mono whitespace-pre">
+                                {dayjs(item.timestamp).format().replace('T', '\n')}
+                            </span>
+                        ),
+                        width: 160,
+                    },
                     {
                         title: 'Query',
                         render: function query(_, item) {
                             return (
-                                <>
-                                    {item.exception}
+                                <div className="max-w-200">
+                                    {item.exception && (
+                                        <LemonBanner type="error" className="text-xs font-mono">
+                                            {item.exception}
+                                        </LemonBanner>
+                                    )}
                                     <CodeSnippet
                                         language={Language.SQL}
                                         thing="query"
                                         maxLinesWithoutExpansion={5}
-                                        style={{ maxWidth: 600, fontSize: 12 }}
+                                        style={{ fontSize: 12 }}
                                     >
                                         {item.query}
                                     </CodeSnippet>
-                                </>
+                                </div>
                             )
                         },
                     },
                     {
-                        title: 'Execution duration (ms)',
+                        title: 'Execution duration',
                         render: function exec(_, item) {
-                            return <>{Math.round((item.execution_time + Number.EPSILON) * 100) / 100}</>
+                            return <>{Math.round((item.execution_time + Number.EPSILON) * 100) / 100} ms</>
                         },
                     },
                 ]}
-                dataSource={results}
+                dataSource={filteredQueries}
+                loading={queriesLoading}
+                loadingSkeletonRows={5}
                 size="small"
                 pagination={undefined}
             />
         </>
     )
-}
-
-export async function debugCHQueries(): Promise<void> {
-    const results = await api.get('api/debug_ch_queries/')
-
-    Modal.info({
-        visible: true,
-        width: '80%',
-        title: 'ClickHouse queries recently executed for this user',
-        icon: null,
-        content: <ModalContent origResult={results} />,
-        closable: true,
-        maskClosable: true,
-        okText: 'Close',
-    })
-    setTimeout(() => document?.querySelector('.ant-modal-wrap')?.scrollTo(0, 0), 200)
 }

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -559,7 +559,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>({
                     preflightLogic.values.preflight?.instance_preferences?.debug_queries
                         ? {
                               icon: IconTools,
-                              display: 'Debug queries (ClickHouse)',
+                              display: 'Debug ClickHouse Queries',
                               executor: () => {
                                   debugCHQueries()
                               },

--- a/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
+++ b/frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.tsx
@@ -100,7 +100,7 @@ export function HTMLElementsDisplay({
         <div className="flex flex-col gap-1">
             {editable && !!elements.length && (
                 <div>
-                    Selector: <CodeSnippet copyDescription={'chosen selector'}>{chosenSelector}</CodeSnippet>
+                    Selector: <CodeSnippet thing={'chosen selector'}>{chosenSelector}</CodeSnippet>
                 </div>
             )}
             {checkUniqueness && (

--- a/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
@@ -6,9 +6,9 @@ import { useValues } from 'kea'
 import { router } from 'kea-router'
 
 export type LemonDialogProps = Pick<LemonModalProps, 'title' | 'description' | 'width' | 'inline'> & {
-    primaryButton?: LemonButtonProps
-    secondaryButton?: LemonButtonProps
-    tertiaryButton?: LemonButtonProps
+    primaryButton?: LemonButtonProps | null
+    secondaryButton?: LemonButtonProps | null
+    tertiaryButton?: LemonButtonProps | null
     content?: ReactNode
     onClose?: () => void
     onAfterClose?: () => void
@@ -29,12 +29,18 @@ export function LemonDialog({
     const { currentLocation } = useValues(router)
     const lastLocation = useRef(currentLocation.pathname)
 
-    primaryButton = primaryButton || {
-        children: 'Okay',
+    primaryButton =
+        primaryButton ||
+        (primaryButton === null
+            ? null
+            : {
+                  children: 'Okay',
+              })
+    if (primaryButton) {
+        primaryButton.type = primaryButton.type || 'primary'
     }
-    primaryButton.type = primaryButton.type || 'primary'
 
-    const renderButton = (button: LemonButtonProps | undefined): JSX.Element | null => {
+    const renderButton = (button: LemonButtonProps | null | undefined): JSX.Element | null => {
         if (!button) {
             return null
         }
@@ -64,11 +70,13 @@ export function LemonDialog({
             onClose={() => setIsOpen(false)}
             onAfterClose={() => onAfterClose?.()}
             footer={
-                <>
-                    <div className="flex-1">{renderButton(tertiaryButton)}</div>
-                    {renderButton(secondaryButton)}
-                    {renderButton(primaryButton)}
-                </>
+                primaryButton || secondaryButton || tertiaryButton ? (
+                    <>
+                        <div className="flex-1">{renderButton(tertiaryButton)}</div>
+                        {renderButton(secondaryButton)}
+                        {renderButton(primaryButton)}
+                    </>
+                ) : null
             }
         >
             {content}

--- a/frontend/src/scenes/ingestion/panels/ThirdPartyPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/ThirdPartyPanel.tsx
@@ -181,7 +181,7 @@ export function IntegrationInstructionsModal(): JSX.Element {
                                                 provides a detailed overview of how to set up this integration.
                                             </p>
                                             <b>PostHog Project API Key</b>
-                                            <CodeSnippet copyDescription="project API key">
+                                            <CodeSnippet thing="project API key">
                                                 {currentTeam?.api_token || ''}
                                             </CodeSnippet>
                                         </div>

--- a/frontend/src/scenes/project/Settings/IngestionInfo.tsx
+++ b/frontend/src/scenes/project/Settings/IngestionInfo.tsx
@@ -97,7 +97,7 @@ export function IngestionInfo({ loadingComponent }: { loadingComponent: JSX.Elem
                           ]
                         : []
                 }
-                copyDescription="project API key"
+                thing="project API key"
             >
                 {currentTeam?.api_token || ''}
             </CodeSnippet>
@@ -111,7 +111,7 @@ export function IngestionInfo({ loadingComponent }: { loadingComponent: JSX.Elem
             <p>
                 You can use this ID to reference your project in our <a href="https://posthog.com/docs/api">API</a>.
             </p>
-            <CodeSnippet copyDescription="project ID">{String(currentTeam?.id || '')}</CodeSnippet>
+            <CodeSnippet thing="project ID">{String(currentTeam?.id || '')}</CodeSnippet>
         </>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemConsoleLog.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemConsoleLog.tsx
@@ -41,7 +41,7 @@ export function ItemConsoleLog({ item, expanded, setExpanded }: ItemConsoleLogPr
                             <LemonDivider dashed />
                         </>
                     ) : null}
-                    <CodeSnippet language={Language.JavaScript} wrap copyDescription="console log">
+                    <CodeSnippet language={Language.JavaScript} wrap thing="console log">
                         {item.data.lines.join(' ')}
                     </CodeSnippet>
 
@@ -49,7 +49,7 @@ export function ItemConsoleLog({ item, expanded, setExpanded }: ItemConsoleLogPr
                         <>
                             <LemonDivider dashed />
                             <LemonLabel>Stack trace</LemonLabel>
-                            <CodeSnippet language={Language.Markup} wrap copyDescription="stack trace">
+                            <CodeSnippet language={Language.Markup} wrap thing="stack trace">
                                 {item.data.trace.join('\n')}
                             </CodeSnippet>
                         </>

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemPerformanceEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemPerformanceEvent.tsx
@@ -219,7 +219,7 @@ export function ItemPerformanceEvent({
             {expanded && (
                 <div className="p-2 text-xs border-t">
                     {item.name && (
-                        <CodeSnippet language={Language.Markup} wrap copyDescription="performance event name">
+                        <CodeSnippet language={Language.Markup} wrap thing="performance event name">
                             {item.name}
                         </CodeSnippet>
                     )}


### PR DESCRIPTION
## Problem

The CH queries modal is super useful for debugging, but it looked wonky, didn't have any "Refresh" button, didn't allow copying collapsed queries, and only popped up once the CH queries data loaded instead of showing a loading state. Not to mention it was an Ant modal:

<img width="1200" alt="Screenshot 2023-07-27 at 09 14 26" src="https://github.com/PostHog/posthog/assets/4550621/4b14b480-0ba8-46c4-8897-81a79f0f6497">

## Changes

This looks nicer, has a "Refresh" button, always allows copying queries, shows up instantly… and has no ants:

<img width="1227" alt="Screenshot 2023-07-27 at 09 19 36" src="https://github.com/PostHog/posthog/assets/4550621/21103b53-85df-44f4-aeed-799296e02f0b">

Contributes to #13624.
