### PR TITLE
refactor(insights): Unify relative date parsing

### DIFF
--- a/ee/api/session_recording_playlist.py
+++ b/ee/api/session_recording_playlist.py
@@ -181,9 +181,13 @@ class SessionRecordingPlaylistViewSet(StructuredViewSetMixin, ForbidDestroyModel
             elif key == "pinned":
                 queryset = queryset.filter(pinned=True)
             elif key == "date_from":
-                queryset = queryset.filter(last_modified_at__gt=relative_date_parse(request.GET["date_from"]))
+                queryset = queryset.filter(
+                    last_modified_at__gt=relative_date_parse(request.GET["date_from"], self.team.timezone_info)
+                )
             elif key == "date_to":
-                queryset = queryset.filter(last_modified_at__lt=relative_date_parse(request.GET["date_to"]))
+                queryset = queryset.filter(
+                    last_modified_at__lt=relative_date_parse(request.GET["date_to"], self.team.timezone_info)
+                )
             elif key == "search":
                 queryset = queryset.filter(
                     Q(name__icontains=request.GET["search"]) | Q(derived_name__icontains=request.GET["search"])

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -638,6 +638,7 @@ class FunnelCorrelation:
             correlation, e.g. "watched video"
 
         """
+        self._filter.team = self._team
 
         event_contingency_tables, success_total, failure_total = self.get_partial_event_contingency_tables()
 

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -666,9 +666,13 @@ class InsightViewSet(
             elif key == "favorited":
                 queryset = queryset.filter(Q(favorited=True))
             elif key == "date_from":
-                queryset = queryset.filter(last_modified_at__gt=relative_date_parse(request.GET["date_from"]))
+                queryset = queryset.filter(
+                    last_modified_at__gt=relative_date_parse(request.GET["date_from"], self.team.timezone_info)
+                )
             elif key == "date_to":
-                queryset = queryset.filter(last_modified_at__lt=relative_date_parse(request.GET["date_to"]))
+                queryset = queryset.filter(
+                    last_modified_at__lt=relative_date_parse(request.GET["date_to"], self.team.timezone_info)
+                )
             elif key == INSIGHT:
                 insight = request.GET[INSIGHT]
                 if insight == "JSON":

--- a/posthog/api/notebook.py
+++ b/posthog/api/notebook.py
@@ -247,7 +247,9 @@ class NotebookViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.Model
                     last_modified_at__gt=relative_date_parse(request.GET["date_from"], self.team.timezone_info)
                 )
             elif key == "date_to":
-                queryset = queryset.filter(last_modified_at__lt=relative_date_parse(request.GET["date_to"], self.team.timezone_info))
+                queryset = queryset.filter(
+                    last_modified_at__lt=relative_date_parse(request.GET["date_to"], self.team.timezone_info)
+                )
             elif key == "s":
                 queryset = queryset.filter(title__icontains=request.GET["s"])
             elif key == "contains":

--- a/posthog/api/notebook.py
+++ b/posthog/api/notebook.py
@@ -243,9 +243,11 @@ class NotebookViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.Model
             elif key == "created_by":
                 queryset = queryset.filter(created_by__uuid=request.GET["created_by"])
             elif key == "date_from":
-                queryset = queryset.filter(last_modified_at__gt=relative_date_parse(request.GET["date_from"]))
+                queryset = queryset.filter(
+                    last_modified_at__gt=relative_date_parse(request.GET["date_from"], self.team.timezone_info)
+                )
             elif key == "date_to":
-                queryset = queryset.filter(last_modified_at__lt=relative_date_parse(request.GET["date_to"]))
+                queryset = queryset.filter(last_modified_at__lt=relative_date_parse(request.GET["date_to"], self.team.timezone_info))
             elif key == "s":
                 queryset = queryset.filter(title__icontains=request.GET["s"])
             elif key == "contains":

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -1,9 +1,7 @@
 import json
 import re
-from datetime import datetime
 from typing import Dict, Optional, cast, Any, List
 
-from dateutil.parser import isoparse
 from django.http import HttpResponse, JsonResponse
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
@@ -35,24 +33,11 @@ from posthog.queries.time_to_see_data.serializers import SessionEventsQuerySeria
 from posthog.queries.time_to_see_data.sessions import get_session_events, get_sessions
 from posthog.rate_limit import AIBurstRateThrottle, AISustainedRateThrottle, TeamRateThrottle
 from posthog.schema import EventsQuery, HogQLQuery, HogQLMetadata
-from posthog.utils import relative_date_parse
 
 
 class QueryThrottle(TeamRateThrottle):
     scope = "query"
     rate = "120/hour"
-
-
-def parse_as_date_or(date_string: str | None, default: datetime) -> datetime:
-    if not date_string:
-        return default
-
-    try:
-        timestamp = isoparse(date_string)
-    except ValueError:
-        timestamp = relative_date_parse(date_string)
-
-    return timestamp or default
 
 
 class QuerySchemaParser(JSONParser):

--- a/posthog/api/test/__snapshots__/test_properties_timeline.ambr
+++ b/posthog/api/test/__snapshots__/test_properties_timeline.ambr
@@ -1,23 +1,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_for_existing_actor_with_six_events_but_only_two_relevant_changes
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."person_properties" AS "person_properties"
@@ -25,8 +22,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -40,31 +37,28 @@
 # name: TestPersonPropertiesTimeline.test_timeline_for_existing_actor_with_six_events_but_only_two_relevant_changes_without_events
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."person_properties" AS "person_properties"
                  FROM events e
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -78,23 +72,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_for_existing_actor_with_six_events_but_only_two_relevant_changes_without_filters
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array() AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array() AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."person_properties" AS "person_properties"
@@ -102,8 +93,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -117,23 +108,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_for_existing_actor_with_three_events_and_return_to_previous_value
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."person_properties" AS "person_properties"
@@ -141,8 +129,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -156,23 +144,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_for_existing_person_with_three_events_and_return_to_previous_value_at_single_day_point
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."person_properties" AS "person_properties"
@@ -180,8 +165,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-02 00:00:00', 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-02 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-02 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-02 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -195,23 +180,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_for_existing_person_with_three_events_and_return_to_previous_value_at_single_hour_point
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."person_properties" AS "person_properties"
@@ -219,8 +201,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-02 00:00:00', 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-02 01:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-02 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-02 01:00:00', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -234,23 +216,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_for_existing_person_with_three_events_and_return_to_previous_value_at_single_month_point
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."person_properties" AS "person_properties"
@@ -258,8 +237,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfMonth(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-31 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfMonth(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-31 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -273,23 +252,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_for_existing_person_with_three_events_and_return_to_previous_value_using_relative_date_from
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."person_properties" AS "person_properties"
@@ -297,8 +273,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-02 00:00:00', 'UTC')), 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-09 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-02 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-09 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -312,23 +288,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_for_new_actor_with_one_event_before_range
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."person_properties" AS "person_properties"
@@ -336,8 +309,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -351,23 +324,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_for_new_actor_with_one_event_before_range_materialized
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array("mat_pp_bar") AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array("mat_pp_bar") AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."mat_pp_bar" AS "mat_pp_bar",
@@ -376,8 +346,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -392,23 +362,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_for_new_actor_with_one_event_in_range
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."person_properties" AS "person_properties"
@@ -416,8 +383,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -431,23 +398,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_for_new_actor_with_one_event_in_range_materialized
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array("mat_pp_bar") AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array("mat_pp_bar") AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."mat_pp_bar" AS "mat_pp_bar",
@@ -456,8 +420,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -472,23 +436,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_with_two_events_in_range_using_breakdown
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array(replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."person_properties" AS "person_properties"
@@ -496,8 +457,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -511,23 +472,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_with_two_events_in_range_using_breakdown_materialized
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array("mat_pp_foo", "mat_pp_bar") AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array("mat_pp_foo", "mat_pp_bar") AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."mat_pp_bar" AS "mat_pp_bar",
@@ -537,8 +495,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -554,23 +512,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_with_two_events_in_range_using_filter_on_series
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array(replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."person_properties" AS "person_properties"
@@ -578,8 +533,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,
@@ -593,23 +548,20 @@
 # name: TestPersonPropertiesTimeline.test_timeline_with_two_events_in_range_using_filter_on_series_materialized
   '
   /* user_id:0 request:_snapshot_ */
-  SELECT timestamp,
-         properties,
-         end_event_number - start_event_number AS relevant_event_count
+  SELECT timestamp, properties,
+                    end_event_number - start_event_number AS relevant_event_count
   FROM
-    (SELECT timestamp,
-            properties,
-            start_event_number,
-            leadInFrame(start_event_number) OVER (
-                                                  ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
+    (SELECT timestamp, properties,
+                       start_event_number,
+                       leadInFrame(start_event_number) OVER (
+                                                             ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
-       (SELECT timestamp,
-               person_properties AS properties,
-               array("mat_pp_foo", "mat_pp_bar") AS relevant_property_values,
-               lagInFrame(relevant_property_values) OVER (
-                                                          ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
-                                                         row_number() OVER (
-                                                                            ORDER BY timestamp ASC) AS start_event_number
+       (SELECT timestamp, person_properties AS properties,
+                          array("mat_pp_foo", "mat_pp_bar") AS relevant_property_values,
+                          lagInFrame(relevant_property_values) OVER (
+                                                                     ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
+                                                                    row_number() OVER (
+                                                                                       ORDER BY timestamp ASC) AS start_event_number
         FROM (
                 (SELECT e.timestamp AS timestamp,
                         e."mat_pp_bar" AS "mat_pp_bar",
@@ -619,8 +571,8 @@
                  WHERE team_id = 2
                    AND person_id = '12345678-0000-0000-0000-000000000001'
                    AND event = '$pageview'
-                   AND toDateTime(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                   AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
                  ORDER BY timestamp ASC)
               UNION ALL
                 (SELECT NULL AS timestamp,

--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -7,7 +7,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -24,7 +24,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val3'), 0), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val3'), 0), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -42,7 +42,7 @@
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'path'), ''), 'null'), '^"|"$', ''), '%/%'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'path'), ''), 'null'), '^"|"$', ''))
-                                              and isNull('%/%')), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+                                              and isNull('%/%')), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -59,7 +59,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -76,7 +76,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val3'), 0), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val3'), 0), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -94,7 +94,7 @@
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
   WHERE and(equals(events.team_id, 2), ifNull(ilike(nullIf(nullIf(events.mat_path, ''), 'null'), '%/%'), isNull(nullIf(nullIf(events.mat_path, ''), 'null'))
-                                              and isNull('%/%')), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+                                              and isNull('%/%')), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -120,7 +120,7 @@
   /* user_id:0 request:_snapshot_ */
   SELECT events.event
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2022-01-12 00:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2022-01-12 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -133,7 +133,7 @@
   /* user_id:0 request:_snapshot_ */
   SELECT events.event
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2022-01-01 00:00:00.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2019-01-12 00:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2022-01-01 00:00:00.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2019-01-12 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -210,7 +210,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -227,7 +227,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), 0, ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), 0, ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -244,7 +244,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), 1, ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), 1, ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -261,7 +261,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val2'), 0), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val2'), 0), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -278,7 +278,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -295,7 +295,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), 0, ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), 0, ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -312,7 +312,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), 1, ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), 1, ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -329,7 +329,7 @@
          'a%sd',
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val2'), 0), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val2'), 0), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -360,7 +360,7 @@
      WHERE equals(person.team_id, 2)
      GROUP BY person.id
      HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
-  WHERE and(equals(events.team_id, 2), ifNull(equals(events__pdi__person.properties___email, 'tom@posthog.com'), 0), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(equals(events__pdi__person.properties___email, 'tom@posthog.com'), 0), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -391,7 +391,7 @@
      WHERE equals(person.team_id, 2)
      GROUP BY person.id
      HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0)) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
-  WHERE and(equals(events.team_id, 2), ifNull(equals(events__pdi__person.properties___email, 'tom@posthog.com'), 0), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(equals(events__pdi__person.properties___email, 'tom@posthog.com'), 0), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -405,7 +405,7 @@
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''),
          count()
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')
   ORDER BY count() DESC
   LIMIT 101
@@ -420,7 +420,7 @@
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''),
          count()
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')
   HAVING and(ifNull(greater(count(), 1), 0))
   ORDER BY count() DESC
@@ -436,7 +436,7 @@
   SELECT nullIf(nullIf(events.mat_key, ''), 'null'),
          count()
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   GROUP BY nullIf(nullIf(events.mat_key, ''), 'null')
   ORDER BY count() DESC
   LIMIT 101
@@ -451,7 +451,7 @@
   SELECT nullIf(nullIf(events.mat_key, ''), 'null'),
          count()
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   GROUP BY nullIf(nullIf(events.mat_key, ''), 'null')
   HAVING and(ifNull(greater(count(), 1), 0))
   ORDER BY count() DESC
@@ -468,7 +468,7 @@
          events.distinct_id,
          events.distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -484,7 +484,7 @@
          events.distinct_id,
          concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -498,7 +498,7 @@
   SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')),
          events.event
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   ORDER BY tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
@@ -512,7 +512,7 @@
   SELECT count(),
          events.event
   FROM events
-  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   GROUP BY events.event
   ORDER BY count() DESC
   LIMIT 101
@@ -527,7 +527,7 @@
   SELECT count(),
          events.event
   FROM events
-  WHERE and(equals(events.team_id, 2), or(equals(events.event, 'sign up'), like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), '%val2')), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:00:00.000000', 6, 'UTC')), 0))
+  WHERE and(equals(events.team_id, 2), or(equals(events.event, 'sign up'), like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), '%val2')), ifNull(less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), 0), ifNull(greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')), 0))
   GROUP BY events.event
   ORDER BY count() DESC, events.event ASC
   LIMIT 101

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -264,13 +264,13 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
 
         # with relative values
         with freeze_time("2020-01-11T12:03:03.829294Z"):
-            response = self.client.get(f"/api/projects/{self.team.id}/events/?after=5d&before=1d").json()
+            response = self.client.get(f"/api/projects/{self.team.id}/events/?after=4d&before=1d").json()
             self.assertEqual(len(response["results"]), 2)
 
             response = self.client.get(f"/api/projects/{self.team.id}/events/?after=6d&before=2h").json()
             self.assertEqual(len(response["results"]), 3)
 
-            response = self.client.get(f"/api/projects/{self.team.id}/events/?before=3d").json()
+            response = self.client.get(f"/api/projects/{self.team.id}/events/?before=4d").json()
             self.assertEqual(len(response["results"]), 1)
 
         action = Action.objects.create(team=self.team)

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -87,13 +87,13 @@ class BatchExportRunViewSet(StructuredViewSetMixin, viewsets.ReadOnlyModelViewSe
 
     def list(self, request: request.Request, *args, **kwargs) -> response.Response:
         """Get all BatchExportRuns for a BatchExport."""
-        if not isinstance(request.user, User) or request.user.current_team is None:
+        if not isinstance(request.user, User) or request.user.team is None:
             raise NotAuthenticated()
 
         after = self.request.query_params.get("after", "-7d")
         before = self.request.query_params.get("before", None)
-        after_datetime = relative_date_parse(after)
-        before_datetime = relative_date_parse(before) if before else now()
+        after_datetime = relative_date_parse(after, request.user.team.timezone_info)
+        before_datetime = relative_date_parse(before, request.user.team.timezone_info) if before else now()
         date_range = (after_datetime, before_datetime)
 
         page = self.paginate_queryset(self.get_queryset(date_range=date_range))

--- a/posthog/models/event/events_query.py
+++ b/posthog/models/event/events_query.py
@@ -98,7 +98,7 @@ def run_events_query(
     try:
         parsed_date = isoparse(before)
     except ValueError:
-        parsed_date = relative_date_parse(before)
+        parsed_date = relative_date_parse(before, team.timezone_info)
     where_exprs.append(parse_expr("timestamp < {timestamp}", {"timestamp": ast.Constant(value=parsed_date)}))
 
     # limit to the last 24h by default
@@ -107,7 +107,7 @@ def run_events_query(
         try:
             parsed_date = isoparse(after)
         except ValueError:
-            parsed_date = relative_date_parse(after)
+            parsed_date = relative_date_parse(after, team.timezone_info)
         where_exprs.append(parse_expr("timestamp > {timestamp}", {"timestamp": ast.Constant(value=parsed_date)}))
 
     # where & having

--- a/posthog/models/event/events_query.py
+++ b/posthog/models/event/events_query.py
@@ -98,7 +98,7 @@ def run_events_query(
     try:
         parsed_date = isoparse(before)
     except ValueError:
-        parsed_date = relative_date_parse(before, team.timezone_info)
+        parsed_date = relative_date_parse(before, team.timezone_info, always_truncate=True)
     where_exprs.append(parse_expr("timestamp < {timestamp}", {"timestamp": ast.Constant(value=parsed_date)}))
 
     # limit to the last 24h by default
@@ -107,7 +107,7 @@ def run_events_query(
         try:
             parsed_date = isoparse(after)
         except ValueError:
-            parsed_date = relative_date_parse(after, team.timezone_info)
+            parsed_date = relative_date_parse(after, team.timezone_info, always_truncate=True)
         where_exprs.append(parse_expr("timestamp > {timestamp}", {"timestamp": ast.Constant(value=parsed_date)}))
 
     # where & having

--- a/posthog/models/event/events_query.py
+++ b/posthog/models/event/events_query.py
@@ -98,7 +98,7 @@ def run_events_query(
     try:
         parsed_date = isoparse(before)
     except ValueError:
-        parsed_date = relative_date_parse(before, team.timezone_info, always_truncate=True)
+        parsed_date = relative_date_parse(before, team.timezone_info)
     where_exprs.append(parse_expr("timestamp < {timestamp}", {"timestamp": ast.Constant(value=parsed_date)}))
 
     # limit to the last 24h by default
@@ -107,7 +107,7 @@ def run_events_query(
         try:
             parsed_date = isoparse(after)
         except ValueError:
-            parsed_date = relative_date_parse(after, team.timezone_info, always_truncate=True)
+            parsed_date = relative_date_parse(after, team.timezone_info)
         where_exprs.append(parse_expr("timestamp > {timestamp}", {"timestamp": ast.Constant(value=parsed_date)}))
 
     # where & having

--- a/posthog/models/filters/__init__.py
+++ b/posthog/models/filters/__init__.py
@@ -1,5 +1,21 @@
+from typing import TypeAlias
 from .filter import Filter
 from .path_filter import PathFilter
 from .retention_filter import RetentionFilter
+from .stickiness_filter import StickinessFilter
+from .session_recordings_filter import SessionRecordingsFilter
+from .properties_timeline_filter import PropertiesTimelineFilter
 
-__all__ = ["Filter", "PathFilter", "RetentionFilter"]
+__all__ = [
+    "Filter",
+    "PathFilter",
+    "RetentionFilter",
+    "StickinessFilter",
+    "SessionRecordingsFilter",
+    "PropertiesTimelineFilter",
+    "AnyFilter",
+]
+
+AnyFilter: TypeAlias = (
+    Filter | PathFilter | RetentionFilter | StickinessFilter | SessionRecordingsFilter | PropertiesTimelineFilter
+)

--- a/posthog/models/filters/base_filter.py
+++ b/posthog/models/filters/base_filter.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 from rest_framework import request
 
 from posthog.hogql.context import HogQLContext
-from posthog.models.filters.mixins.common import BaseParamMixin
+from .mixins.common import BaseParamMixin
 from posthog.models.utils import sane_repr
 from posthog.utils import encode_get_request_params
 from rest_framework.exceptions import ValidationError

--- a/posthog/models/filters/filter.py
+++ b/posthog/models/filters/filter.py
@@ -1,5 +1,5 @@
-from posthog.models.filters.base_filter import BaseFilter
-from posthog.models.filters.mixins.common import (
+from .base_filter import BaseFilter
+from .mixins.common import (
     BreakdownMixin,
     BreakdownValueMixin,
     ClientQueryIdMixin,
@@ -26,7 +26,7 @@ from posthog.models.filters.mixins.common import (
     SmoothingIntervalsMixin,
     UpdatedAfterMixin,
 )
-from posthog.models.filters.mixins.funnel import (
+from .mixins.funnel import (
     FunnelCorrelationActorsMixin,
     FunnelCorrelationMixin,
     FunnelFromToStepsMixin,
@@ -40,10 +40,10 @@ from posthog.models.filters.mixins.funnel import (
     HistogramMixin,
     FunnelHogQLAggregationMixin,
 )
-from posthog.models.filters.mixins.groups import GroupsAggregationMixin
-from posthog.models.filters.mixins.interval import IntervalMixin
-from posthog.models.filters.mixins.property import PropertyMixin
-from posthog.models.filters.mixins.simplify import SimplifyFilterMixin
+from .mixins.groups import GroupsAggregationMixin
+from .mixins.interval import IntervalMixin
+from .mixins.property import PropertyMixin
+from .mixins.simplify import SimplifyFilterMixin
 
 
 class Filter(

--- a/posthog/models/filters/lifecycle_filter.py
+++ b/posthog/models/filters/lifecycle_filter.py
@@ -24,7 +24,8 @@ class LifecycleFilter(Filter):
         if data:
             target_date = data.get("target_date", None)
             if target_date:
-                self.target_date = relative_date_parse(target_date)
+                assert self.team is not None
+                self.target_date = relative_date_parse(target_date, self.team.timezone_info)
             if self.target_date is None:
                 raise ValidationError("Must include specified target date")
 

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -343,7 +343,7 @@ class DateMixin(BaseParamMixin):
             if self._date_from == "all":
                 return None
             elif isinstance(self._date_from, str):
-                date, delta_mapping = relative_date_parse_with_delta_mapping(self._date_from, team=self.team)
+                date, delta_mapping = relative_date_parse_with_delta_mapping(self._date_from, self.team.timezone_info)  # type: ignore
                 self.date_from_delta_mapping = delta_mapping
                 return date
             else:
@@ -367,7 +367,7 @@ class DateMixin(BaseParamMixin):
                     try:
                         return datetime.datetime.strptime(self._date_to, "%Y-%m-%d %H:%M:%S").replace(tzinfo=pytz.UTC)
                     except ValueError:
-                        date, delta_mapping = relative_date_parse_with_delta_mapping(self._date_to, team=self.team)
+                        date, delta_mapping = relative_date_parse_with_delta_mapping(self._date_to, self.team.timezone_info)  # type: ignore
                         self.date_to_delta_mapping = delta_mapping
                         return date
             else:

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -343,7 +343,7 @@ class DateMixin(BaseParamMixin):
             if self._date_from == "all":
                 return None
             elif isinstance(self._date_from, str):
-                date, delta_mapping = relative_date_parse_with_delta_mapping(self._date_from, self.team.timezone_info)  # type: ignore
+                date, delta_mapping = relative_date_parse_with_delta_mapping(self._date_from, self.team.timezone_info, always_truncate=True)  # type: ignore
                 self.date_from_delta_mapping = delta_mapping
                 return date
             else:
@@ -367,7 +367,7 @@ class DateMixin(BaseParamMixin):
                     try:
                         return datetime.datetime.strptime(self._date_to, "%Y-%m-%d %H:%M:%S").replace(tzinfo=pytz.UTC)
                     except ValueError:
-                        date, delta_mapping = relative_date_parse_with_delta_mapping(self._date_to, self.team.timezone_info)  # type: ignore
+                        date, delta_mapping = relative_date_parse_with_delta_mapping(self._date_to, self.team.timezone_info, always_truncate=True)  # type: ignore
                         self.date_to_delta_mapping = delta_mapping
                         return date
             else:

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -343,7 +343,7 @@ class DateMixin(BaseParamMixin):
             if self._date_from == "all":
                 return None
             elif isinstance(self._date_from, str):
-                date, delta_mapping = relative_date_parse_with_delta_mapping(self._date_from)
+                date, delta_mapping = relative_date_parse_with_delta_mapping(self._date_from, team=self.team)
                 self.date_from_delta_mapping = delta_mapping
                 return date
             else:
@@ -367,7 +367,7 @@ class DateMixin(BaseParamMixin):
                     try:
                         return datetime.datetime.strptime(self._date_to, "%Y-%m-%d %H:%M:%S").replace(tzinfo=pytz.UTC)
                     except ValueError:
-                        date, delta_mapping = relative_date_parse_with_delta_mapping(self._date_to)
+                        date, delta_mapping = relative_date_parse_with_delta_mapping(self._date_to, team=self.team)
                         self.date_to_delta_mapping = delta_mapping
                         return date
             else:

--- a/posthog/models/filters/mixins/funnel.py
+++ b/posthog/models/filters/mixins/funnel.py
@@ -264,7 +264,7 @@ class FunnelTrendsPersonsMixin(BaseParamMixin):
     @cached_property
     def entrance_period_start(self) -> Optional[datetime.datetime]:
         entrance_period_start_raw = self._data.get(ENTRANCE_PERIOD_START)
-        return relative_date_parse(entrance_period_start_raw) if entrance_period_start_raw else None
+        return relative_date_parse(entrance_period_start_raw, self.team.timezone_info) if entrance_period_start_raw else None  # type: ignore
 
     @cached_property
     def drop_off(self) -> Optional[bool]:

--- a/posthog/models/filters/mixins/retention.py
+++ b/posthog/models/filters/mixins/retention.py
@@ -82,7 +82,7 @@ class RetentionDateDerivedMixin(PeriodMixin, TotalIntervalsMixin, DateMixin, Sel
     def date_to(self) -> datetime:
         if self._date_to:
             if isinstance(self._date_to, str):
-                date_to = relative_date_parse(self._date_to)
+                date_to = relative_date_parse(self._date_to, self.team.timezone_info)  # type: ignore
             else:
                 date_to = self._date_to
         else:

--- a/posthog/models/filters/mixins/stickiness.py
+++ b/posthog/models/filters/mixins/stickiness.py
@@ -42,7 +42,7 @@ class StickinessDateMixin(DateMixin):
         elif _date_from:
             return _date_from
         else:
-            return relative_date_parse("-7d")
+            return relative_date_parse("-7d", self.team.timezone_info)
 
     @cached_property
     def _date_to(self) -> Optional[Union[str, datetime]]:

--- a/posthog/models/filters/mixins/stickiness.py
+++ b/posthog/models/filters/mixins/stickiness.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Callable, Optional, Union
+from typing import TYPE_CHECKING, Callable, Optional, Union
 
 from rest_framework.exceptions import ValidationError
 
@@ -7,8 +7,10 @@ from posthog.constants import DATE_FROM, DATE_TO, STICKINESS_DAYS
 from posthog.models.filters.mixins.common import BaseParamMixin, DateMixin
 from posthog.models.filters.mixins.interval import IntervalMixin
 from posthog.models.filters.mixins.utils import cached_property, include_dict
-from posthog.models.team import Team
 from posthog.utils import relative_date_parse
+
+if TYPE_CHECKING:
+    from posthog.models.team import Team
 
 
 class SelectedIntervalMixin(BaseParamMixin):
@@ -23,7 +25,7 @@ class SelectedIntervalMixin(BaseParamMixin):
 
 class StickinessDateMixin(DateMixin):
     get_earliest_timestamp: Optional[Callable]
-    team: Team
+    team: "Team"
 
     @cached_property
     def _date_from(self) -> Optional[Union[str, datetime]]:

--- a/posthog/models/filters/path_filter.py
+++ b/posthog/models/filters/path_filter.py
@@ -3,8 +3,8 @@ from typing import Any, Dict, Optional
 from rest_framework.request import Request
 
 from posthog.constants import INSIGHT_PATHS
-from posthog.models.filters.base_filter import BaseFilter
-from posthog.models.filters.mixins.common import (
+from .base_filter import BaseFilter
+from .mixins.common import (
     BreakdownMixin,
     ClientQueryIdMixin,
     DateMixin,
@@ -17,10 +17,10 @@ from posthog.models.filters.mixins.common import (
     SampleMixin,
     SearchMixin,
 )
-from posthog.models.filters.mixins.funnel import FunnelCorrelationMixin, FunnelPersonsStepMixin, FunnelWindowMixin
-from posthog.models.filters.mixins.groups import GroupsAggregationMixin
-from posthog.models.filters.mixins.interval import IntervalMixin
-from posthog.models.filters.mixins.paths import (
+from .mixins.funnel import FunnelCorrelationMixin, FunnelPersonsStepMixin, FunnelWindowMixin
+from .mixins.groups import GroupsAggregationMixin
+from .mixins.interval import IntervalMixin
+from .mixins.paths import (
     ComparatorDerivedMixin,
     EndPointMixin,
     FunnelPathsMixin,
@@ -36,8 +36,8 @@ from posthog.models.filters.mixins.paths import (
     TargetEventsMixin,
     PathsHogQLExpressionMixin,
 )
-from posthog.models.filters.mixins.property import PropertyMixin
-from posthog.models.filters.mixins.simplify import SimplifyFilterMixin
+from .mixins.property import PropertyMixin
+from .mixins.simplify import SimplifyFilterMixin
 
 
 class PathFilter(

--- a/posthog/models/filters/properties_timeline_filter.py
+++ b/posthog/models/filters/properties_timeline_filter.py
@@ -1,8 +1,8 @@
-from posthog.models.filters.base_filter import BaseFilter
-from posthog.models.filters.mixins.common import BreakdownMixin, DisplayDerivedMixin, EntitiesMixin
-from posthog.models.filters.mixins.groups import GroupsAggregationMixin
-from posthog.models.filters.mixins.interval import IntervalMixin
-from posthog.models.filters.mixins.property import PropertyMixin
+from .base_filter import BaseFilter
+from .mixins.common import BreakdownMixin, DisplayDerivedMixin, EntitiesMixin
+from .mixins.groups import GroupsAggregationMixin
+from .mixins.interval import IntervalMixin
+from .mixins.property import PropertyMixin
 
 
 class PropertiesTimelineFilter(

--- a/posthog/models/filters/retention_filter.py
+++ b/posthog/models/filters/retention_filter.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, Optional, Tuple, Union
 from rest_framework.request import Request
 
 from posthog.constants import INSIGHT_RETENTION
-from posthog.models.filters.base_filter import BaseFilter
-from posthog.models.filters.mixins.common import (
+from .base_filter import BaseFilter
+from .mixins.common import (
     BreakdownMixin,
     ClientQueryIdMixin,
     DisplayDerivedMixin,
@@ -15,12 +15,12 @@ from posthog.models.filters.mixins.common import (
     OffsetMixin,
     SampleMixin,
 )
-from posthog.models.filters.mixins.funnel import FunnelCorrelationMixin
-from posthog.models.filters.mixins.groups import GroupsAggregationMixin
-from posthog.models.filters.mixins.property import PropertyMixin
-from posthog.models.filters.mixins.retention import EntitiesDerivedMixin, RetentionDateDerivedMixin, RetentionTypeMixin
-from posthog.models.filters.mixins.simplify import SimplifyFilterMixin
-from posthog.models.filters.mixins.utils import cached_property, include_dict
+from .mixins.funnel import FunnelCorrelationMixin
+from .mixins.groups import GroupsAggregationMixin
+from .mixins.property import PropertyMixin
+from .mixins.retention import EntitiesDerivedMixin, RetentionDateDerivedMixin, RetentionTypeMixin
+from .mixins.simplify import SimplifyFilterMixin
+from .mixins.utils import cached_property, include_dict
 
 RETENTION_DEFAULT_INTERVALS = 11
 

--- a/posthog/models/filters/session_recordings_filter.py
+++ b/posthog/models/filters/session_recordings_filter.py
@@ -1,5 +1,5 @@
-from posthog.models import Filter
-from posthog.models.filters.mixins.session_recordings import PersonUUIDMixin, SessionRecordingsMixin
+from .filter import Filter
+from .mixins.session_recordings import PersonUUIDMixin, SessionRecordingsMixin
 
 
 class SessionRecordingsFilter(SessionRecordingsMixin, PersonUUIDMixin, Filter):

--- a/posthog/models/filters/stickiness_filter.py
+++ b/posthog/models/filters/stickiness_filter.py
@@ -1,11 +1,11 @@
-from typing import Any, Callable, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
 
 from django.db.models.functions.datetime import TruncDay, TruncHour, TruncMonth, TruncWeek
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 
-from posthog.models.filters.base_filter import BaseFilter
-from posthog.models.filters.mixins.common import (
+from .base_filter import BaseFilter
+from .mixins.common import (
     ClientQueryIdMixin,
     CompareMixin,
     EntitiesMixin,
@@ -21,10 +21,12 @@ from posthog.models.filters.mixins.common import (
     SearchMixin,
     ShownAsMixin,
 )
-from posthog.models.filters.mixins.property import PropertyMixin
-from posthog.models.filters.mixins.simplify import SimplifyFilterMixin
-from posthog.models.filters.mixins.stickiness import SelectedIntervalMixin, TotalIntervalsDerivedMixin
-from posthog.models.team import Team
+from .mixins.property import PropertyMixin
+from .mixins.simplify import SimplifyFilterMixin
+from .mixins.stickiness import SelectedIntervalMixin, TotalIntervalsDerivedMixin
+
+if TYPE_CHECKING:
+    from posthog.models.team import Team
 
 
 class StickinessFilter(
@@ -49,11 +51,11 @@ class StickinessFilter(
     BaseFilter,
 ):
     get_earliest_timestamp: Optional[Callable]
-    team: Team
+    team: "Team"
 
     def __init__(self, data: Optional[Dict[str, Any]] = None, request: Optional[Request] = None, **kwargs) -> None:
         super().__init__(data, request, **kwargs)
-        team: Optional[Team] = kwargs.get("team", None)
+        team: Optional["Team"] = kwargs.get("team", None)
         if not team:
             raise ValidationError("Team must be provided to stickiness filter")
         self.team = team

--- a/posthog/models/filters/test/test_lifecycle_filter.py
+++ b/posthog/models/filters/test/test_lifecycle_filter.py
@@ -64,4 +64,4 @@ class TestLifecycleFilter(BaseTest):
             },
         )
         self.assertEqual(filter.lifecycle_type, lifecycle_type)
-        self.assertEqual(filter.target_date, relative_date_parse(target_date))
+        self.assertEqual(filter.target_date, relative_date_parse(target_date, self.team.timezone_info))

--- a/posthog/models/filters/test/test_retention_filter.py
+++ b/posthog/models/filters/test/test_retention_filter.py
@@ -9,7 +9,7 @@ class TestFilter(BaseTest):
 
     def test_fill_date_from_and_date_to(self):
         with freeze_time("2020-10-01T12:00:00Z"):
-            filter = RetentionFilter(data={})
+            filter = RetentionFilter(data={}, team=self.team)
             self.assertEqual(filter.date_from.isoformat(), "2020-09-21T00:00:00+00:00")
             self.assertEqual(filter.date_to.isoformat(), "2020-10-02T00:00:00+00:00")
         #  Make sure these dates aren't present in final filter to ensure rolling retention
@@ -50,7 +50,7 @@ class TestFilter(BaseTest):
         }
 
         with freeze_time("2020-10-01T12:00:00Z"):
-            filter = RetentionFilter(data={"date_to": "2020-08-01"})
+            filter = RetentionFilter(data={"date_to": "2020-08-01"}, team=self.team)
         self.assertEqual(filter.date_from.isoformat(), "2020-07-22T00:00:00+00:00")
         self.assertEqual(filter.date_to.isoformat(), "2020-08-02T00:00:00+00:00")
         #  Make sure these dates aren't present in final filter to ensure rolling retention

--- a/posthog/models/filters/utils.py
+++ b/posthog/models/filters/utils.py
@@ -22,10 +22,10 @@ def earliest_timestamp_func(team_id: int):
 
 
 def get_filter(team, data: dict = {}, request: Optional[Request] = None):
-    from posthog.models.filters.filter import Filter
-    from posthog.models.filters.path_filter import PathFilter
-    from posthog.models.filters.retention_filter import RetentionFilter
-    from posthog.models.filters.stickiness_filter import StickinessFilter
+    from .filter import Filter
+    from .path_filter import PathFilter
+    from .retention_filter import RetentionFilter
+    from .stickiness_filter import StickinessFilter
 
     insight = data.get("insight")
     if not insight and request:

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -9,7 +9,6 @@ from django.contrib.postgres.fields import ArrayField
 from django.core.validators import MinLengthValidator
 from django.db import models
 from django.db.models.signals import post_delete, post_save
-import datetime as dt
 from zoneinfo import ZoneInfo
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.cloud_utils import is_cloud
@@ -302,10 +301,6 @@ class Team(UUIDClassicModel):
     @cached_property
     def timezone_info(self) -> ZoneInfo:
         return ZoneInfo(self.timezone)
-
-    def now(self) -> dt.datetime:
-        """Return the current time in the team's timezone."""
-        return dt.datetime.now().astimezone(self.timezone_info)
 
     def __str__(self):
         if self.name:

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -9,7 +9,8 @@ from django.contrib.postgres.fields import ArrayField
 from django.core.validators import MinLengthValidator
 from django.db import models
 from django.db.models.signals import post_delete, post_save
-
+import datetime as dt
+from zoneinfo import ZoneInfo
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.cloud_utils import is_cloud
 from posthog.helpers.dashboard_templates import create_dashboard_from_template
@@ -297,6 +298,14 @@ class Team(UUIDClassicModel):
         """,
             {"team_id": self.pk, "group_type_index": group_type_index},
         )[0][0]
+
+    @cached_property
+    def timezone_info(self) -> ZoneInfo:
+        return ZoneInfo(self.timezone)
+
+    def now(self) -> dt.datetime:
+        """Return the current time in the team's timezone."""
+        return dt.datetime.now().astimezone(self.timezone_info)
 
     def __str__(self):
         if self.name:

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -98,6 +98,7 @@ class ActorBaseQuery:
         self,
     ) -> Tuple[Union[QuerySet[Person], QuerySet[Group]], Union[List[SerializedGroup], List[SerializedPerson]], int]:
         """Get actors in data model and dict formats. Builds query and executes"""
+        self._filter.team = self._team
         query, params = self.actor_query()
         raw_result = insight_sync_execute(
             query,

--- a/posthog/queries/app_metrics/app_metrics.py
+++ b/posthog/queries/app_metrics/app_metrics.py
@@ -79,12 +79,12 @@ class AppMetricsQuery:
 
     @property
     def date_from(self):
-        return relative_date_parse(self.filter.validated_data.get("date_from"))
+        return relative_date_parse(self.filter.validated_data.get("date_from"), self.team.timezone_info)
 
     @property
     def date_to(self):
         date_to_string = self.filter.validated_data.get("date_to")
-        return relative_date_parse(date_to_string) if date_to_string is not None else now()
+        return relative_date_parse(date_to_string, self.team.timezone_info) if date_to_string is not None else now()
 
     @property
     def interval(self) -> IntervalType:

--- a/posthog/queries/app_metrics/app_metrics.py
+++ b/posthog/queries/app_metrics/app_metrics.py
@@ -79,12 +79,18 @@ class AppMetricsQuery:
 
     @property
     def date_from(self):
-        return relative_date_parse(self.filter.validated_data.get("date_from"), self.team.timezone_info)
+        return relative_date_parse(
+            self.filter.validated_data.get("date_from"), self.team.timezone_info, always_truncate=True
+        )
 
     @property
     def date_to(self):
         date_to_string = self.filter.validated_data.get("date_to")
-        return relative_date_parse(date_to_string, self.team.timezone_info) if date_to_string is not None else now()
+        return (
+            relative_date_parse(date_to_string, self.team.timezone_info, always_truncate=True)
+            if date_to_string is not None
+            else now()
+        )
 
     @property
     def interval(self) -> IntervalType:

--- a/posthog/queries/event_query/event_query.py
+++ b/posthog/queries/event_query/event_query.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from posthog.clickhouse.materialized_columns import ColumnName
 from posthog.models import Cohort, Filter, Property
 from posthog.models.cohort.util import is_precalculated_query
+from posthog.models.filters import AnyFilter
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.properties_timeline_filter import PropertiesTimelineFilter
@@ -30,9 +31,7 @@ class EventQuery(metaclass=ABCMeta):
     EVENT_TABLE_ALIAS = "e"
     PERSON_ID_OVERRIDES_TABLE_ALIAS = "overrides"
 
-    _filter: Union[
-        Filter, PathFilter, RetentionFilter, StickinessFilter, SessionRecordingsFilter, PropertiesTimelineFilter
-    ]
+    _filter: AnyFilter
     _team_id: int
     _column_optimizer: ColumnOptimizer
     _should_join_distinct_ids = False

--- a/posthog/queries/funnels/base.py
+++ b/posthog/queries/funnels/base.py
@@ -267,6 +267,7 @@ class ClickhouseFunnelBase(ABC):
             return self._format_single_funnel(results[0])
 
     def _exec_query(self) -> List[Tuple]:
+        self._filter.team = self._team
         query = self.get_query()
         return insight_sync_execute(
             query,

--- a/posthog/queries/funnels/base.py
+++ b/posthog/queries/funnels/base.py
@@ -133,7 +133,7 @@ class ClickhouseFunnelBase(ABC):
         # format default dates
         data: Dict[str, Any] = {}
         if not self._filter._date_from:
-            data.update({"date_from": relative_date_parse("-7d")})
+            data.update({"date_from": relative_date_parse("-7d", self._team.timezone_info)})
 
         if self._filter.breakdown and not self._filter.breakdown_type:
             data.update({"breakdown_type": "event"})

--- a/posthog/queries/property_values.py
+++ b/posthog/queries/property_values.py
@@ -14,7 +14,9 @@ def get_property_values_for_key(
     key: str, team: Team, event_names: Optional[List[str]] = None, value: Optional[str] = None
 ):
     property_field, mat_column_exists = get_property_string_expr("events", key, "%(key)s", "properties")
-    parsed_date_from = "AND timestamp >= '{}'".format(relative_date_parse("-7d").strftime("%Y-%m-%d 00:00:00"))
+    parsed_date_from = "AND timestamp >= '{}'".format(
+        relative_date_parse("-7d", team.timezone_info).strftime("%Y-%m-%d 00:00:00")
+    )
     parsed_date_to = "AND timestamp <= '{}'".format(timezone.now().strftime("%Y-%m-%d 23:59:59"))
     property_exists_filter = ""
     event_filter = ""

--- a/posthog/queries/query_date_range.py
+++ b/posthog/queries/query_date_range.py
@@ -1,31 +1,28 @@
-import re
 from datetime import datetime, timedelta
 from functools import cached_property
-from typing import Dict, Generic, Literal, Optional, Tuple, TypeVar
+from typing import Dict, Literal, Optional, Tuple
 
 import pytz
-from dateutil import parser
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
+from posthog.models.filters import AnyFilter
+from posthog.models.filters.filter import Filter
 
-from posthog.models.filters.mixins.common import DateMixin
-from posthog.models.filters.mixins.interval import IntervalMixin
 from posthog.models.team import Team
 from posthog.queries.util import PERIOD_TO_TRUNC_FUNC, TIME_IN_SECONDS, get_earliest_timestamp
-from posthog.utils import DEFAULT_DATE_FROM_DAYS
-
-F = TypeVar("F", DateMixin, IntervalMixin)
+from posthog.utils import DEFAULT_DATE_FROM_DAYS, relative_date_parse
 
 
 # Assume that any date being sent from the client is timezone aware according to the timezone that the team has set
-class QueryDateRange(Generic[F]):
-    _filter: F
+class QueryDateRange:
+    _filter: AnyFilter
     _team: Team
     _table: str
     _should_round: Optional[bool]
 
-    def __init__(self, filter: F, team: Team, should_round: Optional[bool] = None, table="") -> None:
+    def __init__(self, filter: Filter, team: Team, should_round: Optional[bool] = None, table="") -> None:
+        filter.team = team  # This is a dirty - but the easiest - way to get the team into the filter
         self._filter = filter
         self._team = team
         self._table = f"{table}." if table else ""
@@ -33,12 +30,9 @@ class QueryDateRange(Generic[F]):
 
     @cached_property
     def date_to_param(self) -> datetime:
-        if isinstance(self._filter, IntervalMixin) and not self._filter._date_to and self._filter.interval == "hour":
-            return self._now + relativedelta(minutes=1)
-
         date_to = self._now
         if isinstance(self._filter._date_to, str):
-            date_to = self._parse_date(self._filter._date_to)
+            date_to = relative_date_parse(self._filter._date_to, team=self._team)
         elif isinstance(self._filter._date_to, datetime):
             date_to = self._localize_to_team(self._filter._date_to)
 
@@ -61,7 +55,7 @@ class QueryDateRange(Generic[F]):
         if self._filter._date_from == "all":
             date_from = self.get_earliest_timestamp()
         elif isinstance(self._filter._date_from, str):
-            date_from = self._parse_date(self._filter._date_from)
+            date_from = relative_date_parse(self._filter._date_from, team=self._team)
         elif isinstance(self._filter._date_from, datetime):
             date_from = self._localize_to_team(self._filter._date_from)
         else:
@@ -81,66 +75,9 @@ class QueryDateRange(Generic[F]):
     def _localize_to_team(self, target: datetime):
         return target.astimezone(pytz.timezone(self._team.timezone))
 
-    # TODO: logic mirrors util function
-    def _parse_date(self, input):
-
-        try:
-            return datetime.strptime(input, "%Y-%m-%d")
-        except ValueError:
-            pass
-
-        # when input also contains the time for intervals "hour" and "minute"
-        # the above try fails. Try one more time from isoformat.
-        try:
-            return parser.isoparse(input)
-        except ValueError:
-            pass
-
-        # Check if the date passed in is an abbreviated date form (example: -5d)
-        regex = r"\-?(?P<number>[0-9]+)?(?P<type>[a-z])(?P<position>Start|End)?"
-        match = re.search(regex, input)
-        date = self._now
-
-        if not match:
-            return date
-        if match.group("type") == "h":
-            date -= relativedelta(hours=int(match.group("number")))
-            return date.replace(minute=0, second=0, microsecond=0)
-        elif match.group("type") == "d":
-            if match.group("number"):
-                date -= relativedelta(days=int(match.group("number")))
-                date += timedelta(seconds=1)  # prevent timestamps from capturing the previous day
-
-            if match.group("position") == "Start":
-                date = date.replace(hour=0, minute=0, second=0, microsecond=0)
-            if match.group("position") == "End":
-                date = date.replace(hour=23, minute=59, second=59, microsecond=59)
-        elif match.group("type") == "w":
-            if match.group("number"):
-                date -= relativedelta(weeks=int(match.group("number")))
-        elif match.group("type") == "m":
-            if match.group("number"):
-                date -= relativedelta(months=int(match.group("number")))
-            if match.group("position") == "Start":
-                date -= relativedelta(day=1)
-            if match.group("position") == "End":
-                date -= relativedelta(day=31)
-        elif match.group("type") == "q":
-            if match.group("number"):
-                date -= relativedelta(weeks=13 * int(match.group("number")))
-        elif match.group("type") == "y":
-            if match.group("number"):
-                date -= relativedelta(years=int(match.group("number")))
-            if match.group("position") == "Start":
-                date -= relativedelta(month=1, day=1)
-            if match.group("position") == "End":
-                date -= relativedelta(month=12, day=31)
-
-        return date
-
     @cached_property
     def interval_annotation(self) -> str:
-        period = self._filter.interval if isinstance(self._filter, IntervalMixin) else None
+        period = getattr(self._filter, "interval", None)
         if period is None:
             period = "day"
         ch_function = PERIOD_TO_TRUNC_FUNC.get(period.lower())
@@ -232,20 +169,20 @@ class QueryDateRange(Generic[F]):
 
     @cached_property
     def num_intervals(self) -> int:
-        if not isinstance(self._filter, IntervalMixin):
+        if not hasattr(self._filter, "interval"):
             return 1
-        if self._filter.interval == "month":
+        if self._filter.interval == "month":  # type: ignore
             rel_delta = relativedelta(self._end_time.replace(day=1), self._start_time.replace(day=1))
             return (rel_delta.years * 12) + rel_delta.months + 1
 
-        return int(self.time_difference.total_seconds() / TIME_IN_SECONDS[self._filter.interval]) + 1
+        return int(self.time_difference.total_seconds() / TIME_IN_SECONDS[self._filter.interval]) + 1  # type: ignore
 
     @cached_property
     def should_round(self) -> bool:
         if self._should_round is not None:
             return self._should_round
 
-        if not isinstance(self._filter, IntervalMixin) or self._filter.use_explicit_dates:
+        if not hasattr(self._filter, "interval") or self._filter.use_explicit_dates:
             return False
 
         round_interval = False
@@ -257,6 +194,6 @@ class QueryDateRange(Generic[F]):
         return round_interval
 
     def is_hourly(self, target):
-        if not isinstance(self._filter, IntervalMixin):
+        if not hasattr(self._filter, "interval"):
             return False
         return self._filter.interval == "hour" or (target and isinstance(target, str) and "h" in target)

--- a/posthog/queries/query_date_range.py
+++ b/posthog/queries/query_date_range.py
@@ -14,7 +14,7 @@ from posthog.utils import DEFAULT_DATE_FROM_DAYS, relative_date_parse, relative_
 
 
 class QueryDateRange:
-    """Translation of the raw `date_from` and `date_to` filter values to datetimes in the relevant project's timezone.
+    """Translation of the raw `date_from` and `date_to` filter values to datetimes.
 
     A raw `date_from` and `date_to` value can either be:
     - unset, in which case `date_from` takes the timestamp of the earliest event in the project and `date_to` equals now
@@ -55,12 +55,7 @@ class QueryDateRange:
         return date_to
 
     def get_earliest_timestamp(self):
-        try:
-            earliest_date = get_earliest_timestamp(self._team.pk)
-        except IndexError:
-            return timezone.now()  # TODO: fix
-        else:
-            return earliest_date
+        return get_earliest_timestamp(self._team.pk)
 
     @cached_property
     def date_from_param(self) -> datetime:

--- a/posthog/queries/query_date_range.py
+++ b/posthog/queries/query_date_range.py
@@ -177,7 +177,7 @@ class QueryDateRange:
         if not hasattr(self._filter, "interval"):
             return 1
         if self._filter.interval == "month":  # type: ignore
-            rel_delta = relativedelta(self._end_time.replace(day=1), self._start_time.replace(day=1))
+            rel_delta = relativedelta(self.date_to_param, self.date_from_param)
             return (rel_delta.years * 12) + rel_delta.months + 1
 
         return int(self.delta.total_seconds() / TIME_IN_SECONDS[self._filter.interval]) + 1  # type: ignore

--- a/posthog/queries/query_date_range.py
+++ b/posthog/queries/query_date_range.py
@@ -40,7 +40,7 @@ class QueryDateRange:
         delta_mapping = None
         if isinstance(self._filter._date_to, str):
             date_to, delta_mapping = relative_date_parse_with_delta_mapping(
-                self._filter._date_to, self._team.timezone_info
+                self._filter._date_to, self._team.timezone_info, always_truncate=True
             )
         elif isinstance(self._filter._date_to, datetime):
             date_to = self._localize_to_team(self._filter._date_to)

--- a/posthog/queries/retention/retention.py
+++ b/posthog/queries/retention/retention.py
@@ -23,6 +23,7 @@ class Retention:
         self._base_uri = base_uri
 
     def run(self, filter: RetentionFilter, team: Team, *args, **kwargs) -> List[Dict[str, Any]]:
+        filter.team = team
         retention_by_breakdown = self._get_retention_by_breakdown_values(filter, team)
         if filter.breakdowns:
             return self.process_breakdown_table_result(retention_by_breakdown, filter)

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -2775,8 +2775,8 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-05 10:01:01', 'UTC') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC')), toDateTime('2020-01-05 10:01:01', 'UTC')))
+               toStartOfHour(toDateTime('2020-01-05 10:59:59', 'UTC') - toIntervalHour(number)) AS day_start
+        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC')), toDateTime('2020-01-05 10:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC'))
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
@@ -2792,7 +2792,7 @@
         WHERE team_id = 2
           AND event = 'sign up'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC')), 'UTC')
