### PR TITLE
fix(usage-report): Count unique events only

### DIFF
--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -11,7 +11,7 @@
   '
   
   SELECT team_id,
-         count(1) as count
+         count(distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) as count
   FROM events
   WHERE timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
     AND event != '$feature_flag_called'

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -37,6 +37,7 @@ from posthog.test.base import (
     flush_persons_and_events,
     snapshot_clickhouse_queries,
 )
+from posthog.models.event.util import create_event
 from posthog.utils import get_machine_id
 
 logger = structlog.get_logger(__name__)
@@ -46,6 +47,9 @@ logger = structlog.get_logger(__name__)
 class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin):
     def setUp(self) -> None:
         super().setUp()
+
+        # make sure we don't collapse duplicate rows
+        sync_execute("SYSTEM STOP MERGES")
 
         self.expected_properties: dict = {}
 
@@ -109,14 +113,28 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                 active=True,
             )
 
-            for _ in range(0, 10):
-                _create_event(
+            uuids = [uuid4() for _ in range(0, 10)]
+            for uuid in uuids:
+                create_event(
+                    event_uuid=uuid,
                     distinct_id=distinct_id,
                     event="$event1",
                     properties={"$lib": "$web"},
                     timestamp=now() - relativedelta(hours=12),
                     team=self.org_1_team_1,
                 )
+
+            # create duplicate events
+            for uuid in uuids:
+                _create_event(
+                    event_uuid=uuid,
+                    distinct_id=distinct_id,
+                    event="$event1",
+                    properties={"$lib": "$web"},
+                    timestamp=now() - relativedelta(hours=12),
+                    team=self.org_1_team_1,
+                )
+
             _create_event(
                 distinct_id=distinct_id,
                 event="$feature_flag_called",
@@ -307,9 +325,9 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "plugins_installed": {"Installed and enabled": 1, "Installed but not enabled": 1},
                     "plugins_enabled": {"Installed and enabled": 1},
                     "instance_tag": "none",
-                    "event_count_lifetime": 44,
+                    "event_count_lifetime": 54,
                     "event_count_in_period": 22,
-                    "event_count_in_month": 32,
+                    "event_count_in_month": 42,
                     "event_count_with_groups_in_period": 2,
                     "recording_count_in_period": 5,
                     "recording_count_total": 16,
@@ -346,9 +364,9 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "team_count": 2,
                     "teams": {
                         str(self.org_1_team_1.id): {
-                            "event_count_lifetime": 33,
+                            "event_count_lifetime": 43,
                             "event_count_in_period": 12,
-                            "event_count_in_month": 22,
+                            "event_count_in_month": 32,
                             "event_count_with_groups_in_period": 2,
                             "recording_count_in_period": 0,
                             "recording_count_total": 0,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -330,6 +330,9 @@ def get_teams_with_billable_event_count_in_period(
     begin: datetime, end: datetime, count_distinct: bool = False
 ) -> List[Tuple[int, int]]:
     # count only unique events
+    # Duplicate events will be eventually removed by ClickHouse and likely came from our library or pipeline.
+    # We shouldn't bill for these. However counting unique events is more expensive, and likely to fail on longer time ranges.
+    # So, we count uniques in small time periods only, controlled by the count_distinct parameter.
     if count_distinct:
         # Uses the same expression as the one used to de-duplicate events on the merge tree:
         # https://github.com/PostHog/posthog/blob/master/posthog/models/event/sql.py#L92

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -331,6 +331,8 @@ def get_teams_with_billable_event_count_in_period(
 ) -> List[Tuple[int, int]]:
     # count only unique events
     if count_distinct:
+        # Uses the same expression as the one used to de-duplicate events on the merge tree:
+        # https://github.com/PostHog/posthog/blob/master/posthog/models/event/sql.py#L92
         distinct_expression = "distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)"
     else:
         distinct_expression = "1"


### PR DESCRIPTION
## Problem

Sometimes we have duplicate events in clickhouse, which are eventually de-duplicated.

Billing should not consider these as multiple events.

At the same time, getting the monthly events with this deduplication will OOM, so:

1. only daily counts per team are deduplicated for billing (this is what's used to compute billing)
2. For general stats, event count in lifetime and in month are not de-duplicated.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
unit tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
