### PR TITLE
fix: Add postgres workflow to worker

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -892,7 +892,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:69 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:68 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -1089,7 +1089,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter
   '
-  /* user_id:71 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:70 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -892,7 +892,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:68 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:69 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -1089,7 +1089,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter
   '
-  /* user_id:70 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:71 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/posthog/temporal/workflows/__init__.py
+++ b/posthog/temporal/workflows/__init__.py
@@ -2,6 +2,10 @@ from typing import Callable, Sequence
 
 from posthog.temporal.workflows.base import *
 from posthog.temporal.workflows.noop import *
+from posthog.temporal.workflows.postgres_batch_export import (
+    PostgresBatchExportWorkflow,
+    insert_into_postgres_activity,
+)
 from posthog.temporal.workflows.s3_batch_export import *
 from posthog.temporal.workflows.snowflake_batch_export import (
     SnowflakeBatchExportWorkflow,
@@ -9,8 +13,13 @@ from posthog.temporal.workflows.snowflake_batch_export import (
 )
 from posthog.temporal.workflows.squash_person_overrides import *
 
-
-WORKFLOWS = [NoOpWorkflow, SquashPersonOverridesWorkflow, S3BatchExportWorkflow, SnowflakeBatchExportWorkflow]
+WORKFLOWS = [
+    NoOpWorkflow,
+    SquashPersonOverridesWorkflow,
+    S3BatchExportWorkflow,
+    SnowflakeBatchExportWorkflow,
+    PostgresBatchExportWorkflow,
+]
 
 ACTIVITIES: Sequence[Callable] = [
     create_export_run,
@@ -18,6 +27,7 @@ ACTIVITIES: Sequence[Callable] = [
     delete_squashed_person_overrides_from_postgres,
     drop_dictionary,
     insert_into_s3_activity,
+    insert_into_postgres_activity,
     insert_into_snowflake_activity,
     noop_activity,
     prepare_dictionary,

--- a/posthog/temporal/workflows/__init__.py
+++ b/posthog/temporal/workflows/__init__.py
@@ -15,10 +15,10 @@ from posthog.temporal.workflows.squash_person_overrides import *
 
 WORKFLOWS = [
     NoOpWorkflow,
-    SquashPersonOverridesWorkflow,
+    PostgresBatchExportWorkflow,
     S3BatchExportWorkflow,
     SnowflakeBatchExportWorkflow,
-    PostgresBatchExportWorkflow,
+    SquashPersonOverridesWorkflow,
 ]
 
 ACTIVITIES: Sequence[Callable] = [
@@ -26,8 +26,8 @@ ACTIVITIES: Sequence[Callable] = [
     delete_squashed_person_overrides_from_clickhouse,
     delete_squashed_person_overrides_from_postgres,
     drop_dictionary,
-    insert_into_s3_activity,
     insert_into_postgres_activity,
+    insert_into_s3_activity,
     insert_into_snowflake_activity,
     noop_activity,
     prepare_dictionary,


### PR DESCRIPTION
## Problem

We deployed the PostgresBatchExportWorkflow in #17045, but didn't configure the script that starts the Temporal Worker to start with the aforementioned workflow.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add the PostgresBatchExportWorkflow and insert_into_postgres_activity to the Worker starter script.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
