### PR TITLE
feat: OnEvent efficient batching by actually used events

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
@@ -4,20 +4,18 @@ import { EachBatchPayload, KafkaMessage } from 'kafkajs'
 import { RawClickHouseEvent } from '../../../types'
 import { convertToIngestionEvent } from '../../../utils/event'
 import { status } from '../../../utils/status'
-import { groupIntoBatches } from '../../../utils/utils'
 import { runInstrumentedFunction } from '../../utils'
 import { KafkaJSIngestionConsumer } from '../kafka-queue'
 import { eventDroppedCounter, latestOffsetTimestampGauge } from '../metrics'
+import { eachBatchHandlerHelper } from './each-batch-webhooks'
 
 // Must require as `tsc` strips unused `import` statements and just requiring this seems to init some globals
 require('@sentry/tracing')
 
 export async function eachMessageAppsOnEventHandlers(
-    message: KafkaMessage,
+    clickHouseEvent: RawClickHouseEvent,
     queue: KafkaJSIngestionConsumer
 ): Promise<void> {
-    const clickHouseEvent = JSON.parse(message.value!.toString()) as RawClickHouseEvent
-
     const pluginConfigs = queue.pluginsServer.pluginConfigsPerTeam.get(clickHouseEvent.team_id)
     if (pluginConfigs) {
         // Elements parsing can be extremely slow, so we skip it for some plugins
@@ -50,7 +48,14 @@ export async function eachBatchAppsOnEventHandlers(
     payload: EachBatchPayload,
     queue: KafkaJSIngestionConsumer
 ): Promise<void> {
-    await eachBatch(payload, queue, eachMessageAppsOnEventHandlers, groupIntoBatches, 'async_handlers_on_event')
+    await eachBatchHandlerHelper(
+        payload,
+        (teamId) => queue.pluginsServer.pluginConfigsPerTeam.has(teamId),
+        (event) => eachMessageAppsOnEventHandlers(event, queue),
+        queue.pluginsServer.statsd,
+        queue.pluginsServer.WORKER_CONCURRENCY * queue.pluginsServer.TASKS_PER_WORKER,
+        'on_event'
+    )
 }
 
 export async function eachBatch(

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-webhooks.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-webhooks.ts
@@ -84,7 +84,7 @@ export async function eachBatchHandlerHelper(
     const loggingKey = `each_batch_${key}`
     const { batch, resolveOffset, heartbeat, commitOffsetsIfNecessary, isRunning, isStale }: EachBatchPayload = payload
 
-    const transaction = Sentry.startTransaction({ name: `eachBatchWebhooks` })
+    const transaction = Sentry.startTransaction({ name: `eachBatch${stats_key}` })
 
     try {
         const batchesWithOffsets = groupIntoBatchesByUsage(batch.messages, concurrency, shouldProcess)

--- a/plugin-server/src/utils/utils.ts
+++ b/plugin-server/src/utils/utils.ts
@@ -312,14 +312,6 @@ export function escapeClickHouseString(string: string): string {
     return string.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
 }
 
-export function groupIntoBatches<T>(array: T[], batchSize: number): T[][] {
-    const batches = []
-    for (let i = 0; i < array.length; i += batchSize) {
-        batches.push(array.slice(i, i + batchSize))
-    }
-    return batches
-}
-
 /** Standardize JS code used internally to form without extraneous indentation. Template literal function. */
 export function code(strings: TemplateStringsArray): string {
     const stringsConcat = strings.join('…')

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -9,10 +9,7 @@ import {
     eachBatchLegacyIngestion,
     splitKafkaJSIngestionBatch,
 } from '../../../src/main/ingestion-queues/batch-processing/each-batch-ingestion-kafkajs'
-import {
-    eachBatch,
-    eachBatchAppsOnEventHandlers,
-} from '../../../src/main/ingestion-queues/batch-processing/each-batch-onevent'
+import { eachBatchAppsOnEventHandlers } from '../../../src/main/ingestion-queues/batch-processing/each-batch-onevent'
 import {
     eachBatchWebhooksHandlers,
     groupIntoBatchesByUsage,
@@ -24,7 +21,6 @@ import {
     PostIngestionEvent,
     RawClickHouseEvent,
 } from '../../../src/types'
-import { groupIntoBatches } from '../../../src/utils/utils'
 import { ActionManager } from '../../../src/worker/ingestion/action-manager'
 import { ActionMatcher } from '../../../src/worker/ingestion/action-matcher'
 import { HookCommander } from '../../../src/worker/ingestion/hooks'
@@ -148,26 +144,6 @@ describe('eachBatchX', () => {
                 runEventPipeline: jest.fn(() => Promise.resolve({})),
             },
         }
-    })
-
-    describe('eachBatch', () => {
-        it('calls eachMessage with the correct arguments', async () => {
-            const eachMessage = jest.fn(() => Promise.resolve())
-            const batch = createKafkaJSBatch(event)
-            await eachBatch(batch, queue, eachMessage, groupIntoBatches, 'key')
-
-            expect(eachMessage).toHaveBeenCalledWith({ value: JSON.stringify(event) }, queue)
-        })
-
-        it('tracks metrics based on the key', async () => {
-            const eachMessage = jest.fn(() => Promise.resolve())
-            await eachBatch(createKafkaJSBatch(event), queue, eachMessage, groupIntoBatches, 'my_key')
-
-            expect(queue.pluginsServer.statsd.timing).toHaveBeenCalledWith(
-                'kafka_queue.each_batch_my_key',
-                expect.any(Date)
-            )
-        })
     })
 
     describe('eachBatchAppsOnEventHandlers', () => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We currently batch N random events to be processed in parallel, but many of those don't have any plugins to be processed, so we often end up waiting on a single fetch at a time, which could cause lag.
This is similar to the change we already did for webhooks.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
