### PR TITLE
feat(flags): Move local evaluation to the read replica

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -112,7 +112,7 @@ runs:
           if: ${{ inputs.segment == 'FOSS' && inputs.group == 1 && inputs.person-on-events != 'true' }}
           env:
               POSTHOG_DB_NAME: posthog
-              READ_REPLICA_OPT_IN: 'decide,PersonalAPIKey, Team,OrganizationMembership,local_evaluation'
+              READ_REPLICA_OPT_IN: 'decide,PersonalAPIKey, local_evaluation'
               POSTHOG_POSTGRES_READ_HOST: localhost
               POSTHOG_DB_PASSWORD: posthog
               POSTHOG_DB_USER: posthog

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -112,7 +112,7 @@ runs:
           if: ${{ inputs.segment == 'FOSS' && inputs.group == 1 && inputs.person-on-events != 'true' }}
           env:
               POSTHOG_DB_NAME: posthog
-              READ_REPLICA_OPT_IN: decide
+              READ_REPLICA_OPT_IN: 'decide,PersonalAPIKey, local_evaluation'
               POSTHOG_POSTGRES_READ_HOST: localhost
               POSTHOG_DB_PASSWORD: posthog
               POSTHOG_DB_USER: posthog

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -112,7 +112,7 @@ runs:
           if: ${{ inputs.segment == 'FOSS' && inputs.group == 1 && inputs.person-on-events != 'true' }}
           env:
               POSTHOG_DB_NAME: posthog
-              READ_REPLICA_OPT_IN: 'decide,PersonalAPIKey, local_evaluation'
+              READ_REPLICA_OPT_IN: 'decide,PersonalAPIKey, Team,OrganizationMembership,local_evaluation'
               POSTHOG_POSTGRES_READ_HOST: localhost
               POSTHOG_DB_PASSWORD: posthog
               POSTHOG_DB_USER: posthog

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -132,7 +132,7 @@ class CohortSerializer(serializers.ModelSerializer):
                 flags: QuerySet[FeatureFlag] = FeatureFlag.objects.filter(
                     team_id=self.context["team_id"], active=True, deleted=False
                 )
-                cohort_used_in_flags = len([flag for flag in flags if cohort_id in flag.cohort_ids]) > 0
+                cohort_used_in_flags = len([flag for flag in flags if cohort_id in flag.get_cohort_ids()]) > 0
 
                 for prop in parsed_filter.property_groups.flat:
                     if prop.type == "behavioral":

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Dict, List, Optional, cast
 
 from django.db.models import QuerySet
+from django.conf import settings
 from django.db.models.query_utils import Q
 from rest_framework import authentication, exceptions, request, serializers, status, viewsets
 from rest_framework.decorators import action
@@ -35,6 +36,12 @@ from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.property import Property
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.rate_limit import BurstRateThrottle
+
+DATABASE_FOR_LOCAL_EVALUATION = (
+    "default"
+    if ("local_evaluation" not in settings.READ_REPLICA_OPT_IN or "replica" not in settings.DATABASES)
+    else "replica"
+)
 
 
 class FeatureFlagThrottle(BurstRateThrottle):
@@ -393,17 +400,29 @@ class FeatureFlagViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidD
     @action(methods=["GET"], detail=False, throttle_classes=[FeatureFlagThrottle])
     def local_evaluation(self, request: request.Request, **kwargs):
 
-        feature_flags: QuerySet[FeatureFlag] = FeatureFlag.objects.filter(team=self.team, deleted=False)
+        feature_flags: QuerySet[FeatureFlag] = FeatureFlag.objects.using(DATABASE_FOR_LOCAL_EVALUATION).filter(
+            team_id=self.team_id, deleted=False
+        )
         cohorts = {}
+        seen_cohorts_cache: Dict[str, Cohort] = {}
 
         parsed_flags = []
         for feature_flag in feature_flags:
             filters = feature_flag.get_filters()
             # transform cohort filters to be evaluated locally
