### PR TITLE
fix: Fix keying of kafka partition based on session_id

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -538,11 +538,8 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid=
     # Setting the partition key to None means using random partitioning.
     kafka_partition_key = None
 
-    if event["event"] in ("$snapshot", "$performance_event"):
-        # We only need locality for snapshot events, not performance events, so
-        # we only set the partition key for snapshot events.
-        if event["event"] == "$snapshot":
-            kafka_partition_key = event["properties"]["$session_id"]
+    if event["event"] in SESSION_RECORDING_EVENT_NAMES:
+        kafka_partition_key = event["properties"]["$session_id"]
         return log_event(parsed_event, event["event"], partition_key=kafka_partition_key)
 
     candidate_partition_key = f"{token}:{distinct_id}"


### PR DESCRIPTION
## Problem

We didn't include the new event in the code path that uses the session_id as key.

## Changes

* Fixes it
* Applies it to perf events as well a we dont use them atm.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
