### PR TITLE
fix: Clean JSON responses from NaN system-wide, with markers

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -138,7 +138,7 @@ jobs:
             - name: Check static typing
               run: |
                   cd current
-                  mypy -p posthog --exclude bin/migrate_kafka_data.py --exclude posthog/hogql/grammar/HogQLParser.py --exclude gunicorn.config.py
+                  mypy -p posthog --exclude bin/migrate_kafka_data.py --exclude posthog/hogql/grammar/HogQLParser.py --exclude gunicorn.config.py --enable-recursive-aliases
 
             - name: Check if "schema.py" is up to date
               run: |

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -192,7 +192,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
     }),
 
     loaders(({ actions, props, values }) => ({
-        // TODO this is a terrible name... it is "dashboard" but there's a "dashboard" reducer ¯\_(ツ)_/¯
         dashboard: [
             null as DashboardType | null,
             {

--- a/frontend/src/scenes/project-homepage/RecentRecordings.tsx
+++ b/frontend/src/scenes/project-homepage/RecentRecordings.tsx
@@ -62,7 +62,7 @@ export function RecentRecordings(): JSX.Element {
                     currentTeam?.session_recording_opt_in
                         ? {
                               title: 'There are no recordings for this project',
-                              description: 'Make sure you have the javascript snippet setup in your website.',
+                              description: 'Make sure you have the HTML snippet setup in your website.',
                               buttonText: 'Learn more',
                               buttonTo: 'https://posthog.com/docs/user-guides/recordings',
                           }

--- a/frontend/src/scenes/project-homepage/RecentRecordings.tsx
+++ b/frontend/src/scenes/project-homepage/RecentRecordings.tsx
@@ -62,7 +62,7 @@ export function RecentRecordings(): JSX.Element {
                     currentTeam?.session_recording_opt_in
                         ? {
                               title: 'There are no recordings for this project',
-                              description: 'Make sure you have the HTML snippet setup in your website.',
+                              description: 'Make sure you have the javascript snippet setup in your website.',
                               buttonText: 'Learn more',
                               buttonTo: 'https://posthog.com/docs/user-guides/recordings',
                           }

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -53,7 +53,7 @@ class Database(BaseModel):
     raw_person_overrides: RawPersonOverridesTable = RawPersonOverridesTable()
 
     # clunky: keep table names in sync with above
-    _table_names: List[Table] = [
+    _table_names: List[str] = [
         "events",
         "groups",
         "person",
@@ -120,6 +120,7 @@ class _SerializedFieldBase(TypedDict):
         "datetime",
         "date",
         "boolean",
+        "array",
         "json",
         "lazy_table",
         "virtual_table",

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -59,7 +59,6 @@ from posthog.queries.trends.util import (
     COUNT_PER_ACTOR_MATH_FUNCTIONS,
     PROPERTY_MATH_FUNCTIONS,
     correct_result_for_sampling,
-    ensure_value_is_json_serializable,
     enumerate_time_range,
     get_active_user_params,
     parse_response,
@@ -515,7 +514,7 @@ class TrendsBreakdown:
             parsed_results = []
             cache_invalidation_key = generate_short_id()
             for stats in result:
-                aggregated_value = ensure_value_is_json_serializable(stats[0])
+                aggregated_value = stats[0]
                 result_descriptors = self._breakdown_result_descriptors(stats[1], filter, entity)
                 filter_params = filter.to_params()
                 extra_params = {

--- a/posthog/queries/trends/formula.py
+++ b/posthog/queries/trends/formula.py
@@ -12,7 +12,7 @@ from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
 from posthog.queries.breakdown_props import get_breakdown_cohort_name
 from posthog.queries.insight import insight_sync_execute
-from posthog.queries.trends.util import ensure_value_is_json_serializable, parse_response
+from posthog.queries.trends.util import parse_response
 
 # Regex for adding the formula variable index to all params, except HogQL params
 PARAM_DISAMBIGUATION_REGEX = re.compile(r"%\((?!hogql_)")
@@ -102,7 +102,7 @@ class TrendsFormula:
 
                 if is_aggregate:
                     additional_values["data"] = []
-                    additional_values["aggregated_value"] = ensure_value_is_json_serializable(item[1][0])
+                    additional_values["aggregated_value"] = item[1][0]
                 else:
                     additional_values["data"] = [
                         round(number, 2) if not math.isnan(number) and not math.isinf(number) else 0.0

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -34,7 +34,6 @@ from posthog.queries.trends.util import (
     COUNT_PER_ACTOR_MATH_FUNCTIONS,
     PROPERTY_MATH_FUNCTIONS,
     determine_aggregator,
-    ensure_value_is_json_serializable,
     enumerate_time_range,
     parse_response,
     process_math,
@@ -221,7 +220,7 @@ class TrendsTotalVolume:
 
     def _parse_aggregate_volume_result(self, filter: Filter, entity: Entity, team_id: int) -> Callable:
         def _parse(result: List) -> List:
-            aggregated_value = ensure_value_is_json_serializable(result[0][0]) if result and len(result) else 0
+            aggregated_value = result[0][0] if result else 0
             seconds_in_interval = TIME_IN_SECONDS[filter.interval]
             time_range = enumerate_time_range(filter, seconds_in_interval)
             filter_params = filter.to_params()

--- a/posthog/renderers.py
+++ b/posthog/renderers.py
@@ -29,11 +29,11 @@ def clean_data_for_json(data) -> Tuple[CleaningMarker, CleaningMarker]:
         for key, value in data.items():
             nan, inf = clean_data_for_json(value)
             if nan:
-                marker_payload[f"{key}::nan!"] = nan
+                marker_payload[f"{key}::nan"] = nan
                 if nan is True:
                     data[key] = None
             if inf:
-                marker_payload[f"{key}::inf!"] = inf
+                marker_payload[f"{key}::inf"] = inf
                 if inf is True:
                     data[key] = None
         data.update(marker_payload)

--- a/posthog/renderers.py
+++ b/posthog/renderers.py
@@ -1,0 +1,46 @@
+import math
+from typing import Dict, Tuple
+from rest_framework.renderers import JSONRenderer
+
+CleaningMarker = bool | Dict[int, "CleaningMarker"]
+
+
+def clean_data_for_json(data) -> Tuple[CleaningMarker, CleaningMarker]:
+    """Replace NaNs and Infinities with None, in-place, marking which fields had to be scrubbed.
+    Return markers that should be set at the parent level, which is used for setting the markers recursively."""
+    if isinstance(data, float):
+        return (math.isnan(data), math.isinf(data))
+    if isinstance(data, list):
+        nan_map: Dict[int, CleaningMarker] = {}
+        inf_map: Dict[int, CleaningMarker] = {}
+        for index, item in enumerate(data):
+            nan, inf = clean_data_for_json(item)
+            if nan:
+                nan_map[index] = nan
+                if nan is True:
+                    data[index] = None
+            if inf:
+                inf_map[index] = inf
+                if inf is True:
+                    data[index] = None
+        return (nan_map, inf_map)
+    if isinstance(data, dict):
+        marker_payload: Dict[str, CleaningMarker] = {}
+        for key, value in data.items():
+            nan, inf = clean_data_for_json(value)
+            if nan:
+                marker_payload[f"{key}::nan!"] = nan
+                if nan is True:
+                    data[key] = None
+            if inf:
+                marker_payload[f"{key}::inf!"] = inf
+                if inf is True:
+                    data[key] = None
+        data.update(marker_payload)
+    return (False, False)
+
+
+class SafeJSONRenderer(JSONRenderer):
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        clean_data_for_json(data)
+        return super().render(data, accepted_media_type, renderer_context)

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -238,7 +238,7 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
-    "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer"],
+    "DEFAULT_RENDERER_CLASSES": ["posthog.renderers.SafeJSONRenderer"],
     "PAGE_SIZE": 100,
     "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
@@ -249,6 +249,7 @@ REST_FRAMEWORK = {
         "posthog.rate_limit.BurstRateThrottle",
         "posthog.rate_limit.SustainedRateThrottle",
     ],
+    # The default STRICT_JSON fails the whole request if the data can't be strictly JSON-serialized
     "STRICT_JSON": False,
 }
 if DEBUG:

--- a/posthog/test/test_renderers.py
+++ b/posthog/test/test_renderers.py
@@ -14,7 +14,7 @@ class TestCleanDataForJSON(TestCase):
 
         self.assertEqual(top_level_markers, (False, False))
         self.assertDictEqual(
-            data, {"control": 1.0, "test_1": None, "test_1::nan!": True, "test_2": None, "test_2::inf!": True}
+            data, {"control": 1.0, "test_1": None, "test_1::nan": True, "test_2": None, "test_2::inf": True}
         )
 
     def test_cleans_dict_with_nan_and_inf_list(self):
@@ -26,7 +26,7 @@ class TestCleanDataForJSON(TestCase):
 
         self.assertEqual(top_level_markers, (False, False))
         self.assertDictEqual(
-            {"control": 1.0, "test": [None, 1.0, None], "test::nan!": {2: True}, "test::inf!": {0: True}}, data
+            {"control": 1.0, "test": [None, 1.0, None], "test::nan": {2: True}, "test::inf": {0: True}}, data
         )
 
     def test_cleans_dict_with_nan_and_inf_nested_list(self):
@@ -41,8 +41,8 @@ class TestCleanDataForJSON(TestCase):
             {
                 "control": 1.0,
                 "test": [None, [None, None, 1.0], None, 5.0],
-                "test::nan!": {1: {1: True}, 2: True},
-                "test::inf!": {0: True, 1: {0: True}},
+                "test::nan": {1: {1: True}, 2: True},
+                "test::inf": {0: True, 1: {0: True}},
             },
             data,
         )
@@ -56,6 +56,6 @@ class TestCleanDataForJSON(TestCase):
 
         self.assertEqual(top_level_markers, (False, False))
         self.assertDictEqual(
-            {"control": 1.0, "test": [{"yup": True, "meh": [], "nope": None, "nope::nan!": True}]},
+            {"control": 1.0, "test": [{"yup": True, "meh": [], "nope": None, "nope::nan": True}]},
             data,
         )

--- a/posthog/test/test_renderers.py
+++ b/posthog/test/test_renderers.py
@@ -1,0 +1,61 @@
+from django.test import TestCase
+
+from posthog.renderers import clean_data_for_json
+
+
+class TestCleanDataForJSON(TestCase):
+    def test_cleans_dict_with_nan_and_inf_scalars(self):
+        data = {
+            "control": 1.0,
+            "test_1": float("nan"),
+            "test_2": float("inf"),
+        }
+        top_level_markers = clean_data_for_json(data)
+
+        self.assertEqual(top_level_markers, (False, False))
+        self.assertDictEqual(
+            data, {"control": 1.0, "test_1": None, "test_1::nan!": True, "test_2": None, "test_2::inf!": True}
+        )
+
+    def test_cleans_dict_with_nan_and_inf_list(self):
+        data = {
+            "control": 1.0,
+            "test": [float("inf"), 1.0, float("nan")],
+        }
+        top_level_markers = clean_data_for_json(data)
+
+        self.assertEqual(top_level_markers, (False, False))
+        self.assertDictEqual(
+            {"control": 1.0, "test": [None, 1.0, None], "test::nan!": {2: True}, "test::inf!": {0: True}}, data
+        )
+
+    def test_cleans_dict_with_nan_and_inf_nested_list(self):
+        data = {
+            "control": 1.0,
+            "test": [float("inf"), [float("inf"), float("nan"), 1.0], float("nan"), 5.0],
+        }
+        top_level_markers = clean_data_for_json(data)
+
+        self.assertEqual(top_level_markers, (False, False))
+        self.assertDictEqual(
+            {
+                "control": 1.0,
+                "test": [None, [None, None, 1.0], None, 5.0],
+                "test::nan!": {1: {1: True}, 2: True},
+                "test::inf!": {0: True, 1: {0: True}},
+            },
+            data,
+        )
+
+    def test_cleans_dict_with_nan_nested_dict(self):
+        data = {
+            "control": 1.0,
+            "test": [{"yup": True, "meh": [], "nope": float("nan")}],
+        }
+        top_level_markers = clean_data_for_json(data)
+
+        self.assertEqual(top_level_markers, (False, False))
+        self.assertDictEqual(
+            {"control": 1.0, "test": [{"yup": True, "meh": [], "nope": None, "nope::nan!": True}]},
+            data,
+        )


### PR DESCRIPTION
## Problem

We've improved NaN handling in #12863, but it seems that wasn't enough (and also we've not used any of the tracking added there). The topic of NaNs came up again, this time in the context of a dashboard failing to load because one of its insights has a NaN in the results – see ZEN-4777.

## Changes

The frontend is never able to parse JSON with NaNs, because that's not valid JSON syntax. So we must avoid sending that as much as possible (though DRF's `STRICT_JSON` should still be false, because the errors DRF raises make it challenging to debug where the NaN was exactly). To this end, this PR overrides the default `JSONRenderer` to include a NaN/Infinity cleaning mechanism. It basically works like this:

Previous
```JSON
{
	"control": 1.0,
	"test_1": NaN,
	"test_2": Infinity
}
```
becomes 
```JSON
{
	"control": 1.0,
	"test_1": null,
    "test_1::nan!": true,
	"test_2": null,
    "test_2::inf!": true
}
```

We can debug and the frontend is happy-ish at the same time!

## How did you test this code?

Some unit tests.