### PR TITLE
fix(surveys): Limit all queries to date range

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -321,7 +321,7 @@ function SurveyNPSResults({ survey }: { survey: Survey }): JSX.Element {
                         date_from: dayjs(survey.created_at).format('YYYY-MM-DD'),
                         date_to: survey.end_date
                             ? dayjs(survey.end_date).format('YYYY-MM-DD')
-                            : dayjs().format('YYYY-MM-DD'),
+                            : dayjs().add(1, 'day').format('YYYY-MM-DD'),
                     },
                     series: [
                         {

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -254,17 +254,19 @@ export const surveyLogic = kea<surveyLogicType>([
                 if (surveyId === 'new') {
                     return null
                 }
-                const createdAt = (survey as Survey).created_at
+                const startDate = dayjs((survey as Survey).created_at).format('YYYY-MM-DD')
+                const endDate = survey.end_date
+                    ? dayjs(survey.end_date).format('YYYY-MM-DD')
+                    : dayjs().add(1, 'day').format('YYYY-MM-DD')
 
-                const surveysShownHogqlQuery = `select count(distinct person.id) as 'survey shown' from events where event == 'survey shown' and properties.$survey_id == '${surveyId}'`
-                const surveysDismissedHogqlQuery = `select count(distinct person.id) as 'survey dismissed' from events where event == 'survey dismissed' and properties.$survey_id == '${surveyId}'`
+                const surveysShownHogqlQuery = `select count(distinct person.id) as 'survey shown' from events where event == 'survey shown' and properties.$survey_id == '${surveyId}' and timestamp >= '${startDate}' and timestamp <= '${endDate}' `
+                const surveysDismissedHogqlQuery = `select count(distinct person.id) as 'survey dismissed' from events where event == 'survey dismissed' and properties.$survey_id == '${surveyId}' and timestamp >= '${startDate}' and timestamp <= '${endDate}'`
                 return {
                     surveysShown: {
                         kind: NodeKind.DataTableNode,
                         source: {
                             kind: NodeKind.HogQLQuery,
                             query: surveysShownHogqlQuery,
-                            filters: { dateRange: { date_from: dayjs(createdAt).format('YYYY-MM-DD') } },
                         },
                         showTimings: false,
                     },
@@ -273,7 +275,6 @@ export const surveyLogic = kea<surveyLogicType>([
                         source: {
                             kind: NodeKind.HogQLQuery,
                             query: surveysDismissedHogqlQuery,
-                            filters: { dateRange: { date_from: dayjs(createdAt).format('YYYY-MM-DD') } },
                         },
                         showTimings: false,
                     },
@@ -286,15 +287,18 @@ export const surveyLogic = kea<surveyLogicType>([
                 if (survey.id === 'new') {
                     return null
                 }
-                const createdAt = (survey as Survey).created_at
+                const startDate = dayjs((survey as Survey).created_at).format('YYYY-MM-DD')
+                const endDate = survey.end_date
+                    ? dayjs(survey.end_date).format('YYYY-MM-DD')
+                    : dayjs().add(1, 'day').format('YYYY-MM-DD')
 
                 return {
                     kind: NodeKind.InsightVizNode,
                     source: {
                         kind: NodeKind.TrendsQuery,
                         dateRange: {
-                            date_from: dayjs(createdAt).format('YYYY-MM-DD'),
-                            date_to: dayjs().format('YYYY-MM-DD'),
+                            date_from: startDate,
+                            date_to: endDate,
                         },
                         properties: [
                             {
@@ -318,10 +322,14 @@ export const surveyLogic = kea<surveyLogicType>([
                 if (survey.id === 'new') {
                     return null
                 }
-                const createdAt = (survey as Survey).created_at
 
-                const singleChoiceQuery = `select count(), properties.$survey_response as choice from events where event == 'survey sent' and properties.$survey_id == '${survey.id}' group by choice order by count() desc`
-                const multipleChoiceQuery = `select count(), arrayJoin(JSONExtractArrayRaw(properties, '$survey_response')) as choice from events where event == 'survey sent' and properties.$survey_id == '${survey.id}' group by choice order by count() desc`
+                const startDate = dayjs((survey as Survey).created_at).format('YYYY-MM-DD')
+                const endDate = survey.end_date
+                    ? dayjs(survey.end_date).format('YYYY-MM-DD')
+                    : dayjs().add(1, 'day').format('YYYY-MM-DD')
+
+                const singleChoiceQuery = `select count(), properties.$survey_response as choice from events where event == 'survey sent' and properties.$survey_id == '${survey.id}' and timestamp >= '${startDate}' and timestamp <= '${endDate}' group by choice order by count() desc`
+                const multipleChoiceQuery = `select count(), arrayJoin(JSONExtractArrayRaw(properties, '$survey_response')) as choice from events where event == 'survey sent' and properties.$survey_id == '${survey.id}' and timestamp >= '${startDate}' and timestamp <= '${endDate}'  group by choice order by count() desc`
                 return {
                     kind: NodeKind.DataTableNode,
                     source: {
@@ -330,11 +338,6 @@ export const surveyLogic = kea<surveyLogicType>([
                             survey.questions[0].type === SurveyQuestionType.SingleChoice
                                 ? singleChoiceQuery
                                 : multipleChoiceQuery,
-                        filters: {
-                            dateRange: {
-                                date_from: dayjs(createdAt).format('YYYY-MM-DD'),
-                            },
-                        },
                     },
                     showTimings: false,
                 }


### PR DESCRIPTION
## Problem

We weren't filtering on time range in surveys.

And there's some date range issues where the last day's events don't show up, based on timezone/dst(?)/ idk what - didn't investigate, preferred to just have a cushion in queries instead because it doesn't matter much for surveys :) 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
