### PR TITLE
feat: Blacklisting webhooks

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -166,6 +166,7 @@ export const FEATURE_FLAGS = {
     // owner: #team-monitoring
     SESSION_RECORDING_ALLOW_V1_SNAPSHOTS: 'session-recording-allow-v1-snapshots',
     HOGQL_INSIGHTS: 'hogql-insights', // owner: @mariusandra
+    WEBHOOKS_BLACKLISTED: 'webhooks-blacklisted', // owner: @team-pipeline
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -166,7 +166,7 @@ export const FEATURE_FLAGS = {
     // owner: #team-monitoring
     SESSION_RECORDING_ALLOW_V1_SNAPSHOTS: 'session-recording-allow-v1-snapshots',
     HOGQL_INSIGHTS: 'hogql-insights', // owner: @mariusandra
-    WEBHOOKS_BLACKLISTED: 'webhooks-blacklisted', // owner: @team-pipeline
+    WEBHOOKS_DENYLIST: 'webhooks-denylist', // owner: #team-pipeline
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
+++ b/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
@@ -2,19 +2,36 @@ import { useEffect, useState } from 'react'
 import { useActions, useValues } from 'kea'
 import { teamLogic } from 'scenes/teamLogic'
 import { webhookIntegrationLogic } from './webhookIntegrationLogic'
-import { LemonButton, LemonInput } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, Link } from '@posthog/lemon-ui'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { supportLogic } from 'lib/components/Support/supportLogic'
 
 export function WebhookIntegration(): JSX.Element {
     const [webhook, setWebhook] = useState('')
     const { testWebhook, removeWebhook } = useActions(webhookIntegrationLogic)
     const { loading } = useValues(webhookIntegrationLogic)
     const { currentTeam } = useValues(teamLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { openSupportForm } = useActions(supportLogic)
 
     useEffect(() => {
         if (currentTeam?.slack_incoming_webhook) {
             setWebhook(currentTeam?.slack_incoming_webhook)
         }
     }, [currentTeam])
+
+    const webhooks_blacklisted = featureFlags[FEATURE_FLAGS.WEBHOOKS_BLACKLISTED]
+    if (webhooks_blacklisted) {
+        return (
+            <div>
+                <p>
+                    Webhooks are currently not available for your organization.{' '}
+                    <Link onClick={() => openSupportForm('support', 'apps')}>Contact support</Link>
+                </p>
+            </div>
+        )
+    }
 
     return (
         <div>

--- a/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
+++ b/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
@@ -21,7 +21,7 @@ export function WebhookIntegration(): JSX.Element {
         }
     }, [currentTeam])
 
-    const webhooks_blacklisted = featureFlags[FEATURE_FLAGS.WEBHOOKS_BLACKLISTED]
+    const webhooks_blacklisted = featureFlags[FEATURE_FLAGS.WEBHOOKS_DENYLIST]
     if (webhooks_blacklisted) {
         return (
             <div>


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We've disabled a webhook for the same team twice due to it being really slow and contacted them about it. This will allow us to disable webhooks for the team until they talk to us.

context: https://posthog.slack.com/archives/C0185UNBSJZ/p1694611747313189?thread_ts=1694610989.528059&cid=C0185UNBSJZ

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

ran locally looked at the page first, enabled the feature flag, then it looked like this:
<img width="668" alt="Screenshot 2023-09-13 at 18 13 05" src="https://github.com/PostHog/posthog/assets/890921/61c77965-dccd-4178-97ea-c70ddca060dd">


