### PR TITLE
fix(flags): Local override for cohort expansion

### DIFF
--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -149,6 +149,10 @@ class FeatureFlag(models.Model):
 
         parsed_conditions = []
         for condition in self.conditions:
+            if condition.get("variant"):
+                # variant overrides are not supported for cohort expansion.
+                return self.conditions
+
             cohort_condition = False
             props = condition.get("properties", [])
             cohort_group_rollout = condition.get("rollout_percentage")


### PR DESCRIPTION
## Problem

When we have a variant override, and a cohort in the filter, and it matches conditions for transforming a cohort into person props for local evaluation, we lose the cohort info.

This PR disables expanding cohorts with variant overrides. Accompanying docs change to follow.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
