### PR TITLE
fix: Exclude invalid keys from Temporal Schedule update

### DIFF
--- a/posthog/api/test/batch_exports/test_update.py
+++ b/posthog/api/test/batch_exports/test_update.py
@@ -17,6 +17,8 @@ from posthog.api.test.batch_exports.operations import (
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
+from posthog.batch_exports.service import sync_batch_export
+from posthog.models import BatchExport, BatchExportDestination
 from posthog.temporal.client import sync_connect
 from posthog.temporal.codec import EncryptionCodec
 
@@ -167,3 +169,75 @@ def test_can_patch_config(client: HttpClient, interval):
         decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
         args = json.loads(decoded_payload[0].data)
         assert args["bucket_name"] == "my-new-production-s3-bucket"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("interval", ["hour", "day"])
+def test_can_patch_config_with_invalid_old_values(client: HttpClient, interval):
+    temporal = sync_connect()
+
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "my-production-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "posthog-events/",
+            "aws_access_key_id": "abc123",
+            "aws_secret_access_key": "secret",
+            "invalid_key": "invalid_value",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "interval": interval,
+    }
+
+    organization = create_organization("Test Org")
+    team = create_team(organization)
+    user = create_user("test@user.com", "Test User", organization)
+    client.force_login(user)
+
+    # Create a BatchExport straight in the database/temporal to avoid going through the API
+    # as that's what we are trying to test here.
+    destination = BatchExportDestination(**destination_data)
+    batch_export = BatchExport(team=team, destination=destination, **batch_export_data)
+
+    sync_batch_export(batch_export, created=True)
+
+    destination.save()
+    batch_export.save()
+
+    with start_test_worker(temporal):
+        # We should be able to update the destination config, even if there is an invalid config
+        # in the existing keys.
+        new_destination_data = {
+            "type": "S3",
+            "config": {
+                "bucket_name": "my-new-production-s3-bucket",
+                "region": "us-east-1",
+                "prefix": "posthog-events/",
+            },
+        }
+
+        new_batch_export_data = {
+            "name": "my-production-s3-bucket-destination",
+            "destination": new_destination_data,
+        }
+
+        response = patch_batch_export(client, team.pk, batch_export.id, new_batch_export_data)
+        assert response.status_code == status.HTTP_200_OK, response.json()
+
+        # get the batch export and validate e.g. that bucket_name and interval
+        # has been preserved.
+        batch_export = get_batch_export_ok(client, team.pk, batch_export.id)
+        assert batch_export["interval"] == interval
+        assert batch_export["destination"]["config"]["bucket_name"] == "my-new-production-s3-bucket"
+
+        # validate the underlying temporal schedule has been updated
+        codec = EncryptionCodec(settings=settings)
+        new_schedule = describe_schedule(temporal, batch_export["id"])
+        decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
+        args = json.loads(decoded_payload[0].data)
+        assert args["bucket_name"] == "my-new-production-s3-bucket"
+        assert args.get("invalid_key", None) is None

--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -1,8 +1,8 @@
 from datetime import timedelta
-from typing import Any, Dict, Optional, Tuple, List
+from typing import Any, Dict, List, Optional, Tuple
 
 from freezegun import freeze_time
-from freezegun.api import StepTickTimeFactory, FrozenDateTimeFactory
+from freezegun.api import FrozenDateTimeFactory, StepTickTimeFactory
 from rest_framework import status
 
 from posthog.models import User
@@ -44,7 +44,6 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
         self._create_and_edit_things()
 
     def _create_and_edit_things(self):
-
         with freeze_time("2023-08-17") as frozen_time:
             # almost every change below will be more than 5 minutes apart
             created_insights = []
@@ -223,6 +222,8 @@ class TestActivityLog(APIBaseTest, QueryMatchingTest):
         assert [c["unread"] for c in results] == [True] * 10
 
     def test_reading_notifications_marks_them_unread(self):
+        self.client.force_login(self.user)
+
         changes = self.client.get(f"/api/projects/{self.team.id}/activity_log/important_changes")
         assert changes.status_code == status.HTTP_200_OK
         assert len(changes.json()["results"]) == 10

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -1,5 +1,5 @@
 import datetime as dt
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from uuid import UUID
 
 from asgiref.sync import async_to_sync
@@ -277,6 +277,9 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
         paused=batch_export.paused,
     )
 
+    destination_config_fields = set(field.name for field in fields(workflow_inputs))
+    destination_config = {k: v for k, v in batch_export.destination.config.items() if k in destination_config_fields}
+
     temporal = sync_connect()
     schedule = Schedule(
         action=ScheduleActionStartWorkflow(
@@ -286,7 +289,7 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
                     team_id=batch_export.team.id,
                     batch_export_id=str(batch_export.id),
                     interval=str(batch_export.interval),
-                    **batch_export.destination.config,
+                    **destination_config,
                 )
             ),
             id=str(batch_export.id),


### PR DESCRIPTION
## Problem

We deprecated a few fields from the configuration dataclass, but existing exports cannot be updated as these deprecated fields are passed as workflow inputs.

This is returning a 500 error when attemtping to update a relatively old batch export.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Ensure when updating that only valid keys are passed to the Schedule update.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Add a unit test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
