### PR TITLE
fix: increase maxDiffPixelRatio

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ const config: PlaywrightTestConfig = {
          * For example in `await expect(locator).toHaveText();`
          */
         timeout: 5000,
-        toHaveScreenshot: { maxDiffPixelRatio: 0.003 },
+        toHaveScreenshot: { maxDiffPixelRatio: 0.005 },
     },
     /* Run tests in files in parallel */
     fullyParallel: true,


### PR DESCRIPTION
## Problem

Playwright is finding little 1px pixel differences in shapshots, possibly due to upgrading to storybook 7: https://github.com/PostHog/posthog/pull/17078

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Increases maxDiffPixelRatio to reduce sensitivity to see if that helps. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
This PR 🤷‍♀️ 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
