### PR TITLE
feat: Handle potential races in revoking replay partitions

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/partition-locker.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/partition-locker.ts
@@ -83,7 +83,7 @@ export class PartitionLocker {
                         `PartitionLocker failed to claim keys. Waiting ${this.delay} before retrying...`,
                         {
                             id: this.consumerID,
-                            blockingConsumers,
+                            blockingConsumers: [...blockingConsumers],
                         }
                     )
                     await new Promise((r) => setTimeout(r, this.delay))

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
@@ -107,6 +107,8 @@ export class SessionRecordingIngesterV2 {
     recordingConsumerConfig: PluginsServerConfig
     topic = KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS
 
+    private promises: Promise<any>[] = []
+
     constructor(
         private serverConfig: PluginsServerConfig,
         private postgres: PostgresRouter,
@@ -140,21 +142,21 @@ export class SessionRecordingIngesterV2 {
 
         this.offsetsRefresher = new BackgroundRefresher(async () => {
             const results = await Promise.all(
-                Object.keys(this.partitionAssignments).map(async (partition) => {
+                this.assignedTopicPartitions.map(async ({ partition }) => {
                     return new Promise<[number, number]>((resolve, reject) => {
                         if (!this.batchConsumer) {
                             return reject('Not connected')
                         }
                         this.batchConsumer.consumer.queryWatermarkOffsets(
                             KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS,
-                            parseInt(partition),
+                            partition,
                             (err, offsets) => {
                                 if (err) {
                                     status.error('🔥', 'Failed to query kafka watermark offsets', err)
                                     return reject()
                                 }
 
-                                resolve([parseInt(partition), offsets.highOffset])
+                                resolve([partition, offsets.highOffset])
                             }
                         )
                     })
@@ -166,6 +168,24 @@ export class SessionRecordingIngesterV2 {
                 return acc
             }, {} as Record<number, number>)
         }, 5000)
+    }
+
+    private get assignedTopicPartitions(): TopicPartition[] {
+        return Object.keys(this.partitionAssignments).map((partition) => ({
+            partition: parseInt(partition),
+            topic: this.topic,
+        }))
+    }
+
+    private scheduleWork<T>(promise: Promise<T>): Promise<T> {
+        /**
+         * Helper to handle graceful shutdowns. Every time we do some work we add a promise to this array and remove it when finished.
+         * That way when shutting down we can wait for all promises to finish before exiting.
+         */
+        this.promises.push(promise)
+        promise.finally(() => (this.promises = this.promises.filter((p) => p !== promise)))
+
+        return promise
     }
 
     public async consume(event: IncomingRecordingMessage, sentrySpan?: Sentry.Span): Promise<void> {
@@ -426,12 +446,7 @@ export class SessionRecordingIngesterV2 {
 
         if (this.serverConfig.SESSION_RECORDING_PARTITION_REVOKE_OPTIMIZATION) {
             this.partitionLockInterval = setInterval(async () => {
-                await this.partitionLocker.claim(
-                    Object.keys(this.partitionAssignments).map((partition) => ({
-                        partition: parseInt(partition),
-                        topic: this.topic,
-                    }))
-                )
+                await this.partitionLocker.claim(this.assignedTopicPartitions)
             }, PARTITION_LOCK_INTERVAL_MS)
         }
 
@@ -478,7 +493,7 @@ export class SessionRecordingIngesterV2 {
             }
 
             if (err.code === CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
-                return this.onRevokePartitions(topicPartitions)
+                return this.scheduleWork(this.onRevokePartitions(topicPartitions))
             }
 
             // We had a "real" error
@@ -510,23 +525,12 @@ export class SessionRecordingIngesterV2 {
         await this.batchConsumer?.stop()
 
         // Simulate a revoke command to try and flush all sessions
-        // The rebalance event should have done this but we do it again as an extra precaution and to await the flushes
-        await this.onRevokePartitions(
-            Object.keys(this.partitionAssignments).map((partition) => ({
-                partition: parseInt(partition),
-                topic: this.topic,
-            })) as TopicPartition[]
-        )
+        // There is a race between the revoke callback and this function - Either way one of them gets there and covers the revocations
+        void this.scheduleWork(this.onRevokePartitions(this.assignedTopicPartitions))
 
         await this.realtimeManager.unsubscribe()
         await this.replayEventsIngester.stop()
-
-        // This is inefficient but currently necessary due to new instances restarting from the committed offset point
-        await this.destroySessions(Object.entries(this.sessions))
-
-        this.sessions = {}
-
-        gaugeRealtimeSessions.reset()
+        await Promise.allSettled(this.promises)
     }
 
     public isHealthy() {
@@ -549,39 +553,32 @@ export class SessionRecordingIngesterV2 {
          * As a result, we need to drop all sessions currently managed for the revoked partitions
          */
 
+        /**
+         * IDEA
+         *
+         * 1. Pull out all sessions we are revoking.
+         * 2. Reset all the relevant metrics - that way we don't have to worry about races
+         * 3. Lock all the partitions we are revoking - gives us N seconds to deal with them
+         * 4. Flush all the sessions (probably with a timeout)
+         * 5. We can safely destroy them as they aren't pat of the sessions map
+         */
+
         const revokedPartitions = topicPartitions.map((x) => x.partition)
         if (!revokedPartitions.length) {
             return
         }
 
-        const sessionsToDrop = Object.entries(this.sessions).filter(([_, sessionManager]) =>
-            revokedPartitions.includes(sessionManager.partition)
-        )
+        const sessionsToDrop: SessionManager[] = []
 
-        gaugeSessionsRevoked.set(sessionsToDrop.length)
-        gaugeSessionsHandled.remove()
+        // First we pull out all sessions that are being dropped. This way if we get reassigned and start consuming, we don't accidentally destroy them
+        Object.entries(this.sessions).forEach(([key, sessionManager]) => {
+            if (revokedPartitions.includes(sessionManager.partition)) {
+                sessionsToDrop.push(sessionManager)
+                delete this.sessions[key]
+            }
+        })
 
-        // Attempt to flush all sessions
-        // TODO: Improve this to
-        // - work from oldest to newest
-        // - have some sort of timeout so we don't get stuck here forever
-        if (this.serverConfig.SESSION_RECORDING_PARTITION_REVOKE_OPTIMIZATION) {
-            status.info('🔁', `blob_ingester_consumer - flushing ${sessionsToDrop.length} sessions on revoke...`)
-
-            await runInstrumentedFunction({
-                statsKey: `recordingingester.onRevokePartitions.flushSessions`,
-                logExecutionTime: true,
-                func: async () => {
-                    await Promise.allSettled(
-                        sessionsToDrop
-                            .map(([_, x]) => x)
-                            .sort((x) => x.buffer.oldestKafkaTimestamp ?? Infinity)
-                            .map((x) => x.flush('partition_shutdown'))
-                    )
-                },
-            })
-        }
-
+        // Reset all metrics for the revoked partitions
         topicPartitions.forEach((topicPartition: TopicPartition) => {
             const partition = topicPartition.partition
 
@@ -593,10 +590,31 @@ export class SessionRecordingIngesterV2 {
             this.offsetHighWaterMarker.revoke(topicPartition)
         })
 
+        gaugeSessionsRevoked.set(sessionsToDrop.length)
+        gaugeSessionsHandled.remove()
+
         if (this.serverConfig.SESSION_RECORDING_PARTITION_REVOKE_OPTIMIZATION) {
+            // Extend our claim on these partitions to give us time to flush
+            await this.partitionLocker.claim(topicPartitions)
+            status.info('🔁', `blob_ingester_consumer - flushing ${sessionsToDrop.length} sessions on revoke...`)
+
+            // Flush all the sessions we are supposed to drop
+            await runInstrumentedFunction({
+                statsKey: `recordingingester.onRevokePartitions.flushSessions`,
+                logExecutionTime: true,
+                func: async () => {
+                    await Promise.allSettled(
+                        sessionsToDrop
+                            .sort((x) => x.buffer.oldestKafkaTimestamp ?? Infinity)
+                            .map((x) => x.flush('partition_shutdown'))
+                    )
+                },
+            })
+
             await this.partitionLocker.release(topicPartitions)
         }
-        await this.destroySessions(sessionsToDrop)
+
+        await Promise.allSettled(sessionsToDrop.map((x) => x.destroy()))
         await this.offsetsRefresher.refresh()
     }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
@@ -531,6 +531,7 @@ export class SessionRecordingIngesterV2 {
         await this.realtimeManager.unsubscribe()
         await this.replayEventsIngester.stop()
         await Promise.allSettled(this.promises)
+        status.info('👍', 'blob_ingester_consumer - stopped!')
     }
 
     public isHealthy() {
@@ -689,11 +690,6 @@ export class SessionRecordingIngesterV2 {
         if (this.partitionAssignments[partition]) {
             this.partitionAssignments[partition].lastKnownCommit = highestOffsetToCommit
         }
-
-        status.info('💾', `blob_ingester_consumer.commitOffsets - attempting to commit offset`, {
-            partition,
-            offsetToCommit: highestOffsetToCommit,
-        })
 
         this.batchConsumer?.consumer.commit({
             ...topicPartition,

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
@@ -409,6 +409,11 @@ describe('ingester', () => {
                 otherIngester.onAssignPartitions([createTP(2), createTP(3)]),
             ]
 
+            // Should immediately be removed from the tracked sessions
+            expect(
+                Object.values(ingester.sessions).map((x) => `${x.partition}:${x.sessionId}:${x.buffer.count}`)
+            ).toEqual(['1:session_id_1:1', '1:session_id_2:1'])
+
             // Call the second ingester to receive the messages. The revocation should still be in progress meaning they are "paused" for a bit
             // Once the revocation is complete the second ingester should receive the messages but drop most of them as they got flushes by the revoke
             await otherIngester.handleEachBatch([


### PR DESCRIPTION
## Problem

We started to add revocation handling so that we gracefully flush all sessions on revoke. This works but has some flaws:
1. If the partition is reassigned (perhaps during rollout) then we might eventually resolve the revoke promise and delete the session that is now being re-consumed.
2. On shutdown, the revoke might trigger in the background, leaving us with some dangling promises so we exit too early.

## Changes

* Adds a "promise" tracker that will schedule any important tasks such as revocations, allowing them to be awaited on shutdown
* Adds helper code to DRY up some things
* Remove the sessions being revoked, meaning if we later get reassigned, there will be newly created sessions that we wont mess with.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

* This is really tricky to test. I'll try and add something...
