### PR TITLE
fix: early access cancel not resetting values

### DIFF
--- a/frontend/src/scenes/early-access-features/earlyAccessFeatureLogic.ts
+++ b/frontend/src/scenes/early-access-features/earlyAccessFeatureLogic.ts
@@ -117,9 +117,8 @@ export const earlyAccessFeatureLogic = kea<earlyAccessFeatureLogicType>([
     }),
     listeners(({ actions, values, props }) => ({
         cancel: () => {
-            if (!('id' in values.earlyAccessFeature)) {
-                actions.resetEarlyAccessFeature()
-                router.actions.push(urls.earlyAccessFeatures())
+            if ('id' in values.earlyAccessFeature) {
+                actions.loadEarlyAccessFeature()
             }
             actions.editFeature(false)
         },
@@ -160,8 +159,6 @@ export const earlyAccessFeatureLogic = kea<earlyAccessFeatureLogicType>([
             if (method === 'PUSH') {
                 if (props.id) {
                     actions.loadEarlyAccessFeature()
-                } else {
-                    actions.resetEarlyAccessFeature()
                 }
             }
         },
@@ -169,9 +166,6 @@ export const earlyAccessFeatureLogic = kea<earlyAccessFeatureLogicType>([
     afterMount(async ({ props, actions }) => {
         if (props.id !== 'new') {
             await actions.loadEarlyAccessFeature()
-        }
-        if (props.id === 'new') {
-            actions.resetEarlyAccessFeature()
         }
     }),
 ])


### PR DESCRIPTION
## Problem
https://github.com/PostHog/posthog/issues/16951

When you are editing the early access management feature and you click Cancel it does not reset the UI text on the view page back to original text. It keep what you type in.

## Changes

- reload feature when you click cancel, clearing the values
- removed unused function `resetEarlyAccessFeature` as it was not used and all places it was used already resets it.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

- Local testing