### PR TITLE
chore(python): replace pytz.utc with ZoneInfo('UTC')

### DIFF
--- a/ee/api/test/base.py
+++ b/ee/api/test/base.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Dict, Optional, cast
 
-import pytz
+from zoneinfo import ZoneInfo
 
 from ee.api.test.fixtures.available_product_features import AVAILABLE_PRODUCT_FEATURES
 from ee.models.license import License, LicenseManager
@@ -30,7 +30,7 @@ class LicensedTestMixin:
             cls.license = super(LicenseManager, cast(LicenseManager, License.objects)).create(
                 key=cls.CONFIG_LICENSE_KEY,
                 plan=cls.CONFIG_LICENSE_PLAN,
-                valid_until=datetime.datetime(2038, 1, 19, 3, 14, 7, tzinfo=pytz.UTC),
+                valid_until=datetime.datetime(2038, 1, 19, 3, 14, 7, tzinfo=ZoneInfo("UTC")),
             )
             if hasattr(cls, "organization") and cls.organization:  # type: ignore
                 cls.organization.available_product_features = AVAILABLE_PRODUCT_FEATURES  # type: ignore

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import jwt
-import pytz
+from zoneinfo import ZoneInfo
 from dateutil.relativedelta import relativedelta
 from django.utils.timezone import now
 from freezegun import freeze_time
@@ -377,13 +377,13 @@ class TestBillingAPI(APILicensedTest):
         self.client.get("/api/billing-v2")
         self.license.refresh_from_db()
 
-        self.license.valid_until = datetime(2022, 1, 2, 0, 0, 0, tzinfo=pytz.UTC)
+        self.license.valid_until = datetime(2022, 1, 2, 0, 0, 0, tzinfo=ZoneInfo("UTC"))
         self.license.save()
         assert self.license.plan == "scale"
         TEST_clear_instance_license_cache()
         license = get_cached_instance_license()
         assert license.plan == "scale"
