### PR TITLE
chore: skip flapping tests

### DIFF
--- a/playwright/e2e-vrt/scenes-app/insights.spec.ts
+++ b/playwright/e2e-vrt/scenes-app/insights.spec.ts
@@ -2,7 +2,8 @@ import { toId } from '../../helpers/storybook'
 import { test, expect } from '../../fixtures/storybook'
 
 test.describe('tooltip', () => {
-    test('displays correctly', async ({ page, storyPage }) => {
+    // skipped because this flaps like a fish out of water
+    test.skip('displays correctly', async ({ page, storyPage }) => {
         await storyPage.goto(toId('Scenes-App/Insights', 'Trends Line'))
 
         // hover over the graph to show the tooltip
@@ -14,18 +15,21 @@ test.describe('tooltip', () => {
         })
 
         const tooltip = await page.locator('.InsightTooltip')
+
         await expect(tooltip).toHaveScreenshot()
     })
 })
 
 test.describe('annotations popover', () => {
-    test('displays correctly', async ({ page, storyPage }) => {
+    // skipped because this flaps like a fish out of water
+    test.skip('displays correctly', async ({ page, storyPage }) => {
         await storyPage.goto(toId('Scenes-App/Insights', 'Trends Line'))
 
         // hover over the graph to show the annotations overlay
         await page.locator('.AnnotationsOverlay > button:nth-child(4)').hover()
 
         const popover = await page.locator('.AnnotationsPopover')
+
         await expect(popover).toHaveScreenshot()
     })
 })


### PR DESCRIPTION
These tests are flapping like wild, yesterday they accounted for 59 commits on a single PR.

They vary very slightly in the X position. Presumably, the hover before the screenshot isn't precise. 

I tried delaying the screenshot which didn't help. and setting a max diff ratio wouldn't help since they show as 100% different.

It'd be nice to fix them but until then let's stop burning time and money