### PR TITLE
fix: Always publish subscription message for realtime replay

### DIFF
--- a/posthog/session_recordings/realtime_snapshots.py
+++ b/posthog/session_recordings/realtime_snapshots.py
@@ -38,6 +38,10 @@ def get_realtime_snapshots(team_id: str, session_id: str, attempt_count=0) -> Op
         key = get_key(team_id, session_id)
         encoded_snapshots = redis.zrange(key, 0, -1, withscores=True)
 
+        # We always publish as it could be that a rebalance has occured and the consumer doesn't know it should be
+        # sending data to redis
+        redis.publish(SUBSCRIPTION_CHANNEL, json.dumps({"team_id": team_id, "session_id": session_id}))
+
         if not encoded_snapshots and attempt_count < ATTEMPT_MAX:
             logger.info(
                 "No realtime snapshots found, publishing subscription and retrying",


### PR DESCRIPTION
## Problem

We can get into a state where we have data in redis but a rebalance occurred and the consumer doesn't know it should be updating the redis content in real time

## Changes

* Publish on every request just in case.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
