### PR TITLE
fix: Only show the notebook sidebar if editable and fix re-rendering of filters

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
@@ -60,12 +60,14 @@ export const Settings = ({
     updateAttributes,
 }: NotebookNodeWidgetSettings<NotebookNodeRecordingAttributes>): JSX.Element => {
     return (
-        <LemonSwitch
-            onChange={() => updateAttributes({ noInspector: !attributes.noInspector })}
-            label="Hide Inspector"
-            checked={attributes.noInspector}
-            fullWidth={true}
-        />
+        <div className="p-3">
+            <LemonSwitch
+                onChange={() => updateAttributes({ noInspector: !attributes.noInspector })}
+                label="Hide Inspector"
+                checked={attributes.noInspector}
+                fullWidth={true}
+            />
+        </div>
     )
 }
 

--- a/frontend/src/scenes/notebooks/Notebook/NotebookSidebar.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookSidebar.tsx
@@ -5,7 +5,11 @@ import { notebookLogic } from './notebookLogic'
 import { notebookNodeLogicType } from '../Nodes/notebookNodeLogicType'
 
 export const NotebookSidebar = (): JSX.Element | null => {
-    const { selectedNodeLogic, isShowingSidebar } = useValues(notebookLogic)
+    const { selectedNodeLogic, isShowingSidebar, isEditable } = useValues(notebookLogic)
+
+    if (!isEditable) {
+        return null
+    }
 
     return (
         <div

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsListLogic.ts
@@ -1,6 +1,6 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
 import api from 'lib/api'
-import { objectClean, toParams } from 'lib/utils'
+import { objectClean, objectsEqual, toParams } from 'lib/utils'
 import {
     AnyPropertyFilter,
     PropertyFilterType,
@@ -206,7 +206,7 @@ export const sessionRecordingsListLogic = kea<sessionRecordingsListLogicType>([
         loadPrev: true,
     }),
     propsChanged(({ actions, props }, oldProps) => {
-        if (props.filters !== oldProps.filters) {
+        if (!objectsEqual(props.filters, oldProps.filters)) {
             props.filters ? actions.setFilters(props.filters) : actions.resetFilters()
         }
     }),


### PR DESCRIPTION
## Problem

We shouldn't show the sidebar if not editable (yet). Also we were re-fetching the playlist filters due to object inequality

## Changes

* Fixes these
* We should consider improving the get and set of attributes to handle object equality serialisation stuff better if possible.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