-            if len(feature_flag.cohort_ids) == 1:
+            if (
+                len(
+                    feature_flag.get_cohort_ids(
+                        using_database=DATABASE_FOR_LOCAL_EVALUATION, seen_cohorts_cache=seen_cohorts_cache
+                    )
+                )
+                == 1
+            ):
                 feature_flag.filters = {
                     **filters,
-                    "groups": feature_flag.transform_cohort_filters_for_easy_evaluation(),
+                    "groups": feature_flag.transform_cohort_filters_for_easy_evaluation(
+                        using_database=DATABASE_FOR_LOCAL_EVALUATION, seen_cohorts_cache=seen_cohorts_cache
+                    ),
                 }
             else:
                 feature_flag.filters = filters
@@ -413,10 +432,18 @@ class FeatureFlagViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidD
             # when param set, send cohorts, for libraries that can handle evaluating them locally
             # irrespective of complexity
             if "send_cohorts" in request.GET:
-                for id in feature_flag.cohort_ids:
+                for id in feature_flag.get_cohort_ids(
+                    using_database=DATABASE_FOR_LOCAL_EVALUATION, seen_cohorts_cache=seen_cohorts_cache
+                ):
                     # don't duplicate queries for already added cohorts
                     if id not in cohorts:
-                        cohort = Cohort.objects.get(id=id)
+                        parsed_cohort_id = str(id)
+                        if parsed_cohort_id in seen_cohorts_cache:
+                            cohort = seen_cohorts_cache[parsed_cohort_id]
+                        else:
+                            cohort = Cohort.objects.using(DATABASE_FOR_LOCAL_EVALUATION).get(id=id)
+                            seen_cohorts_cache[parsed_cohort_id] = cohort
+
                         if not cohort.is_static:
                             cohorts[cohort.pk] = cohort.properties.to_dict()
 
@@ -431,7 +458,9 @@ class FeatureFlagViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidD
                 ],
                 "group_type_mapping": {
                     str(row.group_type_index): row.group_type
-                    for row in GroupTypeMapping.objects.filter(team_id=self.team_id)
+                    for row in GroupTypeMapping.objects.using(DATABASE_FOR_LOCAL_EVALUATION).filter(
+                        team_id=self.team_id
+                    )
                 },
                 "cohorts": cohorts,
             }

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -1,4 +1,4 @@
-from functools import cached_property
+from functools import cached_property, lru_cache
 from typing import TYPE_CHECKING, Any, Dict, Optional, cast
 
 from rest_framework import authentication
@@ -157,6 +157,7 @@ class StructuredViewSetMixin(_GenericViewSet):
         serializer_context["get_organization"] = lambda: self.organization
         return serializer_context
 
+    @lru_cache(maxsize=1)
     def _get_team_from_request(self) -> Optional["Team"]:
         team_found = None
         token = get_token(None, self.request)

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -10,6 +10,7 @@ from django.core.cache import cache
 from django.db import connection, connections
 from django.test import TransactionTestCase, TestCase
 from django.test.client import Client
+from rest_framework.test import APIClient
 from freezegun import freeze_time
 import pytest
 from rest_framework import status
@@ -2930,6 +2931,539 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             injected = response.json()["siteApps"]
             self.assertEqual(len(injected), 1)
