### PR TITLE
fix(flags): Only pre-query cohorts when sending

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -30,10 +30,6 @@ from posthog.models.feature_flag import (
     get_all_feature_flags,
     get_user_blast_radius,
 )
-from posthog.models.feature_flag.feature_flag import (
-    get_feature_flags_for_team_in_cache,
-    set_feature_flags_for_team_in_cache,
-)
 from posthog.models.feature_flag.flag_analytics import increment_request_count
 from posthog.models.feedback.survey import Survey
 from posthog.models.group_type_mapping import GroupTypeMapping
@@ -404,19 +400,22 @@ class FeatureFlagViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidD
     @action(methods=["GET"], detail=False, throttle_classes=[FeatureFlagThrottle])
     def local_evaluation(self, request: request.Request, **kwargs):
 
-        feature_flags = get_feature_flags_for_team_in_cache(self.team_id)
-        if feature_flags is None:
-            feature_flags = set_feature_flags_for_team_in_cache(
-                self.team_id, using_database=DATABASE_FOR_LOCAL_EVALUATION
-            )
+        feature_flags: QuerySet[FeatureFlag] = FeatureFlag.objects.using(DATABASE_FOR_LOCAL_EVALUATION).filter(
+            team_id=self.team_id, deleted=False, active=True
+        )
+
+        should_send_cohorts = "send_cohorts" in request.GET
 
         cohorts = {}
-        seen_cohorts_cache: Dict[str, Cohort] = {
-            str(cohort.pk): cohort
-            for cohort in Cohort.objects.using(DATABASE_FOR_LOCAL_EVALUATION).filter(
-                team_id=self.team_id, deleted=False
-            )
-        }
+        seen_cohorts_cache: Dict[str, Cohort] = {}
+
+        if should_send_cohorts:
+            seen_cohorts_cache = {
+                str(cohort.pk): cohort
+                for cohort in Cohort.objects.using(DATABASE_FOR_LOCAL_EVALUATION).filter(
+                    team_id=self.team_id, deleted=False
+                )
+            }
 
         parsed_flags = []
         for feature_flag in feature_flags:
@@ -443,7 +442,7 @@ class FeatureFlagViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidD
 
             # when param set, send cohorts, for libraries that can handle evaluating them locally
             # irrespective of complexity
-            if "send_cohorts" in request.GET:
+            if should_send_cohorts:
                 for id in feature_flag.get_cohort_ids(
                     using_database=DATABASE_FOR_LOCAL_EVALUATION, seen_cohorts_cache=seen_cohorts_cache
                 ):

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -3014,7 +3014,7 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             response = self.client.get(f"/api/feature_flag/local_evaluation")
             self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-        with self.assertNumQueries(4, using="replica"), self.assertNumQueries(3, using="default"):
+        with self.assertNumQueries(3, using="replica"), self.assertNumQueries(3, using="default"):
             # Captured queries for write DB:
             # E   1. UPDATE "posthog_personalapikey" SET "last_used_at" = '2023-08-01T11:26:50.728057+00:00'
             # E   2. SELECT "posthog_team"."id", "posthog_team"."uuid", "posthog_team"."organization_id"
@@ -3022,7 +3022,6 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             # Captured queries for replica DB:
             # E   1. SELECT "posthog_personalapikey"."id", "posthog_personalapikey"."user_id", "posthog_personalapikey"."label", "posthog_personalapikey"."value", -- check API key, joined with user
             # E   2. SELECT "posthog_featureflag"."id", "posthog_featureflag"."key", "posthog_featureflag"."name", "posthog_featureflag"."filters", -- get flags
-            # E   3. SELECT "posthog_cohort"."id", "posthog_cohort"."name" -- get all cohorts, even if in this specific case they do nothing.
             # E   3. SELECT "posthog_grouptypemapping"."id", "posthog_grouptypemapping"."team_id", -- get groups
 
             response = self.client.get(
@@ -3352,14 +3351,14 @@ class TestDecideUsesReadReplica(TransactionTestCase):
         client.logout()
         self.client.logout()
 
-        with self.assertNumQueries(3, using="replica"), self.assertNumQueries(3, using="default"):
+        with self.assertNumQueries(4, using="replica"), self.assertNumQueries(3, using="default"):
             # Captured queries for write DB:
             # E   1. UPDATE "posthog_personalapikey" SET "last_used_at" = '2023-08-01T11:26:50.728057+00:00'
             # E   2. SELECT "posthog_team"."id", "posthog_team"."uuid", "posthog_team"."organization_id"
             # E   3. SELECT "posthog_organizationmembership"."id", "posthog_organizationmembership"."organization_id", - user org permissions check
             # Captured queries for replica DB:
             # E   1. SELECT "posthog_personalapikey"."id", "posthog_personalapikey"."user_id", "posthog_personalapikey"."label", "posthog_personalapikey"."value", -- check API key, joined with user
-            # get flags from cache
+            # E   2. SELECT feature flags
             # E   3. SELECT "posthog_cohort"."id", "posthog_cohort"."name", "posthog_cohort"."description", -- select all cohorts
             # E   5. SELECT "posthog_grouptypemapping"."id", "posthog_grouptypemapping"."team_id", -- get groups
 


### PR DESCRIPTION
## Problem

With https://github.com/PostHog/posthog/pull/16939 - while this has reduced latency for local eval requests, it increased it for `/decide`, and also surprisingly increased the QPS on the read replica.

I suspect the former is because redis latency is increasing when handling multiple requests.

For the QPS on replica, I suspect it's because not all local evaluation requests need cohorts, so now just prequerying them for those that need them.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
