### PR TITLE
feat(plugin-server): add profiling http endpoints

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -83,6 +83,7 @@
         "snowflake-sdk": "^1.6.10",
         "tail": "^2.2.6",
         "uuid": "^8.3.2",
+        "v8-profiler-next": "^1.9.0",
         "vm2": "3.9.18"
     },
     "devDependencies": {

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -154,6 +154,9 @@ dependencies:
   uuid:
     specifier: ^8.3.2
     version: 8.3.2
+  v8-profiler-next:
+    specifier: ^1.9.0
+    version: 1.9.0
   vm2:
     specifier: 3.9.18
     version: 3.9.18
@@ -4341,6 +4344,26 @@ packages:
       eslint-visitor-keys: 3.4.0
     dev: true
 
+  /@xprofiler/node-pre-gyp@1.0.11:
+    resolution: {integrity: sha512-kNFT4XscrA+Hjh+jSHs49PiG/YGf08a6eNDo16qjSnCaT4B5ngrKDcNtEJ6CnS0sDP/1oZmHCBYECB6wGKP7lg==}
+    hasBin: true
+    dependencies:
+      detect-libc: 1.0.3
+      https-proxy-agent: 5.0.1
+      make-dir: 3.1.0
+      node-fetch: 2.6.9
+      node-gyp: 9.3.1
+      nopt: 5.0.0
+      npmlog: 5.0.1
+      rimraf: 3.0.2
+      semver: 7.5.0
+      tar: 6.1.13
+    transitivePeerDependencies:
+      - bluebird
+      - encoding
+      - supports-color
+    dev: false
+
   /JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
@@ -4515,6 +4538,14 @@ packages:
 
   /archy@1.0.0:
     resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
+    dev: false
+
+  /are-we-there-yet@2.0.0:
+    resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
+    engines: {node: '>=10'}
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
     dev: false
 
   /are-we-there-yet@3.0.1:
@@ -5834,6 +5865,12 @@ packages:
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
     dev: false
 
+  /detect-libc@1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+    dev: false
+
   /detect-libc@2.0.1:
     resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==}
     engines: {node: '>=8'}
@@ -6795,6 +6832,21 @@ packages:
   /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: true
+
+  /gauge@3.0.2:
+    resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      aproba: 2.0.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      object-assign: 4.1.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
+    dev: false
 
   /gauge@4.0.4:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
@@ -9144,6 +9196,14 @@ packages:
       abbrev: 1.1.1
     dev: true
 
