### PR TITLE
chore: log when we fail to normalize the event or parse the timestamp

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -1,7 +1,9 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
+import { DateTime } from 'luxon'
 import { Person } from 'types'
 
 import { normalizeEvent } from '../../../utils/event'
+import { status } from '../../../utils/status'
 import { PersonState } from '../person-state'
 import { parseEventTimestamp } from '../timestamps'
 import { EventPipelineRunner } from './runner'
@@ -10,9 +12,15 @@ export async function processPersonsStep(
     runner: EventPipelineRunner,
     pluginEvent: PluginEvent
 ): Promise<[PluginEvent, Person]> {
-    const event = normalizeEvent(pluginEvent)
-
-    const timestamp = parseEventTimestamp(event)
+    let event: PluginEvent
+    let timestamp: DateTime
+    try {
+        event = normalizeEvent(pluginEvent)
+        timestamp = parseEventTimestamp(event)
+    } catch (error) {
+        status.warn('⚠️', 'Failed normalizing event', { team_id: pluginEvent.team_id, uuid: pluginEvent.uuid, error })
+        throw error
+    }
 
     const person = await new PersonState(
         event,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
I'm seeing some events in DLQ and I'm not sure if they are from this normalization and timestamp parsing or from person processing part, this log line would help identify it.

DLQ: http://metabase-prod-us/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiItLSBzZWxlY3QgdGVhbV9pZCwgY291bnQoKikgZnJvbSBldmVudHNfZGVhZF9sZXR0ZXJfcXVldWUgd2hlcmUgX3RpbWVzdGFtcCA-IHRvZGF5KCkgLSA1IGdyb3VwIGJ5IHRlYW1faWQgb3JkZXIgYnkgdGVhbV9pZFxuXG4tLSBzZWxlY3QgZXJyb3IsIGNvdW50KCopIGZyb20gZXZlbnRzX2RlYWRfbGV0dGVyX3F1ZXVlIHdoZXJlIF90aW1lc3RhbXAgPiB0b2RheSgpIGdyb3VwIGJ5IGVycm9yXG5cbnNlbGVjdCBlcnJvciwgSlNPTkV4dHJhY3RTdHJpbmcocHJvcGVydGllcywgJyRkaXN0aW5jdF9pZCcpLCAqIGZyb20gZXZlbnRzX2RlYWRfbGV0dGVyX3F1ZXVlIHdoZXJlIF90aW1lc3RhbXAgPiB0b2RheSgpIGxpbWl0IDIwIiwidGVtcGxhdGUtdGFncyI6e319LCJkYXRhYmFzZSI6MzZ9LCJkaXNwbGF5IjoidGFibGUiLCJkaXNwbGF5SXNMb2NrZWQiOnRydWUsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7InRhYmxlLnBpdm90X2NvbHVtbiI6ImNvdW50KCkiLCJ0YWJsZS5jZWxsX2NvbHVtbiI6InRlYW1faWQifSwib3JpZ2luYWxfY2FyZF9pZCI6MjU5fQ==

Stack trace could be nice to have too 🤔 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
