### PR TITLE
fix: Wait for ingester shutdown before redis shutdown

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/partition-locker.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/partition-locker.ts
@@ -131,6 +131,7 @@ export class PartitionLocker {
                     keys,
                 },
             })
+            throw error
         }
     }
 }

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/realtime-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/realtime-manager.ts
@@ -66,6 +66,7 @@ export class RealtimeManager extends EventEmitter {
         )
 
         this.pubsubRedis?.disconnect()
+        this.pubsubRedis = undefined
     }
 
     private async run<T>(description: string, fn: (client: Redis) => Promise<T>): Promise<T | null> {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
@@ -528,10 +528,13 @@ export class SessionRecordingIngesterV2 {
 
         await this.realtimeManager.unsubscribe()
         await this.replayEventsIngester.stop()
+
+        await Promise.allSettled(this.promises)
+
+        // Finally we clear up redis once we are sure everything else has been handled
         await this.redisPool.drain()
         await this.redisPool.clear()
 
-        await Promise.allSettled(this.promises)
         status.info('👍', 'blob_ingester_consumer - stopped!')
     }
 

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -17,7 +17,7 @@ import { captureEventLoopMetrics } from '../utils/metrics'
 import { cancelAllScheduledJobs } from '../utils/node-schedule'
 import { PubSub } from '../utils/pubsub'
 import { status } from '../utils/status'
-import { createRedisPool, delay } from '../utils/utils'
+import { delay } from '../utils/utils'
 import { OrganizationManager } from '../worker/ingestion/organization-manager'
 import { TeamManager } from '../worker/ingestion/team-manager'
 import Piscina, { makePiscina as defaultMakePiscina } from '../worker/piscina'
@@ -420,27 +420,18 @@ export async function startPluginsServer(
             const statsd = hub?.statsd ?? createStatsdClient(serverConfig, null)
             const postgres = hub?.postgres ?? new PostgresRouter(serverConfig, statsd)
             const s3 = hub?.objectStorage ?? getObjectStorage(recordingConsumerConfig)
-            const redisPool = hub?.db.redisPool ?? createRedisPool(recordingConsumerConfig)
 
             if (!s3) {
                 throw new Error("Can't start session recording blob ingestion without object storage")
             }
             // NOTE: We intentionally pass in the original serverConfig as the ingester uses both kafkas
-            const ingester = new SessionRecordingIngesterV2(serverConfig, postgres, s3, redisPool)
+            const ingester = new SessionRecordingIngesterV2(serverConfig, postgres, s3)
             await ingester.start()
 
             const batchConsumer = ingester.batchConsumer
 
             if (batchConsumer) {
-                stopSessionRecordingBlobConsumer = async () => {
-                    // Tricky - in some cases the hub is responsible, in which case it will drain and clear. Otherwise we are responsible.
-                    await ingester.stop()
-
-                    if (!hub?.db.redisPool) {
-                        await redisPool.drain()
-                        await redisPool.clear()
-                    }
-                }
+                stopSessionRecordingBlobConsumer = () => ingester.stop()
                 joinSessionRecordingBlobConsumer = () => batchConsumer.join()
                 healthChecks['session-recordings-blob'] = () => ingester.isHealthy() ?? false
             }

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -434,12 +434,12 @@ export async function startPluginsServer(
             if (batchConsumer) {
                 stopSessionRecordingBlobConsumer = async () => {
                     // Tricky - in some cases the hub is responsible, in which case it will drain and clear. Otherwise we are responsible.
+                    await ingester.stop()
+
                     if (!hub?.db.redisPool) {
                         await redisPool.drain()
                         await redisPool.clear()
                     }
-
-                    await ingester.stop()
                 }
                 joinSessionRecordingBlobConsumer = () => batchConsumer.join()
                 healthChecks['session-recordings-blob'] = () => ingester.isHealthy() ?? false

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v2.test.ts
@@ -88,7 +88,7 @@ describe('ingester', () => {
 
     // these tests assume that a flush won't run while they run
     beforeEach(async () => {
-        ingester = new SessionRecordingIngesterV2(config, hub.postgres, hub.objectStorage, hub.redisPool)
+        ingester = new SessionRecordingIngesterV2(config, hub.postgres, hub.objectStorage)
         await ingester.start()
     })
 
@@ -339,7 +339,7 @@ describe('ingester', () => {
         jest.setTimeout(5000) // Increased to cover lock delay
 
         beforeEach(async () => {
-            otherIngester = new SessionRecordingIngesterV2(config, hub.postgres, hub.objectStorage, hub.redisPool)
+            otherIngester = new SessionRecordingIngesterV2(config, hub.postgres, hub.objectStorage)
             await otherIngester.start()
         })
 


### PR DESCRIPTION
## Problem

We have a lot of errors about redis being disconnected. This could be because we disconnect before waiting for the ingester to be finished.

## Changes

* Swaps the order around

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
