### PR TITLE
feat: Create BatchExport from Export App

### DIFF
--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -123,13 +123,24 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -140,7 +151,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -151,7 +162,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -162,7 +173,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -191,7 +202,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -212,22 +223,6 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
-  '
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginconfig"."web_token",
-         "posthog_pluginsourcefile"."updated_at",
-         "posthog_plugin"."updated_at",
-         "posthog_pluginconfig"."updated_at"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_flag_with_behavioural_cohorts

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -123,24 +123,13 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
-  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -151,7 +140,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -162,7 +151,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -173,7 +162,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -202,7 +191,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -223,6 +212,22 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
+  '
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_flag_with_behavioural_cohorts

--- a/posthog/management/commands/create_batch_export_from_app.py
+++ b/posthog/management/commands/create_batch_export_from_app.py
@@ -96,8 +96,8 @@ class Command(BaseCommand):
         if options.get("backfill_batch_export", False) and dry_run is False:
             client = sync_connect()
             end_at = dt.datetime.utcnow()
-            start_at = end_at - (dt.timedelta(hours=1) if interval == "hourly" else dt.timedelta(days=1))
-            backfill_export(client, batch_export_id=batch_export.id, start_at=start_at, end_at=end_at)
+            start_at = end_at - (dt.timedelta(hours=1) if interval == "hour" else dt.timedelta(days=1))
+            backfill_export(client, batch_export_id=str(batch_export.id), start_at=start_at, end_at=end_at)
             self.stdout.write(f"Triggered backfill for BatchExport '{name}'.")
 
         self.stdout.write("Done!")

--- a/posthog/management/commands/create_batch_export_from_app.py
+++ b/posthog/management/commands/create_batch_export_from_app.py
@@ -90,7 +90,7 @@ class Command(BaseCommand):
 
         if options.get("disable_plugin_config", False) and dry_run is False:
             plugin_config.enabled = False
-            plugin_config.saved()
+            plugin_config.save()
             self.stdout.write("Disabled existing PluginConfig.")
 
         if options.get("backfill_batch_export", False) and dry_run is False:

