### PR TITLE
fix: allow AWS and GCP tracing headers

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -40,7 +40,8 @@ from posthog.session_recordings.session_recording_helpers import (
     preprocess_replay_events_for_blob_ingestion,
     split_replay_events,
 )
-from posthog.utils import cors_response, get_ip_address
+from posthog.utils import get_ip_address
+from posthog.utils_cors import cors_response
 
 logger = structlog.get_logger(__name__)
 

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -25,8 +25,8 @@ from posthog.models import Team, User
 from posthog.models.feature_flag import get_all_feature_flags
 from posthog.models.utils import execute_with_timeout
 from posthog.plugins.site import get_decide_site_apps
-from posthog.utils import cors_response, get_ip_address, label_for_team_id_to_track, load_data_from_request
-
+from posthog.utils import get_ip_address, label_for_team_id_to_track, load_data_from_request
+from posthog.utils_cors import cors_response
 
 FLAG_EVALUATION_COUNTER = Counter(
     "flag_evaluation_total",

--- a/posthog/api/early_access_feature.py
+++ b/posthog/api/early_access_feature.py
@@ -19,7 +19,7 @@ from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMembe
 from django.utils.text import slugify
 from django.views.decorators.csrf import csrf_exempt
 
-from posthog.utils import cors_response
+from posthog.utils_cors import cors_response
 from typing import Any
 
 

--- a/posthog/api/prompt.py
+++ b/posthog/api/prompt.py
@@ -15,7 +15,7 @@ from posthog.celery import app
 from posthog.exceptions import generate_exception_response
 from posthog.models.prompt import Prompt, PromptSequence, UserPromptState
 from posthog.models.user import User
-from posthog.utils import cors_response
+from posthog.utils_cors import cors_response
 
 
 class PromptButtonSerializer(serializers.Serializer):

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -22,7 +22,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from typing import Any
 
-from posthog.utils import cors_response
+from posthog.utils_cors import cors_response
 
 
 class SurveySerializer(serializers.ModelSerializer):

--- a/posthog/api/test/__snapshots__/test_cohort.ambr
+++ b/posthog/api/test/__snapshots__/test_cohort.ambr
@@ -1,6 +1,6 @@
 # name: TestCohort.test_async_deletion_of_cohort
   '
-  /* user_id:106 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:116 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -10,7 +10,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.1
   '
-  /* user_id:106 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:116 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   INSERT INTO cohortpeople
   SELECT id,
          2 as cohort_id,
@@ -83,7 +83,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.2
   '
-  /* user_id:106 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:116 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -93,7 +93,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.3
   '
-  /* user_id:106 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
+  /* user_id:116 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
   SELECT count()
   FROM cohortpeople
   WHERE team_id = 2
@@ -103,7 +103,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.4
   '
-  /* user_id:106 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:116 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -113,7 +113,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.5
   '
-  /* user_id:106 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:116 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   INSERT INTO cohortpeople
   SELECT id,
          2 as cohort_id,
@@ -147,7 +147,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.6
   '
-  /* user_id:106 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:116 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -157,7 +157,7 @@
 ---
 # name: TestCohort.test_async_deletion_of_cohort.7
   '
-  /* user_id:106 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
+  /* user_id:116 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
   SELECT count()
   FROM cohortpeople
   WHERE team_id = 2

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -21,6 +21,7 @@ from freezegun import freeze_time
 from kafka.errors import KafkaError
 from kafka.producer.future import FutureProduceResult, FutureRecordMetadata
 from kafka.structs import TopicPartition
+from parameterized import parameterized
 from prance import ResolvingParser
 from rest_framework import status
 from token_bucket import Limiter, MemoryStorage
@@ -1131,56 +1132,46 @@ class TestCapture(BaseTest):
             ),
         )
 
-    def test_sentry_tracing_headers(self):
+    @parameterized.expand(
+        (f"{headers[0]} tracing headers to {path[0]}", path[1], headers[1])
+        for path in [
+            ("events", "/e/?ip=1&_=1651741927805"),
+            ("decide", "/decide/"),
+            ("recordings", "/s/?ip=1&_=1651741927805"),
+        ]
+        for headers in [
+            (
+                "sentry",
+                [
+                    "traceparent",
+                    "request-id",
+                ],
+            ),
+            (
+                "aws",
+                ["x-amzn-trace-id"],
+            ),
+            (
+                "azure",
+                ["traceparent", "request-id", "request-context"],
+            ),
+            (
+                "gcp",
+                ["x-cloud-trace-context"],
+            ),
+        ]
+    )
+    def test_cors_allows_tracing_headers(self, _: str, path: str, headers: List[str]) -> None:
+        expected_headers = ",".join(["X-Requested-With", "Content-Type"] + headers)
+        presented_headers = ",".join(headers + ["someotherrandomheader"])
         response = self.client.options(
-            "/e/?ip=1&_=1651741927805",
+            path,
             HTTP_ORIGIN="https://localhost",
-            HTTP_ACCESS_CONTROL_REQUEST_HEADERS="traceparent,request-id,someotherrandomheader",
+            HTTP_ACCESS_CONTROL_REQUEST_HEADERS=presented_headers,
             HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.headers["Access-Control-Allow-Headers"], "X-Requested-With,Content-Type,traceparent,request-id"
-        )
-
-        response = self.client.options(
-            "/decide/",
-            HTTP_ORIGIN="https://localhost",
-            HTTP_ACCESS_CONTROL_REQUEST_HEADERS="traceparent,request-id,someotherrandomheader",
-            HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.headers["Access-Control-Allow-Headers"], "X-Requested-With,Content-Type,traceparent,request-id"
-        )
-
-    def test_azure_app_insights_tracing_headers(self):
-        # Azure App Insights sends the same tracing headers as Sentry
-        # _and_ a request-context header
-
-        response = self.client.options(
-            "/e/?ip=1&_=1651741927805",
-            HTTP_ORIGIN="https://localhost",
-            HTTP_ACCESS_CONTROL_REQUEST_HEADERS="traceparent,request-id,someotherrandomheader,request-context",
-            HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.headers["Access-Control-Allow-Headers"],
-            "X-Requested-With,Content-Type,traceparent,request-id,request-context",
-        )
-
-        response = self.client.options(
-            "/decide/",
-            HTTP_ORIGIN="https://localhost",
-            HTTP_ACCESS_CONTROL_REQUEST_HEADERS="traceparent,request-id,someotherrandomheader,request-context",
-            HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.headers["Access-Control-Allow-Headers"],
-            "X-Requested-With,Content-Type,traceparent,request-id,request-context",
-        )
+        self.assertEqual(response.headers["Access-Control-Allow-Headers"], expected_headers)
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_legacy_recording_ingestion_data_sent_to_kafka(self, kafka_produce) -> None:

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1133,6 +1133,7 @@ class TestCapture(BaseTest):
         )
 
     @parameterized.expand(
+        # zips request paths, and tracing headers. As well as constructing a meaningful name for the test
         (f"{headers[0]} tracing headers to {path[0]}", path[1], headers[1])
         for path in [
             ("events", "/e/?ip=1&_=1651741927805"),

--- a/posthog/api/test/test_element.py
+++ b/posthog/api/test/test_element.py
@@ -2,12 +2,12 @@ import json
 from datetime import timedelta
 from typing import Dict, List
 
-from corsheaders.defaults import default_headers
 from django.test import override_settings
 from freezegun import freeze_time
 from rest_framework import status
 
 from posthog.models import Element, ElementGroup, Organization
+from posthog.settings import CORS_ALLOW_HEADERS
 from posthog.test.base import (
     APIBaseTest,
     ClickhouseTestMixin,
@@ -287,14 +287,7 @@ class TestElement(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
         )
 
-        assert response.headers["Access-Control-Allow-Headers"] == ", ".join(
-            default_headers
-            + (
-                "traceparent",
-                "request-id",
-                "request-context",
-            )
-        )
+        assert response.headers["Access-Control-Allow-Headers"] == ", ".join(CORS_ALLOW_HEADERS)
 
     def test_element_stats_does_not_allow_non_numeric_limit(self) -> None:
         response = self.client.get(f"/api/element/stats/?limit=not-a-number")

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -36,6 +36,7 @@ from posthog.test.base import (
     _create_person,
     snapshot_clickhouse_queries,
     snapshot_postgres_queries_context,
+    FuzzyInt,
 )
 from posthog.test.db_context_capturing import capture_db_queries
 
@@ -960,7 +961,7 @@ class TestFeatureFlag(APIBaseTest):
             format="json",
         ).json()
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(FuzzyInt(10, 11)):
             response = self.client.get(f"/api/projects/{self.team.id}/feature_flags")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -971,7 +972,7 @@ class TestFeatureFlag(APIBaseTest):
                 format="json",
             ).json()
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(FuzzyInt(10, 11)):
             response = self.client.get(f"/api/projects/{self.team.id}/feature_flags")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -17,7 +17,8 @@ from posthog.models import Entity, EventDefinition
 from posthog.models.entity import MathType
 from posthog.models.filters.filter import Filter
 from posthog.models.filters.stickiness_filter import StickinessFilter
-from posthog.utils import cors_response, load_data_from_request
+from posthog.utils import load_data_from_request
+from posthog.utils_cors import cors_response
 
 logger = structlog.get_logger(__name__)
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -29,7 +29,7 @@ from posthog.rate_limit import DecideRateThrottle
 from posthog.settings import SITE_URL
 from posthog.settings.statsd import STATSD_HOST
 from posthog.user_permissions import UserPermissions
-from posthog.utils import cors_response
+from .utils_cors import cors_response
 
 from .auth import PersonalAPIKeyAuthentication
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -8,6 +8,7 @@ from corsheaders.defaults import default_headers
 from posthog.settings.base_variables import BASE_DIR, DEBUG, TEST
 from posthog.settings.statsd import STATSD_HOST
 from posthog.settings.utils import get_from_env, get_list, str_to_bool
+from posthog.utils_cors import CORS_ALLOWED_TRACING_HEADERS
 
 # django-axes settings to lockout after too many attempts
 
@@ -227,7 +228,7 @@ LOGOUT_URL = "/logout"
 LOGIN_REDIRECT_URL = "/"
 APPEND_SLASH = False
 CORS_URLS_REGEX = r"^/api/(?!early_access_features|surveys).*$"
-CORS_ALLOW_HEADERS = default_headers + ("traceparent", "request-id", "request-context")
+CORS_ALLOW_HEADERS = default_headers + CORS_ALLOWED_TRACING_HEADERS
 X_FRAME_OPTIONS = "SAMEORIGIN"
 
 REST_FRAMEWORK = {

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -559,26 +559,6 @@ def get_compare_period_dates(
     return new_date_from, new_date_to
 
 
-def cors_response(request, response):
-    if not request.META.get("HTTP_ORIGIN"):
-        return response
-    url = urlparse(request.META["HTTP_ORIGIN"])
-    response["Access-Control-Allow-Origin"] = f"{url.scheme}://{url.netloc}"
-    response["Access-Control-Allow-Credentials"] = "true"
-    response["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
-
-    # Handle headers that sentry randomly sends for every request.
-    # Would cause a CORS failure otherwise.
-    # specified here to override the default added by the cors headers package in web.py
-    allow_headers = request.META.get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS", "").split(",")
-    allow_headers = [header for header in allow_headers if header in ["traceparent", "request-id", "request-context"]]
-
-    response["Access-Control-Allow-Headers"] = "X-Requested-With,Content-Type" + (
-        "," + ",".join(allow_headers) if len(allow_headers) > 0 else ""
-    )
-    return response
-
-
 def generate_cache_key(stringified: str) -> str:
     return "cache_" + hashlib.md5(stringified.encode("utf-8")).hexdigest()
 

--- a/posthog/utils_cors.py
+++ b/posthog/utils_cors.py
@@ -1,0 +1,29 @@
+from urllib.parse import urlparse
+
+CORS_ALLOWED_TRACING_HEADERS = (
+    "traceparent",
+    "request-id",
+    "request-context",
+    "x-amzn-trace-id",
+    "x-cloud-trace-context",
+)
+
+
+def cors_response(request, response):
+    if not request.META.get("HTTP_ORIGIN"):
+        return response
+    url = urlparse(request.META["HTTP_ORIGIN"])
+    response["Access-Control-Allow-Origin"] = f"{url.scheme}://{url.netloc}"
+    response["Access-Control-Allow-Credentials"] = "true"
+    response["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
+
+    # Handle headers that sentry randomly sends for every request.
+    # Would cause a CORS failure otherwise.
+    # specified here to override the default added by the cors headers package in web.py
+    allow_headers = request.META.get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS", "").split(",")
+    allow_headers = [header for header in allow_headers if header in CORS_ALLOWED_TRACING_HEADERS]
+
+    response["Access-Control-Allow-Headers"] = "X-Requested-With,Content-Type" + (
+        "," + ",".join(allow_headers) if len(allow_headers) > 0 else ""
+    )
+    return response


### PR DESCRIPTION
## Problem

If a service includes tracing headers then our cors responses fail. Over time we've added sentry and azure trace headers to our allow list

A user reports they had problems because of AWS trace headers https://posthoghelp.zendesk.com/agent/tickets/5090 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/8045)

These problems can be very tricky to diagnose

## Changes

* adds AWS and GCP headers to our allow list
* parameterizes the test for the headers
* use the same list of headers for django-cors settings and our custom cors_response code
* then move the cors_response to a different file to avoid some circular import fun

## How did you test this code?

developer tests
