### PR TITLE
feat: add additional fields to the supportModal

### DIFF
--- a/frontend/src/lib/components/Support/SupportModal.tsx
+++ b/frontend/src/lib/components/Support/SupportModal.tsx
@@ -56,6 +56,16 @@ export function SupportModal({ loggedIn = true }: { loggedIn?: boolean }): JSX.E
     // the support model can be shown when logged out, file upload is not offered to anonymous users
     const { user } = useValues(userLogic)
 
+    const handleReportTypeChange = (kind: string = supportLogic.values.sendSupportRequest.kind ?? ''): void => {
+        if (kind === 'bug') {
+            supportLogic.values.sendSupportRequest.message = SUPPORT_TICKET_TEMPLATES.bug
+        } else if (kind === 'feedback') {
+            supportLogic.values.sendSupportRequest.message = SUPPORT_TICKET_TEMPLATES.feedback
+        } else if (kind === 'support') {
+            supportLogic.values.sendSupportRequest.message = SUPPORT_TICKET_TEMPLATES.support
+        }
+    }
+
     useEffect(() => {
         handleReportTypeChange()
     }, [])
@@ -76,16 +86,6 @@ export function SupportModal({ loggedIn = true }: { loggedIn?: boolean }): JSX.E
             lemonToast.error(`Error uploading image: ${detail}`)
         },
     })
-
-    const handleReportTypeChange = (kind: string = supportLogic.values.sendSupportRequest.kind ?? ''): void => {
-        if (kind === 'bug') {
-            supportLogic.values.sendSupportRequest.message = SUPPORT_TICKET_TEMPLATES.bug
-        } else if (kind === 'feedback') {
-            supportLogic.values.sendSupportRequest.message = SUPPORT_TICKET_TEMPLATES.feedback
-        } else if (kind === 'support') {
-            supportLogic.values.sendSupportRequest.message = SUPPORT_TICKET_TEMPLATES.support
-        }
-    }
 
     return (
         <LemonModal

--- a/frontend/src/lib/components/Support/SupportModal.tsx
+++ b/frontend/src/lib/components/Support/SupportModal.tsx
@@ -70,6 +70,10 @@ export function SupportModal({ loggedIn = true }: { loggedIn?: boolean }): JSX.E
         handleReportTypeChange()
     }, [])
 
+    useEffect(() => {
+        handleReportTypeChange()
+    }, [isSupportFormOpen])
+
     if (!preflightLogic.values.preflight?.cloud) {
         if (isSupportFormOpen) {
             lemonToast.error(`In-app support isn't provided for self-hosted instances.`)

--- a/frontend/src/lib/components/Support/SupportModal.tsx
+++ b/frontend/src/lib/components/Support/SupportModal.tsx
@@ -60,7 +60,7 @@ export function SupportModal({ loggedIn = true }: { loggedIn?: boolean }): JSX.E
         handleReportTypeChange()
     }, [])
 
-    if (false && !preflightLogic.values.preflight?.cloud) {
+    if (!preflightLogic.values.preflight?.cloud) {
         if (isSupportFormOpen) {
             lemonToast.error(`In-app support isn't provided for self-hosted instances.`)
         }

--- a/frontend/src/lib/components/Support/SupportModal.tsx
+++ b/frontend/src/lib/components/Support/SupportModal.tsx
@@ -56,13 +56,36 @@ export function SupportModal({ loggedIn = true }: { loggedIn?: boolean }): JSX.E
     // the support model can be shown when logged out, file upload is not offered to anonymous users
     const { user } = useValues(userLogic)
 
-    const handleReportTypeChange = (kind: string = supportLogic.values.sendSupportRequest.kind ?? ''): void => {
+    const handleReportTypeChange = (
+        kind: string = supportLogic.values.sendSupportRequest.kind ??
+            supportLogic.values.sendSupportLoggedOutRequest.kind ??
+            ''
+    ): void => {
+        const message = loggedIn
+            ? supportLogic.values.sendSupportRequest.message
+            : supportLogic.values.sendSupportLoggedOutRequest.message
+
+        // do not overwrite modified message
+        if (
+            !(
+                message === SUPPORT_TICKET_TEMPLATES.bug ||
+                message === SUPPORT_TICKET_TEMPLATES.feedback ||
+                message === SUPPORT_TICKET_TEMPLATES.support ||
+                !message
+            )
+        ) {
+            return
+        }
+
         if (kind === 'bug') {
             supportLogic.values.sendSupportRequest.message = SUPPORT_TICKET_TEMPLATES.bug
+            supportLogic.values.sendSupportLoggedOutRequest.message = SUPPORT_TICKET_TEMPLATES.bug
         } else if (kind === 'feedback') {
             supportLogic.values.sendSupportRequest.message = SUPPORT_TICKET_TEMPLATES.feedback
+            supportLogic.values.sendSupportLoggedOutRequest.message = SUPPORT_TICKET_TEMPLATES.feedback
         } else if (kind === 'support') {
             supportLogic.values.sendSupportRequest.message = SUPPORT_TICKET_TEMPLATES.support
+            supportLogic.values.sendSupportLoggedOutRequest.message = SUPPORT_TICKET_TEMPLATES.support
         }
     }
 


### PR DESCRIPTION
## Problem

There are a lot of instances where we have to ask users to provide additional information (context, links, etc..). This will hopefully reduce that.

## Changes

<img width="495" alt="Screenshot 2023-09-19 at 00 04 45@2x" src="https://github.com/PostHog/posthog/assets/13001502/0b588514-f9da-49c9-93cf-29dc0cd7588f">

- [x] remove debug code

## How did you test this code?

I created a bunch of zendesk tickets
