### PR TITLE
fix: screenshot flapping from selector

### DIFF
--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -56,6 +56,7 @@ const LOADER_SELECTORS = [
     '.LemonSkeleton',
     '.LemonTableLoader',
     '[aria-busy="true"]',
+    '[aria-label="Content is loading..."]',
     '.SessionRecordingPlayer--buffering',
     '.Lettermark--unknown',
 ]


### PR DESCRIPTION
## Problem

Seeing these two snapshots flapping quite a lot
`playwright/e2e-vrt/layout/Navigation.spec.ts-snapshots/Navigation-App-Page-With-Side-Bar-Hidden-Mobile-1-chromium-linux.png`
`playwright/e2e-vrt/layout/Navigation.spec.ts-snapshots/Navigation-App-Page-With-Side-Bar-Shown-Mobile-1-chromium-linux.png`

Example:
<img width="916" alt="Screenshot 2023-09-20 at 17 10 16" src="https://github.com/PostHog/posthog/assets/6685876/5d069f2e-360e-4f71-9f06-0abf766c13d7">


Looking at Storybook it seems to be a Storybook loading state
<img width="1129" alt="Screenshot 2023-09-20 at 17 07 19" src="https://github.com/PostHog/posthog/assets/6685876/d6b76a4c-9b3c-42f5-a78a-a0f44ad6d528">


## Changes

Add a loader selector to the test runner to make sure Storybook has fully loaded before taking a screenshot

## How did you test this code?

Who tests the tests 🤔 