### PR TITLE
fix: pressing enter putting early access feature in edit mode

### DIFF
--- a/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
+++ b/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
@@ -133,12 +133,7 @@ export function EarlyAccessFeature({ id }: { id?: string } = {}): JSX.Element {
                                 )}
                                 <LemonDivider vertical />
                                 {earlyAccessFeature.stage != EarlyAccessFeatureStage.GeneralAvailability && (
-                                    <LemonButton
-                                        type="secondary"
-                                        htmlType="submit"
-                                        onClick={() => editFeature(true)}
-                                        loading={false}
-                                    >
+                                    <LemonButton type="secondary" onClick={() => editFeature(true)} loading={false}>
                                         Edit
                                     </LemonButton>
                                 )}
@@ -406,11 +401,9 @@ function PersonsTableByFilter({ properties, emptyState }: PersonsTableByFilterPr
 
     return (
         <div className="space-y-2">
-            {
-                <div className="flex-col">
-                    <PersonsSearch />
-                </div>
-            }
+            <div className="flex-col">
+                <PersonsSearch />
+            </div>
             <div className="flex flex-row justify-between">
                 <PropertyFilters
                     pageKey="persons-list-page"


### PR DESCRIPTION
## Problem
https://github.com/PostHog/posthog/issues/16946
- Within the Early Access Feature Section, when searching for users, if you press `Enter` it would submit the form and send you to edit mode which would hide the entire user section.

## Changes
- Prevent enter from submitting a form a sending the user to edit mode.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
- manual testing locally
