### PR TITLE
chore(python): replace pytz usages with ZoneInfo

### DIFF
--- a/ee/clickhouse/queries/experiments/funnel_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/funnel_experiment_result.py
@@ -1,8 +1,8 @@
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import List, Optional, Tuple, Type
+from zoneinfo import ZoneInfo
 
-import pytz
 from numpy.random import default_rng
 from rest_framework.exceptions import ValidationError
 
@@ -57,7 +57,6 @@ class ClickhouseFunnelExperimentResult:
         experiment_end_date: Optional[datetime] = None,
         funnel_class: Type[ClickhouseFunnel] = ClickhouseFunnel,
     ):
-
         breakdown_key = f"$feature/{feature_flag.key}"
         self.variants = [variant["key"] for variant in feature_flag.variants]
 
@@ -65,9 +64,9 @@ class ClickhouseFunnelExperimentResult:
         # while start and end date are in UTC.
         # so we need to convert them to the project timezone
         if team.timezone:
-            start_date_in_project_timezone = experiment_start_date.astimezone(pytz.timezone(team.timezone))
+            start_date_in_project_timezone = experiment_start_date.astimezone(ZoneInfo(team.timezone))
             end_date_in_project_timezone = (
-                experiment_end_date.astimezone(pytz.timezone(team.timezone)) if experiment_end_date else None
+                experiment_end_date.astimezone(ZoneInfo(team.timezone)) if experiment_end_date else None
             )
 
         query_filter = filter.shallow_clone(

--- a/ee/clickhouse/queries/experiments/secondary_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/secondary_experiment_result.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Dict, Optional
+from zoneinfo import ZoneInfo
 
-import pytz
 from rest_framework.exceptions import ValidationError
 from ee.clickhouse.queries.experiments.trend_experiment_result import (
     uses_count_per_property_value_aggregation,
@@ -32,7 +32,6 @@ class ClickhouseSecondaryExperimentResult:
         experiment_start_date: datetime,
         experiment_end_date: Optional[datetime] = None,
     ):
-
         breakdown_key = f"$feature/{feature_flag.key}"
         self.variants = [variant["key"] for variant in feature_flag.variants]
 
@@ -40,9 +39,9 @@ class ClickhouseSecondaryExperimentResult:
         # while start and end date are in UTC.
         # so we need to convert them to the project timezone
         if team.timezone:
-            start_date_in_project_timezone = experiment_start_date.astimezone(pytz.timezone(team.timezone))
+            start_date_in_project_timezone = experiment_start_date.astimezone(ZoneInfo(team.timezone))
             end_date_in_project_timezone = (
-                experiment_end_date.astimezone(pytz.timezone(team.timezone)) if experiment_end_date else None
+                experiment_end_date.astimezone(ZoneInfo(team.timezone)) if experiment_end_date else None
             )
 
         query_filter = filter.shallow_clone(
@@ -67,7 +66,6 @@ class ClickhouseSecondaryExperimentResult:
         self.query_filter = query_filter
 
     def get_results(self):
-
         if self.query_filter.insight == INSIGHT_TRENDS:
             trend_results = Trends().run(self.query_filter, self.team)
             variants = self.get_trend_count_data_for_variants(trend_results)

--- a/ee/clickhouse/queries/experiments/trend_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/trend_experiment_result.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from functools import lru_cache
 from math import exp, lgamma, log
 from typing import List, Optional, Tuple, Type
+from zoneinfo import ZoneInfo
 
-import pytz
 from numpy.random import default_rng
 from rest_framework.exceptions import ValidationError
 
@@ -77,7 +77,6 @@ class ClickhouseTrendExperimentResult:
         trend_class: Type[Trends] = Trends,
         custom_exposure_filter: Optional[Filter] = None,
     ):
-
         breakdown_key = f"$feature/{feature_flag.key}"
         variants = [variant["key"] for variant in feature_flag.variants]
 
@@ -85,9 +84,9 @@ class ClickhouseTrendExperimentResult:
         # while start and end date are in UTC.
         # so we need to convert them to the project timezone
         if team.timezone:
-            start_date_in_project_timezone = experiment_start_date.astimezone(pytz.timezone(team.timezone))
+            start_date_in_project_timezone = experiment_start_date.astimezone(ZoneInfo(team.timezone))
             end_date_in_project_timezone = (
-                experiment_end_date.astimezone(pytz.timezone(team.timezone)) if experiment_end_date else None
+                experiment_end_date.astimezone(ZoneInfo(team.timezone)) if experiment_end_date else None
             )
 
         count_per_user_aggregation = uses_count_per_user_aggregation(filter)

--- a/ee/tasks/auto_rollback_feature_flag.py
+++ b/ee/tasks/auto_rollback_feature_flag.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from typing import Dict
+from zoneinfo import ZoneInfo
 
-import pytz
 from celery import shared_task
 
 from ee.api.sentry_stats import get_stats_for_timerange
@@ -31,7 +31,7 @@ def check_feature_flag_rollback_conditions(feature_flag_id: int) -> None:
 
 
 def calculate_rolling_average(threshold_metric: Dict, team: Team, timezone: str) -> float:
-    curr = datetime.now(tz=pytz.timezone(timezone))
+    curr = datetime.now(tz=ZoneInfo(timezone))
 
     rolling_average_days = 7
 

--- a/posthog/demo/products/hedgebox/models.py
+++ b/posthog/demo/products/hedgebox/models.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 import pytz
+from zoneinfo import ZoneInfo
 
 from posthog.demo.matrix.models import Effect, SimPerson, SimSessionIntent
 
@@ -673,7 +674,7 @@ class HedgeboxPerson(SimPerson):
         if not self.account.was_billing_scheduled:
             self.account.was_billing_scheduled = True
             future_months = math.ceil(
-                (self.cluster.end.astimezone(pytz.timezone(self.timezone)) - self.cluster.simulation_time).days / 30
+                (self.cluster.end.astimezone(ZoneInfo(self.timezone)) - self.cluster.simulation_time).days / 30
             )
             for i in range(future_months):
                 bill_timestamp = self.cluster.simulation_time + dt.timedelta(days=30 * i)

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -3,7 +3,6 @@ import json
 import uuid
 from typing import Any, Dict, List, Optional, Set, Union
 
-import pytz
 from zoneinfo import ZoneInfo
 from dateutil.parser import isoparse
 from django.utils import timezone
@@ -120,7 +119,7 @@ def bulk_create_events(events: List[Dict[str, Any]], person_mapping: Optional[Di
         # Offset timezone-naive datetime by project timezone, to facilitate @also_test_with_different_timezones
         if timestamp.tzinfo is None:
             team_timezone = event["team"].timezone if event.get("team") else "UTC"
-            timestamp = pytz.timezone(team_timezone).localize(timestamp)
+            timestamp = timestamp.replace(tzinfo=ZoneInfo(team_timezone))
         # Format for ClickHouse
         timestamp = timestamp.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%d %H:%M:%S.%f")
 

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -3,6 +3,7 @@ import json
 import uuid
 from typing import Any, Dict, List, Optional, Set, Union
 
+import pytz
 from zoneinfo import ZoneInfo
 from dateutil.parser import isoparse
 from django.utils import timezone
@@ -119,7 +120,7 @@ def bulk_create_events(events: List[Dict[str, Any]], person_mapping: Optional[Di
         # Offset timezone-naive datetime by project timezone, to facilitate @also_test_with_different_timezones
         if timestamp.tzinfo is None:
             team_timezone = event["team"].timezone if event.get("team") else "UTC"
-            timestamp = timestamp.replace(tzinfo=ZoneInfo(team_timezone))
+            timestamp = pytz.timezone(team_timezone).localize(timestamp)
         # Format for ClickHouse
         timestamp = timestamp.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%d %H:%M:%S.%f")
 

--- a/posthog/queries/properties_timeline/properties_timeline_event_query.py
+++ b/posthog/queries/properties_timeline/properties_timeline_event_query.py
@@ -1,7 +1,6 @@
 import datetime as dt
 from typing import Any, Dict, Optional, Tuple
-
-import pytz
+from zoneinfo import ZoneInfo
 
 from posthog.models.entity.util import get_entity_filtering_params
 from posthog.models.filters.properties_timeline_filter import PropertiesTimelineFilter
@@ -76,7 +75,7 @@ class PropertiesTimelineEventQuery(EventQuery):
     def _get_date_filter(self) -> Tuple[str, Dict]:
         query_params: Dict[str, Any] = {}
         query_date_range = QueryDateRange(self._filter, self._team)
-        effective_timezone = pytz.timezone(self._team.timezone)
+        effective_timezone = ZoneInfo(self._team.timezone)
         # Get effective date range from QueryDateRange
         # We need to explicitly replace tzinfo in those datetimes with the team's timezone, because QueryDateRange
         # does not reliably make those datetimes timezone-aware. That's annoying, but it'd be a significant effort

--- a/posthog/queries/query_date_range.py
+++ b/posthog/queries/query_date_range.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta
 from functools import cached_property
 from typing import Dict, Literal, Optional, Tuple
-from zoneinfo import ZoneInfo
 
+import pytz
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from posthog.models.filters.base_filter import BaseFilter
@@ -82,7 +82,7 @@ class QueryDateRange:
         return self._localize_to_team(timezone.now())
 
     def _localize_to_team(self, target: datetime):
-        return target.replace(tzinfo=ZoneInfo(self._team.timezone))
+        return target.astimezone(pytz.timezone(self._team.timezone))
 
     @cached_property
     def date_to_clause(self):

--- a/posthog/queries/query_date_range.py
+++ b/posthog/queries/query_date_range.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta
 from functools import cached_property
 from typing import Dict, Literal, Optional, Tuple
+from zoneinfo import ZoneInfo
 
-import pytz
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from posthog.models.filters.base_filter import BaseFilter
@@ -82,7 +82,7 @@ class QueryDateRange:
         return self._localize_to_team(timezone.now())
 
     def _localize_to_team(self, target: datetime):
-        return target.astimezone(pytz.timezone(self._team.timezone))
+        return target.replace(tzinfo=ZoneInfo(self._team.timezone))
 
     @cached_property
     def date_to_clause(self):

--- a/posthog/queries/query_date_range.py
+++ b/posthog/queries/query_date_range.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta
 from functools import cached_property
 from typing import Dict, Literal, Optional, Tuple
+from zoneinfo import ZoneInfo
 
-import pytz
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from posthog.models.filters.base_filter import BaseFilter
@@ -82,7 +82,7 @@ class QueryDateRange:
         return self._localize_to_team(timezone.now())
 
     def _localize_to_team(self, target: datetime):
-        return target.astimezone(pytz.timezone(self._team.timezone))
+        return target.astimezone(ZoneInfo(self._team.timezone))
 
     @cached_property
     def date_to_clause(self):

--- a/posthog/queries/retention/retention.py
+++ b/posthog/queries/retention/retention.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlencode
-
-import pytz
+from zoneinfo import ZoneInfo
 
 from posthog.constants import RETENTION_FIRST_TIME, RetentionQueryType
 from posthog.models.filters.retention_filter import RetentionFilter
@@ -33,7 +32,6 @@ class Retention:
     def _get_retention_by_breakdown_values(
         self, filter: RetentionFilter, team: Team
     ) -> Dict[CohortKey, Dict[str, Any]]:
-
         actor_query, actor_query_params = build_actor_activity_query(
             filter=filter, team=team, retention_events_query=self.event_query
         )
@@ -109,10 +107,8 @@ class Retention:
                     for day in range(filter.total_intervals - first_day)
                 ],
                 "label": "{} {}".format(filter.period, first_day),
-                "date": pytz.timezone(team.timezone).localize(
-                    (filter.date_from + RetentionFilter.determine_time_delta(first_day, filter.period)[0]).replace(
-                        tzinfo=None
-                    )
+                "date": (filter.date_from + RetentionFilter.determine_time_delta(first_day, filter.period)[0]).replace(
+                    tzinfo=ZoneInfo(team.timezone)
                 ),
                 "people_url": construct_url(first_day),
             }

--- a/posthog/queries/retention/retention.py
+++ b/posthog/queries/retention/retention.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlencode
-from zoneinfo import ZoneInfo
+
+import pytz
 
 from posthog.constants import RETENTION_FIRST_TIME, RetentionQueryType
 from posthog.models.filters.retention_filter import RetentionFilter
@@ -107,8 +108,10 @@ class Retention:
                     for day in range(filter.total_intervals - first_day)
                 ],
                 "label": "{} {}".format(filter.period, first_day),
-                "date": (filter.date_from + RetentionFilter.determine_time_delta(first_day, filter.period)[0]).replace(
-                    tzinfo=ZoneInfo(team.timezone)
+                "date": pytz.timezone(team.timezone).localize(
+                    (filter.date_from + RetentionFilter.determine_time_delta(first_day, filter.period)[0]).replace(
+                        tzinfo=None
+                    )
                 ),
                 "people_url": construct_url(first_day),
             }

--- a/posthog/queries/retention/retention.py
+++ b/posthog/queries/retention/retention.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlencode
-
-import pytz
+from zoneinfo import ZoneInfo
 
 from posthog.constants import RETENTION_FIRST_TIME, RetentionQueryType
 from posthog.models.filters.retention_filter import RetentionFilter
@@ -108,11 +107,8 @@ class Retention:
                     for day in range(filter.total_intervals - first_day)
                 ],
                 "label": "{} {}".format(filter.period, first_day),
-                "date": pytz.timezone(team.timezone).localize(
-                    (filter.date_from + RetentionFilter.determine_time_delta(first_day, filter.period)[0]).replace(
-                        tzinfo=None
-                    )
-                ),
+                "date": filter.date_from.replace(tzinfo=ZoneInfo(team.timezone))
+                + RetentionFilter.determine_time_delta(first_day, filter.period)[0],
                 "people_url": construct_url(first_day),
             }
             for first_day in range(filter.total_intervals)

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -2,7 +2,6 @@ import json
 import uuid
 from datetime import datetime
 
-import pytz
 from zoneinfo import ZoneInfo
 from django.test import override_settings
 from rest_framework import status
@@ -37,7 +36,6 @@ def _create_action(**kwargs):
 
 
 def _create_signup_actions(team, user_and_timestamps):
-
     for distinct_id, timestamp in user_and_timestamps:
         _create_event(team=team, event="sign up", distinct_id=distinct_id, timestamp=timestamp)
     sign_up_action = _create_action(team=team, name="sign up")
@@ -54,7 +52,7 @@ def pluck(list_of_dicts, key, child_key=None):
 
 def _create_events(team, user_and_timestamps, event="$pageview"):
     i = 0
-    for (distinct_id, timestamp, *properties_args) in user_and_timestamps:
+    for distinct_id, timestamp, *properties_args in user_and_timestamps:
         properties = {"$some_property": "value"} if i % 2 == 0 else {}
         if len(properties_args) == 1:
             properties.update(properties_args[0])
@@ -872,7 +870,6 @@ def retention_test_factory(retention):
             )
 
         def test_retention_with_properties(self):
