### PR TITLE
fix(retention): move weekly active users interval by a day

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -597,7 +597,7 @@
                  GROUP BY timestamp, person_id,
                                      breakdown_value) e
               WHERE e.timestamp <= d.timestamp
-                AND e.timestamp > d.timestamp - INTERVAL 6 DAY
+                AND e.timestamp > d.timestamp - INTERVAL 7 DAY
               GROUP BY d.timestamp,
                        breakdown_value
               ORDER BY d.timestamp)

--- a/posthog/queries/trends/sql.py
+++ b/posthog/queries/trends/sql.py
@@ -66,7 +66,7 @@ SELECT counts AS total, timestamp AS day_start FROM (
             {aggregator} AS actor_id
         {event_query_base}
         GROUP BY timestamp, actor_id
-    ) e WHERE e.timestamp <= d.timestamp + INTERVAL 1 DAY AND e.timestamp > d.timestamp - INTERVAL {prev_interval}
+    ) e WHERE e.timestamp <= d.timestamp AND e.timestamp > d.timestamp - INTERVAL {prev_interval}
     GROUP BY d.timestamp
     ORDER BY d.timestamp
 ) WHERE 1 = 1 {parsed_date_from} {parsed_date_to}

--- a/posthog/queries/trends/util.py
+++ b/posthog/queries/trends/util.py
@@ -121,7 +121,7 @@ def get_active_user_params(filter: Filter, entity: Entity, team_id: int) -> Tupl
     date_to = filter.date_to
 
     format_params = {
-        "prev_interval": "6 DAY" if entity.math == WEEKLY_ACTIVE else "29 DAY",
+        "prev_interval": "7 DAY" if entity.math == WEEKLY_ACTIVE else "30 DAY",
         "parsed_date_from_prev_range": f"AND toDateTime(timestamp, 'UTC') >= toDateTime(%(date_from_active_users_adjusted)s, %(timezone)s)",
     }
 


### PR DESCRIPTION
## Problem

The retention insight and the retention persons modal seem to be using wrong query ranges independently.

The insight query is built by using the cartesian product of eligible events and the individual dates, then filtering out by `event <= day + 1` and `event > day - 6`.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
