### PR TITLE
chore: Allow impersonated users to trigger historical exports

### DIFF
--- a/frontend/src/scenes/apps/HistoricalExportsTab.tsx
+++ b/frontend/src/scenes/apps/HistoricalExportsTab.tsx
@@ -7,13 +7,16 @@ import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Progress } from 'antd'
 import { PluginJobModal } from 'scenes/plugins/edit/interface-jobs/PluginJobConfiguration'
 import { useEffect } from 'react'
+import { LemonButton } from 'lib/lemon-ui/LemonButton/LemonButton'
+import { userLogic } from 'scenes/userLogic'
 
 const RELOAD_HISTORICAL_EXPORTS_FREQUENCY_MS = 20000
 
 export function HistoricalExportsTab(): JSX.Element {
     const { historicalExports, historicalExportsLoading, pluginConfig, interfaceJobsProps, hasRunningExports } =
         useValues(appMetricsSceneLogic)
-    const { loadHistoricalExports } = useActions(appMetricsSceneLogic)
+    const { openHistoricalExportModal, loadHistoricalExports } = useActions(appMetricsSceneLogic)
+    const { user } = useValues(userLogic)
 
     useEffect(() => {
         let timer: NodeJS.Timeout | undefined
@@ -33,6 +36,13 @@ export function HistoricalExportsTab(): JSX.Element {
 
     return (
         <div className="space-y-2">
+            {user?.is_impersonated && (
+                <div className="flex items-center justify-end">
+                    <LemonButton type="primary" onClick={openHistoricalExportModal} disabled={!interfaceJobsProps}>
+                        Start new export
+                    </LemonButton>
+                </div>
+            )}
             <LemonTable
                 dataSource={historicalExports}
                 loading={historicalExportsLoading}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Need to run a backfill for a user - this feels like the safest way to do this and allow us to do it in the future too

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tested out the button locally (without impersonating).

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
