### PR TITLE
chore: faster event count for system status

### DIFF
--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -362,10 +362,12 @@ def get_event_count_for_team(team_id: Union[str, int]) -> int:
 
 
 def get_event_count() -> int:
+    """
+    ```SELECT count(1) as count FROM events``` is too slow on cloud
+    """
     result = sync_execute(
         """
-        SELECT count(1) as count
-        FROM events
+        SELECT sum(rows) FROM system.parts WHERE (active = 1) AND (table = 'sharded_events')
     """
     )[0][0]
     return result


### PR DESCRIPTION
Maybe the error is pointing me in the wrong direction but trying to load the system status page is failing because the event count is timing out.

I _think_ this is a reasonable alternative

<img width="1189" alt="Screenshot 2023-09-19 at 15 39 01" src="https://github.com/PostHog/posthog/assets/984817/cf74c09c-b9a0-4690-a015-d5e5a6a6a93d">

These all give the same result on my machine

```
SELECT sum(rows) 
        FROM system.parts 
        WHERE (active = 1) AND (table = 'sharded_events');

select count (1) from events;

select count() from events;
```
but only the first succeeds on cloud