### PR TITLE
Fix a bug with System Status where tabs weren't being appended correctly

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/index.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/index.tsx
@@ -39,7 +39,7 @@ export function SystemStatus(): JSX.Element {
     ] as LemonTab<InstanceStatusTabName>[]
 
     if (user?.is_staff) {
-        tabs.concat([
+        tabs.push(
             {
                 key: 'metrics',
                 label: 'Internal metrics',
@@ -62,7 +62,7 @@ export function SystemStatus(): JSX.Element {
                 label: 'Staff Users',
                 content: <StaffUsersTab />,
             },
-        ])
+        )
 
         if (featureFlags[FEATURE_FLAGS.KAFKA_INSPECTOR]) {
             tabs.push({


### PR DESCRIPTION
## Problem

Instance Status and Settings page only displays "System Overview" due to a bug in a refactor.

## Changes

* Change `tabs.concat` to `tabs.push` so the changes are actually persisted.

## How did you test this code?

After making the change, the other tabs show up as expected.