### PR TITLE
fix(decide): Make property override matching case insensitive for exa…

### DIFF
--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -106,8 +106,8 @@ def match_property(property: Property, override_property_values: Dict[str, Any])
             return str(override_value).lower() == str(truthy).lower()
 
         if isinstance(value, list):
-            return override_value in value
-        return value == override_value
+            return str(override_value).lower() in [str(val).lower() for val in value]
+        return str(value).lower() == str(override_value).lower()
 
     if operator == "is_not":
         if isinstance(value, list):

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -621,7 +621,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
             FeatureFlagMatcher([feature_flag], "307", property_value_overrides={"Organizer Id": 307}).get_match(
                 feature_flag
             ),
-            FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
         )
 
         # test with a flag where the property is a number
@@ -643,7 +643,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
             FeatureFlagMatcher([feature_flag2], "307", property_value_overrides={"Distinct Id": 307}).get_match(
                 feature_flag2
             ),
-            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 1),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
         )
 
     def test_coercion_of_booleans(self):
@@ -809,12 +809,12 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
             FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
         )
 
-        # require explicit type correctness for overrides
+        # don't require explicit type correctness for overrides when you're already at /decide
         self.assertEqual(
             FeatureFlagMatcher([feature_flag], "307", property_value_overrides={"Distinct Id": 307}).get_match(
                 feature_flag
             ),
-            FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
         )
 
         # test with a flag where the property is a number


### PR DESCRIPTION
…ct operator

## Problem

It seems to have been a poor decision to let users worry about types - there's almost no case where they worry about different types matching (ex: I set override to 307, and I want it to match 307 the number but not 307 the string).

While we ought to update SDKs as well to make this nicer, doing this atleast for decide for now, since this becomes more prevalent as we automatically add property overrides whenever someone calls identify.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tests!
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
