### PR TITLE
feat: notebooks list updates on deletion

### DIFF
--- a/cypress/e2e/notebooks-creation-and-deletion.cy.ts
+++ b/cypress/e2e/notebooks-creation-and-deletion.cy.ts
@@ -1,0 +1,43 @@
+import { randomString } from '../support/random'
+
+function visitNotebooksList(): void {
+    cy.clickNavMenu('dashboards')
+    cy.location('pathname').should('include', '/dashboard')
+    cy.get('h1').should('contain', 'Dashboards & Notebooks')
+    cy.get('li').contains('Notebooks').should('exist').click()
+}
+
+function createNotebookAndFindInList(notebookTitle: string): void {
+    cy.get('[data-attr="new-notebook"]').click()
+    cy.get('.NotebookEditor').type(notebookTitle)
+
+    visitNotebooksList()
+    cy.get('[data-attr="notebooks-search"]').type(notebookTitle)
+}
+
+describe('Notebooks', () => {
+    beforeEach(() => {
+        visitNotebooksList()
+    })
+
+    it('can create and name a notebook', () => {
+        const notebookTitle = randomString('My new notebook')
+
+        createNotebookAndFindInList(notebookTitle)
+        cy.get('[data-attr="notebooks-table"] tbody tr').should('have.length', 1)
+    })
+
+    it('can delete a notebook', () => {
+        const notebookTitle = randomString('My notebook to delete')
+
+        createNotebookAndFindInList(notebookTitle)
+
+        cy.contains('[data-attr="notebooks-table"] tr', notebookTitle).within(() => {
+            cy.get('[aria-label="more"]').click()
+        })
+        cy.contains('.LemonButton', 'Delete').click()
+
+        // and the table updates
+        cy.contains('[data-attr="notebooks-table"] tr', notebookTitle).should('not.exist')
+    })
+})

--- a/cypress/e2e/notebooks.cy.ts
+++ b/cypress/e2e/notebooks.cy.ts
@@ -61,44 +61,39 @@ describe('Notebooks', () => {
         cy.get('.NotebookRecordingTimestamp').should('contain.text', '0:00')
     })
 
-    it('Can add a number list', () => {
-        cy.get('li').contains('Notebooks').should('exist').click()
-        cy.get('[data-attr="new-notebook"]').click()
-        // we don't actually get a new notebook because the API is mocked
-        // so, press enter twice to "exit" the timestamp block we start in
-        cy.get('.NotebookEditor').type('{enter}{enter}')
-        cy.get('.NotebookEditor').type('{enter}')
-        cy.get('.NotebookEditor').type('1. the first')
-        cy.get('.NotebookEditor').type('{enter}')
-        // no need to type the number now. it should be inserted automatically
-        cy.get('.NotebookEditor').type('the second')
-        cy.get('.NotebookEditor').type('{enter}')
-        cy.get('ol').should('contain.text', 'the first')
-        cy.get('ol').should('contain.text', 'the second')
-        // the numbered list auto inserts the next list item
-        cy.get('.NotebookEditor ol li').should('have.length', 3)
-    })
+    describe('text types', () => {
+        beforeEach(() => {
+            cy.get('li').contains('Notebooks').should('exist').click()
+            cy.get('[data-attr="new-notebook"]').click()
+            // we don't actually get a new notebook because the API is mocked
+            // so, "exit" the timestamp block we start in
+            cy.get('.NotebookEditor').type('esc')
+            cy.get('.NotebookEditor').type('{enter}')
+        })
 
-    it('Can add bold', () => {
-        cy.get('li').contains('Notebooks').should('exist').click()
-        cy.get('[data-attr="new-notebook"]').click()
-        // we don't actually get a new notebook because the API is mocked
-        // so, press enter twice to "exit" the timestamp block we start in
-        cy.get('.NotebookEditor').type('{enter}{enter}')
-        cy.get('.NotebookEditor').type('**bold**')
-        cy.get('.NotebookEditor p').last().should('contain.html', '<strong>bold</strong>')
-    })
+        it('Can add a number list', () => {
+            cy.get('.NotebookEditor').type('1. the first')
+            cy.get('.NotebookEditor').type('{enter}')
+            // no need to type the number now. it should be inserted automatically
+            cy.get('.NotebookEditor').type('the second')
+            cy.get('.NotebookEditor').type('{enter}')
+            cy.get('ol').should('contain.text', 'the first')
+            cy.get('ol').should('contain.text', 'the second')
+            // the numbered list auto inserts the next list item
+            cy.get('.NotebookEditor ol li').should('have.length', 3)
+        })
 
-    it('Can add bullet list', () => {
-        cy.get('li').contains('Notebooks').should('exist').click()
-        cy.get('[data-attr="new-notebook"]').click()
-        // we don't actually get a new notebook because the API is mocked
-        // so, press enter twice to "exit" the timestamp block we start in
-        cy.get('.NotebookEditor').type('{enter}{enter}')
-        cy.get('.NotebookEditor').type('* the first{enter}the second{enter}')
-        cy.get('ul').should('contain.text', 'the first')
-        cy.get('ul').should('contain.text', 'the second')
-        // the list auto inserts the next list item
-        cy.get('.NotebookEditor ul li').should('have.length', 3)
+        it('Can add bold', () => {
+            cy.get('.NotebookEditor').type('**bold**')
+            cy.get('.NotebookEditor p').last().should('contain.html', '<strong>bold</strong>')
+        })
+
+        it('Can add bullet list', () => {
+            cy.get('.NotebookEditor').type('* the first{enter}the second{enter}')
+            cy.get('ul').should('contain.text', 'the first')
+            cy.get('ul').should('contain.text', 'the second')
+            // the list auto inserts the next list item
+            cy.get('.NotebookEditor ul li').should('have.length', 3)
+        })
     })
 })

