### PR TITLE
fix(surveys): show zeros for surveys with no responses

### DIFF
--- a/frontend/src/scenes/surveys/Surveys.tsx
+++ b/frontend/src/scenes/surveys/Surveys.tsx
@@ -153,7 +153,7 @@ export function Surveys(): JSX.Element {
                                                 {surveysResponsesCountLoading ? (
                                                     <Spinner />
                                                 ) : (
-                                                    <div>{surveysResponsesCount[survey.id]}</div>
+                                                    <div>{surveysResponsesCount[survey.id] ?? 0}</div>
                                                 )}
                                             </>
                                         )


### PR DESCRIPTION
## Problem
If there are no responses for a survey, the cell doesn't show any value.

![Screenshot 2023-09-27 at 15 46 07](https://github.com/PostHog/posthog/assets/22996112/e259a07c-60ad-4f17-81fb-92ee9b381969)

## Changes
Default to zero if no responses were found.

## How did you test this code?
Manually in the browser.