### PR TITLE
perf(ingestion): only transpile frontend apps on scheduler pods

### DIFF
--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -20,6 +20,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 processAsyncWebhooksHandlers: true,
                 sessionRecordingIngestion: true,
                 sessionRecordingBlobIngestion: true,
+                transpileFrontendApps: true,
                 ...sharedCapabilities,
             }
         case PluginServerMode.ingestion:
@@ -77,6 +78,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
         case PluginServerMode.scheduler:
             return {
                 pluginScheduledTasks: true,
+                transpileFrontendApps: true, // TODO: move this away from pod startup, into a graphile job
                 ...sharedCapabilities,
             }
     }

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -31,7 +31,7 @@ import { TeamManager } from './worker/ingestion/team-manager'
 import { PluginsApiKeyManager } from './worker/vm/extensions/helpers/api-key-manager'
 import { RootAccessManager } from './worker/vm/extensions/helpers/root-acess-manager'
 import { LazyPluginVM } from './worker/vm/lazy'
-import { PromiseManager } from './worker/vm/promise-manager' /** Re-export Element from scaffolding, for backwards compat. */
+import { PromiseManager } from './worker/vm/promise-manager'
 
 /** Re-export Element from scaffolding, for backwards compat. */
 export { Element } from '@posthog/plugin-scaffold'

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -31,7 +31,7 @@ import { TeamManager } from './worker/ingestion/team-manager'
 import { PluginsApiKeyManager } from './worker/vm/extensions/helpers/api-key-manager'
 import { RootAccessManager } from './worker/vm/extensions/helpers/root-acess-manager'
 import { LazyPluginVM } from './worker/vm/lazy'
-import { PromiseManager } from './worker/vm/promise-manager'
+import { PromiseManager } from './worker/vm/promise-manager' /** Re-export Element from scaffolding, for backwards compat. */
 
 /** Re-export Element from scaffolding, for backwards compat. */
 export { Element } from '@posthog/plugin-scaffold'
@@ -267,6 +267,7 @@ export interface PluginServerCapabilities {
     processAsyncWebhooksHandlers?: boolean
     sessionRecordingIngestion?: boolean
     sessionRecordingBlobIngestion?: boolean
+    transpileFrontendApps?: boolean // TODO: move this away from pod startup, into a graphile job
     http?: boolean
     mmdb?: boolean
 }

--- a/plugin-server/src/worker/plugins/loadPlugin.ts
+++ b/plugin-server/src/worker/plugins/loadPlugin.ts
@@ -52,7 +52,7 @@ export async function loadPlugin(hub: Hub, pluginConfig: PluginConfig): Promise<
             transpile: (source: string) => string
         }): Promise<boolean> => {
             const source = isLocalPlugin ? readFileIfExists(hub.BASE_DIR, plugin, filename) : plugin[pluginKey]
-            if (source) {
+            if (source && hub.capabilities.transpileFrontendApps) {
                 if (await hub.db.getPluginTranspilationLock(plugin.id, filename)) {
                     status.info('🔌', `Transpiling ${pluginDigest(plugin)}`)
                     const transpilationStartTimer = new Date()


### PR DESCRIPTION
## Problem

Every plugin-server transpiles the frontend / site apps on every startup, a process that takes a PG lock and slows down pod startup + adds unnecessary load to PG.



## Changes

- only run this logic on scheduler pods, or the all-in-one container. I chose this one because it's the smallest deployment on prod, and some slowdown at startup is OK
- added a TODO that this is a bad kludge and that this logic does not belong in the backend app code. But let's focus on damage-control for now

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
