### PR TITLE
fix: hedgehog mode meets dark mode badly

### DIFF
--- a/frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.stories.tsx
+++ b/frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.stories.tsx
@@ -19,6 +19,7 @@ export const TheHedgehog: StoryFn<typeof HedgehogBuddy> = () => {
                     // eslint-disable-next-line no-console
                     console.log('should close')
                 }}
+                isDarkModeOn={false}
             />
         </div>
     )

--- a/frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.tsx
+++ b/frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.tsx
@@ -390,16 +390,17 @@ export function HedgehogBuddy({
     onClick: _onClick,
     onPositionChange,
     popoverOverlay,
+    isDarkModeOn,
 }: {
     actorRef?: MutableRefObject<HedgehogActor | undefined>
     onClose: () => void
     onClick?: () => void
     onPositionChange?: (actor: HedgehogActor) => void
     popoverOverlay?: React.ReactNode
+    // passed in because toolbar needs to check this differently than the app
+    isDarkModeOn: boolean
 }): JSX.Element {
     const actorRef = useRef<HedgehogActor>()
-
-    const { isDarkModeOn } = useValues(themeLogic)
 
     if (!actorRef.current) {
         actorRef.current = new HedgehogActor()
@@ -538,6 +539,11 @@ export function HedgehogBuddy({
 export function HedgehogBuddyWithLogic(): JSX.Element {
     const { hedgehogModeEnabled } = useValues(hedgehogbuddyLogic)
     const { setHedgehogModeEnabled } = useActions(hedgehogbuddyLogic)
+    const { isDarkModeOn } = useValues(themeLogic)
 
-    return hedgehogModeEnabled ? <HedgehogBuddy onClose={() => setHedgehogModeEnabled(false)} /> : <></>
+    return hedgehogModeEnabled ? (
+        <HedgehogBuddy onClose={() => setHedgehogModeEnabled(false)} isDarkModeOn={isDarkModeOn} />
+    ) : (
+        <></>
+    )
 }

--- a/frontend/src/toolbar/button/HedgehogButton.tsx
+++ b/frontend/src/toolbar/button/HedgehogButton.tsx
@@ -45,6 +45,7 @@ export function HedgehogButton(): JSX.Element {
                     onPositionChange={(actor) => {
                         saveDragPosition(actor.x + SPRITE_SIZE * 0.5, -actor.y - SPRITE_SIZE * 0.5)
                     }}
+                    isDarkModeOn={false}
                 />
             )}
         </>


### PR DESCRIPTION
I thought this bug was introduced _and_ fixed in #17276 

But actually it exists separate to the PR already

When switching to hedgehog mode in the toolbar we try and read a feature flag that is only available in the app.... So, if you try to activate hedgehog mode then the toolbar crashes

<img width="834" alt="Screenshot 2023-09-10 at 20 06 37" src="https://github.com/PostHog/posthog/assets/984817/c8abc380-8a6a-49ea-afa7-b7e905a93634">

Well, not any more!