### PR TITLE
fix: Update fix_person_distinct_ids_after_delete.py

### DIFF
--- a/posthog/management/commands/fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/fix_person_distinct_ids_after_delete.py
@@ -51,7 +51,7 @@ def get_distinct_ids_tied_to_deleted_persons(team_id: int) -> List[str]:
         """
             SELECT distinct_id FROM (
                 SELECT distinct_id, argMax(person_id, version) AS person_id FROM person_distinct_id2 WHERE team_id = %(team)s GROUP BY distinct_id
-            ) AS pdi2 
+            ) AS pdi2
             WHERE pdi2.person_id NOT IN (SELECT id FROM person WHERE team_id = %(team)s)
             OR
             pdi2.person_id IN (SELECT id FROM person WHERE team_id = %(team)s AND is_deleted = 1)

--- a/posthog/management/commands/fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/fix_person_distinct_ids_after_delete.py
@@ -51,10 +51,10 @@ def get_distinct_ids_tied_to_deleted_persons(team_id: int) -> List[str]:
         """
             SELECT distinct_id FROM (
                 SELECT distinct_id, argMax(person_id, version) AS person_id FROM person_distinct_id2 WHERE team_id = %(team)s GROUP BY distinct_id
-            ) AS pdi2 INNER JOIN (
-                SELECT id FROM person WHERE team_id = %(team)s GROUP BY id HAVING max(is_deleted) = 1
-            ) AS p
-            ON pdi2.person_id = p.id
+            ) AS pdi2 
+            WHERE pdi2.person_id NOT IN (SELECT id FROM person WHERE team_id = %(team)s)
+            OR
+            pdi2.person_id IN (SELECT id FROM person WHERE team_id = %(team)s AND is_deleted = 1)
         """,
         {
             "team": team_id,


### PR DESCRIPTION
If the person didn't exist in CH for whatever reason the old query wouldn't find it and we wouldn't update the distinct_id

needed for https://posthoghelp.zendesk.com/agent/tickets/4428 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/7245) query verification: https://metabase.posthog.net/question/789-person-deletion-fix-distinct-ids-script-query

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
