### PR TITLE
fix: S3 key generation aware of directory separators

### DIFF
--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -49,12 +49,11 @@ def get_s3_key(inputs) -> str:
     """Return an S3 key given S3InsertInputs."""
     template_variables = get_allowed_template_variables(inputs)
     key_prefix = inputs.prefix.format(**template_variables)
-
-    if posixpath.isabs(key_prefix):
-        # Keys are relative to root dir, so this would add an extra "/"
-        key_prefix = posixpath.relpath(key_prefix, "/").replace(".", "")
-
     key = posixpath.join(key_prefix, f"{inputs.data_interval_start}-{inputs.data_interval_end}.jsonl")
+
+    if posixpath.isabs(key):
+        # Keys are relative to root dir, so this would add an extra "/"
+        key = posixpath.relpath(key, "/")
 
     return key
 


### PR DESCRIPTION
## Problem

When handling S3 key prefixes, we were being a bit too naive by just appending everything. This could generate keys like `///file-name.jsonl` if a user provided a prefix like the root directory (`/`), or `//file-name.jsonl` if a use provided an empty prefix `""`. Since S3 keys are always relative to the root directory, we understand passing `/` or `""` to mean "drop the files in the root directory".

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Use `posixpath` functions to generate an s3 key:
1. Format key prefix with template variables.
2. If directory structure is absolute, make it relative to root.
3. Join prefix with file name.

TODO: Allow users to edit the file name prefix. Supporting this now would require updating some existing keys, so for the time being let's not. As it stands, this change only affects users with `""` and `/` key prefixes, which will see one or two less `"/"` appended to the beginning of their files (respectively).

~TODO: The `replace` call doesn't quite work with keys that have a dot in them. No such key exists yet in any export, but we should fix this. Maybe it's not required, depending on how S3 would handle a key like `"./file_name.jsonl"`.~ We can remove the call if we do the check later.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a unit test with a bunch of possible cases. Suggest more!

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
