### PR TITLE
fix(trends): fix active user queries with PoE v1

### DIFF
--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -3199,7 +3199,7 @@
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
-        UNION ALL SELECT count(DISTINCT person_id) AS total,
+        UNION ALL SELECT count(DISTINCT e.person_id) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
         INNER JOIN

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -54,7 +54,7 @@ class TrendsTotalVolume:
         if team.person_on_events_mode == PersonOnEventsMode.V2_ENABLED:
             person_id_alias = f"if(notEmpty({self.PERSON_ID_OVERRIDES_TABLE_ALIAS}.person_id), {self.PERSON_ID_OVERRIDES_TABLE_ALIAS}.person_id, {self.EVENT_TABLE_ALIAS}.person_id)"
         elif team.person_on_events_mode == PersonOnEventsMode.V1_ENABLED:
-            person_id_alias = "person_id"
+            person_id_alias = f"{self.EVENT_TABLE_ALIAS}.person_id"
 
         aggregate_operation, join_condition, math_params = process_math(
             entity,


### PR DESCRIPTION
## Problem

A user has been complaining that queries stopped working for them https://posthoghelp.zendesk.com/agent/tickets/5514. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/7962) Brief investigation led me to PoE v1.

Repro:
- Enable PoE v1 for the team
- Create a trends insight with "unique users" math
- Make sure there is at least one other condition on a user property e.g. a test account filter for user email

## Changes

This PR adds the event table alias to the person_id, inline with what we do at other places.

## How did you test this code?

Verified the repro works again