### PR TITLE
feat: Usage reports based on replay events

### DIFF
--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -389,17 +389,17 @@ def get_teams_with_recording_count_in_period(begin: datetime, end: datetime) -> 
     result = sync_execute(
         """
         SELECT team_id, count(distinct session_id) as count
-        FROM session_recording_events
-        WHERE first_event_timestamp BETWEEN %(begin)s AND %(end)s
+        FROM session_replay_events
+        WHERE toDate(min_first_timestamp) = toDate(%(begin)s)
         AND session_id NOT IN (
             -- we want to exclude sessions that might have events with timestamps
             -- before the period we are interested in
             SELECT DISTINCT session_id
-            FROM session_recording_events
+            FROM session_replay_events
             -- begin is the very first instant of the period we are interested in
             -- we assume it is also the very first instant of a day
             -- so we can to subtract 1 second to get the day before
-            WHERE toDate(first_event_timestamp) = toDate(%(begin)s) - INTERVAL 1 DAY
+            WHERE toDate(min_first_timestamp) = toDate(%(begin)s) - INTERVAL 1 DAY
             GROUP BY session_id
         )
         GROUP BY team_id


### PR DESCRIPTION
## Problem

We base usage reports on the recording_events table but we can do this on replay events now.

## Changes

* Swaps to replay events

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Need to fix the tests