### PR TITLE
feat(plugin-server): add slowlogs around ExportEventsBuffer flushes

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/export-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/export-events.ts
@@ -74,7 +74,7 @@ export function upgradeExportEvents(
             : null
     )
 
-    meta.global.exportEventsBuffer = new ExportEventsBuffer(hub, {
+    meta.global.exportEventsBuffer = new ExportEventsBuffer(hub, pluginConfig, {
         limit: uploadBytes,
         timeoutSeconds: uploadSeconds,
         onFlush: async (batch) => {

--- a/plugin-server/tests/worker/buffer.test.ts
+++ b/plugin-server/tests/worker/buffer.test.ts
@@ -1,5 +1,6 @@
 import { delay } from '../../src/utils/utils'
 import { PromiseManager } from '../../src/worker/vm/promise-manager'
+import { pluginConfig39 } from '../helpers/plugins'
 import { Hub } from './../../src/types'
 import { ExportEventsBuffer } from './../../src/worker/vm/upgrades/utils/export-events-buffer'
 
@@ -48,7 +49,7 @@ describe('ExportEventsBuffer', () => {
     beforeEach(() => {
         promiseManager = new PromiseManager({ MAX_PENDING_PROMISES_PER_WORKER: 1 } as any)
         mockHub = { promiseManager } as any
-        exportEventsBuffer = new ExportEventsBuffer(mockHub, { limit: 2 })
+        exportEventsBuffer = new ExportEventsBuffer(mockHub, pluginConfig39, { limit: 2 })
     })
 
     test('add and flush work as expected', async () => {


### PR DESCRIPTION
## Problem

The `on_event` consumer repeatedly hangs while waiting for a `ExportEventsBuffer` promise that does not resolve. This PR .

## Changes

- adds a 5 minute `timeoutGuard` around the promise so that we can pinpoint what app is missing a client-side timeout
- set the timeout relatively high, because I foresee a lot of noise if we set it to one minute, because it surrounds the retry loop. 1 minute is OK, and basically what the PromiseManager is "designed" to work with, we're concerned about much slower flushes

## How did you test this code?

#yolo