### PR TITLE
fix: Some experiment and flag fixes

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -368,7 +368,7 @@ export function Experiment(): JSX.Element {
                                                 </Link>
                                             )}
                                         </div>
-                                        {experimentId === 'new' && (
+                                        {experimentId === 'new' && groupTypes.length > 0 && (
                                             <>
                                                 <div className="mt-4">
                                                     <strong>Default participant type</strong>

--- a/frontend/src/scenes/experiments/SecondaryMetrics.tsx
+++ b/frontend/src/scenes/experiments/SecondaryMetrics.tsx
@@ -145,7 +145,7 @@ export function SecondaryMetrics({
             >
                 <Form
                     logic={secondaryMetricsLogic}
-                    props={{ onMetricsChange, initialMetrics, experimentId }}
+                    props={{ onMetricsChange, initialMetrics, experimentId, defaultAggregationType }}
                     formKey="secondaryMetricModal"
                     id="secondary-metric-modal-form"
                     className="space-y-4"

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -59,7 +59,7 @@ export const experimentsLogic = kea<experimentsLogicType>([
                     if (!values.hasExperimentAvailableFeature) {
                         return []
                     }
-                    const response = await api.get(`api/projects/${values.currentTeamId}/experiments`)
+                    const response = await api.get(`api/projects/${values.currentTeamId}/experiments?limit=1000`)
                     return response.results as Experiment[]
                 },
                 deleteExperiment: async (id: number) => {

--- a/frontend/src/scenes/experiments/secondaryMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/secondaryMetricsLogic.ts
@@ -51,7 +51,7 @@ const defaultFormValuesGenerator: (
 
 export const secondaryMetricsLogic = kea<secondaryMetricsLogicType>([
     props({} as SecondaryMetricsProps),
-    key((props) => `${props.experimentId}-${props.defaultAggregationType}` || `new-${props.defaultAggregationType}`),
+    key((props) => `${props.experimentId || 'new'}-${props.defaultAggregationType}`),
     path((key) => ['scenes', 'experiment', 'secondaryMetricsLogic', key]),
     connect({
         logic: [insightLogic({ dashboardItemId: SECONDARY_METRIC_INSIGHT_ID, syncWithUrl: false })],

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -479,8 +479,8 @@ class FeatureFlagViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidD
         parsed_flags = []
         for feature_flag in feature_flags:
             filters = feature_flag.get_filters()
-            # transform cohort filters to be evaluated locally
-            if (
+            # transform cohort filters to be evaluated locally, but only if send_cohorts is false
+            if not should_send_cohorts and (
                 len(
                     feature_flag.get_cohort_ids(
                         using_database=DATABASE_FOR_LOCAL_EVALUATION, seen_cohorts_cache=seen_cohorts_cache

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1865,11 +1865,7 @@ class TestFeatureFlag(APIBaseTest):
                 "filters": {
                     "groups": [
                         {
-                            "properties": [{"key": "$some_prop", "type": "person", "value": "nomatchihope"}],
-                            "rollout_percentage": 20,
-                        },
-                        {
-                            "properties": [{"key": "$some_prop2", "type": "person", "value": "nomatchihope2"}],
+                            "properties": [{"key": "id", "type": "cohort", "value": cohort_valid_for_ff.pk}],
                             "rollout_percentage": 20,
                         },
                     ],


### PR DESCRIPTION
## Problem

A few misc. experiment fixes:

1. You couldn't save the name of secondary metrics with default aggregation set, because the form logic key was incorrect
2. Default participants shouldn't show up when you don't have groups
3. transforming filters for local eval is unnecessary when we're sending cohorts
4. Some teams were hitting experiment pagination limits (>100), so bumps that up

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
