### PR TITLE
chore: Add more logs for onEvent to faster find slowness sources

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/runAsyncHandlersStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runAsyncHandlersStep.ts
@@ -11,7 +11,8 @@ export async function processOnEventStep(runner: EventPipelineRunner, event: Pos
 
     await runInstrumentedFunction({
         timeoutContext: () => ({
-            event: JSON.stringify(processedPluginEvent),
+            team_id: event.teamId,
+            event_uuid: event.eventUuid,
         }),
         func: () => runOnEvent(runner.hub, processedPluginEvent),
         statsKey: `kafka_queue.single_on_event`,

--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -12,39 +12,48 @@ async function runSingleTeamPluginOnEvent(
     pluginConfig: PluginConfig,
     onEvent: any
 ): Promise<void> {
-    // Runs onEvent for a single plugin without any retries
-    const metricName = 'plugin.on_event'
-    const metricTags = {
-        plugin: pluginConfig.plugin?.name ?? '?',
-        teamId: event.team_id.toString(),
-    }
-
-    const timer = new Date()
+    const timeout = setTimeout(() => {
+        console.log(
+            `⌛⌛⌛ Still running single onEvent plugin for team ${event.team_id} for plugin ${pluginConfig.id}`
+        )
+    }, 10 * 1000) // 10 seconds
     try {
-        await onEvent!(event)
-        await hub.appMetrics.queueMetric({
-            teamId: event.team_id,
-            pluginConfigId: pluginConfig.id,
-            category: 'onEvent',
-            successes: 1,
-        })
-    } catch (error) {
-        hub.statsd?.increment(`${metricName}.ERROR`, metricTags)
-        await processError(hub, pluginConfig, error, event)
-        await hub.appMetrics.queueError(
-            {
+        // Runs onEvent for a single plugin without any retries
+        const metricName = 'plugin.on_event'
+        const metricTags = {
+            plugin: pluginConfig.plugin?.name ?? '?',
+            teamId: event.team_id.toString(),
+        }
+
+        const timer = new Date()
+        try {
+            await onEvent!(event)
+            await hub.appMetrics.queueMetric({
                 teamId: event.team_id,
                 pluginConfigId: pluginConfig.id,
                 category: 'onEvent',
-                failures: 1,
-            },
-            {
-                error,
-                event,
-            }
-        )
+                successes: 1,
+            })
+        } catch (error) {
+            hub.statsd?.increment(`${metricName}.ERROR`, metricTags)
+            await processError(hub, pluginConfig, error, event)
+            await hub.appMetrics.queueError(
+                {
+                    teamId: event.team_id,
+                    pluginConfigId: pluginConfig.id,
+                    category: 'onEvent',
+                    failures: 1,
+                },
+                {
+                    error,
+                    event,
+                }
+            )
+        }
+        hub.statsd?.timing(metricName, timer, metricTags)
+    } finally {
+        clearTimeout(timeout)
     }
-    hub.statsd?.timing(metricName, timer, metricTags)
 }
 
 export async function runOnEvent(hub: Hub, event: ProcessedPluginEvent): Promise<void> {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

I've updated a bunch of apps away from exportEvents to onEvent and we're seeing some lag happening.

The problem with the current logs is that we have newlines in them, which means it's super annoying to use in [grafana](http://grafana-prod-us/explore?panes=%7B%22EJa%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22builder%22,%22expr%22:%22%7Bcontainer%3D%5C%22ingestion-plugins-onevent%5C%22%7D%20%7C%3D%20%60After%2030%20seconds%60%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-3h%22,%22to%22:%22now%22%7D%7D%7D&schemaVersion=1&orgId=1). 
Furthermore we have already sent this event to CH, so there's no reason for us to log the whole thing into Loki and Sentry. Plus we'd have customer customer data in Sentry, which isn't good.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