+  /nopt@5.0.0:
+    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dependencies:
+      abbrev: 1.1.1
+    dev: false
+
   /nopt@6.0.0:
     resolution: {integrity: sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -9174,6 +9234,15 @@ packages:
     dependencies:
       path-key: 3.1.1
     dev: true
+
+  /npmlog@5.0.1:
+    resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    dependencies:
+      are-we-there-yet: 2.0.0
+      console-control-strings: 1.1.0
+      gauge: 3.0.2
+      set-blocking: 2.0.0
+    dev: false
 
   /npmlog@6.0.2:
     resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
@@ -11456,6 +11525,18 @@ packages:
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  /v8-profiler-next@1.9.0:
+    resolution: {integrity: sha512-+k2Lb0c9lEDsGNT1GfrrlV4evR2KsF3LljW8PUfRaM1OQmr+F3lXGxVIffa+LNXaw3CnwdsSdqI2zaYEhDdu5Q==}
+    requiresBuild: true
+    dependencies:
+      '@xprofiler/node-pre-gyp': 1.0.11
+      nan: 2.17.0
+    transitivePeerDependencies:
+      - bluebird
+      - encoding
+      - supports-color
+    dev: false
 
   /v8-to-istanbul@9.1.0:
     resolution: {integrity: sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==}

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -133,7 +133,7 @@ function exportProfile(req: IncomingMessage, res: ServerResponse) {
     const durationSeconds = url.searchParams.get('seconds') ? parseInt(url.searchParams.get('seconds')!) : 30
 
     const sendHeaders = function (extension: string) {
-        const fileName = `${type}-${DateTime.now().toFormat('yyyyMMdd-HHmmss')}.${extension}`
+        const fileName = `${type}-${DateTime.now().toUTC().toFormat('yyyyMMdd-HHmmss')}.${extension}`
         res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`)
         res.setHeader('Profile-Type', type ?? 'invalid')
         res.setHeader('Profile-Duration-Seconds', durationSeconds)

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -1,4 +1,5 @@
 import { createServer, IncomingMessage, Server, ServerResponse } from 'http'
+import { DateTime } from 'luxon'
 import { IngestionConsumer, KafkaJSIngestionConsumer } from 'main/ingestion-queues/kafka-queue'
 import * as prometheus from 'prom-client'
 
@@ -7,13 +8,20 @@ import { status } from '../../utils/status'
 export const HTTP_SERVER_PORT = 6738
 
 prometheus.collectDefaultMetrics()
+const v8Profiler = require('v8-profiler-next')
+v8Profiler.setGenerateType(1)
 
 export function createHttpServer(
     healthChecks: { [service: string]: () => Promise<boolean> | boolean },
     analyticsEventsIngestionConsumer?: KafkaJSIngestionConsumer | IngestionConsumer
 ): Server {
     const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-        if (req.url === '/_health' && req.method === 'GET') {
+        if (req.method !== 'GET') {
+            res.statusCode = 404
+            res.end()
+            return
+        }
+        if (req.url === '/_health') {
             // Check that all health checks pass. Note that a failure of these
             // _may_ result in the process being terminated by e.g. Kubernetes
             // so the stakes are high.
@@ -67,7 +75,7 @@ export function createHttpServer(
             }
 
             res.end(JSON.stringify({ status: statusCode === 200 ? 'ok' : 'error', checks: checkResultsMapping }))
-        } else if (req.url === '/_ready' && req.method === 'GET') {
+        } else if (req.url === '/_ready') {
             // Check that, if the server should have a kafka queue,
             // the Kafka consumer is ready to consume messages
             if (!analyticsEventsIngestionConsumer || analyticsEventsIngestionConsumer.consumerReady) {
@@ -85,17 +93,25 @@ export function createHttpServer(
                 res.statusCode = 503
                 res.end(JSON.stringify(responseBody))
             }
-        } else if (req.url === '/_metrics' && req.method === 'GET') {
+        } else if (req.url === '/_metrics') {
             prometheus.register
                 .metrics()
                 .then((metrics) => {
                     res.end(metrics)
                 })
                 .catch((err) => {
-                    status.error('🩺', 'Error while collecting metrics', err)
+                    status.error('🩺', 'Error while collecting metrics', { err })
                     res.statusCode = 500
                     res.end()
                 })
+        } else if (req.url!.startsWith('/_profile/')) {
+            try {
+                exportProfile(req, res)
+            } catch (err) {
+                status.error('🩺', 'Error while collecting profile', { err })
+                res.statusCode = 500
+                res.end()
+            }
         } else {
             res.statusCode = 404
             res.end()
@@ -107,4 +123,61 @@ export function createHttpServer(
     })
 
     return server
+}
+
+function exportProfile(req: IncomingMessage, res: ServerResponse) {
+    // Mirrors golang's pprof behaviour of exposing on-off profiles through HTTP endpoints
+    // Port-forward a target pod and run: curl -vOJ "http://localhost:6738/_profile/cpu?seconds=30"
+    const url = new URL(req.url!, `http://${req.headers.host}`)
+    const type = url.pathname.split('/').pop()
+    const durationSeconds = url.searchParams.get('seconds') ? parseInt(url.searchParams.get('seconds')!) : 30
+
+    const sendHeaders = function (extension: string) {
+        const fileName = `${type}-${DateTime.now().toFormat('yyyyMMdd-HHmmss')}.${extension}`
+        res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`)
+        res.setHeader('Profile-Type', type ?? 'invalid')
+        res.setHeader('Profile-Duration-Seconds', durationSeconds)
+        res.flushHeaders()
+    }
+
+    status.info('🩺', `Collecting ${type} profile...`)
+
+    switch (type) {
+        case 'cpu':
+            sendHeaders('cpuprofile')
+            v8Profiler.startProfiling('cpu', true)
+            setTimeout(() => {
+                outputProfileResult(res, type, v8Profiler.stopProfiling('cpu'))
+            }, durationSeconds * 1000)
+            break
+        case 'heap':
+            sendHeaders('json')
+            v8Profiler.startSamplingHeapProfiling()
+            setTimeout(() => {
+                outputProfileResult(res, type, v8Profiler.stopSamplingHeapProfiling())
+            }, durationSeconds * 1000)
+            break
+        default:
+            res.statusCode = 404
+            res.end()
+    }
+}
+
+function outputProfileResult(res: ServerResponse, type: string, output: any) {
+    status.info('🩺', `${type} profile collected, sending to client`)
+    output.export(function (error: any, result: any) {
+        if (error) {
+            status.error('😖', 'Error while exporting profile', { error })
+            res.statusCode = 500
+            res.end()
+        } else {
+            res.end(result)
+            try {
+                output.delete()
+            } catch {
+                // heapprofile do not need delete
+            }
+        }
+    })
+    status.info('🩺', `${type} profile successfully exported`)
 }

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -172,11 +172,7 @@ function outputProfileResult(res: ServerResponse, type: string, output: any) {
             res.end()
         } else {
             res.end(result)
-            try {
-                output.delete()
-            } catch {
-                // heapprofile do not need delete
-            }
+            output.delete?.() // heap profiles do not implement delete
         }
     })
     status.info('🩺', `${type} profile successfully exported`)

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -129,13 +129,13 @@ function exportProfile(req: IncomingMessage, res: ServerResponse) {
     // Mirrors golang's pprof behaviour of exposing on-off profiles through HTTP endpoints
     // Port-forward a target pod and run: curl -vOJ "http://localhost:6738/_profile/cpu?seconds=30"
     const url = new URL(req.url!, `http://${req.headers.host}`)
-    const type = url.pathname.split('/').pop()
+    const type = url.pathname.split('/').pop() ?? 'unknown'
     const durationSeconds = url.searchParams.get('seconds') ? parseInt(url.searchParams.get('seconds')!) : 30
 
     const sendHeaders = function (extension: string) {
         const fileName = `${type}-${DateTime.now().toUTC().toFormat('yyyyMMdd-HHmmss')}.${extension}`
         res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`)
-        res.setHeader('Profile-Type', type ?? 'invalid')
+        res.setHeader('Profile-Type', type)
         res.setHeader('Profile-Duration-Seconds', durationSeconds)
         res.flushHeaders()
     }

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -151,7 +151,7 @@ function exportProfile(req: IncomingMessage, res: ServerResponse) {
             }, durationSeconds * 1000)
             break
         case 'heap':
-            sendHeaders('json')
+            sendHeaders('heapprofile')
             v8Profiler.startSamplingHeapProfiling()
             setTimeout(() => {
                 outputProfileResult(res, type, v8Profiler.stopSamplingHeapProfiling())

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -126,8 +126,12 @@ export function createHttpServer(
 }
 
 function exportProfile(req: IncomingMessage, res: ServerResponse) {
-    // Mirrors golang's pprof behaviour of exposing on-off profiles through HTTP endpoints
-    // Port-forward a target pod and run: curl -vOJ "http://localhost:6738/_profile/cpu?seconds=30"
+    // Mirrors golang's pprof behaviour of exposing ad-hoc profiles through HTTP endpoints
+    // Port-forward pod 6738 on a target pod and run:
+    //       curl -vOJ "http://localhost:6738/_profile/cpu"
+    //   or  curl -vOJ "http://localhost:6738/_profile/heap?seconds=30"
+    // The output can be loaded in the chrome devtools, in the Memory or Javascript profiler tabs.
+
     const url = new URL(req.url!, `http://${req.headers.host}`)
     const type = url.pathname.split('/').pop() ?? 'unknown'
     const durationSeconds = url.searchParams.get('seconds') ? parseInt(url.searchParams.get('seconds')!) : 30


### PR DESCRIPTION
## Problem

One-off profiling of CPU usage and heap allocations is immensely useful, but tedious to do manually.

I could not manage to get node's official profiler to return useful results, but v8's internal sampling profiler seems to work OK. This PR adds HTTP endpoints to retrieve ad-hoc profiles, mirroring [golang's pprof package](https://pkg.go.dev/net/http/pprof).

This uses https://github.com/hyj1991/v8-profiler-next which is still under active development, but node upgrades might break this, due to v8 internal API changes.

Endpoints default to 30 seconds of sample-based profiling, but the user can set a different duration.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

```bash
curl -vOJ "http://localhost:6738/_profile/cpu?seconds=30"
curl -vOJ "http://localhost:6738/_profile/heap?seconds=10"
```

![image](https://github.com/PostHog/posthog/assets/6241083/abde1e3b-39ce-4783-a19f-195d58d1ead2)
