### PR TITLE
fix: add shutdown method for node.js in the getting started docs

### DIFF
--- a/frontend/src/scenes/ingestion/frameworks/NodeInstructions.tsx
+++ b/frontend/src/scenes/ingestion/frameworks/NodeInstructions.tsx
@@ -32,7 +32,14 @@ const client = new PostHog(
 function NodeCaptureSnippet(): JSX.Element {
     return (
         <CodeSnippet language={Language.JavaScript}>
-            {"client.capture({\n    distinctId: 'test-id',\n    event: 'test-event'\n})"}
+            {`client.capture({
+    distinctId: 'test-id',
+    event: 'test-event'
+})
+
+// Send queued events immediately. Use for example in a serverless environment
+// where the program may terminate before everything is sent
+client.flush()`}
         </CodeSnippet>
     )
 }


### PR DESCRIPTION
## Problem

I've found that without the `client.shutdown()` call node frequently quits before the event actually gets sent, which makes for a confusing first experience.

This might not be needed in a regular application, but makes a difference when just starting.

## Changes

![image](https://github.com/PostHog/posthog/assets/44905/d6270953-4d50-4358-8bc0-69d1671abc8a)

## How did you test this code?

Just reloaded the local dev instance when in the http://localhost:8000/ingestion/backend/nodejs page.