### PR TITLE
feat(notebooks): Create early access management component

### DIFF
--- a/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
+++ b/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
@@ -201,9 +201,9 @@ export function EarlyAccessFeature({ id }: { id?: string } = {}): JSX.Element {
                             <div>
                                 <LemonTag
                                     type={
-                                        earlyAccessFeature.stage === 'beta'
+                                        earlyAccessFeature.stage === EarlyAccessFeatureStage.Beta
                                             ? 'warning'
-                                            : earlyAccessFeature.stage === 'general-availability'
+                                            : earlyAccessFeature.stage === EarlyAccessFeatureStage.GeneralAvailability
                                             ? 'success'
                                             : 'default'
                                     }
@@ -308,7 +308,7 @@ interface PersonListProps {
     earlyAccessFeature: EarlyAccessFeatureType
 }
 
-function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element {
+export function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element {
     const { implementOptInInstructionsModal, activeTab } = useValues(earlyAccessFeatureLogic)
     const { toggleImplementOptInInstructionsModal, setActiveTab } = useActions(earlyAccessFeatureLogic)
 

--- a/frontend/src/scenes/early-access-features/earlyAccessFeatureLogic.ts
+++ b/frontend/src/scenes/early-access-features/earlyAccessFeatureLogic.ts
@@ -24,14 +24,14 @@ const NEW_EARLY_ACCESS_FEATURE: NewEarlyAccessFeatureType = {
     feature_flag_id: undefined,
 }
 
-export interface FeatureLogicProps {
+export interface EarlyAccessFeatureLogicProps {
     /** Either a UUID or "new". */
     id: string
 }
 
 export const earlyAccessFeatureLogic = kea<earlyAccessFeatureLogicType>([
     path(['scenes', 'features', 'featureLogic']),
-    props({} as FeatureLogicProps),
+    props({} as EarlyAccessFeatureLogicProps),
     key(({ id }) => id),
     connect(() => ({
         values: [teamLogic, ['currentTeamId'], earlyAccessFeaturesLogic, ['earlyAccessFeatures']],

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeEarlyAccessFeature.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeEarlyAccessFeature.tsx
@@ -1,0 +1,148 @@
+import { createPostHogWidgetNode } from 'scenes/notebooks/Nodes/NodeWrapper'
+import { EarlyAccessFeatureStage, EarlyAccessFeatureType, NotebookNodeType } from '~/types'
+import { BindLogic, useActions, useValues } from 'kea'
+import { IconFlag, IconRocketLaunch } from 'lib/lemon-ui/icons'
+import { LemonButton, LemonDivider, LemonTag } from '@posthog/lemon-ui'
+import { urls } from 'scenes/urls'
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { notebookNodeLogic } from './notebookNodeLogic'
+import { JSONContent, NotebookNodeViewProps } from '../Notebook/utils'
+import api from 'lib/api'
+import {
+    EarlyAccessFeatureLogicProps,
+    earlyAccessFeatureLogic,
+} from 'scenes/early-access-features/earlyAccessFeatureLogic'
+import { PersonList } from 'scenes/early-access-features/EarlyAccessFeature'
+import { buildFlagContent } from './NotebookNodeFlag'
+
+const Component = (props: NotebookNodeViewProps<NotebookNodeEarlyAccessAttributes>): JSX.Element => {
+    const { id } = props.node.attrs
+    const { earlyAccessFeature, earlyAccessFeatureLoading } = useValues(earlyAccessFeatureLogic({ id }))
+    const { expanded } = useValues(notebookNodeLogic)
+    const { insertAfter } = useActions(notebookNodeLogic)
+
+    return (
+        <div>
+            <BindLogic logic={earlyAccessFeatureLogic} props={{ id }}>
+                <div className="flex items-center gap-2 p-3">
+                    <IconRocketLaunch className="text-lg" />
+                    {earlyAccessFeatureLoading ? (
+                        <LemonSkeleton className="h-6 flex-1" />
+                    ) : (
+                        <>
+                            <span className="flex-1 font-semibold truncate">{earlyAccessFeature.name}</span>
+                            <LemonTag
+                                type={
+                                    earlyAccessFeature.stage === EarlyAccessFeatureStage.Beta
+                                        ? 'warning'
+                                        : earlyAccessFeature.stage === EarlyAccessFeatureStage.GeneralAvailability
+                                        ? 'success'
+                                        : 'default'
+                                }
+                                className="uppercase"
+                            >
+                                {earlyAccessFeature.stage}
+                            </LemonTag>
+                        </>
+                    )}
+                </div>
+
+                {expanded ? (
+                    <>
+                        <LemonDivider className="my-0" />
+                        {earlyAccessFeature.stage === EarlyAccessFeatureStage.Beta ? (
+                            <div className="p-2">
+                                <PersonList earlyAccessFeature={earlyAccessFeature as EarlyAccessFeatureType} />
+                            </div>
+                        ) : (
+                            <div className="p-2">
+                                <div className="mb-2">
+                                    <b>Description</b>
+                                    <div>
+                                        {earlyAccessFeature.description ? (
+                                            earlyAccessFeature.description
+                                        ) : (
+                                            <span className="text-muted">No description</span>
+                                        )}
+                                    </div>
+                                </div>
+                                <div className="mb-2">
+                                    <b>Documentation Url</b>
+                                    <div>
+                                        {earlyAccessFeature.documentation_url ? (
+                                            earlyAccessFeature.documentation_url
+                                        ) : (
+                                            <span className="text-muted">No documentation url</span>
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+                    </>
+                ) : null}
+
+                <LemonDivider className="my-0" />
+                <div className="p-2 mr-1 flex justify-end gap-2">
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        icon={<IconFlag />}
+                        onClick={() => {
+                            insertAfter(
+                                buildFlagContent(
+                                    (earlyAccessFeature as EarlyAccessFeatureType).feature_flag?.id || 'new'
+                                )
+                            )
+                        }}
+                    >
+                        View Feature Flag
+                    </LemonButton>
+                </div>
+            </BindLogic>
+        </div>
+    )
+}
+
+type NotebookNodeEarlyAccessAttributes = {
+    id: EarlyAccessFeatureLogicProps['id']
+}
+
+export const NotebookNodeEarlyAccessFeature = createPostHogWidgetNode<NotebookNodeEarlyAccessAttributes>({
+    nodeType: NotebookNodeType.EarlyAccessFeature,
+    title: async (attributes) => {
+        if (typeof attributes.title === 'string' && attributes.title.length > 0) {
+            return attributes.title
+        }
+
+        const mountedEarlyAccessFeatureLogic = earlyAccessFeatureLogic.findMounted({ id: attributes.id })
+        let title = mountedEarlyAccessFeatureLogic?.values.earlyAccessFeature.name || null
+        if (title === null) {
+            const retrievedEarlyAccessFeature: EarlyAccessFeatureType = await api.earlyAccessFeatures.get(attributes.id)
+            if (retrievedEarlyAccessFeature) {
+                title = retrievedEarlyAccessFeature.name
+            }
+        }
+
+        return title ? `Early Access Management: ${title}` : 'Early Access Management'
+    },
+    Component,
+    heightEstimate: '3rem',
+    href: (attrs) => urls.earlyAccessFeature(attrs.id),
+    resizeable: false,
+    attributes: {
+        id: {},
+    },
+    pasteOptions: {
+        find: urls.earlyAccessFeature('') + '(.+)',
+        getAttributes: async (match) => {
+            return { id: match[1] as EarlyAccessFeatureLogicProps['id'] }
+        },
+    },
+})
+
+export function buildEarlyAccessFeatureContent(id: EarlyAccessFeatureLogicProps['id']): JSONContent {
+    return {
+        type: NotebookNodeType.EarlyAccessFeature,
+        attrs: { id },
+    }
+}

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -29,6 +29,7 @@ import { NotebookNodeImage } from '../Nodes/NotebookNodeImage'
 import { JSONContent, NotebookEditor, EditorFocusPosition, EditorRange, Node } from './utils'
 import { SlashCommandsExtension } from './SlashCommands'
 import { BacklinkCommandsExtension } from './BacklinkCommands'
+import { NotebookNodeEarlyAccessFeature } from '../Nodes/NotebookNodeEarlyAccessFeature'
 
 const CustomDocument = ExtensionDocument.extend({
     content: 'heading block*',
@@ -92,6 +93,7 @@ export function Editor({
             NotebookNodeFlagCodeExample,
             NotebookNodeFlag,
             NotebookNodeExperiment,
+            NotebookNodeEarlyAccessFeature,
             NotebookNodeImage,
             SlashCommandsExtension,
             BacklinkCommandsExtension,

--- a/frontend/src/scenes/notebooks/NotebooksTable/ContainsTypeFilter.tsx
+++ b/frontend/src/scenes/notebooks/NotebooksTable/ContainsTypeFilter.tsx
@@ -6,6 +6,7 @@ export const fromNodeTypeToLabel: Omit<Record<NotebookNodeType, string>, Noteboo
     [NotebookNodeType.FeatureFlag]: 'Feature flags',
     [NotebookNodeType.FeatureFlagCodeExample]: 'Feature flag Code Examples',
     [NotebookNodeType.Experiment]: 'Experiments',
+    [NotebookNodeType.EarlyAccessFeature]: 'Early Access Features',
     [NotebookNodeType.Image]: 'Images',
     [NotebookNodeType.Insight]: 'Insights',
     [NotebookNodeType.Person]: 'Persons',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3033,6 +3033,7 @@ export enum NotebookNodeType {
     FeatureFlag = 'ph-feature-flag',
     FeatureFlagCodeExample = 'ph-feature-flag-code-example',
     Experiment = 'ph-experiment',
+    EarlyAccessFeature = 'ph-early-access-feature',
     Person = 'ph-person',
     Backlink = 'ph-backlink',
     ReplayTimestamp = 'ph-replay-timestamp',


### PR DESCRIPTION
## Problem

Another day, another component in notebooks

<img width="1240" alt="image" src="https://github.com/PostHog/posthog/assets/7115141/4dbf7fdf-3b52-4cea-9612-8e9852418a42">

<img width="1226" alt="image" src="https://github.com/PostHog/posthog/assets/7115141/ba3062fa-a128-4bb5-95cc-279f06f846c1">



<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
