### PR TITLE
chore: Bump psycopg2

### DIFF
--- a/posthog/temporal/workflows/postgres_batch_export.py
+++ b/posthog/temporal/workflows/postgres_batch_export.py
@@ -58,9 +58,10 @@ def copy_tsv_to_postgres(tsv_file, postgres_connection, schema: str, table_name:
     tsv_file.seek(0)
 
     with postgres_connection.cursor() as cursor:
+        cursor.execute(sql.SQL("SET search_path TO {schema}").format(schema=sql.Identifier(schema)))
         cursor.copy_from(
             tsv_file,
-            sql.Identifier(schema, table_name).as_string(postgres_connection),
+            table_name,
             null="",
             columns=schema_columns,
         )

--- a/requirements.in
+++ b/requirements.in
@@ -55,7 +55,7 @@ pickleshare==0.7.5
 Pillow==9.2.0
 posthoganalytics==3.0.1
 prance==0.22.2.22.0
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.7
 pyarrow==12.0.1
 pydantic==1.10.4
 pyjwt==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,8 @@ botocore-stubs==1.29.130
     # via boto3-stubs
 brotli==1.0.9
     # via -r requirements.in
+cachetools==5.3.1
+    # via google-auth
 celery==4.4.7
     # via
     #   -r requirements.in
@@ -319,7 +321,7 @@ protobuf==4.22.1
     #   grpcio-status
     #   proto-plus
     #   temporalio
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.7
     # via -r requirements.in
 ptyprocess==0.6.0
     # via pexpect


### PR DESCRIPTION
## Problem

We are currently running version 13 of `libpq` as it comes bundled with `psycopg2-binary`. Version 14 and later of `libpq` come with SNI support (deduced this by comparing [Postgres docs](https://www.postgresql.org/docs/13/libpq-connect.html)). SNI support is required for Postgres instances hosted by Vercel/Neon which may be users of batch exports. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

We may have a quick win by bumping `psycopg2-binary`. This would install a newer `libpq` (15) and potentially address the issue. Even if it doesn't work, keeping up to date with minor version bumps of dependencies should be safe. Moreover, we will need to bump this eventually to support Python 3.11.

EDIT: Also had to do a small update on batch exports: Starting with psycopg2 version 2.9, the `copy_from` function now quotes the table identifier, so we don't need to pass a `sql.Identifier` ourselves. However, this means we cannot pass a schema, and instead need to set the search path before running COPY.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