-          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 10:01:01', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 10:59:59', 'UTC')
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start)
@@ -2837,8 +2837,8 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-05 10:01:01', 'UTC') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC')), toDateTime('2020-01-05 10:01:01', 'UTC')))
+               toStartOfHour(toDateTime('2020-01-05 10:59:59', 'UTC') - toIntervalHour(number)) AS day_start
+        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC')), toDateTime('2020-01-05 10:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) AS total,
@@ -2847,7 +2847,7 @@
         WHERE team_id = 2
           AND event = 'sign up'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC')), 'UTC')
-          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 10:01:01', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 10:59:59', 'UTC')
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start)
@@ -2863,8 +2863,8 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-05 10:01:01', 'America/Phoenix') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix')), toDateTime('2020-01-05 10:01:01', 'America/Phoenix')))
+               toStartOfHour(toDateTime('2020-01-05 10:59:59', 'America/Phoenix') - toIntervalHour(number)) AS day_start
+        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix')), toDateTime('2020-01-05 10:59:59', 'America/Phoenix')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix'))
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
@@ -2880,7 +2880,7 @@
         WHERE team_id = 2
           AND event = 'sign up'
           AND toTimeZone(timestamp, 'America/Phoenix') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix')), 'America/Phoenix')
-          AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 10:01:01', 'America/Phoenix')
+          AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 10:59:59', 'America/Phoenix')
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start)
@@ -2925,8 +2925,8 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-05 10:01:01', 'America/Phoenix') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix')), toDateTime('2020-01-05 10:01:01', 'America/Phoenix')))
+               toStartOfHour(toDateTime('2020-01-05 10:59:59', 'America/Phoenix') - toIntervalHour(number)) AS day_start
+        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix')), toDateTime('2020-01-05 10:59:59', 'America/Phoenix')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix'))
         UNION ALL SELECT count(*) AS total,
