### PR TITLE
fix: toolbar still needs ant

### DIFF
--- a/frontend/src/toolbar/index.tsx
+++ b/frontend/src/toolbar/index.tsx
@@ -1,5 +1,4 @@
-// import global directly to avoid importing antd
-import '../../src/styles/global.scss'
+import '~/styles'
 import './styles.scss'
 
 import ReactDOM from 'react-dom'


### PR DESCRIPTION
follow up to #17206 

It's not clear why this was working when tested locally... once deployed it's no bueno
<img width="728" alt="Screenshot 2023-08-29 at 16 32 05" src="https://github.com/PostHog/posthog/assets/984817/b912cbe9-4ba3-4073-896c-a91505adc081">

(the size savings were real but it's easy to make a very small app that doesn't work 🙈)
<img width="544" alt="Screenshot 2023-08-29 at 16 23 59" src="https://github.com/PostHog/posthog/assets/984817/dc3068dc-5c0b-4c41-b8e5-652556e2cb58">
