### PR TITLE
fix: Stop realtime manager on destroy

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
@@ -538,6 +538,7 @@ export class SessionManager {
     public async destroy(): Promise<void> {
         this.destroying = true
         this.unsubscribe()
+        this.stopRealtime()
         if (this.inProgressUpload !== null) {
             await this.inProgressUpload.abort().catch((error) => {
                 status.error('🧨', '[session-manager][realtime] failed to abort in progress upload', {


### PR DESCRIPTION
## Problem

Noticed some logs erroring when we destroy a session as we don't clean up the realtime tailer. 

## Changes

* Simple line so it destroys via the shutdown route rather than only via the error message

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
