### PR TITLE
chore(data-warehouse): Make external tab the focus

### DIFF
--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -38,7 +38,7 @@ export const appScenes: Record<Scene, () => any> = {
     [Scene.EarlyAccessFeature]: () => import('./early-access-features/EarlyAccessFeature'),
     [Scene.Surveys]: () => import('./surveys/Surveys'),
     [Scene.Survey]: () => import('./surveys/Survey'),
-    [Scene.DataWarehouse]: () => import('./data-warehouse/posthog/DataWarehousePosthogScene'),
+    [Scene.DataWarehouse]: () => import('./data-warehouse/external/DataWarehouseExternalScene'),
     [Scene.DataWarehousePosthog]: () => import('./data-warehouse/posthog/DataWarehousePosthogScene'),
     [Scene.DataWarehouseExternal]: () => import('./data-warehouse/external/DataWarehouseExternalScene'),
     [Scene.DataWarehouseSavedQueries]: () => import('./data-warehouse/saved_queries/DataWarehouseSavedQueriesScene'),

--- a/frontend/src/scenes/data-warehouse/DataWarehousePageTabs.tsx
+++ b/frontend/src/scenes/data-warehouse/DataWarehousePageTabs.tsx
@@ -13,19 +13,19 @@ export enum DataWarehouseTab {
 }
 
 const tabUrls = {
-    [DataWarehouseTab.Posthog]: urls.dataWarehousePosthog(),
     [DataWarehouseTab.External]: urls.dataWarehouseExternal(),
+    [DataWarehouseTab.Posthog]: urls.dataWarehousePosthog(),
     [DataWarehouseTab.Views]: urls.dataWarehouseSavedQueries(),
 }
 
-const dataWarehouseTabsLogic = kea<dataWarehouseTabsLogicType>({
+export const dataWarehouseTabsLogic = kea<dataWarehouseTabsLogicType>({
     path: ['scenes', 'warehouse', 'dataWarehouseTabsLogic'],
     actions: {
         setTab: (tab: DataWarehouseTab) => ({ tab }),
     },
     reducers: {
         tab: [
-            DataWarehouseTab.Posthog as DataWarehouseTab,
+            DataWarehouseTab.External as DataWarehouseTab,
             {
                 setTab: (_, { tab }) => tab,
             },
@@ -59,12 +59,12 @@ export function DataWarehousePageTabs({ tab }: { tab: DataWarehouseTab }): JSX.E
                 onChange={(t) => setTab(t)}
                 tabs={[
                     {
-                        key: DataWarehouseTab.Posthog,
-                        label: <span data-attr="data-warehouse-Posthog-tab">Posthog</span>,
-                    },
-                    {
                         key: DataWarehouseTab.External,
                         label: <span data-attr="data-warehouse-external-tab">External</span>,
+                    },
+                    {
+                        key: DataWarehouseTab.Posthog,
+                        label: <span data-attr="data-warehouse-Posthog-tab">Posthog</span>,
                     },
                     ...(featureFlags[FEATURE_FLAGS.DATA_WAREHOUSE_VIEWS]
                         ? [

--- a/frontend/src/scenes/data-warehouse/DataWarehousePageTabs.tsx
+++ b/frontend/src/scenes/data-warehouse/DataWarehousePageTabs.tsx
@@ -18,7 +18,7 @@ const tabUrls = {
     [DataWarehouseTab.Views]: urls.dataWarehouseSavedQueries(),
 }
 
-export const dataWarehouseTabsLogic = kea<dataWarehouseTabsLogicType>({
+const dataWarehouseTabsLogic = kea<dataWarehouseTabsLogicType>({
     path: ['scenes', 'warehouse', 'dataWarehouseTabsLogic'],
     actions: {
         setTab: (tab: DataWarehouseTab) => ({ tab }),

--- a/frontend/src/scenes/data-warehouse/external/DataWarehouseExternalScene.tsx
+++ b/frontend/src/scenes/data-warehouse/external/DataWarehouseExternalScene.tsx
@@ -30,13 +30,15 @@ export function DataWarehouseExternalScene(): JSX.Element {
                     </div>
                 }
                 buttons={
-                    <LemonButton
-                        type="primary"
-                        to={urls.dataWarehouseTable('new')}
-                        data-attr="new-data-warehouse-table"
-                    >
-                        New Table
-                    </LemonButton>
+                    !shouldShowProductIntroduction ? (
+                        <LemonButton
+                            type="primary"
+                            to={urls.dataWarehouseTable('new')}
+                            data-attr="new-data-warehouse-table"
+                        >
+                            New Table
+                        </LemonButton>
+                    ) : undefined
                 }
                 caption={
                     <div>

--- a/frontend/src/scenes/data-warehouse/posthog/DataWarehousePosthogScene.tsx
+++ b/frontend/src/scenes/data-warehouse/posthog/DataWarehousePosthogScene.tsx
@@ -2,7 +2,7 @@ import { LemonButton, LemonTag } from '@posthog/lemon-ui'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SceneExport } from 'scenes/sceneTypes'
 import { databaseSceneLogic } from 'scenes/data-management/database/databaseSceneLogic'
-import { DataWarehousePageTabs, DataWarehouseTab } from '../DataWarehousePageTabs'
+import { DataWarehousePageTabs, dataWarehouseTabsLogic } from '../DataWarehousePageTabs'
 import { DatabaseTablesContainer } from 'scenes/data-management/database/DatabaseTables'
 import { ViewLinkModal } from '../ViewLinkModal'
 import { useActions, useValues } from 'kea'
@@ -17,6 +17,7 @@ export const scene: SceneExport = {
 
 export function DataWarehousePosthogScene(): JSX.Element {
     const { toggleFieldModal } = useActions(viewLinkLogic)
+    const { tab } = useValues(dataWarehouseTabsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     return (
         <div>
@@ -46,7 +47,7 @@ export function DataWarehousePosthogScene(): JSX.Element {
                     ) : undefined
                 }
             />
-            <DataWarehousePageTabs tab={DataWarehouseTab.Posthog} />
+            <DataWarehousePageTabs tab={tab} />
             <DatabaseTablesContainer />
             <ViewLinkModal tableSelectable={true} />
         </div>

--- a/frontend/src/scenes/data-warehouse/posthog/DataWarehousePosthogScene.tsx
+++ b/frontend/src/scenes/data-warehouse/posthog/DataWarehousePosthogScene.tsx
@@ -2,7 +2,7 @@ import { LemonButton, LemonTag } from '@posthog/lemon-ui'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SceneExport } from 'scenes/sceneTypes'
 import { databaseSceneLogic } from 'scenes/data-management/database/databaseSceneLogic'
-import { DataWarehousePageTabs, dataWarehouseTabsLogic } from '../DataWarehousePageTabs'
+import { DataWarehousePageTabs, DataWarehouseTab } from '../DataWarehousePageTabs'
 import { DatabaseTablesContainer } from 'scenes/data-management/database/DatabaseTables'
 import { ViewLinkModal } from '../ViewLinkModal'
 import { useActions, useValues } from 'kea'
@@ -17,7 +17,6 @@ export const scene: SceneExport = {
 
 export function DataWarehousePosthogScene(): JSX.Element {
     const { toggleFieldModal } = useActions(viewLinkLogic)
-    const { tab } = useValues(dataWarehouseTabsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     return (
         <div>
@@ -47,7 +46,7 @@ export function DataWarehousePosthogScene(): JSX.Element {
                     ) : undefined
                 }
             />
-            <DataWarehousePageTabs tab={tab} />
+            <DataWarehousePageTabs tab={DataWarehouseTab.Posthog} />
             <DatabaseTablesContainer />
             <ViewLinkModal tableSelectable={true} />
         </div>


### PR DESCRIPTION
## Problem

- it's confusing right now to click on data warehouse and see the posthog tables rather than the prompt for external tables

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- make external tables the first page on the scene

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