--- a/posthog/management/commands/create_batch_export_from_app.py
+++ b/posthog/management/commands/create_batch_export_from_app.py
@@ -136,7 +136,7 @@ def map_plugin_config_to_destination(plugin_config: PluginConfig) -> tuple[str, 
         config = {
             "bucket_name": plugin_config.config["s3BucketName"],
             "region": plugin_config.config["awsRegion"],
-            "prefix": plugin_config.config["prefix"],
+            "prefix": plugin_config.config.get("prefix", ""),
             "aws_access_key_id": plugin_config.config["awsAccessKey"],
             "aws_secret_access_key": plugin_config.config["awsSecretAccessKey"],
         }

--- a/posthog/management/commands/create_batch_export_from_app.py
+++ b/posthog/management/commands/create_batch_export_from_app.py
@@ -1,0 +1,161 @@
+import datetime as dt
+import json
+
+from django.core.management.base import BaseCommand, CommandError
+
+from posthog.batch_exports.service import backfill_export, create_batch_export
+from posthog.models.plugin import PluginConfig
+from posthog.temporal.client import sync_connect
+
+
+class Command(BaseCommand):
+    help = "Create a BatchExport from an existing Export app"
+
+    def add_arguments(self, parser):
+        """Add arguments to the parser."""
+        parser.add_argument(
+            "--plugin-config-id", type=int, help="The ID of the PluginConfig to use as a base for the new BatchExport"
+        )
+        parser.add_argument(
+            "--team-id",
+            type=int,
+            help="The ID of the team that owns the PluginConfig and where to create the BatchExport.",
+        )
+        parser.add_argument("--name", default=None, help="The name for the new BatchExport.")
+        parser.add_argument(
+            "--interval",
+            type=str,
+            default="hour",
+            choices=["hour", "day"],
+            help="The frequency of the new BatchExport.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=False,
+            help="Without this flag, nothing will be executed.",
+        )
+        parser.add_argument(
+            "--disable-plugin-config",
+            action="store_true",
+            default=False,
+            help="Disable existing PluginConfig after creating new BatchExport.",
+        )
+        parser.add_argument(
+            "--backfill-batch-export",
+            action="store_true",
+            default=False,
+            help="Backfill the newly created BatchExport with the last period of data.",
+        )
+
+    def handle(self, *args, **options):
+        """Handle creation of a BatchExport from a given PluginConfig."""
+        team_id = options["team_id"]
+        plugin_config_id = options["plugin_config_id"]
+
+        try:
+            plugin_config = PluginConfig.objects.get(pk=plugin_config_id, team_id=team_id)
+        except PluginConfig.DoesNotExist:
+            raise CommandError(f"PluginConfig '{plugin_config_id}' does not exist in team '{team_id}'")
+
+        export_type, config = map_plugin_config_to_destination(plugin_config)
+
+        destination_data = {
+            "type": export_type,
+            "config": {k: v for k, v in config.items() if v is not None},
+        }
+
+        interval = options["interval"]
+        name = options["name"] if options["name"] is not None else f"{export_type} Export"
+        dry_run = options["dry_run"]
+
+        self.stdout.write(f"A BatchExport in Team '{team_id}' will be created with the following configuration:")
+        self.stdout.write(f"Name: {name}")
+        self.stdout.write(f"Interval: {interval}")
+        self.stdout.write(f"Destination: {destination_data}")
+
+        batch_export_data = {
+            "team_id": team_id,
+            "interval": interval,
+            "name": name,
+            "destination_data": destination_data,
+        }
+
+        if dry_run is True:
+            self.stdout.write("No BatchExport will be created as this is a dry run or confirmation check rejected.")
+            return json.dumps(batch_export_data, indent=4, default=str)
+        else:
+            batch_export = create_batch_export(**batch_export_data)
+            self.stdout.write(f"Created BatchExport '{name}' with id '{batch_export.id}'")
+
+        if options.get("disable_plugin_config", False) and dry_run is False:
+            plugin_config.enabled = False
+            plugin_config.saved()
+            self.stdout.write("Disabled existing PluginConfig.")
+
+        if options.get("backfill_batch_export", False) and dry_run is False:
+            client = sync_connect()
+            end_at = dt.datetime.utcnow()
+            start_at = end_at - (dt.timedelta(hours=1) if interval == "hourly" else dt.timedelta(days=1))
+            backfill_export(client, batch_export_id=batch_export.id, start_at=start_at, end_at=end_at)
+            self.stdout.write(f"Triggered backfill for BatchExport '{name}'.")
+
+        self.stdout.write("Done!")
+
+        return json.dumps(
+            {
+                "id": batch_export.id,
+                "team_id": batch_export.team.id,
+                "interval": batch_export.interval,
+                "name": batch_export.name,
+                "destination_data": {
+                    "type": batch_export.destination.type,
+                    "config": batch_export.destination.config,
+                },
+            },
+            indent=4,
+            default=str,
+        )
+
+
+def map_plugin_config_to_destination(plugin_config: PluginConfig) -> tuple[str, dict]:
+    """Map a PluginConfig model to a destination type and config.
+
+    Args:
+        plugin_config: The PluginConfig model from which to extract destination data.
+
+    Returns:
+        A tuple with the destination type and config.
+
+    Raises:
+        CommandError: On unsupported Plugin.
+    """
+    plugin = plugin_config.plugin
+
+    if plugin.name == "S3 Export":
+        config = {
+            "bucket_name": plugin_config.config["s3BucketName"],
+            "region": plugin_config.config["awsRegion"],
+            "prefix": plugin_config.config["prefix"],
+            "aws_access_key_id": plugin_config.config["awsAccessKey"],
+            "aws_secret_access_key": plugin_config.config["awsSecretAccessKey"],
+        }
+        export_type = "S3"
+    elif plugin.name == "Snowflake Export":
+        config = {
+            "account": plugin_config.config["account"],
+            "database": plugin_config.config["database"],
+            "warehouse": plugin_config.config["warehouse"],
+            "user": plugin_config.config["username"],
+            "password": plugin_config.config.get("password", None),
+            "schema": plugin_config.config["dbschema"],
+            "table_name": plugin_config.config["table"],
+            "role": plugin_config.config.get("role", None),
+        }
+        export_type = "Snowflake"
+    else:
+        raise CommandError(
+            f"Unsupported Plugin: '{plugin.name}'.  Supported Plugins are: 'Snowflake Export' and 'S3 Export'"
+        )
+
+    return (export_type, config)

--- a/posthog/management/commands/test/test_create_batch_export_from_app.py
+++ b/posthog/management/commands/test/test_create_batch_export_from_app.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import json
+import typing
 
 import pytest
 from asgiref.sync import async_to_sync
@@ -10,6 +11,9 @@ from django.core.management.base import CommandError
 from posthog.api.test.batch_exports.conftest import describe_schedule
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
+from posthog.management.commands.create_batch_export_from_app import (
+    map_plugin_config_to_destination,
+)
 from posthog.models import Plugin, PluginConfig
 from posthog.temporal.client import sync_connect
 from posthog.temporal.codec import EncryptionCodec
@@ -30,7 +34,7 @@ def team(organization):
 
 
 @pytest.fixture
-def snowflake_plugin(organization):
+def snowflake_plugin(organization) -> typing.Generator[Plugin, None, None]:
     plugin = Plugin.objects.create(
         name="Snowflake Export",
         url="https://github.com/PostHog/snowflake-export-plugin",
@@ -41,7 +45,19 @@ def snowflake_plugin(organization):
     plugin.delete()
 
 
-test_config = {
+@pytest.fixture
+def s3_plugin(organization) -> typing.Generator[Plugin, None, None]:
+    plugin = Plugin.objects.create(
+        name="S3 Export",
+        url="https://github.com/PostHog/s3-export-plugin",
+        plugin_type="custom",
+        organization=organization,
+    )
+    yield plugin
+    plugin.delete()
+
+
+test_snowflake_config = {
     "account": "snowflake-account",
     "username": "test-user",
     "password": "test-password",
@@ -51,88 +67,133 @@ test_config = {
     "table": "test-table",
     "role": "test-role",
 }
+test_s3_config = {
+    "awsAccessKey": "access-key",
+    "awsSecretAccessKey": "secret-access-key",
+    "s3BucketName": "test-bucket",
+    "awsRegion": "eu-central-1",
+    "prefix": "posthog/",
+}
 
 
 @pytest.fixture
-def snowflake_plugin_config(snowflake_plugin, team):
+def config(request):
+    if request.param == "S3":
+        return test_s3_config
+    elif request.param == "Snowflake":
+        return test_snowflake_config
+    else:
+        raise ValueError(f"Unsupported plugin: {request.param}")
+
+
+@pytest.fixture
+def snowflake_plugin_config(snowflake_plugin, team) -> typing.Generator[PluginConfig, None, None]:
     plugin_config = PluginConfig.objects.create(
-        plugin=snowflake_plugin, order=1, team=team, enabled=True, config=test_config
+        plugin=snowflake_plugin, order=1, team=team, enabled=True, config=test_snowflake_config
     )
     yield plugin_config
     plugin_config.delete()
 
 
+@pytest.fixture
+def s3_plugin_config(s3_plugin, team) -> typing.Generator[PluginConfig, None, None]:
+    plugin_config = PluginConfig.objects.create(
+        plugin=s3_plugin, order=1, team=team, enabled=True, config=test_s3_config
+    )
+    yield plugin_config
+    plugin_config.delete()
+
+
+@pytest.fixture
+def plugin_config(request, s3_plugin_config, snowflake_plugin_config) -> PluginConfig:
+    if request.param == "S3":
+        return s3_plugin_config
+    elif request.param == "Snowflake":
+        return snowflake_plugin_config
+    else:
+        raise ValueError(f"Unsupported plugin: {request.param}")
+
+
 @pytest.mark.django_db
-def test_create_batch_export_from_app_fails_with_mismatched_team_id(snowflake_plugin_config):
+@pytest.mark.parametrize(
+    "plugin_config,config,expected_type",
+    [("S3", "S3", "S3"), ("Snowflake", "Snowflake", "Snowflake")],
+    indirect=["plugin_config", "config"],
+)
+def test_map_plugin_config_to_destination(plugin_config, config, expected_type):
+    """Test we are mapping PluginConfig to the correct destination type and values."""
+    export_type, export_config = map_plugin_config_to_destination(plugin_config)
+
+    assert export_type == expected_type
+
+    result_values = list(export_config.values())
+    for value in config.values():
+        assert value in result_values
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("plugin_config", ["S3", "Snowflake"], indirect=True)
+def test_create_batch_export_from_app_fails_with_mismatched_team_id(plugin_config):
     """Test the create_batch_export_from_app command fails if team_id does not match PluginConfig.team_id."""
 
     with pytest.raises(CommandError):
         call_command(
             "create_batch_export_from_app",
-            "--name='Snowflake BatchExport'",
-            f"--plugin-config-id={snowflake_plugin_config.id}",
+            "--name='BatchExport'",
+            f"--plugin-config-id={plugin_config.id}",
             "--team-id=0",
         )
 
 
 @pytest.mark.django_db
-def test_create_batch_export_from_app_dry_run(snowflake_plugin_config, team):
+@pytest.mark.parametrize("plugin_config", ["S3", "Snowflake"], indirect=True)
+def test_create_batch_export_from_app_dry_run(plugin_config):
     """Test a dry_run of the create_batch_export_from_app command."""
 
     output = call_command(
         "create_batch_export_from_app",
-        f"--plugin-config-id={snowflake_plugin_config.id}",
-        f"--team-id={team.id}",
+        f"--plugin-config-id={plugin_config.id}",
+        f"--team-id={plugin_config.team.id}",
         "--dry-run",
     )
+    export_type, config = map_plugin_config_to_destination(plugin_config)
+
     batch_export_data = json.loads(output)
 
-    assert batch_export_data["team_id"] == team.id
+    assert batch_export_data["team_id"] == plugin_config.team.id
     assert batch_export_data["interval"] == "hour"
-    assert batch_export_data["name"] == "Snowflake Export"
+    assert batch_export_data["name"] == f"{export_type} Export"
     assert batch_export_data["destination_data"] == {
-        "type": "Snowflake",
-        "config": {
-            "account": test_config["account"],
-            "database": test_config["database"],
-            "warehouse": test_config["warehouse"],
-            "user": test_config["username"],
-            "password": test_config["password"],
-            "schema": test_config["dbschema"],
-            "table_name": test_config["table"],
-            "role": test_config["role"],
-        },
+        "type": export_type,
+        "config": config,
     }
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("interval", ["hour", "day"])
-def test_create_batch_export_from_app(snowflake_plugin_config, team, interval):
+@pytest.mark.parametrize(
+    "interval,plugin_config",
+    [("hour", "S3"), ("day", "S3"), ("hour", "Snowflake"), ("day", "Snowflake")],
+    indirect=["plugin_config"],
+)
+def test_create_batch_export_from_app(interval, plugin_config):
     """Test a dry_run of the create_batch_export_from_app command."""
 
     output = call_command(
         "create_batch_export_from_app",
-        f"--plugin-config-id={snowflake_plugin_config.id}",
-        f"--team-id={team.id}",
+        f"--plugin-config-id={plugin_config.id}",
+        f"--team-id={plugin_config.team.id}",
         f"--interval={interval}",
     )
+    export_type, config = map_plugin_config_to_destination(plugin_config)
+
     batch_export_data = json.loads(output)
 
-    assert batch_export_data["team_id"] == team.id
+    assert batch_export_data["team_id"] == plugin_config.team.id
     assert batch_export_data["interval"] == interval
-    assert batch_export_data["name"] == "Snowflake Export"
+    assert batch_export_data["name"] == f"{export_type} Export"
     assert batch_export_data["destination_data"] == {
-        "type": "Snowflake",
-        "config": {
-            "account": test_config["account"],
-            "database": test_config["database"],
-            "warehouse": test_config["warehouse"],
-            "user": test_config["username"],
-            "password": test_config["password"],
-            "schema": test_config["dbschema"],
-            "table_name": test_config["table"],
-            "role": test_config["role"],
-        },
+        "type": export_type,
+        "config": config,
     }
 
     temporal = sync_connect()
@@ -146,16 +207,10 @@ def test_create_batch_export_from_app(snowflake_plugin_config, team, interval):
     args = json.loads(decoded_payload[0].data)
 
     # Common inputs
-    assert args["team_id"] == team.pk
+    assert args["team_id"] == plugin_config.team.pk
     assert args["batch_export_id"] == str(batch_export_data["id"])
     assert args["interval"] == interval
 
-    # Snowflake specific inputs
-    assert args["account"] == test_config["account"]
-    assert args["database"] == test_config["database"]
-    assert args["warehouse"] == test_config["warehouse"]
-    assert args["user"] == test_config["username"]
-    assert args["password"] == test_config["password"]
-    assert args["schema"] == test_config["dbschema"]
-    assert args["table_name"] == test_config["table"]
-    assert args["role"] == test_config["role"]
+    # Type specific inputs
+    for key, expected in config.items():
+        assert args[key] == expected

--- a/posthog/management/commands/test/test_create_batch_export_from_app.py
+++ b/posthog/management/commands/test/test_create_batch_export_from_app.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
-from posthog.api.test.batch_exports.conftest import describe_schedule
+from posthog.api.test.batch_exports.conftest import describe_schedule, start_test_worker
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.management.commands.create_batch_export_from_app import (
@@ -185,7 +185,7 @@ def test_create_batch_export_from_app_dry_run(plugin_config):
     indirect=["plugin_config"],
 )
 def test_create_batch_export_from_app(interval, plugin_config, disable_plugin_config):
-    """Test a dry_run of the create_batch_export_from_app command."""
+    """Test a live run of the create_batch_export_from_app command."""
     args = [
         f"--plugin-config-id={plugin_config.id}",
         f"--team-id={plugin_config.team.id}",
@@ -229,3 +229,49 @@ def test_create_batch_export_from_app(interval, plugin_config, disable_plugin_co
     # Type specific inputs
     for key, expected in config.items():
         assert args[key] == expected
+
+
+@async_to_sync
+async def list_workflows(temporal, schedule_id: str):
+    """List Workflows scheduled by given Schedule."""
+    workflows = []
+
+    while len(workflows) == 0:
+        workflows = [workflow async for workflow in temporal.list_workflows(f'TemporalScheduledById="{schedule_id}"')]
+
+    return workflows
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "interval,plugin_config",
+    [
+        ("hour", "S3"),
+        ("day", "S3"),
+        ("hour", "Snowflake"),
+        ("day", "Snowflake"),
+    ],
+    indirect=["plugin_config"],
+)
+def test_create_batch_export_from_app_with_backfill(interval, plugin_config):
+    """Test a live run of the create_batch_export_from_app command with the backfill flag set."""
+    args = (
+        f"--plugin-config-id={plugin_config.id}",
+        f"--team-id={plugin_config.team.id}",
+        f"--interval={interval}",
+        "--backfill-batch-export",
+    )
+    export_type, _ = map_plugin_config_to_destination(plugin_config)
+
+    temporal = sync_connect()
+
+    with start_test_worker(temporal):
+        output = call_command("create_batch_export_from_app", *args)
+
+        batch_export_data = json.loads(output)
+        # time.sleep(10)
+        workflows = list_workflows(temporal, str(batch_export_data["id"]))
+
+        assert len(workflows) == 1
+        workflow_execution = workflows[0]
+        assert workflow_execution.workflow_type == f"{export_type.lower()}-export"

--- a/posthog/management/commands/test/test_create_batch_export_from_app.py
+++ b/posthog/management/commands/test/test_create_batch_export_from_app.py
@@ -1,0 +1,161 @@
+import datetime as dt
+import json
+
+import pytest
+from asgiref.sync import async_to_sync
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from posthog.api.test.batch_exports.conftest import describe_schedule
+from posthog.api.test.test_organization import create_organization
+from posthog.api.test.test_team import create_team
+from posthog.models import Plugin, PluginConfig
+from posthog.temporal.client import sync_connect
+from posthog.temporal.codec import EncryptionCodec
+
+
+@pytest.fixture
+def organization():
+    organization = create_organization("test")
+    yield organization
+    organization.delete()
+
+
+@pytest.fixture
+def team(organization):
+    team = create_team(organization=organization)
+    yield team
+    team.delete()
+
+
+@pytest.fixture
+def snowflake_plugin(organization):
+    plugin = Plugin.objects.create(
+        name="Snowflake Export",
+        url="https://github.com/PostHog/snowflake-export-plugin",
+        plugin_type="custom",
+        organization=organization,
+    )
+    yield plugin
+    plugin.delete()
+
+
+test_config = {
+    "account": "snowflake-account",
+    "username": "test-user",
+    "password": "test-password",
+    "warehouse": "test-warehouse",
+    "database": "test-db",
+    "dbschema": "test-schema",
+    "table": "test-table",
+    "role": "test-role",
+}
+
+
+@pytest.fixture
+def snowflake_plugin_config(snowflake_plugin, team):
+    plugin_config = PluginConfig.objects.create(
+        plugin=snowflake_plugin, order=1, team=team, enabled=True, config=test_config
+    )
+    yield plugin_config
+    plugin_config.delete()
+
+
+@pytest.mark.django_db
+def test_create_batch_export_from_app_fails_with_mismatched_team_id(snowflake_plugin_config):
+    """Test the create_batch_export_from_app command fails if team_id does not match PluginConfig.team_id."""
+
+    with pytest.raises(CommandError):
+        call_command(
+            "create_batch_export_from_app",
+            "--name='Snowflake BatchExport'",
+            f"--plugin-config-id={snowflake_plugin_config.id}",
+            "--team-id=0",
+        )
+
+
+@pytest.mark.django_db
+def test_create_batch_export_from_app_dry_run(snowflake_plugin_config, team):
+    """Test a dry_run of the create_batch_export_from_app command."""
+
+    output = call_command(
+        "create_batch_export_from_app",
+        f"--plugin-config-id={snowflake_plugin_config.id}",
+        f"--team-id={team.id}",
+        "--dry-run",
+    )
+    batch_export_data = json.loads(output)
+
+    assert batch_export_data["team_id"] == team.id
+    assert batch_export_data["interval"] == "hour"
+    assert batch_export_data["name"] == "Snowflake Export"
+    assert batch_export_data["destination_data"] == {
+        "type": "Snowflake",
+        "config": {
+            "account": test_config["account"],
+            "database": test_config["database"],
+            "warehouse": test_config["warehouse"],
+            "user": test_config["username"],
+            "password": test_config["password"],
+            "schema": test_config["dbschema"],
+            "table_name": test_config["table"],
+            "role": test_config["role"],
+        },
+    }
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("interval", ["hour", "day"])
+def test_create_batch_export_from_app(snowflake_plugin_config, team, interval):
+    """Test a dry_run of the create_batch_export_from_app command."""
+
+    output = call_command(
+        "create_batch_export_from_app",
+        f"--plugin-config-id={snowflake_plugin_config.id}",
+        f"--team-id={team.id}",
+        f"--interval={interval}",
+    )
+    batch_export_data = json.loads(output)
+
+    assert batch_export_data["team_id"] == team.id
+    assert batch_export_data["interval"] == interval
+    assert batch_export_data["name"] == "Snowflake Export"
+    assert batch_export_data["destination_data"] == {
+        "type": "Snowflake",
+        "config": {
+            "account": test_config["account"],
+            "database": test_config["database"],
+            "warehouse": test_config["warehouse"],
+            "user": test_config["username"],
+            "password": test_config["password"],
+            "schema": test_config["dbschema"],
+            "table_name": test_config["table"],
+            "role": test_config["role"],
+        },
+    }
+
+    temporal = sync_connect()
+
+    schedule = describe_schedule(temporal, str(batch_export_data["id"]))
+    expected_interval = dt.timedelta(**{f"{interval}s": 1})
+    assert schedule.schedule.spec.intervals[0].every == expected_interval
+
+    codec = EncryptionCodec(settings=settings)
+    decoded_payload = async_to_sync(codec.decode)(schedule.schedule.action.args)
+    args = json.loads(decoded_payload[0].data)
+
+    # Common inputs
+    assert args["team_id"] == team.pk
+    assert args["batch_export_id"] == str(batch_export_data["id"])
+    assert args["interval"] == interval
+
+    # Snowflake specific inputs
+    assert args["account"] == test_config["account"]
+    assert args["database"] == test_config["database"]
+    assert args["warehouse"] == test_config["warehouse"]
+    assert args["user"] == test_config["username"]
+    assert args["password"] == test_config["password"]
+    assert args["schema"] == test_config["dbschema"]
+    assert args["table_name"] == test_config["table"]
+    assert args["role"] == test_config["role"]

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -19,7 +19,10 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 from ee.clickhouse.materialized_columns.columns import materialize
 from posthog.api.test.test_organization import acreate_organization
 from posthog.api.test.test_team import acreate_team
-from posthog.temporal.tests.batch_exports.fixtures import acreate_batch_export, afetch_batch_export_runs
+from posthog.temporal.tests.batch_exports.fixtures import (
+    acreate_batch_export,
+    afetch_batch_export_runs,
+)
 from posthog.temporal.workflows.base import create_export_run, update_export_run_status
 from posthog.temporal.workflows.batch_exports import get_results_iterator
 from posthog.temporal.workflows.clickhouse import ClickHouseClient
@@ -545,7 +548,7 @@ async def test_s3_export_workflow_with_minio_bucket_and_a_lot_of_data(client: Ht
                     id=workflow_id,
                     task_queue=settings.TEMPORAL_TASK_QUEUE,
                     retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=dt.timedelta(seconds=120),
+                    execution_timeout=dt.timedelta(seconds=180),
                 )
 
     runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)


### PR DESCRIPTION
## Problem

This PR adds a command to allow migrating from a PluginConfig to a BatchExport. It works by taking as inputs:
* `team_id`: The id of the Team which contains the PluginConfig to migrate. Technically, this information is contained in the PluginConfig, which we obtain with the `plugin_config_id`, but we request `team_id` too as a safety check.
* `plugin_config_id`: The id of the PluginConfig to migrate. Only Snowflake Export and S3 Export plugins are supported.
* `name`: The name for the new BatchExport. If not given, we will use a generic "<type> Export" as name.
* `interval`: The interval of the new BatchExport. Defaults to "hour".
* `dry_run`: Safety flag.
* `disable-plugin-config`: If this flag is present, the PluginConfig will be disabled after the batch export is created.
* `backfill-batch-export: If this flag is present the last period of the BatchExport will be backfilled.

And executing the following steps:
1. Find the existing PluginConfig.
2. Create a BatchExport using the existing PluginConfig to extract destination data.
3. (Optional) Disable the PluginConfig.
4. (Optional) Backfill the last period (i.e. hour or day, depending on interval) of the BatchExport.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Lots of unit tests for the command.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
