### PR TITLE
chore(webdriver-manager): upgrade to v4

### DIFF
--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -15,7 +15,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 from sentry_sdk import capture_exception, configure_scope, push_scope
 
 from webdriver_manager.chrome import ChromeDriverManager
-from webdriver_manager.core.utils import ChromeType
+from webdriver_manager.core.os_manager import ChromeType
 
 from posthog.caching.fetch_from_cache import synchronously_update_cache
 from posthog.logging.timing import timed

--- a/requirements.in
+++ b/requirements.in
@@ -77,7 +77,7 @@ sqlparse==0.4.4
 temporalio==1.1.0
 token-bucket==0.3.0
 toronado==0.1.0
-webdriver_manager==3.8.5
+webdriver_manager==4.0.1
 whitenoise==6.5.0
 mimesis==5.2.1
 more-itertools==9.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -467,9 +467,7 @@ token-bucket==0.3.0
 toronado==0.1.0
     # via -r requirements.in
 tqdm==4.64.1
-    # via
-    #   openai
-    #   webdriver-manager
+    # via openai
 trio==0.20.0
     # via
     #   selenium
@@ -512,7 +510,7 @@ vine==1.3.0
     # via
     #   amqp
     #   celery
-webdriver-manager==3.8.5
+webdriver-manager==4.0.1
     # via -r requirements.in
 whitenoise==6.5.0
     # via -r requirements.in


### PR DESCRIPTION
## Problem

I was getting `ValueError: There is no such driver by url https://chromedriver.storage.googleapis.com/117.0.5938/chromedriver_mac_arm64.zip` when trying to debug another problem related to image exports.

## Changes

This PR upgrades `webdriver_manager` to the latest version, which has a change mechanism for detecting the chrome version to download. I'm assuming we don't rely on a specific version for export?

## How did you test this code?

Exported a dashboard to png locally