### PR TITLE
chore: remove autosize input

### DIFF
--- a/frontend/src/lib/components/EditableField/EditableField.scss
+++ b/frontend/src/lib/components/EditableField/EditableField.scss
@@ -37,6 +37,15 @@
         align-self: center;
         min-width: 0;
     }
+    .EditableField__autosize__sizer {
+        position: absolute;
+        top: 0;
+        left: 0;
+        visibility: hidden;
+        height: 0;
+        overflow: scroll;
+        white-space: pre;
+    }
     input,
     textarea {
         max-width: 100%;

--- a/frontend/src/lib/components/EditableField/EditableField.tsx
+++ b/frontend/src/lib/components/EditableField/EditableField.tsx
@@ -148,7 +148,6 @@ export function EditableField({
                                     minLength={minLength}
                                     maxLength={maxLength}
                                     autoFocus={autoFocus}
-                                    className="EditableField__autosize"
                                 />
                             )}
                             {!mode && (
@@ -222,7 +221,6 @@ const AutosizeInput = ({
     minLength,
     maxLength,
     autoFocus,
-    className,
 }: {
     name: string
     value: string
@@ -233,7 +231,6 @@ const AutosizeInput = ({
     minLength?: number
     maxLength?: number
     autoFocus?: boolean
-    className?: string
 }): JSX.Element => {
     const [inputWidth, setInputWidth] = useState<number | string>(1)
     const inputRef = useRef<HTMLInputElement>(null)
@@ -281,7 +278,7 @@ const AutosizeInput = ({
     }, [sizerRef.current, placeHolderSizerRef.current, placeholder, value])
 
     return (
-        <div className={className}>
+        <div className="EditableField__autosize">
             <input
                 name={name}
                 value={value}
@@ -296,32 +293,10 @@ const AutosizeInput = ({
                 /* eslint-disable-next-line react/forbid-dom-props */
                 style={{ boxSizing: 'content-box', width: `${inputWidth}px` }}
             />
-            <div
-                ref={sizerRef}
-                style={{
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    visibility: 'hidden',
-                    height: 0,
-                    overflow: 'scroll',
-                    whiteSpace: 'pre',
-                }}
-            >
+            <div ref={sizerRef} className="EditableField__autosize__sizer">
                 {value}
             </div>
-            <div
-                ref={placeHolderSizerRef}
-                style={{
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    visibility: 'hidden',
-                    height: 0,
-                    overflow: 'scroll',
-                    whiteSpace: 'pre',
-                }}
-            >
+            <div ref={placeHolderSizerRef} className="EditableField__autosize__sizer">
                 {placeholder}
             </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
         "react-dom": "^16.14.0",
         "react-draggable": "^4.2.0",
         "react-grid-layout": "^1.3.0",
-        "react-input-autosize": "^3.0.0",
         "react-intersection-observer": "^9.4.3",
         "react-json-view": "^1.21.3",
         "react-markdown": "^5.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,9 +227,6 @@ dependencies:
   react-grid-layout:
     specifier: ^1.3.0
     version: 1.3.4(react-dom@16.14.0)(react@16.14.0)
-  react-input-autosize:
-    specifier: ^3.0.0
-    version: 3.0.0(react@16.14.0)
   react-intersection-observer:
     specifier: ^9.4.3
     version: 9.4.3(react@16.14.0)
@@ -16926,15 +16923,6 @@ packages:
       react-dom: 16.14.0(react@16.14.0)
       react-draggable: 4.4.5(react-dom@16.14.0)(react@16.14.0)
       react-resizable: 3.0.4(react-dom@16.14.0)(react@16.14.0)
-    dev: false
-
-  /react-input-autosize@3.0.0(react@16.14.0):
-    resolution: {integrity: sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==}
-    peerDependencies:
-      react: ^16.3.0 || ^17.0.0
-    dependencies:
-      prop-types: 15.8.1
-      react: 16.14.0
     dev: false
 
   /react-inspector@5.1.1(react@16.14.0):


### PR DESCRIPTION
## Problem

We're relying on the `react-input-autosize` which is not maintained and does not support React 18

Towards https://github.com/PostHog/posthog/pull/16605

## Changes

Reimplement the parts of the autosizing input that we need, in the one place we actually need it (`EditableField`).

## How did you test this code?

Manually. Snapshots should throw up any visual differences but seems to work as before
![resizable](https://github.com/PostHog/posthog/assets/6685876/c2490849-7806-4e94-9c5f-cda275a269a8)