### PR TITLE
chore: test different buildjet runners

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -4,9 +4,6 @@
 #
 name: Run Django tests
 inputs:
-    running-on:
-        required: true
-        description: Which buildjet runner is being used
     python-version:
         required: true
         description: Python version, e.g. 3.10.10
@@ -94,7 +91,7 @@ runs:
 
         # Tests
 
-        - name: Run FOSS tests - ${{ inputs.running-on }}
+        - name: Run FOSS tests
           if: ${{ inputs.segment == 'FOSS' }}
           env:
               PERSON_ON_EVENTS_V2_ENABLED: ${{ inputs.person-on-events }}
@@ -106,7 +103,7 @@ runs:
                   --durations=100 --durations-min=1.0 --store-durations \
                   $PYTEST_ARGS
 
-        - name: Run Decide read replica tests - ${{ inputs.running-on }}
+        - name: Run Decide read replica tests
           if: ${{ inputs.segment == 'FOSS' && inputs.group == 1 && inputs.person-on-events != 'true' }}
           env:
               POSTHOG_DB_NAME: posthog
@@ -120,7 +117,7 @@ runs:
                   --durations=100 --durations-min=1.0 \
                   $PYTEST_ARGS
 
-        - name: Run EE tests - ${{ inputs.running-on }}
+        - name: Run EE tests
           if: ${{ inputs.segment == 'EE' }}
           env:
               PERSON_ON_EVENTS_V2_ENABLED: ${{ inputs.person-on-events }}
@@ -138,5 +135,5 @@ runs:
           uses: actions/upload-artifact@v2
           if: ${{ inputs.segment == 'EE' && inputs.person-on-events != 'true'}}
           with:
-              name: timing_data-${{ inputs.group }}-${{ inputs.running-on }}
+              name: timing_data-${{ inputs.group }}
               path: .test_durations

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -4,6 +4,9 @@
 #
 name: Run Django tests
 inputs:
+    running-on:
+        required: true
+        description: Which buildjet runner is being used
     python-version:
         required: true
         description: Python version, e.g. 3.10.10
@@ -91,7 +94,7 @@ runs:
 
         # Tests
 
-        - name: Run FOSS tests
+        - name: Run FOSS tests - ${{matrix.runs-on}}
           if: ${{ inputs.segment == 'FOSS' }}
           env:
               PERSON_ON_EVENTS_V2_ENABLED: ${{ inputs.person-on-events }}
@@ -103,7 +106,7 @@ runs:
                   --durations=100 --durations-min=1.0 --store-durations \
                   $PYTEST_ARGS
 
-        - name: Run Decide read replica tests
+        - name: Run Decide read replica tests - ${{matrix.runs-on}}
           if: ${{ inputs.segment == 'FOSS' && inputs.group == 1 && inputs.person-on-events != 'true' }}
           env:
               POSTHOG_DB_NAME: posthog
@@ -117,7 +120,7 @@ runs:
                   --durations=100 --durations-min=1.0 \
                   $PYTEST_ARGS
 
-        - name: Run EE tests
+        - name: Run EE tests - ${{matrix.runs-on}}
           if: ${{ inputs.segment == 'EE' }}
           env:
               PERSON_ON_EVENTS_V2_ENABLED: ${{ inputs.person-on-events }}
@@ -135,5 +138,5 @@ runs:
           uses: actions/upload-artifact@v2
           if: ${{ inputs.segment == 'EE' && inputs.person-on-events != 'true'}}
           with:
-              name: timing_data-${{ inputs.group }}
+              name: timing_data-${{ inputs.group }}-${{matrix.runs-on}}
               path: .test_durations

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -94,7 +94,7 @@ runs:
 
         # Tests
 
-        - name: Run FOSS tests - ${{matrix.runs-on}}
+        - name: Run FOSS tests - ${{ inputs.running-on }}
           if: ${{ inputs.segment == 'FOSS' }}
           env:
               PERSON_ON_EVENTS_V2_ENABLED: ${{ inputs.person-on-events }}
@@ -106,7 +106,7 @@ runs:
                   --durations=100 --durations-min=1.0 --store-durations \
                   $PYTEST_ARGS
 
-        - name: Run Decide read replica tests - ${{matrix.runs-on}}
+        - name: Run Decide read replica tests - ${{ inputs.running-on }}
           if: ${{ inputs.segment == 'FOSS' && inputs.group == 1 && inputs.person-on-events != 'true' }}
           env:
               POSTHOG_DB_NAME: posthog
