### PR TITLE
fix(surveys): add missing logic for the *Thank you header* field

### DIFF
--- a/frontend/src/scenes/surveys/Survey.tsx
+++ b/frontend/src/scenes/surveys/Survey.tsx
@@ -120,14 +120,23 @@ export function SurveyForm({ id }: { id: string }): JSX.Element {
                                 <Field name="type" label="Question type" className="max-w-60">
                                     <LemonSelect
                                         onSelect={(newType) => {
-                                            const stateObj = survey.questions[0]
+                                            const questionObj = survey.questions[0]
                                             const isEditingQuestion =
-                                                defaultSurveyFieldValues[stateObj.type].questions[0].question !==
-                                                stateObj.question
+                                                defaultSurveyFieldValues[questionObj.type].questions[0].question !==
+                                                questionObj.question
                                             const isEditingDescription =
-                                                defaultSurveyFieldValues[stateObj.type].questions[0].description !==
-                                                stateObj.description
-                                            setDefaultForQuestionType(newType, isEditingQuestion, isEditingDescription)
+                                                defaultSurveyFieldValues[questionObj.type].questions[0].description !==
+                                                questionObj.description
+                                            const isEditingThankYouMessage =
+                                                defaultSurveyFieldValues[questionObj.type].appearance
+                                                    .thankYouMessageHeader !== survey.appearance.thankYouMessageHeader
+
+                                            setDefaultForQuestionType(
+                                                newType,
+                                                isEditingQuestion,
+                                                isEditingDescription,
+                                                isEditingThankYouMessage
+                                            )
                                         }}
                                         options={[
                                             { label: 'Open text', value: SurveyQuestionType.Open },

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -69,6 +69,7 @@ export const defaultSurveyFieldValues = {
         ],
         appearance: {
             submitButtonText: 'Submit',
+            thankYouMessageHeader: 'Thank you for your feedback!',
         },
     },
     [SurveyQuestionType.Link]: {
@@ -94,7 +95,9 @@ export const defaultSurveyFieldValues = {
                 upperBoundLabel: 'Very likely',
             },
         ],
-        appearance: {},
+        appearance: {
+            thankYouMessageHeader: 'Thank you for your feedback!',
+        },
     },
     [SurveyQuestionType.SingleChoice]: {
         questions: [
@@ -106,6 +109,7 @@ export const defaultSurveyFieldValues = {
         ],
         appearance: {
             submitButtonText: 'Submit',
+            thankYouMessageHeader: 'Thank you for your feedback!',
         },
     },
     [SurveyQuestionType.MultipleChoice]: {
@@ -118,6 +122,7 @@ export const defaultSurveyFieldValues = {
         ],
         appearance: {
             submitButtonText: 'Submit',
+            thankYouMessageHeader: 'Thank you for your feedback!',
         },
     },
 }
@@ -189,11 +194,13 @@ export const surveyLogic = kea<surveyLogicType>([
         setDefaultForQuestionType: (
             type: SurveyQuestionType,
             isEditingQuestion: boolean,
-            isEditingDescription: boolean
+            isEditingDescription: boolean,
+            isEditingThankYouMessage: boolean
         ) => ({
             type,
             isEditingQuestion,
             isEditingDescription,
+            isEditingThankYouMessage,
         }),
         launchSurvey: true,
         stopSurvey: true,
@@ -268,13 +275,19 @@ export const surveyLogic = kea<surveyLogicType>([
         survey: [
             { ...NEW_SURVEY } as NewSurvey | Survey,
             {
-                setDefaultForQuestionType: (state, { type, isEditingQuestion, isEditingDescription }) => {
+                setDefaultForQuestionType: (
+                    state,
+                    { type, isEditingQuestion, isEditingDescription, isEditingThankYouMessage }
+                ) => {
                     const question = isEditingQuestion
                         ? state.questions[0].question
                         : defaultSurveyFieldValues[type].questions[0].question
                     const description = isEditingDescription
                         ? state.questions[0].description
                         : defaultSurveyFieldValues[type].questions[0].description
+                    const thankYouMessageHeader = isEditingThankYouMessage
+                        ? state.appearance.thankYouMessageHeader
+                        : defaultSurveyFieldValues[type].appearance.thankYouMessageHeader
 
                     return {
                         ...state,
@@ -289,6 +302,7 @@ export const surveyLogic = kea<surveyLogicType>([
                         appearance: {
                             ...state.appearance,
                             ...defaultSurveyFieldValues[type].appearance,
+                            thankYouMessageHeader,
                         },
                     }
                 },


### PR DESCRIPTION
## Problem
The **_Thank you header_** field was missing the logic for setting the default value and preserving the user-filled value.

## Changes
Add the missing logic.

## How did you test this code?
Manually in the browser.