### PR TITLE
fix: Next up button in persons

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerUpNext.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerUpNext.tsx
@@ -23,10 +23,14 @@ export function PlayerUpNext({ interrupted, clearInterrupted }: PlayerUpNextProp
 
     const goToRecording = (automatic: boolean): void => {
         reportNextRecordingTriggered(automatic)
-        router.actions.push(router.values.currentLocation.pathname, {
-            ...router.values.currentLocation.searchParams,
-            sessionRecordingId: nextSessionRecording?.id,
-        })
+        router.actions.push(
+            router.values.currentLocation.pathname,
+            {
+                ...router.values.currentLocation.searchParams,
+                sessionRecordingId: nextSessionRecording?.id,
+            },
+            router.values.currentLocation.hashParams
+        )
     }
 
     useEffect(() => {


### PR DESCRIPTION
## Problem

The NextUp button replaces the `sessionRecordingId` query param but it also reset the hashParams that the Person page depends on

## Changes

* Fixes it

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Ideally we have better tests for this but for now just 👀 