### PR TITLE
fix: Freeze 'Series column' on detailed results table

### DIFF
--- a/frontend/src/lib/components/InsightLabel/index.tsx
+++ b/frontend/src/lib/components/InsightLabel/index.tsx
@@ -68,7 +68,7 @@ function MathTag({ math, mathProperty, mathHogQL, mathGroupTypeIndex }: MathTagP
                 <Tag>{mathDefinitions[math]?.name || capitalizeFirstLetter(math)}</Tag>
                 {mathProperty && (
                     <>
-                        <span className="pl-1 pr-0.5">of</span>
+                        <span>of</span>
                         <PropertyKeyInfo disableIcon value={mathProperty} />
                     </>
                 )}

--- a/frontend/src/lib/components/PropertyKeyInfo.scss
+++ b/frontend/src/lib/components/PropertyKeyInfo.scss
@@ -6,7 +6,6 @@
     vertical-align: bottom;
     overflow: hidden;
     max-width: 100%;
-    cursor: default;
 }
 
 .PropertyKeyInfo__header {

--- a/frontend/src/lib/hooks/useScrollable.ts
+++ b/frontend/src/lib/hooks/useScrollable.ts
@@ -2,7 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useResizeObserver } from './useResizeObserver'
 
 /** Determine whether an element is horizontally scrollable, on the left and on the right respectively. */
-export function useScrollable(): [React.RefObject<HTMLDivElement>, string[]] {
+export function useScrollable(): [React.RefObject<HTMLDivElement>, [boolean, boolean]] {
     const [isScrollable, setIsScrollable] = useState<[boolean, boolean]>([false, false])
     const scrollRef = useRef<HTMLDivElement>(null)
 
@@ -41,13 +41,5 @@ export function useScrollable(): [React.RefObject<HTMLDivElement>, string[]] {
         }
     }, [width])
 
-    const relevantClassNames: string[] = ['scrollable']
-    if (isScrollable[0]) {
-        relevantClassNames.push('scrollable--left')
-    }
-    if (isScrollable[1]) {
-        relevantClassNames.push('scrollable--right')
-    }
-
-    return [scrollRef, relevantClassNames]
+    return [scrollRef, isScrollable]
 }

--- a/frontend/src/lib/lemon-ui/LemonCheckbox/LemonCheckbox.scss
+++ b/frontend/src/lib/lemon-ui/LemonCheckbox/LemonCheckbox.scss
@@ -20,7 +20,7 @@
         gap: 0.5rem;
         min-height: 1.5rem;
 
