### PR TITLE
fix: Min value for Blobby lag

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
@@ -312,12 +312,12 @@ export class SessionRecordingIngesterV2 {
                             })
                             .set(now() - timestamp)
 
-                        // NOTE: This is an important metric used by the autoscaler
                         const offsetsByPartition = await this.offsetsRefresher.get()
                         const highOffset = offsetsByPartition[partition]
 
                         if (highOffset) {
-                            gaugeLag.set({ partition }, highOffset - metrics.lastMessageOffset)
+                            // NOTE: This is an important metric used by the autoscaler
+                            gaugeLag.set({ partition }, Math.max(0, highOffset - metrics.lastMessageOffset))
                         }
                     }
 


### PR DESCRIPTION
## Problem

We load the latestOffsets async and cache them so if we are basically realtime lag can be negative.

## Changes

* Fixes this to a max of zero instead

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
