### PR TITLE
feat(plugin-server): add new ValueMatcher<T> helper

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -1,4 +1,4 @@
-import { LogLevel, PluginsServerConfig, stringToPluginServerMode } from '../types'
+import { LogLevel, PluginsServerConfig, stringToPluginServerMode, ValueMatcher } from '../types'
 import { isDevEnv, isTestEnv, stringToBoolean } from '../utils/env-utils'
 import { KAFKAJS_LOG_LEVEL_MAPPING } from './constants'
 import {
@@ -205,4 +205,19 @@ export function overrideWithEnv(
         )
     }
     return newConfig
+}
+
+export function buildIntegerMatcher(config: string, allowStar: boolean): ValueMatcher<number> {
+    // Builds a ValueMatcher on a coma-separated list of values.
+    // Optionally, supports a '*' value to match everything
+    if (!config) {
+        return () => false
+    } else if (allowStar && config === '*') {
+        return () => true
+    } else {
+        const values = new Set(config.split(',').map((n) => parseInt(n)))
+        return (v: number) => {
+            return values.has(v)
+        }
+    }
 }

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -1143,3 +1143,7 @@ export type RRWebEvent = Record<string, any> & {
     type: number
     data: any
 }
+
+export interface ValueMatcher<T> {
+    (value: T): boolean
+}

--- a/plugin-server/tests/config.test.ts
+++ b/plugin-server/tests/config.test.ts
@@ -1,4 +1,4 @@
-import { getDefaultConfig, overrideWithEnv } from '../src/config/config'
+import { buildIntegerMatcher, getDefaultConfig, overrideWithEnv } from '../src/config/config'
 
 describe('config', () => {
     test('overrideWithEnv 1', () => {
@@ -62,5 +62,32 @@ describe('config', () => {
             const config = overrideWithEnv(getDefaultConfig(), env)
             expect(config.DATABASE_URL).toEqual('my_db_url')
         })
+    })
+})
+
+describe('buildIntegerMatcher', () => {
+    test('empty input', () => {
+        const matcher = buildIntegerMatcher('', false)
+        expect(matcher(2)).toBe(false)
+    })
+    test('ignores star star when not allowed', () => {
+        const matcher = buildIntegerMatcher('*', false)
+        expect(matcher(2)).toBe(false)
+    })
+    test('matches star when allowed', () => {
+        const matcher = buildIntegerMatcher('*', true)
+        expect(matcher(2)).toBe(true)
+    })
+    test('can match on a single value', () => {
+        const matcher = buildIntegerMatcher('2', true)
+        expect(matcher(2)).toBe(true)
+        expect(matcher(3)).toBe(false)
+    })
+    test('can match on several values', () => {
+        const matcher = buildIntegerMatcher('2,3,4', true)
+        expect(matcher(2)).toBe(true)
+        expect(matcher(3)).toBe(true)
+        expect(matcher(4)).toBe(true)
+        expect(matcher(5)).toBe(false)
     })
 })


### PR DESCRIPTION
## Problem

We often gate code on team_id / plugin_id values, and the usual pattern is to run `process.env.ENVVARNAME?.split(',').includes(value)` in the hot path, which is not great.

This PR introduces a `ValueMatcher<T>` interface to parse these lists once and only pay one Set lookup in the hot path. 

## Changes

- Add `ValueMatcher<T>` interface
- Add `buildIntegerMatcher` to implement it for int numbers, we can add more to match on strings later

We might be able to auto-wire the parsing into the `overrideWithEnv` function, but I don't want to get into the edge cases of `instanceof` matching today.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
