### PR TITLE
fix: fetch follows redirects when not mocked

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -683,11 +683,6 @@ export interface SessionPlayerSnapshotData {
     sources?: SessionRecordingSnapshotSource[]
     next?: string
     blob_keys?: string[]
-
-    // TODO: remove this once we're sure we don't need to support v1 anymore
-    // need to be able to return from loadSnapshotsV1 without triggering success
-    // when redirecting to v2
-    redirected_to_v2?: boolean
 }
 
 export interface SessionPlayerData {


### PR DESCRIPTION
## Problem

follow up to https://github.com/PostHog/posthog/pull/17013

That change was driven by tests added to the JS relying on mocked API calls, which turn out to behave differently to reality 🙈 

## Changes

since the API call will auto-follow redirect returned from the API we need to handle the shape of the response not the status code

## How did you test this code?

developer tests and seeing the API call upgraded locally _and_ seeing the call made to load the blob represented in the upgraded API call