### PR TITLE
chore: move billing celery job to use offline cluster and increase timeout from 2 minutes to 5 min

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -40,13 +40,7 @@ is_invalid_algorithm = lambda algo: algo not in CLICKHOUSE_SUPPORTED_JOIN_ALGORI
 
 @lru_cache(maxsize=1)
 def default_settings() -> Dict:
-    # On CH 22.3 we need to disable optimize_move_to_prewhere due to a bug. This is verified fixed on 22.8 (LTS),
-    # so we only disable on versions below that.
-    # This is calculated once per deploy
-    if clickhouse_at_least_228():
-        return {"join_algorithm": "direct,parallel_hash", "distributed_replica_max_ignored_errors": 1000}
-    else:
-        return {"optimize_move_to_prewhere": 0}
+    return {"join_algorithm": "direct,parallel_hash", "distributed_replica_max_ignored_errors": 1000}
 
 
 @lru_cache(maxsize=1)

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 import requests
+from retry import retry
 import structlog
 from dateutil import parser
 from django.conf import settings
@@ -51,6 +52,10 @@ TableSizes = TypedDict("TableSizes", {"posthog_event": int, "posthog_sessionreco
 CH_BILLING_SETTINGS = {
     "max_execution_time": 5 * 60,  # 5 minutes
 }
+
+QUERY_RETRIES = 3
+QUERY_RETRY_DELAY = 1
+QUERY_RETRY_BACKOFF = 2
 
 
 @dataclasses.dataclass
@@ -320,6 +325,7 @@ def capture_event(
 
 
 @timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_event_count_lifetime() -> List[Tuple[int, int]]:
     result = sync_execute(
         """
@@ -334,6 +340,7 @@ def get_teams_with_event_count_lifetime() -> List[Tuple[int, int]]:
 
 
 @timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_billable_event_count_in_period(
     begin: datetime, end: datetime, count_distinct: bool = False
 ) -> List[Tuple[int, int]]:
@@ -363,6 +370,7 @@ def get_teams_with_billable_event_count_in_period(
 
 
 @timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_event_count_with_groups_in_period(begin: datetime, end: datetime) -> List[Tuple[int, int]]:
     result = sync_execute(
         """
@@ -380,6 +388,7 @@ def get_teams_with_event_count_with_groups_in_period(begin: datetime, end: datet
 
 
 @timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_event_count_by_lib(begin: datetime, end: datetime) -> List[Tuple[int, str, int]]:
     results = sync_execute(
         """
@@ -396,6 +405,7 @@ def get_teams_with_event_count_by_lib(begin: datetime, end: datetime) -> List[Tu
 
 
 @timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_event_count_by_name(begin: datetime, end: datetime) -> List[Tuple[int, str, int]]:
     results = sync_execute(
         """
@@ -412,6 +422,7 @@ def get_teams_with_event_count_by_name(begin: datetime, end: datetime) -> List[T
 
 
 @timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_recording_count_in_period(begin: datetime, end: datetime) -> List[Tuple[int, int]]:
     previous_begin = begin - (end - begin)
 
@@ -442,6 +453,7 @@ def get_teams_with_recording_count_in_period(begin: datetime, end: datetime) -> 
 
 
 @timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_recording_count_total() -> List[Tuple[int, int]]:
     result = sync_execute(
         """
@@ -456,6 +468,7 @@ def get_teams_with_recording_count_total() -> List[Tuple[int, int]]:
 
 
 @timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_hogql_metric(
     begin: datetime,
     end: datetime,
@@ -488,6 +501,7 @@ def get_teams_with_hogql_metric(
 
 
 @timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_feature_flag_requests_count_in_period(
     begin: datetime, end: datetime, request_type: FlagRequestType
 ) -> List[Tuple[int, int]]:

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -30,6 +30,7 @@ types-freezegun==1.1.10
 types-python-dateutil>=2.8.3
 types-pytz==2021.3.2
 types-redis==4.3.20
+types-retry==0.9.9.4
 types-requests==2.26.1
 parameterized==0.9.0
 pytest==7.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -315,6 +315,8 @@ types-redis==4.3.20
     # via -r requirements-dev.in
 types-requests==2.26.1
     # via -r requirements-dev.in
+types-retry==0.9.9.4
+    # via -r requirements-dev.in
 typing-extensions==4.7.1
     # via
     #   -c requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -63,6 +63,7 @@ python-dateutil>=2.8.2
 python3-saml==1.12.0
 pytz==2021.1
 redis==4.5.4
+retry==0.9.2
 requests==2.28.1
 requests-oauthlib==1.3.0
 selenium==4.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,6 +99,8 @@ cssselect==1.1.0
     # via toronado
 cssutils==1.0.2
     # via toronado
+decorator==5.1.1
+    # via retry
 defusedxml==0.6.0
     # via
     #   -r requirements.in
@@ -327,6 +329,8 @@ psycopg2-binary==2.9.7
     # via -r requirements.in
 ptyprocess==0.6.0
     # via pexpect
+py==1.11.0
+    # via retry
 pyarrow==12.0.1
     # via -r requirements.in
 pyasn1==0.5.0
@@ -411,6 +415,8 @@ requests-oauthlib==1.3.0
     # via
     #   -r requirements.in
     #   social-auth-core
+retry==0.9.2
+    # via -r requirements.in
 rsa==4.9
     # via google-auth
 ruamel-yaml==0.17.21


### PR DESCRIPTION
## Problem

We had some issues with the billing reporting timing out because the queries were taking longer than 120 seconds. They were also running on the online vs offline cluster. This moves the queries to the offline cluster and bumps the timeout to 5 minutes.

We may need to bump the timeout even higher.

Also adds retry logic for the queries.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
