### PR TITLE
fix(ci): ensure container image is built before e2e tests

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -67,11 +67,30 @@ jobs:
               id: chunk
               run: echo "chunks=$(ls cypress/e2e/* | jq --slurp --raw-input -c 'split("\n")[:-1] | _nwise(3) | join("\n")' | jq --slurp -c .)" >> $GITHUB_OUTPUT
 
+    container:
+        name: Build and cache container image
+        runs-on: ubuntu-latest
+        timeout-minutes: 60
+        needs: [changes]
+        permissions:
+            contents: read
+            id-token: write # allow issuing OIDC tokens for this workflow run
+        steps:
+            - name: Checkout
+              if: needs.changes.outputs.shouldTriggerCypress == 'true'
+              uses: actions/checkout@v3
+            - name: Get Docker image cached in Depot
+              if: needs.changes.outputs.shouldTriggerCypress == 'true'
+              # Build the container image in preparation for the E2E tests
+              uses: ./.github/actions/build-n-cache-image
+              with:
+                  actions-id-token-request-url: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}
+
     cypress:
         name: Cypress E2E tests (${{ strategy.job-index }})
         runs-on: ubuntu-latest
         timeout-minutes: 60
-        needs: [chunks, changes]
+        needs: [chunks, changes, container]
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
 

--- a/.github/workflows/customer-data-pipeline.yml
+++ b/.github/workflows/customer-data-pipeline.yml
@@ -46,7 +46,7 @@ jobs:
                   images: ghcr.io/${{ steps.lowercase.outputs.repository }}/cdp
 
             # Make the image tags used for docker cache. We use this rather than
-            # ${{ github.repository }} directly because the repository
+            # ${{ github.repository }} directly because the repository
             # organization name is has upper case characters, which are not
             # allowed in docker image names.
             - uses: docker/metadata-action@v4


### PR DESCRIPTION
## Problem

It's possible for the "fetch container from Depot" step in the e2e tests to not find a cached container - this is because currently it is relying on the `container-images-ci.yml` workflow to build the container, but it's effectively a race condition which one starts first.

This results in longer builds, since each of the 11 workflows starts its own build, and this consumes unnecessary Depot build minutes.

## Changes

To mitigate this, this PR adds a `container` build job to the `ci-e2e.yml` workflow, as a dependency of the `cypress` matrix job. This ensures that the container will be fully built and present in the cache before it's pulled to each of the 11 matrix jobs with `load: true`

## How did you test this code?

This hasn't been tested, given it runs in Actions.