### PR TITLE
fix: event joining choice

### DIFF
--- a/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/queries/session_recordings/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -1427,6 +1427,37 @@
           GROUP BY distinct_id
           HAVING argMax(is_deleted, version) = 0
           AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), 'bla'), 0))) as session_persons_sub_query)
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0))
+            AND e.distinct_id in
+              (select distinct_id
+               from
+                 (SELECT distinct_id,
+                         argMax(person_id, version) as person_id ,
+                         argMax(person_props, version) as person_props
+                  FROM person_distinct_id2 as pdi
+                  INNER JOIN
+                    (SELECT id,
+                            argMax(properties, version) as person_props
+                     FROM person
+                     WHERE team_id = 2
+                     GROUP BY id
+                     HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                  WHERE team_id = 2
+                  GROUP BY distinct_id
+                  HAVING argMax(is_deleted, version) = 0
+                  AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), 'bla'), 0))) as events_persons_sub_query)
+          GROUP BY `$session_id`
+          HAVING 1=1) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -1598,6 +1629,36 @@
           GROUP BY distinct_id
           HAVING argMax(is_deleted, version) = 0
           AND (ifNull(equals(nullIf(nullIf(pmat_email, ''), 'null'), 'bla'), 0))) as session_persons_sub_query)
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (ifNull(equals(nullIf(nullIf(events.`mat_$browser`, ''), 'null'), 'Chrome'), 0))
+            AND e.distinct_id in
+              (select distinct_id
+               from
+                 (SELECT distinct_id,
+                         argMax(person_id, version) as person_id
+                  FROM person_distinct_id2 as pdi
+                  INNER JOIN
+                    (SELECT id,
+                            argMax(pmat_email, version) as pmat_email
+                     FROM person
+                     WHERE team_id = 2
+                     GROUP BY id
+                     HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                  WHERE team_id = 2
+                  GROUP BY distinct_id
+                  HAVING argMax(is_deleted, version) = 0
+                  AND (ifNull(equals(nullIf(nullIf(pmat_email, ''), 'null'), 'bla'), 0))) as events_persons_sub_query)
+          GROUP BY `$session_id`
+          HAVING 1=1) as session_events_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC
@@ -3347,6 +3408,735 @@
           GROUP BY distinct_id
           HAVING argMax(is_deleted, version) = 0
           and person_id = '00000000-0000-0000-0000-000000000000') as session_persons_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_event_property_test_account_filter
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_event_property_test_account_filter.1
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (has(['false'], replaceRegexpAll(JSONExtractRaw(e.properties, 'is_internal_user'), '^"|"$', '')))
+          GROUP BY `$session_id`
+          HAVING 1=1) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_event_property_test_account_filter_materialized
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_event_property_test_account_filter_materialized.1
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (has(['false'], "mat_is_internal_user"))
+          GROUP BY `$session_id`
+          HAVING 1=1) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_hogql_event_property_test_account_filter
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_hogql_event_property_test_account_filter.1
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'is_internal_user'), ''), 'null'), '^"|"$', ''), 'true'), 0))
+          GROUP BY `$session_id`
+          HAVING 1=1) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_hogql_event_property_test_account_filter_materialized
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_hogql_event_property_test_account_filter_materialized.1
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (ifNull(equals(nullIf(nullIf(events.mat_is_internal_user, ''), 'null'), 'true'), 0))
+          GROUP BY `$session_id`
+          HAVING 1=1) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_hogql_person_property_test_account_filter
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_hogql_person_property_test_account_filter.1
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.distinct_id in
+      (select distinct_id
+       from
+         (SELECT distinct_id,
+                 argMax(person_id, version) as person_id ,
+                 argMax(person_props, version) as person_props
+          FROM person_distinct_id2 as pdi
+          INNER JOIN
+            (SELECT id,
+                    argMax(properties, version) as person_props
+             FROM person
+             WHERE team_id = 2
+             GROUP BY id
+             HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0
+          AND (ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), 'bla'), 0))) as session_persons_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_hogql_person_property_test_account_filter_materialized
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_hogql_person_property_test_account_filter_materialized.1
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.distinct_id in
+      (select distinct_id
+       from
+         (SELECT distinct_id,
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2 as pdi
+          INNER JOIN
+            (SELECT id,
+                    argMax(pmat_email, version) as pmat_email
+             FROM person
+             WHERE team_id = 2
+             GROUP BY id
+             HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0
+          AND (ifNull(equals(nullIf(nullIf(pmat_email, ''), 'null'), 'bla'), 0))) as session_persons_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_person_property_test_account_filter
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_person_property_test_account_filter.1
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.distinct_id in
+      (select distinct_id
+       from
+         (SELECT distinct_id,
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2 as pdi
+          INNER JOIN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND id IN
+                 (SELECT id
+                  FROM person
+                  WHERE team_id = 2
+                    AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))) )
+             GROUP BY id
+             HAVING max(is_deleted) = 0
+             AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))) person ON person.id = pdi.person_id
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0) as session_persons_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_person_property_test_account_filter_materialized
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          WHERE notEmpty(`$session_id`)
+            AND timestamp >= '2021-01-13 12:00:00'
+            AND timestamp <= '2021-01-22 08:00:00'
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_person_property_test_account_filter_materialized.1
+  '
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.distinct_id in
+      (select distinct_id
+       from
+         (SELECT distinct_id,
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2 as pdi
+          INNER JOIN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND id IN
+                 (SELECT id
+                  FROM person
+                  WHERE team_id = 2
+                    AND (has(['bla'], "pmat_email")) )
+             GROUP BY id
+             HAVING max(is_deleted) = 0
+             AND (has(['bla'], argMax(person."pmat_email", version)))) person ON person.id = pdi.person_id
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0) as session_persons_sub_query)
   GROUP BY session_id
   HAVING 1=1
   ORDER BY start_time DESC


### PR DESCRIPTION
## Problem

private zendesk issue https://posthoghelp.zendesk.com/agent/tickets/4676 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/7676)

We avoid joining on events and persons as much as possible when listing replay, but weren't taking into account the test account filters which can add "top-level" event and person filters

## Changes

Takes that into account

## How did you test this code?

developer tests and 👀  locally