### PR TITLE
fix: Remove sportshog during loading

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -87,11 +87,16 @@ export function InsightContainer({
 
     // Empty states that completely replace the graph
     const BlockingEmptyState = (() => {
-        if (insightDataLoading && timedOutQueryId === null) {
+        if (insightDataLoading) {
             return (
-                <div className="text-center">
-                    <Animation type={AnimationType.LaptopHog} />
-                </div>
+                <>
+                    <div className="text-center">
+                        <Animation type={AnimationType.LaptopHog} />
+                    </div>
+                    {!!timedOutQueryId && (
+                        <InsightTimeoutState isLoading={true} queryId={timedOutQueryId} insightProps={insightProps} />
+                    )}
+                </>
             )
         }
 

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -9,8 +9,6 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import './EmptyStates.scss'
 import { urls } from 'scenes/urls'
 import { Link } from 'lib/lemon-ui/Link'
-import { Animation } from 'lib/components/Animation/Animation'
-import { AnimationType } from 'lib/animations/animations'
 import { LemonButton } from '@posthog/lemon-ui'
 import { samplingFilterLogic } from '../EditorFilters/samplingFilterLogic'
 import { posthog } from 'posthog-js'
@@ -57,18 +55,13 @@ export function InsightTimeoutState({
     return (
         <div className="insight-empty-state warning">
             <div className="empty-state-inner">
-                <div className="illustration-main">
-                    {isLoading ? <Animation type={AnimationType.SportsHog} /> : <IconErrorOutline />}
-                </div>
-                {isLoading ? (
-                    <div className="m-auto text-center">
-                        Your query is taking a long time to complete. <b>We're still working on it.</b>
-                        <br />
-                        {suggestedSamplingPercentage ? 'See below some options to speed things up.' : ''}
-                        <br />
-                    </div>
-                ) : (
-                    <h2>Your query took too long to complete</h2>
+                {!isLoading && (
+                    <>
+                        <div className="illustration-main">
+                            <IconErrorOutline />
+                        </div>
+                        <h2>Your query took too long to complete</h2>
+                    </>
                 )}
                 {isLoading && suggestedSamplingPercentage ? (
                     <div>


### PR DESCRIPTION
## Problem

For some reason it's incredibly frustrating when sportshog pops up. After the sampling feature we introduced, in now appears after 5 seconds, so you see it a lot. Realistically, a lot of our queries do take longer than 5 seconds, so we shouldn't emphasize the fact the query is being slow.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Continue the same loading image, but give people the option to sample.
<img width="1555" alt="image" src="https://github.com/PostHog/posthog/assets/1727427/38f9b7d2-c9ee-42bb-85cf-7f8a73944341">



<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
