### PR TITLE
fix(decide): Log all exceptions

### DIFF
--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -1300,7 +1300,10 @@ class TestDecide(BaseTest, QueryMatchingTest):
                     team_id=str(self.team.pk), errors_computing=True, has_hash_key_override=False
                 )
                 mock_counter.labels.return_value.inc.assert_called_once()
-                mock_error_counter.labels.assert_called_once_with(reason="healthcheck_failed")
+                mock_error_counter.labels.assert_any_call(reason="healthcheck_failed")
+                mock_error_counter.labels.assert_any_call(reason="timeout")
+                self.assertEqual(mock_error_counter.labels.call_count, 2)
+
                 mock_hash_key_counter.labels.assert_not_called()
 
     def test_feature_flags_v3_with_database_errors_and_no_flags(self, *args):

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -654,7 +654,7 @@ def get_all_feature_flags(
                 flags_with_no_overrides = [row[0] for row in cursor.fetchall()]
                 should_write_hash_key_override = len(flags_with_no_overrides) > 0
         except Exception as e:
-            handle_feature_flag_exception(e)
+            handle_feature_flag_exception(e, "[Feature Flags] Error figuring out hash key overrides")
 
         if should_write_hash_key_override:
             try:
@@ -699,7 +699,10 @@ def get_all_feature_flags(
                 target_distinct_ids.append(str(hash_key_override))
             person_overrides = get_feature_flag_hash_key_overrides(team_id, target_distinct_ids, using_database)
 
-    except Exception:
+    except Exception as e:
+        handle_feature_flag_exception(
+            e, "[Feature Flags] Error fetching hash key overrides", set_healthcheck=not writing_hash_key_override
+        )
         # database is down, we can't handle experience continuity flags at all.
         # Treat this same as if there are no experience continuity flags.
         # This automatically sets 'errorsWhileComputingFlags' to True.

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -688,6 +688,7 @@ def get_all_feature_flags(
                 )
 
     # This is the read-path for experience continuity. We need to get the overrides, and to do that, we get the person_id.
+    using_database = None
     try:
         # when we're writing a hash_key_override, we query the main database, not the replica
         # this is because we need to make sure the write is successful before we read it
@@ -701,7 +702,9 @@ def get_all_feature_flags(
 
     except Exception as e:
         handle_feature_flag_exception(
-            e, "[Feature Flags] Error fetching hash key overrides", set_healthcheck=not writing_hash_key_override
+            e,
+            f"[Feature Flags] Error fetching hash key overrides from {using_database} db",
+            set_healthcheck=not writing_hash_key_override,
         )
         # database is down, we can't handle experience continuity flags at all.
         # Treat this same as if there are no experience continuity flags.


### PR DESCRIPTION
## Problem

Noticed some health check errors spring up out of nowhere inmetrics. Turns out because I was missing one place where we should be logging.

Hopefully this gives a better idea of reasons for which getting overrides fails

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
