### PR TITLE
fix(cohorts): Don't show "All events" option

### DIFF
--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -125,6 +125,9 @@ export function CohortTaxonomicField({
             onChange={(v, g) => {
                 onChange({ [fieldKey]: v, [groupTypeFieldKey]: g })
             }}
+            excludedProperties={{
+                [TaxonomicFilterGroupType.Events]: [null], // "All events" isn't supported by Cohorts currently
+            }}
             groupTypes={taxonomicGroupTypes}
             placeholder={placeholder}
             data-attr={`cohort-taxonomic-field-${fieldKey}`}


### PR DESCRIPTION
## Problem

In cohorts for "completed event" conditions, "All events" was mistakenly shown as selected by default:

<img width="494" alt="Screenshot 2023-08-03 at 15 25 57" src="https://github.com/PostHog/posthog/assets/4550621/dec262b0-61eb-4e16-82f6-2e1a54c05d52">

This option is not supported by cohorts though.

## Changes

"All events" is no longer shown.

## How did you test this code?

Just local clicking.