### PR TITLE
chore(ci): Don't shame draft PRs

### DIFF
--- a/.github/workflows/lint-new-pr.yml
+++ b/.github/workflows/lint-new-pr.yml
@@ -2,12 +2,13 @@ name: Lint new PR
 
 on:
     pull_request:
-        types: [opened]
+        types: [opened, ready_for_review]
 
 jobs:
     check-description:
         name: Check that PR has description
         runs-on: ubuntu-20.04
+        if: github.event.pull_request.draft == false
 
         steps:
             - name: Check if PR is shame-worthy


### PR DESCRIPTION
## Problem

I often make draft PRs just to share a diff or get feedback on something WIP so it doesn't make sense to flesh out the PR.

## Changes

Disable the no description check for draft PRs, run the check when a PR is ready for review

## How did you test this code?

Made this PR a draft with no description -> no message
Made this PR ready for review -> got the message (see below)
