### PR TITLE
fix: Recording ingestion metrics with proper lag metric

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
@@ -432,10 +432,6 @@ export class SessionRecordingIngesterV2 {
                  * As a result, we need to drop all sessions currently managed for the revoked partitions
                  */
 
-                topicPartitions.forEach((topicPartition: TopicPartition) => {
-                    delete this.partitionAssignments[topicPartition.partition]
-                })
-
                 const revokedPartitions = topicPartitions.map((x) => x.partition)
                 if (!revokedPartitions.length) {
                     return
@@ -451,12 +447,12 @@ export class SessionRecordingIngesterV2 {
                 topicPartitions.forEach((topicPartition: TopicPartition) => {
                     const partition = topicPartition.partition
 
+                    delete this.partitionAssignments[partition]
                     gaugeLag.remove({ partition })
                     gaugeLagMilliseconds.remove({ partition })
                     gaugeOffsetCommitted.remove({ partition })
                     gaugeOffsetCommitFailed.remove({ partition })
                     this.offsetHighWaterMarker.revoke(topicPartition)
-                    delete this.partitionAssignments[partition]
                 })
 
                 await this.destroySessions(sessionsToDrop)

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
@@ -404,8 +404,6 @@ export class SessionRecordingIngesterV2 {
                     revokedPartitions.includes(sessionManager.partition)
                 )
 
-                await this.destroySessions(sessionsToDrop)
-
                 gaugeSessionsRevoked.set(sessionsToDrop.length)
                 gaugeSessionsHandled.remove()
 
@@ -419,6 +417,8 @@ export class SessionRecordingIngesterV2 {
                     this.partitionNow[partition] = null
                     this.partitionLastKnownCommit[partition] = null
                 })
+
+                await this.destroySessions(sessionsToDrop)
 
                 return
             }

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
@@ -53,7 +53,7 @@ const gaugeLagMilliseconds = new Gauge({
     labelNames: ['partition'],
 })
 
-// NOTE: This guage is important! It is used as our primary metric for scaling up / down
+// NOTE: This gauge is important! It is used as our primary metric for scaling up / down
 const gaugeLag = new Gauge({
     name: 'recording_blob_ingestion_lag',
     help: 'A gauge of the lag in messages, taking into account in progress messages',

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
@@ -135,8 +135,10 @@ describe('ingester', () => {
         await ingester.consume(event)
         expect(ingester.sessions['1-session_id_1']).toBeDefined()
         // Force the flush
-        ingester.partitionNow[event.metadata.partition] =
-            Date.now() + defaultConfig.SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS
+        ingester.partitionAssignments[event.metadata.partition] = {
+            lastMessageTimestamp: Date.now() + defaultConfig.SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS,
+        }
+
         await ingester.flushAllReadySessions(true)
 
         jest.runOnlyPendingTimers() // flush timer

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
@@ -184,6 +184,8 @@ describe('ingester', () => {
         })
 
         it('should commit higher values but not lower', async () => {
+            // We need to simulate the paritition assignent logic here
+            ingester.partitionAssignments[1] = {}
             await ingester.consume(addMessage('sid1'))
             await ingester.sessions['1-sid1']?.flush('buffer_age')
             await tryToCommitLatestOffset()


### PR DESCRIPTION
## Problem

We sometimes get a race condition where we still report metrics for a partition, even though we aren't in charge of it anymore.

## Changes

* Fixes this to make sure we don't report if we aren't assigned.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
