### PR TITLE
fix: misaligned 'match by' dropdown

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -394,7 +394,7 @@ export function FeatureFlagReleaseConditions({
     return (
         <>
             <div className={`feature-flag-form-row ${excludeTitle && 'mb-2'}`}>
-                <div data-attr="feature-flag-release-conditions">
+                <div data-attr="feature-flag-release-conditions" className="w-full">
                     {readOnly ? (
                         excludeTitle ? null : (
                             <h3 className="l3">{isSuper ? 'Super Release Conditions' : 'Release conditions'}</h3>


### PR DESCRIPTION
## Problem

Since _feature-flag-form-row_ component uses a flex container, the 'Match by' dropdown was displayed in the same row as the text content.

<img width="957" alt="Screenshot 2023-09-18 at 15 18 11" src="https://github.com/PostHog/posthog/assets/22996112/3e1a58d8-af7f-4de6-9d94-69854acbc6ee">

## Changes

Make the text content span the full width, thus forcing the 'Match by' dropdown on a new line.
 
<img width="811" alt="Screenshot 2023-09-18 at 15 18 59" src="https://github.com/PostHog/posthog/assets/22996112/e29b82c0-cf41-4c89-a0e8-68f47369dfd5">

## How did you test this code?

Manually in the browser and for different screen sizes.