### PR TITLE
fix(retention): handle timezones with daylight saving transitions correctly

### DIFF
--- a/frontend/src/scenes/retention/retentionLineGraphLogic.ts
+++ b/frontend/src/scenes/retention/retentionLineGraphLogic.ts
@@ -71,7 +71,7 @@ export const retentionLineGraphLogic = kea<retentionLineGraphLogicType>({
                         label: cohortRetention.date
                             ? period === 'Hour'
                                 ? dayjs(cohortRetention.date).format('MMM D, h A')
-                                : dayjs.utc(cohortRetention.date).format('MMM D')
+                                : dayjs(cohortRetention.date).format('MMM D')
                             : cohortRetention.label,
                         data:
                             retention_reference === 'previous'

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -73,7 +73,7 @@ export const retentionTableLogic = kea<retentionTableLogicType>({
                         ? results[rowIndex].label
                         : period === 'Hour'
                         ? dayjs(results[rowIndex].date).format('MMM D, h A')
-                        : dayjs.utc(results[rowIndex].date).format('MMM D'),
+                        : dayjs(results[rowIndex].date).format('MMM D'),
                     // Second column is the first value (which is essentially the total)
                     results[rowIndex].values[0].count,
                     // All other columns are rendered as percentage

--- a/posthog/queries/retention/retention.py
+++ b/posthog/queries/retention/retention.py
@@ -109,9 +109,9 @@ class Retention:
                     for day in range(filter.total_intervals - first_day)
                 ],
                 "label": "{} {}".format(filter.period, first_day),
-                "date": (filter.date_from + RetentionFilter.determine_time_delta(first_day, filter.period)[0]).replace(
-                    tzinfo=pytz.timezone(team.timezone)
-                ),
+                "date": (
+                    filter.date_from + RetentionFilter.determine_time_delta(first_day, filter.period)[0]
+                ).astimezone(pytz.timezone(team.timezone)),
                 "people_url": construct_url(first_day),
             }
             for first_day in range(filter.total_intervals)

--- a/posthog/queries/retention/retention.py
+++ b/posthog/queries/retention/retention.py
@@ -109,9 +109,11 @@ class Retention:
                     for day in range(filter.total_intervals - first_day)
                 ],
                 "label": "{} {}".format(filter.period, first_day),
-                "date": (
-                    filter.date_from + RetentionFilter.determine_time_delta(first_day, filter.period)[0]
-                ).astimezone(pytz.timezone(team.timezone)),
+                "date": pytz.timezone(team.timezone).localize(
+                    (filter.date_from + RetentionFilter.determine_time_delta(first_day, filter.period)[0]).replace(
+                        tzinfo=None
+                    )
+                ),
                 "people_url": construct_url(first_day),
             }
             for first_day in range(filter.total_intervals)

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -1270,7 +1270,8 @@ def retention_test_factory(retention):
                 ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6", "Day 7", "Day 8", "Day 9", "Day 10"],
             )
 
-            self.assertEqual(result_pacific[0]["date"], datetime(2020, 6, 10, 0, tzinfo=pytz.timezone("US/Pacific")))
+            self.assertEqual(result_pacific[0]["date"], pytz.timezone("US/Pacific").localize(datetime(2020, 6, 10)))
+            self.assertEqual(result_pacific[0]["date"].isoformat(), "2020-06-10T00:00:00-07:00")
 
             self.assertEqual(
                 pluck(result, "values", "count"),


### PR DESCRIPTION
## Problem

We've had a [customer report](https://posthoghelp.zendesk.com/agent/tickets/5219) that the data for retention and lifecycle insights are shifted exactly one day. Further investigation showed that we're handling timezone with daylight savings time transition incorrectly for the retention insight.

## Changes

This PR changes the timezone conversion from `dt.replace(tzinfo=tz)` to `tz.localize(naive_dt)`. According to [pytz docs](https://pypi.org/project/pytz/#localized-times-and-date-arithmetic) replace is only valid for timezones without daylight savings time transition, so they generally recommend against it.

```python
import pytz
from datetime import datetime, timedelta
day =  datetime(2023, 8, 26, 0, 0, tzinfo=pytz.utc)

>>> day
datetime.datetime(2023, 8, 26, 0, 0, tzinfo=<UTC>)
>>> day.replace(tzinfo=pytz.timezone('Europe/Vienna'))
datetime.datetime(2023, 8, 26, 0, 0, tzinfo=<DstTzInfo 'Europe/Vienna' LMT+1:05:00 STD>)
>>> pytz.timezone('Europe/Vienna').localize(day.replace(tzinfo=None))
datetime.datetime(2023, 8, 26, 0, 0, tzinfo=<DstTzInfo 'Europe/Vienna' CEST+2:00:00 DST>)
>>> day.astimezone(pytz.timezone('Europe/Vienna'))
datetime.datetime(2023, 8, 26, 2, 0, tzinfo=<DstTzInfo 'Europe/Vienna' CEST+2:00:00 DST>)
```

## Follow ups

I briefly audited other usages in the code and these two seem suspicious to me:
1. https://github.com/PostHog/posthog/blob/master/posthog/queries/trends/trends.py#L83
2. https://github.com/PostHog/posthog/blob/master/posthog/utils.py#L184

Python 3.9 also includes the IATA timezone database, removing the requirement for `pytz`.

> Projects using Python 3.9 or later should be using the support now included as part of the standard library, and third party packages work with it such as [tzdata](https://pypi.org/project/tzdata/). pytz offers no advantages beyond backwards compatibility with code written for earlier versions of Python.

## How did you test this code?

Tried this locally with timezone `Europe/Vienna`