### PR TITLE
chore: add toolbar to support options

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -55,6 +55,7 @@ export const TARGET_AREA_TO_NAME = {
     feature_flags: 'Feature Flags',
     analytics: 'Product Analytics (Insights, Dashboards, Annotations)',
     session_replay: 'Session Replay (Recordings)',
+    tool_bar: 'Toolbar & heatmaps',
     surveys: 'Surveys',
 }
 
@@ -81,7 +82,7 @@ export const URL_PATH_TO_TARGET_AREA: Record<string, SupportTicketTargetArea> = 
     persons: 'data_integrity',
     groups: 'data_integrity',
     app: 'apps',
-    toolbar: 'analytics',
+    toolbar: 'session_replay',
     warehouse: 'data_warehouse',
     surveys: 'surveys',
 }

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -55,7 +55,7 @@ export const TARGET_AREA_TO_NAME = {
     feature_flags: 'Feature Flags',
     analytics: 'Product Analytics (Insights, Dashboards, Annotations)',
     session_replay: 'Session Replay (Recordings)',
-    tool_bar: 'Toolbar & heatmaps',
+    toolbar: 'Toolbar & heatmaps',
     surveys: 'Surveys',
 }
 


### PR DESCRIPTION
toolbar support gets routed to analytics and then to monitoring

let's just offer it as an option and route it straight to us