@@ -120,7 +120,7 @@ runs:
                   --durations=100 --durations-min=1.0 \
                   $PYTEST_ARGS
 
-        - name: Run EE tests - ${{matrix.runs-on}}
+        - name: Run EE tests - ${{ inputs.running-on }}
           if: ${{ inputs.segment == 'EE' }}
           env:
               PERSON_ON_EVENTS_V2_ENABLED: ${{ inputs.person-on-events }}
@@ -138,5 +138,5 @@ runs:
           uses: actions/upload-artifact@v2
           if: ${{ inputs.segment == 'EE' && inputs.person-on-events != 'true'}}
           with:
-              name: timing_data-${{ inputs.group }}-${{matrix.runs-on}}
+              name: timing_data-${{ inputs.group }}-${{ inputs.running-on }}
               path: .test_durations

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -225,8 +225,6 @@ jobs:
         needs: changes
         timeout-minutes: 30
 
-        name: Django tests – ${{ matrix.segment }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
-
         strategy:
             fail-fast: false
             matrix:
@@ -245,6 +243,7 @@ jobs:
                 concurrency: [5]
                 group: [1, 2, 3, 4, 5]
 
+        name: Django tests – ${{matrix.runs-on}} ${{ matrix.segment }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
         runs-on: ${{matrix.runs-on}}
 
         steps:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -226,11 +226,17 @@ jobs:
         timeout-minutes: 30
 
         name: Django tests – ${{ matrix.segment }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
-        runs-on: buildjet-4vcpu-ubuntu-2204
 
         strategy:
             fail-fast: false
             matrix:
+                runs-on:
+                    [
+                        buildjet-2vcpu-ubuntu-2204,
+                        buildjet-4vcpu-ubuntu-2204,
+                        buildjet-8vcpu-ubuntu-2204,
+                        buildjet-16vcpu-ubuntu-2204,
+                    ]
                 python-version: ['3.10.10']
                 clickhouse-server-image: ['clickhouse/clickhouse-server:23.6.1.1524']
                 segment: ['FOSS', 'EE']
@@ -238,6 +244,8 @@ jobs:
                 # :NOTE: Keep concurrency and groups in sync
                 concurrency: [5]
                 group: [1, 2, 3, 4, 5]
+
+        runs-on: ${{matrix.runs-on}}
 
         steps:
             # The first step is the only one that should run if `needs.changes.outputs.backend == 'false'`.
@@ -254,6 +262,7 @@ jobs:
             - uses: ./.github/actions/run-backend-tests
               if: needs.changes.outputs.backend == 'true'
               with:
+                  running-on: ${{ matrix.runs-on }}
                   segment: ${{ matrix.segment }}
                   person-on-events: ${{ matrix.person-on-events }}
                   python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -239,8 +239,8 @@ jobs:
                     ]
                 python-version: ['3.10.10']
                 clickhouse-server-image: ['clickhouse/clickhouse-server:23.6.1.1524']
-                segment: ['FOSS', 'EE']
-                person-on-events: [false, true]
+                segment: ['FOSS']
+                person-on-events: [false]
                 # :NOTE: Keep concurrency and groups in sync
                 concurrency: [5]
                 group: [1, 2, 3, 4, 5]

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -229,22 +229,16 @@ jobs:
             fail-fast: false
             matrix:
                 runs-on:
-                    [
-                        buildjet-2vcpu-ubuntu-2204,
-                        buildjet-4vcpu-ubuntu-2204,
-                        buildjet-8vcpu-ubuntu-2204,
-                        buildjet-16vcpu-ubuntu-2204,
-                    ]
                 python-version: ['3.10.10']
                 clickhouse-server-image: ['clickhouse/clickhouse-server:23.6.1.1524']
-                segment: ['FOSS']
-                person-on-events: [false]
+                segment: ['FOSS', 'EE']
+                person-on-events: [false, true]
                 # :NOTE: Keep concurrency and groups in sync
                 concurrency: [5]
                 group: [1, 2, 3, 4, 5]
 
-        name: Django tests – ${{matrix.runs-on}} ${{ matrix.segment }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
-        runs-on: ${{matrix.runs-on}}
+        name: Django tests – ${{ matrix.segment }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
+        runs-on: buildjet-4vcpu-ubuntu-2204
 
         steps:
             # The first step is the only one that should run if `needs.changes.outputs.backend == 'false'`.


### PR DESCRIPTION
Following the instructions here https://buildjet.com/for-github-actions/docs/guides/which-runner-should-i-use

I think this will test the speed of backend tests on various different buildjet runners