### PR TITLE
fix: break circular references in hub to reduce jest memory usage

### DIFF
--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -177,7 +177,7 @@ jobs:
                   # Below DB name has `test_` prepended, as that's how Django (ran above) creates the test DB
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/test_posthog'
                   REDIS_URL: 'redis://localhost'
-                  NODE_OPTIONS: '--max_old_space_size=6144'
+                  NODE_OPTIONS: '--max_old_space_size=4096'
               run: cd plugin-server && pnpm test -- --runInBand --forceExit tests/ --shard=${{matrix.shard}}
 
     functional-tests:

--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -24,7 +24,7 @@ LOG_FILE=$(mktemp)
 
 echo '::group::Starting plugin server'
 
-NODE_OPTIONS='--max_old_space_size=6144' ./node_modules/.bin/c8 --reporter html node dist/index.js >"$LOG_FILE" 2>&1 &
+NODE_OPTIONS='--max_old_space_size=4096' ./node_modules/.bin/c8 --reporter html node dist/index.js >"$LOG_FILE" 2>&1 &
 SERVER_PID=$!
 SECONDS=0
 

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -192,6 +192,11 @@ export async function createHub(
     const closeHub = async () => {
         await Promise.allSettled([kafkaProducer.disconnect(), redisPool.drain(), hub.postgres?.end()])
         await redisPool.clear()
+
+        // Break circular references to allow the hub to be GCed when running unit tests
+        // TODO: change these structs to not directly reference the hub
+        hub.eventsProcessor = undefined
+        hub.appMetrics = undefined
     }
 
     return [hub as Hub, closeHub]


### PR DESCRIPTION
## Problem

plugin-server unit tests currently require more than 5GiB of heap to succeed. We just upped the limit to 6GiB last week, and the runners only have 7GiB of RAM (and PG, Kafka and CH running!). My first instinct is that these are due to cyclical references in the `Hub` struct, preventing it to be GCed.

## Changes

- Break the two cyclical refs during `closeHub` to allow the `Hub` to be GCed
- Lower the heap back to 4GiB in unit and functional tests to confirm impact. Not going lower as going lower could slow down the tests due to GC pressure elsewhere, and there's available RAM anyway

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

