### PR TITLE
fix(insights): fix refresh link z-index

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
@@ -22,7 +22,7 @@ export function ComputationTimeWithRefresh({ disableRefresh }: { disableRefresh?
     }
 
     return (
-        <div className="flex items-center text-muted-alt">
+        <div className="flex items-center text-muted-alt z-10">
             Computed {lastRefresh ? dayjs(lastRefresh).fromNow() : 'a while ago'}
             {!disableRefresh && (
                 <>


### PR DESCRIPTION
## Problem

The Refresh button doesn't display a tooltip and isn't clickable for funnel insights.

Customer reporter issue: https://posthoghelp.zendesk.com/agent/tickets/5041 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/7582)

![2023-08-16 10 41 57](https://github.com/PostHog/posthog/assets/1851359/00d3bb32-73b0-4eb4-8a44-9229bf191ff5)

## Changes

This PR ups the z-index of the container to solve this.

## How did you test this code?

Clicked around locally.