### PR TITLE
fix clickhouse env var name in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
         "DATABASE_URL": "postgres://posthog:posthog@localhost:5432/posthog",
         "KAFKA_ENABLED": "true",
         "KAFKA_HOSTS": "kafka:9092",
-        "CLICKHOUST_HOST": "localhost",
+        "CLICKHOUSE_HOST": "localhost",
         "CLICKHOUSE_DATABASE": "posthog_test",
         "CLICKHOUSE_VERIFY": "False",
         "REDIS_URL": "redis://localhost:6379",


### PR DESCRIPTION
## Changes
Fixed a typo in devcontainer's env var name.

## How did you test this code?
I did not test this change.
