### PR TITLE
fix: event can be none

### DIFF
--- a/posthog/helpers/tests/test_session_recording_helpers.py
+++ b/posthog/helpers/tests/test_session_recording_helpers.py
@@ -371,6 +371,10 @@ def test_get_events_summary_from_snapshot_data():
             "timestamp": "it was about a hundred years ago, that I remember this happening",
             "data": {"source": 3},
         },
+        # we can see malformed packets
+        {"data": {}},
+        {},
+        None,
     ]
 
     assert get_events_summary_from_snapshot_data(snapshot_events) == [

--- a/posthog/session_recordings/session_recording_helpers.py
+++ b/posthog/session_recordings/session_recording_helpers.py
@@ -404,7 +404,7 @@ def get_events_summary_from_snapshot_data(snapshot_data: List[SnapshotData]) -> 
     events_summary = []
 
     for event in snapshot_data:
-        if "timestamp" not in event or "type" not in event:
+        if not event or "timestamp" not in event or "type" not in event:
             continue
 
         # Get all top level data values


### PR DESCRIPTION
## Problem

We see a relatively small, but consistent number of errors in Sentry where an event is none when enumerating snapshot data

## Changes

Don't throw if that's true

## How did you test this code?

dev test