@@ -2935,7 +2935,7 @@
         WHERE team_id = 2
           AND event = 'sign up'
           AND toTimeZone(timestamp, 'America/Phoenix') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix')), 'America/Phoenix')
-          AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 10:01:01', 'America/Phoenix')
+          AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 10:59:59', 'America/Phoenix')
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start)
@@ -2951,8 +2951,8 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-05 10:01:01', 'Asia/Tokyo') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')), toDateTime('2020-01-05 10:01:01', 'Asia/Tokyo')))
+               toStartOfHour(toDateTime('2020-01-05 10:59:59', 'Asia/Tokyo') - toIntervalHour(number)) AS day_start
+        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')), toDateTime('2020-01-05 10:59:59', 'Asia/Tokyo')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo'))
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
@@ -2968,7 +2968,7 @@
         WHERE team_id = 2
           AND event = 'sign up'
           AND toTimeZone(timestamp, 'Asia/Tokyo') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')), 'Asia/Tokyo')
-          AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 10:01:01', 'Asia/Tokyo')
+          AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 10:59:59', 'Asia/Tokyo')
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start)
@@ -3013,8 +3013,8 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-05 10:01:01', 'Asia/Tokyo') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')), toDateTime('2020-01-05 10:01:01', 'Asia/Tokyo')))
+               toStartOfHour(toDateTime('2020-01-05 10:59:59', 'Asia/Tokyo') - toIntervalHour(number)) AS day_start
+        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')), toDateTime('2020-01-05 10:59:59', 'Asia/Tokyo')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo'))
         UNION ALL SELECT count(*) AS total,
