### PR TITLE
chore: Make apps visible to anyone having an existing config

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -284,8 +284,8 @@ class PluginViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
                 Q(**self.parents_query_dict)
                 | Q(is_global=True)
                 | Q(
-                    id__in=PluginConfig.objects.filter(
-                        team__organization_id=self.organization_id, enabled=True
+                    id__in=PluginConfig.objects.filter(  # If a config exists the org can see the plugin
+                        team__organization_id=self.organization_id
                     ).values_list("plugin_id", flat=True)
                 )
             )

--- a/posthog/api/test/__snapshots__/test_plugin.ambr
+++ b/posthog/api/test/__snapshots__/test_plugin.ambr
@@ -60,8 +60,7 @@
            (SELECT U0."plugin_id"
             FROM "posthog_pluginconfig" U0
             INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (U0."enabled"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid))) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
+            WHERE U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
   '
 ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.11
@@ -115,8 +114,7 @@
            (SELECT U0."plugin_id"
             FROM "posthog_pluginconfig" U0
             INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (U0."enabled"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
+            WHERE U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid))
   LIMIT 100 /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
   '
 ---
@@ -214,8 +212,7 @@
            (SELECT U0."plugin_id"
             FROM "posthog_pluginconfig" U0
             INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (U0."enabled"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid))) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
+            WHERE U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
   '
 ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.17
@@ -269,8 +266,7 @@
            (SELECT U0."plugin_id"
             FROM "posthog_pluginconfig" U0
             INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (U0."enabled"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
+            WHERE U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid))
   LIMIT 100 /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
   '
 ---
@@ -391,8 +387,7 @@
            (SELECT U0."plugin_id"
             FROM "posthog_pluginconfig" U0
             INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (U0."enabled"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid))) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
+            WHERE U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
   '
 ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.23
@@ -446,8 +441,7 @@
            (SELECT U0."plugin_id"
             FROM "posthog_pluginconfig" U0
             INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (U0."enabled"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
+            WHERE U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid))
   LIMIT 100 /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
   '
 ---
@@ -481,8 +475,7 @@
            (SELECT U0."plugin_id"
             FROM "posthog_pluginconfig" U0
             INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (U0."enabled"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid))) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
+            WHERE U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
   '
 ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.6

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -150,21 +150,27 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
         self.assertEqual(list_response_other_org_2_data["count"], 1)
         self.assertEqual(list_response_other_org_2.status_code, 200)
 
-    def test_no_longer_globally_managed_still_visible_to_org_if_enabled(self, mock_get, mock_reload):
+    def test_no_longer_globally_managed_still_visible_to_org_iff_has_config(self, mock_get, mock_reload):
         other_org: Organization = Organization.objects.create(
             name="FooBar2", plugins_access_level=Organization.PluginsAccessLevel.CONFIG
+        )
+        no_plugins_org: Organization = Organization.objects.create(
+            name="NoPlugins", plugins_access_level=Organization.PluginsAccessLevel.CONFIG
         )
         other_team: Team = Team.objects.create(organization=other_org, name="FooBar2")
         OrganizationMembership.objects.create(user=self.user, organization=other_org)
         plugin = Plugin.objects.create(organization=self.organization)
-        PluginConfig.objects.create(plugin=plugin, enabled=True, team=other_team, order=0)
-        # The plugin is NOT global BUT it was before and it was enabled for one of the projects back then,
+        PluginConfig.objects.create(plugin=plugin, enabled=False, team=other_team, order=0)
+        # The plugin is NOT global and it has a config for one of the projects,
         # so it should still show up for the other org
         list_response = self.client.get(f"/api/organizations/{other_org.id}/plugins/")
         self.assertEqual(list_response.status_code, 200, list_response.json())
         list_response_data = list_response.json()
         self.assertEqual(list_response_data["count"], 1)
         self.assertEqual(list_response_data["results"][0]["id"], plugin.id)
+        # but org without any plugin configs won't have access
+        list_response = self.client.get(f"/api/organizations/{no_plugins_org.id}/plugins/")
+        self.assertEqual(list_response.status_code, 403, list_response.json())
 
     def test_globally_managed_only_manageable_by_owner_org(self, mock_get, mock_reload):
         my_org = self.organization


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Previously we filtered by config being enabled, but if we automatically disable the app for whatever reason, then the user wouldn't be able to re-enable.
Additionally this enables us to safely make the plugin visible for the only a specific org.

context: https://posthog.slack.com/archives/C0374DA782U/p1691671511138699

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
