### PR TITLE
chore: Ignore broken elements chains and ingest event

### DIFF
--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -117,7 +117,11 @@ export class EventsProcessor {
         let elementsList: Element[] = []
 
         if (elements && elements.length) {
-            elementsList = extractElements(elements)
+            try {
+                elementsList = extractElements(elements)
+            } catch (error) {
+                status.warn('⚠️', 'Failed to extract elements from an event', { eventUuid, elements, error })
+            }
             delete properties['$elements']
         }
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
I'm not sure what should be happening here, but currently we send the events to DLQ, which is not what we want to be doing. DLQ helps us find bugs in our recent changes, but if it's always firing we can't use it for that.

Context: https://posthog.slack.com/archives/C02E3BKC78F/p1678366510948779?thread_ts=1677853782.695289&cid=C02E3BKC78F

So I'm opting to keep the event, ingest it to CH and log an error about the elements chain parsing problem.

DLQ: http://metabase-prod-us/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiItLSBzZWxlY3QgdGVhbV9pZCwgY291bnQoKikgZnJvbSBldmVudHNfZGVhZF9sZXR0ZXJfcXVldWUgd2hlcmUgX3RpbWVzdGFtcCA-IHRvZGF5KCkgLSA1IGdyb3VwIGJ5IHRlYW1faWQgb3JkZXIgYnkgdGVhbV9pZFxuXG4tLSBzZWxlY3QgZXJyb3IsIGNvdW50KCopIGZyb20gZXZlbnRzX2RlYWRfbGV0dGVyX3F1ZXVlIHdoZXJlIF90aW1lc3RhbXAgPiB0b2RheSgpIGdyb3VwIGJ5IGVycm9yXG5cbnNlbGVjdCBlcnJvciwgKiBmcm9tIGV2ZW50c19kZWFkX2xldHRlcl9xdWV1ZSB3aGVyZSBfdGltZXN0YW1wID4gdG9kYXkoKSBsaW1pdCAyMCIsInRlbXBsYXRlLXRhZ3MiOnt9fSwiZGF0YWJhc2UiOjM2fSwiZGlzcGxheSI6InRhYmxlIiwiZGlzcGxheUlzTG9ja2VkIjp0cnVlLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6eyJ0YWJsZS5waXZvdF9jb2x1bW4iOiJjb3VudCgpIiwidGFibGUuY2VsbF9jb2x1bW4iOiJ0ZWFtX2lkIn0sIm9yaWdpbmFsX2NhcmRfaWQiOjI1OX0= 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
