### PR TITLE
fix: parse `Start` and `End` for day, week and quarter in relative dates

### DIFF
--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -159,33 +159,64 @@ class TestRelativeDateParse(TestCase):
 
     @freeze_time("2020-01-31")
     def test_day(self):
-        self.assertEqual(relative_date_parse("dStart").strftime("%Y-%m-%d"), "2020-01-31")
-        self.assertEqual(relative_date_parse("-1d").strftime("%Y-%m-%d"), "2020-01-30")
-        self.assertEqual(relative_date_parse("-2d").strftime("%Y-%m-%d"), "2020-01-29")
+        self.assertEqual(relative_date_parse("dStart").isoformat(), "2020-01-31T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("dEnd").isoformat(), "2020-01-31T23:59:59.999999+00:00")
+
+        self.assertEqual(relative_date_parse("-1d").isoformat(), "2020-01-30T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("-2d").isoformat(), "2020-01-29T00:00:00+00:00")
+
+        self.assertEqual(relative_date_parse("-1dStart").isoformat(), "2020-01-30T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("-1dEnd").isoformat(), "2020-01-30T23:59:59.999999+00:00")
+
+    @freeze_time("2020-01-31")
+    def test_week(self):
+        self.assertEqual(relative_date_parse("wStart").isoformat(), "2020-01-26T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("wEnd").isoformat(), "2020-02-01T23:59:59.999999+00:00")
+
+        self.assertEqual(relative_date_parse("-1w").isoformat(), "2020-01-24T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("-2w").isoformat(), "2020-01-17T00:00:00+00:00")
+
+        self.assertEqual(relative_date_parse("-1wStart").isoformat(), "2020-01-19T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("-1wEnd").isoformat(), "2020-01-25T23:59:59.999999+00:00")
+
+    @freeze_time("2020-01-31")
+    def test_quarter(self):
+        self.assertEqual(relative_date_parse("qStart").isoformat(), "2020-01-01T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("qEnd").isoformat(), "2020-03-31T23:59:59.999999+00:00")
+
+        self.assertEqual(relative_date_parse("-1q").isoformat(), "2019-11-01T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("-2q").isoformat(), "2019-08-02T00:00:00+00:00")
+
+        self.assertEqual(relative_date_parse("-1qStart").isoformat(), "2019-10-01T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("-1qEnd").isoformat(), "2019-12-31T23:59:59.999999+00:00")
 
     @freeze_time("2020-01-31")
     def test_month(self):
-        self.assertEqual(relative_date_parse("-1m").strftime("%Y-%m-%d"), "2019-12-31")
-        self.assertEqual(relative_date_parse("-2m").strftime("%Y-%m-%d"), "2019-11-30")
+        self.assertEqual(relative_date_parse("-1m").isoformat(), "2019-12-31T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("-2m").isoformat(), "2019-11-30T00:00:00+00:00")
 
-        self.assertEqual(relative_date_parse("mStart").strftime("%Y-%m-%d"), "2020-01-01")
-        self.assertEqual(relative_date_parse("-1mStart").strftime("%Y-%m-%d"), "2019-12-01")
-        self.assertEqual(relative_date_parse("-2mStart").strftime("%Y-%m-%d"), "2019-11-01")
+        self.assertEqual(relative_date_parse("mStart").isoformat(), "2020-01-01T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("-1mStart").isoformat(), "2019-12-01T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("-2mStart").isoformat(), "2019-11-01T00:00:00+00:00")
 
-        self.assertEqual(relative_date_parse("-1mEnd").strftime("%Y-%m-%d"), "2019-12-31")
-        self.assertEqual(relative_date_parse("-2mEnd").strftime("%Y-%m-%d"), "2019-11-30")
+        self.assertEqual(relative_date_parse("mEnd").isoformat(), "2020-01-31T23:59:59.999999+00:00")
+        self.assertEqual(relative_date_parse("-1mEnd").isoformat(), "2019-12-31T23:59:59.999999+00:00")
+        self.assertEqual(relative_date_parse("-2mEnd").isoformat(), "2019-11-30T23:59:59.999999+00:00")
 
     @freeze_time("2020-01-31")
     def test_year(self):
-        self.assertEqual(relative_date_parse("-1y").strftime("%Y-%m-%d"), "2019-01-31")
-        self.assertEqual(relative_date_parse("-2y").strftime("%Y-%m-%d"), "2018-01-31")
+        self.assertEqual(relative_date_parse("-1y").isoformat(), "2019-01-31T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("-2y").isoformat(), "2018-01-31T00:00:00+00:00")
 
-        self.assertEqual(relative_date_parse("yStart").strftime("%Y-%m-%d"), "2020-01-01")
-        self.assertEqual(relative_date_parse("-1yStart").strftime("%Y-%m-%d"), "2019-01-01")
+        self.assertEqual(relative_date_parse("yStart").isoformat(), "2020-01-01T00:00:00+00:00")
+        self.assertEqual(relative_date_parse("-1yStart").isoformat(), "2019-01-01T00:00:00+00:00")
+
+        self.assertEqual(relative_date_parse("yEnd").isoformat(), "2020-12-31T23:59:59.999999+00:00")
+        self.assertEqual(relative_date_parse("-1yEnd").isoformat(), "2019-12-31T23:59:59.999999+00:00")
 
     @freeze_time("2020-01-31")
     def test_normal_date(self):
-        self.assertEqual(relative_date_parse("2019-12-31").strftime("%Y-%m-%d"), "2019-12-31")
+        self.assertEqual(relative_date_parse("2019-12-31").isoformat(), "2019-12-31T00:00:00+00:00")
 
 
 class TestDefaultEventName(BaseTest):


### PR DESCRIPTION
## Problem

Currently, the specifying `Start` and `End` in relative dates for day, week and quarter granularities is not implemented. Due to this filtering by "Yesterday" doesn't work. Ref: https://github.com/PostHog/posthog/issues/17094

## Changes

- Added support for truncating dates to start/end of the day or hour.
- Added support for `Start` and `End` for week and quarter granularities. Used the [frontend tests](https://github.com/PostHog/posthog/blob/master/frontend/src/lib/utils.test.ts#L405) as reference.
- Added unit tests for above mentioned changes and also made the asserts stricter.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally & unit tests.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
