### PR TITLE
fix: toolbar session lookup

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -37,9 +37,6 @@ describe('API helper', () => {
                 '/api/projects/2/events?properties=%5B%7B%22key%22%3A%22something%22%2C%22value%22%3A%22is_set%22%2C%22operator%22%3A%22is_set%22%2C%22type%22%3A%22event%22%7D%5D&limit=10&orderBy=%5B%22-timestamp%22%5D',
                 {
                     signal: undefined,
-                    headers: {
-                        'X-POSTHOG-SESSION-ID': 'fake-session-id',
-                    },
                 }
             )
         })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -611,16 +611,6 @@ const ensureProjectIdNotInvalid = (url: string): void => {
     }
 }
 
-function getSessionId(): string | undefined {
-    // get_session_id is not always present e.g. in the toolbar
-    // but our typing in the SDK doesn't make this clear
-    // TODO when the SDK makes this safe this check can be simplified
-    if (typeof posthog?.get_session_id !== 'function') {
-        return undefined
-    }
-    return posthog.get_session_id()
-}
-
 const api = {
     insights: {
         loadInsight(
@@ -1608,9 +1598,6 @@ const api = {
         try {
             response = await fetch(url, {
                 signal: options?.signal,
-                headers: {
-                    ...(getSessionId() ? { 'X-POSTHOG-SESSION-ID': getSessionId() } : {}),
-                },
             })
         } catch (e) {
             throw { status: 0, message: e }
@@ -1634,7 +1621,6 @@ const api = {
             headers: {
                 ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
                 'X-CSRFToken': getCookie(CSRF_COOKIE_NAME) || '',
-                ...(getSessionId() ? { 'X-POSTHOG-SESSION-ID': getSessionId() } : {}),
             },
             body: isFormData ? data : JSON.stringify(data),
             signal: options?.signal,
@@ -1666,7 +1652,6 @@ const api = {
             headers: {
                 ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
                 'X-CSRFToken': getCookie(CSRF_COOKIE_NAME) || '',
-                ...(getSessionId() ? { 'X-POSTHOG-SESSION-ID': getSessionId() } : {}),
             },
             body: data ? (isFormData ? data : JSON.stringify(data)) : undefined,
             signal: options?.signal,
@@ -1692,7 +1677,6 @@ const api = {
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
                 'X-CSRFToken': getCookie(CSRF_COOKIE_NAME) || '',
-                ...(getSessionId() ? { 'X-POSTHOG-SESSION-ID': getSessionId() } : {}),
             },
         })
 


### PR DESCRIPTION
we were checking the `posthog.get_session_id function` exists but not the `sessionManager` that it relies on