@@ -3023,7 +3023,7 @@
         WHERE team_id = 2
           AND event = 'sign up'
           AND toTimeZone(timestamp, 'Asia/Tokyo') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')), 'Asia/Tokyo')
-          AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 10:01:01', 'Asia/Tokyo')
+          AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 10:59:59', 'Asia/Tokyo')
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start)

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -2355,58 +2355,6 @@
   ORDER BY breakdown_value
   '
 ---
-# name: TestTrends.test_timezones_daily.6
-  '
-  
-  SELECT groupArray(day_start) as date,
-         groupArray(count) AS total
-  FROM
-    (SELECT SUM(total) AS count,
-            day_start
-     FROM
-       (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-03 23:59:59', 'UTC') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-03 00:00:00', 'UTC')), toDateTime('2020-01-03 23:59:59', 'UTC')))
-        UNION ALL SELECT toUInt16(0) AS total,
-                         toStartOfHour(toDateTime('2020-01-03 00:00:00', 'UTC'))
-        UNION ALL SELECT count(*) AS total,
-                         toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
-        FROM events e
-        WHERE team_id = 2
-          AND event = 'sign up'
-          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-03 00:00:00', 'UTC')), 'UTC')
-          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 23:59:59', 'UTC')
-        GROUP BY date)
-     GROUP BY day_start
-     ORDER BY day_start)
-  '
----
-# name: TestTrends.test_timezones_daily.7
-  '
-  
-  SELECT groupArray(day_start) as date,
-         groupArray(count) AS total
-  FROM
-    (SELECT SUM(total) AS count,
-            day_start
-     FROM
-       (SELECT toUInt16(0) AS total,
-               toStartOfDay(toDateTime('2020-01-03 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
-        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-03 00:00:00', 'UTC')), toDateTime('2020-01-03 23:59:59', 'UTC')))
-        UNION ALL SELECT toUInt16(0) AS total,
-                         toStartOfDay(toDateTime('2020-01-03 00:00:00', 'UTC'))
-        UNION ALL SELECT count(*) AS total,
-                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
-        FROM events e
-        WHERE team_id = 2
-          AND event = 'sign up'
-          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-03 00:00:00', 'UTC')
-          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 23:59:59', 'UTC')
-        GROUP BY date)
-     GROUP BY day_start
-     ORDER BY day_start)
-  '
----
 # name: TestTrends.test_timezones_daily_minus_utc
   '
   
@@ -2610,58 +2558,6 @@
               day_start)
   GROUP BY breakdown_value
   ORDER BY breakdown_value
-  '
----
-# name: TestTrends.test_timezones_daily_minus_utc.6
-  '
-  
-  SELECT groupArray(day_start) as date,
-         groupArray(count) AS total
-  FROM
-    (SELECT SUM(total) AS count,
-            day_start
-     FROM
-       (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-03 23:59:59', 'America/Phoenix') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-03 00:00:00', 'America/Phoenix')), toDateTime('2020-01-03 23:59:59', 'America/Phoenix')))
-        UNION ALL SELECT toUInt16(0) AS total,
-                         toStartOfHour(toDateTime('2020-01-03 00:00:00', 'America/Phoenix'))
-        UNION ALL SELECT count(*) AS total,
-                         toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'America/Phoenix')) AS date
-        FROM events e
-        WHERE team_id = 2
-          AND event = 'sign up'
-          AND toTimeZone(timestamp, 'America/Phoenix') >= toDateTime(toStartOfHour(toDateTime('2020-01-03 00:00:00', 'America/Phoenix')), 'America/Phoenix')
-          AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-03 23:59:59', 'America/Phoenix')
-        GROUP BY date)
-     GROUP BY day_start
-     ORDER BY day_start)
-  '
----
-# name: TestTrends.test_timezones_daily_minus_utc.7
-  '
-  
-  SELECT groupArray(day_start) as date,
-         groupArray(count) AS total
-  FROM
-    (SELECT SUM(total) AS count,
-            day_start
-     FROM
-       (SELECT toUInt16(0) AS total,
-               toStartOfDay(toDateTime('2020-01-03 23:59:59', 'America/Phoenix') - toIntervalDay(number)) AS day_start
-        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-03 00:00:00', 'America/Phoenix')), toDateTime('2020-01-03 23:59:59', 'America/Phoenix')))
-        UNION ALL SELECT toUInt16(0) AS total,
-                         toStartOfDay(toDateTime('2020-01-03 00:00:00', 'America/Phoenix'))
-        UNION ALL SELECT count(*) AS total,
-                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'America/Phoenix')) AS date
-        FROM events e
-        WHERE team_id = 2
-          AND event = 'sign up'
-          AND toTimeZone(timestamp, 'America/Phoenix') >= toDateTime('2020-01-03 00:00:00', 'America/Phoenix')
-          AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-03 23:59:59', 'America/Phoenix')
-        GROUP BY date)
-     GROUP BY day_start
-     ORDER BY day_start)
   '
 ---
 # name: TestTrends.test_timezones_daily_plus_utc
