### PR TITLE
fix: Move redis cache outside of pg transaction

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1348,8 +1348,7 @@ export class DB {
         propertiesLastUpdatedAt: PropertiesLastUpdatedAt,
         propertiesLastOperation: PropertiesLastOperation,
         version: number,
-        tx?: TransactionClient,
-        options: { cache?: boolean } = { cache: true }
+        tx?: TransactionClient
     ): Promise<void> {
         const result = await this.postgres.query(
             tx ?? PostgresUse.COMMON_WRITE,
@@ -1374,13 +1373,6 @@ export class DB {
 
         if (result.rows.length === 0) {
             throw new RaceConditionError('Parallel posthog_group inserts, retry')
-        }
-
-        if (options?.cache) {
-            await this.updateGroupCache(teamId, groupTypeIndex, groupKey, {
-                properties: groupProperties,
-                created_at: castTimestampOrNow(createdAt, TimestampFormat.ClickHouse),
-            })
         }
     }
 
@@ -1418,11 +1410,6 @@ export class DB {
             ],
             'upsertGroup'
         )
-
-        await this.updateGroupCache(teamId, groupTypeIndex, groupKey, {
-            properties: groupProperties,
-            created_at: castTimestampOrNow(createdAt, TimestampFormat.ClickHouse),
-        })
     }
 
     public async upsertGroupClickhouse(

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -140,6 +140,7 @@ export class EventsProcessor {
                 err,
             })
         }
+        // Adds group_0 etc values to properties
         properties = await addGroupProperties(team.id, properties, this.groupTypeManager)
 
         if (event === '$groupidentify') {

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -631,46 +631,6 @@ describe('DB', () => {
                 version: 2,
             })
         })
-
-        describe('with caching', () => {
-            it('insertGroup() and updateGroup() update cache', async () => {
-                expect(await fetchGroupCache(2, 0, 'group_key')).toEqual(null)
-
-                await db.insertGroup(
-                    2,
-                    0,
-                    'group_key',
-                    { prop: 'val' },
-                    TIMESTAMP,
-                    { prop: TIMESTAMP.toISO() },
-                    { prop: PropertyUpdateOperation.Set },
-                    1,
-                    undefined,
-                    { cache: true }
-                )
-
-                expect(await fetchGroupCache(2, 0, 'group_key')).toEqual({
-                    created_at: CLICKHOUSE_TIMESTAMP,
-                    properties: { prop: 'val' },
-                })
-
-                await db.updateGroup(
-                    2,
-                    0,
-                    'group_key',
-                    { prop: 'newVal', prop2: 2 },
-                    TIMESTAMP,
-                    { prop: TIMESTAMP.toISO(), prop2: TIMESTAMP.toISO() },
-                    { prop: PropertyUpdateOperation.Set, prop2: PropertyUpdateOperation.Set },
-                    2
-                )
-
-                expect(await fetchGroupCache(2, 0, 'group_key')).toEqual({
-                    created_at: CLICKHOUSE_TIMESTAMP,
-                    properties: { prop: 'newVal', prop2: 2 },
-                })
-            })
-        })
     })
 
     describe('updateGroupCache()', () => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We were doing redis updates within a PG transaction - that's a bad idea. This caused groupidentify events processing to lock up PG and when we got a lot of groupidentify events coming in that would create lag in ingestion.

There isn't really any way to guarantee consistency across the two different data sources, so we might as well do it afterwards outside of the transaction. We run into the same problem with the CH writes anyway too.

more context: https://posthog.slack.com/archives/C0185UNBSJZ/p1695056250917589?thread_ts=1695050984.560789&cid=C0185UNBSJZ

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
