### PR TITLE
chore(plugin-server): Allow full rollout of hostname guard

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -268,7 +268,8 @@ export interface Hub extends PluginsServerConfig {
     lastActivityType: string
     statelessVms: StatelessVmMap
     conversionBufferEnabledTeams: Set<number>
-    fetchHostnameGuardTeams: Set<number>
+    /** null means that the hostname guard is enabled for everyone */
+    fetchHostnameGuardTeams: Set<number> | null
     // functions
     enqueuePluginJob: (job: EnqueuedPluginJob) => Promise<void>
     // ValueMatchers used for various opt-in/out features

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -70,9 +70,10 @@ export async function createHub(
     const conversionBufferEnabledTeams = new Set(
         serverConfig.CONVERSION_BUFFER_ENABLED_TEAMS.split(',').filter(String).map(Number)
     )
-    const fetchHostnameGuardTeams = new Set(
-        serverConfig.FETCH_HOSTNAME_GUARD_TEAMS.split(',').filter(String).map(Number)
-    )
+    const fetchHostnameGuardTeams =
+        serverConfig.FETCH_HOSTNAME_GUARD_TEAMS === '*'
+            ? null
+            : new Set(serverConfig.FETCH_HOSTNAME_GUARD_TEAMS.split(',').filter(String).map(Number))
 
     const statsd: StatsD | undefined = createStatsdClient(serverConfig, threadId)
 

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -257,6 +257,7 @@ export class HookCommander {
     organizationManager: OrganizationManager
     statsd: StatsD | undefined
     siteUrl: string
+    /** null means that the hostname guard is enabled for everyone */
     fetchHostnameGuardTeams: Set<number> | null
 
     /** Hook request timeout in ms. */

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -257,7 +257,7 @@ export class HookCommander {
     organizationManager: OrganizationManager
     statsd: StatsD | undefined
     siteUrl: string
-    fetchHostnameGuardTeams: Set<number>
+    fetchHostnameGuardTeams: Set<number> | null
 
     /** Hook request timeout in ms. */
     EXTERNAL_REQUEST_TIMEOUT = 10 * 1000
@@ -266,13 +266,13 @@ export class HookCommander {
         postgres: PostgresRouter,
         teamManager: TeamManager,
         organizationManager: OrganizationManager,
-        fetchHostnameGuardTeams?: Set<number>,
+        fetchHostnameGuardTeams: Set<number> | null = new Set(),
         statsd?: StatsD
     ) {
         this.postgres = postgres
         this.teamManager = teamManager
         this.organizationManager = organizationManager
-        this.fetchHostnameGuardTeams = fetchHostnameGuardTeams || new Set()
+        this.fetchHostnameGuardTeams = fetchHostnameGuardTeams
         if (process.env.SITE_URL) {
             this.siteUrl = process.env.SITE_URL
         } else {
@@ -362,7 +362,10 @@ export class HookCommander {
                 `⌛⌛⌛ Posting Webhook slow. Timeout warning after 5 sec! url=${webhookUrl} team_id=${team.id} event_id=${event.eventUuid}`
             )
         }, 5000)
-        const relevantFetch = isCloud() && this.fetchHostnameGuardTeams.has(team.id) ? safeTrackedFetch : trackedFetch
+        const relevantFetch =
+            isCloud() && (!this.fetchHostnameGuardTeams || this.fetchHostnameGuardTeams.has(team.id))
+                ? safeTrackedFetch
+                : trackedFetch
         try {
             await instrumentWebhookStep('fetch', async () => {
                 const request = await relevantFetch(webhookUrl, {
@@ -405,7 +408,9 @@ export class HookCommander {
             )
         }, 5000)
         const relevantFetch =
-            isCloud() && this.fetchHostnameGuardTeams.has(hook.team_id) ? safeTrackedFetch : trackedFetch
+            isCloud() && (!this.fetchHostnameGuardTeams || this.fetchHostnameGuardTeams.has(hook.team_id))
+                ? safeTrackedFetch
+                : trackedFetch
         try {
             const request = await relevantFetch(hook.target, {
                 method: 'POST',

--- a/plugin-server/src/worker/vm/imports.ts
+++ b/plugin-server/src/worker/vm/imports.ts
@@ -35,7 +35,10 @@ export function determineImports(hub: Hub, teamId: number) {
         'aws-sdk': AWS,
         ethers: ethers,
         'generic-pool': genericPool,
-        'node-fetch': isCloud() && hub.fetchHostnameGuardTeams.has(teamId) ? safeTrackedFetch : trackedFetch,
+        'node-fetch':
+            isCloud() && (!hub.fetchHostnameGuardTeams || hub.fetchHostnameGuardTeams.has(teamId))
+                ? safeTrackedFetch
+                : trackedFetch,
         'snowflake-sdk': snowflake,
         crypto: crypto,
         jsonwebtoken: jsonwebtoken,


### PR DESCRIPTION
## Changes

Follow-up to #17183, adding `*` as a `FETCH_HOSTNAME_GUARD_TEAMS` value meaning "roll out for all projects".