### PR TITLE
chore: App metrics no hub no promise manager

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -62,6 +62,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_MAX_MESSAGE_BATCH_SIZE: isDevEnv() ? 0 : 900_000,
         KAFKA_FLUSH_FREQUENCY_MS: isTestEnv() ? 5 : 500,
         APP_METRICS_FLUSH_FREQUENCY_MS: isTestEnv() ? 5 : 20_000,
+        APP_METRICS_FLUSH_MAX_QUEUE_SIZE: isTestEnv() ? 5 : 1000,
         REDIS_URL: 'redis://127.0.0.1',
         POSTHOG_REDIS_PASSWORD: '',
         POSTHOG_REDIS_HOST: '',

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -145,6 +145,7 @@ export interface PluginsServerConfig {
     KAFKA_MAX_MESSAGE_BATCH_SIZE: number
     KAFKA_FLUSH_FREQUENCY_MS: number
     APP_METRICS_FLUSH_FREQUENCY_MS: number
+    APP_METRICS_FLUSH_MAX_QUEUE_SIZE: number
     BASE_DIR: string // base path for resolving local plugins
     PLUGINS_RELOAD_PUBSUB_CHANNEL: string // Redis channel for reload events'
     LOG_LEVEL: LogLevel


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
I want to use app metrics for webhooks, which don't have hub. 
1. We don't need a hub. 
2. We also don't want to use promiseManager (it makes things unpredictable and hard to debug).
3. we weren't flushing the app metrics on app shutdown
4. removed the no longer relevant isAvailable stuff (it's 100% enabled on cloud and also that was more for the self-hosted model)
5. added logs to keep track of how long flushes are taking to make sure they aren't causing problems

## Changes

6. Added an ability to flush by key limit too - giving us more options to configure when flushes happen. Too big of a queue is a problem too, e.g. when we're getting lot's of errors as each of these is a separate row currently.

The guard for not flushing in tests is because of our tests not being properly set-up isolated, ideally we'd move the app metrics completely outside of the hub, but that's for the future.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
