### PR TITLE
fix: Crash on S3 upload issues

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
@@ -365,6 +365,7 @@ export class SessionManager {
             counterS3FilesWritten.labels(reason).inc(1)
             histogramS3LinesWritten.observe(count)
             histogramS3KbWritten.observe(sizeEstimate / 1024)
+            this.endFlush()
         } catch (error: any) {
             // TRICKY: error can for some reason sometimes be undefined...
             error = error || new Error('Unknown Error')
@@ -385,10 +386,11 @@ export class SessionManager {
             })
             this.captureException(error)
             counterS3WriteErrored.inc()
+
+            throw error
         } finally {
             clearTimeout(flushTimeout)
             endFlushTimer()
-            this.endFlush()
         }
     }
 


### PR DESCRIPTION
## Problem

Currently we silently ignore S3 write issues. Realistically we never want this. We want to crash and let the lag grow so we can investigate what is going on.

## Changes

* Flat out crash if this happens


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
