### PR TITLE
fix: group notifications by five minutes

### DIFF
--- a/posthog/api/activity_log.py
+++ b/posthog/api/activity_log.py
@@ -126,12 +126,17 @@ class ActivityLogViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
         # Step 2: Retrieve the most recent model instance for each group.
         other_peoples_changes = []
         for group in other_peoples_changes_by_minute:
-            instance = self.queryset.filter(
-                scope=group["scope"],
-                item_id=group["item_id"],
-                created_at__gte=group["created_at_minute"],
-                created_at__lt=group["created_at_minute"] + timedelta(minutes=1),
-            ).latest("created_at")
+            instance = (
+                self.queryset.exclude(user=user)
+                .filter(team_id=self.team.id)
+                .filter(
+                    scope=group["scope"],
+                    item_id=group["item_id"],
+                    created_at__gte=group["created_at_minute"],
+                    created_at__lt=group["created_at_minute"] + timedelta(minutes=1),
+                )
+                .latest("created_at")
+            )
             other_peoples_changes.append(instance)
 
         serialized_data = ActivityLogSerializer(

--- a/posthog/api/activity_log.py
+++ b/posthog/api/activity_log.py
@@ -103,6 +103,7 @@ class ActivityLogViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
                     ) AS row_number,
                     *
                     FROM (
+                        -- copied from https://stackoverflow.com/a/43028800
                         SELECT to_timestamp(floor(Extract(epoch FROM created_at) / extract(epoch FROM interval '5 min')) *
                                             extract(epoch FROM interval '5 min')) AS five_minute_window,
                                activity, item_id, scope, id, created_at

--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -1,5 +1,8 @@
+from datetime import timedelta
 from typing import Any, Dict, Optional, Tuple, List
 
+from freezegun import freeze_time
+from freezegun.api import StepTickTimeFactory, FrozenDateTimeFactory
 from rest_framework import status
 
 from posthog.models import User
@@ -41,39 +44,54 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
         self._create_and_edit_things()
 
     def _create_and_edit_things(self):
-        created_insights = []
-        for _ in range(0, 11):
-            insight_id, _ = self._create_insight({})
-            created_insights.append(insight_id)
 
-        flag_one = self.client.post(
-            f"/api/projects/{self.team.id}/feature_flags/", _feature_flag_json_payload("one")
-        ).json()["id"]
+        with freeze_time("2023-08-17") as frozen_time:
+            # almost every change below will be more than 5 minutes apart
+            created_insights = []
+            for _ in range(0, 11):
+                frozen_time.tick(delta=timedelta(minutes=6))
+                insight_id, _ = self._create_insight({})
+                created_insights.append(insight_id)
 
-        flag_two = self.client.post(
-            f"/api/projects/{self.team.id}/feature_flags/", _feature_flag_json_payload("two")
-        ).json()["id"]
+            frozen_time.tick(delta=timedelta(minutes=6))
+            flag_one = self.client.post(
+                f"/api/projects/{self.team.id}/feature_flags/", _feature_flag_json_payload("one")
+            ).json()["id"]
 
-        notebook_json = self.client.post(
-            f"/api/projects/{self.team.id}/notebooks/",
-            {"content": "print('hello world')", "name": "notebook"},
-        ).json()
+            frozen_time.tick(delta=timedelta(minutes=6))
+            flag_two = self.client.post(
+                f"/api/projects/{self.team.id}/feature_flags/", _feature_flag_json_payload("two")
+            ).json()["id"]
 
-        # other user now edits them
-        self._edit_them_all(
-            created_insights, flag_one, flag_two, notebook_json["short_id"], notebook_json["version"], self.other_user
-        )
-        # third user edits them
-        self._edit_them_all(
-            created_insights,
-            flag_one,
-            flag_two,
-            notebook_json["short_id"],
-            notebook_json["version"] + 1,
-            self.third_user,
-        )
+            frozen_time.tick(delta=timedelta(minutes=6))
 
-        self.client.force_login(self.user)
+            notebook_json = self.client.post(
+                f"/api/projects/{self.team.id}/notebooks/",
+                {"content": "print('hello world')", "name": "notebook"},
+            ).json()
+
+            # other user now edits them
+            notebook_version = self._edit_them_all(
+                created_insights,
+                flag_one,
+                flag_two,
+                notebook_json["short_id"],
+                notebook_json["version"],
+                self.other_user,
+                frozen_time,
+            )
+            # third user edits them
+            self._edit_them_all(
+                created_insights,
+                flag_one,
+                flag_two,
+                notebook_json["short_id"],
+                notebook_version,
+                self.third_user,
+                frozen_time,
+            )
+
+            self.client.force_login(self.user)
 
     def _edit_them_all(
         self,
@@ -83,33 +101,53 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
         notebook_short_id: str,
         notebook_version: int,
         the_user: User,
-    ) -> None:
+        frozen_time: FrozenDateTimeFactory | StepTickTimeFactory,
+    ) -> int:
         self.client.force_login(the_user)
         for created_insight_id in created_insights[:7]:
+            frozen_time.tick(delta=timedelta(minutes=6))
             update_response = self.client.patch(
                 f"/api/projects/{self.team.id}/insights/{created_insight_id}",
                 {"name": f"{created_insight_id}-insight-changed-by-{the_user.id}"},
             )
             self.assertEqual(update_response.status_code, status.HTTP_200_OK)
+
+            frozen_time.tick(delta=timedelta(minutes=6))
         assert (
             self.client.patch(
                 f"/api/projects/{self.team.id}/feature_flags/{flag_one}", {"name": f"one-edited-by-{the_user.id}"}
             ).status_code
             == status.HTTP_200_OK
         )
+
+        frozen_time.tick(delta=timedelta(minutes=6))
         assert (
             self.client.patch(
                 f"/api/projects/{self.team.id}/feature_flags/{flag_two}", {"name": f"two-edited-by-{the_user.id}"}
             ).status_code
             == status.HTTP_200_OK
         )
-        assert (
-            self.client.patch(
-                f"/api/projects/{self.team.id}/notebooks/{notebook_short_id}",
-                {"content": f"print('hello world again from {the_user.id}')", "version": notebook_version},
-            ).status_code
-            == status.HTTP_200_OK
-        )
+
+        frozen_time.tick(delta=timedelta(minutes=6))
+        # notebooks save while you're typing so, we get multiple activities per edit
+        for typed_text in [
+            "print",
+            "print(",
+            "print('hello world again')",
+            "print('hello world again from ",
+            f"print('hello world again from {the_user.id}')",
+        ]:
+            frozen_time.tick(delta=timedelta(seconds=5))
+            assert (
+                self.client.patch(
+                    f"/api/projects/{self.team.id}/notebooks/{notebook_short_id}",
+                    {"content": typed_text, "version": notebook_version},
+                ).status_code
+                == status.HTTP_200_OK
+            )
+            notebook_version = notebook_version + 1
+
+        return notebook_version
 
     def test_can_get_top_ten_important_changes(self) -> None:
         # user one is shown the most recent 10 of those changes
@@ -197,7 +235,7 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
         assert bookmark_response.status_code == status.HTTP_204_NO_CONTENT
 
         changes = self.client.get(f"/api/projects/{self.team.id}/activity_log/important_changes")
-
+        assert changes.status_code == status.HTTP_200_OK
         assert [c["unread"] for c in changes.json()["results"]] == [True, True]
         assert changes.json()["last_read"] == most_recent_date
 

--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -225,7 +225,22 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
     def test_reading_notifications_marks_them_unread(self):
         changes = self.client.get(f"/api/projects/{self.team.id}/activity_log/important_changes")
         assert changes.status_code == status.HTTP_200_OK
-
+        assert len(changes.json()["results"]) == 10
+        assert changes.json()["last_read"] is None
+        assert [c["unread"] for c in changes.json()["results"]] == [True] * 10
+        assert [c["created_at"] for c in changes.json()["results"]] == [
+            # time is frozen in test setup so
+            "2023-08-17T04:36:50Z",
+            "2023-08-17T04:30:25Z",
+            "2023-08-17T04:24:25Z",
+            "2023-08-17T04:18:25Z",
+            "2023-08-17T04:06:25Z",
+            "2023-08-17T03:54:25Z",
+            "2023-08-17T03:42:25Z",
+            "2023-08-17T03:30:25Z",
+            "2023-08-17T03:18:25Z",
+            "2023-08-17T03:06:25Z",
+        ]
         most_recent_date = changes.json()["results"][2]["created_at"]
 
         # the user can mark where they have read up to
@@ -236,8 +251,8 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
 
         changes = self.client.get(f"/api/projects/{self.team.id}/activity_log/important_changes")
         assert changes.status_code == status.HTTP_200_OK
+        assert changes.json()["last_read"] == "2023-08-17T04:24:25Z"
         assert [c["unread"] for c in changes.json()["results"]] == [True, True]
-        assert changes.json()["last_read"] == most_recent_date
 
     def _create_insight(
         self, data: Dict[str, Any], team_id: Optional[int] = None, expected_status: int = status.HTTP_201_CREATED


### PR DESCRIPTION
## Problem

Notebooks save multiple times while you edit them. This makes the notifications area very noisy. It only shows ten changes and they might all be for the same notebook editing session.

## Changes

To avoid writing custom SQL for this

This change groups changes by scope, item_id, activity and its activity date truncated to 5 minutes. And then chooses the latest change for each of those groupings. So that we get up-to the ten latest changes by 5 minutes instead of by instant of time.

### e.g. here 

over ten edits were made an hour ago and a few minutes ago, but we show only two notifications instead of 20

<img width="455" alt="Screenshot 2023-08-17 at 17 32 03" src="https://github.com/PostHog/posthog/assets/984817/0cd40bb1-20c4-4af5-9c33-ba1ee94826bf">

---

It's not super clever since it doesn't window by group so if someone edits across the five minute boundary they'd get two notifications but it should still be a fast query so feels an ok trade-off

## How did you test this code?

developer tests