+
+    # Adding local evaluation tests for read replica in one place for now, until we move to a separate CI flow for all read replica tests
+    # since code-level overrides don't work for theses tests, as they affect the DATABASES setting
+    @patch("posthog.api.feature_flag.report_user_action")
+    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
+    def test_local_evaluation(self, mock_rate_limit, mock_capture):
+        org, team, user = self.setup_user_and_team_in_db("replica")
+        self.organization, self.team, self.user = org, team, user
+
+        FeatureFlag.objects.all().delete()
+        GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
+        GroupTypeMapping.objects.create(team=self.team, group_type="company", group_type_index=1)
+
+        client = APIClient()
+        client.force_login(self.user)
+
+        client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            {
+                "name": "Alpha feature",
+                "key": "alpha-feature",
+                "filters": {
+                    "groups": [{"rollout_percentage": 20}],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "first-variant", "name": "First Variant", "rollout_percentage": 50},
+                            {"key": "second-variant", "name": "Second Variant", "rollout_percentage": 25},
+                            {"key": "third-variant", "name": "Third Variant", "rollout_percentage": 25},
+                        ]
+                    },
+                },
+            },
+            format="json",
+        )
+
+        client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            {
+                "name": "Group feature",
+                "key": "group-feature",
+                "filters": {"aggregation_group_type_index": 0, "groups": [{"rollout_percentage": 21}]},
+            },
+            format="json",
+        )
+
+        # old style feature flags
+        FeatureFlag.objects.create(
+            name="Beta feature",
+            key="beta-feature",
+            team=self.team,
+            rollout_percentage=51,
+            filters={"properties": [{"key": "beta-property", "value": "beta-value"}]},
+            created_by=self.user,
+        )
+        # and inactive flag
+        FeatureFlag.objects.create(
+            name="Inactive feature",
+            key="inactive-flag",
+            team=self.team,
+            active=False,
+            rollout_percentage=100,
+            filters={"properties": []},
+            created_by=self.user,
+        )
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+
+        client.logout()
+        self.client.logout()
+        # `local_evaluation` is called by logged out clients!
+
+        # missing API key
+        with self.assertNumQueries(0, using="replica"), self.assertNumQueries(0, using="default"):
+            response = self.client.get(f"/api/feature_flag/local_evaluation?token={self.team.api_token}")
+            self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        with self.assertNumQueries(0, using="replica"), self.assertNumQueries(0, using="default"):
+            response = self.client.get(f"/api/feature_flag/local_evaluation")
+            self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        with self.assertNumQueries(3, using="replica"), self.assertNumQueries(3, using="default"):
+            # Captured queries for write DB:
+            # E   1. UPDATE "posthog_personalapikey" SET "last_used_at" = '2023-08-01T11:26:50.728057+00:00'
+            # E   2. SELECT "posthog_team"."id", "posthog_team"."uuid", "posthog_team"."organization_id"
+            # E   3. SELECT "posthog_organizationmembership"."id", "posthog_organizationmembership"."organization_id", - user org permissions check
+            # Captured queries for replica DB:
+            # E   1. SELECT "posthog_personalapikey"."id", "posthog_personalapikey"."user_id", "posthog_personalapikey"."label", "posthog_personalapikey"."value", -- check API key, joined with user
+            # E   2. SELECT "posthog_featureflag"."id", "posthog_featureflag"."key", "posthog_featureflag"."name", "posthog_featureflag"."filters", -- get flags
+            # E   3. SELECT "posthog_grouptypemapping"."id", "posthog_grouptypemapping"."team_id", -- get groups
+
+            response = self.client.get(
+                f"/api/feature_flag/local_evaluation?token={self.team.api_token}",
+                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertTrue("flags" in response_data and "group_type_mapping" in response_data)
+        self.assertEqual(len(response_data["flags"]), 4)
+
+        sorted_flags = sorted(response_data["flags"], key=lambda x: x["key"])
+
+        self.assertDictContainsSubset(
+            {
+                "name": "Alpha feature",
+                "key": "alpha-feature",
+                "filters": {
+                    "groups": [{"rollout_percentage": 20}],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "first-variant", "name": "First Variant", "rollout_percentage": 50},
+                            {"key": "second-variant", "name": "Second Variant", "rollout_percentage": 25},
+                            {"key": "third-variant", "name": "Third Variant", "rollout_percentage": 25},
+                        ]
+                    },
+                },
+                "deleted": False,
+                "active": True,
+                "ensure_experience_continuity": False,
+            },
+            sorted_flags[0],
+        )
+        self.assertDictContainsSubset(
+            {
+                "name": "Beta feature",
+                "key": "beta-feature",
+                "filters": {
+                    "groups": [
+                        {"properties": [{"key": "beta-property", "value": "beta-value"}], "rollout_percentage": 51}
+                    ]
+                },
+                "deleted": False,
+                "active": True,
+                "ensure_experience_continuity": False,
+            },
+            sorted_flags[1],
+        )
+        self.assertDictContainsSubset(
+            {
+                "name": "Group feature",
+                "key": "group-feature",
+                "filters": {"groups": [{"rollout_percentage": 21}], "aggregation_group_type_index": 0},
+                "deleted": False,
+                "active": True,
+                "ensure_experience_continuity": False,
+            },
+            sorted_flags[2],
+        )
+        self.assertDictContainsSubset(
+            {
+                "name": "Inactive feature",
+                "key": "inactive-flag",
+                "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]},
+                "deleted": False,
+                "active": False,
+                "ensure_experience_continuity": False,
+            },
+            sorted_flags[3],
+        )
+
+        self.assertEqual(response_data["group_type_mapping"], {"0": "organization", "1": "company"})
+
+    @patch("posthog.api.feature_flag.report_user_action")
+    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
+    def test_local_evaluation_for_cohorts(self, mock_rate_limit, mock_capture):
+        FeatureFlag.objects.all().delete()
+
+        org, team, user = self.setup_user_and_team_in_db("replica")
+        self.organization, self.team, self.user = org, team, user
+
+        client = APIClient()
+        client.force_login(self.user)
+
+        cohort_valid_for_ff = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$some_prop", "value": "nomatchihope", "type": "person"},
+                                {"key": "$some_prop2", "value": "nomatchihope2", "type": "person"},
+                            ],
+                        }
+                    ],
+                }
+            },
+            name="cohort1",
+        )
+
+        other_cohort1 = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$some_prop", "value": "nomatchihope", "type": "person"},
+                            ],
+                        }
+                    ],
+                }
+            },
+            name="cohort2",
+        )
+
+        client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            {
+                "name": "Alpha feature",
+                "key": "alpha-feature",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 20,
+                            "properties": [{"key": "id", "type": "cohort", "value": cohort_valid_for_ff.pk}],
+                        }
+                    ],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "first-variant", "name": "First Variant", "rollout_percentage": 50},
+                            {"key": "second-variant", "name": "Second Variant", "rollout_percentage": 25},
+                            {"key": "third-variant", "name": "Third Variant", "rollout_percentage": 25},
+                        ]
+                    },
+                },
+            },
+            format="json",
+        )
+        client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            {
+                "name": "Beta feature",
+                "key": "beta-feature",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 20,
+                            "properties": [{"key": "id", "type": "cohort", "value": other_cohort1.pk}],
+                        }
+                    ],
+                },
+            },
+            format="json",
+        )
+
+        client.logout()
+        self.client.logout()
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+
+        with self.assertNumQueries(5, using="replica"), self.assertNumQueries(3, using="default"):
+            # Captured queries for write DB:
+            # E   1. UPDATE "posthog_personalapikey" SET "last_used_at" = '2023-08-01T11:26:50.728057+00:00'
+            # E   2. SELECT "posthog_team"."id", "posthog_team"."uuid", "posthog_team"."organization_id"
+            # E   3. SELECT "posthog_organizationmembership"."id", "posthog_organizationmembership"."organization_id", - user org permissions check
+            # Captured queries for replica DB:
+            # E   1. SELECT "posthog_personalapikey"."id", "posthog_personalapikey"."user_id", "posthog_personalapikey"."label", "posthog_personalapikey"."value", -- check API key, joined with user
+            # E   2. SELECT "posthog_featureflag"."id", "posthog_featureflag"."key", "posthog_featureflag"."name", "posthog_featureflag"."filters", -- get flags
+            # E   3. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select first cohort
+            # E   4. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select second cohort
+            # E   5. SELECT "posthog_grouptypemapping"."id", "posthog_grouptypemapping"."team_id", -- get groups
+
+            response = self.client.get(
+                f"/api/feature_flag/local_evaluation?token={self.team.api_token}&send_cohorts",
+                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            response_data = response.json()
+            self.assertTrue(
+                "flags" in response_data and "group_type_mapping" in response_data and "cohorts" in response_data
+            )
+            self.assertEqual(len(response_data["flags"]), 2)
+
+        sorted_flags = sorted(response_data["flags"], key=lambda x: x["key"])
+
+        self.assertDictContainsSubset(
+            {
+                "name": "Alpha feature",
+                "key": "alpha-feature",
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [{"key": "$some_prop", "type": "person", "value": "nomatchihope"}],
+                            "rollout_percentage": 20,
+                        },
+                        {
+                            "properties": [{"key": "$some_prop2", "type": "person", "value": "nomatchihope2"}],
+                            "rollout_percentage": 20,
+                        },
+                    ],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "first-variant", "name": "First Variant", "rollout_percentage": 50},
+                            {"key": "second-variant", "name": "Second Variant", "rollout_percentage": 25},
+                            {"key": "third-variant", "name": "Third Variant", "rollout_percentage": 25},
+                        ]
+                    },
+                },
+                "deleted": False,
+                "active": True,
+                "ensure_experience_continuity": False,
+            },
+            sorted_flags[0],
+        )
+
+        self.assertDictContainsSubset(
+            {
+                "name": "Beta feature",
+                "key": "beta-feature",
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [{"key": "$some_prop", "type": "person", "value": "nomatchihope"}],
+                            "rollout_percentage": 20,
+                        },
+                    ],
+                },
+                "deleted": False,
+                "active": True,
+                "ensure_experience_continuity": False,
+            },
+            sorted_flags[1],
+        )
+
+        self.assertEqual(response_data["cohorts"], {})
+        # No cohorts used in flags after transformation, so no cohorts returned
+
+    @patch("posthog.api.feature_flag.report_user_action")
+    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
+    def test_local_evaluation_for_arbitrary_cohorts(self, mock_rate_limit, mock_capture):
+        FeatureFlag.objects.all().delete()
+
+        org, team, user = self.setup_user_and_team_in_db("replica")
+        self.organization, self.team, self.user = org, team, user
+
+        cohort_valid_for_ff = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$some_prop", "value": "nomatchihope", "type": "person"},
+                                {"key": "$some_prop2", "value": "nomatchihope2", "type": "person"},
+                            ],
+                        }
+                    ],
+                }
+            },
+            name="cohort1",
+        )
+
+        cohort2 = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$some_prop", "value": "nomatchihope", "type": "person"},
+                                {"key": "$some_prop2", "value": "nomatchihope2", "type": "person"},
+                                {"key": "id", "value": cohort_valid_for_ff.pk, "type": "cohort", "negation": True},
+                            ],
+                        }
+                    ],
+                }
+            },
+            name="cohort2",
+        )
+
+        client = APIClient()
+        client.force_login(self.user)
+        client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            {
+                "name": "Alpha feature",
+                "key": "alpha-feature",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 20,
+                            "properties": [{"key": "id", "type": "cohort", "value": cohort2.pk}],
+                        }
+                    ],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "first-variant", "name": "First Variant", "rollout_percentage": 50},
+                            {"key": "second-variant", "name": "Second Variant", "rollout_percentage": 25},
+                            {"key": "third-variant", "name": "Third Variant", "rollout_percentage": 25},
+                        ]
+                    },
+                },
+            },
+            format="json",
+        )
+
+        client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            {
+                "name": "Alpha feature",
+                "key": "alpha-feature-2",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 20,
+                            "properties": [{"key": "id", "type": "cohort", "value": cohort_valid_for_ff.pk}],
+                        }
+                    ],
+                },
+            },
+            format="json",
+        )
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+
+        client.logout()
+        self.client.logout()
+
+        with self.assertNumQueries(5, using="replica"), self.assertNumQueries(3, using="default"):
+            # Captured queries for write DB:
+            # E   1. UPDATE "posthog_personalapikey" SET "last_used_at" = '2023-08-01T11:26:50.728057+00:00'
+            # E   2. SELECT "posthog_team"."id", "posthog_team"."uuid", "posthog_team"."organization_id"
+            # E   3. SELECT "posthog_organizationmembership"."id", "posthog_organizationmembership"."organization_id", - user org permissions check
+            # Captured queries for replica DB:
+            # E   1. SELECT "posthog_personalapikey"."id", "posthog_personalapikey"."user_id", "posthog_personalapikey"."label", "posthog_personalapikey"."value", -- check API key, joined with user
+            # E   2. SELECT "posthog_featureflag"."id", "posthog_featureflag"."key", "posthog_featureflag"."name", "posthog_featureflag"."filters", -- get flags
+            # E   3. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select first cohort
+            # E   4. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select second cohort
+            # E   5. SELECT "posthog_grouptypemapping"."id", "posthog_grouptypemapping"."team_id", -- get groups
+
+            response = self.client.get(
+                f"/api/feature_flag/local_evaluation?token={self.team.api_token}&send_cohorts",
+                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            response_data = response.json()
+            self.assertTrue(
+                "flags" in response_data and "group_type_mapping" in response_data and "cohorts" in response_data
+            )
+            self.assertEqual(len(response_data["flags"]), 2)
+
+        sorted_flags = sorted(response_data["flags"], key=lambda x: x["key"])
+
+        self.assertEqual(
+            response_data["cohorts"],
+            {
+                str(cohort_valid_for_ff.pk): {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$some_prop", "type": "person", "value": "nomatchihope"},
+                                {"key": "$some_prop2", "type": "person", "value": "nomatchihope2"},
+                            ],
+                        }
+                    ],
+                },
+                str(cohort2.pk): {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$some_prop", "type": "person", "value": "nomatchihope"},
+                                {"key": "$some_prop2", "type": "person", "value": "nomatchihope2"},
+                                {"key": "id", "type": "cohort", "value": cohort_valid_for_ff.pk, "negation": True},
+                            ],
+                        }
+                    ],
+                },
+            },
+        )
+
+        self.assertDictContainsSubset(
+            {
+                "name": "Alpha feature",
+                "key": "alpha-feature",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 20,
+                            "properties": [{"key": "id", "type": "cohort", "value": cohort2.pk}],
+                        }
+                    ],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "first-variant", "name": "First Variant", "rollout_percentage": 50},
+                            {"key": "second-variant", "name": "Second Variant", "rollout_percentage": 25},
+                            {"key": "third-variant", "name": "Third Variant", "rollout_percentage": 25},
+                        ]
+                    },
+                },
+                "deleted": False,
+                "active": True,
+                "ensure_experience_continuity": False,
+            },
+            sorted_flags[0],
+        )
+
+        self.assertDictContainsSubset(
+            {
+                "name": "Alpha feature",
+                "key": "alpha-feature-2",
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [{"key": "$some_prop", "type": "person", "value": "nomatchihope"}],
+                            "rollout_percentage": 20,
+                        },
+                        {
+                            "properties": [{"key": "$some_prop2", "type": "person", "value": "nomatchihope2"}],
+                            "rollout_percentage": 20,
+                        },
+                    ],
+                },
+                "deleted": False,
+                "active": True,
+                "ensure_experience_continuity": False,
+            },
+            sorted_flags[1],
+        )
 
 
 class TestDecideMetricLabel(TestCase):

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -3012,13 +3012,13 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             response = self.client.get(f"/api/feature_flag/local_evaluation")
             self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-        with self.assertNumQueries(3, using="replica"), self.assertNumQueries(3, using="default"):
