### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere, Replicate Models - using litellm

### DIFF
--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Optional
 import openai
+from litellm import completion
 from posthog.event_usage import report_user_action
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.errors import HogQLException
@@ -91,7 +92,7 @@ def write_sql_from_prompt(prompt: str, *, current_query: Optional[str] = None, t
     prompt_tokens_total, completion_tokens_total = 0, 0
     for _ in range(3):  # Try up to 3 times in case the generated SQL is not valid HogQL
         attempt_count += 1
-        result = openai.ChatCompletion.create(
+        result = completion(
             model="gpt-3.5-turbo",
             temperature=0.8,
             messages=messages,

--- a/requirements.in
+++ b/requirements.in
@@ -82,3 +82,4 @@ more-itertools==9.0.0
 django-two-factor-auth==1.14.0
 phonenumberslite==8.13.6
 openai==0.27.8
+litellm==0.1.351


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Adding support for Azure, Claude-2, Llama2, Palm LLM models. Claude-2 has larger context windows and IMO is better at generating SQL queries. instead of needing to leave posthog to use it, i'd rather us it on the product. 

## Changes
This PR adds support for models from all the above mentioned providers using litellm https://github.com/BerriAI/litellm - a simple & light package to call OpenAI, Azure, Cohere, Anthropic API Endpoints

Here's a sample of how it's used:

```
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
Ran locally and ensured all liteLLM supported model calls worked 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
