### PR TITLE
fix(insights): Don't throw on `id`-less entities

### DIFF
--- a/posthog/models/entity/entity.py
+++ b/posthog/models/entity/entity.py
@@ -1,6 +1,6 @@
 import inspect
 from collections import Counter
-from typing import Any, Dict, Literal, Optional, Union
+from typing import Any, Dict, Literal, Optional
 
 from django.conf import settings
 from rest_framework.exceptions import ValidationError
@@ -48,7 +48,7 @@ class Entity(PropertyMixin):
     This class just allows for stronger typing of this object.
     """
 
-    id: Union[int, str, None]
+    id: Optional[int | str]
     type: Literal["events", "actions"]
     order: Optional[int]
     name: Optional[str]
@@ -64,9 +64,9 @@ class Entity(PropertyMixin):
     index: int
 
     def __init__(self, data: Dict[str, Any]) -> None:
-        self.id = data["id"]
-        if not data.get("type") or data["type"] not in [TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS]:
-            raise TypeError("Type needs to be either TREND_FILTER_TYPE_ACTIONS or TREND_FILTER_TYPE_EVENTS")
+        self.id = data.get("id")
+        if data.get("type") not in [TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS]:
+            raise ValueError("Type needs to be either TREND_FILTER_TYPE_ACTIONS or TREND_FILTER_TYPE_EVENTS")
         self.type = data["type"]
         order_provided = data.get("order")
         if order_provided is not None:

--- a/posthog/models/test/test_entity_model.py
+++ b/posthog/models/test/test_entity_model.py
@@ -4,6 +4,11 @@ from posthog.models.entity import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_E
 
 
 class TestEntity(TestCase):
+    def test_can_init_without_id(self):
+        entity = Entity({"type": TREND_FILTER_TYPE_EVENTS})  # This is an "All events" entity
+
+        self.assertEqual(entity.id, None)
+
     def test_inclusion(self):
         entity1 = Entity(
             {


### PR DESCRIPTION
## Changes

A hotfix for [https://posthog.sentry.io/issues/4351268146/?query=is%3Aunresolved+id%3A4a7786f48df04[…]f04a355&referrer=issue-stream&statsPeriod=14d&stream_index=0](https://posthog.sentry.io/issues/4351268146/?query=is%3Aunresolved+id%3A4a7786f48df04405badf8348ff04a355&referrer=issue-stream&statsPeriod=14d&stream_index=0).

We used to throw if entity `id` was missing completely from a filter, instead of just `None`, which doesn't make sense, given the `None` value was already supported.