### PR TITLE
fix: celery types and redis queue depth schedule

### DIFF
--- a/posthog/api/test/__snapshots__/test_person.ambr
+++ b/posthog/api/test/__snapshots__/test_person.ambr
@@ -1252,8 +1252,8 @@
          (SELECT id
           FROM person
           WHERE team_id = 2
-            AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000001%')
-                 OR (id = '00000000-0000-4000-8000-000000000001'
+            AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000000%')
+                 OR (id = '00000000-0000-4000-8000-000000000000'
                      OR id IN
                        (SELECT person_id
                         FROM
@@ -1263,12 +1263,12 @@
                            WHERE team_id = 2
                            GROUP BY distinct_id
                            HAVING argMax(is_deleted, version) = 0)
-                        WHERE distinct_id = '00000000-0000-4000-8000-000000000001' ))) )
+                        WHERE distinct_id = '00000000-0000-4000-8000-000000000000' ))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000001%')
-          OR (id = '00000000-0000-4000-8000-000000000001'
+     AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000000%')
+          OR (id = '00000000-0000-4000-8000-000000000000'
               OR id IN
                 (SELECT person_id
                  FROM
@@ -1278,7 +1278,7 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0)
-                 WHERE distinct_id = '00000000-0000-4000-8000-000000000001' )))
+                 WHERE distinct_id = '00000000-0000-4000-8000-000000000000' )))
      ORDER BY argMax(person.created_at, version) DESC, id DESC
      LIMIT 100) person
   LEFT JOIN


### PR DESCRIPTION
We run a celery task once a second to check the redis queue depth. This seems excessive. Let's run it every ten.

Also, cron tab should take strings but we were passing ints