### PR TITLE
feat(insights): ignore display changes from requests

### DIFF
--- a/frontend/src/scenes/insights/utils/compareInsightQuery.ts
+++ b/frontend/src/scenes/insights/utils/compareInsightQuery.ts
@@ -1,7 +1,31 @@
 import { InsightQueryNode } from '~/queries/schema'
 
 import { objectCleanWithEmpty, objectsEqual } from 'lib/utils'
-import { filterForQuery, filterPropertyForQuery, isEventsNode, isInsightQueryWithSeries } from '~/queries/utils'
+import {
+    filterForQuery,
+    filterPropertyForQuery,
+    isEventsNode,
+    isInsightQueryWithDisplay,
+    isInsightQueryWithSeries,
+} from '~/queries/utils'
+import { ChartDisplayType } from '~/types'
+
+const groupedChartDisplayTypes: Record<ChartDisplayType, ChartDisplayType> = {
+    // time series
+    [ChartDisplayType.ActionsLineGraph]: ChartDisplayType.ActionsLineGraph,
+    [ChartDisplayType.ActionsBar]: ChartDisplayType.ActionsLineGraph,
+    [ChartDisplayType.ActionsAreaGraph]: ChartDisplayType.ActionsLineGraph,
+
+    // cumulative time series
+    [ChartDisplayType.ActionsLineGraphCumulative]: ChartDisplayType.ActionsLineGraphCumulative,
+
+    // total value
+    [ChartDisplayType.BoldNumber]: ChartDisplayType.ActionsBarValue,
+    [ChartDisplayType.ActionsBarValue]: ChartDisplayType.ActionsBarValue,
+    [ChartDisplayType.ActionsPie]: ChartDisplayType.ActionsBarValue,
+    [ChartDisplayType.ActionsTable]: ChartDisplayType.ActionsBarValue,
+    [ChartDisplayType.WorldMap]: ChartDisplayType.ActionsBarValue,
+}
 
 /** clean insight queries so that we can check for semantic equality with a deep equality check */
 const cleanInsightQuery = (query: InsightQueryNode, ignoreVisualizationOnlyChanges: boolean): InsightQueryNode => {
@@ -32,6 +56,11 @@ const cleanInsightQuery = (query: InsightQueryNode, ignoreVisualizationOnlyChang
             aggregation_axis_postfix: undefined,
             layout: undefined,
             toggledLifecycles: undefined,
+        }
+
+        if (isInsightQueryWithDisplay(cleanedQuery)) {
+            cleanedQuery[insightFilterKey].display =
+                groupedChartDisplayTypes[cleanedQuery[insightFilterKey].display || ChartDisplayType.ActionsLineGraph]
         }
     }
 


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/pull/17150 - We're making unnecessary requests to the backend for frontend-only changes to the query node. This also causes an ugly re-render.

## Changes

This PR prevents unnecessary requests for display type changes, as suggested here https://github.com/PostHog/posthog/pull/17150#pullrequestreview-1591879605

## How did you test this code?

Played around locally