### PR TITLE
fix(persons): fix user path and trend funnel persons cache invalidation

### DIFF
--- a/frontend/src/scenes/funnels/FunnelLineGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelLineGraph.tsx
@@ -1,5 +1,5 @@
 import { LineGraph } from 'scenes/insights/views/LineGraph/LineGraph'
-import { ChartParams, GraphType, GraphDataset, EntityTypes } from '~/types'
+import { ChartParams, GraphType, GraphDataset } from '~/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { capitalizeFirstLetter, shortTimeZone } from 'lib/utils'
 import { dayjs } from 'lib/dayjs'
@@ -67,18 +67,13 @@ export function FunnelLineGraph({
                           const label = dataset?.label ?? dataset?.labels?.[index] ?? ''
 
                           const filters = queryNodeToFilter(querySource) // for persons modal
-                          const props = {
-                              action: { id: index, name: label ?? null, properties: [], type: EntityTypes.ACTIONS },
-                              date_from: day ?? '',
-                              date_to: day ?? '',
+                          const personsUrl = buildPeopleUrl({
                               filters,
-                          }
-
-                          const url = buildPeopleUrl(props)
-
-                          if (url) {
+                              date_from: day ?? '',
+                          })
+                          if (personsUrl) {
                               openPersonsModal({
-                                  url,
+                                  url: personsUrl,
                                   title: `${capitalizeFirstLetter(aggregationTargetLabel.plural)} converted on ${dayjs(
                                       label
                                   ).format('MMMM Do YYYY')}`,

--- a/frontend/src/scenes/funnels/FunnelLineGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelLineGraph.tsx
@@ -70,6 +70,7 @@ export function FunnelLineGraph({
                           const personsUrl = buildPeopleUrl({
                               filters,
                               date_from: day ?? '',
+                              response: insightData,
                           })
                           if (personsUrl) {
                               openPersonsModal({

--- a/frontend/src/scenes/paths/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.ts
@@ -108,7 +108,6 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
             }
             const personsUrl = buildPeopleUrl({
                 date_from: '',
-                date_to: '',
                 filters,
             })
             if (personsUrl) {

--- a/frontend/src/scenes/paths/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.ts
@@ -109,6 +109,7 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
             const personsUrl = buildPeopleUrl({
                 date_from: '',
                 filters,
+                response: values.insightData,
             })
             if (personsUrl) {
                 openPersonsModal({

--- a/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
+++ b/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
@@ -5,7 +5,6 @@ import { capitalizeFirstLetter, pluralize, toParams } from 'lib/utils'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
 import { isFunnelsFilter, isPathsFilter } from 'scenes/insights/sharedUtils'
 import {
-    ActionFilter,
     FunnelsFilterType,
     FunnelVizType,
     GraphDataset,
@@ -115,13 +114,8 @@ export const urlsForDatasets = (
 }
 
 interface PeopleUrlBuilderParams {
-    action?: ActionFilter
-    date_to?: string | number
-    date_from?: string | number
-    breakdown_value?: string | number
-    target_date?: number | string
-    lifecycle_type?: string | number
     filters: Partial<FunnelsFilterType> | Partial<PathsFilterType>
+    date_from?: string | number
     funnelStep?: number
 }
 


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/pull/16802 for two other insight types.

## Changes

This PR implements a frontend side cache invalidation key for user path and trend funnel insights.

## How did you test this code?

Tested locally