### PR TITLE
fix(trends): support actors query with hogql breakdown

### DIFF
--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -817,7 +817,9 @@ def count_hogql_properties(
 ) -> TCounter[PropertyIdentifier]:
     if not counter:
         counter = Counter()
-    node = parse_expr(expr)
+    node = parse_expr(
+        expr
+    )  # this does not support %-signs. is a previous translate_hogql necessary? better to use another approach?
     property_checker = HogQLPropertyChecker()
     property_checker.visit(node)
     for field in property_checker.event_properties:

--- a/posthog/queries/trends/trends_actors.py
+++ b/posthog/queries/trends/trends_actors.py
@@ -77,7 +77,9 @@ class TrendsActors(ActorBaseQuery):
             else:
                 breakdown_props = [
                     Property(
-                        key=self._filter.breakdown,
+                        key=f"({self._filter.breakdown}) = '{self._filter.breakdown_value}'"
+                        if self._filter.breakdown_type == "hogql"
+                        else self._filter.breakdown,
                         value=self._filter.breakdown_value,
                         type=self._filter.breakdown_type,
                         group_type_index=self._filter.breakdown_group_type_index

--- a/posthog/queries/trends/trends_actors.py
+++ b/posthog/queries/trends/trends_actors.py
@@ -77,7 +77,7 @@ class TrendsActors(ActorBaseQuery):
             else:
                 breakdown_props = [
                     Property(
-                        key=f"({self._filter.breakdown}) = '{self._filter.breakdown_value}'"
+                        key=f"({self._filter.breakdown}) = {self._filter.hogql_context.add_value(self._filter.breakdown_value)}"
                         if self._filter.breakdown_type == "hogql"
                         else self._filter.breakdown,
                         value=self._filter.breakdown_value,


### PR DESCRIPTION
## Problem

Fetching the actors for a trends insight with hogql breakdown results in a server error.

<img width="1162" alt="Screenshot 2023-08-28 at 14 47 24" src="https://github.com/PostHog/posthog/assets/1851359/1fd0ea89-6193-43ca-b929-e3430057885d">

Related Sentry issue: https://posthog.sentry.io/issues/4232217541/?project=1899813&query=is%3Aunresolved+url%3Ahttp%3A%2F%2Fapp.posthog.com%2Fapi%2Fprojects%2F20866%2Fpersons%2Ftrends%2F&referrer=issue-stream&statsPeriod=14d&stream_index=0
Related Ticket: https://posthoghelp.zendesk.com/agent/tickets/5068 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/8144)

## Changes

This PR transforms the HogQL breakdown into an expression matching the breakdown value. e.g. a HogQL breakdown `event` for value `$pageview` becomes the HogQL property filter `(event) = '$pageview'`. I don't know if that's the right approach or if there would be a better place to make this change.

## How did you test this code?

Added a test and verified a failing example works