### PR TITLE
perf(plugin-server): chainToElements only parses 1Kib of attributes per element

### DIFF
--- a/plugin-server/src/utils/db/elements-chain.ts
+++ b/plugin-server/src/utils/db/elements-chain.ts
@@ -55,10 +55,16 @@ export function chainToElements(chain: string, teamId: number, options: { throwO
             .map((r) => r[0])
             .forEach((elString, index) => {
                 const elStringSplit = Array.from(elString.matchAll(splitClassAttributes))[0]
-                const attributes =
-                    elStringSplit.length > 3 && elStringSplit[3]
-                        ? Array.from(elStringSplit[3].matchAll(parseAttributesRegex)).map((a) => [a[2], a[3]])
-                        : []
+                const attributes: [string, string][] = []
+                if (elStringSplit.length > 3 && elStringSplit[3]) {
+                    // parseAttributesRegex's cost grows non-linear to the input length
+                    // we only parse the first 1KiB to reduce the processing cost.
+                    const trimmedAttributes = elStringSplit[3].slice(0, 1024)
+                    const matchedAttributes = trimmedAttributes.matchAll(parseAttributesRegex)
+                    for (const a of matchedAttributes) {
+                        attributes.push([a[2], a[3]])
+                    }
+                }
 
                 const element: Element = {
                     attributes: {},

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1133,7 +1133,7 @@ test('long htext', async () => {
                     {
                         tag_name: 'a',
                         $el_text: 'a'.repeat(2050),
-                        attr__href: 'a'.repeat(2050),
+                        attr__href: 'a'.repeat(200),
                         nth_child: 1,
                         nth_of_type: 2,
                         attr__class: 'btn btn-sm',
@@ -1148,7 +1148,7 @@ test('long htext', async () => {
 
     const [event] = await hub.db.fetchEvents()
     const [element] = event.elements_chain!
-    expect(element.href?.length).toEqual(2048)
+    expect(element.href?.length).toEqual(200)
     expect(element.text?.length).toEqual(400)
 })
 


### PR DESCRIPTION
## Problem

Sibling PR to https://github.com/PostHog/posthog/pull/17198 to reduce processing cost of events with huge autocapture chains.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
