### PR TITLE
feat: Support test higher frequencies in get_data_interval

### DIFF
--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -217,6 +217,10 @@ def get_data_interval(interval: str, data_interval_end: str | None) -> tuple[dt.
         data_interval_start_dt = data_interval_end_dt - dt.timedelta(hours=1)
     elif interval == "day":
         data_interval_start_dt = data_interval_end_dt - dt.timedelta(days=1)
+    elif interval == "every-5-minutes":
+        data_interval_start_dt = data_interval_end_dt - dt.timedelta(minutes=5)
+    elif interval == "every-10-minutes":
+        data_interval_start_dt = data_interval_end_dt - dt.timedelta(minutes=10)
     else:
         raise ValueError(f"Unsupported interval: '{interval}'")
 


### PR DESCRIPTION
## Problem

In order to allow us to test higher frequency exports, we need to update `get_data_interval` to return intervals of data corresponding to these higher frequencies. We are not exposing this parameter yet, so PostHog models will block any attempts to use them. But, we can edit Temporal Schedules directly after creation of a dummy BatchExport for testing purposes.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Update `get_data_interval` to support `every-5-minutes` and `every-10-minutes` intervals.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
