### PR TITLE
chore: bump cypress timeout to 60 mins

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -70,7 +70,7 @@ jobs:
     cypress:
         name: Cypress E2E tests (${{ strategy.job-index }})
         runs-on: ubuntu-latest
-        timeout-minutes: 30
+        timeout-minutes: 60
         needs: [chunks, changes]
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run


### PR DESCRIPTION
## Problem

Cypress runs were timing out and failing. See: https://posthog.slack.com/archives/C0113360FFV/p1694118907658599

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Bumps from 30 to 60 mins timeout.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
