### PR TITLE
feat: Ask for confirmation before discarding action changes

### DIFF
--- a/frontend/src/scenes/actions/actionEditLogic.tsx
+++ b/frontend/src/scenes/actions/actionEditLogic.tsx
@@ -54,6 +54,12 @@ export const actionEditLogic = kea<actionEditLogicType>([
                 setCreateNew: (_, { createNew }) => createNew,
             },
         ],
+        wasDeleted: [
+            false,
+            {
+                deleteAction: () => true,
+            },
+        ],
     }),
 
     forms(({ actions, props }) => ({
@@ -172,7 +178,7 @@ export const actionEditLogic = kea<actionEditLogicType>([
     })),
 
     beforeUnload(({ values }) => ({
-        enabled: () => values.actionChanged,
+        enabled: () => values.actionChanged && !values.wasDeleted,
         message: `Leave action?\nChanges you made will be discarded.`,
     })),
 ])

--- a/frontend/src/scenes/actions/actionEditLogic.tsx
+++ b/frontend/src/scenes/actions/actionEditLogic.tsx
@@ -7,7 +7,7 @@ import { ActionStepType, ActionType } from '~/types'
 import { lemonToast } from 'lib/lemon-ui/lemonToast'
 import { loaders } from 'kea-loaders'
 import { forms } from 'kea-forms'
-import { router, urlToAction } from 'kea-router'
+import { beforeUnload, router, urlToAction } from 'kea-router'
 import { urls } from 'scenes/urls'
 import { eventDefinitionsTableLogic } from 'scenes/data-management/events/eventDefinitionsTableLogic'
 import { Link } from 'lib/lemon-ui/Link'
@@ -169,5 +169,10 @@ export const actionEditLogic = kea<actionEditLogicType>([
                 throw new Error('Could not parse action to copy from URL')
             }
         },
+    })),
+
+    beforeUnload(({ values }) => ({
+        enabled: () => values.actionChanged,
+        message: `Leave action?\nChanges you made will be discarded.`,
     })),
 ])

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -244,7 +244,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                     !!values.insightDataLogicRef?.logic.values.queryChanged)
             )
         },
-        message: 'Leave insight? Changes you made will be discarded.',
+        message: 'Leave insight?\nChanges you made will be discarded.',
         onConfirm: () => {
             values.insightLogicRef?.logic.actions.cancelChanges()
             values.insightDataLogicRef?.logic.actions.cancelChanges()

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -85,7 +85,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
 
     beforeUnload(({ values, actions }) => ({
         enabled: (newLocation) => values.hasChanges && newLocation?.pathname !== router.values.location.pathname,
-        message: 'Leave playlist? Changes you made will be discarded.',
+        message: 'Leave playlist?\nChanges you made will be discarded.',
         onConfirm: () => {
             actions.setFilters(values.playlist?.filters || null)
         },


### PR DESCRIPTION
## Problem

Resolves #10677. This came up again in ZEN-4387 in the context of action tags specifically.

## Changes

Using Kea's `beforeUnload` to ask for confirmation:

<img width="473" alt="Screenshot 2023-08-01 at 16 21 42" src="https://github.com/PostHog/posthog/assets/4550621/1757ae1b-441f-40e9-a709-569f3a3c5e00">
