### PR TITLE
fix(plugin-server): don't ping CH on startup

### DIFF
--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -91,7 +91,6 @@ export async function createHub(
             : undefined,
         rejectUnauthorized: serverConfig.CLICKHOUSE_CA ? false : undefined,
     })
-    await clickhouse.querying('SELECT 1') // test that the connection works
     status.info('👍', `ClickHouse ready`)
 
     status.info('🤔', `Connecting to Kafka...`)


### PR DESCRIPTION
## Problem

ingestion pods fail with `DB::Exception: Too many simultaneous queries. Maximum: 100.` on prod-us.
Let's stop DoSing CH on startup

## Changes

- remove the `SELECT 1` query on hub init

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
