### PR TITLE
feat(management): add split_person command

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -364,7 +364,7 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         person: Person = self.get_object()
         distinct_ids = person.distinct_ids
 
-        split_person.delay(person.id, request.data.get("main_distinct_id", None))
+        split_person.delay(person.id, request.data.get("main_distinct_id", None), None)
 
         log_activity(
             organization_id=self.organization.id,

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -43,7 +43,7 @@ class KafkaProducerForTests:
         future.success(None)
         return future
 
-    def flush(self):
+    def flush(self, timeout=None):
         return
 
 

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -3,16 +3,16 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import kafka.errors
+from django.conf import settings
 from kafka import KafkaConsumer as KC
 from kafka import KafkaProducer as KP
 from kafka.producer.future import FutureProduceResult, FutureRecordMetadata, RecordMetadata
 from kafka.structs import TopicPartition
 from statshog.defaults.django import statsd
 from structlog import get_logger
-from django.conf import settings
+
 from posthog.client import sync_execute
 from posthog.kafka_client import helper
-
 from posthog.utils import SingletonDecorator
 
 KAFKA_PRODUCER_RETRIES = 5
@@ -154,6 +154,9 @@ class _KafkaProducer:
         # Record if the send request was successful or not
         future.add_callback(self.on_send_success).add_errback(lambda exc: self.on_send_failure(topic=topic, exc=exc))
         return future
+
+    def flush(self, timeout=None):
+        self.producer.flush(timeout)
 
     def close(self):
         self.producer.flush()

--- a/posthog/management/commands/split_person.py
+++ b/posthog/management/commands/split_person.py
@@ -3,6 +3,7 @@ import logging
 import structlog
 from django.core.management.base import BaseCommand
 
+from posthog.kafka_client.client import KafkaProducer
 from posthog.models import Person
 
 logger = structlog.get_logger(__name__)
@@ -51,5 +52,8 @@ def run(options):
     logger.info(f"Person has {distinct_id_count} distinct_ids to split")
     if live_run:
         person.split_person(None)
+        logger.info("Waiting on Kafka producer flush, for up to 2 minutes")
+        KafkaProducer().flush(120)
+        logger.info("Kafka producer queue flushed.")
     else:
         logger.info("Skipping the split, pass --live-run to run it")

--- a/posthog/management/commands/split_person.py
+++ b/posthog/management/commands/split_person.py
@@ -28,11 +28,11 @@ class Command(BaseCommand):
 def run(options):
     live_run = options["live_run"]
 
-    if not options["team_id"]:
+    if options["team_id"] is None:
         logger.error("You must specify --team-id to run this script")
         exit(1)
 
-    if not options["person_id"]:
+    if options["person_id"] is None:
         logger.error("You must specify --person-id to run this script")
         exit(1)
 
@@ -52,8 +52,8 @@ def run(options):
     logger.info(f"Person has {distinct_id_count} distinct_ids to split")
     if live_run:
         person.split_person(None)
-        logger.info("Waiting on Kafka producer flush, for up to 2 minutes")
-        KafkaProducer().flush(120)
+        logger.info("Waiting on Kafka producer flush, for up to 5 minutes")
+        KafkaProducer().flush(5 * 60)
         logger.info("Kafka producer queue flushed.")
     else:
         logger.info("Skipping the split, pass --live-run to run it")

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -42,12 +42,16 @@ class Person(models.Model):
         for distinct_id in distinct_ids:
             self.add_distinct_id(distinct_id)
 
-    def split_person(self, main_distinct_id: Optional[str]):
+    def split_person(self, main_distinct_id: Optional[str], max_splits: Optional[int]):
         distinct_ids = Person.objects.get(pk=self.pk).distinct_ids
         if not main_distinct_id:
             self.properties = {}
             self.save()
             main_distinct_id = distinct_ids[0]
+
+        if max_splits is not None and len(distinct_ids) > max_splits:
+            # Split the last N distinct_ids of the list
+            distinct_ids = distinct_ids[-1 * max_splits :]
 
         for distinct_id in distinct_ids:
             if not distinct_id == main_distinct_id:

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -42,7 +42,7 @@ class Person(models.Model):
         for distinct_id in distinct_ids:
             self.add_distinct_id(distinct_id)
 
-    def split_person(self, main_distinct_id: Optional[str], max_splits: Optional[int]):
+    def split_person(self, main_distinct_id: Optional[str], max_splits: Optional[int] = None):
         distinct_ids = Person.objects.get(pk=self.pk).distinct_ids
         if not main_distinct_id:
             self.properties = {}

--- a/posthog/tasks/split_person.py
+++ b/posthog/tasks/split_person.py
@@ -5,9 +5,9 @@ from posthog.models import Person
 
 
 @app.task(ignore_result=True, max_retries=1)
-def split_person(person_id: int, main_distinct_id: Optional[str]) -> None:
+def split_person(person_id: int, main_distinct_id: Optional[str], max_splits: Optional[int]) -> None:
     """
     Split all distinct ids into separate persons
     """
     person = Person.objects.get(pk=person_id)
-    person.split_person(main_distinct_id)
+    person.split_person(main_distinct_id, max_splits)


### PR DESCRIPTION
## Problem

The endpoint to split persons can timeout if the person has too many distinct_ids.

## Changes

- Add a management command that calls the same split code as the endpoint, but allows for longer runtimes
- The team-id param is required as a guardrail against fat-fingering the person ID
- Add a `flush` method to the `KafkaProducer` to make sure we wait for messages to be produced.

## How did you test this code?

```
DEBUG=1 python manage.py split_person --team-id=1 --person-id=1 --live-run
2023-08-04 16:54.27 [warning  ] ['️Environment variable DEBUG is set - PostHog is running in DEVELOPMENT MODE!', 'Be sure to unset DEBUG if this is supposed to be a PRODUCTION ENVIRONMENT!']
2023-08-04T14:54:27.510368Z [warning  ] Skipping async migrations setup. This is unsafe in production! [posthog.apps] pid=21629 tid=8609963520
2023-08-04T14:54:27.512383Z [info     ] AXES: BEGIN LOG                [axes.apps] pid=21629 tid=8609963520
2023-08-04T14:54:27.512707Z [info     ] AXES: Using django-axes version 5.9.0 [axes.apps] pid=21629 tid=8609963520
2023-08-04T14:54:27.512753Z [info     ] AXES: blocking by IP only.     [axes.apps] pid=21629 tid=8609963520
2023-08-04T14:54:28.076975Z [info     ] Person has 3 distinct_ids to split [posthog.management.commands.split_person] pid=21629 tid=8609963520
2023-08-04T14:54:28.221730Z [info     ] Waiting on Kafka producer flush, for up to 2 minutes [posthog.management.commands.split_person] pid=21629 tid=8609963520
2023-08-04T14:54:28.223773Z [info     ] Kafka producer queue flushed.  [posthog.management.commands.split_person] pid=21629 tid=8609963520
2023-08-04T14:54:28.224256Z [info     ] Closing the Kafka producer with 0 secs timeout. [kafka.producer.kafka] pid=21629 tid=8609963520
2023-08-04T14:54:28.224330Z [info     ] Proceeding to force close the producer since pending requests could not be completed within timeout 0. [kafka.producer.kafka] pid=21629 tid=8609963520
```

Without waiting on producer flush, some message might be dropped:

```
DEBUG=1 python manage.py split_person --team-id=1 --person-id=1 --live-run
2023-08-04 16:31.09 [warning  ] ['️Environment variable DEBUG is set - PostHog is running in DEVELOPMENT MODE!', 'Be sure to unset DEBUG if this is supposed to be a PRODUCTION ENVIRONMENT!']
2023-08-04T14:31:09.809602Z [warning  ] Skipping async migrations setup. This is unsafe in production! [posthog.apps] pid=17566 tid=8609963520
2023-08-04T14:31:09.811454Z [info     ] AXES: BEGIN LOG                [axes.apps] pid=17566 tid=8609963520
2023-08-04T14:31:09.811794Z [info     ] AXES: Using django-axes version 5.9.0 [axes.apps] pid=17566 tid=8609963520
2023-08-04T14:31:09.811840Z [info     ] AXES: blocking by IP only.     [axes.apps] pid=17566 tid=8609963520
2023-08-04T14:31:10.398193Z [info     ] Person has 2 distinct_ids to split [posthog.management.commands.split_person] pid=17566 tid=8609963520
2023-08-04T14:31:10.601494Z [info     ] Closing the Kafka producer with 0 secs timeout. [kafka.producer.kafka] pid=17566 tid=8609963520
2023-08-04T14:31:10.601669Z [info     ] Proceeding to force close the producer since pending requests could not be completed within timeout 0. [kafka.producer.kafka] pid=17566 tid=8609963520
2023-08-04T14:31:10.604515Z [warning  ] Produced messages to topic-partition TopicPartition(topic='clickhouse_person_distinct_id', partition=0) with base offset None log start offset None and error None. [kafka.producer.record_accumulator] pid=17566 tid=6325039104
2023-08-04T14:31:10.604869Z [warning  ] Produced messages to topic-partition TopicPartition(topic='clickhouse_person', partition=0) with base offset None log start offset None and error None. [kafka.producer.record_accumulator] pid=17566 tid=6325039104
```