### PR TITLE
feat(relative-date): implement day end with time granularity

### DIFF
--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -163,6 +163,9 @@ class TestRelativeDateParse(TestCase):
         self.assertEqual(relative_date_parse("-1d").strftime("%Y-%m-%d"), "2020-01-30")
         self.assertEqual(relative_date_parse("-2d").strftime("%Y-%m-%d"), "2020-01-29")
 
+        self.assertEqual(relative_date_parse("-1dStart").isoformat(), "2020-01-30T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("-1dEnd").isoformat(), "2020-01-30T23:59:59.999999+00:00")
+
     @freeze_time("2020-01-31")
     def test_month(self):
         self.assertEqual(relative_date_parse("-1m").strftime("%Y-%m-%d"), "2019-12-31")

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -239,7 +239,10 @@ def relative_date_parse_with_delta_mapping(input: str) -> Tuple[datetime.datetim
     if "hours" in delta_mapping:
         date = date.replace(minute=0, second=0, microsecond=0)
     else:
-        date = date.replace(hour=0, minute=0, second=0, microsecond=0)
+        if match.group("type") == "d" and match.group("position") == "End":
+            date = date.replace(hour=23, minute=59, second=59, microsecond=999999)
+        else:
+            date = date.replace(hour=0, minute=0, second=0, microsecond=0)
     return date, delta_mapping
 
 


### PR DESCRIPTION
## Problem

See https://github.com/PostHog/posthog/issues/17094 and https://posthog.slack.com/archives/C0368RPHLQH/p1692368569555589. The relative date function is implemented with a date granularity, so using it as a datetime doesn't work.

## Changes

This PR implements `-1dEnd` with datetime granularity, to fix the mentioned issue. Obviously other cases where results from this function are used as datetimes are broken as well. Changing this would be a breaking change - happy for opinions wether we want to keep this function on a date granularity or if I should rework it.

## How did you test this code?

Added tests and checked the Event Explorer for yesterday