### PR TITLE
chore: Remove OptiPNG from local dev

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,16 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-# Check if staged files contain any added or modified PNGs - skip when merging
-if \
-  git rev-parse -q --verify MERGE_HEAD \
-  && git diff --cached --name-status | grep '^[AM]' | grep -q '.png$'
-then
-  # Error if OptiPNG is not installed
-    if ! command -v optipng >/dev/null; then
-        echo "PNG files must be optimized before being committed, but OptiPNG is not installed! Fix this with \`brew/apt install optipng\`."
-        exit 1
-    fi
-fi
-
 pnpm lint-staged

--- a/package.json
+++ b/package.json
@@ -296,9 +296,6 @@
         "!(posthog/hogql/grammar/*)*.{py,pyi}": [
             "black",
             "ruff"
-        ],
-        "*.png": [
-            "optipng -clobber -o4 -strip all"
         ]
     },
     "browserslist": {


### PR DESCRIPTION
## Problem

We use OptiPNG for compressing UI snapshots updated locally, but it's making merges very slow due to redundant optimization runs – and we practically don't update snapshots locally since CI takes care of that.

## Changes

Getting rid of local OptiPNG. Leaving it in in CI.