### PR TITLE
fix: only handle external links

### DIFF
--- a/frontend/src/scenes/notebooks/Marks/NotebookMarkLink.tsx
+++ b/frontend/src/scenes/notebooks/Marks/NotebookMarkLink.tsx
@@ -1,5 +1,5 @@
 import { Mark, mergeAttributes } from '@tiptap/core'
-import { externalLinkPasteRule, posthogLinkPasteRule } from '../Nodes/utils'
+import { linkPasteRule } from '../Nodes/utils'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { router } from 'kea-router'
 
@@ -26,7 +26,7 @@ export const NotebookMarkLink = Mark.create({
     },
 
     addPasteRules() {
-        return [posthogLinkPasteRule(), externalLinkPasteRule()]
+        return [linkPasteRule()]
     },
 
     addProseMirrorPlugins() {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePlaylist.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePlaylist.tsx
@@ -84,7 +84,7 @@ export const NotebookNodePlaylist = createPostHogWidgetNode<NotebookNodePlaylist
     },
     pasteOptions: {
         find: urls.replay() + '(.+)',
-        getAttributes: (match) => {
+        getAttributes: async (match) => {
             const searchParams = fromParamsGivenUrl(match[1].split('?')[1] || '')
             return { filters: searchParams.filters }
         },

--- a/frontend/src/scenes/notebooks/Nodes/utils.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/utils.tsx
@@ -56,23 +56,16 @@ export function posthogNodePasteRule(options: {
     })
 }
 
-export function posthogLinkPasteRule(): PasteRule {
-    return markPasteRule(true)
-}
-
-export function externalLinkPasteRule(): PasteRule {
-    return markPasteRule(false)
-}
-
-function markPasteRule(internal: boolean): PasteRule {
-    const regex = createUrlRegex("([a-zA-Z0-9-._~:/?#\\[\\]!@$&'()*,;=]*)", internal ? undefined : '(https?|mailto)://')
-
+export function linkPasteRule(): PasteRule {
     return new PasteRule({
-        find: regex,
+        find: createUrlRegex(
+            `(?!${window.location.host})([a-zA-Z0-9-._~:/?#\\[\\]!@$&'()*,;=]*)`,
+            '^(https?|mailto)://'
+        ),
         handler: ({ match, chain, range }) => {
             if (match.input) {
                 const url = new URL(match[0])
-                const href = internal ? url.pathname : url.toString()
+                const href = url.origin === window.location.origin ? url.pathname : url.toString()
                 chain()
                     .deleteRange(range)
                     .insertContent([


### PR DESCRIPTION
## Problem

There is a [bug in TipTap](https://github.com/ueberdosis/tiptap/issues/4336) that prevents node paste handlers from running alongside mark paste handlers

## Changes

Get around the bug for now by limiting the mark paste handler to only work on external links

## How did you test this code?

Manually