-
             _create_person(team_id=self.team.pk, distinct_ids=["person1", "alias1"])
             _create_person(team_id=self.team.pk, distinct_ids=["person2"])
 
@@ -1157,7 +1154,6 @@ def retention_test_factory(retention):
             return p1, p2, p3, p4
 
         def test_retention_aggregate_by_distinct_id(self):
-
             _create_person(team_id=self.team.pk, distinct_ids=["person1", "alias1"], properties={"test": "ok"})
             _create_person(team_id=self.team.pk, distinct_ids=["person2"])
 
@@ -1271,7 +1267,7 @@ def retention_test_factory(retention):
                 ["Day 0", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6", "Day 7", "Day 8", "Day 9", "Day 10"],
             )
 
-            self.assertEqual(result_pacific[0]["date"], pytz.timezone("US/Pacific").localize(datetime(2020, 6, 10)))
+            self.assertEqual(result_pacific[0]["date"], datetime(2020, 6, 10, tzinfo=ZoneInfo("US/Pacific")))
             self.assertEqual(result_pacific[0]["date"].isoformat(), "2020-06-10T00:00:00-07:00")
 
             self.assertEqual(

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -5,7 +5,6 @@ from typing import Dict, List, Optional, Tuple, Union
 from unittest.mock import patch, ANY
 from urllib.parse import parse_qsl, urlparse
 
-import pytz
 from zoneinfo import ZoneInfo
 from django.conf import settings
 from django.core.cache import cache
@@ -5604,7 +5603,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-05T08:01:01",
         )
 