+        with self.assertNumQueries(5, using="replica"), self.assertNumQueries(1, using="default"):
             # Captured queries for write DB:
             # E   1. UPDATE "posthog_personalapikey" SET "last_used_at" = '2023-08-01T11:26:50.728057+00:00'
-            # E   2. SELECT "posthog_team"."id", "posthog_team"."uuid", "posthog_team"."organization_id"
-            # E   3. SELECT "posthog_organizationmembership"."id", "posthog_organizationmembership"."organization_id", - user org permissions check
             # Captured queries for replica DB:
             # E   1. SELECT "posthog_personalapikey"."id", "posthog_personalapikey"."user_id", "posthog_personalapikey"."label", "posthog_personalapikey"."value", -- check API key, joined with user
+            # E   2. SELECT "posthog_team"."id", "posthog_team"."uuid", "posthog_team"."organization_id"
+            # E   3. SELECT "posthog_organizationmembership"."id", "posthog_organizationmembership"."organization_id", - user org permissions check
             # E   2. SELECT "posthog_featureflag"."id", "posthog_featureflag"."key", "posthog_featureflag"."name", "posthog_featureflag"."filters", -- get flags
             # E   3. SELECT "posthog_grouptypemapping"."id", "posthog_grouptypemapping"."team_id", -- get groups
 
