### PR TITLE
fix(exports): fix csv export of breakdown insights

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -253,7 +253,7 @@ def make_api_call(
 ) -> requests.models.Response:
     request_url: str = absolute_uri(next_url or path)
     try:
-        url = add_query_params(request_url, {get_limit_param_key(): str(limit), "is_csv_export": "1"})
+        url = add_query_params(request_url, {get_limit_param_key(request_url): str(limit), "is_csv_export": "1"})
         response = requests.request(
             method=method.lower(), url=url, json=body, headers={"Authorization": f"Bearer {access_token}"}
         )

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -226,7 +226,6 @@ class TestCSVExporter(APIBaseTest):
         self, mocked_request, mocked_object_storage_write, mocked_uuidt
     ) -> None:
         path = "api/projects/1/insights/trend/?insight=TRENDS&breakdown=email&date_from=-7d"
-
         exported_asset = self._create_asset({"path": path})
         mock_response = Mock()
         mock_response.status_code = 200


### PR DESCRIPTION
## Problem

We have reports of insights that can't be exported to csv (see below). 

My investigation led me to think this is because they are breakdown insights, which do not utilize the `limit` parameter, but instead utilize a separate `breakdown_limit` parameter. Therefore they only fetch 25 values per API call, instead of the usual 1000 values.

To verify this I manually crafted an export URL with `breakdown_limit`. In the tested case a call to this URL takes 20 seconds whereas a call to the unchanged URL takes 10 seconds. Thus to get to the `max_limit` of 10000 for exports, it would take 10 * 20s = 3.5min (`breakdown_limit`) vs 400 * 10s > 1h (`limit`).

Note: I was wondering if we haven't used a higher paginating limit for breakdowns, since this would break other insights with a more complex query. Since I haven't gotten feedback on this, I propose moving forward with this PR and to implement a separate limit and max_limit default for breakdown insights, if we find this to be the case.

## Changes

This PR uses `breakdown_limit` instead of `limit` for breakdown insights.

## How did you test this code?

Added a test and exported a breakdown and non-breakdown insight

## Related support tickets (check after deploy)

- https://posthoghelp.zendesk.com/agent/tickets/4279 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/7537)
- https://posthoghelp.zendesk.com/agent/tickets/4659 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/7671)