### PR TITLE
chore: longer timeout

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -169,7 +169,7 @@ jobs:
     check-migrations:
         needs: changes
         if: needs.changes.outputs.backend == 'true'
-        timeout-minutes: 5
+        timeout-minutes: 10
 
         name: Validate Django migrations
         runs-on: ubuntu-latest


### PR DESCRIPTION
The `Backend CI / Validate Django migrations` CI action has a timeout of 5 minutes

Starting the docker compose stack and installing python dependencies is taking over half of that. So, sometimes it times out.

The timeout is only there to stop a runaway job never finishing... 

Let's double it