@@ -3187,12 +3187,12 @@ class TestDecideUsesReadReplica(TransactionTestCase):
         personal_api_key = generate_random_token_personal()
         PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
 
-        with self.assertNumQueries(5, using="replica"), self.assertNumQueries(3, using="default"):
+        with self.assertNumQueries(7, using="replica"), self.assertNumQueries(1, using="default"):
             # Captured queries for write DB:
             # E   1. UPDATE "posthog_personalapikey" SET "last_used_at" = '2023-08-01T11:26:50.728057+00:00'
+            # Captured queries for replica DB:
             # E   2. SELECT "posthog_team"."id", "posthog_team"."uuid", "posthog_team"."organization_id"
             # E   3. SELECT "posthog_organizationmembership"."id", "posthog_organizationmembership"."organization_id", - user org permissions check
-            # Captured queries for replica DB:
             # E   1. SELECT "posthog_personalapikey"."id", "posthog_personalapikey"."user_id", "posthog_personalapikey"."label", "posthog_personalapikey"."value", -- check API key, joined with user
             # E   2. SELECT "posthog_featureflag"."id", "posthog_featureflag"."key", "posthog_featureflag"."name", "posthog_featureflag"."filters", -- get flags
             # E   3. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select first cohort
@@ -3360,17 +3360,17 @@ class TestDecideUsesReadReplica(TransactionTestCase):
         client.logout()
         self.client.logout()
 
