### PR TITLE
feat: onboarding invite members, other products, verification steps

### DIFF
--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -49,12 +49,13 @@ const OnboardingWrapper = ({ children }: { children: React.ReactNode }): JSX.Ele
         if (Array.isArray(children)) {
             steps = [ProductIntro, ...children]
         } else {
-            steps = [ProductIntro, children as JSX.Element, OtherProductsStep]
+            steps = [ProductIntro, children as JSX.Element]
         }
         if (shouldShowBillingStep) {
             const BillingStep = <OnboardingBillingStep product={product} />
-            steps = [...steps, BillingStep, OtherProductsStep]
+            steps = [...steps, BillingStep]
         }
+        steps = [...steps, OtherProductsStep]
         setAllSteps(steps)
     }
 

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -13,6 +13,7 @@ import { SessionReplaySDKInstructions } from './sdks/session-replay/SessionRepla
 import { OnboardingBillingStep } from './OnboardingBillingStep'
 import { OnboardingOtherProductsStep } from './OnboardingOtherProductsStep'
 import { teamLogic } from 'scenes/teamLogic'
+import { OnboardingVerificationStep } from './OnboardingVerificationStep'
 
 export const scene: SceneExport = {
     component: Onboarding,
@@ -67,6 +68,7 @@ const ProductAnalyticsOnboarding = (): JSX.Element => {
     return (
         <OnboardingWrapper>
             <SDKs usersAction="collecting events" sdkInstructionMap={ProductAnalyticsSDKInstructions} />
+            <OnboardingVerificationStep listeningForName="event" teamPropertyToVerify="ingested_event" />
         </OnboardingWrapper>
     )
 }
@@ -85,7 +87,7 @@ const SessionReplayOnboarding = (): JSX.Element => {
             <SDKs
                 usersAction="recording sessions"
                 sdkInstructionMap={SessionReplaySDKInstructions}
-                subtitle="Choose the framework your frontend is built on, or use our all-purpose JavaScript library. if you already have the snippet installed, you can skip this step!"
+                subtitle="Choose the framework your frontend is built on, or use our all-purpose JavaScript library. If you already have the snippet installed, you can skip this step!"
             />
         </OnboardingWrapper>
     )

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -11,6 +11,7 @@ import { ProductKey } from '~/types'
 import { ProductAnalyticsSDKInstructions } from './sdks/product-analytics/ProductAnalyticsSDKInstructions'
 import { SessionReplaySDKInstructions } from './sdks/session-replay/SessionReplaySDKInstructions'
 import { OnboardingBillingStep } from './OnboardingBillingStep'
+import { OnboardingOtherProductsStep } from './OnboardingOtherProductsStep'
 
 export const scene: SceneExport = {
     component: Onboarding,
@@ -43,15 +44,16 @@ const OnboardingWrapper = ({ children }: { children: React.ReactNode }): JSX.Ele
 
     const createAllSteps = (): void => {
         const ProductIntro = <OnboardingProductIntro product={product} />
+        const OtherProductsStep = <OnboardingOtherProductsStep />
         let steps = []
         if (Array.isArray(children)) {
             steps = [ProductIntro, ...children]
         } else {
-            steps = [ProductIntro, children as JSX.Element]
+            steps = [ProductIntro, children as JSX.Element, OtherProductsStep]
         }
         if (shouldShowBillingStep) {
             const BillingStep = <OnboardingBillingStep product={product} />
-            steps = [...steps, BillingStep]
+            steps = [...steps, BillingStep, OtherProductsStep]
         }
         setAllSteps(steps)
     }

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -75,7 +75,7 @@ const SessionReplayOnboarding = (): JSX.Element => {
             <SDKs
                 usersAction="recording sessions"
                 sdkInstructionMap={SessionReplaySDKInstructions}
-                subtitle="Choose the framework your frontend is built on, or use our all-purpose JavaScript library."
+                subtitle="Choose the framework your frontend is built on, or use our all-purpose JavaScript library. if you already have the snippet installed, you can skip this step!"
             />
         </OnboardingWrapper>
     )

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -12,6 +12,7 @@ import { ProductAnalyticsSDKInstructions } from './sdks/product-analytics/Produc
 import { SessionReplaySDKInstructions } from './sdks/session-replay/SessionReplaySDKInstructions'
 import { OnboardingBillingStep } from './OnboardingBillingStep'
 import { OnboardingOtherProductsStep } from './OnboardingOtherProductsStep'
+import { teamLogic } from 'scenes/teamLogic'
 
 export const scene: SceneExport = {
     component: Onboarding,
@@ -21,7 +22,7 @@ export const scene: SceneExport = {
 /**
  * Wrapper for custom onboarding content. This automatically includes the product intro and billing step.
  */
-const OnboardingWrapper = ({ children }: { children: React.ReactNode }): JSX.Element => {
+const OnboardingWrapper = ({ children, onStart }: { children: React.ReactNode; onStart?: () => void }): JSX.Element => {
     const { currentOnboardingStepNumber, shouldShowBillingStep } = useValues(onboardingLogic)
     const { setAllOnboardingSteps } = useActions(onboardingLogic)
     const { product } = useValues(onboardingLogic)
@@ -43,7 +44,7 @@ const OnboardingWrapper = ({ children }: { children: React.ReactNode }): JSX.Ele
     }
 
     const createAllSteps = (): void => {
-        const ProductIntro = <OnboardingProductIntro product={product} />
+        const ProductIntro = <OnboardingProductIntro product={product} onStart={onStart} />
         const OtherProductsStep = <OnboardingOtherProductsStep />
         let steps = []
         if (Array.isArray(children)) {
@@ -70,8 +71,17 @@ const ProductAnalyticsOnboarding = (): JSX.Element => {
     )
 }
 const SessionReplayOnboarding = (): JSX.Element => {
+    const { updateCurrentTeam } = useActions(teamLogic)
     return (
-        <OnboardingWrapper>
+        <OnboardingWrapper
+            onStart={() => {
+                updateCurrentTeam({
+                    session_recording_opt_in: true,
+                    capture_console_log_opt_in: true,
+                    capture_performance_opt_in: true,
+                })
+            }}
+        >
             <SDKs
                 usersAction="recording sessions"
                 sdkInstructionMap={SessionReplaySDKInstructions}

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -14,6 +14,7 @@ import { OnboardingBillingStep } from './OnboardingBillingStep'
 import { OnboardingOtherProductsStep } from './OnboardingOtherProductsStep'
 import { teamLogic } from 'scenes/teamLogic'
 import { OnboardingVerificationStep } from './OnboardingVerificationStep'
+import { FeatureFlagsSDKInstructions } from './sdks/feature-flags/FeatureFlagsSDKInstructions'
 
 export const scene: SceneExport = {
     component: Onboarding,
@@ -93,7 +94,11 @@ const SessionReplayOnboarding = (): JSX.Element => {
     )
 }
 const FeatureFlagsOnboarding = (): JSX.Element => {
-    return <OnboardingWrapper>{/* <SDKs usersAction="loading flags" /> */}</OnboardingWrapper>
+    return (
+        <OnboardingWrapper>
+            <SDKs usersAction="loading flags" sdkInstructionMap={FeatureFlagsSDKInstructions} />
+        </OnboardingWrapper>
+    )
 }
 
 export function Onboarding(): JSX.Element | null {

--- a/frontend/src/scenes/onboarding/OnboardingBillingStep.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingBillingStep.tsx
@@ -50,7 +50,7 @@ export const OnboardingBillingStep = ({ product }: { product: BillingProductV2Ty
                                     <IconCheckCircleOutline className="text-success text-3xl mb-6" />
                                     <div>
                                         <h3 className="text-lg font-bold mb-1 text-left">Subscribe successful</h3>
-                                        <p className="mx-0 mb-0">You're all ready to use PostHog.</p>
+                                        <p className="mx-0 mb-0">You're all ready to use {product.name}.</p>
                                     </div>
                                 </div>
                                 <div className="h-20">

--- a/frontend/src/scenes/onboarding/OnboardingOtherProductsStep.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingOtherProductsStep.tsx
@@ -1,0 +1,56 @@
+import { LemonButton, LemonCard } from '@posthog/lemon-ui'
+import { OnboardingStep } from './OnboardingStep'
+import { onboardingLogic } from './onboardingLogic'
+import { useActions, useValues } from 'kea'
+import { billingLogic } from 'scenes/billing/billingLogic'
+import { urls } from 'scenes/urls'
+
+export const OnboardingOtherProductsStep = (): JSX.Element => {
+    const { product } = useValues(onboardingLogic)
+    const { completeOnboarding } = useActions(onboardingLogic)
+    const { billing } = useValues(billingLogic)
+    const suggestedProducts = billing?.products?.filter(
+        (p) => p.type !== product?.type && !p.contact_support && !p.inclusion_only
+    )
+
+    return (
+        <OnboardingStep
+            title={`${product?.name} pairs with...`}
+            subtitle="The magic in PostHog is having everyting all in one place. Get started with our other products to unlock your product and data superpowers."
+            showSkip
+            continueOverride={<></>}
+        >
+            <div className="flex flex-col gap-y-6 my-6">
+                {suggestedProducts?.map((suggestedProduct) => (
+                    <LemonCard
+                        className="flex items-center justify-between"
+                        hoverEffect={false}
+                        key={suggestedProduct.type}
+                    >
+                        <div className="flex items-center">
+                            <div className="mr-4">
+                                <img
+                                    src={suggestedProduct.image_url || ''}
+                                    alt={suggestedProduct.name}
+                                    className="w-8 h-8"
+                                />
+                            </div>
+                            <div>
+                                <h3 className="font-bold mb-0">{suggestedProduct.name}</h3>
+                                <p className="m-0">{suggestedProduct.description}</p>
+                            </div>
+                        </div>
+                        <div className="justify-self-end min-w-30 flex justify-end">
+                            <LemonButton
+                                type="primary"
+                                onClick={() => completeOnboarding(urls.onboarding(suggestedProduct.type))}
+                            >
+                                Get started
+                            </LemonButton>
+                        </div>
+                    </LemonCard>
+                ))}
+            </div>
+        </OnboardingStep>
+    )
+}

--- a/frontend/src/scenes/onboarding/OnboardingOtherProductsStep.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingOtherProductsStep.tsx
@@ -2,16 +2,14 @@ import { LemonButton, LemonCard } from '@posthog/lemon-ui'
 import { OnboardingStep } from './OnboardingStep'
 import { onboardingLogic } from './onboardingLogic'
 import { useActions, useValues } from 'kea'
-import { billingLogic } from 'scenes/billing/billingLogic'
 import { urls } from 'scenes/urls'
 
 export const OnboardingOtherProductsStep = (): JSX.Element => {
-    const { product } = useValues(onboardingLogic)
+    const { product, suggestedProducts } = useValues(onboardingLogic)
     const { completeOnboarding } = useActions(onboardingLogic)
-    const { billing } = useValues(billingLogic)
-    const suggestedProducts = billing?.products?.filter(
-        (p) => p.type !== product?.type && !p.contact_support && !p.inclusion_only
-    )
+    if (suggestedProducts.length === 0) {
+        completeOnboarding()
+    }
 
     return (
         <OnboardingStep

--- a/frontend/src/scenes/onboarding/OnboardingProductIntro.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingProductIntro.tsx
@@ -9,7 +9,13 @@ import { ProductPricingModal } from 'scenes/billing/ProductPricingModal'
 import { IconArrowLeft, IconCheckCircleOutline, IconOpenInNew } from 'lib/lemon-ui/icons'
 import { urls } from 'scenes/urls'
 
-export const OnboardingProductIntro = ({ product }: { product: BillingProductV2Type }): JSX.Element => {
+export const OnboardingProductIntro = ({
+    product,
+    onStart,
+}: {
+    product: BillingProductV2Type
+    onStart?: () => void
+}): JSX.Element => {
     const { currentAndUpgradePlans, isPricingModalOpen } = useValues(billingProductLogic({ product }))
     const { toggleIsPricingModalOpen } = useActions(billingProductLogic({ product }))
     const { setCurrentOnboardingStepNumber } = useActions(onboardingLogic)
@@ -52,7 +58,10 @@ export const OnboardingProductIntro = ({ product }: { product: BillingProductV2T
                         <div className="flex gap-x-2">
                             <LemonButton
                                 type="primary"
-                                onClick={() => setCurrentOnboardingStepNumber(currentOnboardingStepNumber + 1)}
+                                onClick={() => {
+                                    onStart && onStart()
+                                    setCurrentOnboardingStepNumber(currentOnboardingStepNumber + 1)
+                                }}
                             >
                                 Get started
                             </LemonButton>

--- a/frontend/src/scenes/onboarding/OnboardingStep.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingStep.tsx
@@ -9,12 +9,14 @@ export const OnboardingStep = ({
     subtitle,
     children,
     showSkip = false,
+    onSkip,
     continueOverride,
 }: {
     title: string
     subtitle?: string
     children: React.ReactNode
     showSkip?: boolean
+    onSkip?: () => void
     continueOverride?: JSX.Element
 }): JSX.Element => {
     const { currentOnboardingStepNumber, totalOnboardingSteps } = useValues(onboardingLogic)
@@ -47,11 +49,12 @@ export const OnboardingStep = ({
                     {showSkip && (
                         <LemonButton
                             type="tertiary"
-                            onClick={() =>
+                            onClick={() => {
+                                onSkip && onSkip()
                                 isLastStep
                                     ? completeOnboarding()
                                     : setCurrentOnboardingStepNumber(currentOnboardingStepNumber + 1)
-                            }
+                            }}
                             status="muted"
                         >
                             Skip {isLastStep ? 'and finish' : 'for now'}

--- a/frontend/src/scenes/onboarding/OnboardingStep.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingStep.tsx
@@ -19,6 +19,7 @@ export const OnboardingStep = ({
 }): JSX.Element => {
     const { currentOnboardingStepNumber, totalOnboardingSteps } = useValues(onboardingLogic)
     const { setCurrentOnboardingStepNumber, completeOnboarding } = useActions(onboardingLogic)
+    const isLastStep = currentOnboardingStepNumber == totalOnboardingSteps
     return (
         <BridgePage
             view="onboarding-step"
@@ -47,13 +48,13 @@ export const OnboardingStep = ({
                         <LemonButton
                             type="tertiary"
                             onClick={() =>
-                                currentOnboardingStepNumber == totalOnboardingSteps
+                                isLastStep
                                     ? completeOnboarding()
                                     : setCurrentOnboardingStepNumber(currentOnboardingStepNumber + 1)
                             }
                             status="muted"
                         >
-                            Skip for now
+                            Skip {isLastStep ? 'and finish' : 'for now'}
                         </LemonButton>
                     )}
                     {continueOverride ? (

--- a/frontend/src/scenes/onboarding/OnboardingVerificationStep.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingVerificationStep.tsx
@@ -1,0 +1,51 @@
+import { Spinner } from '@posthog/lemon-ui'
+import { OnboardingStep } from './OnboardingStep'
+import { useActions, useValues } from 'kea'
+import { teamLogic } from 'scenes/teamLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { useInterval } from 'lib/hooks/useInterval'
+import { BlushingHog } from 'lib/components/hedgehogs'
+import { capitalizeFirstLetter } from 'lib/utils'
+
+export const OnboardingVerificationStep = ({
+    listeningForName,
+    teamPropertyToVerify,
+}: {
+    listeningForName: string
+    teamPropertyToVerify: string
+}): JSX.Element => {
+    const { loadCurrentTeam } = useActions(teamLogic)
+    const { currentTeam } = useValues(teamLogic)
+    const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
+
+    useInterval(() => {
+        if (!currentTeam?.[teamPropertyToVerify]) {
+            loadCurrentTeam()
+        }
+    }, 2000)
+
+    return !currentTeam?.[teamPropertyToVerify] ? (
+        <OnboardingStep
+            title={`Listening for ${listeningForName}s...`}
+            subtitle={`Once you have integrated the snippet, we will verify the ${listeningForName} was properly received. It can take up to 2 minutes to recieve the ${listeningForName}.`}
+            showSkip={true}
+            onSkip={() => {
+                reportIngestionContinueWithoutVerifying()
+            }}
+            continueOverride={<></>}
+        >
+            <div className="text-center mt-8">
+                <Spinner className="text-5xl" />
+            </div>
+        </OnboardingStep>
+    ) : (
+        <OnboardingStep
+            title={`${capitalizeFirstLetter(listeningForName)}s successfully sent!`}
+            subtitle={`Your ${listeningForName.toLocaleLowerCase()}s will now be available in PostHog. Use them to unlock your product and data superpowers.`}
+        >
+            <div className="w-40 mx-auto">
+                <BlushingHog className="h-full w-full" />
+            </div>
+        </OnboardingStep>
+    )
+}

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -4,6 +4,7 @@ import { urls } from 'scenes/urls'
 
 import type { onboardingLogicType } from './onboardingLogicType'
 import { billingLogic } from 'scenes/billing/billingLogic'
+import { teamLogic } from 'scenes/teamLogic'
 
 export interface OnboardingLogicProps {
     productKey: ProductKey | null
@@ -32,7 +33,7 @@ export const onboardingLogic = kea<onboardingLogicType>({
     path: ['scenes', 'onboarding', 'onboardingLogic'],
     connect: {
         values: [billingLogic, ['billing']],
-        actions: [billingLogic, ['loadBillingSuccess']],
+        actions: [billingLogic, ['loadBillingSuccess'], teamLogic, ['updateCurrentTeam']],
     },
     actions: {
         setProduct: (product: BillingProductV2Type | null) => ({ product }),
@@ -131,6 +132,8 @@ export const onboardingLogic = kea<onboardingLogicType>({
             }
         },
         completeOnboarding: ({ redirectUri }) => {
+            values.productKey &&
+                actions.updateCurrentTeam({ has_completed_onboarding_for: { [values.productKey]: true } })
             window.location.href = redirectUri || values.onCompleteOnbardingRedirectUrl
         },
         setAllOnboardingSteps: ({ allOnboardingSteps }) => {

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -15,6 +15,7 @@ export enum OnboardingStepKey {
     SDKS = 'sdks',
     BILLING = 'billing',
     OTHER_PRODUCTS = 'other_products',
+    VERIFY = 'verify',
 }
 
 export type OnboardingStepMap = Record<OnboardingStepKey, string>
@@ -24,6 +25,7 @@ const onboardingStepMap: OnboardingStepMap = {
     [OnboardingStepKey.SDKS]: 'SDKs',
     [OnboardingStepKey.BILLING]: 'OnboardingBillingStep',
     [OnboardingStepKey.OTHER_PRODUCTS]: 'OnboardingOtherProductsStep',
+    [OnboardingStepKey.VERIFY]: 'OnboardingVerificationStep',
 }
 
 export type AllOnboardingSteps = JSX.Element[]
@@ -39,7 +41,7 @@ export const onboardingLogic = kea<onboardingLogicType>({
         setProduct: (product: BillingProductV2Type | null) => ({ product }),
         setProductKey: (productKey: string | null) => ({ productKey }),
         setCurrentOnboardingStepNumber: (currentOnboardingStepNumber: number) => ({ currentOnboardingStepNumber }),
-        completeOnboarding: (redirectUri: string | undefined | null) => ({ redirectUri }),
+        completeOnboarding: (redirectUri?: string) => ({ redirectUri }),
         setAllOnboardingSteps: (allOnboardingSteps: AllOnboardingSteps) => ({ allOnboardingSteps }),
         setStepKey: (stepKey: string) => ({ stepKey }),
         setSubscribedDuringOnboarding: (subscribedDuringOnboarding: boolean) => ({ subscribedDuringOnboarding }),

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -42,7 +42,7 @@ export const onboardingLogic = kea<onboardingLogicType>({
         completeOnboarding: (redirectUri: string | undefined | null) => ({ redirectUri }),
         setAllOnboardingSteps: (allOnboardingSteps: AllOnboardingSteps) => ({ allOnboardingSteps }),
         setStepKey: (stepKey: string) => ({ stepKey }),
-        setSubscribedDuringOnboarding: (subscribedDuringOnboarding) => ({ subscribedDuringOnboarding }),
+        setSubscribedDuringOnboarding: (subscribedDuringOnboarding: boolean) => ({ subscribedDuringOnboarding }),
     },
     reducers: () => ({
         productKey: [
@@ -119,7 +119,7 @@ export const onboardingLogic = kea<onboardingLogicType>({
                         p.type !== product?.type &&
                         !p.contact_support &&
                         !p.inclusion_only &&
-                        !currentTeam.has_completed_onboarding_for[p.type]
+                        !currentTeam?.has_completed_onboarding_for?.[p.type]
                 ) || [],
         ],
     },

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -13,7 +13,7 @@ export enum OnboardingStepKey {
     PRODUCT_INTRO = 'product_intro',
     SDKS = 'sdks',
     BILLING = 'billing',
-    PAIRS_WITH = 'pairs_with',
+    OTHER_PRODUCTS = 'other_products',
 }
 
 export type OnboardingStepMap = Record<OnboardingStepKey, string>
@@ -22,7 +22,7 @@ const onboardingStepMap: OnboardingStepMap = {
     [OnboardingStepKey.PRODUCT_INTRO]: 'OnboardingProductIntro',
     [OnboardingStepKey.SDKS]: 'SDKs',
     [OnboardingStepKey.BILLING]: 'OnboardingBillingStep',
-    [OnboardingStepKey.PAIRS_WITH]: 'OnboardingPairsWithStep',
+    [OnboardingStepKey.OTHER_PRODUCTS]: 'OnboardingOtherProductsStep',
 }
 
 export type AllOnboardingSteps = JSX.Element[]
@@ -38,7 +38,7 @@ export const onboardingLogic = kea<onboardingLogicType>({
         setProduct: (product: BillingProductV2Type | null) => ({ product }),
         setProductKey: (productKey: string | null) => ({ productKey }),
         setCurrentOnboardingStepNumber: (currentOnboardingStepNumber: number) => ({ currentOnboardingStepNumber }),
-        completeOnboarding: true,
+        completeOnboarding: (redirectUri: string | undefined | null) => ({ redirectUri }),
         setAllOnboardingSteps: (allOnboardingSteps: AllOnboardingSteps) => ({ allOnboardingSteps }),
         setStepKey: (stepKey: string) => ({ stepKey }),
         setSubscribedDuringOnboarding: (subscribedDuringOnboarding) => ({ subscribedDuringOnboarding }),
@@ -130,8 +130,8 @@ export const onboardingLogic = kea<onboardingLogicType>({
                 actions.setProduct(values.billing?.products.find((p) => p.type === values.productKey) || null)
             }
         },
-        completeOnboarding: () => {
-            window.location.href = values.onCompleteOnbardingRedirectUrl
+        completeOnboarding: ({ redirectUri }) => {
+            window.location.href = redirectUri || values.onCompleteOnbardingRedirectUrl
         },
         setAllOnboardingSteps: ({ allOnboardingSteps }) => {
             // once we have the onboarding steps we need to make sure the step key is valid,

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -111,6 +111,17 @@ export const onboardingLogic = kea<onboardingLogicType>({
                 return !product?.subscribed || !hasAllAddons || subscribedDuringOnboarding
             },
         ],
+        suggestedProducts: [
+            (s) => [s.billing, s.product, s.currentTeam],
+            (billing, product, currentTeam) =>
+                billing?.products?.filter(
+                    (p) =>
+                        p.type !== product?.type &&
+                        !p.contact_support &&
+                        !p.inclusion_only &&
+                        !currentTeam.has_completed_onboarding_for[p.type]
+                ) || [],
+        ],
     },
     listeners: ({ actions, values }) => ({
         loadBillingSuccess: () => {

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -32,7 +32,7 @@ export const onboardingLogic = kea<onboardingLogicType>({
     props: {} as OnboardingLogicProps,
     path: ['scenes', 'onboarding', 'onboardingLogic'],
     connect: {
-        values: [billingLogic, ['billing']],
+        values: [billingLogic, ['billing'], teamLogic, ['currentTeam']],
         actions: [billingLogic, ['loadBillingSuccess'], teamLogic, ['updateCurrentTeam']],
     },
     actions: {
@@ -132,8 +132,15 @@ export const onboardingLogic = kea<onboardingLogicType>({
             }
         },
         completeOnboarding: ({ redirectUri }) => {
-            values.productKey &&
-                actions.updateCurrentTeam({ has_completed_onboarding_for: { [values.productKey]: true } })
+            if (values.productKey) {
+                // update the current team has_completed_onboarding_for field, only writing over the current product
+                actions.updateCurrentTeam({
+                    has_completed_onboarding_for: {
+                        ...values.currentTeam?.has_completed_onboarding_for,
+                        [values.productKey]: true,
+                    },
+                })
+            }
             window.location.href = redirectUri || values.onCompleteOnbardingRedirectUrl
         },
         setAllOnboardingSteps: ({ allOnboardingSteps }) => {

--- a/frontend/src/scenes/onboarding/sdks/SDKs.tsx
+++ b/frontend/src/scenes/onboarding/sdks/SDKs.tsx
@@ -1,4 +1,4 @@
-import { LemonButton, LemonDivider, LemonSelect } from '@posthog/lemon-ui'
+import { LemonButton, LemonCard, LemonDivider, LemonSelect } from '@posthog/lemon-ui'
 import { sdksLogic } from './sdksLogic'
 import { useActions, useValues } from 'kea'
 import { OnboardingStep } from '../OnboardingStep'
@@ -7,6 +7,7 @@ import { onboardingLogic } from '../onboardingLogic'
 import { useEffect } from 'react'
 import React from 'react'
 import { SDKInstructionsMap } from '~/types'
+import { InviteMembersButton } from '~/layout/navigation/TopBar/SitePopover'
 
 export function SDKs({
     usersAction,
@@ -32,7 +33,7 @@ export function SDKs({
         >
             <LemonDivider className="my-8" />
             <div className="flex gap-x-8 mt-8">
-                <div className={`flex flex-col gap-y-2 flex-wrap gap-x-4 min-w-50`}>
+                <div className={`flex flex-col gap-y-2 flex-wrap gap-x-4 min-w-50 w-50`}>
                     {showSourceOptionsSelect && (
                         <LemonSelect
                             allowClear
@@ -58,6 +59,11 @@ export function SDKs({
                             </LemonButton>
                         </React.Fragment>
                     ))}
+                    <LemonCard className="mt-6" hoverEffect={false}>
+                        <h3 className="font-bold">Need help with this step?</h3>
+                        <p>Invite a team member to help you get set up.</p>
+                        <InviteMembersButton type="primary" />
+                    </LemonCard>
                 </div>
                 {selectedSDK && productKey && !!sdkInstructionMap[selectedSDK.key] && (
                     <div className="shrink min-w-8">

--- a/frontend/src/scenes/onboarding/sdks/feature-flags/FeatureFlagsSDKInstructions.tsx
+++ b/frontend/src/scenes/onboarding/sdks/feature-flags/FeatureFlagsSDKInstructions.tsx
@@ -1,0 +1,8 @@
+import { SDKInstructionsMap, SDKKey } from '~/types'
+import { JSWebInstructions, NextJSInstructions, ReactInstructions } from '.'
+
+export const FeatureFlagsSDKInstructions: SDKInstructionsMap = {
+    [SDKKey.JS_WEB]: JSWebInstructions,
+    [SDKKey.NEXT_JS]: NextJSInstructions,
+    [SDKKey.REACT]: ReactInstructions,
+}

--- a/frontend/src/scenes/onboarding/sdks/feature-flags/index.tsx
+++ b/frontend/src/scenes/onboarding/sdks/feature-flags/index.tsx
@@ -1,0 +1,3 @@
+export * from './js-web'
+export * from './next-js'
+export * from './react'

--- a/frontend/src/scenes/onboarding/sdks/feature-flags/js-web.tsx
+++ b/frontend/src/scenes/onboarding/sdks/feature-flags/js-web.tsx
@@ -1,0 +1,42 @@
+import { JSSnippet } from 'lib/components/JSSnippet'
+import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { useValues } from 'kea'
+import { teamLogic } from 'scenes/teamLogic'
+import { JSInstallSnippet, SessionReplayFinalSteps } from '../shared-snippets'
+
+function JSSetupSnippet(): JSX.Element {
+    const { currentTeam } = useValues(teamLogic)
+
+    return (
+        <CodeSnippet language={Language.JavaScript}>
+            {[
+                "import posthog from 'posthog-js'",
+                '',
+                `posthog.init('${currentTeam?.api_token}', { api_host: '${window.location.origin}' })`,
+            ].join('\n')}
+        </CodeSnippet>
+    )
+}
+
+export function JSWebInstructions(): JSX.Element {
+    return (
+        <>
+            <h3>Option 1. Code snippet</h3>
+            <p>
+                Just add this snippet to your website within the <code>&lt;head&gt;</code> tag and we'll automatically
+                capture page views, sessions and all relevant interactions within your website.
+            </p>
+            <JSSnippet />
+            <LemonDivider thick dashed className="my-4" />
+            <h3>Option 2. Javascript Library</h3>
+            <h4>Install the package</h4>
+            <JSInstallSnippet />
+            <h4>Initialize</h4>
+            <JSSetupSnippet />
+            <LemonDivider thick dashed className="my-4" />
+            <h3>Final steps</h3>
+            <SessionReplayFinalSteps />
+        </>
+    )
+}

--- a/frontend/src/scenes/onboarding/sdks/feature-flags/next-js.tsx
+++ b/frontend/src/scenes/onboarding/sdks/feature-flags/next-js.tsx
@@ -1,0 +1,98 @@
+import { Link } from 'lib/lemon-ui/Link'
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { useValues } from 'kea'
+import { teamLogic } from 'scenes/teamLogic'
+import { JSInstallSnippet, SessionReplayFinalSteps } from '../shared-snippets'
+
+function NextEnvVarsSnippet(): JSX.Element {
+    const { currentTeam } = useValues(teamLogic)
+
+    return (
+        <CodeSnippet language={Language.Bash}>
+            {[
+                `NEXT_PUBLIC_POSTHOG_KEY=${currentTeam?.api_token}`,
+                `NEXT_PUBLIC_POSTHOG_HOST=${window.location.origin}`,
+            ].join('\n')}
+        </CodeSnippet>
+    )
+}
+
+function NextPagesRouterCodeSnippet(): JSX.Element {
+    return (
+        <CodeSnippet language={Language.JavaScript}>
+            {`// pages/_app.js
+...
+import posthog from 'posthog-js' // Import PostHog
+
+if (typeof window !== 'undefined') { // checks that we are client-side
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
+    loaded: (posthog) => {
+      if (process.env.NODE_ENV === 'development') posthog.debug() // debug mode in development
+    },
+  })
+}
+
+export default function App({ Component, pageProps }) {
+  const router = useRouter()
+  ...`}
+        </CodeSnippet>
+    )
+}
+
+function NextAppRouterCodeSnippet(): JSX.Element {
+    return (
+        <CodeSnippet language={Language.JavaScript}>
+            {`// app/providers.js
+'use client'
+...
+import posthog from 'posthog-js'
+
+if (typeof window !== 'undefined') {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+  })
+}
+...`}
+        </CodeSnippet>
+    )
+}
+
+export function NextJSInstructions(): JSX.Element {
+    return (
+        <>
+            <h3>Install posthog-js using your package manager</h3>
+            <JSInstallSnippet />
+            <h3>Add environment variables</h3>
+            <p>
+                Add your environment variables to your .env.local file and to your hosting provider (e.g. Vercel,
+                Netlify, AWS). You can find your project API key in your project settings.
+            </p>
+            <p className="italic">
+                These values need to start with <code className="not-italic">NEXT_PUBLIC_</code> to be accessible on the
+                client-side.
+            </p>
+            <NextEnvVarsSnippet />
+
+            <h3>Initialize</h3>
+            <h4>With App router</h4>
+            <p>
+                If your Next.js app to uses the <Link to="https://nextjs.org/docs/app">app router</Link>, you can
+                integrate PostHog by creating a providers file in your app folder. This is because the posthog-js
+                library needs to be initialized on the client-side using the Next.js{' '}
+                <Link to="https://nextjs.org/docs/getting-started/react-essentials#client-components" target="_blank">
+                    <code>'use client'</code> directive
+                </Link>
+                .
+            </p>
+            <NextAppRouterCodeSnippet />
+            <h4>With Pages router</h4>
+            <p>
+                If your Next.js app uses the <Link to={'https://nextjs.org/docs/pages'}>pages router</Link>, you can
+                integrate PostHog at the root of your app (pages/_app.js).
+            </p>
+            <NextPagesRouterCodeSnippet />
+            <SessionReplayFinalSteps />
+        </>
+    )
+}

--- a/frontend/src/scenes/onboarding/sdks/feature-flags/react.tsx
+++ b/frontend/src/scenes/onboarding/sdks/feature-flags/react.tsx
@@ -1,0 +1,64 @@
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { useValues } from 'kea'
+import { teamLogic } from 'scenes/teamLogic'
+import { JSInstallSnippet, SessionReplayFinalSteps } from '../shared-snippets'
+
+function ReactEnvVarsSnippet(): JSX.Element {
+    const { currentTeam } = useValues(teamLogic)
+
+    return (
+        <CodeSnippet language={Language.Bash}>
+            {[
+                `REACT_APP_POSTHOG_PUBLIC_KEY=${currentTeam?.api_token}`,
+                `REACT_APP_PUBLIC_POSTHOG_HOST=${window.location.origin}`,
+            ].join('\n')}
+        </CodeSnippet>
+    )
+}
+
+function ReactSetupSnippet(): JSX.Element {
+    return (
+        <CodeSnippet language={Language.JavaScript}>
+            {`// src/index.js
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+import { PostHogProvider} from 'posthog-js/react'
+
+const options = {
+  api_host: process.env.REACT_APP_PUBLIC_POSTHOG_HOST,
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <PostHogProvider 
+      apiKey={process.env.REACT_APP_PUBLIC_POSTHOG_KEY}
+      options={options}
+    >
+      <App />
+    </PostHogProvider>
+  </React.StrictMode>
+);`}
+        </CodeSnippet>
+    )
+}
+
+export function ReactInstructions(): JSX.Element {
+    return (
+        <>
+            <h3>Install the package</h3>
+            <JSInstallSnippet />
+            <h3>Add environment variables</h3>
+            <ReactEnvVarsSnippet />
+            <h3>Initialize</h3>
+            <p>
+                Integrate PostHog at the root of your app (<code>src/index.js</code> for the default{' '}
+                <code>create-react-app</code>).
+            </p>
+            <ReactSetupSnippet />
+            <SessionReplayFinalSteps />
+        </>
+    )
+}

--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -76,6 +76,8 @@ function ProductCard({ product }: { product: BillingProductV2Type }): JSX.Elemen
 export function Products(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const { billing } = useValues(billingLogic)
+    const { currentTeam } = useValues(teamLogic)
+    const isFirstProduct = Object.keys(currentTeam?.has_completed_onboarding_for || {}).length === 0
     const products = billing?.products || []
 
     useEffect(() => {
@@ -87,9 +89,10 @@ export function Products(): JSX.Element {
     return (
         <div className="flex flex-col w-full h-full p-6 items-center justify-center bg-mid">
             <div className="mb-8">
-                <h1 className="text-center text-4xl">Pick your first product.</h1>
+                <h1 className="text-center text-4xl">Pick your {isFirstProduct ? 'first' : 'next'} product.</h1>
                 <p className="text-center">
-                    Pick your first product to get started with. You can set up any others you'd like later.
+                    Pick your {isFirstProduct ? 'first' : 'next'} product to get started with. You can set up any others
+                    you'd like later.
                 </p>
             </div>
             {products.length > 0 ? (

--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -96,13 +96,20 @@ export function Products(): JSX.Element {
                 </p>
             </div>
             {products.length > 0 ? (
-                <div className="flex w-full max-w-xl justify-center gap-6 flex-wrap">
-                    {products
-                        .filter((product) => !product.contact_support && !product.inclusion_only)
-                        .map((product) => (
-                            <ProductCard product={product} key={product.type} />
-                        ))}
-                </div>
+                <>
+                    <div className="flex w-full max-w-xl justify-center gap-6 flex-wrap">
+                        {products
+                            .filter((product) => !product.contact_support && !product.inclusion_only)
+                            .map((product) => (
+                                <ProductCard product={product} key={product.type} />
+                            ))}
+                    </div>
+                    <div className="mt-20">
+                        <LemonButton status="muted" to={urls.default()} size="small">
+                            None of these
+                        </LemonButton>
+                    </div>
+                </>
             ) : (
                 <Spinner className="text-3xl" />
             )}


### PR DESCRIPTION
redo of https://github.com/PostHog/posthog/pull/17592 because rebase got messy and I'm too lazy to fix

## Problem

new onboarding needs a way for people to invite team members, verify data receipt, and get a slight upsell to other products.

## Changes

Prompt to invite members if they need help with the SDKs section:
<img width="919" alt="image" src="https://github.com/PostHog/posthog/assets/18598166/a45f4755-d963-4799-9c69-4088c77b98a5">

Verifying data was received (extensible for other products, but we don't currently have the properties):
<img width="901" alt="image" src="https://github.com/PostHog/posthog/assets/18598166/6a61959f-11a3-4624-bf01-78418141e74a">

After data received:
<img width="904" alt="image" src="https://github.com/PostHog/posthog/assets/18598166/ae09787b-72e1-427d-953e-189333a90345">

Last step (after billing) is CTA to try another product out:
<img width="917" alt="image" src="https://github.com/PostHog/posthog/assets/18598166/57369374-6e43-4dd0-97af-8ad1b14c1e2c">

Also adds example SDKs for feature flags that need to be redone/extended, but that onboarding works now.

Also automatically enables session replay settings when someone starts onboarding.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

🙈 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
