### PR TITLE
fix: drop suggestion position fix

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/NotebookPopover.scss
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookPopover.scss
@@ -40,10 +40,6 @@
         transition: transform var(--notebook-popover-transition-properties),
             width var(--notebook-popover-transition-properties);
 
-        > * + * {
-            margin-top: 1rem;
-        }
-
         .NotebookPopover__content__card {
             flex: 1;
             display: flex;
@@ -102,6 +98,7 @@
 
     transition: all 150ms;
     height: 4rem;
+    margin-bottom: 1rem;
     backdrop-filter: blur(5px);
     display: flex;
 


### PR DESCRIPTION
## Problem
The drop suggestion was misaligned

https://github.com/PostHog/posthog/assets/6685876/878f35ee-9023-4053-8ec7-4eee4b4196b6

## Changes

Couldn't fully figure out why but the margin top was affecting the drop position of the editor. So instead added a margin bottom to the other element

## How did you test this code?

https://github.com/PostHog/posthog/assets/6685876/81c1a89d-8c54-458c-ab5c-a10c0ebbbb56

