### PR TITLE
fix(ingestion): run processEvent apps on overflow and historical

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -70,8 +70,6 @@ export enum KafkaSaslMechanism {
 }
 
 export enum PluginServerMode {
-    // Warning: when adding more modes, make sure to update worker/vm/capabilities.ts
-    // and the shouldSetupPluginInServer() test accordingly.
     ingestion = 'ingestion',
     ingestion_overflow = 'ingestion-overflow',
     ingestion_historical = 'ingestion-historical',
@@ -260,6 +258,8 @@ export interface Hub extends PluginsServerConfig {
 }
 
 export interface PluginServerCapabilities {
+    // Warning: when adding more entries, make sure to update worker/vm/capabilities.ts
+    // and the shouldSetupPluginInServer() test accordingly.
     ingestion?: boolean
     ingestionOverflow?: boolean
     ingestionHistorical?: boolean

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -70,6 +70,8 @@ export enum KafkaSaslMechanism {
 }
 
 export enum PluginServerMode {
+    // Warning: when adding more modes, make sure to update worker/vm/capabilities.ts
+    // and the shouldSetupPluginInServer() test accordingly.
     ingestion = 'ingestion',
     ingestion_overflow = 'ingestion-overflow',
     ingestion_historical = 'ingestion-historical',

--- a/plugin-server/src/worker/vm/capabilities.ts
+++ b/plugin-server/src/worker/vm/capabilities.ts
@@ -1,6 +1,8 @@
 import { PluginCapabilities, PluginConfigVMResponse, VMMethods } from '../../types'
 import { PluginServerCapabilities } from './../../types'
 
+const PROCESS_EVENT_CAPABILITIES = ['ingestion', 'ingestionOverflow', 'ingestionHistorical']
+
 export function getVMPluginCapabilities(vm: PluginConfigVMResponse): PluginCapabilities {
     const capabilities: Required<PluginCapabilities> = { scheduled_tasks: [], jobs: [], methods: [] }
 
@@ -35,7 +37,7 @@ export function getVMPluginCapabilities(vm: PluginConfigVMResponse): PluginCapab
 }
 
 function shouldSetupPlugin(serverCapability: keyof PluginServerCapabilities, pluginCapabilities: PluginCapabilities) {
-    if (serverCapability === 'ingestion') {
+    if (PROCESS_EVENT_CAPABILITIES.includes(serverCapability)) {
         return pluginCapabilities.methods?.includes('processEvent')
     }
     if (serverCapability === 'pluginScheduledTasks') {

--- a/plugin-server/src/worker/vm/capabilities.ts
+++ b/plugin-server/src/worker/vm/capabilities.ts
@@ -1,7 +1,7 @@
 import { PluginCapabilities, PluginConfigVMResponse, VMMethods } from '../../types'
 import { PluginServerCapabilities } from './../../types'
 
-const PROCESS_EVENT_CAPABILITIES = ['ingestion', 'ingestionOverflow', 'ingestionHistorical']
+const PROCESS_EVENT_CAPABILITIES = new Set(['ingestion', 'ingestionOverflow', 'ingestionHistorical'])
 
 export function getVMPluginCapabilities(vm: PluginConfigVMResponse): PluginCapabilities {
     const capabilities: Required<PluginCapabilities> = { scheduled_tasks: [], jobs: [], methods: [] }
@@ -37,7 +37,7 @@ export function getVMPluginCapabilities(vm: PluginConfigVMResponse): PluginCapab
 }
 
 function shouldSetupPlugin(serverCapability: keyof PluginServerCapabilities, pluginCapabilities: PluginCapabilities) {
-    if (PROCESS_EVENT_CAPABILITIES.includes(serverCapability)) {
+    if (PROCESS_EVENT_CAPABILITIES.has(serverCapability)) {
         return pluginCapabilities.methods?.includes('processEvent')
     }
     if (serverCapability === 'pluginScheduledTasks') {

--- a/plugin-server/tests/worker/capabilities.test.ts
+++ b/plugin-server/tests/worker/capabilities.test.ts
@@ -109,6 +109,50 @@ describe('capabilities', () => {
             })
         })
 
+        describe('ingestionOverflow', () => {
+            it('returns true if plugin has processEvent method and server has ingestionOverflow capability', () => {
+                const shouldSetupPlugin = shouldSetupPluginInServer(
+                    { ingestionOverflow: true },
+                    { methods: ['processEvent'] }
+                )
+                expect(shouldSetupPlugin).toEqual(true)
+            })
+
+            it('returns false if plugin does not have processEvent method and server only has ingestionOverflow capability', () => {
+                const shouldSetupPlugin = shouldSetupPluginInServer(
+                    { ingestionOverflow: true },
+                    {
+                        methods: ['onEvent', 'exportEvents'],
+                        scheduled_tasks: ['runEveryMinute'],
+                        jobs: ['someJob'],
+                    }
+                )
+                expect(shouldSetupPlugin).toEqual(false)
+            })
+        })
+
+        describe('ingestionHistorical', () => {
+            it('returns true if plugin has processEvent method and server has ingestionHistorical capability', () => {
+                const shouldSetupPlugin = shouldSetupPluginInServer(
+                    { ingestionHistorical: true },
+                    { methods: ['processEvent'] }
+                )
+                expect(shouldSetupPlugin).toEqual(true)
+            })
+
+            it('returns false if plugin does not have processEvent method and server only has ingestionHistorical capability', () => {
+                const shouldSetupPlugin = shouldSetupPluginInServer(
+                    { ingestionHistorical: true },
+                    {
+                        methods: ['onEvent', 'exportEvents'],
+                        scheduled_tasks: ['runEveryMinute'],
+                        jobs: ['someJob'],
+                    }
+                )
+                expect(shouldSetupPlugin).toEqual(false)
+            })
+        })
+
         describe('scheduled tasks', () => {
             it('returns true if plugin has any scheduled tasks and the server has pluginScheduledTasks capability', () => {
                 const shouldSetupPlugin = shouldSetupPluginInServer(


### PR DESCRIPTION
## Problem

Apps are currently not processing events in the overflow and historical lanes. I think that this is not intentional and should be fixed. Local devenv / hobby are not affected, as all capabilities are enabled.

## Changes

- Update `worker/vm/capabilities.ts` to be aware of these two new capabilities, update the test
- Add a warning comment on the `PluginServerCapabilities` struct so that we don't forget next time

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