--- a/cypress/e2e/notebooks.cy.ts
+++ b/cypress/e2e/notebooks.cy.ts
@@ -67,8 +67,7 @@ describe('Notebooks', () => {
             cy.get('[data-attr="new-notebook"]').click()
             // we don't actually get a new notebook because the API is mocked
             // so, "exit" the timestamp block we start in
-            cy.get('.NotebookEditor').type('esc')
-            cy.get('.NotebookEditor').type('{enter}')
+            cy.get('.NotebookEditor').type('{esc}{enter}{enter}')
         })
 
         it('Can add a number list', () => {

--- a/frontend/src/scenes/notebooks/NotebooksTable/NotebooksTable.tsx
+++ b/frontend/src/scenes/notebooks/NotebooksTable/NotebooksTable.tsx
@@ -103,6 +103,7 @@ export function NotebooksTable(): JSX.Element {
                         setFilters({ search: s })
                     }}
                     value={filters.search}
+                    data-attr={'notebooks-search'}
                 />
                 <div className="flex items-center gap-4 flex-wrap">
                     <ContainsTypeFilters filters={filters} setFilters={setFilters} />
@@ -127,7 +128,7 @@ export function NotebooksTable(): JSX.Element {
                 </div>
             </div>
             <LemonTable
-                data-attr="dashboards-table"
+                data-attr="notebooks-table"
                 pagination={{ pageSize: 100 }}
                 dataSource={notebooksAndTemplates}
                 rowKey="short_id"

--- a/frontend/src/scenes/notebooks/NotebooksTable/notebooksTableLogic.ts
+++ b/frontend/src/scenes/notebooks/NotebooksTable/notebooksTableLogic.ts
@@ -28,6 +28,7 @@ export const notebooksTableLogic = kea<notebooksTableLogicType>([
     }),
     connect({
         values: [notebooksModel, ['notebookTemplates']],
+        actions: [notebooksModel, ['deleteNotebookSuccess']],
     }),
     reducers({
         filters: [
@@ -64,6 +65,10 @@ export const notebooksTableLogic = kea<notebooksTableLogicType>([
     })),
     listeners(({ actions }) => ({
         setFilters: () => {
+            actions.loadNotebooks()
+        },
+        deleteNotebookSuccess: () => {
+            // TODO at some point this will be slow enough it makes sense to patch the in-memory list but for simplicity...
             actions.loadNotebooks()
         },
     })),


### PR DESCRIPTION
If you delete a notebook from the context menu on the table listing you had to refresh the page to see the update

Well, not any more