### PR TITLE
fix: notebooks inserter icon

### DIFF
--- a/frontend/src/scenes/notebooks/Suggestions/FloatingSuggestions.scss
+++ b/frontend/src/scenes/notebooks/Suggestions/FloatingSuggestions.scss
@@ -4,6 +4,9 @@
 
 .NotebookFloatingButton__plus {
     border-radius: 1rem;
-    min-height: 0.25rem;
-    padding: 0.25rem !important; // NOTE - yuck
+    min-width: 2rem;
+
+    .LemonButton__icon {
+        margin: 0 auto;
+    }
 }


### PR DESCRIPTION
## Problem

Width was incorrect

## Changes

Before
<img width="79" alt="Screenshot 2023-08-16 at 15 53 38" src="https://github.com/PostHog/posthog/assets/6685876/d2478185-414d-4ddd-8adf-6cd1c1a59a88">

After
<img width="125" alt="Screenshot 2023-08-16 at 15 53 06" src="https://github.com/PostHog/posthog/assets/6685876/c5545011-4717-4065-a998-17fb48f73083">


## How did you test this code?

By 👁️ 