### PR TITLE
fix: Add jitter to batch exports Temporal schedules

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -133,7 +133,7 @@ jobs:
             - name: Check formatting
               run: |
                   cd current
-                  black --exclude posthog/hogql/grammar --check .
+                  black --exclude posthog/hogql/grammar --check --diff .
 
             - name: Check static typing
               run: |

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -322,6 +322,7 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
             start_at=batch_export.start_at,
             end_at=batch_export.end_at,
             intervals=[ScheduleIntervalSpec(every=batch_export.interval_time_delta)],
+            jitter=(batch_export.interval_time_delta / 12),
         ),
         state=state,
         policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.ALLOW_ALL),


### PR DESCRIPTION
We absolutely hammer the database on the hour every hour as all s3-exports start at the exact same time

Add some jitter to spread the load

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
