### PR TITLE
feat: a little analytics fangling

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -100,18 +100,6 @@ interface RecordingViewedProps {
     load_time: number // DEPRECATE: How much time it took to load the session (backend) (milliseconds)
 }
 
-export interface RecordingViewedSummaryAnalytics {
-    viewed_time_ms?: number
-    recording_duration_ms?: number
-    recording_age_days?: number
-    meta_data_load_time_ms?: number
-    first_snapshot_load_time_ms?: number
-    first_snapshot_and_meta_load_time_ms?: number
-    all_snapshots_load_time_ms?: number
-    rrweb_warning_count: number
-    error_count_during_recording_playback: number
-}
-
 function flattenProperties(properties: AnyPropertyFilter[]): string[] {
     const output = []
     for (const prop of properties || []) {
@@ -377,9 +365,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportRecordingPlayerSeekbarEventHovered: true,
         reportRecordingPlayerSpeedChanged: (newSpeed: number) => ({ newSpeed }),
         reportRecordingPlayerSkipInactivityToggled: (skipInactivity: boolean) => ({ skipInactivity }),
-        reportRecordingViewedSummary: (recordingViewedSummary: RecordingViewedSummaryAnalytics) => ({
-            recordingViewedSummary,
-        }),
         reportRecordingInspectorTabViewed: (tab: SessionRecordingPlayerTab) => ({ tab }),
         reportRecordingInspectorItemExpanded: (tab: SessionRecordingPlayerTab, index: number) => ({ tab, index }),
         reportRecordingInspectorMiniFilterViewed: (tab: SessionRecordingPlayerTab, minifilterKey: string) => ({
@@ -909,9 +894,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         },
         reportRecordingPlayerSkipInactivityToggled: ({ skipInactivity }) => {
             posthog.capture('recording player skip inactivity toggled', { skip_inactivity: skipInactivity })
-        },
-        reportRecordingViewedSummary: ({ recordingViewedSummary }) => {
-            posthog.capture('recording viewed summary', { ...recordingViewedSummary })
         },
         reportRecordingInspectorTabViewed: ({ tab }) => {
             posthog.capture('recording inspector tab viewed', { tab })

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -65,8 +65,16 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
         mode,
         playerRef,
     }
-    const { setIsFullScreen, setPause, togglePlayPause, seekBackward, seekForward, setSpeed, closeExplorer } =
-        useActions(sessionRecordingPlayerLogic(logicProps))
+    const {
+        incrementClickCount,
+        setIsFullScreen,
+        setPause,
+        togglePlayPause,
+        seekBackward,
+        seekForward,
+        setSpeed,
+        closeExplorer,
+    } = useActions(sessionRecordingPlayerLogic(logicProps))
     const { isNotFound } = useValues(sessionRecordingDataLogic(logicProps))
     const { isFullScreen, explorerMode } = useValues(sessionRecordingPlayerLogic(logicProps))
     const speedHotkeys = useMemo(() => createPlaybackSpeedKey(setSpeed), [setSpeed])
@@ -148,6 +156,7 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
                         'SessionRecordingPlayer--inspector-focus': inspectorFocus,
                         'SessionRecordingPlayer--inspector-hidden': noInspector,
                     })}
+                    onClick={incrementClickCount}
                 >
                     <div className="SessionRecordingPlayer__main">
                         {includeMeta || isFullScreen ? <PlayerMeta /> : null}

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -62,8 +62,7 @@ export interface RecordingViewedSummaryAnalytics {
     all_snapshots_load_time_ms?: number
     rrweb_warning_count: number
     error_count_during_recording_playback: number
-    // as a very loose metric for engagement, how many clicks were there
-    click_count: number
+    engagement_score: number
 }
 
 export interface Player {
@@ -931,7 +930,8 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                     : undefined,
             rrweb_warning_count: values.warningCount,
             error_count_during_recording_playback: values.errorCount,
-            click_count: values.clickCount,
+            // as a starting and very loose measure of engagement, we count clicks
+            engagement_score: values.clickCount,
         }
         posthog.capture('recording viewed summary', summaryAnalytics)
     }),


### PR DESCRIPTION
## Problem

When we set up our filters experiment we weren't super keen on the metrics we used to measure it.

It turns out there was already a better set of metrics being gathered

## Changes

* fix the recording age measure (which was recording negative days)
* switch the recording age measure to milliseconds so we can graph it nicer-er
* count time the player spent playing (there's probably a nicer way of doing this). It's a better measure than age of the logic when unmounted
* move call to capture out of the gigantic eventUsageLogic
* use click count as v1 of "engagement score"

## How did you test this code?

clicking around locally and seeing the events coming in