### PR TITLE
fix: dashboard templates

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -414,6 +414,14 @@ export function objectsEqual(obj1: any, obj2: any): boolean {
     return equal(obj1, obj2)
 }
 
+export function isObject(candidate: unknown): candidate is Record<string, unknown> {
+    return typeof candidate === 'object' && candidate !== null
+}
+
+export function isEmptyObject(candidate: unknown): boolean {
+    return isObject(candidate) && Object.keys(candidate).length === 0
+}
+
 // https://stackoverflow.com/questions/25421233/javascript-removing-undefined-fields-from-an-object
 export function objectClean<T extends Record<string | number | symbol, unknown>>(obj: T): T {
     const response = { ...obj }

--- a/frontend/src/scenes/dashboard/DashboardTemplateVariables.tsx
+++ b/frontend/src/scenes/dashboard/DashboardTemplateVariables.tsx
@@ -14,21 +14,12 @@ export function DashboardTemplateVariables(): JSX.Element {
     const { variables } = useValues(theDashboardTemplateVariablesLogic)
     const { setVariable } = useActions(theDashboardTemplateVariablesLogic)
 
-    const FALLBACK_EVENT = {
-        id: '$pageview',
-        math: 'dau',
-        type: 'events',
-    }
-
     return (
         <div className="mb-4 DashboardTemplateVariables max-w-md">
             {variables.map((variable, index) => (
                 <div key={index} className="mb-6">
                     <div className="mb-2">
-                        <LemonLabel
-                            showOptional={!variable.required}
-                            // info={variable.description} TODO: fix info, currently not working
-                        >
+                        <LemonLabel showOptional={!variable.required} info={<>{variable.description}</>}>
                             {variable.name}
                         </LemonLabel>
                         <p className="text-sm text-muted">{variable.description}</p>
@@ -37,7 +28,7 @@ export function DashboardTemplateVariables(): JSX.Element {
                         <ActionFilter
                             filters={{
                                 insight: InsightType.TRENDS,
-                                events: variable.default ? [variable.default] : [FALLBACK_EVENT],
+                                events: [variable.default],
                             }}
                             setFilters={(filters: FilterType) => {
                                 setVariable(variable.name, filters)

--- a/frontend/src/scenes/dashboard/NewDashboardModal.tsx
+++ b/frontend/src/scenes/dashboard/NewDashboardModal.tsx
@@ -170,16 +170,16 @@ export function NewDashboardModal(): JSX.Element {
         <LemonModal
             onClose={hideNewDashboardModal}
             isOpen={newDashboardModalVisible}
-            title={activeDashboardTemplate ? 'Setup your events' : 'Create a dashboard'}
+            title={activeDashboardTemplate ? 'Choose your events' : 'Create a dashboard'}
             description={
-                activeDashboardTemplate
-                    ? `The dashboard template you selected requires you to set up ${pluralize(
-                          (activeDashboardTemplate.variables || []).length,
-                          'event',
-                          'events',
-                          true
-                      )}.`
-                    : 'Choose a template or start with a blank slate'
+                activeDashboardTemplate ? (
+                    <>
+                        The <i>{activeDashboardTemplate.template_name}</i> template requires you to choose{' '}
+                        {pluralize((activeDashboardTemplate.variables || []).length, 'event', 'events', true)}.
+                    </>
+                ) : (
+                    'Choose a template or start with a blank slate'
+                )
             }
         >
             <div className="NewDashboardModal">

--- a/frontend/src/scenes/dashboard/dashboardTemplateVariablesLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardTemplateVariablesLogic.ts
@@ -2,9 +2,16 @@ import { actions, kea, path, props, propsChanged, reducers } from 'kea'
 import { DashboardTemplateVariableType, FilterType, Optional } from '~/types'
 
 import type { dashboardTemplateVariablesLogicType } from './dashboardTemplateVariablesLogicType'
+import { isEmptyObject } from 'lib/utils'
 
 export interface DashboardTemplateVariablesLogicProps {
     variables: DashboardTemplateVariableType[]
+}
+
+const FALLBACK_EVENT = {
+    id: '$pageview',
+    math: 'dau',
+    type: 'events',
 }
 
 export const dashboardTemplateVariablesLogic = kea<dashboardTemplateVariablesLogicType>([
@@ -21,7 +28,14 @@ export const dashboardTemplateVariablesLogic = kea<dashboardTemplateVariablesLog
         variables: [
             [] as DashboardTemplateVariableType[],
             {
-                setVariables: (_, { variables }) => variables,
+                setVariables: (_, { variables }) => {
+                    return variables.map((v) => {
+                        if (v.default && !isEmptyObject(v.default)) {
+                            return v
+                        }
+                        return { ...v, default: FALLBACK_EVENT } as unknown as DashboardTemplateVariableType
+                    })
+                },
                 setVariable: (state, { variable_name: variableName, filterGroup }): DashboardTemplateVariableType[] => {
                     // TODO: handle actions as well as events
                     return state.map((v: DashboardTemplateVariableType) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1388,7 +1388,7 @@ export interface DashboardTemplateVariableType {
     name: string
     description: string
     type: 'event'
-    default: Record<string, JsonType> | null | undefined
+    default: Record<string, JsonType>
     required: boolean
 }
 


### PR DESCRIPTION
## Problem

In a user interview I asked someone to try dashboard templates

They

* picked one randomly
* didn't understand what was happening on the variables page
* clicked create without changing anything
* saw an error

## Changes

* put the name of the dashboard in the variable modal page
* work if someone accepts defaults
* don't show "all events" as the default

## How did you test this code?

👀 locally