### PR TITLE
feat: add better tooltip to"auto-refresh" in dashboards

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -61,15 +61,7 @@ export function DashboardReloadAction(): JSX.Element {
                                         title="Auto-refresh will only work while this tab is open"
                                         placement="topRight"
                                     >
-                                        <div
-                                            id="auto-refresh-check"
-                                            key="auto-refresh-check"
-                                            onClick={(e) => {
-                                                e.preventDefault()
-                                                e.stopPropagation()
-                                                setAutoRefresh(!autoRefresh.enabled, autoRefresh.interval)
-                                            }}
-                                        >
+                                        <div>
                                             <LemonSwitch
                                                 onChange={(checked) => setAutoRefresh(checked, autoRefresh.interval)}
                                                 label={'Auto refresh'}

--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -57,24 +57,27 @@ export function DashboardReloadAction(): JSX.Element {
                                     data-attr="auto-refresh-picker"
                                     id="auto-refresh-picker"
                                 >
-                                    <div
-                                        id="auto-refresh-check"
-                                        key="auto-refresh-check"
-                                        onClick={(e) => {
-                                            e.preventDefault()
-                                            e.stopPropagation()
-                                            setAutoRefresh(!autoRefresh.enabled, autoRefresh.interval)
-                                        }}
+                                    <Tooltip
+                                        title="Auto-refresh will only work while this tab is open"
+                                        placement="topRight"
                                     >
-                                        <Tooltip title={`Refresh dashboard automatically`} placement="bottomLeft">
+                                        <div
+                                            id="auto-refresh-check"
+                                            key="auto-refresh-check"
+                                            onClick={(e) => {
+                                                e.preventDefault()
+                                                e.stopPropagation()
+                                                setAutoRefresh(!autoRefresh.enabled, autoRefresh.interval)
+                                            }}
+                                        >
                                             <LemonSwitch
                                                 onChange={(checked) => setAutoRefresh(checked, autoRefresh.interval)}
                                                 label={'Auto refresh'}
                                                 checked={autoRefresh.enabled}
                                                 fullWidth={true}
                                             />
-                                        </Tooltip>
-                                    </div>
+                                        </div>
+                                    </Tooltip>
                                     <LemonDivider />
                                     <div className={'flex flex-col'}>
                                         <div role="heading" className="text-muted mb-2">


### PR DESCRIPTION
## Problem
https://github.com/PostHog/posthog/issues/16983
- "auto-refresh" was a little bit unclear what it meant within the dashboards

## Changes

- changed the tooltip text of "auto-refresh" to "Auto-refresh will only work while this tab is open"
- Moved the tooltip so it actually is visible when a user hovers over the switch.

![image](https://github.com/PostHog/posthog/assets/69441127/4950e721-8c5e-49ff-906a-360dd907c720)


## How did you test this code?
- Locally
