### PR TITLE
chore: Gather more detailed stats about person endpoint usage

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -300,7 +300,7 @@ class CohortViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
                 for actor in serialized_actors
             ]
 
-        statsd.incr("api_cohort_person_total", tags={"team_id": team.pk})
+        # TEMPORARY: Work out usage patterns of this endpoint
         renderer = SafeJSONRenderer()
         size = len(renderer.render(serialized_actors))
         statsd.incr("api_cohort_person_bytes_read_from_postgres", size, tags={"team_id": team.pk})

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -1,4 +1,5 @@
 import json
+from posthog.renderers import SafeJSONRenderer
 from datetime import datetime
 from typing import (
     Any,
@@ -274,6 +275,12 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             if filter.offset - filter.limit >= 0
             else None
         )
+
+        # TEMPORARY: Work out usage patterns of this endpoint
+        statsd.incr("api_person_list_total", tags={"team_id": team.pk})
+        renderer = SafeJSONRenderer()
+        size = len(renderer.render(serialized_actors))
+        statsd.incr("api_person_list_bytes_read_from_postgres", size, tags={"team_id": team.pk})
 
         return Response(
             {

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -277,7 +277,6 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         )
 
         # TEMPORARY: Work out usage patterns of this endpoint
-        statsd.incr("api_person_list_total", tags={"team_id": team.pk})
         renderer = SafeJSONRenderer()
         size = len(renderer.render(serialized_actors))
         statsd.incr("api_person_list_bytes_read_from_postgres", size, tags={"team_id": team.pk})

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -479,16 +479,15 @@ class PrometheusAfterMiddlewareWithTeamIds(PrometheusAfterMiddleware):
     def label_metric(self, metric, request, response=None, **labels):
         new_labels = labels
         if metric._name in PROMETHEUS_EXTENDED_METRICS:
-            if (
-                request
-                and getattr(request, "user", None)
-                and request.user.is_authenticated
-                and hasattr(request.user, "team")
-                and request.user.team
-            ):
-                team_id = request.user.team.pk
-            else:
-                team_id = None
+            team_id = None
+            if request and getattr(request, "user", None) and request.user.is_authenticated:
+                if request.resolver_match.kwargs.get("parent_lookup_team_id"):
+                    team_id = request.resolver_match.kwargs["parent_lookup_team_id"]
+                    if team_id == "@current":
+                        if hasattr(request.user, "current_team_id"):
+                            team_id = request.user.team
+                        else:
+                            team_id = None
 
             new_labels = {LABEL_TEAM_ID: team_id}
             new_labels.update(labels)

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -484,6 +484,7 @@ class PrometheusAfterMiddlewareWithTeamIds(PrometheusAfterMiddleware):
                 and getattr(request, "user", None)
                 and request.user.is_authenticated
                 and hasattr(request.user, "team")
+                and request.user.team
             ):
                 team_id = request.user.team.pk
             else:

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -483,9 +483,9 @@ class PrometheusAfterMiddlewareWithTeamIds(PrometheusAfterMiddleware):
                 request
                 and getattr(request, "user", None)
                 and request.user.is_authenticated
-                and hasattr(request.user, "current_team_id")
+                and hasattr(request.user, "team")
             ):
-                team_id = request.user.current_team_id
+                team_id = request.user.team.pk
             else:
                 team_id = None
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -485,7 +485,7 @@ class PrometheusAfterMiddlewareWithTeamIds(PrometheusAfterMiddleware):
                     team_id = request.resolver_match.kwargs["parent_lookup_team_id"]
                     if team_id == "@current":
                         if hasattr(request.user, "current_team_id"):
-                            team_id = request.user.team
+                            team_id = request.user.current_team_id
                         else:
                             team_id = None
 


### PR DESCRIPTION
## Problem

For some reason 95% of `django_http_responses_total_by_status_view_method_total` stats are missing `team_id`. I also want to get a sense of the amount of data we're reading from postgres from this endpoint to see if there are outliers.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
