### PR TITLE
feat(copy): improve autocapture and custom insight date range copy

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -101,7 +101,7 @@ export function DateFilter({
                     const dateValue = dateFilterToText(
                         values[0],
                         values[1],
-                        'No date selected',
+                        'Date range specified in the respective Insight',
                         dateOptions,
                         isDateFormatted
                     )

--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -101,7 +101,7 @@ export function DateFilter({
                     const dateValue = dateFilterToText(
                         values[0],
                         values[1],
-                        'Date range specified in the respective Insight',
+                        'Date range specified in respective insights',
                         dateOptions,
                         isDateFormatted
                     )

--- a/frontend/src/scenes/project/Settings/AutocaptureSettings.tsx
+++ b/frontend/src/scenes/project/Settings/AutocaptureSettings.tsx
@@ -23,13 +23,13 @@ export function AutocaptureSettings(): JSX.Element {
         <>
             <h2 className="subtitle">Autocapture</h2>
             <p>
-                Automagically capture frontend interactions like pageviews, clicks, and more when using our JavaScript
-                library.{' '}
+                Automagically capture front-end interactions like pageviews, clicks, and more when using our web
+                JavaScript SDK.{' '}
             </p>
             <p>
-                Autocapture for React Native has to be{' '}
+                Autocapture is also available for React Native, where it has to be{' '}
                 <Link to="https://posthog.com/docs/libraries/react-native#autocapture" target="_blank">
-                    configured in code
+                    configured directly in code
                 </Link>
                 .
             </p>
@@ -44,7 +44,7 @@ export function AutocaptureSettings(): JSX.Element {
                     }}
                     checked={!currentTeam?.autocapture_opt_out}
                     disabled={userLoading}
-                    label="Enable Autocapture"
+                    label="Enable autocapture for web"
                     bordered
                 />
                 <FlaggedFeature flag={FEATURE_FLAGS.EXCEPTION_AUTOCAPTURE}>
@@ -61,7 +61,7 @@ export function AutocaptureSettings(): JSX.Element {
                             disabled={userLoading}
                             label={
                                 <>
-                                    Enable Exception Autocapture <LemonTag>ALPHA</LemonTag>
+                                    Enable exception autocapture <LemonTag>ALPHA</LemonTag>
                                 </>
                             }
                             bordered

--- a/frontend/src/scenes/project/Settings/AutocaptureSettings.tsx
+++ b/frontend/src/scenes/project/Settings/AutocaptureSettings.tsx
@@ -1,6 +1,6 @@
 import { useValues, useActions } from 'kea'
 import { userLogic } from 'scenes/userLogic'
-import { LemonSwitch, LemonTag, LemonTextArea } from '@posthog/lemon-ui'
+import { LemonSwitch, LemonTag, LemonTextArea, Link } from '@posthog/lemon-ui'
 import { teamLogic } from 'scenes/teamLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
@@ -24,7 +24,14 @@ export function AutocaptureSettings(): JSX.Element {
             <h2 className="subtitle">Autocapture</h2>
             <p>
                 Automagically capture frontend interactions like pageviews, clicks, and more when using our JavaScript
-                or React Native libraries.
+                library.{' '}
+            </p>
+            <p>
+                Autocapture for React Native has to be{' '}
+                <Link to="https://posthog.com/docs/libraries/react-native#autocapture" target="_blank">
+                    configured in code
+                </Link>
+                .
             </p>
             <div className="space-y-2">
                 <LemonSwitch

--- a/frontend/src/scenes/project/Settings/IngestionInfo.tsx
+++ b/frontend/src/scenes/project/Settings/IngestionInfo.tsx
@@ -16,16 +16,18 @@ export function IngestionInfo({ loadingComponent }: { loadingComponent: JSX.Elem
         return (
             <>
                 <h2 id="snippet" className="subtitle">
-                    Event Ingestion
+                    Event ingestion
                 </h2>
                 <p>
                     PostHog can ingest events from almost anywhere - JavaScript, Android, iOS, React Native, Node.js,
                     Ruby, Go, and more.
                 </p>
                 <p>
-                    Demo projects like this one can't ingest any more events, but you can{' '}
-                    <Link to="https://posthog.com/docs/integrations">read about ingestion in our Docs</Link> and use a
-                    non-demo project to ingest your own events.
+                    Demo projects like this one can't ingest events, but you can{' '}
+                    <Link to="https://posthog.com/docs/integrations" target="_blank">
+                        read about ingestion in our Docs
+                    </Link>{' '}
+                    and use a non-demo project to ingest your own events.
                 </p>
             </>
         )


### PR DESCRIPTION
## Problem

The autocapture description in settings [isn't accurate](https://posthog.slack.com/archives/C02E3BKC78F/p1690448666026269) and the tooltip for [custom insight date range isn't clear](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1690394290863519).

## Changes

This PR changes that.

## How did you test this code?

No tests.