### PR TITLE
feat: use passed in setQuery value to update insight viz node

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -34,7 +34,11 @@ let uniqueNode = 0
 
 export function InsightViz({ uniqueKey, query, setQuery, context, readOnly }: InsightVizProps): JSX.Element {
     const [key] = useState(() => `InsightViz.${uniqueKey || uniqueNode++}`)
-    const insightProps: InsightLogicProps = context?.insightProps || { dashboardItemId: `new-AdHoc.${key}`, query }
+    const insightProps: InsightLogicProps = context?.insightProps || {
+        dashboardItemId: `new-AdHoc.${key}`,
+        query,
+        setQuery,
+    }
     const dataNodeLogicProps: DataNodeLogicProps = {
         query: query.source,
         key: insightVizDataNodeKey(insightProps),

--- a/frontend/src/queries/nodes/InsightViz/TrendsSeries.tsx
+++ b/frontend/src/queries/nodes/InsightViz/TrendsSeries.tsx
@@ -1,7 +1,7 @@
 import { useValues, useActions } from 'kea'
 import { groupsModel } from '~/models/groupsModel'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
-import { InsightType, FilterType, InsightLogicProps } from '~/types'
+import { InsightType, FilterType, EditorFilterProps } from '~/types'
 import { alphabet } from 'lib/utils'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -13,11 +13,7 @@ import { actionsAndEventsToSeries } from '../InsightQuery/utils/filtersToQueryNo
 
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
-type TrendsSeriesProps = {
-    insightProps: InsightLogicProps
-}
-
-export function TrendsSeries({ insightProps }: TrendsSeriesProps): JSX.Element | null {
+export function TrendsSeries({ insightProps }: EditorFilterProps): JSX.Element | null {
     const { querySource, isTrends, isLifecycle, isStickiness, display, hasFormula } = useValues(
         insightVizDataLogic(insightProps)
     )

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -47,7 +47,6 @@ import { toLocalFilters } from './filters/ActionFilter/entityFilterLogic'
 import { loaders } from 'kea-loaders'
 import { queryExportContext } from '~/queries/query'
 import { tagsModel } from '~/models/tagsModel'
-import { isInsightVizNode } from '~/queries/utils'
 import { userLogic } from 'scenes/userLogic'
 import { transformLegacyHiddenLegendKeys } from 'scenes/funnels/funnelUtils'
 import { summarizeInsight } from 'scenes/insights/summarizeInsight'
@@ -389,12 +388,6 @@ export const insightLogic = kea<insightLogicType>([
         ],
         insightName: [(s) => [s.insight, s.derivedName], (insight, derivedName) => insight.name || derivedName],
         insightId: [(s) => [s.insight], (insight) => insight?.id || null],
-        isFilterBasedInsight: [
-            (s) => [s.insight],
-            (insight) => Object.keys(insight.filters || {}).length > 0 && !insight.query,
-        ],
-        isQueryBasedInsight: [(s) => [s.insight], (insight) => !!insight.query],
-        isInsightVizQuery: [(s) => [s.insight], (insight) => isInsightVizNode(insight.query)],
         canEditInsight: [
             (s) => [s.insight],
             (insight) =>

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -8,7 +8,6 @@ import {
     InsightFilter,
     InsightQueryNode,
     InsightVizNode,
-    Node,
     NodeKind,
     TrendsQuery,
 } from '~/queries/schema'
@@ -191,7 +190,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         timezone: [(s) => [s.insightData], (insightData) => insightData?.timezone || 'UTC'],
     }),
 
-    listeners(({ actions, values }) => ({
+    listeners(({ actions, values, props }) => ({
         updateDateRange: ({ dateRange }) => {
             const localQuerySource = values.querySource
                 ? values.querySource
@@ -235,10 +234,11 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
                 ? values.query
                 : queryFromKind(NodeKind.TrendsQuery, values.filterTestAccountsDefault)
             if (localQuery && isInsightVizNode(localQuery)) {
-                actions.setQuery({
+                const newQuery = {
                     ...localQuery,
                     source: { ...(localQuery as InsightVizNode).source, ...querySource },
-                } as Node)
+                } as InsightVizNode
+                props.setQuery ? props.setQuery(newQuery) : actions.setQuery(newQuery)
             }
         },
         setQuery: ({ query }) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2055,6 +2055,8 @@ export interface InsightLogicProps {
     doNotLoad?: boolean
     /** query when used as ad-hoc insight */
     query?: InsightVizNode
+    /** callback when query changes in ad-hoc insight */
+    setQuery?: (node: InsightVizNode) => void
 }
 
 export interface SetInsightOptions {


### PR DESCRIPTION
## Problem

There is no way to call `setQuery` in the insight viz node right now

## Changes

Add it as part of the props to the `InsightLogicProps` and call it instead of the internal `setQuery` method

## How did you test this code?

None, because yolo to see if this is the right approach