### PR TITLE
feat: no whitenoise compression

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -219,7 +219,7 @@ USE_TZ = True
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 STATIC_URL = "/static/"
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "frontend/dist"), os.path.join(BASE_DIR, "posthog/year_in_posthog/images")]
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STATICFILES_STORAGE = "whitenoise.storage.ManifestStaticFilesStorage"
 
 AUTH_USER_MODEL = "posthog.User"
 

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@ antlr4-python3-runtime==4.13.0
 amqp==2.6.0
 boto3==1.26.66
 boto3-stubs[s3]
-brotli==1.0.9
+brotli==1.1.0
 celery==4.4.7
 celery-redbeat==2.0.0
 clickhouse-driver==0.2.4
@@ -78,7 +78,7 @@ temporalio==1.1.0
 token-bucket==0.3.0
 toronado==0.1.0
 webdriver_manager==3.8.5
-whitenoise==5.2.0
+whitenoise==6.5.0
 mimesis==5.2.1
 more-itertools==9.0.0
 django-two-factor-auth==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,8 +51,10 @@ botocore==1.29.66
     #   s3transfer
 botocore-stubs==1.29.130
     # via boto3-stubs
-brotli==1.0.9
+brotli==1.1.0
     # via -r requirements.in
+cachetools==5.3.1
+    # via google-auth
 celery==4.4.7
     # via
     #   -r requirements.in
@@ -507,7 +509,7 @@ vine==1.3.0
     #   celery
 webdriver-manager==3.8.5
     # via -r requirements.in
-whitenoise==5.2.0
+whitenoise==6.5.0
     # via -r requirements.in
 wsproto==1.1.0
     # via trio-websocket


### PR DESCRIPTION
## Problem

We use `whitenoise` to serve static files from Django, and have that configured to compress files when we run `collectstatic`.

The time to run `collectstatic` varies pretty wildly in our Depot build. Sometimes taking over 12 minutes. Running locally you can see that the time is spent producing a brotli and gzip compressed version of each file. When running Django `whitenoise` picks the appropriate file based on the request headers.

Running `collectstatic` without compression completes in seconds.

However, we now have app.posthog.com behind the cloudfront CDN. Cloudfront requests the uncompressed version of the file, compresses it (if appropriate) and serves that version of the file. So, we're spending build minutes and developer minutes waiting on the compression of files that will never be served.

----

Technically, if whitenoise is serving files with [the correct combination of headers _and_ returning compressed content](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html) then CloudFront will cache that already compressed content without compressing it. 

However, we allow long cache times for static assets and JIT compression with CloudFront after a deploy will be fast enough for rock and roll

[cache policy](https://github.com/PostHog/posthog-cloud-infra/blob/ca7a8081806b235cc91cedd2315aee53d5818062/terraform/modules/posthog/s3/static_assets.tf#L81) means we [cache for one year](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-caching-optimized) 


----

## Changes

* upgrades `whitenoise` and brotli because
    a) why not
    b) to confirm that doesn't affect the `collectstatic` time
    c) the version of `whitenoise` we were using didn't officially support Python 3.10
* switches the `whitenoise` storage we use so that we don't produce compressed files

NB this means that if someone is using the docker image and doesn't have it behind a proxy/CDN that is compressing files they will no longer serve compressed static files. I think this trade-off is ok... if someone wants their self-hosted deployment to perform well they should already be using a proxy or CDN that could do this compression - they may well already be using cloudfront and be in the same position as us.

## How did you test this code?

running locally and seeing I could still run Django
