### PR TITLE
fix(plugin-server): remove pluginconfig cardinality of storageSet metrics

### DIFF
--- a/plugin-server/src/worker/vm/extensions/storage.ts
+++ b/plugin-server/src/worker/vm/extensions/storage.ts
@@ -26,7 +26,7 @@ export function createStorage(server: Hub, pluginConfig: PluginConfig): StorageE
                     DO UPDATE SET value = $3
                 `,
                 [pluginConfig.id, key, JSON.stringify(value)],
-                `storageSet(pluginConfig.id=${pluginConfig.id})`
+                `storageSet`
             )
         }
 


### PR DESCRIPTION
I assumed the tag was low-cardinality and added it as a prometheus label, but it's not for one use case, and we're spamming VictoriaMetrics 🤦 


## Problem

- remove the pluginconfig.id from the tag for now. we could re-add the plugin ID later on

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
