### PR TITLE
feat: Add support for exclude events in S3 migration command

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -552,7 +552,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results
   '
-  /* user_id:65 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:66 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -749,7 +749,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
   '
-  /* user_id:66 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:67 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -892,7 +892,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:68 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:69 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -1089,7 +1089,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter
   '
-  /* user_id:70 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:71 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -552,7 +552,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results
   '
-  /* user_id:66 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:65 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -749,7 +749,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
   '
-  /* user_id:67 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:66 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -892,7 +892,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:69 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:68 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -1089,7 +1089,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter
   '
-  /* user_id:71 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:70 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/posthog/management/commands/create_batch_export_from_app.py
+++ b/posthog/management/commands/create_batch_export_from_app.py
@@ -144,7 +144,7 @@ def map_plugin_config_to_destination(plugin_config: PluginConfig) -> tuple[str, 
     """
     plugin = plugin_config.plugin
 
-    if plugin.name == "S3 Export":
+    if plugin.name == "S3 Export Plugin":
         config = {
             "bucket_name": plugin_config.config["s3BucketName"],
             "region": plugin_config.config["awsRegion"],
@@ -169,7 +169,7 @@ def map_plugin_config_to_destination(plugin_config: PluginConfig) -> tuple[str, 
         export_type = "Snowflake"
     else:
         raise CommandError(
-            f"Unsupported Plugin: '{plugin.name}'.  Supported Plugins are: 'Snowflake Export' and 'S3 Export'"
+            f"Unsupported Plugin: '{plugin.name}'.  Supported Plugins are: 'Snowflake Export' and 'S3 Export Plugin'"
         )
 
     return (export_type, config)

--- a/posthog/management/commands/create_batch_export_from_app.py
+++ b/posthog/management/commands/create_batch_export_from_app.py
@@ -151,6 +151,8 @@ def map_plugin_config_to_destination(plugin_config: PluginConfig) -> tuple[str, 
             "prefix": plugin_config.config.get("prefix", ""),
             "aws_access_key_id": plugin_config.config["awsAccessKey"],
             "aws_secret_access_key": plugin_config.config["awsSecretAccessKey"],
+            "compression": plugin_config.config["compression"],
+            "exclude_events": plugin_config.config["eventsToIgnore"].split(","),
         }
         export_type = "S3"
     elif plugin.name == "Snowflake Export":

--- a/posthog/management/commands/test/test_create_batch_export_from_app.py
+++ b/posthog/management/commands/test/test_create_batch_export_from_app.py
@@ -48,7 +48,7 @@ def snowflake_plugin(organization) -> typing.Generator[Plugin, None, None]:
 @pytest.fixture
 def s3_plugin(organization) -> typing.Generator[Plugin, None, None]:
     plugin = Plugin.objects.create(
-        name="S3 Export",
+        name="S3 Export Plugin",
         url="https://github.com/PostHog/s3-export-plugin",
         plugin_type="custom",
         organization=organization,

--- a/posthog/management/commands/test/test_create_batch_export_from_app.py
+++ b/posthog/management/commands/test/test_create_batch_export_from_app.py
@@ -73,6 +73,8 @@ test_s3_config = {
     "s3BucketName": "test-bucket",
     "awsRegion": "eu-central-1",
     "prefix": "posthog/",
+    "compression": "gzip",
+    "eventsToIgnore": "$feature_flag_called",
 }
 
 
@@ -127,7 +129,11 @@ def test_map_plugin_config_to_destination(plugin_config, config, expected_type):
     assert export_type == expected_type
 
     result_values = list(export_config.values())
-    for value in config.values():
+    for key, value in config.items():
+        if key == "eventsToIgnore":
+            assert value in export_config["exclude_events"]
+            continue
+
         assert value in result_values
 
 


### PR DESCRIPTION
## Problem

S3 BatchExports now support compression and exclude events, so let's support those when migrating too.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

New config parameters are now taken from plugin config when migrating.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Updated unit tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
