### PR TITLE
fix: Wrap Editor with ErrorBoundary and solve all problems

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
@@ -16,6 +16,7 @@ import { EditorFocusPosition } from './utils'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { NotebookSidebar } from './NotebookSidebar'
+import { ErrorBoundary } from '~/layout/ErrorBoundary'
 
 export type NotebookProps = {
     shortId: string
@@ -101,23 +102,25 @@ export function Notebook({ shortId, editable = false, initialAutofocus = null }:
                     <FlaggedFeature flag={FEATURE_FLAGS.NOTEBOOK_SETTINGS_WIDGETS}>
                         <NotebookSidebar />
                     </FlaggedFeature>
-                    <Editor
-                        initialContent={content}
-                        onCreate={setEditor}
-                        onUpdate={onEditorUpdate}
-                        onSelectionUpdate={onEditorSelectionUpdate}
-                        placeholder={({ node }: { node: any }) => {
-                            if (node.type.name === 'heading' && node.attrs.level === 1) {
-                                return `Untitled - maybe.. "${headingPlaceholder}"`
-                            }
+                    <ErrorBoundary>
+                        <Editor
+                            initialContent={content}
+                            onCreate={setEditor}
+                            onUpdate={onEditorUpdate}
+                            onSelectionUpdate={onEditorSelectionUpdate}
+                            placeholder={({ node }: { node: any }) => {
+                                if (node.type.name === 'heading' && node.attrs.level === 1) {
+                                    return `Untitled - maybe.. "${headingPlaceholder}"`
+                                }
 
-                            if (node.type.name === 'heading') {
-                                return `Heading ${node.attrs.level}`
-                            }
+                                if (node.type.name === 'heading') {
+                                    return `Heading ${node.attrs.level}`
+                                }
 
-                            return ''
-                        }}
-                    />
+                                return ''
+                            }}
+                        />
+                    </ErrorBoundary>
                 </div>
             </div>
         </BindLogic>


### PR DESCRIPTION
## Problem

Related to the tiptap bug.

I was getting annoyed locally debugging, so thought "I'll wrap it with an ErrorBoundary for now". Turns out this _basically_ solves the problem...

## Changes

As far as I understand:
1. The Editor errors out
2. The ErrorBoundary catches it and renders a handled error screen...
3. ...but the parent component gets unmounted...
4. Meaning there is no error anymore!


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
