### PR TITLE
fix: upgrade snapshot version requests

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -100,7 +100,7 @@ export async function getJSONOrThrow(response: Response): Promise<any> {
     try {
         return await response.json()
     } catch (e) {
-        return { statusText: response.statusText }
+        return { statusText: response.statusText, status: response.status }
     }
 }
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -365,7 +365,7 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                             // instead of reading the location header
                             return {
                                 redirected_to_v2: true,
-                            } satisfies SessionPlayerSnapshotData
+                            } as SessionPlayerSnapshotData
                         }
                         throw e
                     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -683,6 +683,11 @@ export interface SessionPlayerSnapshotData {
     sources?: SessionRecordingSnapshotSource[]
     next?: string
     blob_keys?: string[]
+
+    // TODO: remove this once we're sure we don't need to support v1 anymore
+    // need to be able to return from loadSnapshotsV1 without triggering success
+    // when redirecting to v2
+    redirected_to_v2?: boolean
 }
 
 export interface SessionPlayerData {

--- a/posthog/api/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/api/test/__snapshots__/test_session_recordings.ambr
@@ -183,10 +183,10 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '2',
-                                                     '3',
                                                      '4',
-                                                     '1')
+                                                     '1',
+                                                     '3',
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -559,11 +559,11 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '2',
-                                                     '3',
                                                      '4',
-                                                     '6',
-                                                     '1')
+                                                     '1',
+                                                     '3',
+                                                     '2',
+                                                     '6')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -937,12 +937,12 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '2',
-                                                     '3',
                                                      '4',
+                                                     '1',
+                                                     '3',
+                                                     '2',
                                                      '7',
-                                                     '6',
-                                                     '1')
+                                                     '6')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -1352,13 +1352,13 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '2',
-                                                     '3',
                                                      '4',
-                                                     '7',
-                                                     '6',
                                                      '1',
-                                                     '8')
+                                                     '8',
+                                                     '3',
+                                                     '2',
+                                                     '7',
+                                                     '6')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -1783,14 +1783,14 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '2',
-                                                     '3',
                                                      '4',
-                                                     '7',
-                                                     '6',
                                                      '1',
                                                      '8',
-                                                     '9')
+                                                     '3',
+                                                     '2',
+                                                     '7',
+                                                     '9',
+                                                     '6')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -2214,15 +2214,15 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '2',
-                                                     '3',
                                                      '4',
-                                                     '7',
-                                                     '10',
-                                                     '6',
                                                      '1',
                                                      '8',
-                                                     '9')
+                                                     '3',
+                                                     '2',
+                                                     '7',
+                                                     '9',
+                                                     '6',
+                                                     '10')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -2796,8 +2796,8 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
-                                                     '1')
+  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -3155,9 +3155,9 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
                                                      '3',
-                                                     '1')
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -3527,10 +3527,10 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('4',
+                                                     '1',
                                                      '3',
-                                                     '4',
-                                                     '1')
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -4173,12 +4173,12 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '2',
-                                                     '3',
                                                      '4',
+                                                     '1',
+                                                     '3',
+                                                     '2',
                                                      '7',
-                                                     '6',
-                                                     '1')
+                                                     '6')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -4536,13 +4536,13 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '2',
-                                                     '3',
                                                      '4',
-                                                     '7',
-                                                     '6',
                                                      '1',
-                                                     '8')
+                                                     '8',
+                                                     '3',
+                                                     '2',
+                                                     '7',
+                                                     '6')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -4923,14 +4923,14 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '2',
-                                                     '3',
                                                      '4',
-                                                     '7',
-                                                     '6',
                                                      '1',
                                                      '8',
-                                                     '9')
+                                                     '3',
+                                                     '2',
+                                                     '7',
+                                                     '9',
+                                                     '6')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -5270,15 +5270,15 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '2',
-                                                     '3',
                                                      '4',
-                                                     '7',
-                                                     '10',
-                                                     '6',
                                                      '1',
                                                      '8',
-                                                     '9')
+                                                     '3',
+                                                     '2',
+                                                     '7',
+                                                     '9',
+                                                     '6',
+                                                     '10')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -5782,8 +5782,8 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
-                                                     '1')
+  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -6108,9 +6108,9 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
                                                      '3',
-                                                     '1')
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -6425,10 +6425,10 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('4',
+                                                     '1',
                                                      '3',
-                                                     '4',
-                                                     '1')
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -6756,10 +6756,10 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '2',
-                                                     '3',
                                                      '4',
-                                                     '1')
+                                                     '1',
+                                                     '3',
+                                                     '2')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -7077,11 +7077,11 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '2',
-                                                     '3',
                                                      '4',
-                                                     '6',
-                                                     '1')
+                                                     '1',
+                                                     '3',
+                                                     '2',
+                                                     '6')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '

--- a/posthog/api/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/api/test/__snapshots__/test_session_recordings.ambr
@@ -183,10 +183,10 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '4',
-                                                     '1',
+                                                     '2',
                                                      '3',
-                                                     '2')
+                                                     '4',
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -559,11 +559,11 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '4',
-                                                     '1',
-                                                     '3',
                                                      '2',
-                                                     '6')
+                                                     '3',
+                                                     '4',
+                                                     '6',
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -937,12 +937,12 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '4',
-                                                     '1',
-                                                     '3',
                                                      '2',
+                                                     '3',
+                                                     '4',
                                                      '7',
-                                                     '6')
+                                                     '6',
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -1352,13 +1352,13 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '4',
-                                                     '1',
-                                                     '8',
-                                                     '3',
                                                      '2',
+                                                     '3',
+                                                     '4',
                                                      '7',
-                                                     '6')
+                                                     '6',
+                                                     '1',
+                                                     '8')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -1783,14 +1783,14 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
+                                                     '2',
+                                                     '3',
                                                      '4',
+                                                     '7',
+                                                     '6',
                                                      '1',
                                                      '8',
-                                                     '3',
-                                                     '2',
-                                                     '7',
-                                                     '9',
-                                                     '6')
+                                                     '9')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -2214,15 +2214,15 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
+                                                     '2',
+                                                     '3',
                                                      '4',
+                                                     '7',
+                                                     '10',
+                                                     '6',
                                                      '1',
                                                      '8',
-                                                     '3',
-                                                     '2',
-                                                     '7',
-                                                     '9',
-                                                     '6',
-                                                     '10')
+                                                     '9')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -2796,8 +2796,8 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
-                                                     '2')
+  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -3155,9 +3155,9 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
                                                      '3',
-                                                     '2')
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -3527,10 +3527,10 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('4',
-                                                     '1',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
                                                      '3',
-                                                     '2')
+                                                     '4',
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -4173,12 +4173,12 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '4',
-                                                     '1',
-                                                     '3',
                                                      '2',
+                                                     '3',
+                                                     '4',
                                                      '7',
-                                                     '6')
+                                                     '6',
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -4536,13 +4536,13 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '4',
-                                                     '1',
-                                                     '8',
-                                                     '3',
                                                      '2',
+                                                     '3',
+                                                     '4',
                                                      '7',
-                                                     '6')
+                                                     '6',
+                                                     '1',
+                                                     '8')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -4923,14 +4923,14 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
+                                                     '2',
+                                                     '3',
                                                      '4',
+                                                     '7',
+                                                     '6',
                                                      '1',
                                                      '8',
-                                                     '3',
-                                                     '2',
-                                                     '7',
-                                                     '9',
-                                                     '6')
+                                                     '9')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -5270,15 +5270,15 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
+                                                     '2',
+                                                     '3',
                                                      '4',
+                                                     '7',
+                                                     '10',
+                                                     '6',
                                                      '1',
                                                      '8',
-                                                     '3',
-                                                     '2',
-                                                     '7',
-                                                     '9',
-                                                     '6',
-                                                     '10')
+                                                     '9')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -5782,8 +5782,8 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
-                                                     '2')
+  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -6108,9 +6108,9 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('1',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
                                                      '3',
-                                                     '2')
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -6425,10 +6425,10 @@
          COUNT("posthog_sessionrecordingplaylistitem"."id") AS "pinned_count"
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
-  WHERE ("posthog_sessionrecording"."session_id" IN ('4',
-                                                     '1',
+  WHERE ("posthog_sessionrecording"."session_id" IN ('2',
                                                      '3',
-                                                     '2')
+                                                     '4',
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -6756,10 +6756,10 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '4',
-                                                     '1',
+                                                     '2',
                                                      '3',
-                                                     '2')
+                                                     '4',
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
@@ -7077,11 +7077,11 @@
   FROM "posthog_sessionrecording"
   LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecording"."session_id" = "posthog_sessionrecordingplaylistitem"."recording_id")
   WHERE ("posthog_sessionrecording"."session_id" IN ('5',
-                                                     '4',
-                                                     '1',
-                                                     '3',
                                                      '2',
-                                                     '6')
+                                                     '3',
+                                                     '4',
+                                                     '6',
+                                                     '1')
          AND "posthog_sessionrecording"."team_id" = 2)
   GROUP BY "posthog_sessionrecording"."id" /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '


### PR DESCRIPTION
## Problem

I made a bad assumption when migrating LTS recordings away from dependency on ClickHouse and now people can't load their pinned recordings.

## Changes

This "force upgrades" requests for snapshots to version 2 so that they can play them

## How did you test this code?

a few developer tests
and manually editing a recording and seeing the 302 followed by a new request with the version parameter added