@@ -2869,7 +2765,7 @@
   ORDER BY breakdown_value
   '
 ---
-# name: TestTrends.test_timezones_daily_plus_utc.6
+# name: TestTrends.test_timezones_hourly_relative_from
   '
   
   SELECT groupArray(day_start) as date,
@@ -2879,60 +2775,8 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-03 23:59:59', 'Asia/Tokyo') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-03 00:00:00', 'Asia/Tokyo')), toDateTime('2020-01-03 23:59:59', 'Asia/Tokyo')))
-        UNION ALL SELECT toUInt16(0) AS total,
-                         toStartOfHour(toDateTime('2020-01-03 00:00:00', 'Asia/Tokyo'))
-        UNION ALL SELECT count(*) AS total,
-                         toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'Asia/Tokyo')) AS date
-        FROM events e
-        WHERE team_id = 2
-          AND event = 'sign up'
-          AND toTimeZone(timestamp, 'Asia/Tokyo') >= toDateTime(toStartOfHour(toDateTime('2020-01-03 00:00:00', 'Asia/Tokyo')), 'Asia/Tokyo')
-          AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-03 23:59:59', 'Asia/Tokyo')
-        GROUP BY date)
-     GROUP BY day_start
-     ORDER BY day_start)
-  '
----
-# name: TestTrends.test_timezones_daily_plus_utc.7
-  '
-  
-  SELECT groupArray(day_start) as date,
-         groupArray(count) AS total
-  FROM
-    (SELECT SUM(total) AS count,
-            day_start
-     FROM
-       (SELECT toUInt16(0) AS total,
-               toStartOfDay(toDateTime('2020-01-03 23:59:59', 'Asia/Tokyo') - toIntervalDay(number)) AS day_start
-        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-03 00:00:00', 'Asia/Tokyo')), toDateTime('2020-01-03 23:59:59', 'Asia/Tokyo')))
-        UNION ALL SELECT toUInt16(0) AS total,
-                         toStartOfDay(toDateTime('2020-01-03 00:00:00', 'Asia/Tokyo'))
-        UNION ALL SELECT count(*) AS total,
-                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'Asia/Tokyo')) AS date
-        FROM events e
-        WHERE team_id = 2
-          AND event = 'sign up'
-          AND toTimeZone(timestamp, 'Asia/Tokyo') >= toDateTime('2020-01-03 00:00:00', 'Asia/Tokyo')
-          AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-03 23:59:59', 'Asia/Tokyo')
-        GROUP BY date)
-     GROUP BY day_start
-     ORDER BY day_start)
-  '
----
-# name: TestTrends.test_timezones_hourly
-  '
-  
-  SELECT groupArray(day_start) as date,
-         groupArray(count) AS total
-  FROM
-    (SELECT SUM(total) AS count,
-            day_start
-     FROM
-       (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-05 10:02:01', 'UTC') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC')), toDateTime('2020-01-05 10:02:01', 'UTC')))
+               toStartOfHour(toDateTime('2020-01-05 10:01:01', 'UTC') - toIntervalHour(number)) AS day_start
+        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC')), toDateTime('2020-01-05 10:01:01', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC'))
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
@@ -2948,13 +2792,13 @@
         WHERE team_id = 2
           AND event = 'sign up'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC')), 'UTC')
