### PR TITLE
feat: blobby should never drop a message because of consumer destination now

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
@@ -105,16 +105,6 @@ export class ReplayEventsIngester {
             return drop('producer_not_ready')
         }
 
-        if (event.replayIngestionConsumer !== 'v2') {
-            eventDroppedCounter
-                .labels({
-                    event_type: 'session_recordings_replay_events',
-                    drop_cause: 'not_target_consumer',
-                })
-                .inc()
-            return
-        }
-
         if (
             await this.offsetHighWaterMarker.isBelowHighWaterMark(
                 event.metadata,

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
@@ -279,7 +279,6 @@ export class SessionRecordingIngesterV2 {
             session_id: event.properties?.$session_id,
             window_id: event.properties?.$window_id,
             events: event.properties.$snapshot_items,
-            replayIngestionConsumer: event.properties?.$snapshot_consumer ?? 'v1',
         }
 
         return recordingMessage

--- a/plugin-server/src/main/ingestion-queues/session-recording/types.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/types.ts
@@ -14,8 +14,6 @@ export type IncomingRecordingMessage = {
     session_id: string
     window_id?: string
     events: RRWebEvent[]
-    // NOTE: This is only for migrating from one consumer to the other
-    replayIngestionConsumer: 'v1' | 'v2'
 }
 
 // This is the incoming message from Kafka

--- a/plugin-server/tests/main/ingestion-queues/session-recording/fixtures.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/fixtures.ts
@@ -16,7 +16,6 @@ export function createIncomingRecordingMessage(
         session_id: 'session_id_1',
         window_id: 'window_id_1',
         events: [{ ...jsonFullSnapshot }],
-        replayIngestionConsumer: 'v2',
         ...partialIncomingMessage,
 
         metadata: {

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
@@ -211,7 +211,6 @@ describe('ingester', () => {
                     timestamp: 1,
                     topic: 'the_topic',
                 },
-                replayIngestionConsumer: 'v2',
                 session_id: '018a47c2-2f4a-70a8-b480-5e51d8b8d070',
                 team_id: 1,
                 window_id: '018a47c2-2f4a-70a8-b480-5e52f5480448',


### PR DESCRIPTION
We don't ever want to roll ingestion back to the "legacy" consumer.

let's make sure we can't drop messages because of consumer destination 