### PR TITLE
chore: Optimize admin and add dashboards

### DIFF
--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -72,7 +72,6 @@ class DashboardAdmin(admin.ModelAdmin):
 
 @admin.register(Text)
 class TextAdmin(admin.ModelAdmin):
-    autocomplete_fields = ("insight", "text")
     autocomplete_fields = ("created_by", "last_modified_by", "team")
     search_fields = ("id", "body", "team__name", "team__organization__name")
 
@@ -325,7 +324,7 @@ class UserAdmin(DjangoUserAdmin):
     ordering = ("email",)
 
     def current_team_link(self, user: User):
-        if not user.organization:
+        if not user.team:
             return "–"
 
         return format_html('<a href="/admin/posthog/team/{}/change/">{}</a>', user.team.pk, user.team.name)
@@ -413,7 +412,11 @@ class OrganizationAdmin(admin.ModelAdmin):
 
     def first_member(self, organization: Organization):
         user = organization.members.order_by("id").first()
-        return format_html(f'<a href="/admin/posthog/user/{user.pk}/change/">{user.email}</a>')
+        return (
+            format_html(f'<a href="/admin/posthog/user/{user.pk}/change/">{user.email}</a>')
+            if user is not None
+            else "None"
+        )
 
     def billing_link_v2(self, organization: Organization) -> str:
         url = f"{settings.BILLING_SERVICE_URL}/admin/billing/customer/?q={organization.pk}"

--- a/posthog/models/dashboard.py
+++ b/posthog/models/dashboard.py
@@ -2,6 +2,7 @@ from typing import Any, Dict
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
+from posthog.models.utils import sane_repr
 
 from posthog.utils import absolute_uri
 
@@ -57,6 +58,11 @@ class Dashboard(models.Model):
     share_token: models.CharField = models.CharField(max_length=400, null=True, blank=True)
     # DEPRECATED: using the new "is_sharing_enabled" relation instead
     is_shared: models.BooleanField = models.BooleanField(default=False)
+
+    __repr__ = sane_repr("team_id", "id", "name")
+
+    def __str__(self):
+        return self.name or self.id
 
     @property
     def is_sharing_enabled(self):

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -10,6 +10,7 @@ from rest_framework.exceptions import ValidationError
 from posthog.logging.timing import timed
 from posthog.models.dashboard import Dashboard
 from posthog.models.filters.utils import get_filter
+from posthog.models.utils import sane_repr
 from posthog.utils import absolute_uri, generate_cache_key, generate_short_id
 
 logger = structlog.get_logger(__name__)
@@ -79,6 +80,11 @@ class Insight(models.Model):
 
     # Changing these fields materially alters the Insight, so these count for the "last_modified_*" fields
     MATERIAL_INSIGHT_FIELDS = {"name", "description", "filters"}
+
+    __repr__ = sane_repr("team_id", "id", "short_id", "name")
+
+    def __str__(self):
+        return self.name or self.derived_name or self.short_id
 
     @property
     def is_sharing_enabled(self):


### PR DESCRIPTION
## Problem

I need access to dashboards in the admin interface to debug a customer issue. Also, noticed that teams load slowly. This seems to be because of the recent addition of actions to that interface, which have this rascal:

<img width="413" alt="Screenshot 2023-08-02 at 13 35 33" src="https://github.com/PostHog/posthog/assets/4550621/32bf72e0-e6d5-423b-8a60-2c446464cee5">

This select lists _all_ the users in the PostHog instance, which is insanely inefficient (but very easy to miss).

## Changes

Registered Dashboard, plus Text models for listing DashboardTiles. And solved all the overzealous selects by adding them to `autocomplete_fields`.