-          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 10:02:01', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 10:01:01', 'UTC')
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start)
   '
 ---
-# name: TestTrends.test_timezones_hourly.1
+# name: TestTrends.test_timezones_hourly_relative_from.1
   '
   /* user_id:0 request:_snapshot_ */
   SELECT person_id AS actor_id,
@@ -2983,7 +2827,7 @@
   OFFSET 0
   '
 ---
-# name: TestTrends.test_timezones_hourly.2
+# name: TestTrends.test_timezones_hourly_relative_from.2
   '
   
   SELECT groupArray(day_start) as date,
@@ -2993,8 +2837,8 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-05 10:02:01', 'UTC') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC')), toDateTime('2020-01-05 10:02:01', 'UTC')))
+               toStartOfHour(toDateTime('2020-01-05 10:01:01', 'UTC') - toIntervalHour(number)) AS day_start
+        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC')), toDateTime('2020-01-05 10:01:01', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC'))
         UNION ALL SELECT count(*) AS total,
@@ -3003,13 +2847,13 @@
         WHERE team_id = 2
           AND event = 'sign up'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC')), 'UTC')
-          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 10:02:01', 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 10:01:01', 'UTC')
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start)
   '
 ---
-# name: TestTrends.test_timezones_hourly_minus_utc
+# name: TestTrends.test_timezones_hourly_relative_from_minus_utc
   '
   
   SELECT groupArray(day_start) as date,
@@ -3019,8 +2863,8 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-05 10:02:01', 'America/Phoenix') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix')), toDateTime('2020-01-05 10:02:01', 'America/Phoenix')))
+               toStartOfHour(toDateTime('2020-01-05 10:01:01', 'America/Phoenix') - toIntervalHour(number)) AS day_start
+        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix')), toDateTime('2020-01-05 10:01:01', 'America/Phoenix')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix'))
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
@@ -3036,13 +2880,13 @@
         WHERE team_id = 2
           AND event = 'sign up'
           AND toTimeZone(timestamp, 'America/Phoenix') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix')), 'America/Phoenix')
-          AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 10:02:01', 'America/Phoenix')
+          AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 10:01:01', 'America/Phoenix')
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start)
   '
 ---
-# name: TestTrends.test_timezones_hourly_minus_utc.1
+# name: TestTrends.test_timezones_hourly_relative_from_minus_utc.1
   '
   /* user_id:0 request:_snapshot_ */
   SELECT person_id AS actor_id,
@@ -3071,7 +2915,7 @@
   OFFSET 0
   '
 ---
-# name: TestTrends.test_timezones_hourly_minus_utc.2
+# name: TestTrends.test_timezones_hourly_relative_from_minus_utc.2
   '
   
   SELECT groupArray(day_start) as date,
@@ -3081,8 +2925,8 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-05 10:02:01', 'America/Phoenix') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix')), toDateTime('2020-01-05 10:02:01', 'America/Phoenix')))
+               toStartOfHour(toDateTime('2020-01-05 10:01:01', 'America/Phoenix') - toIntervalHour(number)) AS day_start
+        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix')), toDateTime('2020-01-05 10:01:01', 'America/Phoenix')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix'))
         UNION ALL SELECT count(*) AS total,
@@ -3091,13 +2935,13 @@
         WHERE team_id = 2
           AND event = 'sign up'
           AND toTimeZone(timestamp, 'America/Phoenix') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix')), 'America/Phoenix')
-          AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 10:02:01', 'America/Phoenix')
+          AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 10:01:01', 'America/Phoenix')
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start)
   '
 ---
-# name: TestTrends.test_timezones_hourly_plus_utc
+# name: TestTrends.test_timezones_hourly_relative_from_plus_utc
   '
   
   SELECT groupArray(day_start) as date,
@@ -3107,8 +2951,8 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-05 10:02:01', 'Asia/Tokyo') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')), toDateTime('2020-01-05 10:02:01', 'Asia/Tokyo')))
+               toStartOfHour(toDateTime('2020-01-05 10:01:01', 'Asia/Tokyo') - toIntervalHour(number)) AS day_start
+        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')), toDateTime('2020-01-05 10:01:01', 'Asia/Tokyo')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo'))
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
@@ -3123,14 +2967,14 @@
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
           AND event = 'sign up'
-          AND toTimeZone(timestamp, 'Asia/Tokyo') >= toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')
-          AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 10:02:01', 'Asia/Tokyo')
+          AND toTimeZone(timestamp, 'Asia/Tokyo') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')), 'Asia/Tokyo')
+          AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 10:01:01', 'Asia/Tokyo')
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start)
   '
 ---
-# name: TestTrends.test_timezones_hourly_plus_utc.1
+# name: TestTrends.test_timezones_hourly_relative_from_plus_utc.1
   '
   /* user_id:0 request:_snapshot_ */
   SELECT person_id AS actor_id,
@@ -3159,7 +3003,7 @@
   OFFSET 0
   '
 ---
-# name: TestTrends.test_timezones_hourly_plus_utc.2
+# name: TestTrends.test_timezones_hourly_relative_from_plus_utc.2
   '
   
   SELECT groupArray(day_start) as date,
@@ -3169,8 +3013,8 @@
             day_start
      FROM
        (SELECT toUInt16(0) AS total,
-               toStartOfHour(toDateTime('2020-01-05 10:02:01', 'Asia/Tokyo') - toIntervalHour(number)) AS day_start
-        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')), toDateTime('2020-01-05 10:02:01', 'Asia/Tokyo')))
+               toStartOfHour(toDateTime('2020-01-05 10:01:01', 'Asia/Tokyo') - toIntervalHour(number)) AS day_start
+        FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')), toDateTime('2020-01-05 10:01:01', 'Asia/Tokyo')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo'))
         UNION ALL SELECT count(*) AS total,
@@ -3178,8 +3022,8 @@
         FROM events e
         WHERE team_id = 2
           AND event = 'sign up'
-          AND toTimeZone(timestamp, 'Asia/Tokyo') >= toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')
-          AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 10:02:01', 'Asia/Tokyo')
+          AND toTimeZone(timestamp, 'Asia/Tokyo') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')), 'Asia/Tokyo')
+          AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 10:01:01', 'Asia/Tokyo')
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start)

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -4106,6 +4106,84 @@
   ORDER BY breakdown_value
   '
 ---
+# name: TestTrends.test_trends_compare_day_interval_relative_range
+  '
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total
+  FROM
+    (SELECT SUM(total) AS count,
+            day_start
+     FROM
+       (SELECT toUInt16(0) AS total,
+               toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
+        UNION ALL SELECT toUInt16(0) AS total,
+                         toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
+        UNION ALL SELECT count(*) AS total,
+                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+        FROM events e
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+        GROUP BY date)
+     GROUP BY day_start
+     ORDER BY day_start)
+  '
+---
+# name: TestTrends.test_trends_compare_day_interval_relative_range.1
+  '
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total
+  FROM
+    (SELECT SUM(total) AS count,
+            day_start
+     FROM
+       (SELECT toUInt16(0) AS total,
+               toStartOfDay(toDateTime('2019-12-28 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-21 00:00:00', 'UTC')), toDateTime('2019-12-28 23:59:59', 'UTC')))
+        UNION ALL SELECT toUInt16(0) AS total,
+                         toStartOfDay(toDateTime('2019-12-21 00:00:00', 'UTC'))
+        UNION ALL SELECT count(*) AS total,
+                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+        FROM events e
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-21 00:00:00', 'UTC')), 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2019-12-28 23:59:59', 'UTC')
+        GROUP BY date)
+     GROUP BY day_start
+     ORDER BY day_start)
+  '
+---
+# name: TestTrends.test_trends_compare_day_interval_relative_range.2
+  '
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total
+  FROM
+    (SELECT SUM(total) AS count,
+            day_start
+     FROM
+       (SELECT toUInt16(0) AS total,
+               toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC') - toIntervalDay(number)) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
+        UNION ALL SELECT toUInt16(0) AS total,
+                         toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
+        UNION ALL SELECT count(*) AS total,
+                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+        FROM events e
+        WHERE team_id = 2
+          AND event = 'sign up'
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+        GROUP BY date)
+     GROUP BY day_start
+     ORDER BY day_start)
+  '
+---
 # name: TestTrends.test_trends_count_per_group_average_aggregated
   '
   

--- a/posthog/queries/test/test_base.py
+++ b/posthog/queries/test/test_base.py
@@ -16,7 +16,7 @@ class TestBase(APIBaseTest):
     def test_determine_compared_filter(self):
         from posthog.queries.base import determine_compared_filter
 
-        filter = PathFilter(data={"date_from": "2020-05-23", "date_to": "2020-05-29"})
+        filter = PathFilter(data={"date_from": "2020-05-23", "date_to": "2020-05-29"}, team=self.team)
         compared_filter = determine_compared_filter(filter)
 
         self.assertIsInstance(compared_filter, PathFilter)

--- a/posthog/queries/test/test_query_date_range.py
+++ b/posthog/queries/test/test_query_date_range.py
@@ -51,7 +51,7 @@ class TestQueryDateRange(APIBaseTest):
         )
         self.assertEqual(
             parsed_date_to % date_to_params,
-            "AND toTimeZone(timestamp, UTC) <= toDateTime(2021-08-25 00:01:00, UTC)",
+            "AND toTimeZone(timestamp, UTC) <= toDateTime(2021-08-25 00:59:59, UTC)",
         )  # ensure last hour is included
 
     def test_parsed_date_middle_of_hour(self):

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -584,7 +584,7 @@ def retention_test_factory(retention):
 
             # even if set to hour 6 it should default to beginning of day and include all pageviews above
             result, _ = retention().actors_in_period(
-                RetentionFilter(data={"date_to": _date(10, hour=6), "selected_interval": 0}), self.team
+                RetentionFilter(data={"date_to": _date(10, hour=6), "selected_interval": 0}, team=self.team), self.team
             )
             self.assertEqual(len(result), 1)
             self.assertTrue(result[0]["person"]["id"] == person1.uuid, person1.uuid)
@@ -602,7 +602,8 @@ def retention_test_factory(retention):
                         "target_entity": target_entity,
                         "returning_entity": {"id": "$pageview", "type": "events"},
                         "selected_interval": 0,
-                    }
+                    },
+                    team=self.team,
                 ),
                 self.team,
             )
@@ -618,7 +619,8 @@ def retention_test_factory(retention):
                         "target_entity": target_entity,
                         "returning_entity": {"id": "$pageview", "type": "events"},
                         "selected_interval": 0,
-                    }
+                    },
+                    team=self.team,
                 ),
                 self.team,
             )
