### PR TITLE
fix: Default onEvents to single attempt

### DIFF
--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -3,11 +3,52 @@ import { PluginEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
 import { Hub, PluginConfig, PluginTaskType, VMMethods } from '../../types'
 import { processError } from '../../utils/db/error'
 import { instrument } from '../../utils/metrics'
-import { runRetriableFunction } from '../../utils/retries'
 import { status } from '../../utils/status'
 import { IllegalOperationError } from '../../utils/utils'
 
+async function runSingleTeamPluginOnEvent(
+    hub: Hub,
+    event: ProcessedPluginEvent,
+    pluginConfig: PluginConfig,
+    onEvent: any
+): Promise<void> {
+    // Runs onEvent for a single plugin without any retries
+    const metricName = 'plugin.on_event'
+    const metricTags = {
+        plugin: pluginConfig.plugin?.name ?? '?',
+        teamId: event.team_id.toString(),
+    }
+
+    const timer = new Date()
+    try {
+        await onEvent!(event)
+        await hub.appMetrics.queueMetric({
+            teamId: event.team_id,
+            pluginConfigId: pluginConfig.id,
+            category: 'onEvent',
+            successes: 1,
+        })
+    } catch (error) {
+        hub.statsd?.increment(`${metricName}.ERROR`, metricTags)
+        await processError(hub, pluginConfig, error, event)
+        await hub.appMetrics.queueError(
+            {
+                teamId: event.team_id,
+                pluginConfigId: pluginConfig.id,
+                category: 'onEvent',
+                failures: 1,
+            },
+            {
+                error,
+                event,
+            }
+        )
+    }
+    hub.statsd?.timing(metricName, timer, metricTags)
+}
+
 export async function runOnEvent(hub: Hub, event: ProcessedPluginEvent): Promise<void> {
+    // Runs onEvent for all plugins for this team in parallel
     const pluginMethodsToRun = await getPluginMethodsForTeam(hub, event.team_id, 'onEvent')
 
     await Promise.all(
@@ -21,24 +62,7 @@ export async function runOnEvent(hub: Hub, event: ProcessedPluginEvent): Promise
                         key: 'plugin',
                         tag: pluginConfig.plugin?.name || '?',
                     },
-                    () =>
-                        runRetriableFunction({
-                            hub,
-                            metricName: 'plugin.on_event',
-                            metricTags: {
-                                plugin: pluginConfig.plugin?.name ?? '?',
-                                teamId: event.team_id.toString(),
-                            },
-                            tryFn: async () => await onEvent!(event),
-                            catchFn: async (error) => await processError(hub, pluginConfig, error, event),
-                            payload: event,
-                            appMetric: {
-                                teamId: event.team_id,
-                                pluginConfigId: pluginConfig.id,
-                                category: 'onEvent',
-                            },
-                            appMetricErrorContext: { event },
-                        })
+                    () => runSingleTeamPluginOnEvent(hub, event, pluginConfig, onEvent)
                 )
             )
     )


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
OnEvent consumer is really struggling to keep up, let's make it happer by not doing retries and making everyone's experience with old export apps generally better

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Note that in case exportEvents is defined in the app code, we'll be using the exportEvents code instead ([ref](https://github.com/PostHog/posthog/blob/f5304fc2226be2e2bd27027ed2d66cb4e3eccdfa/plugin-server/src/worker/vm/vm.ts#L229) & [ref2](https://github.com/PostHog/posthog/blob/master/plugin-server/src/worker/vm/upgrades/export-events.ts#L206)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
