### PR TITLE
chore: Ignore {} unset value instead of DLQ the event

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -226,7 +226,10 @@ export class PersonState {
 
         const properties: Properties = this.eventProperties['$set'] || {}
         const propertiesOnce: Properties = this.eventProperties['$set_once'] || {}
-        const unsetProperties: Array<string> = this.eventProperties['$unset'] || []
+        const unsetProps = this.eventProperties['$unset']
+        const unsetProperties: Array<string> = Array.isArray(unsetProps)
+            ? unsetProps
+            : Object.keys(unsetProps || {}) || []
 
         // Figure out which properties we are actually setting
         Object.entries(propertiesOnce).map(([key, value]) => {

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -2813,11 +2813,11 @@ test('$unset person empty set ignored', async () => {
     expect((await hub.db.fetchEvents()).length).toBe(1)
 
     const [event] = await hub.db.fetchEvents()
-    expect(event.properties['$unset']).toEqual([])
+    expect(event.properties['$unset']).toEqual({})
 
     const [person] = await hub.db.fetchPersons()
     expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['distinct_id1'])
-    expect(person.properties).toEqual({ b: 2 })
+    expect(person.properties).toEqual({ a: 1, b: 2, c: 3 })
 })
 
 describe('ingestion in any order', () => {

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -2791,6 +2791,35 @@ test('$unset person property', async () => {
     expect(person.properties).toEqual({ b: 2 })
 })
 
+test('$unset person empty set ignored', async () => {
+    await createPerson(hub, team, ['distinct_id1'], { a: 1, b: 2, c: 3 })
+
+    await processEvent(
+        'distinct_id1',
+        '',
+        '',
+        {
+            event: 'some_event',
+            properties: {
+                token: team.api_token,
+                distinct_id: 'distinct_id1',
+                $unset: {},
+            },
+        } as any as PluginEvent,
+        team.id,
+        now,
+        new UUIDT().toString()
+    )
+    expect((await hub.db.fetchEvents()).length).toBe(1)
+
+    const [event] = await hub.db.fetchEvents()
+    expect(event.properties['$unset']).toEqual([])
+
+    const [person] = await hub.db.fetchPersons()
+    expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['distinct_id1'])
+    expect(person.properties).toEqual({ b: 2 })
+})
+
 describe('ingestion in any order', () => {
     const ts0: DateTime = now
     const ts1: DateTime = now.plus({ minutes: 1 })


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
sometimes people send us `'$unset':{}` <- we should just ignore it not DLQ the whole event. I made it so we just always take the keys if it's an object, so folks can also do `'$unset':{'a':5}`

we send the events to DLQ, which is not what we want to be doing. DLQ helps us find bugs in our recent changes, but if it's always firing we can't use it for that.

DLQ: http://metabase-prod-us/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiItLSBzZWxlY3QgdGVhbV9pZCwgY291bnQoKikgZnJvbSBldmVudHNfZGVhZF9sZXR0ZXJfcXVldWUgd2hlcmUgX3RpbWVzdGFtcCA-IHRvZGF5KCkgLSA1IGdyb3VwIGJ5IHRlYW1faWQgb3JkZXIgYnkgdGVhbV9pZFxuXG4tLSBzZWxlY3QgZXJyb3IsIGNvdW50KCopIGZyb20gZXZlbnRzX2RlYWRfbGV0dGVyX3F1ZXVlIHdoZXJlIF90aW1lc3RhbXAgPiB0b2RheSgpIGdyb3VwIGJ5IGVycm9yXG5cbnNlbGVjdCBlcnJvciwgKiBmcm9tIGV2ZW50c19kZWFkX2xldHRlcl9xdWV1ZSB3aGVyZSBfdGltZXN0YW1wID4gdG9kYXkoKSBsaW1pdCAyMCIsInRlbXBsYXRlLXRhZ3MiOnt9fSwiZGF0YWJhc2UiOjM2fSwiZGlzcGxheSI6InRhYmxlIiwiZGlzcGxheUlzTG9ja2VkIjp0cnVlLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6eyJ0YWJsZS5waXZvdF9jb2x1bW4iOiJjb3VudCgpIiwidGFibGUuY2VsbF9jb2x1bW4iOiJ0ZWFtX2lkIn0sIm9yaWdpbmFsX2NhcmRfaWQiOjI1OX0=

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
