### PR TITLE
feat: Use buildjet for ci-backend

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -43,27 +43,21 @@ runs:
           run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
 
         - name: Set up Python
-          uses: actions/setup-python@v4
+          id: python
+          uses: buildjet/setup-python@v4
           with:
               python-version: ${{ inputs.python-version }}
               token: ${{ inputs.token }}
+              cache: pip
 
         - name: Install SAML (python3-saml) dependencies
           shell: bash
           run: |
               sudo apt-get update
               sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
-
-        - uses: syphar/restore-virtualenv@v1
-          id: cache-backend-tests
-          with:
-              custom_cache_key_element: v1
-
-        - uses: syphar/restore-pip-download-cache@v1
-          if: steps.cache-backend-tests.outputs.cache-hit != 'true'
+          if: steps.python.outputs.cache-hit != 'true'
 
         - name: Install python dependencies
-          if: steps.cache-backend-tests.outputs.cache-hit != 'true'
           shell: bash
           run: |
               python -m pip install -r requirements-dev.txt

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1,4 +1,4 @@
-# This workflow runs all of our backend django tests.
+# This workflow runs all of our backend django tests..ci-back
 #
 # If these tests get too slow, look at increasing concurrency and re-timing the tests by manually dispatching
 # .github/workflows/ci-backend-update-test-timing.yml action
@@ -102,10 +102,12 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@v4
+              id: python
+              uses: buildjet/setup-python@v4
               with:
                   python-version: 3.10.10
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+                  cache: pip
 
             - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests
@@ -119,9 +121,9 @@ jobs:
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+              if: steps.python.outputs.cache-hit != 'true'
 
             - name: Install python dependencies
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
               run: |
                   cd current
                   python -m pip install -r requirements.txt -r requirements-dev.txt
@@ -184,26 +186,20 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@v4
+              id: python
+              uses: buildjet/setup-python@v4
               with:
                   python-version: 3.10.10
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
-
-            - uses: syphar/restore-virtualenv@v1
-              id: cache-backend-tests
-              with:
-                  custom_cache_key_element: v1-
-
-            - uses: syphar/restore-pip-download-cache@v1
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
+                  cache: pip
 
             - name: Install SAML (python3-saml) dependencies
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+              if: steps.python.outputs.cache-hit != 'true'
 
             - name: Install python dependencies
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
               run: |
                   python -m pip install -r requirements.txt -r requirements-dev.txt
 
@@ -328,15 +324,18 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@v4
+              id: python
+              uses: buildjet/setup-python@v4
               with:
                   python-version: 3.10.10
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+                  cache: pip
 
             - name: Install SAML (python3-saml) dependencies
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+              if: steps.python.outputs.cache-hit != 'true'
 
             - uses: syphar/restore-virtualenv@v1
               id: cache-async-migrations-tests
