### PR TITLE
feat(capture): add DUMP_CAPTURE_TO_FILE option for local use

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -298,10 +298,12 @@ def get_event(request):
     # Optionally dump requests and Kafka messages to collect test cases
     if settings.DUMP_CAPTURE_TO_FILE:
         request_dump = {
-            "full_path": request.get_full_path(),
-            "content-encoding": request.headers.get("content-encoding", ""),
-            "body": base64.b64encode(request.body).decode(encoding="ascii"),
+            "path": request.get_full_path(),
+            "method": request.method,
+            "content-encoding": request.META.get("content-encoding", ""),
+            "ip": request.META.get("HTTP_X_FORWARDED_FOR", request.META.get("REMOTE_ADDR")),
             "now": now.isoformat(),
+            "body": base64.b64encode(request.body).decode(encoding="ascii"),
             "output": [],
         }
     else:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -300,7 +300,8 @@ def get_event(request):
         request_dump = {
             "path": request.get_full_path(),
             "method": request.method,
-            "content-encoding": request.META.get("content-encoding", ""),
+            "content_encoding": request.META.get("content-encoding", ""),
+            "content_type": request.content_type,
             "ip": request.META.get("HTTP_X_FORWARDED_FOR", request.META.get("REMOTE_ADDR")),
             "now": now.isoformat(),
             "body": base64.b64encode(request.body).decode(encoding="ascii"),

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -1,10 +1,7 @@
 import os
-import structlog
 
 from posthog.settings.utils import get_from_env, get_list
 from posthog.utils import str_to_bool
-
-logger = structlog.get_logger(__name__)
 
 INGESTION_LAG_METRIC_TEAM_IDS = get_list(os.getenv("INGESTION_LAG_METRIC_TEAM_IDS", ""))
 
@@ -41,3 +38,6 @@ if REPLAY_EVENTS_NEW_CONSUMER_RATIO > 1 or REPLAY_EVENTS_NEW_CONSUMER_RATIO < 0:
 
 REPLAY_RETENTION_DAYS_MIN = 30
 REPLAY_RETENTION_DAYS_MAX = 90
+
+# Used to capture test cases for new capture, meant to be used locally only
+DUMP_CAPTURE_TO_FILE = os.getenv("DUMP_CAPTURE_TO_FILE", "")

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -1,7 +1,11 @@
 import os
 
+import structlog
+
 from posthog.settings.utils import get_from_env, get_list
 from posthog.utils import str_to_bool
+
+logger = structlog.get_logger(__name__)
 
 INGESTION_LAG_METRIC_TEAM_IDS = get_list(os.getenv("INGESTION_LAG_METRIC_TEAM_IDS", ""))
 


### PR DESCRIPTION
## Problem

Our capture input format is currently loosely defined, this will allow us to inspect inputs and outputs.
The dump is used as a test fixture for https://github.com/PostHog/capture/

## Changes

- add a DUMP_CAPTURE_TO_FILE envvar, that is the filename to dump info in, in jsonlines format
- only capturing the `content-type` header, as we don't seem to be using any of the other headers
- capturing `now` as it's used in the payload computation

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
