### PR TITLE
fix: show empty state properly for My Actions

### DIFF
--- a/frontend/src/scenes/actions/ActionsTable.tsx
+++ b/frontend/src/scenes/actions/ActionsTable.tsx
@@ -244,24 +244,22 @@ export function ActionsTable(): JSX.Element {
                     }
                 />
             )}
-            {!shouldShowEmptyState && (
+            {(shouldShowEmptyState && filterByMe) || !shouldShowEmptyState ? (
+                <div className="flex items-center justify-between gap-2 mb-4">
+                    <LemonInput
+                        type="search"
+                        placeholder="Search for actions"
+                        onChange={setSearchTerm}
+                        value={searchTerm}
+                    />
+                    <Radio.Group buttonStyle="solid" value={filterByMe} onChange={(e) => setFilterByMe(e.target.value)}>
+                        <Radio.Button value={false}>All actions</Radio.Button>
+                        <Radio.Button value={true}>My actions</Radio.Button>
+                    </Radio.Group>
+                </div>
+            ) : null}
+            {(!shouldShowEmptyState || filterByMe) && (
                 <>
-                    <div className="flex items-center justify-between gap-2 mb-4">
-                        <LemonInput
-                            type="search"
-                            placeholder="Search for actions"
-                            onChange={setSearchTerm}
-                            value={searchTerm}
-                        />
-                        <Radio.Group
-                            buttonStyle="solid"
-                            value={filterByMe}
-                            onChange={(e) => setFilterByMe(e.target.value)}
-                        >
-                            <Radio.Button value={false}>All actions</Radio.Button>
-                            <Radio.Button value={true}>My actions</Radio.Button>
-                        </Radio.Group>
-                    </div>
                     <LemonTable
                         columns={columns}
                         loading={actionsLoading}


### PR DESCRIPTION
## Problem

If someone selected to see their own actions (My Actions), but they hadn't made any Actions yet, they'd see the empty state and be unable to get back to the All Actions view.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Checks to see if they are viewing My Actions, and if so, show the UI to get back to All Actions. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