-        with self.assertNumQueries(5, using="replica"), self.assertNumQueries(3, using="default"):
+        with self.assertNumQueries(7, using="replica"), self.assertNumQueries(1, using="default"):
             # Captured queries for write DB:
             # E   1. UPDATE "posthog_personalapikey" SET "last_used_at" = '2023-08-01T11:26:50.728057+00:00'
-            # E   2. SELECT "posthog_team"."id", "posthog_team"."uuid", "posthog_team"."organization_id"
-            # E   3. SELECT "posthog_organizationmembership"."id", "posthog_organizationmembership"."organization_id", - user org permissions check
             # Captured queries for replica DB:
             # E   1. SELECT "posthog_personalapikey"."id", "posthog_personalapikey"."user_id", "posthog_personalapikey"."label", "posthog_personalapikey"."value", -- check API key, joined with user
-            # E   2. SELECT "posthog_featureflag"."id", "posthog_featureflag"."key", "posthog_featureflag"."name", "posthog_featureflag"."filters", -- get flags
-            # E   3. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select first cohort
-            # E   4. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select second cohort
-            # E   5. SELECT "posthog_grouptypemapping"."id", "posthog_grouptypemapping"."team_id", -- get groups
+            # E   2. SELECT "posthog_team"."id", "posthog_team"."uuid", "posthog_team"."organization_id"
+            # E   3. SELECT "posthog_organizationmembership"."id", "posthog_organizationmembership"."organization_id", - user org permissions check
+            # E   4. SELECT "posthog_featureflag"."id", "posthog_featureflag"."key", "posthog_featureflag"."name", "posthog_featureflag"."filters", -- get flags
+            # E   5. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select first cohort
+            # E   6. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select second cohort
+            # E   7. SELECT "posthog_grouptypemapping"."id", "posthog_grouptypemapping"."team_id", -- get groups
 
             response = self.client.get(
                 f"/api/feature_flag/local_evaluation?token={self.team.api_token}&send_cohorts",

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1254,6 +1254,8 @@ class TestFeatureFlag(APIBaseTest):
         personal_api_key = generate_random_token_personal()
         PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
 
+        self.client.logout()
+
         response = self.client.get(
             f"/api/feature_flag/local_evaluation?token={self.team.api_token}",
             HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",

--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -11,7 +11,6 @@ from sentry_sdk.api import capture_exception
 from posthog.constants import PropertyOperatorType
 from posthog.models.cohort import Cohort
 from posthog.models.experiment import Experiment
-from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.property import GroupTypeIndex
 from posthog.models.property.property import Property, PropertyGroup
 from posthog.models.signals import mutable_receiver
@@ -114,7 +113,9 @@ class FeatureFlag(models.Model):
                 ],
             }
 
