### PR TITLE
perf: Disable queries that are hammering postgres

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -132,12 +132,12 @@ class OrganizationSerializer(serializers.ModelSerializer, UserPermissionsSeriali
         except ImportError:
             return output
 
-        output["taxonomy_set_events_count"] = EnterpriseEventDefinition.objects.exclude(
-            description="", tagged_items__isnull=True
-        ).count()
-        output["taxonomy_set_properties_count"] = EnterprisePropertyDefinition.objects.exclude(
-            description="", tagged_items__isnull=True
-        ).count()
+        # output["taxonomy_set_events_count"] = EnterpriseEventDefinition.objects.exclude(
+        #     description="", tagged_items__isnull=True
+        # ).count()
+        # output["taxonomy_set_properties_count"] = EnterprisePropertyDefinition.objects.exclude(
+        #     description="", tagged_items__isnull=True
+        # ).count()
 
         return output
 


### PR DESCRIPTION
## Problem

These queries appear to be hammering postgres and causing us to be unable to get online after an upgrade

<img width="1090" alt="image" src="https://github.com/PostHog/posthog/assets/2088870/a4aef455-6475-463f-bab1-08a929f8f026">

Hopefully this metadata is not super important and we can disable until we can optimise this query

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
