### PR TITLE
fix(nav): Make links legible in announcements

### DIFF
--- a/frontend/src/layout/navigation/TopBar/TopBar.scss
+++ b/frontend/src/layout/navigation/TopBar/TopBar.scss
@@ -99,8 +99,8 @@
         font-weight: 700;
     }
 
-    a:link {
-        color: inherit;
+    a {
+        color: var(--brand-red);
         text-decoration: underline;
     }
 }


### PR DESCRIPTION
## Problem

Hard to read:

<img width="148" alt="Screenshot 2023-08-23 at 13 55 33" src="https://github.com/PostHog/posthog/assets/4550621/6d4d15f3-fdf3-4f3b-9f60-98ce1dd500a6">

## Changes

Easier to read:

<img width="153" alt="Screenshot 2023-08-23 at 13 55 06" src="https://github.com/PostHog/posthog/assets/4550621/b99dacf2-fe93-4842-8921-be726432e509">