-    def transform_cohort_filters_for_easy_evaluation(self):
+    def transform_cohort_filters_for_easy_evaluation(
+        self, using_database: str = "default", seen_cohorts_cache: Optional[Dict[str, Cohort]] = None
+    ):
         """
         Expands cohort filters into person property filters when possible.
         This allows for easy local flag evaluation.
@@ -126,7 +127,10 @@ class FeatureFlag(models.Model):
         # Few more edge cases are possible here, where expansion is possible, but it doesn't seem
         # worth it trying to catch all of these.
 
-        if len(self.cohort_ids) != 1:
+        if seen_cohorts_cache is None:
+            seen_cohorts_cache = {}
+
+        if len(self.get_cohort_ids(using_database=using_database, seen_cohorts_cache=seen_cohorts_cache)) != 1:
             return self.conditions
 
         cohort_group_rollout = None
@@ -146,7 +150,12 @@ class FeatureFlag(models.Model):
                             # We cannot expand this cohort condition if it's not the only property in its group.
                             return self.conditions
                         try:
-                            cohort = Cohort.objects.get(pk=cohort_id)
+                            parsed_cohort_id = str(cohort_id)
+                            if parsed_cohort_id in seen_cohorts_cache:
+                                cohort = seen_cohorts_cache[parsed_cohort_id]
+                            else:
+                                cohort = Cohort.objects.using(using_database).get(pk=cohort_id)
+                                seen_cohorts_cache[parsed_cohort_id] = cohort
                         except Cohort.DoesNotExist:
                             return self.conditions
             if not cohort_condition:
@@ -223,9 +232,13 @@ class FeatureFlag(models.Model):
 
         return parsed_conditions
 
-    @cached_property
-    def cohort_ids(self) -> List[int]:
+    def get_cohort_ids(
+        self, using_database: str = "default", seen_cohorts_cache: Optional[Dict[str, Cohort]] = None
+    ) -> List[int]:
         from posthog.models.cohort.util import get_dependent_cohorts
+
+        if seen_cohorts_cache is None:
+            seen_cohorts_cache = {}
 
         cohort_ids = set()
         for condition in self.conditions:
@@ -234,9 +247,22 @@ class FeatureFlag(models.Model):
                 if prop.get("type") == "cohort":
                     cohort_id = prop.get("value")
                     try:
-                        cohort: Cohort = Cohort.objects.get(pk=cohort_id)
+                        parsed_cohort_id = str(cohort_id)
+                        if parsed_cohort_id in seen_cohorts_cache:
+                            cohort: Cohort = seen_cohorts_cache[parsed_cohort_id]
+                        else:
+                            cohort = Cohort.objects.using(using_database).get(pk=cohort_id)
+                            seen_cohorts_cache[parsed_cohort_id] = cohort
+
                         cohort_ids.add(cohort.pk)
-                        cohort_ids.update([dependent_cohort.pk for dependent_cohort in get_dependent_cohorts(cohort)])
+                        cohort_ids.update(
+                            [
+                                dependent_cohort.pk
+                                for dependent_cohort in get_dependent_cohorts(
+                                    cohort, using_database=using_database, seen_cohorts_cache=seen_cohorts_cache
+                                )
+                            ]
+                        )
                     except Cohort.DoesNotExist:
                         continue
 


### PR DESCRIPTION
## Problem

We're getting a lot more local evaluation requests now.

This change moves local evaluation to the read replica (partially). Since the web pod serves local evaluation requests, and not the decide pod, I can't simply opt the remaining models in to use the read replica, since it will affect others too.

Still, this is a worthwhile change, since majority of requests do indeed move to the replica.

At the same time, I noticed we were making 4 requests for the same cohort, for every cohort, when trying to create the package for local evaluation. This is not great.

This PR fixes this by heavily caching seen cohorts, but only for the request lifetime. This implies all cohorts are queried once, which reduces queries by 4x.

Lots of tests in here to validate this behaviour
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
