### PR TITLE
feat: new onboarding navigation

### DIFF
--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -77,7 +77,7 @@ export const billingLogic = kea<billingLogicType>([
                     return window.location.pathname.includes('/ingestion')
                         ? urls.ingestion() + '/billing'
                         : window.location.pathname.includes('/onboarding')
-                        ? window.location.pathname
+                        ? window.location.pathname + window.location.search
                         : ''
                 },
             },

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -162,8 +162,10 @@ export const onboardingLogic = kea<onboardingLogicType>({
     actionToUrl: ({ values }) => ({
         setCurrentOnboardingStepNumber: () => {
             const stepName = values.allOnboardingSteps[values.currentOnboardingStepNumber - 1]?.type?.name
-            const stepKey = Object.keys(onboardingStepMap).find((key) => onboardingStepMap[key] === stepName)
-            if (stepKey && values.allOnboardingSteps.find((step) => step.type.name === stepName)) {
+            const stepKey =
+                Object.keys(onboardingStepMap).find((key) => onboardingStepMap[key] === stepName) ||
+                values.currentOnboardingStepNumber.toString()
+            if (stepKey) {
                 return [`/onboarding/${values.productKey}`, { step: stepKey }]
             } else {
                 return [`/onboarding/${values.productKey}`]
@@ -182,7 +184,7 @@ export const onboardingLogic = kea<onboardingLogicType>({
             if (productKey !== values.productKey) {
                 actions.setProductKey(productKey)
             }
-            if (step && step in onboardingStepMap) {
+            if (step && (step in onboardingStepMap || parseInt(step) > 1)) {
                 actions.setStepKey(step)
             } else {
                 actions.setCurrentOnboardingStepNumber(1)

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -141,6 +141,7 @@ export const onboardingLogic = kea<onboardingLogicType>({
             let stepKey = values.stepKey
             if (values.stepKey) {
                 if (parseInt(values.stepKey) > 0) {
+                    // try to convert the step number to a step key
                     const stepName = allOnboardingSteps[parseInt(values.stepKey) - 1]?.type?.name
                     const newStepKey = Object.keys(onboardingStepMap).find((key) => onboardingStepMap[key] === stepName)
                     if (stepName && stepKey) {
@@ -158,6 +159,7 @@ export const onboardingLogic = kea<onboardingLogicType>({
                         actions.setStepKey('')
                     }
                 } else if (
+                    // if it's a number, just use that and set the correct onboarding step number
                     parseInt(stepKey) > 1 &&
                     allOnboardingSteps.length > 0 &&
                     allOnboardingSteps[parseInt(stepKey) - 1]
@@ -212,6 +214,3 @@ export const onboardingLogic = kea<onboardingLogicType>({
         },
     }),
 })
-
-//  problems:
-// - after upgrading it redirects to the first step

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -157,6 +157,7 @@ export const onboardingLogic = kea<onboardingLogicType>({
                         actions.setCurrentOnboardingStepNumber(stepIndex + 1)
                     } else {
                         actions.setStepKey('')
+                        actions.setCurrentOnboardingStepNumber(1)
                     }
                 } else if (
                     // if it's a number, just use that and set the correct onboarding step number
@@ -169,6 +170,9 @@ export const onboardingLogic = kea<onboardingLogicType>({
             }
         },
         setStepKey: ({ stepKey }) => {
+            // if the step key is invalid (doesn't exist in the onboardingStepMap or the allOnboardingSteps array)
+            // remove it from the state. Numeric step keys are also allowed, as long as they are a valid
+            // index for the allOnboardingSteps array.
             if (
                 stepKey &&
                 values.allOnboardingSteps.length > 0 &&
@@ -183,6 +187,7 @@ export const onboardingLogic = kea<onboardingLogicType>({
     }),
     actionToUrl: ({ values }) => ({
         setCurrentOnboardingStepNumber: () => {
+            // when the current step number changes, update the url to reflect the new step
             const stepName = values.allOnboardingSteps[values.currentOnboardingStepNumber - 1]?.type?.name
             const stepKey =
                 Object.keys(onboardingStepMap).find((key) => onboardingStepMap[key] === stepName) ||


### PR DESCRIPTION
## Problem

We need to know based on the URL what step we are on, and go to the correct step given a single URL. This needs to work for "named" steps, but also unnamed steps for making the process of creating onboarding flows easier.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

I found creating this logic complicated. Each step that the onboarding natively supports (sdks, billing, intro) has a key, eg `?step=billing`. This needs to be dynamic because the billing step won't always be there, and it won't always be in the same order. So we have all the steps stored and find the component with the correct component name for the key. 

If something is just an `<OnboardingStep>` then it won't have a special name, so we set the step key as the step number. 

This works in both directions - navigating to a URL with a specific step and also using the app to go to the next step, the URL will update.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

No tests yet...

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
