### PR TITLE
fix(plugin): Change filter on pluginconfig to team not organization

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -284,9 +284,9 @@ class PluginViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
                 Q(**self.parents_query_dict)
                 | Q(is_global=True)
                 | Q(
-                    id__in=PluginConfig.objects.filter(
-                        team__organization_id=self.organization_id, enabled=True
-                    ).values_list("plugin_id", flat=True)
+                    id__in=PluginConfig.objects.filter(team_id=self.team_id, enabled=True).values_list(
+                        "plugin_id", flat=True
+                    )
                 )
             )
         except ValueError:


### PR DESCRIPTION
## Problem

- based on https://posthog.slack.com/archives/C05KGK1472N/p1690819002850619, plugins that were enabled on one of an organizations projects were showing up as configurable on a different project (team). The plugins should be configurable by team not organization

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- update the configuration to only show up if the team has the plugin enabled not the organization

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
