### PR TITLE
fix: Add missing comma for field literal value to let Go example compile

### DIFF
--- a/frontend/src/scenes/ingestion/frameworks/GoInstructions.tsx
+++ b/frontend/src/scenes/ingestion/frameworks/GoInstructions.tsx
@@ -26,7 +26,7 @@ func main() {
 function GoCaptureSnippet(): JSX.Element {
     return (
         <CodeSnippet language={Language.Go}>
-            {'client.Enqueue(posthog.Capture{\n    DistinctId: "test-user",\n    Event: "test-snippet"\n})'}
+            {'client.Enqueue(posthog.Capture{\n    DistinctId: "test-user",\n    Event: "test-snippet",\n})'}
         </CodeSnippet>
     )
 }


### PR DESCRIPTION
## Problem

The example on how to use PostHog with Go did not compile. It is surprising that this annoys only me.

## Changes

It is a comma, and i cannot deploy with github.dev

## How did you test this code?

I saw that the example did not compile, added a comma in my Go file, and it compiled. Did not test anything with PostHog though.