-        query_time = pytz.timezone(self.team.timezone).localize(datetime(2020, 1, 5, 10, 1, 1))
+        query_time = datetime(2020, 1, 5, 10, 1, 1, tzinfo=ZoneInfo(self.team.timezone))
         utc_offset_hours = query_time.tzinfo.utcoffset(query_time).total_seconds() // 3600  # type: ignore
         utc_offset_sign = "-" if utc_offset_hours < 0 else "+"
         with freeze_time(query_time):
@@ -5798,7 +5797,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-06T00:30:01",  # Shouldn't be included anywhere
         )
 
-        with freeze_time(pytz.timezone(self.team.timezone).localize(datetime(2020, 1, 5, 5, 0))):
+        with freeze_time(datetime(2020, 1, 5, 5, 0, tzinfo=ZoneInfo(self.team.timezone))):
             response = Trends().run(
                 Filter(data={"date_from": "-7d", "events": [{"id": "sign up", "name": "sign up"}]}, team=self.team),
                 self.team,
@@ -6014,7 +6013,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         self.team.save()
 
         # TRICKY: This is the previous UTC day in Asia/Tokyo
-        with freeze_time(pytz.timezone(self.team.timezone).localize(datetime(2020, 1, 26, 3, 0))):
+        with freeze_time(datetime(2020, 1, 26, 3, 0, tzinfo=ZoneInfo(self.team.timezone))):
             # Total volume query
             response_sunday = Trends().run(
                 Filter(
@@ -6035,7 +6034,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         self.team.save()
 
         # TRICKY: This is the previous UTC day in Asia/Tokyo
-        with freeze_time(pytz.timezone(self.team.timezone).localize(datetime(2020, 1, 26, 3, 0))):
+        with freeze_time(datetime(2020, 1, 26, 3, 0, tzinfo=ZoneInfo(self.team.timezone))):
             # Total volume query
             response_monday = Trends().run(
                 Filter(

--- a/posthog/queries/trends/trends.py
+++ b/posthog/queries/trends/trends.py
@@ -3,8 +3,8 @@ import threading
 from datetime import datetime, timedelta
 from itertools import accumulate
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from zoneinfo import ZoneInfo
 
-import pytz
 from dateutil import parser
 from django.db.models.query import Prefetch
 from sentry_sdk import push_scope
@@ -79,7 +79,7 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
             latest_date = cached_result[0]["days"][len(cached_result[0]["days"]) - 1]
 
             parsed_latest_date = parser.parse(latest_date)
-            parsed_latest_date = parsed_latest_date.replace(tzinfo=pytz.timezone(team.timezone))
+            parsed_latest_date = parsed_latest_date.replace(tzinfo=ZoneInfo(team.timezone))
             _is_present = is_filter_date_present(filter, parsed_latest_date)
         else:
             _is_present = False

--- a/posthog/queries/trends/trends.py
+++ b/posthog/queries/trends/trends.py
@@ -3,8 +3,8 @@ import threading
 from datetime import datetime, timedelta
 from itertools import accumulate
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
-from zoneinfo import ZoneInfo
 
+import pytz
 from dateutil import parser
 from django.db.models.query import Prefetch
 from sentry_sdk import push_scope
@@ -79,7 +79,7 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
             latest_date = cached_result[0]["days"][len(cached_result[0]["days"]) - 1]
 
             parsed_latest_date = parser.parse(latest_date)
-            parsed_latest_date = parsed_latest_date.replace(tzinfo=ZoneInfo(team.timezone))
+            parsed_latest_date = parsed_latest_date.replace(tzinfo=pytz.timezone(team.timezone))
             _is_present = is_filter_date_present(filter, parsed_latest_date)
         else:
             _is_present = False

--- a/posthog/queries/trends/trends.py
+++ b/posthog/queries/trends/trends.py
@@ -3,8 +3,8 @@ import threading
 from datetime import datetime, timedelta
 from itertools import accumulate
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from zoneinfo import ZoneInfo
 
-import pytz
 from dateutil import parser
 from django.db.models.query import Prefetch
 from sentry_sdk import push_scope
@@ -49,7 +49,6 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
 
     # Use cached result even on refresh if team has strict caching enabled
     def get_cached_result(self, filter: Filter, team: Team) -> Optional[List[Dict[str, Any]]]:
-
         if not team.strict_caching_enabled or filter.breakdown or filter.display != TRENDS_LINEAR:
             return None
 
@@ -80,7 +79,7 @@ class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
             latest_date = cached_result[0]["days"][len(cached_result[0]["days"]) - 1]
 
             parsed_latest_date = parser.parse(latest_date)
-            parsed_latest_date = parsed_latest_date.replace(tzinfo=pytz.timezone(team.timezone))
+            parsed_latest_date = parsed_latest_date.replace(tzinfo=ZoneInfo(team.timezone))
             _is_present = is_filter_date_present(filter, parsed_latest_date)
         else:
             _is_present = False

--- a/posthog/queries/trends/util.py
+++ b/posthog/queries/trends/util.py
@@ -1,6 +1,7 @@
 import datetime
 from datetime import timedelta
 from typing import Any, Dict, List, Optional, Tuple, TypeVar
+from zoneinfo import ZoneInfo
 
 import structlog
 from dateutil.relativedelta import relativedelta
@@ -190,5 +191,5 @@ def offset_time_series_date_by_interval(date: datetime.datetime, *, filter: F, t
     else:  # "day" is the default interval
         date = date.replace(hour=23, minute=59, second=59, microsecond=999999)
     if date.tzinfo is None:
-        date = date.replace(tzinfo=team.timezone)
+        date = date.replace(tzinfo=ZoneInfo(team.timezone))
     return date

--- a/posthog/queries/trends/util.py
+++ b/posthog/queries/trends/util.py
@@ -2,7 +2,6 @@ import datetime
 from datetime import timedelta
 from typing import Any, Dict, List, Optional, Tuple, TypeVar
 
-import pytz
 import structlog
 from dateutil.relativedelta import relativedelta
 from rest_framework.exceptions import ValidationError
@@ -191,5 +190,5 @@ def offset_time_series_date_by_interval(date: datetime.datetime, *, filter: F, t
     else:  # "day" is the default interval
         date = date.replace(hour=23, minute=59, second=59, microsecond=999999)
     if date.tzinfo is None:
-        date = pytz.timezone(team.timezone).localize(date)
+        date = date.replace(tzinfo=team.timezone)
     return date

--- a/posthog/queries/util.py
+++ b/posthog/queries/util.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from enum import Enum, auto
 from typing import Any, Dict, Optional, Union
 
+import pytz
 from zoneinfo import ZoneInfo
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
@@ -76,8 +77,9 @@ def format_ch_timestamp(timestamp: datetime, convert_to_timezone: Optional[str] 
         # Then we convert it back to UTC (08:00 in UTC)
         if timestamp.tzinfo and timestamp.tzinfo != ZoneInfo("UTC"):
             raise ValidationError(detail="You must pass a timestamp with no timezone or UTC")
-        timestamp = timestamp.replace(tzinfo=ZoneInfo(convert_to_timezone)).astimezone(ZoneInfo("UTC"))
-
+        timestamp = (
+            pytz.timezone(convert_to_timezone).localize(timestamp.replace(tzinfo=None)).astimezone(ZoneInfo("UTC"))
+        )
     return timestamp.strftime("%Y-%m-%d %H:%M:%S")
 
 

--- a/posthog/queries/util.py
+++ b/posthog/queries/util.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from enum import Enum, auto
 from typing import Any, Dict, Optional, Union
 
-import pytz
 from zoneinfo import ZoneInfo
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
@@ -77,9 +76,7 @@ def format_ch_timestamp(timestamp: datetime, convert_to_timezone: Optional[str] 
         # Then we convert it back to UTC (08:00 in UTC)
         if timestamp.tzinfo and timestamp.tzinfo != ZoneInfo("UTC"):
             raise ValidationError(detail="You must pass a timestamp with no timezone or UTC")
-        timestamp = (
-            pytz.timezone(convert_to_timezone).localize(timestamp.replace(tzinfo=None)).astimezone(ZoneInfo("UTC"))
-        )
+        timestamp = timestamp.replace(tzinfo=ZoneInfo(convert_to_timezone)).astimezone(ZoneInfo("UTC"))
 
     return timestamp.strftime("%Y-%m-%d %H:%M:%S")
 

--- a/posthog/queries/util.py
+++ b/posthog/queries/util.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from enum import Enum, auto
 from typing import Any, Dict, Optional, Union
 
-import pytz
 from zoneinfo import ZoneInfo
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
@@ -77,9 +76,7 @@ def format_ch_timestamp(timestamp: datetime, convert_to_timezone: Optional[str] 
         # Then we convert it back to UTC (08:00 in UTC)
         if timestamp.tzinfo and timestamp.tzinfo != ZoneInfo("UTC"):
             raise ValidationError(detail="You must pass a timestamp with no timezone or UTC")
-        timestamp = (
-            pytz.timezone(convert_to_timezone).localize(timestamp.replace(tzinfo=None)).astimezone(ZoneInfo("UTC"))
-        )
+        timestamp = timestamp.replace(tzinfo=ZoneInfo(convert_to_timezone)).astimezone(ZoneInfo("UTC"))
     return timestamp.strftime("%Y-%m-%d %H:%M:%S")
 
 


### PR DESCRIPTION
## Problem

See https://github.com/PostHog/posthog/pull/17310

## Changes

This PR replaces usages of pytz (other than listing timezones) with ZoneInfo.

## How did you test this code?

Debugger / CI run