### PR TITLE
fix: Use explicit encoding for exclude_events

### DIFF
--- a/posthog/api/test/__snapshots__/test_person.ambr
+++ b/posthog/api/test/__snapshots__/test_person.ambr
@@ -458,8 +458,8 @@
       (SELECT id
        FROM person
        WHERE team_id = 2
-         AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000000%')
-              OR (id = '00000000-0000-4000-8000-000000000000'
+         AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000001%')
+              OR (id = '00000000-0000-4000-8000-000000000001'
                   OR id IN
                     (SELECT person_id
                      FROM
@@ -469,12 +469,12 @@
                         WHERE team_id = 2
                         GROUP BY distinct_id
                         HAVING argMax(is_deleted, version) = 0)
-                     WHERE distinct_id = '00000000-0000-4000-8000-000000000000' ))) )
+                     WHERE distinct_id = '00000000-0000-4000-8000-000000000001' ))) )
   GROUP BY id
   HAVING max(is_deleted) = 0
   AND argMax(created_at, version) < now() + INTERVAL 1 DAY
-  AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000000%')
-       OR (id = '00000000-0000-4000-8000-000000000000'
+  AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000001%')
+       OR (id = '00000000-0000-4000-8000-000000000001'
            OR id IN
              (SELECT person_id
               FROM
@@ -484,7 +484,7 @@
                  WHERE team_id = 2
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0)
-              WHERE distinct_id = '00000000-0000-4000-8000-000000000000' )))
+              WHERE distinct_id = '00000000-0000-4000-8000-000000000001' )))
   ORDER BY argMax(created_at, version) DESC, id
   LIMIT 100
   '

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -10,7 +10,11 @@ from posthog.temporal.workflows.clickhouse import encode_clickhouse_data
     "data,expected",
     [
         (uuid.UUID("c4c5547d-8782-4017-8eca-3ea19f4d528e"), b"'c4c5547d-8782-4017-8eca-3ea19f4d528e'"),
+        ("", b"''"),
+        ("'", b"'\\''"),
+        ("\\", b"'\\\\'"),
         ("test-string", b"'test-string'"),
+        ("a'\\b\\'c", b"'a\\'\\\\b\\\\\\'c'"),
         (("a", 1, ("b", 2)), b"('a',1,('b',2))"),
         (["a", 1, ["b", 2]], b"['a',1,['b',2]]"),
         (("; DROP TABLE events --",), b"('; DROP TABLE events --')"),

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -13,6 +13,8 @@ from posthog.temporal.workflows.clickhouse import encode_clickhouse_data
         ("test-string", b"'test-string'"),
         (("a", 1, ("b", 2)), b"('a',1,('b',2))"),
         (["a", 1, ["b", 2]], b"['a',1,['b',2]]"),
+        (("; DROP TABLE events --",), b"('; DROP TABLE events --')"),
+        (("'a'); DROP TABLE events --",), b"('\\'a\\'); DROP TABLE events --')"),
         (dt.datetime(2023, 7, 14, 0, 0, 0, tzinfo=dt.timezone.utc), b"toDateTime('2023-07-14 00:00:00', 'UTC')"),
         (dt.datetime(2023, 7, 14, 0, 0, 0), b"toDateTime('2023-07-14 00:00:00')"),
         (

--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -41,9 +41,11 @@ async def get_rows_count(
     data_interval_end_ch = dt.datetime.fromisoformat(interval_end).strftime("%Y-%m-%d %H:%M:%S")
 
     if exclude_events:
-        exclude_events_statement = f"AND event NOT IN {str(tuple(exclude_events))}"
+        exclude_events_statement = "AND event NOT IN {exclude_events}"
+        events_to_exclude_tuple = tuple(exclude_events)
     else:
         exclude_events_statement = ""
+        events_to_exclude_tuple = ()
 
     query = SELECT_QUERY_TEMPLATE.substitute(
         fields="count(DISTINCT event, cityHash64(distinct_id), cityHash64(uuid)) as count",
@@ -58,6 +60,7 @@ async def get_rows_count(
             "team_id": team_id,
             "data_interval_start": data_interval_start_ch,
             "data_interval_end": data_interval_end_ch,
+            "exclude_events": events_to_exclude_tuple,
         },
     )
 
@@ -96,9 +99,11 @@ def get_results_iterator(
     data_interval_end_ch = dt.datetime.fromisoformat(interval_end).strftime("%Y-%m-%d %H:%M:%S")
 
     if exclude_events:
-        exclude_events_statement = f"AND event NOT IN {str(tuple(exclude_events))}"
+        exclude_events_statement = "AND event NOT IN {exclude_events}"
+        events_to_exclude_tuple = tuple(exclude_events)
     else:
         exclude_events_statement = ""
+        events_to_exclude_tuple = ()
 
     query = SELECT_QUERY_TEMPLATE.substitute(
         fields=FIELDS,
@@ -113,6 +118,7 @@ def get_results_iterator(
             "team_id": team_id,
             "data_interval_start": data_interval_start_ch,
             "data_interval_end": data_interval_end_ch,
+            "exclude_events": events_to_exclude_tuple,
         },
     ):
         yield from iter_batch_records(batch)

--- a/posthog/temporal/workflows/clickhouse.py
+++ b/posthog/temporal/workflows/clickhouse.py
@@ -53,7 +53,7 @@ def encode_clickhouse_data(data: typing.Any) -> bytes:
 
         case _:
             str_data = str(data)
-            str_data.replace("\\", "\\\\").replace("'", "\\'")
+            str_data = str_data.replace("\\", "\\\\").replace("'", "\\'")
             return f"'{str_data}'".encode("utf-8")
 
 


### PR DESCRIPTION
## Problem

We are currently encoding inputs implicitly by type casting to `str(tuple(...))`. For safety, let's be more explicit with the escaping.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Use the available ClickHouse client escaping and add a couple of suspicious test cases.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
