### PR TITLE
feat(plugin-server): better profiling capabilities: adjust sampling precision + profile the pod startup

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -126,6 +126,12 @@ export function getDefaultConfig(): PluginsServerConfig {
         USE_KAFKA_FOR_SCHEDULED_TASKS: true,
         CLOUD_DEPLOYMENT: 'default', // Used as a Sentry tag
 
+        STARTUP_PROFILE_DURATION_SECONDS: 300, // 5 minutes
+        STARTUP_PROFILE_CPU: false,
+        STARTUP_PROFILE_HEAP: false,
+        STARTUP_PROFILE_HEAP_INTERVAL: 512 * 1024, // default v8 value
+        STARTUP_PROFILE_HEAP_DEPTH: 16, // default v8 value
+
         SESSION_RECORDING_KAFKA_HOSTS: undefined,
         SESSION_RECORDING_KAFKA_SECURITY_PROTOCOL: undefined,
         SESSION_RECORDING_KAFKA_BATCH_SIZE: 500,

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -1,10 +1,12 @@
 import * as Sentry from '@sentry/node'
+import fs from 'fs'
 import { Server } from 'http'
 import { CompressionCodecs, CompressionTypes, Consumer, KafkaJSProtocolError } from 'kafkajs'
 // @ts-expect-error no type definitions
 import SnappyCodec from 'kafkajs-snappy'
 import * as schedule from 'node-schedule'
 import { Counter } from 'prom-client'
+import v8Profiler from 'v8-profiler-next'
 
 import { getPluginServerCapabilities } from '../capabilities'
 import { defaultConfig, sessionRecordingConsumerConfig } from '../config/config'
@@ -63,6 +65,7 @@ export async function startPluginsServer(
 
     status.updatePrompt(serverConfig.PLUGIN_SERVER_MODE)
     status.info('ℹ️', `${serverConfig.WORKER_CONCURRENCY} workers, ${serverConfig.TASKS_PER_WORKER} tasks per worker`)
+    runStartupProfiles(serverConfig)
 
     // Structure containing initialized clients for Postgres, Kafka, Redis, etc.
     let hub: Hub | undefined
@@ -508,3 +511,26 @@ const kafkaProtocolErrors = new Counter({
     help: 'Kafka protocol errors encountered, by type',
     labelNames: ['type', 'code'],
 })
+
+function runStartupProfiles(config: PluginsServerConfig) {
+    if (config.STARTUP_PROFILE_CPU) {
+        status.info('🩺', `Collecting cpu profile...`)
+        v8Profiler.setGenerateType(1)
+        v8Profiler.startProfiling('startup', true)
+        setTimeout(() => {
+            const profile = v8Profiler.stopProfiling('startup')
+            fs.writeFileSync('./startup.cpuprofile', JSON.stringify(profile))
+            status.info('🩺', `Wrote cpu profile to disk`)
+            profile.delete()
+        }, config.STARTUP_PROFILE_DURATION_SECONDS * 1000)
+    }
+    if (config.STARTUP_PROFILE_HEAP) {
+        status.info('🩺', `Collecting heap profile...`)
+        v8Profiler.startSamplingHeapProfiling(config.STARTUP_PROFILE_HEAP_INTERVAL, config.STARTUP_PROFILE_HEAP_DEPTH)
+        setTimeout(() => {
+            const profile = v8Profiler.stopSamplingHeapProfiling()
+            fs.writeFileSync('./startup.heapprofile', JSON.stringify(profile))
+            status.info('🩺', `Wrote heap profile to disk`)
+        }, config.STARTUP_PROFILE_DURATION_SECONDS * 1000)
+    }
+}

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -155,8 +155,13 @@ function exportProfile(req: IncomingMessage, res: ServerResponse) {
             }, durationSeconds * 1000)
             break
         case 'heap':
+            // Additional params for sampling heap profile, higher precision means bigger profile.
+            // Defaults are taken from https://v8.github.io/api/head/classv8_1_1HeapProfiler.html
+            const interval = url.searchParams.get('interval') ? parseInt(url.searchParams.get('interval')!) : 512 * 1024
+            const depth = url.searchParams.get('depth') ? parseInt(url.searchParams.get('depth')!) : 16
+
             sendHeaders('heapprofile')
-            v8Profiler.startSamplingHeapProfiling()
+            v8Profiler.startSamplingHeapProfiling(interval, depth)
             setTimeout(() => {
                 outputProfileResult(res, type, v8Profiler.stopSamplingHeapProfiling())
             }, durationSeconds * 1000)

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -21,7 +21,7 @@ import { VM } from 'vm2'
 import { ObjectStorage } from './main/services/object_storage'
 import { DB } from './utils/db/db'
 import { KafkaProducerWrapper } from './utils/db/kafka-producer-wrapper'
-import { PostgresRouter } from './utils/db/postgres' /** Re-export Element from scaffolding, for backwards compat. */
+import { PostgresRouter } from './utils/db/postgres'
 import { UUID } from './utils/utils'
 import { AppMetrics } from './worker/ingestion/app-metrics'
 import { EventPipelineResult } from './worker/ingestion/event-pipeline/runner'
@@ -31,10 +31,9 @@ import { TeamManager } from './worker/ingestion/team-manager'
 import { PluginsApiKeyManager } from './worker/vm/extensions/helpers/api-key-manager'
 import { RootAccessManager } from './worker/vm/extensions/helpers/root-acess-manager'
 import { LazyPluginVM } from './worker/vm/lazy'
-import { PromiseManager } from './worker/vm/promise-manager' /** Re-export Element from scaffolding, for backwards compat. */
+import { PromiseManager } from './worker/vm/promise-manager'
 
-/** Re-export Element from scaffolding, for backwards compat. */
-export { Element } from '@posthog/plugin-scaffold'
+export { Element } from '@posthog/plugin-scaffold' // Re-export Element from scaffolding, for backwards compat.
 
 type Brand<K, T> = K & { __brand: T }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -31,7 +31,7 @@ import { TeamManager } from './worker/ingestion/team-manager'
 import { PluginsApiKeyManager } from './worker/vm/extensions/helpers/api-key-manager'
 import { RootAccessManager } from './worker/vm/extensions/helpers/root-acess-manager'
 import { LazyPluginVM } from './worker/vm/lazy'
-import { PromiseManager } from './worker/vm/promise-manager'
+import { PromiseManager } from './worker/vm/promise-manager' /** Re-export Element from scaffolding, for backwards compat. */
 
 /** Re-export Element from scaffolding, for backwards compat. */
 export { Element } from '@posthog/plugin-scaffold'
@@ -200,6 +200,13 @@ export interface PluginsServerConfig {
     EVENT_OVERFLOW_BUCKET_CAPACITY: number
     EVENT_OVERFLOW_BUCKET_REPLENISH_RATE: number
     CLOUD_DEPLOYMENT: string
+
+    // dump profiles to disk, covering the first N seconds of runtime
+    STARTUP_PROFILE_DURATION_SECONDS: number
+    STARTUP_PROFILE_CPU: boolean
+    STARTUP_PROFILE_HEAP: boolean
+    STARTUP_PROFILE_HEAP_INTERVAL: number
+    STARTUP_PROFILE_HEAP_DEPTH: number
 
     // local directory might be a volume mount or a directory on disk (e.g. in local dev)
     SESSION_RECORDING_LOCAL_DIRECTORY: string


### PR DESCRIPTION
## Problem

I retrieved heap allocations profiles from prod, but the sampling is too coarse to have a clear view on what's happening

## Changes

- Allow to specify the `interval` and `depth` param from the url params
  - Copy default values from https://v8.github.io/api/head/classv8_1_1HeapProfiler.html
  - Not adding bounds to these parameters although bad values could OOM the pod. This port is not exposed to the outside in either cloud or hobby deploy
- Add a set of envvars to dump startup profiles to disk, because we'll want to profile worker init, before the http server is up

## How did you test this code?

```
$ curl -vOJ "http://localhost:6738/_profile/heap?seconds=30"
$ curl -vOJ "http://localhost:6738/_profile/heap?seconds=30&depth=32&interval=1024"

$ ls -lh
-rw-r--r--  1 xavier  wheel   5.1K Sep  7 15:27 heap-20230907-132708.heapprofile
-rw-r--r--  1 xavier  wheel   836K Sep  7 15:28 heap-20230907-132744.heapprofile


$ STARTUP_PROFILE_HEAP_DEPTH=32 STARTUP_PROFILE_DURATION_SECONDS=60 STARTUP_PROFILE_CPU=true STARTUP_PROFILE_HEAP=true DEBUG=1 ./bin/start-worker
$ ls -lh plugin-server/startup.*
-rw-r--r--@ 1 xavier  staff   967K Sep  7 15:59 plugin-server/startup.cpuprofile
-rw-r--r--  1 xavier  staff    44K Sep  7 15:59 plugin-server/startup.heapprofile
```