### PR TITLE
fix(insights): Hide empty "Display" options section

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -55,7 +55,7 @@ export function InsightDisplayConfig({ disableTable }: InsightDisplayConfigProps
     )
 
     const advancedOptions: LemonMenuItems = [
-        ...(showCompare || showValueOnSeries || showPercentStackView
+        ...(showValueOnSeries || showPercentStackView || hasLegend
             ? [
                   {
                       title: 'Display',

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -132,13 +132,8 @@ export function InsightDisplayConfig({ disableTable }: InsightDisplayConfigProps
                 {advancedOptions.length > 0 && (
                     <LemonMenu items={advancedOptions} closeOnClickInside={false}>
                         <LemonButton size="small" status="stealth">
-                            <span className="font-medium">
-                                Options
-                                {advancedOptionsCount ? (
-                                    <>
-                                        &nbsp;<span className="text-muted">({advancedOptionsCount})</span>
-                                    </>
-                                ) : null}
+                            <span className="font-medium whitespace-nowrap">
+                                Options{advancedOptionsCount ? ` (${advancedOptionsCount})` : null}
                             </span>
                         </LemonButton>
                     </LemonMenu>


### PR DESCRIPTION
## Changes

Prevents this from showing up on number insights:

<img width="125" alt="Screenshot 2023-08-15 at 21 04 58" src="https://github.com/PostHog/posthog/assets/4550621/1e151d64-1188-4037-8025-a7c9e45a1870">
