### PR TITLE
fix(funnel): unordered funnel uses correct entity filter order

### DIFF
--- a/posthog/queries/funnels/base.py
+++ b/posthog/queries/funnels/base.py
@@ -533,7 +533,7 @@ class ClickhouseFunnelBase(ABC):
         return step_cols
 
     def _build_step_query(self, entity: Entity, index: int, entity_name: str, step_prefix: str) -> str:
-        filters = self._build_filters(entity, index)
+        filters = self._build_filters(entity, index, entity_name)
         if entity.type == TREND_FILTER_TYPE_ACTIONS:
             action = entity.get_action()
             for action_step_event in action.get_step_events():
@@ -565,11 +565,11 @@ class ClickhouseFunnelBase(ABC):
             content_sql = f"event = %({event_param_key})s {filters}"
         return content_sql
 
-    def _build_filters(self, entity: Entity, index: int) -> str:
+    def _build_filters(self, entity: Entity, index: int, entity_name: str) -> str:
         prop_filters, prop_filter_params = parse_prop_grouped_clauses(
             team_id=self._team.pk,
             property_group=entity.property_groups,
-            prepend=str(index),
+            prepend=f"_{entity_name}_{index}",
             person_properties_mode=get_person_properties_mode(self._team),
             person_id_joined_alias="person_id",
             hogql_context=self._filter.hogql_context,


### PR DESCRIPTION
## Problem

An unordered funnel fails to compute or produces wrong results.

## Changes

- The any order funnel is a [union of queries](https://github.com/PostHog/posthog/blob/master/posthog/queries/funnels/funnel_unordered.py#L17-L23) where the order of entities is [permutated](https://github.com/PostHog/posthog/blob/master/posthog/queries/funnels/funnel_unordered.py#L117-L118).
- When we build the sql for one of the union queries, we index the key/value pair for their step filters like `k0_0`/`v0_0`. Subsequent union queries use the same indexes and thus would overwrite the params for previous queries.
- This PR adds the `entity_name` as a prefix, resulting in unique params.

### Before

```sql
-- first union query
event = %(events_0_event_0)s
AND (has(%(v0_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(k0_0)s), '^"|"$', '')))

-- second union query
event = %(events_1_event_0)s
AND (replaceRegexpAll(JSONExtractRaw(properties, %(k0_0)s), '^"|"$', '') ILIKE %(v0_0)s)                        
```

### After

```sql
-- first union query
event = %(events_0_event_0)s
AND (has(%(v_events_0_0_0) s, replaceRegexpAll(JSONExtractRaw(properties, %(k_events_0_0_0)s), '^"|"$', '')))

-- second union query
event = %(events_1_event_0)s
AND (replaceRegexpAll(JSONExtractRaw(properties, %(k_events_1_0_0)s), '^"|"$', '') ILIKE %(v_events_1_0_0)s)
```

## How did you test this code?

Added a test and tried a local example