### PR TITLE
chore: BatchExports do not retry on OperationalError

### DIFF
--- a/posthog/temporal/workflows/postgres_batch_export.py
+++ b/posthog/temporal/workflows/postgres_batch_export.py
@@ -245,7 +245,11 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
                     initial_interval=dt.timedelta(seconds=10),
                     maximum_interval=dt.timedelta(seconds=120),
                     maximum_attempts=10,
-                    non_retryable_error_types=[],
+                    non_retryable_error_types=[
+                        # Raised on errors that are related to database operation.
+                        # For example: unexpected disconnect, database or other object not found.
+                        "OperationalError"
+                    ],
                 ),
             )
 


### PR DESCRIPTION
## Problem

A handful of exports are failing as they are unable to connect to Postgres. There is not much to do from a retry perspective, so let's not.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add `OperationalError` to Postgres batch export main insert activity.

TODO: 
* Report this error back to the user (coming next sprint).
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
