### PR TITLE
fix: Save destination before saving BatchExport

### DIFF
--- a/posthog/management/commands/create_batch_export_from_app.py
+++ b/posthog/management/commands/create_batch_export_from_app.py
@@ -94,6 +94,7 @@ class Command(BaseCommand):
                 destination=destination,
             )
 
+            destination.save()
             batch_export.save()
 
             sync_batch_export(batch_export, created=True)


### PR DESCRIPTION
## Problem

The create_batch_export_from_app has a small bug as we don't save the destination before saving the BatchExport. Likely not caught by tests as tests do not commit transactions.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add a `destination.save()` before `batch_export.save()`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually, command runs fine after the fix.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
