### PR TITLE
chore: Do not retry on S3 ClientError

### DIFF
--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -455,6 +455,8 @@ class S3BatchExportWorkflow(PostHogWorkflow):
                     non_retryable_error_types=[
                         # S3 parameter validation failed.
                         "ParamValidationError",
+                        # This error usually indicates credentials are incorrect or permissions are missing.
+                        "ClientError",
                     ],
                 ),
             )


### PR DESCRIPTION
## Problem

S3 raises a `ClientError` exception on incorrect credentials, which is a fairly common error. Let's not retry on it as the credentials will not get corrected without user input.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add `ClientError` to non_retryable_error_types.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