@@ -347,7 +346,6 @@ jobs:
               if: steps.cache-backend-tests.outputs.cache-hit != 'true'
 
             - name: Install python dependencies
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
               shell: bash
               run: |
                   python -m pip install -r requirements.txt -r requirements-dev.txt

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1,4 +1,4 @@
-# This workflow runs all of our backend django tests..ci-back
+# This workflow runs all of our backend django tests.
 #
 # If these tests get too slow, look at increasing concurrency and re-timing the tests by manually dispatching
 # .github/workflows/ci-backend-update-test-timing.yml action

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -226,7 +226,7 @@ jobs:
         timeout-minutes: 30
 
         name: Django tests – ${{ matrix.segment }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
-        runs-on: buildjet-2vcpu-ubuntu-2204
+        runs-on: buildjet-4vcpu-ubuntu-2204
 
         strategy:
             fail-fast: false

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -34,7 +34,7 @@ jobs:
     # Job to decide if we should run backend ci
     # See https://github.com/dorny/paths-filter#conditional-execution for more details
     changes:
-        runs-on: buildjet-2vcpu-ubuntu-2204-arm
+        runs-on: buildjet-2vcpu-ubuntu-2204
         timeout-minutes: 5
         if: github.repository == 'PostHog/posthog'
         name: Determine need to run backend checks
@@ -80,7 +80,7 @@ jobs:
         timeout-minutes: 10
 
         name: Python code quality checks
-        runs-on: buildjet-2vcpu-ubuntu-2204-arm
+        runs-on: buildjet-2vcpu-ubuntu-2204
 
         steps:
             # If this run wasn't initiated by the bot (meaning: snapshot update) and we've determined
@@ -168,7 +168,7 @@ jobs:
         timeout-minutes: 5
 
         name: Validate Django migrations
-        runs-on: buildjet-2vcpu-ubuntu-2204-arm
+        runs-on: buildjet-2vcpu-ubuntu-2204
 
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -146,7 +146,8 @@ jobs:
                   # "apt-get install antlr" would install 4.7 which is incompatible with our grammar.
                   export ANTLR_VERSION=4.13.0
                   # java version doesn't matter
-                  sudo apt-get install default-jre
+                  sudo apt update -y
+                  sudo apt-get -y install default-jre
                   mkdir antlr
                   cd antlr
                   curl -o antlr.jar https://www.antlr.org/download/antlr-$ANTLR_VERSION-complete.jar

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -34,7 +34,7 @@ jobs:
     # Job to decide if we should run backend ci
     # See https://github.com/dorny/paths-filter#conditional-execution for more details
     changes:
-        runs-on: buildjet-2vcpu-ubuntu-2204
+        runs-on: buildjet-2vcpu-ubuntu-2204-arm
         timeout-minutes: 5
         if: github.repository == 'PostHog/posthog'
         name: Determine need to run backend checks
@@ -80,7 +80,7 @@ jobs:
         timeout-minutes: 10
 
         name: Python code quality checks
-        runs-on: buildjet-2vcpu-ubuntu-2204
+        runs-on: buildjet-2vcpu-ubuntu-2204-arm
 
         steps:
             # If this run wasn't initiated by the bot (meaning: snapshot update) and we've determined
@@ -168,7 +168,7 @@ jobs:
         timeout-minutes: 5
 
         name: Validate Django migrations
-        runs-on: buildjet-2vcpu-ubuntu-2204
+        runs-on: buildjet-2vcpu-ubuntu-2204-arm
 
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -109,14 +109,6 @@ jobs:
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
                   cache: pip
 
-            - uses: syphar/restore-virtualenv@v1
-              id: cache-backend-tests
-              with:
-                  custom_cache_key_element: v1-
-
-            - uses: syphar/restore-pip-download-cache@v1
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
-
             - name: Install SAML (python3-saml) dependencies
               run: |
                   sudo apt-get update
@@ -336,14 +328,6 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
               if: steps.python.outputs.cache-hit != 'true'
-
-            - uses: syphar/restore-virtualenv@v1
-              id: cache-async-migrations-tests
-              with:
-                  custom_cache_key_element: v1-${{ inputs.cache-id }}
-
-            - uses: syphar/restore-pip-download-cache@v1
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
 
             - name: Install python dependencies
               shell: bash

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -16,6 +16,7 @@ on:
                 type: string
 
 env:
+    DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
     REDIS_URL: 'redis://localhost'
@@ -33,7 +34,7 @@ jobs:
     # Job to decide if we should run backend ci
     # See https://github.com/dorny/paths-filter#conditional-execution for more details
     changes:
-        runs-on: ubuntu-latest
+        runs-on: buildjet-2vcpu-ubuntu-2204
         timeout-minutes: 5
         if: github.repository == 'PostHog/posthog'
         name: Determine need to run backend checks
@@ -79,7 +80,7 @@ jobs:
         timeout-minutes: 10
 
         name: Python code quality checks
-        runs-on: ubuntu-latest
+        runs-on: buildjet-2vcpu-ubuntu-2204
 
         steps:
             # If this run wasn't initiated by the bot (meaning: snapshot update) and we've determined
@@ -172,7 +173,7 @@ jobs:
         timeout-minutes: 5
 
         name: Validate Django migrations
-        runs-on: ubuntu-latest
+        runs-on: buildjet-2vcpu-ubuntu-2204
 
         steps:
             - uses: actions/checkout@v3
@@ -236,7 +237,7 @@ jobs:
         timeout-minutes: 30
 
         name: Django tests – ${{ matrix.segment }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
-        runs-on: ubuntu-latest
+        runs-on: buildjet-2vcpu-ubuntu-2204
 
         strategy:
             fail-fast: false
@@ -313,7 +314,7 @@ jobs:
         name: Async migrations tests
         needs: changes
         if: needs.changes.outputs.backend == 'true'
-        runs-on: ubuntu-latest
+        runs-on: buildjet-2vcpu-ubuntu-2204
         steps:
             - name: 'Checkout repo'
               uses: actions/checkout@v3

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -4,7 +4,7 @@
 
 services:
     db:
-        image: postgres:12-alpine
+        image: ${DOCKER_REGISTRY_PREFIX:-}postgres:12-alpine
         restart: on-failure
         environment:
             POSTGRES_USER: posthog
@@ -16,7 +16,7 @@ services:
             timeout: 5s
 
     redis:
-        image: redis:6.2.7-alpine
+        image: ${DOCKER_REGISTRY_PREFIX:-}redis:6.2.7-alpine
         restart: on-failure
         command: redis-server --maxmemory-policy allkeys-lru --maxmemory 200mb
 
@@ -25,17 +25,17 @@ services:
         # Note: please keep the default version in sync across
         #       `posthog` and the `charts-clickhouse` repos
         #
-        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:23.6.1.1524}
+        image: ${DOCKER_REGISTRY_PREFIX:-}${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:23.6.1.1524}
         restart: on-failure
         depends_on:
             - kafka
             - zookeeper
     zookeeper:
-        image: zookeeper:3.7.0
+        image: ${DOCKER_REGISTRY_PREFIX:-}zookeeper:3.7.0
         restart: on-failure
 
     kafka:
-        image: bitnami/kafka:2.8.1-debian-10-r99
+        image: ${DOCKER_REGISTRY_PREFIX:-}bitnami/kafka:2.8.1-debian-10-r99
         restart: on-failure
         depends_on:
             - zookeeper
@@ -48,7 +48,7 @@ services:
             ALLOW_PLAINTEXT_LISTENER: 'true'
 
     object_storage:
-        image: minio/minio:RELEASE.2022-06-25T15-50-16Z
+        image: ${DOCKER_REGISTRY_PREFIX:-}minio/minio:RELEASE.2022-06-25T15-50-16Z
         restart: on-failure
         environment:
             MINIO_ROOT_USER: object_storage_root_user
@@ -57,7 +57,7 @@ services:
         command: -c 'mkdir -p /data/posthog && minio server --address ":19000" --console-address ":19001" /data' # create the 'posthog' bucket before starting the service
 
     maildev:
-        image: maildev/maildev:2.0.5
+        image: ${DOCKER_REGISTRY_PREFIX:-}maildev/maildev:2.0.5
         restart: on-failure
 
     worker: &worker
@@ -137,7 +137,7 @@ services:
             - discovery.type=single-node
             - ES_JAVA_OPTS=-Xms256m -Xmx256m
             - xpack.security.enabled=false
-        image: elasticsearch:7.16.2
+        image: ${DOCKER_REGISTRY_PREFIX:-}elasticsearch:7.16.2
         expose:
             - 9200
         volumes:
@@ -157,7 +157,7 @@ services:
             - ENABLE_ES=true
             - ES_SEEDS=elasticsearch
             - ES_VERSION=v7
-        image: temporalio/auto-setup:1.20.0
+        image: ${DOCKER_REGISTRY_PREFIX:-}temporalio/auto-setup:1.20.0
         ports:
             - 7233:7233
         labels:
@@ -169,7 +169,7 @@ services:
             - temporal
         environment:
             - TEMPORAL_CLI_ADDRESS=temporal:7233
-        image: temporalio/admin-tools:1.20.0
+        image: ${DOCKER_REGISTRY_PREFIX:-}temporalio/admin-tools:1.20.0
         stdin_open: true
         tty: true
     temporal-ui:
@@ -178,7 +178,7 @@ services:
         environment:
             - TEMPORAL_ADDRESS=temporal:7233
             - TEMPORAL_CORS_ORIGINS=http://localhost:3000
-        image: temporalio/ui:2.10.3
+        image: ${DOCKER_REGISTRY_PREFIX:-}temporalio/ui:2.10.3
         ports:
             - 8081:8080
     temporal-django-worker:


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

We have fairly limited CI concurrency with GitHub, and also limited choice in runners

With Buildjet, we can get as much concurrency as we would like, and far more choice in runners. We also don't need to self host runners (risky - we're open source)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
