### PR TITLE
fix: Styles for clicking bottom of notebook

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/Notebook.scss
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.scss
@@ -1,4 +1,8 @@
 .Notebook {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+
     .NotebookEditor {
         flex: 1;
         width: 100%;
@@ -103,9 +107,10 @@
     }
 
     &--editable {
-        .NotebookEditor {
+        .NotebookEditor .ProseMirror {
             // Add some padding to help clicking below the last element
             padding-bottom: 10rem;
+            flex: 1;
         }
     }
 


### PR DESCRIPTION
## Problem

Looks like in some of the refactoring the styles changed such that the prose editor was no longer filling the view, meaning clicking below the bottom element was really hard. This fixes it 

## Changes

|Before|After|
|----|----|
| <img width="838" alt="Screenshot 2023-09-11 at 14 42 02" src="https://github.com/PostHog/posthog/assets/2536520/c45e988a-6cbd-4a3b-8c19-0a73d31c86af"> | <img width="825" alt="Screenshot 2023-09-11 at 14 41 37" src="https://github.com/PostHog/posthog/assets/2536520/21065020-3290-4057-bfe3-dff909b954ce"> |

* Fixes the styles so it is properly fixed and the padding is in the right place.


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
