### PR TITLE
feat(plugin-server): add backfill mode to plugin-server

### DIFF
--- a/plugin-server/src/index.ts
+++ b/plugin-server/src/index.ts
@@ -64,8 +64,9 @@ switch (alternativeMode) {
 
 async function startBackfill() {
     // This mode can be used as an nodejs counterpart to the django management commands, for incident remediation.
-    // Wire your backfilling logic at the end of the function and run it in a toolbox pod with:
-    // node ./plugin-server/dist/index.js -- --backfill
+    // Add your logic to the runBackfill function and run it:
+    //   - locally with: cd plugin-server && pnpm start:dev -- --backfill
+    //   - in a toolbox pod with: node ./plugin-server/dist/index.js -- --backfill
 
     defaultConfig.PLUGIN_SERVER_MODE = null // Disable all consuming capabilities
     const noCapability = {}

--- a/plugin-server/src/index.ts
+++ b/plugin-server/src/index.ts
@@ -4,6 +4,7 @@ import { defaultConfig } from './config/config'
 import { initApp } from './init'
 import { GraphileWorker } from './main/graphile-worker/graphile-worker'
 import { startPluginsServer } from './main/pluginsServer'
+import { createHub } from './utils/db/hub'
 import { Status } from './utils/status'
 import { makePiscina } from './worker/piscina'
 
@@ -14,6 +15,7 @@ enum AlternativeMode {
     Version = 'VRSN',
     Healthcheck = 'HLTH',
     Migrate = 'MGRT',
+    Backfill = 'BKFL',
 }
 
 let alternativeMode: AlternativeMode | undefined
@@ -21,6 +23,8 @@ if (argv.includes('--version') || argv.includes('-v')) {
     alternativeMode = AlternativeMode.Version
 } else if (argv.includes('--migrate')) {
     alternativeMode = AlternativeMode.Migrate
+} else if (argv.includes('--backfill')) {
+    alternativeMode = AlternativeMode.Backfill
 }
 
 const status = new Status(alternativeMode)
@@ -47,11 +51,40 @@ switch (alternativeMode) {
             }
         })()
         break
-
+    case AlternativeMode.Backfill:
+        void startBackfill()
+        break
     default:
         // void the returned promise
         initApp(defaultConfig)
         const capabilities = getPluginServerCapabilities(defaultConfig)
         void startPluginsServer(defaultConfig, makePiscina, capabilities)
         break
+}
+
+async function startBackfill() {
+    // This mode can be used as an nodejs counterpart to the django management commands, for incident remediation.
+    // Wire your backfilling logic at the end of the function and run it in a toolbox pod with:
+    // node ./plugin-server/dist/index.js -- --backfill
+
+    defaultConfig.PLUGIN_SERVER_MODE = null // Disable all consuming capabilities
+    const noCapability = {}
+    initApp(defaultConfig)
+    const [hub, closeHub] = await createHub(defaultConfig, null, noCapability)
+    status.info('🏁', 'Bootstraping done, starting to backfill')
+
+    await runBackfill(hub)
+
+    // Gracefully tear down the clients.
+    status.info('🏁', 'Backfill done, starting shutdown')
+    await closeHub()
+}
+
+async function runBackfill(hub: Hub) {
+    // Replace this function body with the backfilling logic.
+    // ⚠️ Make sure you can properly restart it if the pod gets killed: either make sure that the processing
+    // is idempotent, or process data in small chunks and persist a cursor.
+    const result = await hub.db.postgresQuery('SELECT 1', undefined, 'backfill')
+    console.assert(result.rows.length == 1, 'Expected one result row')
+    status.info('✅', 'Postgres query succeeded', { result: result.rows })
 }


### PR DESCRIPTION
## Problem

plugin-server does not have management commands, this PR introduces a framework to build such ad-hoc commands for backfilling after incidents

## Changes

- add a `--backfill` flag to the plugin-server command
- add a placeholder implementation of `runBackfill` that checks that the PG client is healthy


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
