### PR TITLE
fix: only use stringy distinct ids

### DIFF
--- a/.run/PostHog.run.xml
+++ b/.run/PostHog.run.xml
@@ -13,12 +13,13 @@
       <env name="KAFKA_HOSTS" value="localhost" />
       <env name="KEA_VERBOSE_LOGGING" value="false" />
       <env name="PRINT_SQL" value="1" />
+      <env name="PYDEVD_USE_CYTHON" value="NO" />
       <env name="PYTHONUNBUFFERED" value="1" />
       <env name="SESSION_RECORDING_KAFKA_COMPRESSION" value="gzip" />
       <env name="SESSION_RECORDING_KAFKA_HOSTS" value="localhost" />
       <env name="SESSION_RECORDING_KAFKA_MAX_REQUEST_SIZE_BYTES" value="524288" />
       <env name="SKIP_SERVICE_VERSION_REQUIREMENTS" value="1" />
-      <env name="PYDEVD_USE_CYTHON" value="NO" />
+      <env name="REPLAY_EVENTS_NEW_CONSUMER_RATIO" value="1" />
     </envs>
     <option name="SDK_HOME" value="$PROJECT_DIR$/env/bin/python" />
     <option name="SDK_NAME" value="Python 3.10 (posthog)" />

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
@@ -1,6 +1,8 @@
 import { mkdirSync, rmSync } from 'node:fs'
+import { Message } from 'node-rdkafka-acosom'
 import path from 'path'
 
+import { expect } from '../../../../../playwright/fixtures/storybook'
 import { waitForExpect } from '../../../../functional_tests/expectations'
 import { defaultConfig } from '../../../../src/config/config'
 import { SessionRecordingIngesterV2 } from '../../../../src/main/ingestion-queues/session-recording/session-recordings-consumer-v2'
@@ -144,6 +146,78 @@ describe('ingester', () => {
         jest.runOnlyPendingTimers() // flush timer
 
         expect(ingester.sessions['1-session_id_1']).not.toBeDefined()
+    })
+
+    describe('parsing the message', () => {
+        it('can handle numeric distinct_ids', async () => {
+            const numeric_id = 12345
+
+            const parsedMessage = await ingester.parseKafkaMessage(
+                {
+                    value: Buffer.from(
+                        JSON.stringify({
+                            uuid: '018a47df-a0f6-7761-8635-439a0aa873bb',
+                            distinct_id: String(numeric_id),
+                            ip: '127.0.0.1',
+                            site_url: 'http://127.0.0.1:8000',
+                            data: JSON.stringify({
+                                uuid: '018a47df-a0f6-7761-8635-439a0aa873bb',
+                                event: '$snapshot_items',
+                                properties: {
+                                    distinct_id: numeric_id,
+                                    $session_id: '018a47c2-2f4a-70a8-b480-5e51d8b8d070',
+                                    $window_id: '018a47c2-2f4a-70a8-b480-5e52f5480448',
+                                    $snapshot_items: [
+                                        {
+                                            type: 6,
+                                            data: {
+                                                plugin: 'rrweb/console@1',
+                                                payload: {
+                                                    level: 'log',
+                                                    trace: [
+                                                        'HedgehogActor.setAnimation (http://127.0.0.1:8000/static/toolbar.js?_ts=1693421010000:105543:17)',
+                                                        'HedgehogActor.setRandomAnimation (http://127.0.0.1:8000/static/toolbar.js?_ts=1693421010000:105550:14)',
+                                                        'HedgehogActor.update (http://127.0.0.1:8000/static/toolbar.js?_ts=1693421010000:105572:16)',
+                                                        'loop (http://127.0.0.1:8000/static/toolbar.js?_ts=1693421010000:105754:15)',
+                                                    ],
+                                                    payload: ['"Hedgehog: Will \'jump\' for 2916.6666666666665ms"'],
+                                                },
+                                            },
+                                            timestamp: 1693422950693,
+                                        },
+                                    ],
+                                    $snapshot_consumer: 'v2',
+                                },
+                                offset: 2187,
+                            }),
+                            now: '2023-08-30T19:15:54.887316+00:00',
+                            sent_at: '2023-08-30T19:15:54.882000+00:00',
+                            token: 'the_token',
+                        })
+                    ),
+                    timestamp: 1,
+                    size: 1,
+                    topic: 'the_topic',
+                    offset: 1,
+                    partition: 1,
+                } satisfies Message,
+                () => Promise.resolve(1)
+            )
+            expect(parsedMessage).toEqual({
+                distinct_id: '12345',
+                events: expect.any(Array),
+                metadata: {
+                    offset: 1,
+                    partition: 1,
+                    timestamp: 1,
+                    topic: 'the_topic',
+                },
+                replayIngestionConsumer: 'v2',
+                session_id: '018a47c2-2f4a-70a8-b480-5e51d8b8d070',
+                team_id: 1,
+                window_id: '018a47c2-2f4a-70a8-b480-5e52f5480448',
+            })
+        })
     })
 
     // NOTE: Committing happens by the parent

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
@@ -2,7 +2,6 @@ import { mkdirSync, rmSync } from 'node:fs'
 import { Message } from 'node-rdkafka-acosom'
 import path from 'path'
 
-import { expect } from '../../../../../playwright/fixtures/storybook'
 import { waitForExpect } from '../../../../functional_tests/expectations'
 import { defaultConfig } from '../../../../src/config/config'
 import { SessionRecordingIngesterV2 } from '../../../../src/main/ingestion-queues/session-recording/session-recordings-consumer-v2'


### PR DESCRIPTION
## Problem

see incident channel https://posthog.slack.com/archives/C05PUV02CSK

You can send non-string distinct ids via an SDK. In capture that distinct ID is stringified (truncated) and added to the payload.

If (during ingestion) you subsequently read the distinct ID from the "event" properties instead of from the "event" as added by capture. Then you will have a non-string value. TypeScript doesn't know about run time, and JavaScript doesn't care what you put in variables.

It also turns out if you send that numeric distinct ID on to kafka to be ingested to a clickhouse table you can stop all ingestion to that table - no bueno

## Changes

* adds a test on the parsing code in the blob ingester to force us to return a string
* injects the team presence check into the parser so I could pass a fake without having to deal with Jest mocks
* modifies the parser to return a string distinct id (still relies on capture sending a string as expected)

## How did you test this code?

adding a developer test but also stepping through in a debugger after sending recordings with a numeric distinct id
