### PR TITLE
chore: Tighten up retries in Batch Exports

### DIFF
--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -293,10 +293,12 @@ class S3BatchExportWorkflow(PostHogWorkflow):
                 insert_inputs,
                 start_to_close_timeout=dt.timedelta(minutes=10),
                 retry_policy=RetryPolicy(
-                    maximum_attempts=6,
+                    initial_interval=dt.timedelta(seconds=10),
+                    maximum_interval=dt.timedelta(seconds=120),
+                    maximum_attempts=10,
                     non_retryable_error_types=[
-                        # Validation failed, and will keep failing.
-                        "ValueError",
+                        # S3 parameter validation failed.
+                        "ParamValidationError",
                     ],
                 ),
             )

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -326,10 +326,15 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
                 insert_inputs,
                 start_to_close_timeout=dt.timedelta(hours=1),
                 retry_policy=RetryPolicy(
-                    maximum_attempts=3,
+                    initial_interval=dt.timedelta(seconds=10),
+                    maximum_interval=dt.timedelta(seconds=120),
+                    maximum_attempts=10,
                     non_retryable_error_types=[
-                        # Validation failed, and will keep failing.
-                        "ValueError",
+                        # Raised when we cannot connect to Snowflake.
+                        "DatabaseError",
+                        # Raised by Snowflake when a query cannot be compiled.
+                        # Usually this means we don't have table permissions or something doesn't exist (db, schema).
+                        "ProgrammingError",
                     ],
                 ),
             )


### PR DESCRIPTION
## Problem

Over the last few weeks, these are the errors that we have seen so far:
Retryable:
* `ConnectionError`: When attempting to connect to ClickHouse.
* `InterfaceError`: Connection already closed when PG is unresponsive.
* `ClickHouseError`: TOO_MANY_QUERIES from ClickHouse.

Non-retryable:
* S3 `ParamValidationError`.
* Snowflake `ProgrammingErrpr`: Object doesn't exist.
* Snowflake `DatabaseError`: cannot access database.

Eventually, we should retry forever on retryable errors and fail immediately on non-retryable.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

In order to get to infinite retries on retryable errors, this PR:
* Increases the number of maximum attempts.
* Properly defines which errors are non-retryable.
* To balance the potential increase in load due to more retries, I've bumped the initial retry interval to 10 seconds, and the maximum interval to 2 minutes. Backoff increase is the default x2.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
