### PR TITLE
feat(hogql): compile the not(), and() and or() functions

### DIFF
--- a/posthog/hogql/bytecode.py
+++ b/posthog/hogql/bytecode.py
@@ -105,6 +105,18 @@ class BytecodeBuilder(Visitor):
             raise NotImplementedException(f"Constant type `{type(node.value)}` is not supported")
 
     def visit_call(self, node: ast.Call):
+        if node.name == "not" and len(node.args) == 1:
+            return [*self.visit(node.args[0]), Operation.NOT]
+        if node.name == "and" and len(node.args) > 1:
+            args = []
+            for arg in reversed(node.args):
+                args.extend(self.visit(arg))
+            return [*args, Operation.AND, len(node.args)]
+        if node.name == "or" and len(node.args) > 1:
+            args = []
+            for arg in reversed(node.args):
+                args.extend(self.visit(arg))
+            return [*args, Operation.OR, len(node.args)]
         if node.name not in SUPPORTED_FUNCTIONS:
             raise NotImplementedException(f"HogQL function `{node.name}` is not supported")
         response = []

--- a/posthog/hogql/test/test_bytecode.py
+++ b/posthog/hogql/test/test_bytecode.py
@@ -58,6 +58,10 @@ class TestBytecode(BaseTest):
         self.assertEqual(
             to_bytecode("match('test', 'x.*')"), [_H, op.STRING, "x.*", op.STRING, "test", op.CALL, "match", 2]
         )
+        self.assertEqual(to_bytecode("not('test')"), [_H, op.STRING, "test", op.NOT])
+        self.assertEqual(to_bytecode("not 'test'"), [_H, op.STRING, "test", op.NOT])
+        self.assertEqual(to_bytecode("or('test', 'test2')"), [_H, op.STRING, "test2", op.STRING, "test", op.OR, 2])
+        self.assertEqual(to_bytecode("and('test', 'test2')"), [_H, op.STRING, "test2", op.STRING, "test", op.AND, 2])
 
     def test_bytecode_create_error(self):
         with self.assertRaises(NotImplementedException) as e:


### PR DESCRIPTION
## Problem

The `not()` function wasn't compiled into HogQL bytecode properly. 

## Changes

Now the `not`, `and` and `or` functions get compiled into their "property" formats.

## How did you test this code?

Wrote a test