-        assert license.valid_until == datetime(2022, 1, 2, 0, 0, 0, tzinfo=pytz.UTC)
+        assert license.valid_until == datetime(2022, 1, 2, 0, 0, 0, tzinfo=ZoneInfo("UTC"))
 
         mock_request.return_value.json.return_value = {
             "license": {
@@ -396,7 +396,7 @@ class TestBillingAPI(APILicensedTest):
         license = get_cached_instance_license()
         assert license.plan == "enterprise"
         # Should be extended by 30 days
-        assert license.valid_until == datetime(2022, 1, 31, 12, 0, 0, tzinfo=pytz.UTC)
+        assert license.valid_until == datetime(2022, 1, 31, 12, 0, 0, tzinfo=ZoneInfo("UTC"))
 
     @patch("ee.api.billing.requests.get")
     def test_organization_available_features_updated_if_different(self, mock_request):

--- a/ee/api/test/test_license.py
+++ b/ee/api/test/test_license.py
@@ -2,7 +2,7 @@ import datetime
 from unittest.mock import Mock, patch
 
 import pytest
-import pytz
+from zoneinfo import ZoneInfo
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from django.utils.timezone import now
@@ -27,7 +27,7 @@ class TestLicenseAPI(APILicensedTest):
         self.assertEqual(response_data["results"][0]["key"], "12345::67890")
         self.assertEqual(
             response_data["results"][0]["valid_until"],
-            timezone.datetime(2038, 1, 19, 3, 14, 7, tzinfo=pytz.UTC).isoformat().replace("+00:00", "Z"),
+            timezone.datetime(2038, 1, 19, 3, 14, 7, tzinfo=ZoneInfo("UTC")).isoformat().replace("+00:00", "Z"),
         )
 
         retrieve_response = self.client.get(f"/api/license/{response_data['results'][0]['id']}")

--- a/ee/clickhouse/queries/test/test_util.py
+++ b/ee/clickhouse/queries/test/test_util.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-import pytz
+from zoneinfo import ZoneInfo
 from freezegun.api import freeze_time
 
 from posthog.client import sync_execute
@@ -18,19 +18,19 @@ def test_get_earliest_timestamp(db, team):
         _create_event(team=team, event="sign up", distinct_id="1", timestamp="2020-01-04T14:10:00Z")
         _create_event(team=team, event="sign up", distinct_id="1", timestamp="2020-01-06T14:10:00Z")
 
-        assert get_earliest_timestamp(team.id) == datetime(2020, 1, 4, 14, 10, tzinfo=pytz.UTC)
+        assert get_earliest_timestamp(team.id) == datetime(2020, 1, 4, 14, 10, tzinfo=ZoneInfo("UTC"))
 
         frozen_time.tick(timedelta(seconds=1))
         _create_event(team=team, event="sign up", distinct_id="1", timestamp="1984-01-06T14:10:00Z")
         _create_event(team=team, event="sign up", distinct_id="1", timestamp="2014-01-01T01:00:00Z")
         _create_event(team=team, event="sign up", distinct_id="1", timestamp="2015-01-01T01:00:00Z")
 
-        assert get_earliest_timestamp(team.id) == datetime(2015, 1, 1, 1, tzinfo=pytz.UTC)
+        assert get_earliest_timestamp(team.id) == datetime(2015, 1, 1, 1, tzinfo=ZoneInfo("UTC"))
 
 
 @freeze_time("2021-01-21")
 def test_get_earliest_timestamp_with_no_events(db, team):
-    assert get_earliest_timestamp(team.id) == datetime(2021, 1, 14, tzinfo=pytz.UTC)
+    assert get_earliest_timestamp(team.id) == datetime(2021, 1, 14, tzinfo=ZoneInfo("UTC"))
 
 
 def test_parse_breakdown_cohort_query(db, team):

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -892,7 +892,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:69 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:68 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -1089,7 +1089,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter
   '
-  /* user_id:71 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:70 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -892,7 +892,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
   '
-  /* user_id:68 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:69 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events
@@ -1089,7 +1089,7 @@
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter
   '
-  /* user_id:70 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:71 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/tasks/test/subscriptions/subscriptions_test_factory.py
+++ b/ee/tasks/test/subscriptions/subscriptions_test_factory.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any
 
-import pytz
+from zoneinfo import ZoneInfo
 
 from posthog.models.subscription import Subscription
 
@@ -12,7 +12,7 @@ def create_subscription(**kwargs: Any) -> Subscription:
         target_value="test1@posthog.com,test2@posthog.com",
         frequency="daily",
         interval=1,
-        start_date=datetime(2022, 1, 1, 9, 0).replace(tzinfo=pytz.UTC),
+        start_date=datetime(2022, 1, 1, 9, 0).replace(tzinfo=ZoneInfo("UTC")),
     )
 
     payload.update(kwargs)

--- a/ee/tasks/test/subscriptions/test_subscriptions.py
+++ b/ee/tasks/test/subscriptions/test_subscriptions.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List
 from unittest.mock import MagicMock, call, patch
 
-import pytz
+from zoneinfo import ZoneInfo
 from freezegun import freeze_time
 
 from ee.tasks.subscriptions import (
@@ -58,9 +58,9 @@ class TestSubscriptionsTasks(APIBaseTest):
             create_subscription(team=self.team, dashboard=self.dashboard, created_by=self.user, deleted=True),
         ]
         # Modify a subscription to have its target time at least an hour ahead
-        subscriptions[2].start_date = datetime(2022, 1, 1, 10, 0).replace(tzinfo=pytz.UTC)
+        subscriptions[2].start_date = datetime(2022, 1, 1, 10, 0).replace(tzinfo=ZoneInfo("UTC"))
         subscriptions[2].save()
-        assert subscriptions[2].next_delivery_date == datetime(2022, 2, 2, 10, 0).replace(tzinfo=pytz.UTC)
+        assert subscriptions[2].next_delivery_date == datetime(2022, 2, 2, 10, 0).replace(tzinfo=ZoneInfo("UTC"))
 
         schedule_all_subscriptions()
 

--- a/posthog/api/test/__snapshots__/test_annotation.ambr
+++ b/posthog/api/test/__snapshots__/test_annotation.ambr
@@ -175,23 +175,89 @@
 ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
-  '
----
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
-  '
   SELECT COUNT(*) AS "__count"
   FROM "posthog_annotation"
   WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
            AND "posthog_annotation"."scope" = 'organization')
           OR "posthog_annotation"."team_id" = 2)
          AND NOT "posthog_annotation"."deleted") /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  '
+---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
+  '
+  SELECT "posthog_annotation"."id",
+         "posthog_annotation"."content",
+         "posthog_annotation"."created_at",
+         "posthog_annotation"."updated_at",
+         "posthog_annotation"."dashboard_item_id",
+         "posthog_annotation"."team_id",
+         "posthog_annotation"."organization_id",
+         "posthog_annotation"."created_by_id",
+         "posthog_annotation"."scope",
+         "posthog_annotation"."creation_type",
+         "posthog_annotation"."date_marker",
+         "posthog_annotation"."deleted",
+         "posthog_annotation"."apply_all",
+         "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."derived_name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."query",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt",
+         "posthog_dashboarditem"."last_modified_at",
+         "posthog_dashboarditem"."last_modified_by_id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."updated_at",
+         "posthog_dashboarditem"."deprecated_tags",
+         "posthog_dashboarditem"."tags",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."requested_password_reset_at",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_annotation"
+  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
+  WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+           AND "posthog_annotation"."scope" = 'organization')
+          OR "posthog_annotation"."team_id" = 2)
+         AND NOT "posthog_annotation"."deleted")
+  ORDER BY "posthog_annotation"."date_marker" DESC
+  LIMIT 1000 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
   '
 ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.15

--- a/posthog/api/test/__snapshots__/test_annotation.ambr
+++ b/posthog/api/test/__snapshots__/test_annotation.ambr
@@ -175,89 +175,23 @@
 ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
   '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  '
+---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
+  '
   SELECT COUNT(*) AS "__count"
   FROM "posthog_annotation"
   WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
            AND "posthog_annotation"."scope" = 'organization')
           OR "posthog_annotation"."team_id" = 2)
          AND NOT "posthog_annotation"."deleted") /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
-  '
----
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
-  '
-  SELECT "posthog_annotation"."id",
-         "posthog_annotation"."content",
-         "posthog_annotation"."created_at",
-         "posthog_annotation"."updated_at",
-         "posthog_annotation"."dashboard_item_id",
-         "posthog_annotation"."team_id",
-         "posthog_annotation"."organization_id",
-         "posthog_annotation"."created_by_id",
-         "posthog_annotation"."scope",
-         "posthog_annotation"."creation_type",
-         "posthog_annotation"."date_marker",
-         "posthog_annotation"."deleted",
-         "posthog_annotation"."apply_all",
-         "posthog_dashboarditem"."id",
-         "posthog_dashboarditem"."name",
-         "posthog_dashboarditem"."derived_name",
-         "posthog_dashboarditem"."description",
-         "posthog_dashboarditem"."team_id",
-         "posthog_dashboarditem"."filters",
-         "posthog_dashboarditem"."filters_hash",
-         "posthog_dashboarditem"."query",
-         "posthog_dashboarditem"."order",
-         "posthog_dashboarditem"."deleted",
-         "posthog_dashboarditem"."saved",
-         "posthog_dashboarditem"."created_at",
-         "posthog_dashboarditem"."last_refresh",
-         "posthog_dashboarditem"."refreshing",
-         "posthog_dashboarditem"."created_by_id",
-         "posthog_dashboarditem"."is_sample",
-         "posthog_dashboarditem"."short_id",
-         "posthog_dashboarditem"."favorited",
-         "posthog_dashboarditem"."refresh_attempt",
-         "posthog_dashboarditem"."last_modified_at",
-         "posthog_dashboarditem"."last_modified_by_id",
-         "posthog_dashboarditem"."dashboard_id",
-         "posthog_dashboarditem"."layouts",
-         "posthog_dashboarditem"."color",
-         "posthog_dashboarditem"."dive_dashboard_id",
-         "posthog_dashboarditem"."updated_at",
-         "posthog_dashboarditem"."deprecated_tags",
-         "posthog_dashboarditem"."tags",
-         "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."pending_email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."is_email_verified",
-         "posthog_user"."requested_password_reset_at",
-         "posthog_user"."has_seen_product_intro_for",
-         "posthog_user"."email_opt_in",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."events_column_config"
-  FROM "posthog_annotation"
-  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
-  LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
-  WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-           AND "posthog_annotation"."scope" = 'organization')
-          OR "posthog_annotation"."team_id" = 2)
-         AND NOT "posthog_annotation"."deleted")
-  ORDER BY "posthog_annotation"."date_marker" DESC
-  LIMIT 1000 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
   '
 ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.15

--- a/posthog/api/test/test_annotation.py
+++ b/posthog/api/test/test_annotation.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from unittest.mock import patch
 
-import pytz
+from zoneinfo import ZoneInfo
 from django.utils.timezone import now
 from rest_framework import status
 
@@ -111,7 +111,7 @@ class TestAnnotation(APIBaseTest, QueryMatchingTest):
                 "team": team2.pk,  # make sure this is set automatically
             },
         )
-        date_marker: datetime = datetime(2020, 1, 1, 0, 0, 0).replace(tzinfo=pytz.UTC)
+        date_marker: datetime = datetime(2020, 1, 1, 0, 0, 0).replace(tzinfo=ZoneInfo("UTC"))
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         instance = Annotation.objects.get(pk=response.json()["id"])
         self.assertEqual(instance.content, "Marketing campaign")

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from unittest.mock import patch
 from urllib.parse import unquote, urlencode
 
-import pytz
+from zoneinfo import ZoneInfo
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
@@ -168,7 +168,6 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
     @also_test_with_materialized_columns(["random_prop"])
     @snapshot_clickhouse_queries
     def test_event_property_values(self):
-
         with freeze_time("2020-01-10"):
             _create_event(
                 distinct_id="bla",
@@ -346,8 +345,8 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         with freeze_time("2021-10-10T12:03:03.829294Z"):
             _create_person(team=self.team, distinct_ids=["1"])
             now = timezone.now() - relativedelta(months=11)
-            after = (now).astimezone(pytz.utc).isoformat()
-            before = (now + relativedelta(days=23)).astimezone(pytz.utc).isoformat()
+            after = (now).astimezone(ZoneInfo("UTC")).isoformat()
+            before = (now + relativedelta(days=23)).astimezone(ZoneInfo("UTC")).isoformat()
             params = {"distinct_id": "1", "after": after, "before": before, "limit": 10}
             params_string = urlencode(params)
             for idx in range(0, 25):

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -5,7 +5,7 @@ from unittest import mock
 from unittest.case import skip
 from unittest.mock import patch
 
-import pytz
+from zoneinfo import ZoneInfo
 from django.test import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
@@ -1860,7 +1860,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(created_insight_viewed.user, self.user)
         self.assertEqual(
             created_insight_viewed.last_viewed_at,
-            datetime(2022, 3, 22, 0, 0, tzinfo=pytz.UTC),
+            datetime(2022, 3, 22, 0, 0, tzinfo=ZoneInfo("UTC")),
         )
 
     def test_update_insight_viewed(self) -> None:
@@ -1882,7 +1882,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             updated_insight_viewed = InsightViewed.objects.all()[0]
             self.assertEqual(
                 updated_insight_viewed.last_viewed_at,
-                datetime(2022, 3, 23, 0, 0, tzinfo=pytz.UTC),
+                datetime(2022, 3, 23, 0, 0, tzinfo=ZoneInfo("UTC")),
             )
 
     def test_cant_view_insight_viewed_for_insight_in_another_team(self) -> None:

--- a/posthog/api/test/test_organization_domain.py
+++ b/posthog/api/test/test_organization_domain.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import dns.resolver
 import dns.rrset
 import pytest
-import pytz
+from zoneinfo import ZoneInfo
 from django.utils import timezone
 from freezegun import freeze_time
 from rest_framework import status
@@ -133,7 +133,7 @@ class TestOrganizationDomainsAPI(APIBaseTest):
 
         instance = OrganizationDomain.objects.get(id=response_data["id"])
         self.assertEqual(instance.domain, "the.posthog.com")
-        self.assertEqual(instance.verified_at, datetime.datetime(2021, 8, 8, 20, 20, 8, tzinfo=pytz.UTC))
+        self.assertEqual(instance.verified_at, datetime.datetime(2021, 8, 8, 20, 20, 8, tzinfo=ZoneInfo("UTC")))
         self.assertEqual(instance.last_verification_retry, None)
         self.assertEqual(instance.sso_enforcement, "")
 
@@ -200,7 +200,7 @@ class TestOrganizationDomainsAPI(APIBaseTest):
         self.assertEqual(response_data["verified_at"], self.domain.verified_at.strftime("%Y-%m-%dT%H:%M:%SZ"))
         self.assertEqual(response_data["is_verified"], True)
 
-        self.assertEqual(self.domain.verified_at, datetime.datetime(2021, 8, 8, 20, 20, 8, tzinfo=pytz.UTC))
+        self.assertEqual(self.domain.verified_at, datetime.datetime(2021, 8, 8, 20, 20, 8, tzinfo=ZoneInfo("UTC")))
         self.assertEqual(self.domain.is_verified, True)
 
     @patch("posthog.models.organization_domain.dns.resolver.resolve")
@@ -220,7 +220,7 @@ class TestOrganizationDomainsAPI(APIBaseTest):
         self.assertEqual(response_data["verified_at"], None)
         self.assertEqual(self.domain.verified_at, None)
         self.assertEqual(
-            self.domain.last_verification_retry, datetime.datetime(2021, 10, 10, 10, 10, 10, tzinfo=pytz.UTC)
+            self.domain.last_verification_retry, datetime.datetime(2021, 10, 10, 10, 10, 10, tzinfo=ZoneInfo("UTC"))
         )
 
     @patch("posthog.models.organization_domain.dns.resolver.resolve")
@@ -240,7 +240,7 @@ class TestOrganizationDomainsAPI(APIBaseTest):
         self.assertEqual(response_data["verified_at"], None)
         self.assertEqual(self.domain.verified_at, None)
         self.assertEqual(
-            self.domain.last_verification_retry, datetime.datetime(2021, 10, 10, 10, 10, 10, tzinfo=pytz.UTC)
+            self.domain.last_verification_retry, datetime.datetime(2021, 10, 10, 10, 10, 10, tzinfo=ZoneInfo("UTC"))
         )
 
     @patch("posthog.models.organization_domain.dns.resolver.resolve")
@@ -262,7 +262,7 @@ class TestOrganizationDomainsAPI(APIBaseTest):
         self.assertEqual(response_data["verified_at"], None)
         self.assertEqual(self.domain.verified_at, None)
         self.assertEqual(
-            self.domain.last_verification_retry, datetime.datetime(2021, 10, 10, 10, 10, 10, tzinfo=pytz.UTC)
+            self.domain.last_verification_retry, datetime.datetime(2021, 10, 10, 10, 10, 10, tzinfo=ZoneInfo("UTC"))
         )
 
     def test_cannot_request_verification_for_verified_domains(self):

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -5,7 +5,7 @@ from typing import Dict, List, cast
 from unittest import mock
 from unittest.mock import ANY, patch
 
-import pytz
+from zoneinfo import ZoneInfo
 from django.core.files.uploadedfile import SimpleUploadedFile
 from freezegun import freeze_time
 from rest_framework import status
@@ -269,7 +269,7 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
 
         plugin = Plugin.objects.get(id=response.json()["id"])
 
-        fake_date = datetime(2022, 1, 1, 0, 0).replace(tzinfo=pytz.UTC)
+        fake_date = datetime(2022, 1, 1, 0, 0).replace(tzinfo=ZoneInfo("UTC"))
         self.assertNotEqual(plugin.updated_at, fake_date)
 
         with freeze_time(fake_date.isoformat()):
@@ -715,7 +715,7 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
             name="FooBar2", plugins_access_level=Organization.PluginsAccessLevel.INSTALL
         )
 
-        fake_date = datetime(2022, 1, 1, 0, 0).replace(tzinfo=pytz.UTC)
+        fake_date = datetime(2022, 1, 1, 0, 0).replace(tzinfo=ZoneInfo("UTC"))
         with freeze_time(fake_date.isoformat()):
             response = self.client.post(
                 f"/api/organizations/{my_org.id}/plugins/", {"url": "https://github.com/PostHog/helloworldplugin"}
@@ -1281,7 +1281,7 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
 
         plugin_id = response.json()["id"]
         plugin = Plugin.objects.get(id=plugin_id)
-        fake_date = datetime(2022, 1, 1, 0, 0).replace(tzinfo=pytz.UTC)
+        fake_date = datetime(2022, 1, 1, 0, 0).replace(tzinfo=ZoneInfo("UTC"))
         self.assertNotEqual(plugin.latest_tag_checked_at, fake_date)
 
         with freeze_time(fake_date.isoformat()):

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -5,7 +5,7 @@ from unittest import mock
 from unittest.mock import ANY, patch
 
 import pytest
-import pytz
+from zoneinfo import ZoneInfo
 from django.core import mail
 from django.urls.base import reverse
 from django.utils import timezone
@@ -733,7 +733,7 @@ class TestInviteSignupAPI(APIBaseTest):
         invite: OrganizationInvite = OrganizationInvite.objects.create(
             target_email="test+59@posthog.com", organization=self.organization
         )
-        invite.created_at = datetime.datetime(2020, 12, 1, tzinfo=pytz.UTC)
+        invite.created_at = datetime.datetime(2020, 12, 1, tzinfo=ZoneInfo("UTC"))
         invite.save()
 
         response = self.client.get(f"/api/signup/{invite.id}/")
@@ -1132,7 +1132,7 @@ class TestInviteSignupAPI(APIBaseTest):
         invite: OrganizationInvite = OrganizationInvite.objects.create(
             target_email="test+799@posthog.com", organization=self.organization
         )
-        invite.created_at = datetime.datetime(2020, 3, 3, tzinfo=pytz.UTC)
+        invite.created_at = datetime.datetime(2020, 3, 3, tzinfo=ZoneInfo("UTC"))
         invite.save()
 
         response = self.client.post(f"/api/signup/{invite.id}/", {"first_name": "Charlie", "password": "test_password"})

--- a/posthog/clickhouse/system_status.py
+++ b/posthog/clickhouse/system_status.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from os.path import abspath, dirname, join
 from typing import Dict, Generator, List, Tuple
-import pytz
+from zoneinfo import ZoneInfo
 
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
@@ -103,7 +103,7 @@ def system_status() -> Generator[SystemStatusRow, None, None]:
     last_event_ingested_timestamp = sync_execute("SELECT max(_timestamp) FROM events")[0][0]
 
     # Therefore we can confidently apply the UTC timezone
-    last_event_ingested_timestamp_utc = last_event_ingested_timestamp.replace(tzinfo=pytz.UTC)
+    last_event_ingested_timestamp_utc = last_event_ingested_timestamp.replace(tzinfo=ZoneInfo("UTC"))
 
     yield {
         "key": "last_event_ingested_timestamp",

--- a/posthog/clickhouse/test/test_person_overrides.py
+++ b/posthog/clickhouse/test/test_person_overrides.py
@@ -5,7 +5,7 @@ from typing import TypedDict
 from uuid import UUID, uuid4
 
 import pytest
-import pytz
+from zoneinfo import ZoneInfo
 from kafka import KafkaProducer
 
 from posthog.clickhouse.client import sync_execute
@@ -35,9 +35,9 @@ def test_can_insert_person_overrides():
         old_person_id = uuid4()
         override_person_id = uuid4()
         oldest_event_string = "2020-01-01 00:00:00"
-        oldest_event = datetime.fromisoformat(oldest_event_string).replace(tzinfo=pytz.UTC)
+        oldest_event = datetime.fromisoformat(oldest_event_string).replace(tzinfo=ZoneInfo("UTC"))
         merged_at_string = "2020-01-02 00:00:00"
-        merged_at = datetime.fromisoformat(merged_at_string).replace(tzinfo=pytz.UTC)
+        merged_at = datetime.fromisoformat(merged_at_string).replace(tzinfo=ZoneInfo("UTC"))
         message = {
             "team_id": 1,
             "old_person_id": str(old_person_id),
@@ -82,7 +82,7 @@ def test_can_insert_person_overrides():
         [result] = results
         created_at, *the_rest = result
         assert the_rest == [1, old_person_id, override_person_id, oldest_event, merged_at, 2]
-        assert created_at > datetime.now(tz=pytz.UTC) - timedelta(seconds=10)
+        assert created_at > datetime.now(tz=ZoneInfo("UTC")) - timedelta(seconds=10)
     finally:
         producer.close()
 

--- a/posthog/demo/test/test_matrix_manager.py
+++ b/posthog/demo/test/test_matrix_manager.py
@@ -2,7 +2,7 @@ import datetime as dt
 from enum import auto
 from typing import Optional
 
-import pytz
+from zoneinfo import ZoneInfo
 
 from posthog.client import sync_execute
 from posthog.demo.matrix.manager import MatrixManager
@@ -54,7 +54,9 @@ class TestMatrixManager(ClickhouseDestroyTablesMixin):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.matrix = DummyMatrix(n_clusters=3, now=dt.datetime(2020, 1, 1, 0, 0, 0, 0, tzinfo=pytz.UTC), days_future=0)
+        cls.matrix = DummyMatrix(
+            n_clusters=3, now=dt.datetime(2020, 1, 1, 0, 0, 0, 0, tzinfo=ZoneInfo("UTC")), days_future=0
+        )
         cls.matrix.simulate()
 
     def test_reset_master(self):

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-import pytz
+from zoneinfo import ZoneInfo
 from django.test import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
@@ -817,21 +817,21 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             expected += [
                 (
                     f"person_{person}_{random_uuid}",
-                    datetime.datetime(2020, 1, 10, 00, 00, 00, tzinfo=pytz.UTC),
+                    datetime.datetime(2020, 1, 10, 00, 00, 00, tzinfo=ZoneInfo("UTC")),
                     "random event",
                     [],
                     ["random bla", "random boo"],
                 ),
                 (
                     f"person_{person}_{random_uuid}",
-                    datetime.datetime(2020, 1, 10, 00, 10, 00, tzinfo=pytz.UTC),
+                    datetime.datetime(2020, 1, 10, 00, 10, 00, tzinfo=ZoneInfo("UTC")),
                     "random bla",
                     ["random event"],
                     ["random boo"],
                 ),
                 (
                     f"person_{person}_{random_uuid}",
-                    datetime.datetime(2020, 1, 10, 00, 20, 00, tzinfo=pytz.UTC),
+                    datetime.datetime(2020, 1, 10, 00, 20, 00, tzinfo=ZoneInfo("UTC")),
                     "random boo",
                     ["random event", "random bla"],
                     [],
@@ -902,7 +902,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             expected += [
                 (
                     f"person_{person}_{random_uuid}",
-                    datetime.datetime(2020, 1, 10, 00, 00, 00, tzinfo=pytz.UTC),
+                    datetime.datetime(2020, 1, 10, 00, 00, 00, tzinfo=ZoneInfo("UTC")),
                     "random event",
                     [],
                     ["random bla", "random boo"],
@@ -917,7 +917,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 ),
                 (
                     f"person_{person}_{random_uuid}",
-                    datetime.datetime(2020, 1, 10, 00, 10, 00, tzinfo=pytz.UTC),
+                    datetime.datetime(2020, 1, 10, 00, 10, 00, tzinfo=ZoneInfo("UTC")),
                     "random bla",
                     ["random event"],
                     ["random boo"],
@@ -932,7 +932,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 ),
                 (
                     f"person_{person}_{random_uuid}",
-                    datetime.datetime(2020, 1, 10, 00, 20, 00, tzinfo=pytz.UTC),
+                    datetime.datetime(2020, 1, 10, 00, 20, 00, tzinfo=ZoneInfo("UTC")),
                     "random boo",
                     ["random event", "random bla"],
                     [],
@@ -1226,7 +1226,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             ("null", "!~*", "null", 0),
         ]
 
-        for (a, op, b, res) in expected:
+        for a, op, b, res in expected:
             # works when selecting directly
             query = f"select {a} {op} {b}"
             response = execute_hogql_query(query, team=self.team)

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -4,7 +4,7 @@ import re
 from math import ceil
 from typing import Any, Dict, List, Literal, Optional, Union, cast
 
-import pytz
+from zoneinfo import ZoneInfo
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
@@ -361,11 +361,13 @@ class DateMixin(BaseParamMixin):
             if isinstance(self._date_to, str):
                 try:
                     return datetime.datetime.strptime(self._date_to, "%Y-%m-%d").replace(
-                        hour=23, minute=59, second=59, microsecond=999999, tzinfo=pytz.UTC
+                        hour=23, minute=59, second=59, microsecond=999999, tzinfo=ZoneInfo("UTC")
                     )
                 except ValueError:
                     try:
-                        return datetime.datetime.strptime(self._date_to, "%Y-%m-%d %H:%M:%S").replace(tzinfo=pytz.UTC)
+                        return datetime.datetime.strptime(self._date_to, "%Y-%m-%d %H:%M:%S").replace(
+                            tzinfo=ZoneInfo("UTC")
+                        )
                     except ValueError:
                         date, delta_mapping = relative_date_parse_with_delta_mapping(self._date_to, self.team.timezone_info, always_truncate=True)  # type: ignore
                         self.date_to_delta_mapping = delta_mapping

--- a/posthog/models/group/util.py
+++ b/posthog/models/group/util.py
@@ -2,7 +2,7 @@ import datetime
 import json
 from typing import Dict, Optional, Union
 
-import pytz
+from zoneinfo import ZoneInfo
 from dateutil.parser import isoparse
 from django.utils.timezone import now
 
@@ -27,7 +27,7 @@ def raw_create_group_ch(
     DON'T USE DIRECTLY - `create_group` is the correct option,
     unless you specifically want to sync Postgres state from ClickHouse yourself."""
     if timestamp is None:
-        timestamp = now().astimezone(pytz.utc)
+        timestamp = now().astimezone(ZoneInfo("UTC"))
     data = {
         "group_type_index": group_type_index,
         "group_key": group_key,
@@ -58,7 +58,7 @@ def create_group(
     if isinstance(timestamp, str):
         timestamp = isoparse(timestamp)
     else:
-        timestamp = timestamp.astimezone(pytz.utc)
+        timestamp = timestamp.astimezone(ZoneInfo("UTC"))
 
     raw_create_group_ch(team_id, group_type_index, group_key, properties, timestamp, timestamp=timestamp, sync=sync)
     group = Group.objects.create(

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -4,7 +4,7 @@ from contextlib import ExitStack
 from typing import Dict, List, Optional, Union
 from uuid import UUID
 
-import pytz
+from zoneinfo import ZoneInfo
 from dateutil.parser import isoparse
 from django.db.models.query import QuerySet
 from django.db.models.signals import post_delete, post_save
@@ -124,12 +124,12 @@ def create_person(
     if isinstance(timestamp, str):
         timestamp = isoparse(timestamp)
     else:
-        timestamp = timestamp.astimezone(pytz.utc)
+        timestamp = timestamp.astimezone(ZoneInfo("UTC"))
 
     if created_at is None:
         created_at = timestamp
     else:
-        created_at = created_at.astimezone(pytz.utc)
+        created_at = created_at.astimezone(ZoneInfo("UTC"))
 
     data = {
         "id": str(uuid),

--- a/posthog/models/test/test_subscription_model.py
+++ b/posthog/models/test/test_subscription_model.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import jwt
 import pytest
-import pytz
+from zoneinfo import ZoneInfo
 from django.conf import settings
 from django.utils import timezone
 from freezegun import freeze_time
@@ -33,7 +33,7 @@ class TestSubscription(BaseTest):
             target_value="tests@posthog.com",
             frequency="weekly",
             interval=2,
-            start_date=datetime(2022, 1, 1, 0, 0, 0, 0).replace(tzinfo=pytz.UTC),
+            start_date=datetime(2022, 1, 1, 0, 0, 0, 0).replace(tzinfo=ZoneInfo("UTC")),
         )
         params.update(**kwargs)
 
@@ -44,8 +44,8 @@ class TestSubscription(BaseTest):
         subscription.save()
 
         assert subscription.title == "My Subscription"
-        subscription.set_next_delivery_date(datetime(2022, 1, 2, 0, 0, 0).replace(tzinfo=pytz.UTC))
-        assert subscription.next_delivery_date == datetime(2022, 1, 15, 0, 0).replace(tzinfo=pytz.UTC)
+        subscription.set_next_delivery_date(datetime(2022, 1, 2, 0, 0, 0).replace(tzinfo=ZoneInfo("UTC")))
+        assert subscription.next_delivery_date == datetime(2022, 1, 15, 0, 0).replace(tzinfo=ZoneInfo("UTC"))
 
     def test_update_next_delivery_date_on_save(self):
         subscription = self._create_insight_subscription()
@@ -60,7 +60,7 @@ class TestSubscription(BaseTest):
         old_date = subscription.next_delivery_date
 
         # Change a property that does affect it
-        subscription.start_date = datetime(2023, 1, 1, 0, 0, 0, 0).replace(tzinfo=pytz.UTC)
+        subscription.start_date = datetime(2023, 1, 1, 0, 0, 0, 0).replace(tzinfo=ZoneInfo("UTC"))
         subscription.save()
         assert old_date != subscription.next_delivery_date
         old_date = subscription.next_delivery_date
@@ -72,7 +72,6 @@ class TestSubscription(BaseTest):
         assert old_date == subscription.next_delivery_date
 
     def test_generating_token(self):
-
         subscription = self._create_insight_subscription(
             target_value="test1@posthog.com,test2@posthog.com,test3@posthog.com"
         )
@@ -143,13 +142,13 @@ class TestSubscription(BaseTest):
 
         # Last wed or fri of 01.22 is Wed 28th
         subscription.save()
-        assert subscription.next_delivery_date == datetime(2022, 1, 28, 0, 0).replace(tzinfo=pytz.UTC)
+        assert subscription.next_delivery_date == datetime(2022, 1, 28, 0, 0).replace(tzinfo=ZoneInfo("UTC"))
         # Last wed or fri of 01.22 is Wed 30th
         subscription.set_next_delivery_date(subscription.next_delivery_date)
-        assert subscription.next_delivery_date == datetime(2022, 3, 30, 0, 0).replace(tzinfo=pytz.UTC)
+        assert subscription.next_delivery_date == datetime(2022, 3, 30, 0, 0).replace(tzinfo=ZoneInfo("UTC"))
         # Last wed or fri of 01.22 is Fri 27th
         subscription.set_next_delivery_date(subscription.next_delivery_date)
-        assert subscription.next_delivery_date == datetime(2022, 5, 27, 0, 0).replace(tzinfo=pytz.UTC)
+        assert subscription.next_delivery_date == datetime(2022, 5, 27, 0, 0).replace(tzinfo=ZoneInfo("UTC"))
 
     def test_should_work_for_nth_days(self):
         # Equivalent to last monday and wednesday of every other month
@@ -160,15 +159,15 @@ class TestSubscription(BaseTest):
             byweekday=["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"],
         )
         subscription.save()
-        assert subscription.next_delivery_date == datetime(2022, 1, 3, 0, 0).replace(tzinfo=pytz.UTC)
+        assert subscription.next_delivery_date == datetime(2022, 1, 3, 0, 0).replace(tzinfo=ZoneInfo("UTC"))
         subscription.set_next_delivery_date(subscription.next_delivery_date)
-        assert subscription.next_delivery_date == datetime(2022, 2, 3, 0, 0).replace(tzinfo=pytz.UTC)
+        assert subscription.next_delivery_date == datetime(2022, 2, 3, 0, 0).replace(tzinfo=ZoneInfo("UTC"))
 
     def test_should_ignore_bysetpos_if_missing_weeekday(self):
         # Equivalent to last monday and wednesday of every other month
         subscription = self._create_insight_subscription(interval=1, frequency="monthly", bysetpos=3)
         subscription.save()
-        assert subscription.next_delivery_date == datetime(2022, 2, 1, 0, 0).replace(tzinfo=pytz.UTC)
+        assert subscription.next_delivery_date == datetime(2022, 2, 1, 0, 0).replace(tzinfo=ZoneInfo("UTC"))
 
     def test_subscription_summary(self):
         subscription = self._create_insight_subscription(interval=1, frequency="monthly", bysetpos=None)

--- a/posthog/queries/app_metrics/historical_exports.py
+++ b/posthog/queries/app_metrics/historical_exports.py
@@ -2,7 +2,7 @@ import json
 from datetime import timedelta
 from typing import Dict, Optional
 
-import pytz
+from zoneinfo import ZoneInfo
 
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.plugin import PluginStorage
@@ -65,10 +65,12 @@ def historical_export_metrics(team: Team, plugin_config_id: int, job_id: str):
     filter_data = {
         "category": "exportEvents",
         "job_id": job_id,
-        "date_from": (export_summary["created_at"] - timedelta(hours=1)).astimezone(pytz.utc).isoformat(),
+        "date_from": (export_summary["created_at"] - timedelta(hours=1)).astimezone(ZoneInfo("UTC")).isoformat(),
     }
     if "finished_at" in export_summary:
-        filter_data["date_to"] = (export_summary["finished_at"] + timedelta(hours=1)).astimezone(pytz.utc).isoformat()
+        filter_data["date_to"] = (
+            (export_summary["finished_at"] + timedelta(hours=1)).astimezone(ZoneInfo("UTC")).isoformat()
+        )
 
     filter = AppMetricsRequestSerializer(data=filter_data)
     filter.is_valid(raise_exception=True)

--- a/posthog/queries/funnels/test/test_funnel_trends.py
+++ b/posthog/queries/funnels/test/test_funnel_trends.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime, timedelta
 
-import pytz
+from zoneinfo import ZoneInfo
 from freezegun.api import freeze_time
 
 from posthog.constants import INSIGHT_FUNNELS, TRENDS_LINEAR, FunnelOrderType
@@ -113,43 +113,43 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
                     "reached_to_step_count": 0,
                     "conversion_rate": 0,
                     "reached_from_step_count": 1,
-                    "timestamp": datetime(2021, 6, 7, 0, 0).replace(tzinfo=pytz.UTC),
+                    "timestamp": datetime(2021, 6, 7, 0, 0).replace(tzinfo=ZoneInfo("UTC")),
                 },
                 {
                     "reached_to_step_count": 0,
                     "conversion_rate": 0,
                     "reached_from_step_count": 0,
-                    "timestamp": datetime(2021, 6, 8, 0, 0).replace(tzinfo=pytz.UTC),
+                    "timestamp": datetime(2021, 6, 8, 0, 0).replace(tzinfo=ZoneInfo("UTC")),
                 },
                 {
                     "reached_to_step_count": 0,
                     "conversion_rate": 0,
                     "reached_from_step_count": 0,
-                    "timestamp": datetime(2021, 6, 9, 0, 0).replace(tzinfo=pytz.UTC),
+                    "timestamp": datetime(2021, 6, 9, 0, 0).replace(tzinfo=ZoneInfo("UTC")),
                 },
                 {
                     "reached_to_step_count": 0,
                     "conversion_rate": 0,
                     "reached_from_step_count": 0,
-                    "timestamp": datetime(2021, 6, 10, 0, 0).replace(tzinfo=pytz.UTC),
+                    "timestamp": datetime(2021, 6, 10, 0, 0).replace(tzinfo=ZoneInfo("UTC")),
                 },
                 {
                     "reached_to_step_count": 0,
                     "conversion_rate": 0,
                     "reached_from_step_count": 0,
-                    "timestamp": datetime(2021, 6, 11, 0, 0).replace(tzinfo=pytz.UTC),
+                    "timestamp": datetime(2021, 6, 11, 0, 0).replace(tzinfo=ZoneInfo("UTC")),
                 },
                 {
                     "reached_to_step_count": 0,
                     "conversion_rate": 0,
                     "reached_from_step_count": 0,
-                    "timestamp": datetime(2021, 6, 12, 0, 0).replace(tzinfo=pytz.UTC),
+                    "timestamp": datetime(2021, 6, 12, 0, 0).replace(tzinfo=ZoneInfo("UTC")),
                 },
                 {
                     "reached_to_step_count": 0,
                     "conversion_rate": 0,
                     "reached_from_step_count": 0,
-                    "timestamp": datetime(2021, 6, 13, 0, 0).replace(tzinfo=pytz.UTC),
+                    "timestamp": datetime(2021, 6, 13, 0, 0).replace(tzinfo=ZoneInfo("UTC")),
                 },
             ],
         )
@@ -531,8 +531,8 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(day["reached_to_step_count"], 0)
         self.assertEqual(day["conversion_rate"], 0)
         self.assertEqual(
-            day["timestamp"].replace(tzinfo=pytz.UTC),
-            (datetime(now.year, now.month, now.day) - timedelta(1)).replace(tzinfo=pytz.UTC),
+            day["timestamp"].replace(tzinfo=ZoneInfo("UTC")),
+            (datetime(now.year, now.month, now.day) - timedelta(1)).replace(tzinfo=ZoneInfo("UTC")),
         )
 
         day = results[1]  # today
@@ -540,7 +540,8 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(day["reached_to_step_count"], 1)
         self.assertEqual(day["conversion_rate"], 100)
         self.assertEqual(
-            day["timestamp"].replace(tzinfo=pytz.UTC), datetime(now.year, now.month, now.day).replace(tzinfo=pytz.UTC)
+            day["timestamp"].replace(tzinfo=ZoneInfo("UTC")),
+            datetime(now.year, now.month, now.day).replace(tzinfo=ZoneInfo("UTC")),
         )
 
     def test_two_runs_by_single_user_in_one_period(self):

--- a/posthog/queries/session_recordings/test/test_session_replay_summaries.py
+++ b/posthog/queries/session_recordings/test/test_session_replay_summaries.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from uuid import uuid4
 
-import pytz
+from zoneinfo import ZoneInfo
 from dateutil.parser import isoparse
 from freezegun import freeze_time
 
@@ -147,8 +147,8 @@ class TestReceiveSummarizedSessionReplays(ClickhouseTestMixin, BaseTest):
                 session_id,
                 self.team.pk,
                 str(self.user.distinct_id),
-                datetime(2023, 4, 27, 10, 0, 0, 309000, tzinfo=pytz.UTC),
-                datetime(2023, 4, 27, 19, 20, 24, 597000, tzinfo=pytz.UTC),
+                datetime(2023, 4, 27, 10, 0, 0, 309000, tzinfo=ZoneInfo("UTC")),
+                datetime(2023, 4, 27, 19, 20, 24, 597000, tzinfo=ZoneInfo("UTC")),
                 33624,
                 "https://first-url-ingested.com",
                 6,

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime
 
 import pytz
+from zoneinfo import ZoneInfo
 from django.test import override_settings
 from rest_framework import status
 
@@ -129,7 +130,7 @@ def retention_test_factory(retention):
                 pluck(result, "label"),
                 ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6", "Day 7", "Day 8", "Day 9", "Day 10"],
             )
-            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=pytz.UTC))
+            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=ZoneInfo("UTC")))
 
             self.assertEqual(
                 pluck(result, "values", "count"),
@@ -211,17 +212,17 @@ def retention_test_factory(retention):
             self.assertEqual(
                 pluck(result, "date"),
                 [
-                    datetime(2020, 1, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 2, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 3, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 4, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 5, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 7, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 8, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 9, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 10, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 11, 10, 0, tzinfo=pytz.UTC),
+                    datetime(2020, 1, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 2, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 3, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 4, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 5, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 7, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 8, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 9, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 10, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 11, 10, 0, tzinfo=ZoneInfo("UTC")),
                 ],
             )
 
@@ -372,17 +373,17 @@ def retention_test_factory(retention):
             self.assertEqual(
                 pluck(result, "date"),
                 [
-                    datetime(2020, 1, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 2, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 3, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 4, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 5, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 7, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 8, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 9, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 10, 10, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 11, 10, 0, tzinfo=pytz.UTC),
+                    datetime(2020, 1, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 2, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 3, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 4, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 5, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 7, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 8, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 9, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 10, 10, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 11, 10, 0, tzinfo=ZoneInfo("UTC")),
                 ],
             )
 
@@ -425,13 +426,13 @@ def retention_test_factory(retention):
             self.assertEqual(
                 pluck(result, "date"),
                 [
-                    datetime(2020, 6, 7, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 14, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 21, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 28, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 7, 5, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 7, 12, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 7, 19, 0, tzinfo=pytz.UTC),
+                    datetime(2020, 6, 7, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 14, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 21, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 28, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 7, 5, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 7, 12, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 7, 19, 0, tzinfo=ZoneInfo("UTC")),
                 ],
             )
 
@@ -498,17 +499,17 @@ def retention_test_factory(retention):
             self.assertEqual(
                 pluck(result, "date"),
                 [
-                    datetime(2020, 6, 10, 6, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 10, 7, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 10, 8, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 10, 9, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 10, 10, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 10, 11, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 10, 12, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 10, 13, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 10, 14, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 10, 15, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 10, 16, tzinfo=pytz.UTC),
+                    datetime(2020, 6, 10, 6, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 10, 7, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 10, 8, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 10, 9, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 10, 10, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 10, 11, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 10, 12, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 10, 13, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 10, 14, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 10, 15, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 10, 16, tzinfo=ZoneInfo("UTC")),
                 ],
             )
 
@@ -552,13 +553,13 @@ def retention_test_factory(retention):
             self.assertEqual(
                 pluck(result, "date"),
                 [
-                    datetime(2020, 6, 7, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 14, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 21, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 6, 28, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 7, 5, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 7, 12, 0, tzinfo=pytz.UTC),
-                    datetime(2020, 7, 19, 0, tzinfo=pytz.UTC),
+                    datetime(2020, 6, 7, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 14, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 21, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 6, 28, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 7, 5, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 7, 12, 0, tzinfo=ZoneInfo("UTC")),
+                    datetime(2020, 7, 19, 0, tzinfo=ZoneInfo("UTC")),
                 ],
             )
 
@@ -838,7 +839,7 @@ def retention_test_factory(retention):
 
             self.assertEqual(len(result), 7)
             self.assertEqual(pluck(result, "label"), ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6"])
-            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=pytz.UTC))
+            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=ZoneInfo("UTC")))
 
             self.assertEqual(
                 pluck(result, "values", "count"),
@@ -902,7 +903,7 @@ def retention_test_factory(retention):
                 pluck(result, "label"),
                 ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6", "Day 7", "Day 8", "Day 9", "Day 10"],
             )
-            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=pytz.UTC))
+            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=ZoneInfo("UTC")))
 
             self.assertEqual(
                 pluck(result, "values", "count"),
@@ -956,7 +957,7 @@ def retention_test_factory(retention):
 
             self.assertEqual(len(result), 7)
             self.assertEqual(pluck(result, "label"), ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6"])
-            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=pytz.UTC))
+            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=ZoneInfo("UTC")))
             self.assertEqual(
                 pluck(result, "values", "count"),
                 [[1, 1, 1, 0, 0, 1, 1], [1, 1, 0, 0, 1, 1], [1, 0, 0, 1, 1], [0, 0, 0, 0], [0, 0, 0], [1, 1], [1]],
@@ -1006,7 +1007,7 @@ def retention_test_factory(retention):
 
             self.assertEqual(len(result), 7)
             self.assertEqual(pluck(result, "label"), ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6"])
-            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=pytz.UTC))
+            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=ZoneInfo("UTC")))
             self.assertEqual(
                 pluck(result, "values", "count"),
                 [[1, 1, 1, 0, 0, 1, 1], [1, 1, 0, 0, 1, 1], [1, 0, 0, 1, 1], [0, 0, 0, 0], [0, 0, 0], [1, 1], [1]],
@@ -1047,7 +1048,7 @@ def retention_test_factory(retention):
 
             self.assertEqual(len(result), 7)
             self.assertEqual(pluck(result, "label"), ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6"])
-            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=pytz.UTC))
+            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=ZoneInfo("UTC")))
 
             self.assertEqual(
                 pluck(result, "values", "count"),
@@ -1086,7 +1087,7 @@ def retention_test_factory(retention):
                 pluck(result, "label"),
                 ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6", "Day 7", "Day 8", "Day 9", "Day 10"],
             )
-            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=pytz.UTC))
+            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=ZoneInfo("UTC")))
 
             self.assertEqual(
                 pluck(result, "values", "count"),
@@ -1196,7 +1197,7 @@ def retention_test_factory(retention):
                         "Day 10",
                     ],
                 )
-                self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=pytz.UTC))
+                self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=ZoneInfo("UTC")))
 
                 self.assertEqual(
                     pluck(result, "values", "count"),
@@ -1337,7 +1338,7 @@ def retention_test_factory(retention):
                 pluck(result, "label"),
                 ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6", "Day 7", "Day 8", "Day 9", "Day 10"],
             )
-            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=pytz.UTC))
+            self.assertEqual(result[0]["date"], datetime(2020, 6, 10, 0, tzinfo=ZoneInfo("UTC")))
 
             self.assertEqual(
                 pluck(result, "values", "count"),

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, ANY
 from urllib.parse import parse_qsl, urlparse
 
 import pytz
+from zoneinfo import ZoneInfo
 from django.conf import settings
 from django.core.cache import cache
 from django.test import override_settings
@@ -1631,8 +1632,8 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         )
         self.assertEqual(
             {
-                "date_from": datetime(2020, 11, 1, 12, tzinfo=pytz.UTC),
-                "date_to": datetime(2020, 11, 1, 13, tzinfo=pytz.UTC),
+                "date_from": datetime(2020, 11, 1, 12, tzinfo=ZoneInfo("UTC")),
+                "date_to": datetime(2020, 11, 1, 13, tzinfo=ZoneInfo("UTC")),
                 "entity_id": "event_name",
                 "entity_math": None,
                 "entity_order": None,
@@ -1687,8 +1688,8 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         )
         self.assertEqual(
             {
-                "date_from": datetime(2020, 11, 1, tzinfo=pytz.UTC),
-                "date_to": datetime(2020, 11, 1, 23, 59, 59, 999999, tzinfo=pytz.UTC),
+                "date_from": datetime(2020, 11, 1, tzinfo=ZoneInfo("UTC")),
+                "date_to": datetime(2020, 11, 1, 23, 59, 59, 999999, tzinfo=ZoneInfo("UTC")),
                 "entity_id": "event_name",
                 "entity_math": None,
                 "entity_order": None,
@@ -3837,8 +3838,8 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             {
                 "breakdown_type": "event",
                 "breakdown_value": "Safari",
-                "date_from": datetime(2020, 11, 1, 12, tzinfo=pytz.UTC),
-                "date_to": datetime(2020, 11, 1, 13, tzinfo=pytz.UTC),
+                "date_from": datetime(2020, 11, 1, 12, tzinfo=ZoneInfo("UTC")),
+                "date_to": datetime(2020, 11, 1, 13, tzinfo=ZoneInfo("UTC")),
                 "entity_id": "event_name",
                 "entity_math": None,
                 "entity_type": "events",

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -4,7 +4,7 @@ import urllib.parse
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import pytz
+from zoneinfo import ZoneInfo
 from django.forms import ValidationError
 
 from posthog.constants import (
@@ -294,7 +294,6 @@ class TrendsBreakdown:
             )
 
         else:
-
             breakdown_filter = breakdown_filter.format(**breakdown_filter_params)
 
             if self.entity.math in [WEEKLY_ACTIVE, MONTHLY_ACTIVE]:
@@ -476,7 +475,6 @@ class TrendsBreakdown:
         return breakdown_value
 
     def _get_histogram_breakdown_values(self, raw_breakdown_value: str, buckets: List[int]):
-
         multi_if_conditionals = []
         values_arr = []
 
@@ -599,8 +597,8 @@ class TrendsBreakdown:
                 getattr(point_date, "hour", 0),
                 getattr(point_date, "minute", 0),
                 getattr(point_date, "second", 0),
-                tzinfo=getattr(point_date, "tzinfo", pytz.UTC),
-            ).astimezone(pytz.UTC)
+                tzinfo=getattr(point_date, "tzinfo", ZoneInfo("UTC")),
+            ).astimezone(ZoneInfo("UTC"))
 
             filter_params = filter.to_params()
             extra_params = {

--- a/posthog/queries/util.py
+++ b/posthog/queries/util.py
@@ -4,6 +4,7 @@ from enum import Enum, auto
 from typing import Any, Dict, Optional, Union
 
 import pytz
+from zoneinfo import ZoneInfo
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
@@ -67,15 +68,18 @@ PERIOD_TO_INTERVAL_FUNC: Dict[str, str] = {
     "month": "toIntervalMonth",
 }
 
+
 # TODO: refactor since this is only used in one spot now
 def format_ch_timestamp(timestamp: datetime, convert_to_timezone: Optional[str] = None):
     if convert_to_timezone:
         # Here we probably get a timestamp set to the beginning of the day (00:00), in UTC
         # We need to convert that UTC timestamp to the local timestamp (00:00 in US/Pacific for example)
         # Then we convert it back to UTC (08:00 in UTC)
-        if timestamp.tzinfo and timestamp.tzinfo != pytz.UTC:
+        if timestamp.tzinfo and timestamp.tzinfo != ZoneInfo("UTC"):
             raise ValidationError(detail="You must pass a timestamp with no timezone or UTC")
-        timestamp = pytz.timezone(convert_to_timezone).localize(timestamp.replace(tzinfo=None)).astimezone(pytz.UTC)
+        timestamp = (
+            pytz.timezone(convert_to_timezone).localize(timestamp.replace(tzinfo=None)).astimezone(ZoneInfo("UTC"))
+        )
 
     return timestamp.strftime("%Y-%m-%d %H:%M:%S")
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -28,11 +28,11 @@ from typing import (
     cast,
 )
 from urllib.parse import urljoin, urlparse
-from zoneinfo import ZoneInfo
 
 import lzstring
 import posthoganalytics
 import pytz
+from zoneinfo import ZoneInfo
 import structlog
 from celery.schedules import crontab
 from dateutil import parser
@@ -128,13 +128,13 @@ def get_previous_day(at: Optional[datetime.datetime] = None) -> Tuple[datetime.d
     period_end: datetime.datetime = datetime.datetime.combine(
         at - datetime.timedelta(days=1),
         datetime.time.max,
-        tzinfo=pytz.UTC,
+        tzinfo=ZoneInfo("UTC"),
     )  # very end of the previous day
 
     period_start: datetime.datetime = datetime.datetime.combine(
         period_end,
         datetime.time.min,
-        tzinfo=pytz.UTC,
+        tzinfo=ZoneInfo("UTC"),
     )  # very start of the previous day
 
     return (period_start, period_end)
@@ -152,13 +152,13 @@ def get_current_day(at: Optional[datetime.datetime] = None) -> Tuple[datetime.da
     period_end: datetime.datetime = datetime.datetime.combine(
         at,
         datetime.time.max,
-        tzinfo=pytz.UTC,
+        tzinfo=ZoneInfo("UTC"),
     )  # very end of the reference day
 
     period_start: datetime.datetime = datetime.datetime.combine(
         period_end,
         datetime.time.min,
-        tzinfo=pytz.UTC,
+        tzinfo=ZoneInfo("UTC"),
     )  # very start of the reference day
 
     return (period_start, period_end)
@@ -1085,7 +1085,7 @@ def cast_timestamp_or_now(timestamp: Optional[Union[timezone.datetime, str]]) ->
     if isinstance(timestamp, str):
         timestamp = parser.isoparse(timestamp)
     else:
-        timestamp = timestamp.astimezone(pytz.utc)
+        timestamp = timestamp.astimezone(ZoneInfo("UTC"))
 
     return timestamp.strftime("%Y-%m-%d %H:%M:%S.%f")
 


### PR DESCRIPTION
## Problem

We're using the obsolete `pytz` for handling timezones. This causes several problems:
- **pytz timezones with DST are serialized to the wrong date string by the default serializers of both DRF and ClickHouse.** This is what caused me to look into this in the first place.
https://gist.github.com/thmsobrmlr/8263f3fab831e19733fc1fb008669669

- **pytz differs from the documented Python API for tzinfo.**
  - We need to use `localize` for creating localized datetimes.
  - We need to use `normalize` when performing date arithmetic on local date times, otherwise transitions that cross DST boundaries are incorrect.
  - We're not doing both of the above, everywhere we'd need to.
- `pytz` themselves [recommend switching](https://pypi.org/project/pytz/#introduction) to ZoneInfo:

    > Projects using Python 3.9 or later should be using the support now included as part of the standard library, and third party packages work with it such as [tzdata](https://pypi.org/project/tzdata/). pytz offers no advantages beyond backwards compatibility with code written for earlier versions of Python.

## Sanity Checks

I've run some sanity checks on our environment to make sure we fulfil all the requirments for the transition. Let me know if there are docs for self-hosted users that need to be updated accordingly.

- `ZoneInfo` was introduced with Python 3.9, so we need to be at least on that version. We're using 3.10.10 in production.
- `ZoneInfo` tries to use tzdata bundled with the system. Our OS is bundled with `2021a`, but has received backports of newer changes. This seems to be better than what we have right now, given that we're using pytz 2021.1.
- ClickHouse and Python fall back to the system's timezone. In our case everything is correctly set to UTC. We should however inform self-hosted users of this requirement (maybe even add a system check?)
- Just in case, pytz timezones used in US/EU tested for compatibility with ZoneInfo
  https://gist.github.com/thmsobrmlr/a1e19ad4ba5c312d777e7c31cfaef4f5

## Changes

This PR is the first of a couple ones aiming to replace `pytz` with `ZoneInfo`. Here we replace `pytz.UTC` with `ZoneInfo("UTC")`, which should be  a drop-in replacement.

Planned stack of PRs:
1. Replace `pytz.UTC` with `zoneinfo("UTC")` - this PR
2. Replace other usages of `pytz`
3. Replace the [enum values for team.timezone](https://github.com/PostHog/posthog/blob/a00aa241c7b1b10c1cc35732a1ca1843788dd5e6/posthog/models/team/team.py#L28) with CLDR timezone data e.g. through babel (how to filter out common timezones?)
4. Remove dependency on `pytz`

## How did you test this code?

CI run
