### PR TITLE
feat: Added button in playlist player to add the Replay below

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerMetaLinks.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMetaLinks.tsx
@@ -4,16 +4,18 @@ import {
 } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { useActions, useValues } from 'kea'
 import { LemonButton, LemonButtonProps } from 'lib/lemon-ui/LemonButton'
-import { IconComment, IconDelete, IconLink } from 'lib/lemon-ui/icons'
+import { IconComment, IconDelete, IconJournalPlus, IconLink } from 'lib/lemon-ui/icons'
 import { openPlayerShareDialog } from 'scenes/session-recordings/player/share/PlayerShare'
 import { PlaylistPopoverButton } from './playlist-popover/PlaylistPopover'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
 import { NotebookNodeType } from '~/types'
+import { useNotebookNode } from 'scenes/notebooks/Nodes/notebookNodeLogic'
 
 export function PlayerMetaLinks(): JSX.Element {
     const { sessionRecordingId, logicProps } = useValues(sessionRecordingPlayerLogic)
     const { setPause, deleteRecording } = useActions(sessionRecordingPlayerLogic)
+    const nodeLogic = useNotebookNode()
 
     const getCurrentPlayerTime = (): number => {
         // NOTE: We pull this value at call time as otherwise it would trigger re-renders if pulled from the hook
@@ -78,9 +80,24 @@ export function PlayerMetaLinks(): JSX.Element {
                         <span>Share</span>
                     </LemonButton>
 
-                    <PlaylistPopoverButton {...commonProps}>
-                        <span>Pin</span>
-                    </PlaylistPopoverButton>
+                    {nodeLogic ? (
+                        nodeLogic.props.nodeType !== NotebookNodeType.Recording ? (
+                            <LemonButton
+                                icon={<IconJournalPlus />}
+                                size="small"
+                                onClick={() => {
+                                    nodeLogic.actions.insertAfter({
+                                        type: NotebookNodeType.Recording,
+                                        attrs: { id: sessionRecordingId },
+                                    })
+                                }}
+                            />
+                        ) : null
+                    ) : (
+                        <PlaylistPopoverButton {...commonProps}>
+                            <span>Pin</span>
+                        </PlaylistPopoverButton>
+                    )}
 
                     {logicProps.playerKey !== 'modal' && (
                         <LemonButton


### PR DESCRIPTION
## Problem

Notebooks sort of replaces playlists so when you are looking at a playlist recording within a notebook it should show a button to pull out the recording below.

## Changes

* As it says
* TODO: Follow up PR will make improvements overall to the playlist UI which will then navigate back to the list and also scroll to the added replay
![2023-09-13 10 00 55](https://github.com/PostHog/posthog/assets/2536520/6ed34aed-d1d8-4e2d-ae59-9d9c0d42fa29)



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
