### PR TITLE
feat: add versioning to notebooks to handle old node types

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
@@ -2,6 +2,10 @@ import { JSONContent } from '@tiptap/core'
 import { NodeKind } from '~/queries/schema'
 import { NotebookNodeType, NotebookType } from '~/types'
 
+// NOTE: Increment this number when you add a new content migration
+// It will bust the cache on the localContent in the notebookLogic
+// so that the latest content will fall back to the remote content which
+// is filtered through the migrate function below that ensures integrity
 export const NOTEBOOKS_VERSION = '1'
 
 export function migrate(notebook: NotebookType): NotebookType {

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
@@ -1,0 +1,33 @@
+import { JSONContent } from '@tiptap/core'
+import { NodeKind } from '~/queries/schema'
+import { NotebookNodeType, NotebookType } from '~/types'
+
+export const NOTEBOOKS_VERSION = '1'
+
+export function migrate(notebook: NotebookType): NotebookType {
+    let content = notebook.content.content
+
+    if (!content) {
+        return notebook
+    }
+
+    content = convertInsightToQueryNode(content)
+    return { ...notebook, content: { type: 'doc', content: content } }
+}
+
+function convertInsightToQueryNode(content: JSONContent[]): JSONContent[] {
+    return content.map((node) => {
+        if (node.type != 'ph-insight') {
+            return node
+        }
+
+        return {
+            ...node,
+            type: NotebookNodeType.Query,
+            attrs: {
+                nodeId: node.attrs?.nodeId,
+                query: { kind: NodeKind.SavedInsightNode, shortId: node.attrs?.id },
+            },
+        }
+    })
+}


### PR DESCRIPTION
## Problem

As pointed out in https://github.com/PostHog/posthog/pull/17289#issuecomment-1704392172 we will break notebooks if a node type is removed but still exists in the local storage or stored data.

## Changes

- Add a migration to change all `NotebookNodeInsight` to `NotebookNodeQuery`
- Add a version (incrementing string integer) that busts the local storage cache when a new migration is added

## How did you test this code?

Manually