### PR TITLE
chore(speed): don't run all tests in PoE and EE runs

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -97,13 +97,29 @@ runs:
               PERSON_ON_EVENTS_V2_ENABLED: ${{ inputs.person-on-events }}
               GROUPS_ON_EVENTS_ENABLED: ${{ inputs.person-on-events }}
           shell: bash
-          run: | # async_migrations are covered in ci-async-migrations.yml
-              pytest hogvm posthog -m "not async_migrations" \
+          run: | # async_migrations covered in ci-async-migrations.yml
+              pytest ${{
+                  inputs.person-on-events == 'true'
+                  && './posthog/clickhouse/ ./posthog/hogql/ ./posthog/queries/ ./posthog/api/test/test_insight* ./posthog/api/test/dashboards/test_dashboard.py'
+                  || 'hogvm posthog'
+              }} -m "not async_migrations" \
                   --splits ${{ inputs.concurrency }} --group ${{ inputs.group }} \
-                  --durations=100 --durations-min=1.0 --store-durations \
+                  --durations=100 --durations-min=1.0 \
                   $PYTEST_ARGS
 
-        - name: Run Decide read replica tests
+        - name: Run EE tests
+          if: ${{ inputs.segment == 'EE' }}
+          env:
+              PERSON_ON_EVENTS_V2_ENABLED: ${{ inputs.person-on-events }}
+              GROUPS_ON_EVENTS_ENABLED: ${{ inputs.person-on-events }}
+          shell: bash
+          run: | # async_migrations covered in ci-async-migrations.yml
+              pytest ${{ inputs.person-on-events == 'true' && 'ee/clickhouse/' || 'ee/' }} -m "not async_migrations" \
+                  --splits ${{ inputs.concurrency }} --group ${{ inputs.group }} \
+                  --durations=100 --durations-min=1.0 \
+                  $PYTEST_ARGS
+
+        - name: Run /decide read replica tests
           if: ${{ inputs.segment == 'FOSS' && inputs.group == 1 && inputs.person-on-events != 'true' }}
           env:
               POSTHOG_DB_NAME: posthog
@@ -116,24 +132,3 @@ runs:
               pytest posthog/api/test/test_decide.py::TestDecideUsesReadReplica \
                   --durations=100 --durations-min=1.0 \
                   $PYTEST_ARGS
-
-        - name: Run EE tests
-          if: ${{ inputs.segment == 'EE' }}
-          env:
-              PERSON_ON_EVENTS_V2_ENABLED: ${{ inputs.person-on-events }}
-              GROUPS_ON_EVENTS_ENABLED: ${{ inputs.person-on-events }}
-          shell: bash
-          run: | # async_migrations are covered in ci-async-migrations.yml
-              pytest ee -m "not async_migrations" \
-                  --splits ${{ inputs.concurrency }} --group ${{ inputs.group }} \
-                  --durations=100 --durations-min=1.0 --store-durations \
-                  $PYTEST_ARGS
-
-        # Post-tests
-
-        - name: Upload updated timing data as artifacts
-          uses: actions/upload-artifact@v2
-          if: ${{ inputs.segment == 'EE' && inputs.person-on-events != 'true'}}
-          with:
-              name: timing_data-${{ inputs.group }}
-              path: .test_durations

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -95,12 +95,6 @@ jobs:
                   fetch-depth: 1
                   path: 'current/'
 
-            - name: Stop/Start stack with Docker Compose
-              run: |
-                  cd current
-                  docker compose -f docker-compose.dev.yml down
-                  docker compose -f docker-compose.dev.yml up -d
-
             - name: Set up Python
               id: python
               uses: buildjet/setup-python@v4

--- a/ee/clickhouse/test/test_system_status.py
+++ b/ee/clickhouse/test/test_system_status.py
@@ -1,7 +1,6 @@
-from posthog.clickhouse.system_status import system_status
-
-
 def test_system_status(db):
+    from posthog.clickhouse.system_status import system_status
+
     results = list(system_status())
     assert [row["key"] for row in results] == [
         "clickhouse_alive",

--- a/posthog/queries/time_to_see_data/serializers.py
+++ b/posthog/queries/time_to_see_data/serializers.py
@@ -2,7 +2,6 @@ from functools import cached_property
 
 from rest_framework import serializers
 
-from posthog.api.shared import UserBasicSerializer
 from posthog.models.user import User
 
 
@@ -35,6 +34,8 @@ class SessionResponseSerializer(serializers.Serializer):
     user = serializers.SerializerMethodField()
 
     def get_user(self, session):
+        from posthog.api.shared import UserBasicSerializer
+
         user = self.context.get("user_lookup", UserLookup([session])).get(session["user_id"])
         return UserBasicSerializer(user).data
 


### PR DESCRIPTION
we run all tests in PoE run - we don't have to
runs slightly fewer tests instead

It's really just this PR https://github.com/PostHog/posthog/pull/17171 but with a cleaner commit 

I worried that this https://github.com/PostHog/posthog/pull/17171/commits/e978b1ac6b72d1bb60ecb9f3475d27ce5a0f998a wasn't really supposed to be in it