### PR TITLE
fix(insights): fix funnel time to convert funnel steps

### DIFF
--- a/frontend/src/lib/components/EntityFilterInfo.tsx
+++ b/frontend/src/lib/components/EntityFilterInfo.tsx
@@ -26,11 +26,7 @@ export function EntityFilterInfo({
     style,
 }: EntityFilterInfoProps): JSX.Element {
     if (isAllEventsEntityFilter(filter)) {
-        return (
-            <TextWrapper title="All events" className="text-muted-alt">
-                All events
-            </TextWrapper>
-        )
+        return <TextWrapper title="All events">All events</TextWrapper>
     }
 
     const title = getDisplayNameFromEntityFilter(filter, false)

--- a/frontend/src/lib/components/EntityFilterInfo.tsx
+++ b/frontend/src/lib/components/EntityFilterInfo.tsx
@@ -25,7 +25,7 @@ export function EntityFilterInfo({
     showSingleName = false,
     style,
 }: EntityFilterInfoProps): JSX.Element {
-    if (isAllEventsEntityFilter(filter)) {
+    if (isAllEventsEntityFilter(filter) && !filter?.custom_name) {
         return <TextWrapper title="All events">All events</TextWrapper>
     }
 

--- a/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
@@ -15,6 +15,23 @@ import { isFunnelsFilter, isLifecycleFilter, isStickinessFilter, isTrendsFilter 
 
 type FilterTypeActionsAndEvents = { events?: ActionFilter[]; actions?: ActionFilter[]; new_entity?: ActionFilter[] }
 
+export const seriesNodeToFilter = (node: EventsNode | ActionsNode, index?: number): ActionFilter => {
+    const entity: ActionFilter = objectClean({
+        type: isActionsNode(node) ? EntityTypes.ACTIONS : EntityTypes.EVENTS,
+        id: (!isActionsNode(node) ? node.event : node.id) || null,
+        order: index,
+        name: node.name,
+        custom_name: node.custom_name,
+        // TODO: math is not supported by funnel and lifecycle queries
+        math: node.math,
+        math_property: node.math_property,
+        math_hogql: node.math_hogql,
+        math_group_type_index: node.math_group_type_index,
+        properties: node.properties as any, // TODO,
+    })
+    return entity
+}
+
 export const seriesToActionsAndEvents = (
     series: (EventsNode | ActionsNode)[]
 ): Required<FilterTypeActionsAndEvents> => {
@@ -22,20 +39,7 @@ export const seriesToActionsAndEvents = (
     const events: ActionFilter[] = []
     const new_entity: ActionFilter[] = []
     series.forEach((node, index) => {
-        const entity: ActionFilter = objectClean({
-            type: isActionsNode(node) ? EntityTypes.ACTIONS : EntityTypes.EVENTS,
-            id: (!isActionsNode(node) ? node.event : node.id) || null,
-            order: index,
-            name: node.name,
-            custom_name: node.custom_name,
-            // TODO: math is not supported by funnel and lifecycle queries
-            math: node.math,
-            math_property: node.math_property,
-            math_hogql: node.math_hogql,
-            math_group_type_index: node.math_group_type_index,
-            properties: node.properties as any, // TODO,
-        })
-
+        const entity = seriesNodeToFilter(node, index)
         if (isEventsNode(node)) {
             events.push(entity)
         } else if (isActionsNode(node)) {

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -39,6 +39,7 @@ import { GroupIntroductionFooter } from 'scenes/groups/GroupsIntroduction'
 import { LemonDropdown } from 'lib/lemon-ui/LemonDropdown'
 import { HogQLEditor } from 'lib/components/HogQLEditor/HogQLEditor'
 import { entityFilterLogicType } from '../entityFilterLogicType'
+import { isAllEventsEntityFilter } from 'scenes/insights/utils'
 
 const DragHandle = sortableHandle(() => (
     <span className="ActionFilterRowDragHandle">
@@ -50,6 +51,19 @@ export enum MathAvailability {
     All,
     ActorsOnly,
     None,
+}
+
+const getValue = (
+    value: string | number | null | undefined,
+    filter: ActionFilter
+): string | number | null | undefined => {
+    if (isAllEventsEntityFilter(filter)) {
+        return 'All events'
+    } else if (filter.type === 'actions') {
+        return typeof value === 'string' ? parseInt(value) : value || undefined
+    } else {
+        return value === null ? null : value || undefined
+    }
 }
 
 export interface ActionFilterRowProps {
@@ -203,7 +217,7 @@ export function ActionFilterRow({
             data-attr={'trend-element-subject-' + index}
             fullWidth
             groupType={filter.type as TaxonomicFilterGroupType}
-            value={filter.type === 'actions' && typeof value === 'string' ? parseInt(value) : value || undefined}
+            value={getValue(value, filter)}
             onChange={(changedValue, taxonomicGroupType, item) => {
                 updateFilter({
                     type: taxonomicFilterGroupTypeToEntityType(taxonomicGroupType) || undefined,

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -29,7 +29,12 @@ import { urls } from 'scenes/urls'
 import { examples } from '~/queries/examples'
 
 export const isAllEventsEntityFilter = (filter: EntityFilter | ActionFilter | null): boolean => {
-    return filter !== null && filter.type === EntityTypes.EVENTS && filter.id === null && !filter.name
+    return (
+        filter !== null &&
+        filter.type === EntityTypes.EVENTS &&
+        filter.id === null &&
+        (!filter.name || filter.name === 'All events')
+    )
 }
 
 export const getDisplayNameFromEntityFilter = (

--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsPicker.tsx
@@ -1,10 +1,10 @@
 import { useActions, useValues } from 'kea'
-import { EntityFilter } from '~/types'
 
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { LemonSelect, LemonSelectOptions, LemonSelectOption } from '@posthog/lemon-ui'
+import { seriesNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 
 export function FunnelStepsPicker(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
@@ -30,8 +30,8 @@ export function FunnelStepsPicker(): JSX.Element | null {
                           label: `Step ${stepIndex + 1}`,
                           labelInMenu: (
                               <>
-                                  <span>Step ${stepIndex + 1} – </span>
-                                  <EntityFilterInfo filter={filterSteps[stepIndex] as EntityFilter} />
+                                  <span>Step {stepIndex + 1} – </span>
+                                  <EntityFilterInfo filter={seriesNodeToFilter(filterSteps[stepIndex])} />
                               </>
                           ),
                       }


### PR DESCRIPTION
## Problem

The funnel steps filter and the funnel steps picker was broken for "all events". Resolves https://github.com/PostHog/posthog/issues/16077, resolves https://github.com/PostHog/posthog/issues/16282.

## Changes

This PR:
- fixes the funnel steps picker all events option (also removing a leftover $ from all steps)
- fixes the funnel steps all events option
- makes the all event option black in general

## How did you test this code?

Tested locally