### PR TITLE
refactor(flags): Cache cohorts and flags for local evaluation

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -892,7 +892,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:71 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:70 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -1089,7 +1089,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter
   '
-  /* user_id:73 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:72 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -892,7 +892,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:70 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:71 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -1089,7 +1089,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter
   '
-  /* user_id:72 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:73 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -406,7 +406,9 @@ class FeatureFlagViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidD
 
         feature_flags = get_feature_flags_for_team_in_cache(self.team_id)
         if feature_flags is None:
-            feature_flags = set_feature_flags_for_team_in_cache(self.team_id)
+            feature_flags = set_feature_flags_for_team_in_cache(
+                self.team_id, using_database=DATABASE_FOR_LOCAL_EVALUATION
+            )
 
         cohorts = {}
         seen_cohorts_cache: Dict[str, Cohort] = {

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -30,6 +30,10 @@ from posthog.models.feature_flag import (
     get_all_feature_flags,
     get_user_blast_radius,
 )
+from posthog.models.feature_flag.feature_flag import (
+    get_feature_flags_for_team_in_cache,
+    set_feature_flags_for_team_in_cache,
+)
 from posthog.models.feature_flag.flag_analytics import increment_request_count
 from posthog.models.feedback.survey import Survey
 from posthog.models.group_type_mapping import GroupTypeMapping
@@ -400,11 +404,17 @@ class FeatureFlagViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidD
     @action(methods=["GET"], detail=False, throttle_classes=[FeatureFlagThrottle])
     def local_evaluation(self, request: request.Request, **kwargs):
 
-        feature_flags: QuerySet[FeatureFlag] = FeatureFlag.objects.using(DATABASE_FOR_LOCAL_EVALUATION).filter(
-            team_id=self.team_id, deleted=False
-        )
+        feature_flags = get_feature_flags_for_team_in_cache(self.team_id)
+        if feature_flags is None:
+            feature_flags = set_feature_flags_for_team_in_cache(self.team_id)
+
         cohorts = {}
-        seen_cohorts_cache: Dict[str, Cohort] = {}
+        seen_cohorts_cache: Dict[str, Cohort] = {
+            str(cohort.pk): cohort
+            for cohort in Cohort.objects.using(DATABASE_FOR_LOCAL_EVALUATION).filter(
+                team_id=self.team_id, deleted=False
+            )
+        }
 
         parsed_flags = []
         for feature_flag in feature_flags:

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -2254,7 +2254,7 @@ class TestDecideUsesReadReplica(TransactionTestCase):
 
     then run this test:
 
-    POSTHOG_DB_NAME='posthog' READ_REPLICA_OPT_IN='decide' POSTHOG_POSTGRES_READ_HOST='localhost'  POSTHOG_DB_PASSWORD='posthog' POSTHOG_DB_USER='posthog'  ./bin/tests posthog/api/test/test_decide.py::TestDecideUsesReadReplica
+    POSTHOG_DB_NAME='posthog' READ_REPLICA_OPT_IN='decide,PersonalAPIKey,local_evaluation' POSTHOG_POSTGRES_READ_HOST='localhost'  POSTHOG_DB_PASSWORD='posthog' POSTHOG_DB_USER='posthog'  ./bin/tests posthog/api/test/test_decide.py::TestDecideUsesReadReplica
 
     or run locally with the same env vars.
     For local run, also change postgres_config in data_stores.py so you can have a different user for the read replica.
@@ -2351,14 +2351,14 @@ class TestDecideUsesReadReplica(TransactionTestCase):
         self.organization, self.team, self.user = org, team, user
         # this create fills up team cache^
 
-        with freeze_time("2021-01-01T00:00:00Z"), self.assertNumQueries(1, using="replica"), self.assertNumQueries(
-            1, using="default"
+        with freeze_time("2021-01-01T00:00:00Z"), self.assertNumQueries(2, using="replica"), self.assertNumQueries(
+            0, using="default"
         ):
             response = self._post_decide()
             # Replica queries:
             # E   1. SELECT 1
-            # Main DB queries:
             # E   1. SELECT "posthog_featureflag"."id", -- fill up feature flags cache
+            # Main DB queries:
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual({}, response.json()["featureFlags"])
@@ -3001,6 +3001,8 @@ class TestDecideUsesReadReplica(TransactionTestCase):
 
         client.logout()
         self.client.logout()
+        cache.clear()
+
         # `local_evaluation` is called by logged out clients!
 
         # missing API key
@@ -3012,7 +3014,7 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             response = self.client.get(f"/api/feature_flag/local_evaluation")
             self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-        with self.assertNumQueries(3, using="replica"), self.assertNumQueries(3, using="default"):
+        with self.assertNumQueries(4, using="replica"), self.assertNumQueries(3, using="default"):
             # Captured queries for write DB:
             # E   1. UPDATE "posthog_personalapikey" SET "last_used_at" = '2023-08-01T11:26:50.728057+00:00'
             # E   2. SELECT "posthog_team"."id", "posthog_team"."uuid", "posthog_team"."organization_id"
@@ -3020,6 +3022,7 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             # Captured queries for replica DB:
             # E   1. SELECT "posthog_personalapikey"."id", "posthog_personalapikey"."user_id", "posthog_personalapikey"."label", "posthog_personalapikey"."value", -- check API key, joined with user
             # E   2. SELECT "posthog_featureflag"."id", "posthog_featureflag"."key", "posthog_featureflag"."name", "posthog_featureflag"."filters", -- get flags
+            # E   3. SELECT "posthog_cohort"."id", "posthog_cohort"."name" -- get all cohorts, even if in this specific case they do nothing.
             # E   3. SELECT "posthog_grouptypemapping"."id", "posthog_grouptypemapping"."team_id", -- get groups
 
             response = self.client.get(
@@ -3029,7 +3032,7 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertTrue("flags" in response_data and "group_type_mapping" in response_data)
-        self.assertEqual(len(response_data["flags"]), 4)
+        self.assertEqual(len(response_data["flags"]), 3)
 
         sorted_flags = sorted(response_data["flags"], key=lambda x: x["key"])
 
@@ -3078,17 +3081,6 @@ class TestDecideUsesReadReplica(TransactionTestCase):
                 "ensure_experience_continuity": False,
             },
             sorted_flags[2],
-        )
-        self.assertDictContainsSubset(
-            {
-                "name": "Inactive feature",
-                "key": "inactive-flag",
-                "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]},
-                "deleted": False,
-                "active": False,
-                "ensure_experience_continuity": False,
-            },
-            sorted_flags[3],
         )
 
         self.assertEqual(response_data["group_type_mapping"], {"0": "organization", "1": "company"})
@@ -3186,8 +3178,9 @@ class TestDecideUsesReadReplica(TransactionTestCase):
 
         personal_api_key = generate_random_token_personal()
         PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+        cache.clear()
 
-        with self.assertNumQueries(5, using="replica"), self.assertNumQueries(3, using="default"):
+        with self.assertNumQueries(4, using="replica"), self.assertNumQueries(3, using="default"):
             # Captured queries for write DB:
             # E   1. UPDATE "posthog_personalapikey" SET "last_used_at" = '2023-08-01T11:26:50.728057+00:00'
             # E   2. SELECT "posthog_team"."id", "posthog_team"."uuid", "posthog_team"."organization_id"
@@ -3195,8 +3188,7 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             # Captured queries for replica DB:
             # E   1. SELECT "posthog_personalapikey"."id", "posthog_personalapikey"."user_id", "posthog_personalapikey"."label", "posthog_personalapikey"."value", -- check API key, joined with user
             # E   2. SELECT "posthog_featureflag"."id", "posthog_featureflag"."key", "posthog_featureflag"."name", "posthog_featureflag"."filters", -- get flags
-            # E   3. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select first cohort
-            # E   4. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select second cohort
+            # E   3. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select all cohorts
             # E   5. SELECT "posthog_grouptypemapping"."id", "posthog_grouptypemapping"."team_id", -- get groups
 
             response = self.client.get(
@@ -3360,16 +3352,15 @@ class TestDecideUsesReadReplica(TransactionTestCase):
         client.logout()
         self.client.logout()
 
-        with self.assertNumQueries(5, using="replica"), self.assertNumQueries(3, using="default"):
+        with self.assertNumQueries(3, using="replica"), self.assertNumQueries(3, using="default"):
             # Captured queries for write DB:
             # E   1. UPDATE "posthog_personalapikey" SET "last_used_at" = '2023-08-01T11:26:50.728057+00:00'
             # E   2. SELECT "posthog_team"."id", "posthog_team"."uuid", "posthog_team"."organization_id"
             # E   3. SELECT "posthog_organizationmembership"."id", "posthog_organizationmembership"."organization_id", - user org permissions check
             # Captured queries for replica DB:
             # E   1. SELECT "posthog_personalapikey"."id", "posthog_personalapikey"."user_id", "posthog_personalapikey"."label", "posthog_personalapikey"."value", -- check API key, joined with user
-            # E   2. SELECT "posthog_featureflag"."id", "posthog_featureflag"."key", "posthog_featureflag"."name", "posthog_featureflag"."filters", -- get flags
-            # E   3. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select first cohort
-            # E   4. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select second cohort
+            # get flags from cache
+            # E   3. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select all cohorts
             # E   5. SELECT "posthog_grouptypemapping"."id", "posthog_grouptypemapping"."team_id", -- get groups
 
             response = self.client.get(

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1140,7 +1140,7 @@ class TestFeatureFlag(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertTrue("flags" in response_data and "group_type_mapping" in response_data)
-        self.assertEqual(len(response_data["flags"]), 4)
+        self.assertEqual(len(response_data["flags"]), 3)  # inactive flags not sent
 
         sorted_flags = sorted(response_data["flags"], key=lambda x: x["key"])
 
@@ -1189,17 +1189,6 @@ class TestFeatureFlag(APIBaseTest):
                 "ensure_experience_continuity": False,
             },
             sorted_flags[2],
-        )
-        self.assertDictContainsSubset(
-            {
-                "name": "Inactive feature",
-                "key": "inactive-flag",
-                "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]},
-                "deleted": False,
-                "active": False,
-                "ensure_experience_continuity": False,
-            },
-            sorted_flags[3],
         )
 
         self.assertEqual(response_data["group_type_mapping"], {"0": "organization", "1": "company"})

--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -316,14 +316,16 @@ class FeatureFlagOverride(models.Model):
 
 
 def set_feature_flags_for_team_in_cache(
-    team_id: int, feature_flags: Optional[List[FeatureFlag]] = None
+    team_id: int, feature_flags: Optional[List[FeatureFlag]] = None, using_database: str = "default"
 ) -> List[FeatureFlag]:
     from posthog.api.feature_flag import MinimalFeatureFlagSerializer
 
     if feature_flags is not None:
         all_feature_flags = feature_flags
     else:
-        all_feature_flags = list(FeatureFlag.objects.filter(team_id=team_id, active=True, deleted=False))
+        all_feature_flags = list(
+            FeatureFlag.objects.using(using_database).filter(team_id=team_id, active=True, deleted=False)
+        )
 
     serialized_flags = MinimalFeatureFlagSerializer(all_feature_flags, many=True).data
 

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -592,7 +592,7 @@ def get_all_feature_flags(
 
     all_feature_flags = get_feature_flags_for_team_in_cache(team_id)
     if all_feature_flags is None:
-        all_feature_flags = set_feature_flags_for_team_in_cache(team_id)
+        all_feature_flags = set_feature_flags_for_team_in_cache(team_id, using_database=DATABASE_FOR_FLAG_MATCHING)
 
     flags_have_experience_continuity_enabled = any(
         feature_flag.ensure_experience_continuity for feature_flag in all_feature_flags


### PR DESCRIPTION
## Problem

We can significantly reduce the number of queries to the db by querying for all cohorts in a single query rather than querying for them one by one.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
