### PR TITLE
fix: Replayer height

### DIFF
--- a/frontend/src/scenes/session-recordings/detail/SessionRecordingDetail.tsx
+++ b/frontend/src/scenes/session-recordings/detail/SessionRecordingDetail.tsx
@@ -12,6 +12,8 @@ import {
 } from 'scenes/session-recordings/detail/sessionRecordingDetailLogic'
 import { RecordingNotFound } from 'scenes/session-recordings/player/RecordingNotFound'
 
+import './SessionRecordingScene.scss'
+
 export const scene: SceneExport = {
     logic: sessionRecordingDetailLogic,
     component: SessionRecordingDetail,
@@ -23,7 +25,7 @@ export const scene: SceneExport = {
 export function SessionRecordingDetail({ id }: SessionRecordingDetailLogicProps = {}): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
     return (
-        <div className="flex flex-col overflow-hidden h-screen">
+        <div className="SessionRecordingScene">
             <PageHeader title={<div>Recording</div>} />
             {currentTeam && !currentTeam?.session_recording_opt_in ? (
                 <div className="mb-4">

--- a/frontend/src/scenes/session-recordings/detail/SessionRecordingScene.scss
+++ b/frontend/src/scenes/session-recordings/detail/SessionRecordingScene.scss
@@ -1,0 +1,6 @@
+.SessionRecordingScene {
+    .SessionRecordingPlayer {
+        height: calc(100vh - 12rem);
+        min-height: 30rem;
+    }
+}

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.scss
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.scss
@@ -31,7 +31,9 @@
     &--wide {
         flex-direction: row;
         justify-content: flex-start;
-        height: calc(100vh - 5rem);
+        // NOTE: Somewhat random way to offset the various headers and tabs above the playlist
+        height: calc(100vh - 14rem);
+        min-height: 30rem;
 
         .SessionRecordingsPlaylist__left-column {
             max-width: 350px;


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/17609

## Changes

* Changes the max height calc for multiple screens.
* This actually means you get _less_ real estate to work with for your screen size but probably a better default experience. 
* Once we move to 3000 and get rid of a lot of the surrounding UI this will be resolved anyways.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
