### PR TITLE
feat: Add ForbiddenError to non-retryable errors

### DIFF
--- a/posthog/api/test/__snapshots__/test_person.ambr
+++ b/posthog/api/test/__snapshots__/test_person.ambr
@@ -458,8 +458,8 @@
       (SELECT id
        FROM person
        WHERE team_id = 2
-         AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000000%')
-              OR (id = '00000000-0000-4000-8000-000000000000'
+         AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000001%')
+              OR (id = '00000000-0000-4000-8000-000000000001'
                   OR id IN
                     (SELECT person_id
                      FROM
@@ -469,12 +469,12 @@
                         WHERE team_id = 2
                         GROUP BY distinct_id
                         HAVING argMax(is_deleted, version) = 0)
-                     WHERE distinct_id = '00000000-0000-4000-8000-000000000000' ))) )
+                     WHERE distinct_id = '00000000-0000-4000-8000-000000000001' ))) )
   GROUP BY id
   HAVING max(is_deleted) = 0
   AND argMax(created_at, version) < now() + INTERVAL 1 DAY
-  AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000000%')
-       OR (id = '00000000-0000-4000-8000-000000000000'
+  AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000001%')
+       OR (id = '00000000-0000-4000-8000-000000000001'
            OR id IN
              (SELECT person_id
               FROM
@@ -484,7 +484,7 @@
                  WHERE team_id = 2
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0)
-              WHERE distinct_id = '00000000-0000-4000-8000-000000000000' )))
+              WHERE distinct_id = '00000000-0000-4000-8000-000000000001' )))
   ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -335,6 +335,8 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
                         # Raised by Snowflake when a query cannot be compiled.
                         # Usually this means we don't have table permissions or something doesn't exist (db, schema).
                         "ProgrammingError",
+                        # Raised by Snowflake with an incorrect account name.
+                        "ForbiddenError",
                     ],
                 ),
             )


### PR DESCRIPTION
## Problem

Snowflake connector raises a `ForbiddenError` when account name is not properly formatted or is incorrect. No reason to keep retrying on these ones.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add `ForbiddenError` to non-retryable-errors.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
