### PR TITLE
feat: Enable brotli compression in S3 batch exports configuration

### DIFF
--- a/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
@@ -190,6 +190,7 @@ export function BatchExportsEditForm(props: BatchExportsEditLogicProps): JSX.Ele
                                             <LemonSelect
                                                 options={[
                                                     { value: 'gzip', label: 'gzip' },
+                                                    { value: 'brotli', label: 'brotli' },
                                                     { value: null, label: 'No compression' },
                                                 ]}
                                             />

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -444,7 +444,7 @@ async def test_s3_export_workflow_with_minio_bucket(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "interval,compression,encryption,exclude_events",
-    itertools.product(["hour", "day"], [None, "gzip", "brotli"], [None, "AES256"], [None, ["test-exclude"]]),
+    itertools.product(["hour", "day"], [None, "gzip", "brotli"], [None, "AES256", "aws:kms"], [None, ["test-exclude"]]),
 )
 async def test_s3_export_workflow_with_s3_bucket(interval, compression, encryption, exclude_events):
     """Test S3 Export Workflow end-to-end by using an S3 bucket.
@@ -457,6 +457,7 @@ async def test_s3_export_workflow_with_s3_bucket(interval, compression, encrypti
     records to the S3 bucket.
     """
     bucket_name = os.getenv("S3_TEST_BUCKET")
+    kms_key_id = os.getenv("S3_TEST_KMS_KEY_ID")
     prefix = f"posthog-events-{str(uuid4())}"
     destination_data = {
         "type": "S3",
@@ -469,6 +470,7 @@ async def test_s3_export_workflow_with_s3_bucket(interval, compression, encrypti
             "compression": compression,
             "exclude_events": exclude_events,
             "encryption": encryption,
+            "kms_key_id": kms_key_id if encryption == "aws:kms" else None,
         },
     }
 


### PR DESCRIPTION
## Problem

Brotli compression was released but not exposed in the frontend.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Since tests are passing, let's go ahead and expose brotli compression as a setting.
Also added AWS KMS to the end-to-end test.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually ran end to end test:
```
> S3_TEST_KMS_KEY_ID='<kms_key_id>' S3_TEST_BUCKET='<test_bucket>' DEBUG=1 pytest posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py::test_s3_export_workflow_with_s3_bucket
===================================================== test session starts =====================================================
platform linux -- Python 3.10.10, pytest-7.4.0, pluggy-0.13.1
django: settings: posthog.settings (from ini)
rootdir: posthog
configfile: pytest.ini
plugins: asyncio-0.21.1, icdiff-0.6, flaky-3.7.0, celery-4.4.7, env-0.8.2, Faker-17.5.0, syrupy-1.7.4, mock-3.11.1, split-0.8.1, django-4.5.2, cov-4.1.0
asyncio: mode=strict
collected 36 items                                                                                                            

posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py ....................................              [100%]

--------------------------------------------------- snapshot report summary ---------------------------------------------------

===================================================== 36 passed in 52.12s =====================================================

```
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
