### PR TITLE
chore(temporal): export temporal client metrics via prometheus

### DIFF
--- a/posthog/temporal/client.py
+++ b/posthog/temporal/client.py
@@ -8,7 +8,7 @@ from temporalio.client import Client, TLSConfig
 from posthog.temporal.codec import EncryptionCodec
 
 
-async def connect(host, port, namespace, server_root_ca_cert=None, client_cert=None, client_key=None):
+async def connect(host, port, namespace, server_root_ca_cert=None, client_cert=None, client_key=None, runtime=None):
     tls: TLSConfig | bool = False
     if server_root_ca_cert and client_cert and client_key:
         tls = TLSConfig(
@@ -20,6 +20,7 @@ async def connect(host, port, namespace, server_root_ca_cert=None, client_cert=N
         f"{host}:{port}",
         namespace=namespace,
         tls=tls,
+        runtime=runtime,
         data_converter=dataclasses.replace(
             temporalio.converter.default(), payload_codec=EncryptionCodec(settings=settings)
         ),

--- a/posthog/temporal/worker.py
+++ b/posthog/temporal/worker.py
@@ -2,6 +2,7 @@ import signal
 import sys
 from datetime import timedelta
 
+from temporalio.runtime import Runtime, TelemetryConfig, PrometheusConfig
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.temporal.client import connect
@@ -9,7 +10,8 @@ from posthog.temporal.workflows import ACTIVITIES, WORKFLOWS
 
 
 async def start_worker(host, port, namespace, task_queue, server_root_ca_cert=None, client_cert=None, client_key=None):
-    client = await connect(host, port, namespace, server_root_ca_cert, client_cert, client_key)
+    runtime = Runtime(telemetry=TelemetryConfig(metrics=PrometheusConfig(bind_address="0.0.0.0:8596")))
+    client = await connect(host, port, namespace, server_root_ca_cert, client_cert, client_key, runtime=runtime)
     worker = Worker(
         client,
         task_queue=task_queue,


### PR DESCRIPTION
## Problem

We want to collect prometheus metrics for the temporal-py-worker pods

## Changes

Enable the temporal SDK's exporter, according to https://docs.temporal.io/dev-guide/python/observability#metrics
- Looks like we cannot pass an existing registry, or retrieve the registry it initializes, so we'll probably need to open another port for our custom metrics
- Hopefully port 8596 is unused 🤞 

# How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
