### PR TITLE
feat: add a tag when writing from mr blobby

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
@@ -347,6 +347,7 @@ export class SessionManager {
                     ContentEncoding: 'gzip',
                     ContentType: 'application/json',
                     Body: readStream,
+                    Tagging: 'lifecycle=default',
                 },
             }))
 


### PR DESCRIPTION
## Problem

We have a default lifecycle for session replay when we write to blob storage. But sometimes want to "move" them to long-term storage. We can change their tag and set lifecycle expiration appropriately.

## Changes

sets the tag when writing to blob storage

## How did you test this code?

🙈 