### PR TITLE
feat: Add sentry to support request

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -11,6 +11,7 @@ import { actionToUrl, router, urlToAction } from 'kea-router'
 import { captureException } from '@sentry/react'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { teamLogic } from 'scenes/teamLogic'
+import * as Sentry from '@sentry/react'
 
 function getSessionReplayLink(): string {
     const link = posthog
@@ -236,15 +237,26 @@ export const supportLogic = kea<supportLogicType>([
                 .then((res) => res.json())
                 .then((res) => {
                     const zendesk_ticket_id = res.request.id
+                    const zendesk_ticket_link = `https://posthoghelp.zendesk.com/agent/tickets/${zendesk_ticket_id}`
                     const properties = {
                         zendesk_ticket_uuid,
                         kind,
                         target_area,
                         message,
                         zendesk_ticket_id,
-                        zendesk_ticket_link: `https://posthoghelp.zendesk.com/agent/tickets/${zendesk_ticket_id}`,
+                        zendesk_ticket_link,
                     }
                     posthog.capture('support_ticket', properties)
+                    Sentry.captureMessage('User submitted zendesk ticket', {
+                        tags: {
+                            zendesk_ticket_uuid,
+                            zendesk_ticket_link,
+                            support_request_kind: kind,
+                            support_request_area: target_area,
+                        },
+                        extra: properties,
+                        level: 'error',
+                    })
                     lemonToast.success(
                         "Got the message! If we have follow-up information for you, we'll reply via email."
                     )

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -247,15 +247,16 @@ export const supportLogic = kea<supportLogicType>([
                         zendesk_ticket_link,
                     }
                     posthog.capture('support_ticket', properties)
-                    Sentry.captureMessage('User submitted zendesk ticket', {
+                    Sentry.captureMessage('User submitted Zendesk ticket', {
                         tags: {
                             zendesk_ticket_uuid,
                             zendesk_ticket_link,
                             support_request_kind: kind,
                             support_request_area: target_area,
+                            team_id: teamLogic.values.currentTeamId,
                         },
                         extra: properties,
-                        level: 'error',
+                        level: 'log',
                     })
                     lemonToast.success(
                         "Got the message! If we have follow-up information for you, we'll reply via email."


### PR DESCRIPTION
## Problem

When someone creates a support request, we are not getting as much information from sentry as we could be. For example, sentry can provide us with breadcrumbs (e.g. console logs, redux actions).

## Changes

Added a sentry.captureException at the point where we send the request off to zendesk and also capture a posthog event

## How did you test this code?

Triggered this manually with a personal sentry account
<img width="1482" alt="Screenshot 2023-08-25 at 12 58 16" src="https://github.com/PostHog/posthog/assets/2056078/8ad8f0ae-284d-4dd0-9558-b75664d87db0">

