### PR TITLE
fix(surveys): delete targeting_flag_filters field after setting targeting flag

### DIFF
--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -136,6 +136,9 @@ class SurveySerializerCreateUpdateOnly(SurveySerializer):
             validated_data["targeting_flag_id"] = targeting_feature_flag.id
             validated_data.pop("targeting_flag_filters")
 
+        if "targeting_flag_filters" in validated_data:
+            validated_data.pop("targeting_flag_filters")
+
         validated_data["created_by"] = self.context["request"].user
         return super().create(validated_data)
 

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -29,6 +29,7 @@ class TestSurvey(APIBaseTest):
                 "description": "Get feedback on the new notebooks feature",
                 "type": "popover",
                 "questions": [{"type": "open", "question": "What do you think of the new notebooks feature?"}],
+                "targeting_flag_filters": None,
             },
             format="json",
         )


### PR DESCRIPTION
## Problem
**_targeting_flag_filters_** is used for setting other fields on Survey. It's not part of the Survey model and thus needs to be deleted before creating a survey. This was not the case when _targeting_flag_filters == null_.

## Changes
Ensure _targeting_flag_filters_ always gets deleted after being used to set other fields.

## How did you test this code?
/posthog/posthog/api/test/test_survey.py::TestSurvey