### PR TITLE
fix(plugin-server): scrub IPs after plugins run

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
@@ -72,7 +72,6 @@ export async function populateTeamDataStep(
     event = {
         ...event,
         team_id: team.id,
-        ip: team.anonymize_ips ? null : event.ip,
     }
 
     return event as PluginEvent

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -121,8 +121,13 @@ export class EventsProcessor {
             delete properties['$elements']
         }
 
-        if (ip && !team.anonymize_ips && !('$ip' in properties)) {
-            properties['$ip'] = ip
+        if (ip) {
+            if (team.anonymize_ips) {
+                ip = null
+                delete properties['$ip']
+            } else if (!('$ip' in properties)) {
+                properties['$ip'] = ip
+            }
         }
 
         try {

--- a/plugin-server/tests/worker/ingestion/event-pipeline/populateTeamDataStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/populateTeamDataStep.test.ts
@@ -80,11 +80,13 @@ describe('populateTeamDataStep()', () => {
         expect(await getMetricValues('ingestion_event_dropped_total')).toEqual([])
     })
 
-    it('event with a valid token for a team with anonymize_ips=true gets its ip set to null', async () => {
+    it('event with a valid token for a team with anonymize_ips=true keeps its ip', async () => {
+        // NOTE: The IP is intentionally kept in `populateTeamDataStep` so that it is still
+        // available for plugins. It is later removed by `prepareEventStep`.
         jest.mocked(runner.hub.teamManager.getTeamByToken).mockReturnValue({ ...teamTwo, anonymize_ips: true })
         const response = await populateTeamDataStep(runner, { ...pipelineEvent, token: teamTwoToken })
 
-        expect(response).toEqual({ ...pipelineEvent, token: teamTwoToken, team_id: 2, ip: null })
+        expect(response).toEqual({ ...pipelineEvent, token: teamTwoToken, team_id: 2, ip: '127.0.0.1' })
         expect(await getMetricValues('ingestion_event_dropped_total')).toEqual([])
     })
 

--- a/plugin-server/tests/worker/ingestion/event-pipeline/prepareEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/prepareEventStep.test.ts
@@ -1,7 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 
-import { Hub, Person } from '../../../../src/types'
+import { Hub, Person, Team } from '../../../../src/types'
 import { createHub } from '../../../../src/utils/db/hub'
 import { UUIDT } from '../../../../src/utils/utils'
 import { prepareEventStep } from '../../../../src/worker/ingestion/event-pipeline/prepareEventStep'
@@ -34,6 +34,18 @@ const person: Person = {
     version: 0,
 }
 
+const teamTwo: Team = {
+    id: 2,
+    uuid: 'af95d312-1a0a-4208-b80f-562ddafc9bcd',
+    organization_id: '66f3f7bf-44e2-45dd-9901-5dbd93744e3a',
+    name: 'testTeam',
+    anonymize_ips: false,
+    api_token: 'token',
+    slack_incoming_webhook: '',
+    session_recording_opt_in: false,
+    ingested_event: true,
+}
+
 describe('prepareEventStep()', () => {
     let runner: any
     let hub: Hub
@@ -48,6 +60,11 @@ describe('prepareEventStep()', () => {
             'my_id',
         ])
         hub.db.kafkaProducer!.queueMessage = jest.fn()
+
+        // eslint-disable-next-line @typescript-eslint/require-await
+        hub.eventsProcessor.teamManager.fetchTeam = jest.fn(async (teamId) => {
+            return teamId === 2 ? teamTwo : null
+        })
 
         runner = {
             nextStep: (...args: any[]) => args,
@@ -71,6 +88,26 @@ describe('prepareEventStep()', () => {
             properties: {
                 $ip: '127.0.0.1',
             },
+            teamId: 2,
+            timestamp: '2020-02-23T02:15:00.000Z',
+        })
+        expect(hub.db.kafkaProducer!.queueMessage).not.toHaveBeenCalled()
+    })
+
+    it('scrubs IPs when team.anonymize_ips=true', async () => {
+        jest.mocked(runner.hub.eventsProcessor.teamManager.fetchTeam).mockReturnValue({
+            ...teamTwo,
+            anonymize_ips: true,
+        })
+        const response = await prepareEventStep(runner, pluginEvent)
+
+        expect(response).toEqual({
+            distinctId: 'my_id',
+            elementsList: [],
+            event: 'default event',
+            eventUuid: '017ef865-19da-0000-3b60-1506093bf40f',
+            ip: null,
+            properties: {},
             teamId: 2,
             timestamp: '2020-02-23T02:15:00.000Z',
         })


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
This is a step towards deprecating the Advanced GeoIP community plugin. By scrubbing IPs after plugins run, we'll allow the official PostHog GeoIP plugin to do its thing even if users enable IP anonymization.

Before merging and deploying this we'll want to disable the GeoIP plugin for anyone with IP anonymization on, so that nothing changes for them.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

* scrub IPs after plugins run

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
Just existing tests.