### PR TITLE
feat: Create insight graphs directly in Notebooks

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -123,6 +123,12 @@ export const NotebookNodeQuery = createPostHogWidgetNode<NotebookNodeQueryAttrib
             } else {
                 title = 'Data exploration'
             }
+        } else if (NodeKind.InsightVizNode === query.kind) {
+            if (query.source.kind) {
+                title = query.source.kind.replace('Node', '').replace('Query', '')
+            } else {
+                title = 'Insight'
+            }
         }
         return Promise.resolve(title)
     },

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.scss
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.scss
@@ -145,7 +145,7 @@
 
         &__content {
             max-height: calc(100vh - 220px);
-            overflow: scroll;
+            overflow: auto;
         }
     }
 

--- a/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
@@ -3,7 +3,19 @@ import Suggestion from '@tiptap/suggestion'
 
 import { ReactRenderer } from '@tiptap/react'
 import { LemonButton, LemonDivider, lemonToast } from '@posthog/lemon-ui'
-import { IconCohort, IconQueryEditor, IconRecording, IconTableChart, IconUploadFile } from 'lib/lemon-ui/icons'
+import {
+    IconCohort,
+    IconRecording,
+    IconTableChart,
+    IconUploadFile,
+    InsightSQLIcon,
+    InsightsFunnelsIcon,
+    InsightsLifecycleIcon,
+    InsightsPathsIcon,
+    InsightsRetentionIcon,
+    InsightsStickinessIcon,
+    InsightsTrendsIcon,
+} from 'lib/lemon-ui/icons'
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react'
 import { EditorCommands, EditorRange } from './utils'
 import { NotebookNodeType } from '~/types'
@@ -58,9 +70,178 @@ const TEXT_CONTROLS: SlashCommandsItem[] = [
 
 const SLASH_COMMANDS: SlashCommandsItem[] = [
     {
+        title: 'Trend',
+        search: 'trend insight',
+        icon: <InsightsTrendsIcon noBackground color="currentColor" />,
+        command: (chain) =>
+            chain.insertContent({
+                type: NotebookNodeType.Query,
+                attrs: {
+                    query: {
+                        kind: 'InsightVizNode',
+                        source: {
+                            kind: 'TrendsQuery',
+                            filterTestAccounts: false,
+                            series: [
+                                {
+                                    kind: 'EventsNode',
+                                    event: '$pageview',
+                                    name: '$pageview',
+                                    math: 'total',
+                                },
+                            ],
+                            interval: 'day',
+                            trendsFilter: {
+                                display: 'ActionsLineGraph',
+                            },
+                        },
+                    },
+                },
+            }),
+    },
+    {
+        title: 'Funnel',
+        search: 'funnel insight',
+        icon: <InsightsFunnelsIcon noBackground color="currentColor" />,
+        command: (chain) =>
+            chain.insertContent({
+                type: NotebookNodeType.Query,
+                attrs: {
+                    query: {
+                        kind: 'InsightVizNode',
+                        source: {
+                            kind: 'FunnelsQuery',
+                            series: [
+                                {
+                                    kind: 'EventsNode',
+                                    name: '$pageview',
+                                    event: '$pageview',
+                                },
+                                {
+                                    kind: 'EventsNode',
+                                    name: '$pageview',
+                                    event: '$pageview',
+                                },
+                            ],
+                            funnelsFilter: {
+                                funnel_viz_type: 'steps',
+                            },
+                        },
+                    },
+                },
+            }),
+    },
+    {
+        title: 'Retention',
+        search: 'retention insight',
+        icon: <InsightsRetentionIcon noBackground color="currentColor" />,
+        command: (chain) =>
+            chain.insertContent({
+                type: NotebookNodeType.Query,
+                attrs: {
+                    query: {
+                        kind: 'InsightVizNode',
+                        source: {
+                            kind: 'RetentionQuery',
+                            retentionFilter: {
+                                period: 'Day',
+                                total_intervals: 11,
+                                target_entity: {
+                                    id: '$pageview',
+                                    name: '$pageview',
+                                    type: 'events',
+                                },
+                                returning_entity: {
+                                    id: '$pageview',
+                                    name: '$pageview',
+                                    type: 'events',
+                                },
+                                retention_type: 'retention_first_time',
+                            },
+                        },
+                    },
+                },
+            }),
+    },
+    {
+        title: 'Paths',
+        search: 'paths insight',
+        icon: <InsightsPathsIcon noBackground color="currentColor" />,
+        command: (chain) =>
+            chain.insertContent({
+                type: NotebookNodeType.Query,
+                attrs: {
+                    query: {
+                        kind: 'InsightVizNode',
+                        source: {
+                            kind: 'PathsQuery',
+                            pathsFilter: {
+                                include_event_types: ['$pageview'],
+                            },
+                        },
+                    },
+                },
+            }),
+    },
+    {
+        title: 'Stickiness',
+        search: 'stickiness insight',
+        icon: <InsightsStickinessIcon noBackground color="currentColor" />,
+        command: (chain) =>
+            chain.insertContent({
+                type: NotebookNodeType.Query,
+                attrs: {
+                    query: {
+                        kind: 'InsightVizNode',
+                        source: {
+                            kind: 'StickinessQuery',
+                            series: [
+                                {
+                                    kind: 'EventsNode',
+                                    name: '$pageview',
+                                    event: '$pageview',
+                                    math: 'total',
+                                },
+                            ],
+                            stickinessFilter: {},
+                        },
+                    },
+                },
+            }),
+    },
+    {
+        title: 'Lifecycle',
+        search: 'lifecycle insight',
+        icon: <InsightsLifecycleIcon noBackground color="currentColor" />,
+        command: (chain) =>
+            chain.insertContent({
+                type: NotebookNodeType.Query,
+                attrs: {
+                    query: {
+                        kind: 'InsightVizNode',
+                        source: {
+                            kind: 'LifecycleQuery',
+                            series: [
+                                {
+                                    kind: 'EventsNode',
+                                    name: '$pageview',
+                                    event: '$pageview',
+                                    math: 'total',
+                                },
+                            ],
+                            lifecycleFilter: {
+                                shown_as: 'Lifecycle',
+                            },
+                        },
+                        full: true,
+                    },
+                },
+            }),
+    },
+    {
         title: 'HogQL',
         search: 'sql',
-        icon: <IconQueryEditor />,
+        icon: <InsightSQLIcon noBackground color="currentColor" />,
         command: (chain) =>
             chain.insertContent({ type: NotebookNodeType.Query, attrs: { query: examples['HogQLTable'] } }),
     },


### PR DESCRIPTION
## Problem

We almost support insights, may as well start making them directly create-able in a notebook

## Changes

* Adds a bunch of slash commands for insights
*  Also fixes the scroll css for settings

<img width="790" alt="Screenshot 2023-09-12 at 18 26 41" src="https://github.com/PostHog/posthog/assets/2536520/5a43af7a-ffcd-430a-b963-197900693be2">
<img width="781" alt="Screenshot 2023-09-12 at 18 26 49" src="https://github.com/PostHog/posthog/assets/2536520/1fd43c66-65a4-4dc8-9174-2bf9b7fad759">



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
