### PR TITLE
feat: Set max block size to 10000

### DIFF
--- a/posthog/temporal/workflows/clickhouse.py
+++ b/posthog/temporal/workflows/clickhouse.py
@@ -346,5 +346,6 @@ async def get_client() -> collections.abc.AsyncIterator[ClickHouseClient]:
                 database=settings.CLICKHOUSE_DATABASE,
                 # TODO: make this a setting.
                 max_execution_time=0,
+                max_block_size=10000,
             ) as client:
                 yield client


### PR DESCRIPTION
## Problem

The batch size read by clickhouse is influenced by the `max_block_size` setting. We can try set this lower to reduce memory overhead.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Set Clickhouse `max_block_size` to 10000 (default=65k).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