-        > svg {
+        > .LemonCheckbox__box {
             width: 1rem;
             height: 1rem;
             transition: border 200ms ease, background 200ms ease;
@@ -59,7 +59,7 @@
         label {
             --box-color: var(--primary-light);
 
-            svg {
+            .LemonCheckbox__box {
                 border-color: var(--box-color);
                 border-color: var(--box-color);
             }
@@ -76,7 +76,7 @@
 
     &.LemonCheckbox--checked {
         label {
-            svg {
+            .LemonCheckbox__box {
                 background: var(--box-color);
                 border-color: transparent;
 

--- a/frontend/src/lib/lemon-ui/LemonCheckbox/LemonCheckbox.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCheckbox/LemonCheckbox.tsx
@@ -88,7 +88,7 @@ export function LemonCheckbox({
             {/* eslint-disable-next-line react/forbid-dom-props */}
             <label htmlFor={id} style={color ? ({ '--box-color': color } as BoxCSSProperties) : {}}>
                 <svg
-                    className='className="LemonCheckbox__box"'
+                    className="LemonCheckbox__box"
                     fill="none"
                     height="16"
                     viewBox="0 0 16 16"

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
@@ -184,9 +184,29 @@
     position: sticky;
     left: 0;
     z-index: 1;
+    overflow: visible !important;
+    // Replicate .scrollable style for sticky cells
+    &::before {
+        transition: box-shadow 200ms ease;
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: -1; // Place below cell content
+        clip-path: inset(0 -16px 0 0);
+        box-shadow: -16px 0 16px 16px transparent;
+        .scrollable--left & {
+            box-shadow: -16px 0 16px 16px rgba(0, 0, 0, 0.25);
+        }
+    }
+}
+
+.LemonTable__cell--sticky::before {
     background: var(--bg-light);
 }
 
-.LemonTable__header--sticky {
-    background-color: var(--mid);
+.LemonTable__header--sticky::before {
+    background: var(--mid);
 }

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
@@ -177,3 +177,15 @@
     border-top: 1px solid var(--border);
     cursor: default;
 }
+
+.LemonTable__header--sticky,
+.LemonTable__td--sticky {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    background: var(--bg-light);
+}
+
+.LemonTable__header--sticky {
+    background-color: var(--mid);
+}

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
@@ -179,7 +179,8 @@
 }
 
 .LemonTable__header--sticky,
-.LemonTable__td--sticky {
+.LemonTable__cell--sticky {
+    padding-right: 0.5rem;
     position: sticky;
     left: 0;
     z-index: 1;

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -160,7 +160,7 @@ export function LemonTable<T extends Record<string, any>>({
     ) as LemonTableColumnGroup<T>[]
     const columns = columnGroups.flatMap((group) => group.children)
 
-    const [scrollRef, scrollableClassNames] = useScrollable()
+    const [scrollRef, [isScrollableLeft, isScrollableRight]] = useScrollable()
 
     /** Sorting. */
     const currentSorting =
@@ -208,14 +208,15 @@ export function LemonTable<T extends Record<string, any>>({
         <div
             id={id}
             className={clsx(
-                'LemonTable',
+                'LemonTable scrollable',
                 size && size !== 'middle' && `LemonTable--${size}`,
                 inset && 'LemonTable--inset',
                 loading && 'LemonTable--loading',
                 embedded && 'LemonTable--embedded',
                 !borderedRows && 'LemonTable--borderlessRows',
                 display === 'stealth' && 'LemonTable--stealth',
-                ...scrollableClassNames,
+                isScrollableLeft && 'scrollable--left',
+                isScrollableRight && 'scrollable--right',
                 className
             )}
             style={style}
@@ -266,10 +267,10 @@ export function LemonTable<T extends Record<string, any>>({
                                                     column.sorter && 'LemonTable__header--actionable',
                                                     columnIndex === columnGroup.children.length - 1 &&
                                                         'LemonTable__boundary',
-                                                    firstColumnSticky &&
+                                                    columnGroupIndex === 0 &&
                                                         columnIndex === 0 &&
                                                         'LemonTable__header--sticky',
-                                                    column.className
+                                                    firstColumnSticky && column.className
                                                 )}
                                                 /* eslint-disable-next-line react/forbid-dom-props */
                                                 style={{ textAlign: column.align }}

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -83,6 +83,7 @@ export interface LemonTableProps<T extends Record<string, any>> {
     display?: 'stealth' | 'default'
     /** Footer to be shown below the table. */
     footer?: React.ReactNode
+    firstColumnSticky?: boolean
 }
 
 export function LemonTable<T extends Record<string, any>>({
@@ -116,6 +117,7 @@ export function LemonTable<T extends Record<string, any>>({
     'data-attr': dataAttr,
     display = 'default',
     footer,
+    firstColumnSticky,
 }: LemonTableProps<T>): JSX.Element {
     /** Search param that will be used for storing and syncing sorting */
     const currentSortingParam = id ? `${id}_order` : 'order'
@@ -264,7 +266,9 @@ export function LemonTable<T extends Record<string, any>>({
                                                     column.sorter && 'LemonTable__header--actionable',
                                                     columnIndex === columnGroup.children.length - 1 &&
                                                         'LemonTable__boundary',
-                                                    column.sticky && 'LemonTable__header--sticky',
+                                                    firstColumnSticky &&
+                                                        columnIndex === 0 &&
+                                                        'LemonTable__header--sticky',
                                                     column.className
                                                 )}
                                                 /* eslint-disable-next-line react/forbid-dom-props */
@@ -373,6 +377,7 @@ export function LemonTable<T extends Record<string, any>>({
                                             columnGroups={columnGroups}
                                             onRow={onRow}
                                             expandable={expandable}
+                                            firstColumnSticky={firstColumnSticky}
                                         />
                                     )
                                 })
@@ -388,7 +393,9 @@ export function LemonTable<T extends Record<string, any>>({
                                                         className={clsx(
                                                             columnIndex === columnGroup.children.length - 1 &&
                                                                 'LemonTable__boundary',
-                                                            column.sticky && 'LemonTable__td--sticky',
+                                                            firstColumnSticky &&
+                                                                columnIndex === 0 &&
+                                                                'LemonTable__cell--sticky',
                                                             column.className
                                                         )}
                                                     >

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -264,6 +264,7 @@ export function LemonTable<T extends Record<string, any>>({
                                                     column.sorter && 'LemonTable__header--actionable',
                                                     columnIndex === columnGroup.children.length - 1 &&
                                                         'LemonTable__boundary',
+                                                    column.sticky && 'LemonTable__header--sticky',
                                                     column.className
                                                 )}
                                                 /* eslint-disable-next-line react/forbid-dom-props */
@@ -387,6 +388,7 @@ export function LemonTable<T extends Record<string, any>>({
                                                         className={clsx(
                                                             columnIndex === columnGroup.children.length - 1 &&
                                                                 'LemonTable__boundary',
+                                                            column.sticky && 'LemonTable__td--sticky',
                                                             column.className
                                                         )}
                                                     >

--- a/frontend/src/lib/lemon-ui/LemonTable/TableRow.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/TableRow.tsx
@@ -93,13 +93,15 @@ function TableRowRaw<T extends Record<string, any>>({
                         const contents = column.render ? column.render(value as T[keyof T], record, recordIndex) : value
                         const areContentsCellRepresentations: boolean =
                             !!contents && typeof contents === 'object' && !React.isValidElement(contents)
+                        const isLastColumnInGroup = columnIndex === columnGroup.children.length - 1
+                        const isSticky = firstColumnSticky && columnGroupIndex === 0 && columnIndex === 0
                         return (
                             <td
-                                key={`LemonTable-td-${columnGroupIndex}-${columnKeyOrIndex}`}
+                                key={`col-${columnGroupIndex}-${columnKeyOrIndex}`}
                                 className={clsx(
-                                    columnIndex === columnGroup.children.length - 1 && 'LemonTable__boundary',
+                                    isLastColumnInGroup && 'LemonTable__boundary',
+                                    isSticky && 'LemonTable__cell--sticky',
                                     column.align && `text-${column.align}`,
-                                    firstColumnSticky && columnIndex === 0 && 'LemonTable__cell--sticky',
                                     column.className
                                 )}
                                 {...(areContentsCellRepresentations ? (contents as TableCellRepresentation).props : {})}

--- a/frontend/src/lib/lemon-ui/LemonTable/TableRow.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/TableRow.tsx
@@ -14,6 +14,7 @@ export interface TableRowProps<T extends Record<string, any>> {
     columnGroups: LemonTableColumnGroup<T>[]
     onRow: ((record: T) => Omit<HTMLProps<HTMLTableRowElement>, 'key'>) | undefined
     expandable: ExpandableConfig<T> | undefined
+    firstColumnSticky: boolean | undefined
 }
 
 function TableRowRaw<T extends Record<string, any>>({
@@ -26,6 +27,7 @@ function TableRowRaw<T extends Record<string, any>>({
     columnGroups,
     onRow,
     expandable,
+    firstColumnSticky,
 }: TableRowProps<T>): JSX.Element {
     const [isRowExpandedLocal, setIsRowExpanded] = useState(false)
     const rowExpandable: number = Number(
@@ -97,7 +99,7 @@ function TableRowRaw<T extends Record<string, any>>({
                                 className={clsx(
                                     columnIndex === columnGroup.children.length - 1 && 'LemonTable__boundary',
                                     column.align && `text-${column.align}`,
-                                    column.sticky && 'LemonTable__td--sticky',
+                                    firstColumnSticky && columnIndex === 0 && 'LemonTable__cell--sticky',
                                     column.className
                                 )}
                                 {...(areContentsCellRepresentations ? (contents as TableCellRepresentation).props : {})}

--- a/frontend/src/lib/lemon-ui/LemonTable/TableRow.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/TableRow.tsx
@@ -97,6 +97,7 @@ function TableRowRaw<T extends Record<string, any>>({
                                 className={clsx(
                                     columnIndex === columnGroup.children.length - 1 && 'LemonTable__boundary',
                                     column.align && `text-${column.align}`,
+                                    column.sticky && 'LemonTable__td--sticky',
                                     column.className
                                 )}
                                 {...(areContentsCellRepresentations ? (contents as TableCellRepresentation).props : {})}

--- a/frontend/src/scenes/funnels/FunnelBarChart/FunnelBarChart.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarChart/FunnelBarChart.tsx
@@ -23,7 +23,7 @@ export function FunnelBarChart({ showPersonsModal: showPersonsModalProp = true }
     const { visibleStepsWithConversionMetrics } = useValues(funnelDataLogic(insightProps))
     const { canOpenPersonModal } = useValues(funnelPersonsModalLogic(insightProps))
 
-    const [scrollRef, scrollableClassNames] = useScrollable()
+    const [scrollRef, [isScrollableLeft, isScrollableRight]] = useScrollable()
     const { height } = useResizeObserver({ ref: scrollRef })
 
     const showPersonsModal = canOpenPersonModal && showPersonsModalProp
@@ -107,7 +107,15 @@ export function FunnelBarChart({ showPersonsModal: showPersonsModalProp = true }
     }, [visibleStepsWithConversionMetrics, height])
 
     return (
-        <div className={clsx('FunnelBarChart', ...scrollableClassNames)} ref={vizRef} data-attr="funnel-bar-graph">
+        <div
+            className={clsx(
+                'FunnelBarChart scrollable',
+                isScrollableLeft && 'scrollable--left',
+                isScrollableRight && 'scrollable--right'
+            )}
+            ref={vizRef}
+            data-attr="funnel-bar-graph"
+        >
             <div className="scrollable__inner" ref={scrollRef}>
                 {table}
             </div>

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -79,30 +79,6 @@ export function InsightsTable({
     // Build up columns to include. Order matters.
     const columns: LemonTableColumn<IndexedTrendResult, keyof IndexedTrendResult | undefined>[] = []
 
-    // if (isLegend) {
-    //     columns.push({
-    //         title: (
-    //             <SeriesCheckColumnTitle
-    //                 indexedResults={indexedResults}
-    //                 canCheckUncheckSeries={canCheckUncheckSeries}
-    //                 hiddenLegendKeys={hiddenLegendKeys}
-    //                 toggleVisibility={toggleVisibility}
-    //             />
-    //         ),
-    //         render: (_, item) => (
-    //             <SeriesCheckColumnItem
-    //                 item={item}
-    //                 canCheckUncheckSeries={canCheckUncheckSeries}
-    //                 hiddenLegendKeys={hiddenLegendKeys}
-    //                 compare={compare}
-    //                 toggleVisibility={toggleVisibility}
-    //             />
-    //         ),
-    //         width: 0,
-    //         sticky: true,
-    //     })
-    // }
-
     columns.push({
         title: (
             <div className="flex items-center gap-2">

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -120,8 +120,6 @@ export function InsightsTable({
             const labelB = b.action?.name || b.label || ''
             return labelA.localeCompare(labelB)
         },
-        width: 2000,
-        sticky: true,
     })
 
     if (breakdown?.breakdown) {

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -79,41 +79,64 @@ export function InsightsTable({
     // Build up columns to include. Order matters.
     const columns: LemonTableColumn<IndexedTrendResult, keyof IndexedTrendResult | undefined>[] = []
 
-    if (isLegend) {
-        columns.push({
-            title: (
-                <SeriesCheckColumnTitle
-                    indexedResults={indexedResults}
-                    canCheckUncheckSeries={canCheckUncheckSeries}
-                    hiddenLegendKeys={hiddenLegendKeys}
-                    toggleVisibility={toggleVisibility}
-                />
-            ),
-            render: (_, item) => (
-                <SeriesCheckColumnItem
-                    item={item}
-                    canCheckUncheckSeries={canCheckUncheckSeries}
-                    hiddenLegendKeys={hiddenLegendKeys}
-                    compare={compare}
-                    toggleVisibility={toggleVisibility}
-                />
-            ),
-            width: 0,
-            sticky: true,
-        })
-    }
+    // if (isLegend) {
+    //     columns.push({
+    //         title: (
+    //             <SeriesCheckColumnTitle
+    //                 indexedResults={indexedResults}
+    //                 canCheckUncheckSeries={canCheckUncheckSeries}
+    //                 hiddenLegendKeys={hiddenLegendKeys}
+    //                 toggleVisibility={toggleVisibility}
+    //             />
+    //         ),
+    //         render: (_, item) => (
+    //             <SeriesCheckColumnItem
+    //                 item={item}
+    //                 canCheckUncheckSeries={canCheckUncheckSeries}
+    //                 hiddenLegendKeys={hiddenLegendKeys}
+    //                 compare={compare}
+    //                 toggleVisibility={toggleVisibility}
+    //             />
+    //         ),
+    //         width: 0,
+    //         sticky: true,
+    //     })
+    // }
 
     columns.push({
-        title: 'Series',
+        title: (
+            <div className="flex items-center gap-2">
+                {isLegend && (
+                    <SeriesCheckColumnTitle
+                        indexedResults={indexedResults}
+                        canCheckUncheckSeries={canCheckUncheckSeries}
+                        hiddenLegendKeys={hiddenLegendKeys}
+                        toggleVisibility={toggleVisibility}
+                    />
+                )}
+                <span>Series</span>
+            </div>
+        ),
         render: (_, item) => (
-            <SeriesColumnItem
-                item={item}
-                indexedResults={indexedResults}
-                canEditSeriesNameInline={canEditSeriesNameInline}
-                compare={compare}
-                handleEditClick={handleSeriesEditClick}
-                hasMultipleSeries={!isSingleSeries}
-            />
+            <div className="flex items-center gap-2">
+                {isLegend && (
+                    <SeriesCheckColumnItem
+                        item={item}
+                        canCheckUncheckSeries={canCheckUncheckSeries}
+                        hiddenLegendKeys={hiddenLegendKeys}
+                        compare={compare}
+                        toggleVisibility={toggleVisibility}
+                    />
+                )}
+                <SeriesColumnItem
+                    item={item}
+                    indexedResults={indexedResults}
+                    canEditSeriesNameInline={canEditSeriesNameInline}
+                    compare={compare}
+                    handleEditClick={handleSeriesEditClick}
+                    hasMultipleSeries={!isSingleSeries}
+                />
+            </div>
         ),
         key: 'label',
         sorter: (a, b) => {
@@ -230,6 +253,7 @@ export function InsightsTable({
             data-attr="insights-table-graph"
             className="insights-table"
             useURLForSorting={insightMode !== ItemMode.Edit}
+            firstColumnSticky
         />
     )
 }

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -99,6 +99,7 @@ export function InsightsTable({
                 />
             ),
             width: 0,
+            sticky: true,
         })
     }
 
@@ -120,6 +121,8 @@ export function InsightsTable({
             const labelB = b.action?.name || b.label || ''
             return labelA.localeCompare(labelB)
         },
+        width: 2000,
+        sticky: true,
     })
 
     if (breakdown?.breakdown) {

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -81,7 +81,7 @@ export function InsightsTable({
 
     columns.push({
         title: (
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-4">
                 {isLegend && (
                     <SeriesCheckColumnTitle
                         indexedResults={indexedResults}
@@ -93,17 +93,8 @@ export function InsightsTable({
                 <span>Series</span>
             </div>
         ),
-        render: (_, item) => (
-            <div className="flex items-center gap-2">
-                {isLegend && (
-                    <SeriesCheckColumnItem
-                        item={item}
-                        canCheckUncheckSeries={canCheckUncheckSeries}
-                        hiddenLegendKeys={hiddenLegendKeys}
-                        compare={compare}
-                        toggleVisibility={toggleVisibility}
-                    />
-                )}
+        render: (_, item) => {
+            const label = (
                 <SeriesColumnItem
                     item={item}
                     indexedResults={indexedResults}
@@ -112,8 +103,20 @@ export function InsightsTable({
                     handleEditClick={handleSeriesEditClick}
                     hasMultipleSeries={!isSingleSeries}
                 />
-            </div>
-        ),
+            )
+            return isLegend ? (
+                <SeriesCheckColumnItem
+                    item={item}
+                    canCheckUncheckSeries={canCheckUncheckSeries}
+                    hiddenLegendKeys={hiddenLegendKeys}
+                    compare={compare}
+                    toggleVisibility={toggleVisibility}
+                    label={<div className="ml-2 font-normal">{label}</div>}
+                />
+            ) : (
+                label
+            )
+        },
         key: 'label',
         sorter: (a, b) => {
             const labelA = a.action?.name || a.label || ''

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesCheckColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesCheckColumn.tsx
@@ -41,6 +41,7 @@ type SeriesCheckColumnItemProps = {
     hiddenLegendKeys: Record<string, boolean | undefined>
     compare?: boolean | null
     toggleVisibility: (id: number) => void
+    label?: JSX.Element
 }
 
 export function SeriesCheckColumnItem({
@@ -49,6 +50,7 @@ export function SeriesCheckColumnItem({
     hiddenLegendKeys,
     compare,
     toggleVisibility,
+    label,
 }: SeriesCheckColumnItemProps): JSX.Element {
     return (
         <LemonCheckbox
@@ -56,6 +58,7 @@ export function SeriesCheckColumnItem({
             checked={!hiddenLegendKeys[item.id]}
             onChange={() => toggleVisibility(item.id)}
             disabled={!canCheckUncheckSeries}
+            label={label}
         />
     )
 }


### PR DESCRIPTION
## Problem

Freeze 'Series column' on detailed results table (resolves https://github.com/PostHog/posthog/issues/11800)

## Changes
@Twixes I did all the changes recommended by you in this PR. (https://github.com/PostHog/posthog/pull/16758). I actually messed up https://github.com/PostHog/posthog/pull/16758, so I am creating a new PR.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
