### PR TITLE
feat: Skip elements chain parsing for some plugins

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -207,7 +207,7 @@ export function overrideWithEnv(
     return newConfig
 }
 
-export function buildIntegerMatcher(config: string, allowStar: boolean): ValueMatcher<number> {
+export function buildIntegerMatcher(config: string | undefined, allowStar: boolean): ValueMatcher<number> {
     // Builds a ValueMatcher on a coma-separated list of values.
     // Optionally, supports a '*' value to match everything
     if (!config) {

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
@@ -21,8 +21,11 @@ export async function eachMessageAppsOnEventHandlers(
     const pluginConfigs = queue.pluginsServer.pluginConfigsPerTeam.get(clickHouseEvent.team_id)
     if (pluginConfigs) {
         // Elements parsing can be extremely slow, so we skip it for some plugins
-        const skipElementsChain = pluginConfigs.every((pluginConfig) =>
-            process.env.SKIP_ELEMENTS_PARSING_PLUGINS?.split(',').includes(pluginConfig.plugin_id.toString())
+        // # SKIP_ELEMENTS_PARSING_PLUGINS
+        const skipElementsChain = pluginConfigs.every(
+            (pluginConfig) =>
+                queue.pluginsServer.pluginConfigsToSkipElementsParsing &&
+                queue.pluginsServer.pluginConfigsToSkipElementsParsing(pluginConfig.plugin_id)
         )
 
         const event = convertToIngestionEvent(clickHouseEvent, skipElementsChain)

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
@@ -18,8 +18,14 @@ export async function eachMessageAppsOnEventHandlers(
 ): Promise<void> {
     const clickHouseEvent = JSON.parse(message.value!.toString()) as RawClickHouseEvent
 
-    if (queue.pluginsServer.pluginConfigsPerTeam.has(clickHouseEvent.team_id)) {
-        const event = convertToIngestionEvent(clickHouseEvent)
+    const pluginConfigs = queue.pluginsServer.pluginConfigsPerTeam.get(clickHouseEvent.team_id)
+    if (pluginConfigs) {
+        // Elements parsing can be extremely slow, so we skip it for some plugins
+        const skipElementsChain = pluginConfigs.every((pluginConfig) =>
+            process.env.SKIP_ELEMENTS_PARSING_PLUGINS?.split(',').includes(pluginConfig.plugin_id.toString())
+        )
+
+        const event = convertToIngestionEvent(clickHouseEvent, skipElementsChain)
         await runInstrumentedFunction({
             event: event,
             func: () => queue.workerMethods.runAppsOnEventPipeline(event),

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -258,6 +258,8 @@ export interface Hub extends PluginsServerConfig {
     conversionBufferEnabledTeams: Set<number>
     // functions
     enqueuePluginJob: (job: EnqueuedPluginJob) => Promise<void>
+    // ValueMatchers used for various opt-in/out features
+    pluginConfigsToSkipElementsParsing: ValueMatcher<number>
 }
 
 export interface PluginServerCapabilities {

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -10,7 +10,7 @@ import { types as pgTypes } from 'pg'
 import { ConnectionOptions } from 'tls'
 
 import { getPluginServerCapabilities } from '../../capabilities'
-import { defaultConfig } from '../../config/config'
+import { buildIntegerMatcher, defaultConfig } from '../../config/config'
 import { KAFKAJS_LOG_LEVEL_MAPPING } from '../../config/constants'
 import { KAFKA_JOBS } from '../../config/kafka-topics'
 import { createRdConnectionConfigFromEnvVars } from '../../kafka/config'
@@ -182,6 +182,7 @@ export async function createHub(
         rootAccessManager,
         promiseManager,
         conversionBufferEnabledTeams,
+        pluginConfigsToSkipElementsParsing: buildIntegerMatcher(process.env.SKIP_ELEMENTS_PARSING_PLUGINS, true),
     }
 
     // :TODO: This is only used on worker threads, not main

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -62,7 +62,7 @@ export function parseRawClickHouseEvent(rawEvent: RawClickHouseEvent): ClickHous
     }
 }
 
-export function convertToIngestionEvent(event: RawClickHouseEvent): PostIngestionEvent {
+export function convertToIngestionEvent(event: RawClickHouseEvent, skipElementsChain = false): PostIngestionEvent {
     const properties = event.properties ? JSON.parse(event.properties) : {}
     return {
         eventUuid: event.uuid,
@@ -72,7 +72,11 @@ export function convertToIngestionEvent(event: RawClickHouseEvent): PostIngestio
         distinctId: event.distinct_id,
         properties,
         timestamp: clickHouseTimestampToISO(event.timestamp),
-        elementsList: event.elements_chain ? chainToElements(event.elements_chain, event.team_id) : [],
+        elementsList: skipElementsChain
+            ? []
+            : event.elements_chain
+            ? chainToElements(event.elements_chain, event.team_id)
+            : [],
         person_id: event.person_id,
         person_created_at: event.person_created_at
             ? clickHouseTimestampSecondPrecisionToISO(event.person_created_at)

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -1,3 +1,4 @@
+import { buildIntegerMatcher } from '../../../src/config/config'
 import { KAFKA_EVENTS_PLUGIN_INGESTION } from '../../../src/config/kafka-topics'
 import {
     eachBatchParallelIngestion,
@@ -198,7 +199,7 @@ describe('eachBatchX', () => {
                 { ...pluginConfig39, plugin_id: 60 },
                 { ...pluginConfig39, plugin_id: 33 },
             ])
-            process.env.SKIP_ELEMENTS_PARSING_PLUGINS = '12,60,100'
+            queue.pluginsServer.pluginConfigsToSkipElementsParsing = buildIntegerMatcher('12,60,100', true)
             await eachBatchAppsOnEventHandlers(
                 createKafkaJSBatch({ ...clickhouseEvent, elements_chain: 'random' }),
                 queue
@@ -216,7 +217,7 @@ describe('eachBatchX', () => {
                 { ...pluginConfig39, plugin_id: 60 },
                 { ...pluginConfig39, plugin_id: 100 },
             ])
-            process.env.SKIP_ELEMENTS_PARSING_PLUGINS = '12,60,100'
+            queue.pluginsServer.pluginConfigsToSkipElementsParsing = buildIntegerMatcher('12,60,100', true)
             await eachBatchAppsOnEventHandlers(
                 createKafkaJSBatch({ ...clickhouseEvent, elements_chain: 'random' }),
                 queue

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -193,6 +193,41 @@ describe('eachBatchX', () => {
                 expect.any(Date)
             )
         })
+        it('parses elements when useful', async () => {
+            queue.pluginsServer.pluginConfigsPerTeam.set(2, [
+                { ...pluginConfig39, plugin_id: 60 },
+                { ...pluginConfig39, plugin_id: 33 },
+            ])
+            process.env.SKIP_ELEMENTS_PARSING_PLUGINS = '12,60,100'
+            await eachBatchAppsOnEventHandlers(
+                createKafkaJSBatch({ ...clickhouseEvent, elements_chain: 'random' }),
+                queue
+            )
+            expect(queue.workerMethods.runAppsOnEventPipeline).toHaveBeenCalledWith({
+                ...event,
+                elementsList: [{ attributes: {}, order: 0, tag_name: 'random' }],
+                properties: {
+                    $ip: '127.0.0.1',
+                },
+            })
+        })
+        it('skips elements parsing when not useful', async () => {
+            queue.pluginsServer.pluginConfigsPerTeam.set(2, [
+                { ...pluginConfig39, plugin_id: 60 },
+                { ...pluginConfig39, plugin_id: 100 },
+            ])
+            process.env.SKIP_ELEMENTS_PARSING_PLUGINS = '12,60,100'
+            await eachBatchAppsOnEventHandlers(
+                createKafkaJSBatch({ ...clickhouseEvent, elements_chain: 'random' }),
+                queue
+            )
+            expect(queue.workerMethods.runAppsOnEventPipeline).toHaveBeenCalledWith({
+                ...event,
+                properties: {
+                    $ip: '127.0.0.1',
+                },
+            })
+        })
     })
 
     describe('eachBatchWebhooksHandlers', () => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Elements chains parsing can be extremely expensive, some plugins don't use it so we can skip it if all the plugins for this team don't use it

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
