### PR TITLE
chore(plugin-server): make it easier to run multiple plugin-server instances locally

### DIFF
--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -46,7 +46,15 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-[[ -n $DEBUG ]] && cmd="pnpm start:dev" || cmd="node dist/index.js"
+if [[ -n $DEBUG ]]; then
+  if [[ -n $NO_WATCH ]]; then
+    cmd="pnpm start:devNoWatch"
+  else
+    cmd="pnpm start:dev"
+  fi
+else
+  cmd="node dist/index.js"
+fi
 
 if [[ -n $NO_RESTART_LOOP ]]; then
   echo "▶️ Starting plugin server..."

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -11,6 +11,7 @@
         "start": "pnpm start:dist",
         "start:dist": "BASE_DIR=.. node dist/index.js",
         "start:dev": "NODE_ENV=dev BASE_DIR=.. nodemon --watch src/ --exec node -r @swc-node/register src/index.ts",
+        "start:devNoWatch": "NODE_ENV=dev BASE_DIR=.. node -r @swc-node/register src/index.ts",
         "build": "pnpm clean && pnpm compile",
         "clean": "rm -rf dist/*",
         "typescript:compile": "tsc -b",

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -75,6 +75,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SENTRY_DSN: null,
         SENTRY_PLUGIN_SERVER_TRACING_SAMPLE_RATE: 0,
         SENTRY_PLUGIN_SERVER_PROFILING_SAMPLE_RATE: 0,
+        HTTP_SERVER_PORT: 6738,
         STATSD_HOST: null,
         STATSD_PORT: 8125,
         STATSD_PREFIX: 'plugin-server.',

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -7,6 +7,8 @@ import {
     KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
 } from './kafka-topics'
 
+export const DEFAULT_HTTP_SERVER_PORT = 6738
+
 export const defaultConfig = overrideWithEnv(getDefaultConfig())
 
 export function getDefaultConfig(): PluginsServerConfig {
@@ -75,7 +77,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SENTRY_DSN: null,
         SENTRY_PLUGIN_SERVER_TRACING_SAMPLE_RATE: 0,
         SENTRY_PLUGIN_SERVER_PROFILING_SAMPLE_RATE: 0,
-        HTTP_SERVER_PORT: 6738,
+        HTTP_SERVER_PORT: DEFAULT_HTTP_SERVER_PORT,
         STATSD_HOST: null,
         STATSD_PORT: 8125,
         STATSD_PREFIX: 'plugin-server.',

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -447,7 +447,7 @@ export async function startPluginsServer(
         }
 
         if (capabilities.http) {
-            httpServer = createHttpServer(healthChecks, analyticsEventsIngestionConsumer)
+            httpServer = createHttpServer(serverConfig.HTTP_SERVER_PORT, healthChecks, analyticsEventsIngestionConsumer)
         }
 
         // If session recordings consumer is defined, then join it. If join

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -5,13 +5,12 @@ import * as prometheus from 'prom-client'
 
 import { status } from '../../utils/status'
 
-export const HTTP_SERVER_PORT = 6738
-
 prometheus.collectDefaultMetrics()
 const v8Profiler = require('v8-profiler-next')
 v8Profiler.setGenerateType(1)
 
 export function createHttpServer(
+    port: number,
     healthChecks: { [service: string]: () => Promise<boolean> | boolean },
     analyticsEventsIngestionConsumer?: KafkaJSIngestionConsumer | IngestionConsumer
 ): Server {
@@ -118,8 +117,8 @@ export function createHttpServer(
         }
     })
 
-    server.listen(HTTP_SERVER_PORT, () => {
-        status.info('🩺', `Status server listening on port ${HTTP_SERVER_PORT}`)
+    server.listen(port, () => {
+        status.info('🩺', `Status server listening on port ${port}`)
     })
 
     return server

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -46,7 +46,7 @@ export function createHttpServer(
             //   }
             // }
             const checkResults = await Promise.all(
-                // Note that we do not ues `Promise.allSettled` here so we can
+                // Note that we do not use `Promise.allSettled` here so we can
                 // assume that all promises have resolved. If there was a
                 // rejected promise, the http server should catch it and return
                 // a 500 status code.

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -151,6 +151,7 @@ export interface PluginsServerConfig {
     SENTRY_DSN: string | null
     SENTRY_PLUGIN_SERVER_TRACING_SAMPLE_RATE: number // Rate of tracing in plugin server (between 0 and 1)
     SENTRY_PLUGIN_SERVER_PROFILING_SAMPLE_RATE: number // Rate of profiling in plugin server (between 0 and 1)
+    HTTP_SERVER_PORT: number
     STATSD_HOST: string | null
     STATSD_PORT: number
     STATSD_PREFIX: string

--- a/plugin-server/tests/http-server.test.ts
+++ b/plugin-server/tests/http-server.test.ts
@@ -1,7 +1,7 @@
 import http from 'http'
 
+import { DEFAULT_HTTP_SERVER_PORT } from '../src/config/config'
 import { startPluginsServer } from '../src/main/pluginsServer'
-import { HTTP_SERVER_PORT } from '../src/main/services/http-server'
 import { makePiscina } from '../src/worker/piscina'
 import { resetTestDatabase } from './helpers/sql'
 
@@ -40,7 +40,7 @@ describe('http server', () => {
             )
 
             await new Promise((resolve) =>
-                http.get(`http://localhost:${HTTP_SERVER_PORT}/_health`, (res) => {
+                http.get(`http://localhost:${DEFAULT_HTTP_SERVER_PORT}/_health`, (res) => {
                     const { statusCode } = res
                     expect(statusCode).toEqual(200)
                     resolve(null)
@@ -68,7 +68,7 @@ describe('http server', () => {
             )
 
             await new Promise((resolve) =>
-                http.get(`http://localhost:${HTTP_SERVER_PORT}/_ready`, (res) => {
+                http.get(`http://localhost:${DEFAULT_HTTP_SERVER_PORT}/_ready`, (res) => {
                     const { statusCode } = res
                     expect(statusCode).toEqual(200)
                     resolve(null)


### PR DESCRIPTION
## Problem

It was first impossible (port collision) and second annoying (autoreload) to run 2 plugin-servers locally. This is useful for trying out things like incompatible Kafka consumer group protocols.

## Changes

Add the ability to customize the status/metric port and whether or not to use nodemon (it's annoying to autorestart a process on changes when the goal is to leave a pre-existing process up in the group).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Used it locally, it's just dev stuff.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