@@ -675,7 +677,7 @@ def retention_test_factory(retention):
 
             # even if set to hour 6 it should default to beginning of day and include all pageviews above
             result, _ = retention().actors_in_period(
-                RetentionFilter(data={"date_to": _date(10, hour=6), "selected_interval": 2}), self.team
+                RetentionFilter(data={"date_to": _date(10, hour=6), "selected_interval": 2}, team=self.team), self.team
             )
 
             # should be descending order on number of appearances
@@ -697,7 +699,8 @@ def retention_test_factory(retention):
                         "target_entity": target_entity,
                         "returning_entity": {"id": "$pageview", "type": "events"},
                         "selected_interval": 0,
-                    }
+                    },
+                    team=self.team,
                 ),
                 self.team,
             )

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -1301,6 +1301,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         breakdown_vals = [val["breakdown_value"] for val in daily_response]
         self.assertTrue("value_21" in breakdown_vals)
 
+    @snapshot_clickhouse_queries
     def test_trends_compare_day_interval_relative_range(self):
         self._create_events()
         with freeze_time("2020-01-04T13:00:01Z"):

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -727,6 +727,57 @@
         ORDER BY day_start)) as sub_B
   '
 ---
+# name: TestFormula.test_hour_interval
+  '
+  SELECT sub_A.date,
+         arrayMap((A, B) -> A + B, arrayResize(sub_A.total, max_length, 0), arrayResize(sub_B.total, max_length, 0)) ,
+         arrayMax([length(sub_A.total), length(sub_B.total)]) as max_length
+  FROM
+    (SELECT groupArray(day_start) as date,
+            groupArray(count) AS total
+     FROM
+       (SELECT SUM(total) AS count,
+               day_start
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  toStartOfHour(toDateTime('2020-01-03 13:06:01', 'UTC') - toIntervalHour(number)) AS day_start
+           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:05:02', 'UTC')), toDateTime('2020-01-03 13:06:01', 'UTC')))
+           UNION ALL SELECT toUInt16(0) AS total,
+                            toStartOfHour(toDateTime('2020-01-02 13:05:02', 'UTC'))
+           UNION ALL SELECT sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) AS total,
+                            toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+           FROM events e
+           WHERE team_id = 2
+             AND event = 'session start'
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:05:02', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:06:01', 'UTC')
+           GROUP BY date)
+        GROUP BY day_start
+        ORDER BY day_start)) as sub_A
+  CROSS JOIN
+    (SELECT groupArray(day_start) as date,
+            groupArray(count) AS total
+     FROM
+       (SELECT SUM(total) AS count,
+               day_start
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  toStartOfHour(toDateTime('2020-01-03 13:06:01', 'UTC') - toIntervalHour(number)) AS day_start
+           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:05:02', 'UTC')), toDateTime('2020-01-03 13:06:01', 'UTC')))
+           UNION ALL SELECT toUInt16(0) AS total,
+                            toStartOfHour(toDateTime('2020-01-02 13:05:02', 'UTC'))
+           UNION ALL SELECT avg(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) AS total,
+                            toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+           FROM events e
+           WHERE team_id = 2
+             AND event = 'session start'
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:05:02', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:06:01', 'UTC')
+           GROUP BY date)
+        GROUP BY day_start
+        ORDER BY day_start)) as sub_B
+  '
+---
 # name: TestFormula.test_regression_formula_with_session_duration_aggregation
   '
   SELECT sub_A.date,

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -740,17 +740,17 @@
                day_start
         FROM
           (SELECT toUInt16(0) AS total,
-                  toStartOfHour(toDateTime('2020-01-03 13:06:01', 'UTC') - toIntervalHour(number)) AS day_start
-           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:05:02', 'UTC')), toDateTime('2020-01-03 13:06:01', 'UTC')))
+                  toStartOfHour(toDateTime('2020-01-03 13:59:59', 'UTC') - toIntervalHour(number)) AS day_start
+           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
            UNION ALL SELECT toUInt16(0) AS total,
-                            toStartOfHour(toDateTime('2020-01-02 13:05:02', 'UTC'))
+                            toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC'))
            UNION ALL SELECT sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) AS total,
                             toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
            FROM events e
            WHERE team_id = 2
              AND event = 'session start'
-             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:05:02', 'UTC')), 'UTC')
-             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:06:01', 'UTC')
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:59:59', 'UTC')
            GROUP BY date)
         GROUP BY day_start
         ORDER BY day_start)) as sub_A
@@ -762,17 +762,119 @@
                day_start
         FROM
           (SELECT toUInt16(0) AS total,
-                  toStartOfHour(toDateTime('2020-01-03 13:06:01', 'UTC') - toIntervalHour(number)) AS day_start
-           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:05:02', 'UTC')), toDateTime('2020-01-03 13:06:01', 'UTC')))
+                  toStartOfHour(toDateTime('2020-01-03 13:59:59', 'UTC') - toIntervalHour(number)) AS day_start
+           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
            UNION ALL SELECT toUInt16(0) AS total,
-                            toStartOfHour(toDateTime('2020-01-02 13:05:02', 'UTC'))
+                            toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC'))
            UNION ALL SELECT avg(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) AS total,
                             toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
            FROM events e
            WHERE team_id = 2
              AND event = 'session start'
-             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:05:02', 'UTC')), 'UTC')
-             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:06:01', 'UTC')
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:59:59', 'UTC')
+           GROUP BY date)
+        GROUP BY day_start
+        ORDER BY day_start)) as sub_B
+  '
+---
+# name: TestFormula.test_hour_interval_day_level_relative
+  '
+  SELECT sub_A.date,
+         arrayMap((A, B) -> A + B, arrayResize(sub_A.total, max_length, 0), arrayResize(sub_B.total, max_length, 0)) ,
+         arrayMax([length(sub_A.total), length(sub_B.total)]) as max_length
+  FROM
+    (SELECT groupArray(day_start) as date,
+            groupArray(count) AS total
+     FROM
+       (SELECT SUM(total) AS count,
+               day_start
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  toStartOfHour(toDateTime('2020-01-03 13:59:59', 'UTC') - toIntervalHour(number)) AS day_start
+           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
+           UNION ALL SELECT toUInt16(0) AS total,
+                            toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC'))
+           UNION ALL SELECT sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) AS total,
+                            toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+           FROM events e
+           WHERE team_id = 2
+             AND event = 'session start'
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:59:59', 'UTC')
+           GROUP BY date)
+        GROUP BY day_start
+        ORDER BY day_start)) as sub_A
+  CROSS JOIN
+    (SELECT groupArray(day_start) as date,
+            groupArray(count) AS total
+     FROM
+       (SELECT SUM(total) AS count,
+               day_start
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  toStartOfHour(toDateTime('2020-01-03 13:59:59', 'UTC') - toIntervalHour(number)) AS day_start
+           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
+           UNION ALL SELECT toUInt16(0) AS total,
+                            toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC'))
+           UNION ALL SELECT avg(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) AS total,
+                            toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+           FROM events e
+           WHERE team_id = 2
+             AND event = 'session start'
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:59:59', 'UTC')
+           GROUP BY date)
+        GROUP BY day_start
+        ORDER BY day_start)) as sub_B
+  '
+---
+# name: TestFormula.test_hour_interval_hour_level_relative
+  '
+  SELECT sub_A.date,
+         arrayMap((A, B) -> A + B, arrayResize(sub_A.total, max_length, 0), arrayResize(sub_B.total, max_length, 0)) ,
+         arrayMax([length(sub_A.total), length(sub_B.total)]) as max_length
+  FROM
+    (SELECT groupArray(day_start) as date,
+            groupArray(count) AS total
+     FROM
+       (SELECT SUM(total) AS count,
+               day_start
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  toStartOfHour(toDateTime('2020-01-03 13:59:59', 'UTC') - toIntervalHour(number)) AS day_start
+           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
+           UNION ALL SELECT toUInt16(0) AS total,
+                            toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC'))
+           UNION ALL SELECT sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) AS total,
+                            toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+           FROM events e
+           WHERE team_id = 2
+             AND event = 'session start'
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:59:59', 'UTC')
+           GROUP BY date)
+        GROUP BY day_start
+        ORDER BY day_start)) as sub_A
+  CROSS JOIN
+    (SELECT groupArray(day_start) as date,
+            groupArray(count) AS total
+     FROM
+       (SELECT SUM(total) AS count,
+               day_start
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  toStartOfHour(toDateTime('2020-01-03 13:59:59', 'UTC') - toIntervalHour(number)) AS day_start
+           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
+           UNION ALL SELECT toUInt16(0) AS total,
+                            toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC'))
+           UNION ALL SELECT avg(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) AS total,
+                            toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+           FROM events e
+           WHERE team_id = 2
+             AND event = 'session start'
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:59:59', 'UTC')
            GROUP BY date)
         GROUP BY day_start
         ORDER BY day_start)) as sub_B

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -792,15 +792,15 @@
         FROM
           (SELECT toUInt16(0) AS total,
                   toStartOfHour(toDateTime('2020-01-03 13:59:59', 'UTC') - toIntervalHour(number)) AS day_start
-           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
+           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
            UNION ALL SELECT toUInt16(0) AS total,
-                            toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC'))
+                            toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC'))
            UNION ALL SELECT sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) AS total,
                             toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
            FROM events e
            WHERE team_id = 2
              AND event = 'session start'
-             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC')), 'UTC')
              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:59:59', 'UTC')
            GROUP BY date)
         GROUP BY day_start
@@ -814,15 +814,15 @@
         FROM
           (SELECT toUInt16(0) AS total,
                   toStartOfHour(toDateTime('2020-01-03 13:59:59', 'UTC') - toIntervalHour(number)) AS day_start
-           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
+           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
            UNION ALL SELECT toUInt16(0) AS total,
-                            toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC'))
+                            toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC'))
            UNION ALL SELECT avg(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) AS total,
                             toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
            FROM events e
            WHERE team_id = 2
              AND event = 'session start'
-             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC')), 'UTC')
              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:59:59', 'UTC')
            GROUP BY date)
         GROUP BY day_start
@@ -843,15 +843,15 @@
         FROM
           (SELECT toUInt16(0) AS total,
                   toStartOfHour(toDateTime('2020-01-03 13:59:59', 'UTC') - toIntervalHour(number)) AS day_start
-           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
+           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
            UNION ALL SELECT toUInt16(0) AS total,
-                            toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC'))
+                            toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC'))
            UNION ALL SELECT sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) AS total,
                             toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
            FROM events e
            WHERE team_id = 2
              AND event = 'session start'
-             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC')), 'UTC')
              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:59:59', 'UTC')
            GROUP BY date)
         GROUP BY day_start
@@ -865,15 +865,15 @@
         FROM
           (SELECT toUInt16(0) AS total,
                   toStartOfHour(toDateTime('2020-01-03 13:59:59', 'UTC') - toIntervalHour(number)) AS day_start
-           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
+           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
            UNION ALL SELECT toUInt16(0) AS total,
-                            toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC'))
+                            toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC'))
            UNION ALL SELECT avg(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) AS total,
                             toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
            FROM events e
            WHERE team_id = 2
              AND event = 'session start'
-             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC')), 'UTC')
              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:59:59', 'UTC')
            GROUP BY date)
         GROUP BY day_start

