### PR TITLE
feat(plugin-server): add KAFKA_CONSUMPTION_RDKAFKA_COOPERATIVE_REBALANCE which defaults to true, fix metrics for eager

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -44,6 +44,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_SASL_PASSWORD: undefined,
         KAFKA_CLIENT_RACK: undefined,
         KAFKA_CONSUMPTION_USE_RDKAFKA: false, // Transitional setting, ignored for consumers that only support one library
+        KAFKA_CONSUMPTION_RDKAFKA_COOPERATIVE_REBALANCE: true, // If true, use the cooperative rebalance strategy, otherwise uses the default ('range,roundrobin')
         KAFKA_CONSUMPTION_MAX_BYTES: 10_485_760, // Default value for kafkajs
         KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION: 1_048_576, // Default value for kafkajs, must be bigger than message size
         KAFKA_CONSUMPTION_MAX_WAIT_MS: 1_000, // Down from the 5s default for kafkajs

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -59,13 +59,12 @@ export const createKafkaConsumer = async (config: ConsumerGlobalConfig) => {
 export function countPartitionsPerTopic(assignments: Assignment[]): Map<string, number> {
     const partitionsPerTopic = new Map()
     for (const assignment of assignments) {
-        if (assignment.topic in partitionsPerTopic) {
+        if (partitionsPerTopic.has(assignment.topic)) {
             partitionsPerTopic.set(assignment.topic, partitionsPerTopic.get(assignment.topic) + 1)
         } else {
             partitionsPerTopic.set(assignment.topic, 1)
         }
     }
-
     return partitionsPerTopic
 }
 

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -255,6 +255,7 @@ export class IngestionConsumer {
             consumerMaxWaitMs: this.pluginsServer.KAFKA_CONSUMPTION_MAX_WAIT_MS,
             fetchBatchSize: 500,
             topicCreationTimeoutMs: this.pluginsServer.KAFKA_TOPIC_CREATION_TIMEOUT_MS,
+            cooperativeRebalance: this.pluginsServer.KAFKA_CONSUMPTION_RDKAFKA_COOPERATIVE_REBALANCE,
             eachBatch: (payload) => this.eachBatchConsumer(payload),
         })
         this.consumerReady = true

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -129,6 +129,7 @@ export interface PluginsServerConfig {
     KAFKA_SASL_PASSWORD: string | undefined
     KAFKA_CLIENT_RACK: string | undefined
     KAFKA_CONSUMPTION_USE_RDKAFKA: boolean
+    KAFKA_CONSUMPTION_RDKAFKA_COOPERATIVE_REBALANCE: boolean
     KAFKA_CONSUMPTION_MAX_BYTES: number
     KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION: number
     KAFKA_CONSUMPTION_MAX_WAIT_MS: number // fetch.wait.max.ms rdkafka parameter

--- a/plugin-server/tests/main/ingestion-queues/kafka-queue.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/kafka-queue.test.ts
@@ -1,4 +1,7 @@
+import { Assignment } from 'node-rdkafka-acosom'
+
 import { KAFKA_EVENTS_PLUGIN_INGESTION } from '../../../src/config/kafka-topics'
+import { countPartitionsPerTopic } from '../../../src/kafka/consumer'
 import { ServerInstance, startPluginsServer } from '../../../src/main/pluginsServer'
 import { LogLevel, PluginsServerConfig } from '../../../src/types'
 import { Hub } from '../../../src/types'
@@ -77,5 +80,24 @@ describe.skip('IngestionConsumer', () => {
 
         const bufferCalls = statsdTimingCalls.filter((item: string[]) => item[0] === 'kafka_queue.ingest_buffer_event')
         expect(bufferCalls.length).toEqual(1)
+    })
+})
+
+describe('countPartitionsPerTopic', () => {
+    it('should correctly count the number of partitions per topic', () => {
+        const assignments: Assignment[] = [
+            { topic: 'topic1', partition: 0 },
+            { topic: 'topic1', partition: 1 },
+            { topic: 'topic2', partition: 0 },
+            { topic: 'topic2', partition: 1 },
+            { topic: 'topic2', partition: 2 },
+            { topic: 'topic3', partition: 0 },
+        ]
+
+        const result = countPartitionsPerTopic(assignments)
+        expect(result.get('topic1')).toBe(2)
+        expect(result.get('topic2')).toBe(3)
+        expect(result.get('topic3')).toBe(1)
+        expect(result.size).toBe(3)
     })
 })


### PR DESCRIPTION
## Problem

We want to try eager rebalances for event ingestion.

## Changes

Add KAFKA_CONSUMPTION_RDKAFKA_COOPERATIVE_REBALANCE (defaults to true so we don't break recordings).

Also fix metric calculcation.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

CI and local.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
