### PR TITLE
feat(hogql): cross join

### DIFF
--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -239,7 +239,14 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return self.visit(ctx.joinExpr())
 
     def visitJoinExprCrossOp(self, ctx: HogQLParser.JoinExprCrossOpContext):
-        raise NotImplementedException(f"Unsupported node: JoinExprCrossOp")
+        join1: ast.JoinExpr = self.visit(ctx.joinExpr(0))
+        join2: ast.JoinExpr = self.visit(ctx.joinExpr(1))
+        join2.join_type = "CROSS JOIN"
+        last_join = join1
+        while last_join.next_join is not None:
+            last_join = last_join.next_join
+        last_join.next_join = join2
+        return join1
 
     def visitJoinOpInner(self, ctx: HogQLParser.JoinOpInnerContext):
         tokens = []

--- a/posthog/hogql/test/test_parser.py
+++ b/posthog/hogql/test/test_parser.py
@@ -747,6 +747,55 @@ class TestParser(BaseTest):
             ),
         )
 
+    def test_select_from_cross_join(self):
+        self.assertEqual(
+            self._select("select 1 from events CROSS JOIN events2"),
+            ast.SelectQuery(
+                select=[ast.Constant(value=1)],
+                select_from=ast.JoinExpr(
+                    table=ast.Field(chain=["events"]),
+                    next_join=ast.JoinExpr(
+                        join_type="CROSS JOIN",
+                        table=ast.Field(chain=["events2"]),
+                    ),
+                ),
+            ),
+        )
+        self.assertEqual(
+            self._select("select 1 from events CROSS JOIN events2 CROSS JOIN events3"),
+            ast.SelectQuery(
+                select=[ast.Constant(value=1)],
+                select_from=ast.JoinExpr(
+                    table=ast.Field(chain=["events"]),
+                    next_join=ast.JoinExpr(
+                        join_type="CROSS JOIN",
+                        table=ast.Field(chain=["events2"]),
+                        next_join=ast.JoinExpr(
+                            join_type="CROSS JOIN",
+                            table=ast.Field(chain=["events3"]),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        self.assertEqual(
+            self._select("select 1 from events, events2 CROSS JOIN events3"),
+            ast.SelectQuery(
+                select=[ast.Constant(value=1)],
+                select_from=ast.JoinExpr(
+                    table=ast.Field(chain=["events"]),
+                    next_join=ast.JoinExpr(
+                        join_type="CROSS JOIN",
+                        table=ast.Field(chain=["events2"]),
+                        next_join=ast.JoinExpr(
+                            join_type="CROSS JOIN",
+                            table=ast.Field(chain=["events3"]),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
     def test_select_array_join(self):
         self.assertEqual(
             self._select("select a from events ARRAY JOIN [1,2,3] a"),

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -409,6 +409,16 @@ class TestPrinter(BaseTest):
             ),
         self.assertEqual(str(error_context.exception), "JoinExpr with table of type CompareOperation not supported")
 
+    def test_select_cross_join(self):
+        self.assertEqual(
+            self._select("select 1 from events cross join raw_groups"),
+            f"SELECT 1 FROM events CROSS JOIN groups WHERE and(equals(groups.team_id, {self.team.pk}), equals(events.team_id, {self.team.pk})) LIMIT 10000",
+        )
+        self.assertEqual(
+            self._select("select 1 from events, raw_groups"),
+            f"SELECT 1 FROM events CROSS JOIN groups WHERE and(equals(groups.team_id, {self.team.pk}), equals(events.team_id, {self.team.pk})) LIMIT 10000",
+        )
+
     def test_select_array_join(self):
         self.assertEqual(
             self._select("select 1, a from events array join [1,2,3] as a"),


### PR DESCRIPTION
## Problem

HogQL does not support the `CROSS JOIN` syntax

## Changes

Now it does. Both of these will now resolve:

```sql
SELECT 1 FROM events CROSS JOIN persons;
SELECT 1 FROM events, persons;
```

## How did you test this code?

Added tests