### PR TITLE
feat: notifications for changed things too

### DIFF
--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -261,7 +261,7 @@ export function flagActivityDescriber(logItem: ActivityLogItem, asNotification?:
         return {
             description: (
                 <>
-                    deleted {asNotification && ' your flag '}
+                    deleted {asNotification && ' the flag '}
                     {logItem.detail.name}
                 </>
             ),
@@ -271,7 +271,7 @@ export function flagActivityDescriber(logItem: ActivityLogItem, asNotification?:
         let changes: Description[] = []
         let changeSuffix: Description = (
             <>
-                on {asNotification && ' your flag '}
+                on {asNotification && ' the flag '}
                 {nameOrLinkToFlag(logItem?.item_id, logItem?.detail.name)}
             </>
         )

--- a/frontend/src/scenes/saved-insights/activityDescriptions.tsx
+++ b/frontend/src/scenes/saved-insights/activityDescriptions.tsx
@@ -59,7 +59,7 @@ const insightActionsMapping: Record<
         return {
             description: [
                 <>
-                    renamed {asNotification && 'your insight '}"{change?.before}" to{' '}
+                    renamed {asNotification && 'the insight '}"{change?.before}" to{' '}
                     <strong>"{nameOrLinkToInsight(logItem?.detail.short_id, change?.after as string)}"</strong>
                 </>,
             ],
@@ -89,7 +89,7 @@ const insightActionsMapping: Record<
             description: [
                 <>
                     {describeChange}
-                    {asNotification && ' your insight '}
+                    {asNotification && ' the insight '}
                 </>,
             ],
             suffix: <>{nameOrLinkToInsight(logItem?.detail.short_id, logItem?.detail.name)}</>,
@@ -99,7 +99,7 @@ const insightActionsMapping: Record<
         return {
             description: [
                 <>
-                    changed the short id {asNotification && ' of your insight '}to <strong>"{change?.after}"</strong>
+                    changed the short id {asNotification && ' of the insight '}to <strong>"{change?.after}"</strong>
                 </>,
             ],
         }
@@ -108,7 +108,7 @@ const insightActionsMapping: Record<
         return {
             description: [
                 <>
-                    renamed {asNotification && ' your insight '}"{change?.before}" to{' '}
+                    renamed {asNotification && ' the insight '}"{change?.before}" to{' '}
                     <strong>"{nameOrLinkToInsight(logItem?.detail.short_id, change?.after as string)}"</strong>
                 </>,
             ],
@@ -119,7 +119,7 @@ const insightActionsMapping: Record<
         return {
             description: [
                 <>
-                    changed the description {asNotification && ' of your insight '}to <strong>"{change?.after}"</strong>
+                    changed the description {asNotification && ' of the insight '}to <strong>"{change?.after}"</strong>
                 </>,
             ],
         }
@@ -130,7 +130,7 @@ const insightActionsMapping: Record<
             description: [
                 <>
                     <div className="highlighted-activity">
-                        {isFavoriteAfter ? '' : 'un-'}favorited{asNotification && ' your insight '}
+                        {isFavoriteAfter ? '' : 'un-'}favorited{asNotification && ' the insight '}
                     </div>
                 </>,
             ],
@@ -178,7 +178,7 @@ const insightActionsMapping: Record<
             <SentenceList
                 prefix={
                     <>
-                        added {asNotification && ' your insight '}
+                        added {asNotification && ' the insight '}
                         {nameOrLinkToInsight(logItem?.detail.short_id, logItem?.detail.name)} to
                     </>
                 }
@@ -192,7 +192,7 @@ const insightActionsMapping: Record<
             <SentenceList
                 prefix={
                     <>
-                        removed {asNotification && ' your insight '}
+                        removed {asNotification && ' the insight '}
                         {nameOrLinkToInsight(logItem?.detail.short_id, logItem?.detail.name)} from
                     </>
                 }
@@ -304,7 +304,7 @@ export function insightActivityDescriber(logItem: ActivityLogItem, asNotificatio
         let extendedDescription: JSX.Element | undefined
         let changeSuffix: Description = (
             <>
-                on {asNotification && ' your insight '}
+                on {asNotification && ' the insight '}
                 {nameOrLinkToInsight(logItem?.detail.short_id, logItem?.detail.name)}
             </>
         )

--- a/posthog/api/activity_log.py
+++ b/posthog/api/activity_log.py
@@ -108,10 +108,18 @@ class ActivityLogViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
                 )
             )
             .order_by("-created_at")
-        )[:10]
+        )
 
-        serialized_data = ActivityLogSerializer(instance=other_peoples_changes, many=True, context={"user": user}).data
         last_read_date = NotificationViewed.objects.filter(user=user).first()
+        if last_read_date:
+            other_peoples_changes = other_peoples_changes.filter(
+                created_at__gt=last_read_date.last_viewed_activity_date
+            )
+
+        serialized_data = ActivityLogSerializer(
+            instance=other_peoples_changes[:10], many=True, context={"user": user}
+        ).data
+
         return Response(
             status=status.HTTP_200_OK,
             data={

--- a/posthog/api/activity_log.py
+++ b/posthog/api/activity_log.py
@@ -55,16 +55,46 @@ class ActivityLogViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
             # this is for mypy
             return Response(status=status.HTTP_401_UNAUTHORIZED)
 
-        my_insights = list(Insight.objects.filter(created_by=user).values_list("id", flat=True))
-        my_feature_flags = list(FeatureFlag.objects.filter(created_by=user).values_list("id", flat=True))
-        my_notebooks = list(Notebook.objects.filter(created_by=user).values_list("id", flat=True))
+        # first things this user created
+        my_insights = list(Insight.objects.filter(created_by=user, team_id=self.team.pk).values_list("id", flat=True))
+        my_feature_flags = list(
+            FeatureFlag.objects.filter(created_by=user, team_id=self.team.pk).values_list("id", flat=True)
+        )
+        my_notebooks = list(Notebook.objects.filter(created_by=user, team_id=self.team.pk).values_list("id", flat=True))
+
+        # then things they edited
+        interesting_changes = ["updated", "exported", "sharing enabled", "sharing disabled"]
+        my_changed_insights = list(
+            ActivityLog.objects.filter(
+                team_id=self.team.id, activity__in=interesting_changes, user_id=user.pk, scope="Insight"
+            )
+            .exclude(item_id__in=my_insights)
+            .values_list("item_id", flat=True)
+        )
+
+        my_changed_notebooks = list(
+            ActivityLog.objects.filter(
+                team_id=self.team.id, activity__in=interesting_changes, user_id=user.pk, scope="Notebook"
+            )
+            .exclude(item_id__in=my_notebooks)
+            .values_list("item_id", flat=True)
+        )
+
+        my_changed_feature_flags = list(
+            ActivityLog.objects.filter(
+                team_id=self.team.id, activity__in=interesting_changes, user_id=user.pk, scope="FeatureFlag"
+            )
+            .exclude(item_id__in=my_feature_flags)
+            .values_list("item_id", flat=True)
+        )
+
         other_peoples_changes = (
             self.queryset.exclude(user=user)
             .filter(team_id=self.team.id)
             .filter(
-                Q(Q(scope="FeatureFlag") & Q(item_id__in=my_feature_flags))
-                | Q(Q(scope="Insight") & Q(item_id__in=my_insights))
-                | Q(Q(scope="Notebook") & Q(item_id__in=my_notebooks))
+                Q(Q(scope="FeatureFlag") & Q(item_id__in=my_feature_flags + my_changed_feature_flags))
+                | Q(Q(scope="Insight") & Q(item_id__in=my_insights + my_changed_insights))
+                | Q(Q(scope="Notebook") & Q(item_id__in=my_notebooks + my_changed_notebooks))
             )
             .order_by("-created_at")
         )[:10]

--- a/posthog/api/test/__snapshots__/test_cohort.ambr
+++ b/posthog/api/test/__snapshots__/test_cohort.ambr
@@ -1,6 +1,6 @@
 # name: TestCohort.test_async_deletion_of_cohort
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:106 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -10,7 +10,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.1
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:106 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   INSERT INTO cohortpeople
   SELECT id,
          2 as cohort_id,
@@ -114,7 +114,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.2
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:106 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -124,7 +124,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.3
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
+  /* user_id:106 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
   SELECT count()
   FROM cohortpeople
   WHERE team_id = 2
@@ -134,7 +134,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.4
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:106 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -144,7 +144,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.5
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:106 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   INSERT INTO cohortpeople
   SELECT id,
          2 as cohort_id,
@@ -178,7 +178,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.6
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:106 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -188,7 +188,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.7
   '
-  /* user_id:102 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
+  /* user_id:106 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
   SELECT count()
   FROM cohortpeople
   WHERE team_id = 2

--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -198,7 +198,7 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
 
         changes = self.client.get(f"/api/projects/{self.team.id}/activity_log/important_changes")
 
-        assert [c["unread"] for c in changes.json()["results"]] == [True, True] + ([False] * 8)
+        assert [c["unread"] for c in changes.json()["results"]] == [True, True]
         assert changes.json()["last_read"] == most_recent_date
 
     def _create_insight(

--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, List
 
 from rest_framework import status
 
@@ -29,6 +29,16 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
             email="other_user@posthog.com",
             password="",
         )
+        self.third_user = User.objects.create_and_join(
+            organization=self.organization,
+            email="third_user@posthog.com",
+            password="",
+        )
+
+        # user one has created 10 insights and 2 flags
+        # user two has edited them all
+        # user three has edited most of them after that
+        self._create_and_edit_things()
 
     def _create_and_edit_things(self):
         created_insights = []
@@ -50,29 +60,58 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
         ).json()
 
         # other user now edits them
-        self.client.force_login(self.other_user)
-        for created_insight_id in created_insights:
-            update_response = self.client.patch(
-                f"/api/projects/{self.team.id}/insights/{created_insight_id}",
-                {"name": f"{created_insight_id}-insight"},
-            )
-            self.assertEqual(update_response.status_code, status.HTTP_200_OK)
-
-        self.client.patch(f"/api/projects/{self.team.id}/feature_flags/{flag_one}", {"name": "one"})
-        self.client.patch(f"/api/projects/{self.team.id}/feature_flags/{flag_two}", {"name": "two"})
-
-        self.client.patch(
-            f"/api/projects/{self.team.id}/notebooks/{notebook_json['short_id']}",
-            {"content": "print('hello world again')", "version": notebook_json["version"]},
+        self._edit_them_all(
+            created_insights, flag_one, flag_two, notebook_json["short_id"], notebook_json["version"], self.other_user
+        )
+        # third user edits them
+        self._edit_them_all(
+            created_insights,
+            flag_one,
+            flag_two,
+            notebook_json["short_id"],
+            notebook_json["version"] + 1,
+            self.third_user,
         )
 
         self.client.force_login(self.user)
 
-    def test_can_get_top_ten_important_changes(self) -> None:
-        # user one has created 10 insights and 2 flags
-        # user two has edited them all
-        self._create_and_edit_things()
+    def _edit_them_all(
+        self,
+        created_insights: List[int],
+        flag_one: str,
+        flag_two: str,
+        notebook_short_id: str,
+        notebook_version: int,
+        the_user: User,
+    ) -> None:
+        self.client.force_login(the_user)
+        for created_insight_id in created_insights[:7]:
+            update_response = self.client.patch(
+                f"/api/projects/{self.team.id}/insights/{created_insight_id}",
+                {"name": f"{created_insight_id}-insight-changed-by-{the_user.id}"},
+            )
+            self.assertEqual(update_response.status_code, status.HTTP_200_OK)
+        assert (
+            self.client.patch(
+                f"/api/projects/{self.team.id}/feature_flags/{flag_one}", {"name": f"one-edited-by-{the_user.id}"}
+            ).status_code
+            == status.HTTP_200_OK
+        )
+        assert (
+            self.client.patch(
+                f"/api/projects/{self.team.id}/feature_flags/{flag_two}", {"name": f"two-edited-by-{the_user.id}"}
+            ).status_code
+            == status.HTTP_200_OK
+        )
+        assert (
+            self.client.patch(
+                f"/api/projects/{self.team.id}/notebooks/{notebook_short_id}",
+                {"content": f"print('hello world again from {the_user.id}')", "version": notebook_version},
+            ).status_code
+            == status.HTTP_200_OK
+        )
 
+    def test_can_get_top_ten_important_changes(self) -> None:
         # user one is shown the most recent 10 of those changes
         self.client.force_login(self.user)
         changes = self.client.get(f"/api/projects/{self.team.id}/activity_log/important_changes")
@@ -93,10 +132,59 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
         ]
         assert [c["unread"] for c in results] == [True] * 10
 
+    def test_can_get_top_ten_important_changes_including_my_edits(self) -> None:
+        # user two is _also_ shown the most recent 10 of those changes
+        # because they edited those things
+        # and they were then changed
+        self.client.force_login(self.other_user)
+        changes = self.client.get(f"/api/projects/{self.team.id}/activity_log/important_changes")
+        assert changes.status_code == status.HTTP_200_OK
+        results = changes.json()["results"]
+        assert [(c["user"]["id"], c["scope"]) for c in results] == [
+            (
+                self.third_user.pk,
+                "Notebook",
+            ),
+            (
+                self.third_user.pk,
+                "FeatureFlag",
+            ),
+            (
+                self.third_user.pk,
+                "FeatureFlag",
+            ),
+            (
+                self.third_user.pk,
+                "Insight",
+            ),
+            (
+                self.third_user.pk,
+                "Insight",
+            ),
+            (
+                self.third_user.pk,
+                "Insight",
+            ),
+            (
+                self.third_user.pk,
+                "Insight",
+            ),
+            (
+                self.third_user.pk,
+                "Insight",
+            ),
+            (
+                self.third_user.pk,
+                "Insight",
+            ),
+            (
+                self.third_user.pk,
+                "Insight",
+            ),
+        ]
+        assert [c["unread"] for c in results] == [True] * 10
+
     def test_reading_notifications_marks_them_unread(self):
-        # user one has created 10 insights and 2 flags
-        # user two has edited them all
-        self._create_and_edit_things()
         changes = self.client.get(f"/api/projects/{self.team.id}/activity_log/important_changes")
         assert changes.status_code == status.HTTP_200_OK
 


### PR DESCRIPTION
## Problem

We show a notification when someone edits flags, insights, or notebooks you created

But those might not be the only things you care about

## Changes

Since the activity log records what things each user changes

We can also show them subsequent edits to things they have edited

This would show you edits before "now" which doesn't make sense so also limits notifications to only those since the last notification read date. This will reduce the chance that someone gets 10 "new" notifications for things in the past. We can remove that after a little while if we want to

## How did you test this code?

developer tests and 👀 locally