### PR TITLE
feat: show links to saved insights

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -32,7 +32,7 @@ export interface NodeWrapperProps<T extends CustomNotebookNodeAttributes> {
     title: string | ((attributes: CustomNotebookNodeAttributes) => Promise<string>)
     nodeType: NotebookNodeType
     children?: ReactNode | ((isEdit: boolean, isPreview: boolean) => ReactNode)
-    href?: string | ((attributes: NotebookNodeAttributes<T>) => string)
+    href?: string | ((attributes: NotebookNodeAttributes<T>) => string | undefined)
 
     // Sizing
     expandable?: boolean

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -149,6 +149,8 @@ export const NotebookNodeQuery = createPostHogWidgetNode<NotebookNodeQueryAttrib
             default: DEFAULT_QUERY,
         },
     },
+    href: (attrs) =>
+        attrs.query.kind === NodeKind.SavedInsightNode ? urls.insightView(attrs.query.shortId) : undefined,
     widgets: [
         {
             key: 'settings',


### PR DESCRIPTION
## Problem

We should show a link to a saved insight in the notebook node header

## Changes

Allow attributes to be passed to a saved insight

## How did you test this code?

https://github.com/PostHog/posthog/assets/6685876/4710ddaa-fa16-417a-ab08-7bc39afbca1b