--- a/posthog/queries/trends/test/test_formula.py
+++ b/posthog/queries/trends/test/test_formula.py
@@ -150,20 +150,7 @@ class TestFormula(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             data,
             [
-                0.0,  # starting at 2020-01-02 00:00 - 1 day before run_at (rounded to start of interval, i.e. day)
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                1200.0,
+                1200.0,  # starting at 2020-01-02 13:00 - 24 h before run_at (rounded to start of interval, i.e. hour)
                 0.0,
                 0.0,
                 0.0,

--- a/posthog/queries/trends/test/test_formula.py
+++ b/posthog/queries/trends/test/test_formula.py
@@ -111,11 +111,58 @@ class TestFormula(ClickhouseTestMixin, APIBaseTest):
         return action_response
 
     @snapshot_clickhouse_queries
-    def test_hour_interval(self):
+    def test_hour_interval_hour_level_relative(self):
+        data = self._run({"date_from": "-24h", "interval": "hour"}, run_at="2020-01-03T13:05:01Z")[0]["data"]
+        self.assertEqual(
+            data,
+            [
+                1200.0,  # starting at 2020-01-02 13:00 - 24 h before run_at (rounded to start of interval, i.e. hour)
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1350.0,
+            ],
+        )
+
+    @snapshot_clickhouse_queries
+    def test_hour_interval_day_level_relative(self):
         data = self._run({"date_from": "-1d", "interval": "hour"}, run_at="2020-01-03T13:05:01Z")[0]["data"]
         self.assertEqual(
             data,
             [
+                0.0,  # starting at 2020-01-02 00:00 - 1 day before run_at (rounded to start of interval, i.e. day)
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
                 1200.0,
                 0.0,
                 0.0,

--- a/posthog/queries/trends/test/test_formula.py
+++ b/posthog/queries/trends/test/test_formula.py
@@ -110,6 +110,7 @@ class TestFormula(ClickhouseTestMixin, APIBaseTest):
             )
         return action_response
 
+    @snapshot_clickhouse_queries
     def test_hour_interval(self):
         data = self._run({"date_from": "-1d", "interval": "hour"}, run_at="2020-01-03T13:05:01Z")[0]["data"]
         self.assertEqual(

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -155,14 +155,17 @@ class TestGeneralUtils(TestCase):
 class TestRelativeDateParse(TestCase):
     @freeze_time("2020-01-31T12:22:23")
     def test_hour(self):
-        self.assertEqual(relative_date_parse("-24h", ZoneInfo("UTC")).isoformat(), "2020-01-30T12:00:00+00:00")
-        self.assertEqual(relative_date_parse("-48h", ZoneInfo("UTC")).isoformat(), "2020-01-29T12:00:00+00:00")
+        self.assertEqual(relative_date_parse("-24h", ZoneInfo("UTC")).isoformat(), "2020-01-30T12:22:23+00:00")
+        self.assertEqual(relative_date_parse("-48h", ZoneInfo("UTC")).isoformat(), "2020-01-29T12:22:23+00:00")
 
     @freeze_time("2020-01-31")
     def test_day(self):
         self.assertEqual(relative_date_parse("dStart", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2020-01-31")
         self.assertEqual(relative_date_parse("-1d", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2020-01-30")
         self.assertEqual(relative_date_parse("-2d", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2020-01-29")
+
+        self.assertEqual(relative_date_parse("-1dStart", ZoneInfo("UTC")).isoformat(), "2020-01-30T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("-1dEnd", ZoneInfo("UTC")).isoformat(), "2020-01-30T23:59:59.999999+00:00")
 
     @freeze_time("2020-01-31")
     def test_month(self):

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from unittest.mock import call, patch
+from zoneinfo import ZoneInfo
 
 import pytest
 from django.core.handlers.wsgi import WSGIRequest
@@ -154,38 +155,38 @@ class TestGeneralUtils(TestCase):
 class TestRelativeDateParse(TestCase):
     @freeze_time("2020-01-31T12:22:23")
     def test_hour(self):
-        self.assertEqual(relative_date_parse("-24h").isoformat(), "2020-01-30T12:00:00+00:00")
-        self.assertEqual(relative_date_parse("-48h").isoformat(), "2020-01-29T12:00:00+00:00")
+        self.assertEqual(relative_date_parse("-24h", ZoneInfo("UTC")).isoformat(), "2020-01-30T12:00:00+00:00")
+        self.assertEqual(relative_date_parse("-48h", ZoneInfo("UTC")).isoformat(), "2020-01-29T12:00:00+00:00")
 
     @freeze_time("2020-01-31")
     def test_day(self):
-        self.assertEqual(relative_date_parse("dStart").strftime("%Y-%m-%d"), "2020-01-31")
-        self.assertEqual(relative_date_parse("-1d").strftime("%Y-%m-%d"), "2020-01-30")
-        self.assertEqual(relative_date_parse("-2d").strftime("%Y-%m-%d"), "2020-01-29")
+        self.assertEqual(relative_date_parse("dStart", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2020-01-31")
+        self.assertEqual(relative_date_parse("-1d", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2020-01-30")
+        self.assertEqual(relative_date_parse("-2d", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2020-01-29")
 
     @freeze_time("2020-01-31")
     def test_month(self):
-        self.assertEqual(relative_date_parse("-1m").strftime("%Y-%m-%d"), "2019-12-31")
-        self.assertEqual(relative_date_parse("-2m").strftime("%Y-%m-%d"), "2019-11-30")
+        self.assertEqual(relative_date_parse("-1m", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2019-12-31")
+        self.assertEqual(relative_date_parse("-2m", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2019-11-30")
 
-        self.assertEqual(relative_date_parse("mStart").strftime("%Y-%m-%d"), "2020-01-01")
-        self.assertEqual(relative_date_parse("-1mStart").strftime("%Y-%m-%d"), "2019-12-01")
-        self.assertEqual(relative_date_parse("-2mStart").strftime("%Y-%m-%d"), "2019-11-01")
+        self.assertEqual(relative_date_parse("mStart", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2020-01-01")
+        self.assertEqual(relative_date_parse("-1mStart", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2019-12-01")
+        self.assertEqual(relative_date_parse("-2mStart", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2019-11-01")
 
-        self.assertEqual(relative_date_parse("-1mEnd").strftime("%Y-%m-%d"), "2019-12-31")
-        self.assertEqual(relative_date_parse("-2mEnd").strftime("%Y-%m-%d"), "2019-11-30")
+        self.assertEqual(relative_date_parse("-1mEnd", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2019-12-31")
+        self.assertEqual(relative_date_parse("-2mEnd", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2019-11-30")
 
     @freeze_time("2020-01-31")
     def test_year(self):
-        self.assertEqual(relative_date_parse("-1y").strftime("%Y-%m-%d"), "2019-01-31")
-        self.assertEqual(relative_date_parse("-2y").strftime("%Y-%m-%d"), "2018-01-31")
+        self.assertEqual(relative_date_parse("-1y", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2019-01-31")
+        self.assertEqual(relative_date_parse("-2y", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2018-01-31")
 
-        self.assertEqual(relative_date_parse("yStart").strftime("%Y-%m-%d"), "2020-01-01")
-        self.assertEqual(relative_date_parse("-1yStart").strftime("%Y-%m-%d"), "2019-01-01")
+        self.assertEqual(relative_date_parse("yStart", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2020-01-01")
+        self.assertEqual(relative_date_parse("-1yStart", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2019-01-01")
 
     @freeze_time("2020-01-31")
     def test_normal_date(self):
-        self.assertEqual(relative_date_parse("2019-12-31").strftime("%Y-%m-%d"), "2019-12-31")
+        self.assertEqual(relative_date_parse("2019-12-31", ZoneInfo("UTC")).strftime("%Y-%m-%d"), "2019-12-31")
 
 
 class TestDefaultEventName(BaseTest):

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -169,14 +169,10 @@ def relative_date_parse_with_delta_mapping(
 ) -> Tuple[datetime.datetime, Optional[Dict[str, int]]]:
     """Returns the parsed datetime, along with the period mapping - if the input was a relative datetime string."""
     try:
-        return datetime.datetime.strptime(input, "%Y-%m-%d").replace(tzinfo=timezone_info), None
-    except ValueError:
-        pass
-
-    # when input also contains the time for intervals "hour" and "minute"
-    # the above try fails. Try one more time from isoformat.
-    try:
-        return parser.isoparse(input).replace(tzinfo=timezone_info), None
+        # This supports a few formats, but we primarily care about:
+        # YYYY-MM-DD, YYYY-MM-DD[T]hh:mm, YYYY-MM-DD[T]hh:mm:ss, YYYY-MM-DD[T]hh:mm:ss.ssssss
+        # (timezone offsets are recognized as well)
+        return parser.isoparse(input).astimezone(timezone_info), None
     except ValueError:
         pass
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -165,7 +165,7 @@ def get_current_day(at: Optional[datetime.datetime] = None) -> Tuple[datetime.da
 
 
 def relative_date_parse_with_delta_mapping(
-    input: str, timezone_info: ZoneInfo
+    input: str, timezone_info: ZoneInfo, *, always_truncate: bool = False
 ) -> Tuple[datetime.datetime, Optional[Dict[str, int]]]:
     """Returns the parsed datetime, along with the period mapping - if the input was a relative datetime string."""
     try:
@@ -230,16 +230,18 @@ def relative_date_parse_with_delta_mapping(
             delta_mapping["month"] = 12
             delta_mapping["day"] = 31
     parsed_dt -= relativedelta(**delta_mapping)  # type: ignore
-    # Truncate to the start of the hour for hour-precision datetimes, to the start of the day for larger intervals
-    if "hours" in delta_mapping:
-        parsed_dt = parsed_dt.replace(minute=0, second=0, microsecond=0)
-    else:
-        parsed_dt = parsed_dt.replace(hour=0, minute=0, second=0, microsecond=0)
+    if always_truncate:
+        # Truncate to the start of the hour for hour-precision datetimes, to the start of the day for larger intervals
+        # TODO: Remove this from this function, this should not be the responsibility of it
+        if "hours" in delta_mapping:
+            parsed_dt = parsed_dt.replace(minute=0, second=0, microsecond=0)
+        else:
+            parsed_dt = parsed_dt.replace(hour=0, minute=0, second=0, microsecond=0)
     return parsed_dt, delta_mapping
 
 
-def relative_date_parse(input: str, timezone_info: ZoneInfo) -> datetime.datetime:
-    return relative_date_parse_with_delta_mapping(input, timezone_info)[0]
+def relative_date_parse(input: str, timezone_info: ZoneInfo, *, always_truncate: bool = False) -> datetime.datetime:
+    return relative_date_parse_with_delta_mapping(input, timezone_info, always_truncate=always_truncate)[0]
 
 
 def get_git_branch() -> Optional[str]:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -115,30 +115,6 @@ def absolute_uri(url: Optional[str] = None) -> str:
     return urljoin(settings.SITE_URL.rstrip("/") + "/", url.lstrip("/"))
 
 
-def get_previous_week(at: Optional[datetime.datetime] = None) -> Tuple[datetime.datetime, datetime.datetime]:
-    """
-    Returns a pair of datetimes, representing the start and end of the week preceding to the passed date's week.
-    `at` is the datetime to use as a reference point.
-    """
-
-    if not at:
-        at = timezone.now()
-
-    period_end: datetime.datetime = datetime.datetime.combine(
-        at - datetime.timedelta(timezone.now().weekday() + 1),
-        datetime.time.max,
-        tzinfo=pytz.UTC,
-    )  # very end of the previous Sunday
-
-    period_start: datetime.datetime = datetime.datetime.combine(
-        period_end - datetime.timedelta(6),
-        datetime.time.min,
-        tzinfo=pytz.UTC,
-    )  # very start of the previous Monday
-
-    return (period_start, period_end)
-
-
 def get_previous_day(at: Optional[datetime.datetime] = None) -> Tuple[datetime.datetime, datetime.datetime]:
     """
     Returns a pair of datetimes, representing the start and end of the preceding day.
@@ -245,28 +221,6 @@ def relative_date_parse_with_delta_mapping(input: str) -> Tuple[datetime.datetim
 
 def relative_date_parse(input: str) -> datetime.datetime:
     return relative_date_parse_with_delta_mapping(input)[0]
-
-
-def request_to_date_query(filters: Dict[str, Any], exact: Optional[bool]) -> Dict[str, datetime.datetime]:
-    if filters.get("date_from"):
-        date_from: Optional[datetime.datetime] = relative_date_parse(filters["date_from"])
-        if filters["date_from"] == "all":
-            date_from = None
-    else:
-        date_from = datetime.datetime.today() - relativedelta(days=DEFAULT_DATE_FROM_DAYS)
-        date_from = date_from.replace(hour=0, minute=0, second=0, microsecond=0)
-
-    date_to = None
-    if filters.get("date_to"):
-        date_to = relative_date_parse(filters["date_to"])
-
-    resp = {}
-    if date_from:
-        resp["timestamp__gte"] = date_from.replace(tzinfo=pytz.UTC)
-    if date_to:
-        days = 1 if not exact else 0
-        resp["timestamp__lte"] = (date_to + relativedelta(days=days)).replace(tzinfo=pytz.UTC)
-    return resp
 
 
 def get_git_branch() -> Optional[str]:


### PR DESCRIPTION
## Problem

Our relative date (e.g. "-7d", "-1mStart") parsing logic was duplicated between `posthog.utils.relative_date_parse` and `posthog.queries.query_date_range.QueryDateRange._parse_date`. This was confusing and those branches already had diverged a bit (some time ago the `posthog.utils` version was refactored to also return the parsed unit-value mapping).

## Changes

This is a second go at this, since there was previously #13713, which seemed more effort than it was worth at the time with some test failures. However, this appears to be a strong pain point, as investigated a report of `dStart` ranges being incorrect in non-UTC timezones – this almost–duplicated logic is confusing there. 


## How did you test this code?

Existing tests should work.