### PR TITLE
feat: use cached insight result in SavedInsight

### DIFF
--- a/frontend/src/queries/nodes/SavedInsight/SavedInsight.tsx
+++ b/frontend/src/queries/nodes/SavedInsight/SavedInsight.tsx
@@ -3,19 +3,18 @@ import { useValues } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { Query } from '~/queries/Query/Query'
 import { SavedInsightNode, QueryContext } from '~/queries/schema'
-import { InsightLogicProps, InsightModel } from '~/types'
+import { InsightLogicProps } from '~/types'
 import { Animation } from 'lib/components/Animation/Animation'
 import { AnimationType } from 'lib/animations/animations'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 
 interface InsightProps {
     query: SavedInsightNode
-    cachedResults?: Partial<InsightModel> | null
     context?: QueryContext
 }
 
-export function SavedInsight({ query: propsQuery, context, cachedResults }: InsightProps): JSX.Element {
-    const insightProps: InsightLogicProps = { dashboardItemId: propsQuery.shortId, cachedInsight: cachedResults }
+export function SavedInsight({ query: propsQuery, context }: InsightProps): JSX.Element {
+    const insightProps: InsightLogicProps = { dashboardItemId: propsQuery.shortId }
     const { insight, insightLoading } = useValues(insightLogic(insightProps))
     const { query: dataQuery } = useValues(insightDataLogic(insightProps))
 
@@ -33,5 +32,5 @@ export function SavedInsight({ query: propsQuery, context, cachedResults }: Insi
 
     const query = { ...propsQuery, ...dataQuery, full: propsQuery.full }
 
-    return <Query query={query} context={{ ...context, insightProps }} />
+    return <Query query={query} cachedResults={insight.result} context={{ ...context, insightProps }} />
 }


### PR DESCRIPTION
## Problem

`cachedResults` was never passed into the query node, and by association the saved insight node.

## Changes

- Remove the `cachedResults` prop from `SavedInsight`
- Pass the `cachedResults` from the `insight` through to the recursive call to `Query`

## How did you test this code?

🙈 