### PR TITLE
chore(plugin-server): add tags to redisGet/Set

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -481,10 +481,12 @@ const startPreflightSchedules = (hub: Hub) => {
     // These are used by the preflight checks in the Django app to determine if
     // the plugin-server is running.
     schedule.scheduleJob('*/5 * * * * *', async () => {
-        await hub.db.redisSet('@posthog-plugin-server/ping', new Date().toISOString(), 60, {
+        await hub.db.redisSet('@posthog-plugin-server/ping', new Date().toISOString(), 'preflightSchedules', 60, {
             jsonSerialize: false,
         })
-        await hub.db.redisSet('@posthog-plugin-server/version', version, undefined, { jsonSerialize: false })
+        await hub.db.redisSet('@posthog-plugin-server/version', version, 'preflightSchedules', undefined, {
+            jsonSerialize: false,
+        })
     })
 }
 

--- a/plugin-server/src/worker/plugins/mmdb.ts
+++ b/plugin-server/src/worker/plugins/mmdb.ts
@@ -30,7 +30,7 @@ export async function setupMmdb(hub: Hub): Promise<schedule.Job | undefined> {
 
 /** Check if MMDB is being currently fetched by any other plugin server worker in the cluster. */
 async function getMmdbStatus(hub: Hub): Promise<MMDBFileStatus> {
-    return (await hub.db.redisGet(MMDB_STATUS_REDIS_KEY, MMDBFileStatus.Idle)) as MMDBFileStatus
+    return (await hub.db.redisGet(MMDB_STATUS_REDIS_KEY, MMDBFileStatus.Idle, 'getMmdbStatus')) as MMDBFileStatus
 }
 
 /** Decompress a Brotli-compressed MMDB buffer and open a reader from it. */
@@ -111,14 +111,19 @@ async function distributableFetchAndInsertFreshMmdb(hub: Hub): Promise<ReaderMod
         return prepareMmdb(hub)
     }
     // Allow 120 seconds of download until another worker retries
-    await hub.db.redisSet(MMDB_STATUS_REDIS_KEY, MMDBFileStatus.Fetching, 120)
+    await hub.db.redisSet(MMDB_STATUS_REDIS_KEY, MMDBFileStatus.Fetching, 'distributableFetchAndInsertFreshMmdb', 120)
     try {
         const mmdb = await fetchAndInsertFreshMmdb(hub)
-        await hub.db.redisSet(MMDB_STATUS_REDIS_KEY, MMDBFileStatus.Idle)
+        await hub.db.redisSet(MMDB_STATUS_REDIS_KEY, MMDBFileStatus.Idle, 'distributableFetchAndInsertFreshMmdb')
         return mmdb
     } catch (e) {
         // In case of an error mark the MMDB feature unavailable for an hour
-        await hub.db.redisSet(MMDB_STATUS_REDIS_KEY, MMDBFileStatus.Unavailable, 120)
+        await hub.db.redisSet(
+            MMDB_STATUS_REDIS_KEY,
+            MMDBFileStatus.Unavailable,
+            'distributableFetchAndInsertFreshMmdb',
+            120
+        )
         status.error('❌', 'An error occurred during MMDB fetch and insert:', e)
         return null
     }

--- a/plugin-server/src/worker/vm/extensions/cache.ts
+++ b/plugin-server/src/worker/vm/extensions/cache.ts
@@ -7,10 +7,10 @@ export function createCache(server: Hub, pluginId: number, teamId: number): Cach
     const getKey = (key: string) => `@plugin/${pluginId}/${typeof teamId === 'undefined' ? '@all' : teamId}/${key}`
     return {
         set: async function (key, value, ttlSeconds, options) {
-            return await server.db.redisSet(getKey(key), value, ttlSeconds, options)
+            return await server.db.redisSet(getKey(key), value, 'app_cache.set', ttlSeconds, options)
         },
         get: async function (key, defaultValue, options) {
-            return await server.db.redisGet(getKey(key), defaultValue, options)
+            return await server.db.redisGet(getKey(key), defaultValue, 'app_cache.get', options)
         },
         incr: async function (key) {
             return await server.db.redisIncr(getKey(key))

--- a/plugin-server/src/worker/vm/extensions/helpers/api-key-manager.ts
+++ b/plugin-server/src/worker/vm/extensions/helpers/api-key-manager.ts
@@ -37,7 +37,7 @@ export class PluginsApiKeyManager {
         }
 
         const cachedKeyRedisKey = `plugins-api-key-manager/${organizationId}`
-        const cachedKey = await this.db.redisGet<string | null>(cachedKeyRedisKey, null)
+        const cachedKey = await this.db.redisGet<string | null>(cachedKeyRedisKey, null, 'fetchOrCreatePersonalApiKey')
         if (cachedKey) {
             return cachedKey as string
         }
@@ -82,7 +82,7 @@ export class PluginsApiKeyManager {
                 throw new Error('Unable to find or create a personal API key')
             }
 
-            await this.db.redisSet(cachedKeyRedisKey, key, 86_400 * 14) // Don't cache keys longer than 14 days
+            await this.db.redisSet(cachedKeyRedisKey, key, 'fetchOrCreatePersonalApiKey', 86_400 * 14) // Don't cache keys longer than 14 days
 
             return key
         } finally {

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -35,7 +35,7 @@ describe('DB', () => {
     const CLICKHOUSE_TIMESTAMP = '2000-10-14 11:42:06.502' as ClickHouseTimestamp
 
     function fetchGroupCache(teamId: number, groupTypeIndex: number, groupKey: string) {
-        return db.redisGet(db.getGroupDataCacheKey(teamId, groupTypeIndex, groupKey), null)
+        return db.redisGet(db.getGroupDataCacheKey(teamId, groupTypeIndex, groupKey), null, 'fetchGroupCache')
     }
 
     describe('fetchAllActionsGroupedByTeam() and fetchAction()', () => {


### PR DESCRIPTION
## Problem

`redisGet` is our second most common call to a data store, as measured by the  `data_store_query_duration_count` metric. We currently don't have visibility on what these keys are.

## Changes

- mirror the PG client by adding a required `tag` argument to `redisGet` and `redisSet` for increased observabilitiy
- the other redis calls should also eventually be instrumented, but `redisIncr` is only used in apps right now, and the others are not in the top20

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
