### PR TITLE
feat: prompt to search 30 days

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -257,11 +257,11 @@ export function RecordingsLists({
                                             data-attr={'expand-replay-listing-from-default-seven-days-to-twenty-one'}
                                             onClick={() => {
                                                 setFilters({
-                                                    date_from: '-21d',
+                                                    date_from: '-30d',
                                                 })
                                             }}
                                         >
-                                            Search over the last 21 days
+                                            Search over the last 30 days
                                         </LemonButton>
                                     </>
                                 ) : (


### PR DESCRIPTION
If we don't find any recordings with the default filters we prompt to "Search over the last 21 days"

Let's change that to 30 days