### PR TITLE
fix(surveys): Add cushion to end date as well

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -256,7 +256,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 }
                 const startDate = dayjs((survey as Survey).created_at).format('YYYY-MM-DD')
                 const endDate = survey.end_date
-                    ? dayjs(survey.end_date).format('YYYY-MM-DD')
+                    ? dayjs(survey.end_date).add(1, 'day').format('YYYY-MM-DD')
                     : dayjs().add(1, 'day').format('YYYY-MM-DD')
 
                 const surveysShownHogqlQuery = `select count(distinct person.id) as 'survey shown' from events where event == 'survey shown' and properties.$survey_id == '${surveyId}' and timestamp >= '${startDate}' and timestamp <= '${endDate}' `
@@ -289,7 +289,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 }
                 const startDate = dayjs((survey as Survey).created_at).format('YYYY-MM-DD')
                 const endDate = survey.end_date
-                    ? dayjs(survey.end_date).format('YYYY-MM-DD')
+                    ? dayjs(survey.end_date).add(1, 'day').format('YYYY-MM-DD')
                     : dayjs().add(1, 'day').format('YYYY-MM-DD')
 
                 return {
@@ -325,7 +325,7 @@ export const surveyLogic = kea<surveyLogicType>([
 
                 const startDate = dayjs((survey as Survey).created_at).format('YYYY-MM-DD')
                 const endDate = survey.end_date
-                    ? dayjs(survey.end_date).format('YYYY-MM-DD')
+                    ? dayjs(survey.end_date).add(1, 'day').format('YYYY-MM-DD')
                     : dayjs().add(1, 'day').format('YYYY-MM-DD')
 
                 const singleChoiceQuery = `select count(), properties.$survey_response as choice from events where event == 'survey sent' and properties.$survey_id == '${survey.id}' and timestamp >= '${startDate}' and timestamp <= '${endDate}' group by choice order by count() desc`


### PR DESCRIPTION
## Problem

When surveys end on the same day as start day, hogql generates a query like:

```
/* user_id:3042 request:_api_projects_2_query_ */ SELECT count(DISTINCT events.person_id) AS `survey shown` FROM events WHERE and(equals(events.team_id, 2), equals(events.event, 'survey shown'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$survey_id'), ''), 'null'), '^"|"$', ''), '018aa7e2-3a49-0000-5faa-431c9106f060'), 0), ifNull(greaterOrEquals(toTimeZone(events.timestamp, 'US/Pacific'), '2023-09-18'), 0), ifNull(lessOrEquals(toTimeZone(events.timestamp, 'US/Pacific'), '2023-09-18'), 0)) LIMIT 100 SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=True
```

and this leads to 0 users because the window is squished to 0 (?)

So, padding the date by 1 here
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

run locally, 👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
