### PR TITLE
fix(property-definitions): allow property type changes on free tier (fixes #17132)

### DIFF
--- a/ee/api/test/test_property_definition.py
+++ b/ee/api/test/test_property_definition.py
@@ -232,6 +232,23 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
         response_data = response.json()
         self.assertEqual(response_data["property_type"], "DateTime")
 
+    def test_can_update_property_type_and_unchanged_keys_without_license(self):
+        property = EnterprisePropertyDefinition.objects.create(team=self.team, name="enterprise property")
+        response = self.client.patch(
+            f"/api/projects/@current/property_definitions/{str(property.id)}/",
+            data={
+                "id": property.id,
+                "name": "enterprise property",
+                "is_numerical": False,
+                "property_type": "DateTime",
+                "is_seen_on_filtered_events": None,
+                "tags": [],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["property_type"], "DateTime")
+
     def test_cannot_update_more_than_property_type_without_license(self):
         property = EnterprisePropertyDefinition.objects.create(team=self.team, name="enterprise property")
         response = self.client.patch(


### PR DESCRIPTION
## Problem

Alternative to https://github.com/PostHog/posthog/pull/17172.

---

https://github.com/PostHog/posthog/issues/17132 

## Changes

See also https://posthog.slack.com/archives/C0368RPHLQH/p1692697007754269.

This PR fixes the problem by only sending the allowed key `property_type` for free tier users.


## How did you test this code?

Tried free and paid tier locally.