### PR TITLE
fix: Notebook Person pasterule

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
@@ -71,7 +71,7 @@ export const NotebookNodePerson = createPostHogWidgetNode<NotebookNodePersonAttr
         id: {},
     },
     pasteOptions: {
-        find: urls.person('(.+)'),
+        find: urls.person('(.+)', false),
         getAttributes: async (match) => {
             return { id: match[1] }
         },


### PR DESCRIPTION
## Problem

The pasterule for a person was broken as it tried to encode the match

## Changes

* Fixes it by passing false to not encode it

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
