### PR TITLE
feat: insight details colored series

### DIFF
--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.insight.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.insight.test.tsx
@@ -4,6 +4,8 @@ import '@testing-library/jest-dom'
 import { MOCK_TEAM_ID } from 'lib/api.mock'
 import { makeTestSetup } from 'lib/components/ActivityLog/activityLogLogic.test.setup'
 
+jest.mock('lib/colors')
+
 describe('the activity log logic', () => {
     describe('humanizing insights', () => {
         const insightTestSetup = makeTestSetup(

--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -1,5 +1,5 @@
 import { useValues } from 'kea'
-import { allOperatorsMapping, alphabet, capitalizeFirstLetter, formatPropertyLabel } from 'lib/utils'
+import { allOperatorsMapping, capitalizeFirstLetter, formatPropertyLabel } from 'lib/utils'
 import { LocalFilter, toLocalFilters } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
 import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
 import { humanizePathsEventTypes } from 'scenes/insights/utils'
@@ -16,7 +16,7 @@ import {
 import { IconCalculate, IconSubdirectoryArrowRight } from 'lib/lemon-ui/icons'
 import { LemonRow } from 'lib/lemon-ui/LemonRow'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
-import { Lettermark } from 'lib/lemon-ui/Lettermark'
+import { SeriesLetter } from 'lib/components/SeriesGlyph'
 import { Link } from 'lib/lemon-ui/Link'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { PropertyKeyInfo } from '../../PropertyKeyInfo'
@@ -122,10 +122,12 @@ function SeriesDisplay({
     filter,
     insightType = InsightType.TRENDS,
     index,
+    hasBreakdown,
 }: {
     filter: LocalFilter
     insightType?: InsightType
     index: number
+    hasBreakdown: boolean
 }): JSX.Element {
     const { mathDefinitions } = useValues(mathsLogic)
 
@@ -141,7 +143,7 @@ function SeriesDisplay({
         <LemonRow
             fullWidth
             className="SeriesDisplay"
-            icon={<Lettermark name={insightType !== InsightType.FUNNELS ? alphabet[index] : index + 1} />}
+            icon={<SeriesLetter seriesIndex={index} hasBreakdown={hasBreakdown} />}
             extendedContent={
                 <>
                     {insightType !== InsightType.FUNNELS && (
@@ -241,11 +243,17 @@ export function QuerySummary({ filters }: { filters: Partial<FilterType> }): JSX
                             <PathsSummary filters={filters} />
                         ) : (
                             <>
-                                <SeriesDisplay filter={localFilters[0]} insightType={filters.insight} index={0} />
+                                <SeriesDisplay
+                                    hasBreakdown={!!filters.breakdown}
+                                    filter={localFilters[0]}
+                                    insightType={filters.insight}
+                                    index={0}
+                                />
                                 {localFilters.slice(1).map((filter, index) => (
                                     <>
                                         <LemonDivider />
                                         <SeriesDisplay
+                                            hasBreakdown={!!filters.breakdown}
                                             key={index}
                                             filter={filter}
                                             insightType={filters.insight}

--- a/frontend/src/lib/components/SeriesGlyph.tsx
+++ b/frontend/src/lib/components/SeriesGlyph.tsx
@@ -36,7 +36,9 @@ export function SeriesLetter({ className, hasBreakdown, seriesIndex, seriesColor
                           color: color,
                           backgroundColor: hexToRGBA(color, 0.15),
                       }
-                    : undefined
+                    : {
+                          color: 'var(--default)',
+                      }
             }
         >
             {alphabet[seriesIndex]}


### PR DESCRIPTION
## Problem
[Issue 14912](https://github.com/PostHog/posthog/issues/14912)
Color coding in the query summary.

## Changes
Old behavior is shown in the Issue 14912 (linked above)
New behavior is shown below
![Screenshot 2023-08-25 at 9 57 35 PM](https://github.com/PostHog/posthog/assets/32753458/2ecc216d-c3c2-4958-801c-cea39195cb2b)
![Screenshot 2023-08-25 at 9 57 20 PM](https://github.com/PostHog/posthog/assets/32753458/b13e14b2-dcb7-44c2-a68e-58a64e37d594)

With breakdown:
![Screenshot 2023-08-25 at 9 59 16 PM](https://github.com/PostHog/posthog/assets/32753458/0e960980-b4c5-4a6c-a620-225cd673e742)
![Screenshot 2023-08-25 at 9 59 27 PM](https://github.com/PostHog/posthog/assets/32753458/0cb1c438-eb57-404d-8565-5305aad6847e)

## How did you test this code?
Can manually test by:
1. Click Edit on a card with a series
2. Add/Remove graph series
3. Note the colors of the letters and the order which the colors appear
4. Hit save
5. Go back to the card and hit
6. Hit "show details"
7. Make sure the letters and the order match