### PR TITLE
feat(hogql): LRU cache for parsing

### DIFF
--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -195,7 +195,8 @@
             replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key
      FROM events
      WHERE equals(events.team_id, 2)
-     ORDER BY toTimeZone(events.timestamp, 'UTC') ASC) AS event_view
+     ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+     LIMIT 100) AS event_view
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=True


### PR DESCRIPTION
## Problem

The HogQL lifecycle query takes ~3s to parse. About 2.5s of those 3s are spent waiting for antlr.
This is work that could only be done once and then cached.

<img width="641" alt="image" src="https://github.com/PostHog/posthog/assets/53387/41d5a138-3474-4545-8593-b60074fa37dc">

There are other optimisations we could take in later stages, but let's tackle the biggest one first.

## Changes

- This is more of an experiment and less of a PR to merge.
- Adds a simple LRU cache for the Antlr query parsing part.
- Note: just the first parsing part is cached. The following parts (resolver, printer, etc) are not.
- This will cache the query per web pod thread. With several dozen of those in operation (not sure of the exact number), we're still doing too much work. A redis-based cache might be better.
- If we use placeholders and compose our queries in the right way, this can yield a big boost. Each query part can be cached independently.

## Alternatives.

- Find a way to make the antlr parser a lot faster (this might be a quick win, I just don't know)
- Replace the antlr parser with a homegrown recursive descent parser (... in Rust for even more oomph)

## How did you test this code?

Saw the lifecycle query load almost instantly on every second refresh.