### PR TITLE
chore(plugin-server): disable preflightSchedules on cloud roles

### DIFF
--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -21,6 +21,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 sessionRecordingIngestion: true,
                 sessionRecordingBlobIngestion: true,
                 transpileFrontendApps: true,
+                preflightSchedules: true,
                 ...sharedCapabilities,
             }
         case PluginServerMode.ingestion:

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -370,7 +370,9 @@ export async function startPluginsServer(
 
             await pubSub.start()
 
-            startPreflightSchedules(hub)
+            if (capabilities.preflightSchedules) {
+                startPreflightSchedules(hub)
+            }
 
             if (hub.statsd) {
                 stopEventLoopMetrics = captureEventLoopMetrics(hub.statsd, hub.instanceId)

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -273,6 +273,7 @@ export interface PluginServerCapabilities {
     sessionRecordingIngestion?: boolean
     sessionRecordingBlobIngestion?: boolean
     transpileFrontendApps?: boolean // TODO: move this away from pod startup, into a graphile job
+    preflightSchedules?: boolean // Used for instance health checks on hobby deploy, not useful on cloud
     http?: boolean
     mmdb?: boolean
 }


### PR DESCRIPTION
## Problem

Every plugin-server pod on cloud does 2 useless `redisSet`  every 5 seconds, that we don't need. These are used in self-hosted scenarios, to report the health of plugin-server during instance setup and on the instance health indicator

## Changes

- Add a new `preflightSchedules` to gate this logic
- Only enable it on the default role, used for devenv and hobby deploy. We don't look at these keys on cloud since https://github.com/PostHog/posthog/pull/13422

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
