### PR TITLE
fix: Display custom name for all events.

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.test.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.test.ts
@@ -61,6 +61,23 @@ describe('entityFilterLogic', () => {
             )
         })
 
+        it('adds new filter (named all events) successfully', async () => {
+            // Select a filter to rename first
+            await expectLogic(logic, () => {
+                logic.actions.addFilter()
+            })
+
+            expect(logic.props.setFilters).toBeCalledWith(
+                expect.objectContaining({
+                    events: expect.arrayContaining([
+                        expect.objectContaining({
+                            id: 'All events',
+                        }),
+                    ]),
+                })
+            )
+        })
+
         it('closes modal after renaming', () => {
             expectLogic(logic, () => {
                 logic.actions.renameFilter('Custom event name')

--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
@@ -196,7 +196,7 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
             const precedingEntity = values.localFilters[previousLength - 1] as LocalFilter | undefined
             const order = precedingEntity ? precedingEntity.order + 1 : 0
             const newFilter = {
-                id: null,
+                id: 'All events',
                 type: EntityTypes.EVENTS,
                 order: order,
                 ...props.addFilterDefaultOptions,


### PR DESCRIPTION
Users would see new funnel insight name after adding a new step to `all events` series.

Fixes #16077

## Problem
Users werent able to see immediate name change step of funnel insights before this. Fixed that.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

![image](https://github.com/PostHog/posthog/assets/39624400/e3248dbd-691c-4614-86a4-98be3791881b)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
Manually and added a new test.
