### PR TITLE
clipboard copy resolve update utils.tsx

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1019,35 +1019,35 @@ export function dateStringToDayJs(date: string | null): dayjs.Dayjs | null {
 }
 
 export async function copyToClipboard(value: string, description: string = 'text'): Promise<boolean> {
-  if (!navigator.clipboard) {
-    lemonToast.warning('Oops! Clipboard capabilities are only available over HTTPS or on localhost');
-    return false;
-  }
-
-  try {
-    await navigator.clipboard.writeText(value);
-     lemonToast.info(`Copied ${description} to clipboard`, {
-            icon: <IconCopy />,
-        })
-    return true;
-  } catch (e) {
-    // If the Clipboard API fails, fallback to textarea method
-    try {
-      const textArea = document.createElement('textarea');
-      textArea.value = value;
-      document.body.appendChild(textArea);
-      textArea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textArea);
-       lemonToast.info(`Copied ${description} to clipboard`, {
-            icon: <IconCopy />,
-        })
-      return true;
-    } catch (err) {
-      lemonToast.error(`Could not copy ${description} to clipboard: ${err}`);
-      return false;
+    if (!navigator.clipboard) {
+        lemonToast.warning('Oops! Clipboard capabilities are only available over HTTPS or on localhost')
+        return false
     }
-  }
+
+    try {
+        await navigator.clipboard.writeText(value)
+        lemonToast.info(`Copied ${description} to clipboard`, {
+            icon: <IconCopy />,
+        })
+        return true
+    } catch (e) {
+        // If the Clipboard API fails, fallback to textarea method
+        try {
+            const textArea = document.createElement('textarea')
+            textArea.value = value
+            document.body.appendChild(textArea)
+            textArea.select()
+            document.execCommand('copy')
+            document.body.removeChild(textArea)
+            lemonToast.info(`Copied ${description} to clipboard`, {
+                icon: <IconCopy />,
+            })
+            return true
+        } catch (err) {
+            lemonToast.error(`Could not copy ${description} to clipboard: ${err}`)
+            return false
+        }
+    }
 }
 
 export function clamp(value: number, min: number, max: number): number {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1026,7 +1026,9 @@ export async function copyToClipboard(value: string, description: string = 'text
 
   try {
     await navigator.clipboard.writeText(value);
-    lemonToast.info(`Copied ${description} to clipboard`);
+     lemonToast.info(`Copied ${description} to clipboard`, {
+            icon: <IconCopy />,
+        })
     return true;
   } catch (e) {
     // If the Clipboard API fails, fallback to textarea method
@@ -1037,7 +1039,9 @@ export async function copyToClipboard(value: string, description: string = 'text
       textArea.select();
       document.execCommand('copy');
       document.body.removeChild(textArea);
-      lemonToast.info(`Copied ${description} to clipboard`);
+       lemonToast.info(`Copied ${description} to clipboard`, {
+            icon: <IconCopy />,
+        })
       return true;
     } catch (err) {
       lemonToast.error(`Could not copy ${description} to clipboard: ${err}`);

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1019,21 +1019,31 @@ export function dateStringToDayJs(date: string | null): dayjs.Dayjs | null {
 }
 
 export async function copyToClipboard(value: string, description: string = 'text'): Promise<boolean> {
-    if (!navigator.clipboard) {
-        lemonToast.warning('Oops! Clipboard capabilities are only available over HTTPS or on localhost')
-        return false
-    }
+  if (!navigator.clipboard) {
+    lemonToast.warning('Oops! Clipboard capabilities are only available over HTTPS or on localhost');
+    return false;
+  }
 
+  try {
+    await navigator.clipboard.writeText(value);
+    lemonToast.info(`Copied ${description} to clipboard`);
+    return true;
+  } catch (e) {
+    // If the Clipboard API fails, fallback to textarea method
     try {
-        await navigator.clipboard.writeText(value)
-        lemonToast.info(`Copied ${description} to clipboard`, {
-            icon: <IconCopy />,
-        })
-        return true
-    } catch (e) {
-        lemonToast.error(`Could not copy ${description} to clipboard: ${e}`)
-        return false
+      const textArea = document.createElement('textarea');
+      textArea.value = value;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+      lemonToast.info(`Copied ${description} to clipboard`);
+      return true;
+    } catch (err) {
+      lemonToast.error(`Could not copy ${description} to clipboard: ${err}`);
+      return false;
     }
+  }
 }
 
 export function clamp(value: number, min: number, max: number): number {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Not all browsers support navigator.clipboard.writeText ticket https://github.com/PostHog/posthog/issues/16059
This solution is for the browsers that did not support the clipboard copy API like duck duck go.

## Changes
We created a fallback using document.execCommand('copy') if navigator.clipboard fails to copy the text.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

![257603271-1258e3a3-f9a8-4489-b26c-99040acffed8](https://github.com/PostHog/posthog/assets/105173154/594c1dfe-215e-4e01-8b78-a9de3a5ed044)
![257603247-4a7a6c57-74d4-447a-9adc-513b7a255b46](https://github.com/PostHog/posthog/assets/105173154/7dcd983d-aa7a-4b71-81bd-01367e78d47f)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
We downloaded duckduck go browser on an android, ran the posthog on it and tried the copy to clipboard feature which worked but initially was not.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

## Comment
From the feedback you gave our colleague on the pr https://github.com/PostHog/posthog/pull/16876 we made some changes and we ended up with this code.