### PR TITLE
fix: Remove draggable to notebook from Query for now

### DIFF
--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -12,10 +12,8 @@ import { AnyResponseType, Node, QueryContext, QuerySchema } from '~/queries/sche
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { useEffect, useState } from 'react'
 import { TimeToSeeData } from '../nodes/TimeToSeeData/TimeToSeeData'
-import { NotebookNodeType } from '~/types'
 import { QueryEditor } from '~/queries/QueryEditor/QueryEditor'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
-import { DraggableToNotebook } from 'scenes/notebooks/AddToNotebook/DraggableToNotebook'
 import { SavedInsight } from '../nodes/SavedInsight/SavedInsight'
 
 export interface QueryProps<T extends Node = QuerySchema | Node> {
@@ -76,12 +74,9 @@ export function Query(props: QueryProps): JSX.Element | null {
     }
 
     if (component) {
-        const queryWithoutFull: any = { ...query }
-        queryWithoutFull.full = false
-
         return (
             <ErrorBoundary>
-                <DraggableToNotebook node={NotebookNodeType.Query} properties={{ query: queryWithoutFull }}>
+                <>
                     {!!props.context?.showQueryEditor ? (
                         <>
                             <QueryEditor
@@ -95,7 +90,7 @@ export function Query(props: QueryProps): JSX.Element | null {
                         </>
                     ) : null}
                     {component}
-                </DraggableToNotebook>
+                </>
             </ErrorBoundary>
         )
     }


### PR DESCRIPTION
## Problem

The new draggable logic made the any dragging within a Query stop working. Forgot to remove it for now until we have dedicated buttons (raised [here](https://posthoghelp.zendesk.com/agent/tickets/4924))

## Changes

Removes the original Draggable wrapper

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
