### PR TITLE
fix(retention): proper rounding of hourly intervals

### DIFF
--- a/posthog/models/filters/mixins/retention.py
+++ b/posthog/models/filters/mixins/retention.py
@@ -90,7 +90,7 @@ class RetentionDateDerivedMixin(PeriodMixin, TotalIntervalsMixin, DateMixin, Sel
 
         date_to = date_to + self.period_increment
         if self.period == "Hour":
-            return date_to
+            return date_to.replace(minute=0, second=0, microsecond=0)
         else:
             return date_to.replace(hour=0, minute=0, second=0, microsecond=0)
 

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -43,8 +43,8 @@ def _create_signup_actions(team, user_and_timestamps):
     return sign_up_action
 
 
-def _date(day, hour=5, month=0):
-    return datetime(2020, 6 + month, 10 + day, hour).isoformat()
+def _date(day, hour=5, month=0, minute=0):
+    return datetime(2020, 6 + month, 10 + day, hour, minute).isoformat()
 
 
 def pluck(list_of_dicts, key, child_key=None):
@@ -457,7 +457,7 @@ def retention_test_factory(retention):
                 ],
             )
 
-            filter = RetentionFilter(data={"date_to": _date(0, hour=16), "period": "Hour"})
+            filter = RetentionFilter(data={"date_to": _date(0, hour=16, minute=13), "period": "Hour"})
 
             result = retention().run(filter, self.team, total_intervals=11)
 


### PR DESCRIPTION
## Problem

When looking at a retention insight with hourly interval on 16:13,  you would get results for 06:13 to 17:13 instead of 06:00 to 17:00.

## Changes

This PR properly truncates hourly results.

## How did you test this code?

Adjusted the existing test case