### PR TITLE
fix(batch-exports): Do not export site url

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_batch_exports.py
+++ b/posthog/temporal/tests/batch_exports/test_batch_exports.py
@@ -270,7 +270,7 @@ async def test_get_results_iterator(client):
             "elements_chain": "this that and the other",
             "elements": json.dumps("this that and the other"),
             "ip": "127.0.0.1",
-            "site_url": "http://localhost.com",
+            "site_url": "",
             "set": None,
             "set_once": None,
         }
@@ -327,7 +327,7 @@ async def test_get_results_iterator_handles_duplicates(client):
             "elements_chain": "this that and the other",
             "elements": json.dumps("this that and the other"),
             "ip": "127.0.0.1",
-            "site_url": "http://localhost.com",
+            "site_url": "",
             "set": None,
             "set_once": None,
         }
@@ -387,7 +387,7 @@ async def test_get_results_iterator_can_exclude_events(client):
             "elements_chain": "this that and the other",
             "elements": json.dumps("this that and the other"),
             "ip": "127.0.0.1",
-            "site_url": "http://localhost.com",
+            "site_url": "",
             "set": None,
             "set_once": None,
         }

--- a/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
@@ -67,7 +67,7 @@ def assert_events_in_bigquery(client, table_id, dataset_id, events, bq_ingested_
             "properties": event.get("properties"),
             "set": properties.get("$set", None) if properties else None,
             "set_once": properties.get("$set_once", None) if properties else None,
-            "site_url": properties.get("$current_url", None) if properties else None,
+            "site_url": "",
             # For compatibility with CH which doesn't parse timezone component, so we add it here assuming UTC.
             "timestamp": dt.datetime.fromisoformat(event.get("timestamp") + "+00:00"),
             "team_id": event.get("team_id"),

--- a/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
@@ -66,7 +66,8 @@ def assert_events_in_postgres(connection, schema, table_name, events):
             "properties": event.get("properties"),
             "set": properties.get("$set", None) if properties else None,
             "set_once": properties.get("$set_once", None) if properties else None,
-            "site_url": properties.get("$current_url", None) if properties else None,
+            # Kept for backwards compatibility, but not exported anymore.
+            "site_url": "",
             # For compatibility with CH which doesn't parse timezone component, so we add it here assuming UTC.
             "timestamp": dt.datetime.fromisoformat(event.get("timestamp") + "+00:00"),
             "team_id": event.get("team_id"),

--- a/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
@@ -67,7 +67,7 @@ def assert_events_in_postgres(connection, schema, table_name, events):
             "set": properties.get("$set", None) if properties else None,
             "set_once": properties.get("$set_once", None) if properties else None,
             # Kept for backwards compatibility, but not exported anymore.
-            "site_url": "",
+            "site_url": None,
             # For compatibility with CH which doesn't parse timezone component, so we add it here assuming UTC.
             "timestamp": dt.datetime.fromisoformat(event.get("timestamp") + "+00:00"),
             "team_id": event.get("team_id"),

--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -155,7 +155,8 @@ def iter_batch_records(batch) -> typing.Generator[dict[str, typing.Any], None, N
             "set": properties.get("$set", None) if properties else None,
             "set_once": properties.get("$set_once", None) if properties else None,
             "properties": properties,
-            "site_url": properties.get("$current_url", None) if properties else None,
+            # Kept for backwards compatibility, but not exported anymore.
+            "site_url": "",
             "team_id": record.get("team_id"),
             "timestamp": record.get("timestamp").isoformat(),
             "uuid": record.get("uuid").decode(),


### PR DESCRIPTION
## Problem

This field should not be exported and its causing issues when schemas have a limit (like for PG exports).

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Export `""` as `site_url` to avoid breaking backwards compatibility.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Update tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
