### PR TITLE
fix(backend): old style property search

### DIFF
--- a/ee/clickhouse/queries/experiments/test_utils.py
+++ b/ee/clickhouse/queries/experiments/test_utils.py
@@ -54,7 +54,11 @@ class TestUtils(ClickhouseTestMixin, APIBaseTest):
 
     def test_with_no_feature_flag_properties_on_actions(self):
         action_credit_card = Action.objects.create(team=self.team, name="paid")
-        ActionStep.objects.create(action=action_credit_card, event="paid", properties=[{"$os": "Windows"}])
+        ActionStep.objects.create(
+            action=action_credit_card,
+            event="paid",
+            properties=[{"key": "$os", "type": "event", "value": ["Windows"], "operator": "exact"}],
+        )
 
         ActionStep.objects.create(action=action_credit_card, event="$autocapture", tag_name="button", text="Pay $10")
 
@@ -88,7 +92,11 @@ class TestUtils(ClickhouseTestMixin, APIBaseTest):
 
     def test_with_feature_flag_properties_on_actions(self):
         action_credit_card = Action.objects.create(team=self.team, name="paid")
-        ActionStep.objects.create(action=action_credit_card, event="paid", properties=[{"$os": "Windows"}])
+        ActionStep.objects.create(
+            action=action_credit_card,
+            event="paid",
+            properties=[{"key": "$os", "type": "event", "value": ["Windows"], "operator": "exact"}],
+        )
 
         filter = Filter(
             data={

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -4365,7 +4365,16 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         )
         sign_up_action = Action.objects.create(team=self.team, name="sign up")
         ActionStep.objects.create(
-            action=sign_up_action, event="sign up", properties={"$current_url": "https://posthog.com/feedback/1234"}
+            action=sign_up_action,
+            event="sign up",
+            properties=[
+                {
+                    "key": "$current_url",
+                    "type": "event",
+                    "value": ["https://posthog.com/feedback/1234"],
+                    "operator": "exact",
+                }
+            ],
         )
 
         with freeze_time("2020-01-02T13:01:01Z"):


### PR DESCRIPTION
## Problem

Splitting out work from https://github.com/PostHog/posthog/pull/16304

## Changes

There are two backend tests that create action steps with properties in the shape `{key: value}`, instead of `[{type:'event', key: 'key', value: 'value'}]` as we've been using forever. I checked and could not find properties of this shape used anywhere.

## How did you test this code?

https://github.com/PostHog/posthog/pull/16304/files#r1267952476
