### PR TITLE
refactor(s3-batch-exports): Swap to asyncio s3 client 

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import datetime as dt
 import functools
 import gzip
@@ -9,7 +10,7 @@ from random import randint
 from unittest import mock
 from uuid import uuid4
 
-import boto3
+import aioboto3
 import botocore.exceptions
 import brotli
 import pytest
@@ -55,18 +56,20 @@ from posthog.temporal.workflows.s3_batch_export import (
 TEST_ROOT_BUCKET = "test-batch-exports"
 
 
-def check_valid_credentials() -> bool:
+async def check_valid_credentials() -> bool:
     """Check if there are valid AWS credentials in the environment."""
-    sts = boto3.client("sts")
+    session = aioboto3.Session()
+    sts = await session.client("sts")
     try:
-        sts.get_caller_identity()
+        await sts.get_caller_identity()
     except botocore.exceptions.ClientError:
         return False
     else:
         return True
 
 
-create_test_client = functools.partial(boto3.client, endpoint_url=settings.OBJECT_STORAGE_ENDPOINT)
+SESSION = aioboto3.Session()
+create_test_client = functools.partial(SESSION.client, endpoint_url=settings.OBJECT_STORAGE_ENDPOINT)
 
 
 @pytest.fixture
@@ -75,39 +78,38 @@ def bucket_name() -> str:
     return f"{TEST_ROOT_BUCKET}-{str(uuid4())}"
 
 
-@pytest.fixture
-def s3_client(bucket_name):
+@pytest_asyncio.fixture
+async def s3_client(bucket_name):
     """Manage a testing S3 client to interact with a testing S3 bucket.
 
     Yields the test S3 client after creating a testing S3 bucket. Upon resuming, we delete
     the contents and the bucket itself.
     """
-    s3_client = create_test_client(
+    async with create_test_client(
         "s3",
         aws_access_key_id="object_storage_root_user",
         aws_secret_access_key="object_storage_root_password",
-    )
+    ) as s3_client:
+        await s3_client.create_bucket(Bucket=bucket_name)
 
-    s3_client.create_bucket(Bucket=bucket_name)
+        yield s3_client
 
-    yield s3_client
+        response = await s3_client.list_objects_v2(Bucket=bucket_name)
 
-    response = s3_client.list_objects_v2(Bucket=bucket_name)
+        if "Contents" in response:
+            for obj in response["Contents"]:
+                if "Key" in obj:
+                    await s3_client.delete_object(Bucket=bucket_name, Key=obj["Key"])
 
-    if "Contents" in response:
-        for obj in response["Contents"]:
-            if "Key" in obj:
-                s3_client.delete_object(Bucket=bucket_name, Key=obj["Key"])
-
-    s3_client.delete_bucket(Bucket=bucket_name)
+        await s3_client.delete_bucket(Bucket=bucket_name)
 
 
-def assert_events_in_s3(
+async def assert_events_in_s3(
     s3_client, bucket_name, key_prefix, events, compression: str | None = None, exclude_events: list[str] | None = None
 ):
     """Assert provided events written to JSON in key_prefix in S3 bucket_name."""
     # List the objects in the bucket with the prefix.
-    objects = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=key_prefix)
+    objects = await s3_client.list_objects_v2(Bucket=bucket_name, Prefix=key_prefix)
 
     # Check that there is only one object.
     assert len(objects.get("Contents", [])) == 1
@@ -115,8 +117,8 @@ def assert_events_in_s3(
     # Get the object.
     key = objects["Contents"][0].get("Key")
     assert key
-    object = s3_client.get_object(Bucket=bucket_name, Key=key)
-    data = object["Body"].read()
+    s3_object = await s3_client.get_object(Bucket=bucket_name, Key=key)
+    data = await s3_object["Body"].read()
 
     # Check that the data is correct.
     match compression:
@@ -306,10 +308,12 @@ async def test_insert_into_s3_activity_puts_data_into_s3(
     with override_settings(
         BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES=5 * 1024**2
     ):  # 5MB, the minimum for Multipart uploads
-        with mock.patch("posthog.temporal.workflows.s3_batch_export.boto3.client", side_effect=create_test_client):
+        with mock.patch(
+            "posthog.temporal.workflows.s3_batch_export.aioboto3.Session.client", side_effect=create_test_client
+        ):
             await activity_environment.run(insert_into_s3_activity, insert_inputs)
 
-    assert_events_in_s3(s3_client, bucket_name, prefix, events, compression, exclude_events)
+    await assert_events_in_s3(s3_client, bucket_name, prefix, events, compression, exclude_events)
 
 
 @pytest.mark.django_db
@@ -436,7 +440,9 @@ async def test_s3_export_workflow_with_minio_bucket(
             activities=[create_export_run, insert_into_s3_activity, update_export_run_status],
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):
-            with mock.patch("posthog.temporal.workflows.s3_batch_export.boto3.client", side_effect=create_test_client):
+            with mock.patch(
+                "posthog.temporal.workflows.s3_batch_export.aioboto3.Session.client", side_effect=create_test_client
+            ):
                 await activity_environment.client.execute_workflow(
                     S3BatchExportWorkflow.run,
                     inputs,
@@ -452,7 +458,7 @@ async def test_s3_export_workflow_with_minio_bucket(
     run = runs[0]
     assert run.status == "Completed"
 
-    assert_events_in_s3(s3_client, bucket_name, prefix, events, compression, exclude_events)
+    await assert_events_in_s3(s3_client, bucket_name, prefix, events, compression, exclude_events)
 
 
 @pytest.mark.skipif(
@@ -581,45 +587,46 @@ async def test_s3_export_workflow_with_s3_bucket(interval, compression, encrypti
         **batch_export.destination.config,
     )
 
-    s3_client = boto3.client("s3")
+    async with aioboto3.Session().client("s3") as s3_client:
 
-    def create_s3_client(*args, **kwargs):
-        """Mock function to return an already initialized S3 client."""
-        return s3_client
+        @contextlib.asynccontextmanager
+        async def create_s3_client(*args, **kwargs):
+            """Mock function to return an already initialized S3 client."""
+            yield s3_client
 
-    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
-        async with Worker(
-            activity_environment.client,
-            task_queue=settings.TEMPORAL_TASK_QUEUE,
-            workflows=[S3BatchExportWorkflow],
-            activities=[create_export_run, insert_into_s3_activity, update_export_run_status],
-            workflow_runner=UnsandboxedWorkflowRunner(),
-        ):
-            with mock.patch("posthog.temporal.workflows.s3_batch_export.boto3.client", side_effect=create_s3_client):
-                await activity_environment.client.execute_workflow(
-                    S3BatchExportWorkflow.run,
-                    inputs,
-                    id=workflow_id,
-                    task_queue=settings.TEMPORAL_TASK_QUEUE,
-                    retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=dt.timedelta(seconds=10),
-                )
+        async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+            async with Worker(
+                activity_environment.client,
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+                workflows=[S3BatchExportWorkflow],
+                activities=[create_export_run, insert_into_s3_activity, update_export_run_status],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                with mock.patch(
+                    "posthog.temporal.workflows.s3_batch_export.aioboto3.Session.client", side_effect=create_s3_client
+                ):
+                    await activity_environment.client.execute_workflow(
+                        S3BatchExportWorkflow.run,
+                        inputs,
+                        id=workflow_id,
+                        task_queue=settings.TEMPORAL_TASK_QUEUE,
+                        retry_policy=RetryPolicy(maximum_attempts=1),
+                        execution_timeout=dt.timedelta(seconds=10),
+                    )
 
-    runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)
-    assert len(runs) == 1
+        runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)
+        assert len(runs) == 1
 
-    run = runs[0]
-    assert run.status == "Completed"
+        run = runs[0]
+        assert run.status == "Completed"
 
-    assert_events_in_s3(s3_client, bucket_name, prefix, events, compression, exclude_events)
+        await assert_events_in_s3(s3_client, bucket_name, prefix, events, compression, exclude_events)
 
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
 @pytest.mark.parametrize("compression", [None, "gzip"])
-async def test_s3_export_workflow_with_minio_bucket_and_a_lot_of_data(
-    client: HttpClient, s3_client, bucket_name, compression
-):
+async def test_s3_export_workflow_with_minio_bucket_and_a_lot_of_data(s3_client, bucket_name, compression):
     """Test the full S3 workflow targetting a MinIO bucket.
 
     The workflow should update the batch export run status to completed and produce the expected
@@ -700,7 +707,9 @@ async def test_s3_export_workflow_with_minio_bucket_and_a_lot_of_data(
             activities=[create_export_run, insert_into_s3_activity, update_export_run_status],
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):
-            with mock.patch("posthog.temporal.workflows.s3_batch_export.boto3.client", side_effect=create_test_client):
+            with mock.patch(
+                "posthog.temporal.workflows.s3_batch_export.aioboto3.Session.client", side_effect=create_test_client
+            ):
                 await activity_environment.client.execute_workflow(
                     S3BatchExportWorkflow.run,
                     inputs,
@@ -716,15 +725,15 @@ async def test_s3_export_workflow_with_minio_bucket_and_a_lot_of_data(
     run = runs[0]
     assert run.status == "Completed"
 
-    assert_events_in_s3(s3_client, bucket_name, prefix.format(year=2023, month="04", day="25"), events, compression)
+    await assert_events_in_s3(
+        s3_client, bucket_name, prefix.format(year=2023, month="04", day="25"), events, compression
+    )
 
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
 @pytest.mark.parametrize("compression", [None, "gzip", "brotli"])
-async def test_s3_export_workflow_defaults_to_timestamp_on_null_inserted_at(
-    client: HttpClient, s3_client, bucket_name, compression
-):
+async def test_s3_export_workflow_defaults_to_timestamp_on_null_inserted_at(s3_client, bucket_name, compression):
     """Test the full S3 workflow targetting a MinIO bucket.
 
     In this scenario we assert that when inserted_at is NULL, we default to _timestamp.
@@ -818,7 +827,9 @@ async def test_s3_export_workflow_defaults_to_timestamp_on_null_inserted_at(
             activities=[create_export_run, insert_into_s3_activity, update_export_run_status],
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):
-            with mock.patch("posthog.temporal.workflows.s3_batch_export.boto3.client", side_effect=create_test_client):
+            with mock.patch(
+                "posthog.temporal.workflows.s3_batch_export.aioboto3.Session.client", side_effect=create_test_client
+            ):
                 await activity_environment.client.execute_workflow(
                     S3BatchExportWorkflow.run,
                     inputs,
@@ -834,15 +845,13 @@ async def test_s3_export_workflow_defaults_to_timestamp_on_null_inserted_at(
     run = runs[0]
     assert run.status == "Completed"
 
-    assert_events_in_s3(s3_client, bucket_name, prefix, events, compression)
+    await assert_events_in_s3(s3_client, bucket_name, prefix, events, compression)
 
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
 @pytest.mark.parametrize("compression", [None, "gzip", "brotli"])
-async def test_s3_export_workflow_with_minio_bucket_and_custom_key_prefix(
-    client: HttpClient, s3_client, bucket_name, compression
-):
+async def test_s3_export_workflow_with_minio_bucket_and_custom_key_prefix(s3_client, bucket_name, compression):
     """Test the S3BatchExport Workflow utilizing a custom key prefix.
 
     We will be asserting that exported events land in the appropiate S3 key according to the prefix.
@@ -921,7 +930,9 @@ async def test_s3_export_workflow_with_minio_bucket_and_custom_key_prefix(
             activities=[create_export_run, insert_into_s3_activity, update_export_run_status],
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):
-            with mock.patch("posthog.temporal.workflows.s3_batch_export.boto3.client", side_effect=create_test_client):
+            with mock.patch(
+                "posthog.temporal.workflows.s3_batch_export.aioboto3.Session.client", side_effect=create_test_client
+            ):
                 await activity_environment.client.execute_workflow(
                     S3BatchExportWorkflow.run,
                     inputs,
@@ -940,20 +951,18 @@ async def test_s3_export_workflow_with_minio_bucket_and_custom_key_prefix(
     expected_key_prefix = prefix.format(
         table="events", year="2023", month="04", day="25", hour="14", minute="30", second="00"
     )
-    objects = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=expected_key_prefix)
+    objects = await s3_client.list_objects_v2(Bucket=bucket_name, Prefix=expected_key_prefix)
     key = objects["Contents"][0].get("Key")
     assert len(objects.get("Contents", [])) == 1
     assert key.startswith(expected_key_prefix)
 
-    assert_events_in_s3(s3_client, bucket_name, expected_key_prefix, events, compression)
+    await assert_events_in_s3(s3_client, bucket_name, expected_key_prefix, events, compression)
 
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
 @pytest.mark.parametrize("compression", [None, "gzip", "brotli"])
-async def test_s3_export_workflow_with_minio_bucket_produces_no_duplicates(
-    client: HttpClient, s3_client, bucket_name, compression
-):
+async def test_s3_export_workflow_with_minio_bucket_produces_no_duplicates(s3_client, bucket_name, compression):
     """Test that S3 Export Workflow end-to-end by using a local MinIO bucket instead of S3.
 
     In this particular instance of the test, we assert no duplicates are exported to S3.
@@ -1065,7 +1074,9 @@ async def test_s3_export_workflow_with_minio_bucket_produces_no_duplicates(
             activities=[create_export_run, insert_into_s3_activity, update_export_run_status],
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):
-            with mock.patch("posthog.temporal.workflows.s3_batch_export.boto3.client", side_effect=create_test_client):
+            with mock.patch(
+                "posthog.temporal.workflows.s3_batch_export.aioboto3.Session.client", side_effect=create_test_client
+            ):
                 await activity_environment.client.execute_workflow(
                     S3BatchExportWorkflow.run,
                     inputs,
@@ -1080,7 +1091,7 @@ async def test_s3_export_workflow_with_minio_bucket_produces_no_duplicates(
         run = runs[0]
         assert run.status == "Completed"
 
-    assert_events_in_s3(s3_client, bucket_name, prefix, events, compression)
+    await assert_events_in_s3(s3_client, bucket_name, prefix, events, compression)
 
 
 @pytest_asyncio.fixture
@@ -1537,9 +1548,11 @@ async def test_insert_into_s3_activity_heartbeats(bucket_name, s3_client, activi
     )
 
     with override_settings(BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES=5 * 1024**2):
-        with mock.patch("posthog.temporal.workflows.s3_batch_export.boto3.client", side_effect=create_test_client):
+        with mock.patch(
+            "posthog.temporal.workflows.s3_batch_export.aioboto3.Session.client", side_effect=create_test_client
+        ):
             await activity_environment.run(insert_into_s3_activity, insert_inputs)
 
     # This checks that the assert_heartbeat_details function was actually called
     assert current_part_number > 1
-    assert_events_in_s3(s3_client, bucket_name, prefix, events, None, None)
+    await assert_events_in_s3(s3_client, bucket_name, prefix, events, None, None)

--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -14,7 +14,6 @@ from string import Template
 
 import brotli
 from asgiref.sync import sync_to_async
-from django.conf import settings
 from temporalio import activity, workflow
 
 from posthog.batch_exports.service import (
@@ -24,7 +23,6 @@ from posthog.batch_exports.service import (
 )
 from posthog.kafka_client.client import KafkaProducer
 from posthog.kafka_client.topics import KAFKA_LOG_ENTRIES
-from posthog.temporal.client import connect
 
 SELECT_QUERY_TEMPLATE = Template(
     """
@@ -296,6 +294,9 @@ class BatchExportTemporaryFile:
     def __exit__(self, exc, value, tb):
         """Context-manager protocol exit method."""
         return self._file.__exit__(exc, value, tb)
+
+    def __iter__(self):
+        yield from self._file
 
     @property
     def brotli_compressor(self):
@@ -609,17 +610,3 @@ class UpdateBatchExportRunStatusInputs:
 async def update_export_run_status(inputs: UpdateBatchExportRunStatusInputs):
     """Activity that updates the status of an BatchExportRun."""
     await sync_to_async(update_batch_export_run_status)(run_id=uuid.UUID(inputs.id), status=inputs.status, latest_error=inputs.latest_error)  # type: ignore
-
-
-async def heartbeat(task_token: bytes, *details):
-    """Async heartbeat function for batch export activities."""
-    client = await connect(
-        settings.TEMPORAL_HOST,
-        settings.TEMPORAL_PORT,
-        settings.TEMPORAL_NAMESPACE,
-        settings.TEMPORAL_CLIENT_ROOT_CA,
-        settings.TEMPORAL_CLIENT_CERT,
-        settings.TEMPORAL_CLIENT_KEY,
-    )
-    handle = client.get_async_activity_handle(task_token=task_token)
-    await handle.heartbeat(*details)

--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -1,11 +1,13 @@
 import asyncio
+import contextlib
 import datetime as dt
+import io
 import json
 import posixpath
 import typing
 from dataclasses import dataclass
 
-import boto3
+import aioboto3
 from django.conf import settings
 from temporalio import activity, exceptions, workflow
 from temporalio.common import RetryPolicy
@@ -21,7 +23,6 @@ from posthog.temporal.workflows.batch_exports import (
     get_data_interval,
     get_results_iterator,
     get_rows_count,
-    heartbeat,
     update_export_run_status,
 )
 from posthog.temporal.workflows.clickhouse import get_client
@@ -91,8 +92,20 @@ Part = dict[str, str | int]
 class S3MultiPartUpload:
     """An S3 multi-part upload."""
 
-    def __init__(self, s3_client, bucket_name: str, key: str, encryption: str | None, kms_key_id: str | None):
-        self.s3_client = s3_client
+    def __init__(
+        self,
+        region_name: str,
+        bucket_name: str,
+        key: str,
+        encryption: str | None,
+        kms_key_id: str | None,
+        aws_access_key_id: str | None = None,
+        aws_secret_access_key: str | None = None,
+    ):
+        self._session = aioboto3.Session()
+        self.region_name = region_name
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
         self.bucket_name = bucket_name
         self.key = key
         self.encryption = encryption
@@ -119,7 +132,17 @@ class S3MultiPartUpload:
             return False
         return True
 
-    def start(self) -> str:
+    @contextlib.asynccontextmanager
+    async def s3_client(self):
+        async with self._session.client(
+            "s3",
+            region_name=self.region_name,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+        ) as client:
+            yield client
+
+    async def start(self) -> str:
         """Start this S3MultiPartUpload."""
         if self.is_upload_in_progress() is True:
             raise UploadAlreadyInProgressError(self.upload_id)
@@ -130,11 +153,13 @@ class S3MultiPartUpload:
         if self.kms_key_id:
             optional_kwargs["SSEKMSKeyId"] = self.kms_key_id
 
-        multipart_response = self.s3_client.create_multipart_upload(
-            Bucket=self.bucket_name,
-            Key=self.key,
-            **optional_kwargs,
-        )
+        async with self.s3_client() as s3_client:
+            multipart_response = await s3_client.create_multipart_upload(
+                Bucket=self.bucket_name,
+                Key=self.key,
+                **optional_kwargs,
+            )
+
         upload_id: str = multipart_response["UploadId"]
         self.upload_id = upload_id
 
@@ -147,66 +172,72 @@ class S3MultiPartUpload:
 
         return self.upload_id
 
-    def complete(self) -> str:
+    async def complete(self) -> str:
         if self.is_upload_in_progress() is False:
             raise NoUploadInProgressError()
 
-        response = self.s3_client.complete_multipart_upload(
-            Bucket=self.bucket_name,
-            Key=self.key,
-            UploadId=self.upload_id,
-            MultipartUpload={"Parts": self.parts},
-        )
+        async with self.s3_client() as s3_client:
+            response = await s3_client.complete_multipart_upload(
+                Bucket=self.bucket_name, Key=self.key, UploadId=self.upload_id, MultipartUpload={"Parts": self.parts}
+            )
 
         self.upload_id = None
         self.parts = []
 
         return response["Location"]
 
-    def abort(self):
+    async def abort(self):
         if self.is_upload_in_progress() is False:
             raise NoUploadInProgressError()
 
-        self.s3_client.abort_multipart_upload(
-            Bucket=self.bucket_name,
-            Key=self.key,
-            UploadId=self.upload_id,
-        )
+        async with self.s3_client() as s3_client:
+            await s3_client.abort_multipart_upload(
+                Bucket=self.bucket_name,
+                Key=self.key,
+                UploadId=self.upload_id,
+            )
 
         self.upload_id = None
         self.parts = []
 
-    def upload_part(self, body: BatchExportTemporaryFile, rewind: bool = True):
+    async def upload_part(self, body: BatchExportTemporaryFile, rewind: bool = True):
         next_part_number = self.part_number + 1
 
         if rewind is True:
             body.rewind()
 
-        response = self.s3_client.upload_part(
-            Bucket=self.bucket_name,
-            Key=self.key,
-            PartNumber=next_part_number,
-            UploadId=self.upload_id,
-            Body=body,
-        )
+        # aiohttp is not duck-type friendly and requires a io.IOBase
+        # We comply with the file-like interface of io.IOBase.
+        # So we tell mypy to be nice with us.
+        reader = io.BufferedReader(body)  # type: ignore
+
+        async with self.s3_client() as s3_client:
+            response = await s3_client.upload_part(
+                Bucket=self.bucket_name,
+                Key=self.key,
+                PartNumber=next_part_number,
+                UploadId=self.upload_id,
+                Body=reader,
+            )
+        reader.detach()  # BufferedReader closes the file otherwise.
 
         self.parts.append({"PartNumber": next_part_number, "ETag": response["ETag"]})
 
-    def __enter__(self):
+    async def __aenter__(self):
         if not self.is_upload_in_progress():
-            self.start()
+            await self.start()
 
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback) -> bool:
+    async def __aexit__(self, exc_type, exc_value, traceback) -> bool:
         if exc_value is None:
             # Succesfully completed the upload
-            self.complete()
+            await self.complete()
             return True
 
         if exc_type == asyncio.CancelledError:
             # Ensure we clean-up the cancelled upload.
-            self.abort()
+            await self.abort()
 
         return False
 
@@ -250,17 +281,20 @@ class S3InsertInputs:
     kms_key_id: str | None = None
 
 
-def initialize_and_resume_multipart_upload(inputs: S3InsertInputs) -> tuple[S3MultiPartUpload, str]:
+async def initialize_and_resume_multipart_upload(inputs: S3InsertInputs) -> tuple[S3MultiPartUpload, str]:
     """Initialize a S3MultiPartUpload and resume it from a hearbeat state if available."""
     logger = get_batch_exports_logger(inputs=inputs)
     key = get_s3_key(inputs)
-    s3_client = boto3.client(
-        "s3",
+
+    s3_upload = S3MultiPartUpload(
+        bucket_name=inputs.bucket_name,
+        key=key,
+        encryption=inputs.encryption,
+        kms_key_id=inputs.kms_key_id,
         region_name=inputs.region,
         aws_access_key_id=inputs.aws_access_key_id,
         aws_secret_access_key=inputs.aws_secret_access_key,
     )
-    s3_upload = S3MultiPartUpload(s3_client, inputs.bucket_name, key, inputs.encryption, inputs.kms_key_id)
 
     details = activity.info().heartbeat_details
 
@@ -292,7 +326,7 @@ def initialize_and_resume_multipart_upload(inputs: S3InsertInputs) -> tuple[S3Mu
             logger.info(
                 f"Export will start from the beginning as we are using brotli compression: {interval_start}",
             )
-            s3_upload.abort()
+            await s3_upload.abort()
 
     return s3_upload, interval_start
 
@@ -336,7 +370,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
 
         logger.info("BatchExporting %s rows to S3", count)
 
-        s3_upload, interval_start = initialize_and_resume_multipart_upload(inputs)
+        s3_upload, interval_start = await initialize_and_resume_multipart_upload(inputs)
 
         # Iterate through chunks of results from ClickHouse and push them to S3
         # as a multipart upload. The intention here is to keep memory usage low,
@@ -354,7 +388,6 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
 
         result = None
         last_uploaded_part_timestamp = None
-        task_token = activity.info().task_token
 
         async def worker_shutdown_handler():
             """Handle the Worker shutting down by heart-beating our latest status."""
@@ -362,11 +395,11 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
             logger.warn(
                 f"Worker shutting down! Reporting back latest exported part {last_uploaded_part_timestamp}",
             )
-            await heartbeat(task_token, last_uploaded_part_timestamp, s3_upload.to_state())
+            activity.heartbeat(last_uploaded_part_timestamp, s3_upload.to_state())
 
         asyncio.create_task(worker_shutdown_handler())
 
-        with s3_upload as s3_upload:
+        async with s3_upload as s3_upload:
             with BatchExportTemporaryFile(compression=inputs.compression) as local_results_file:
                 for result in results_iterator:
                     record = {
@@ -392,10 +425,10 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
                             local_results_file.bytes_since_last_reset,
                         )
 
-                        s3_upload.upload_part(local_results_file)
+                        await s3_upload.upload_part(local_results_file)
 
                         last_uploaded_part_timestamp = result["inserted_at"]
-                        await heartbeat(task_token, last_uploaded_part_timestamp, s3_upload.to_state())
+                        activity.heartbeat(last_uploaded_part_timestamp, s3_upload.to_state())
 
                         local_results_file.reset()
 
@@ -407,10 +440,10 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
                         local_results_file.bytes_since_last_reset,
                     )
 
-                    s3_upload.upload_part(local_results_file)
+                    await s3_upload.upload_part(local_results_file)
 
                     last_uploaded_part_timestamp = result["inserted_at"]
-                    await heartbeat(task_token, last_uploaded_part_timestamp, s3_upload.to_state())
+                    activity.heartbeat(last_uploaded_part_timestamp, s3_upload.to_state())
 
 
 @workflow.defn(name="s3-export")

--- a/requirements.in
+++ b/requirements.in
@@ -5,9 +5,10 @@
 # - `pip-compile --rebuild requirements-dev.in`
 #
 aiohttp>=3.8.4
+aioboto3==11.1
 antlr4-python3-runtime==4.13.0
 amqp==5.1.1
-boto3==1.26.66
+boto3==1.26.76
 boto3-stubs[s3]
 brotli==1.1.0
 celery==5.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,18 @@
 #
 #    pip-compile requirements.in
 #
+aioboto3==11.1
+    # via -r requirements.in
+aiobotocore[boto3]==2.5.0
+    # via aioboto3
 aiohttp==3.8.5
     # via
     #   -r requirements.in
+    #   aiobotocore
     #   geoip2
     #   openai
+aioitertools==0.11.0
+    # via aiobotocore
 aiosignal==1.2.0
     # via aiohttp
 amqp==5.1.1
@@ -43,12 +50,15 @@ backoff==2.2.1
     # via posthoganalytics
 billiard==4.1.0
     # via celery
-boto3==1.26.66
-    # via -r requirements.in
+boto3==1.26.76
+    # via
+    #   -r requirements.in
+    #   aiobotocore
 boto3-stubs[s3]==1.26.138
     # via -r requirements.in
-botocore==1.29.66
+botocore==1.29.76
     # via
+    #   aiobotocore
     #   boto3
     #   s3transfer
 botocore-stubs==1.29.130
@@ -539,6 +549,8 @@ webdriver-manager==4.0.1
     # via -r requirements.in
 whitenoise==6.5.0
     # via -r requirements.in
+wrapt==1.15.0
+    # via aiobotocore
 wsproto==1.1.0
     # via trio-websocket
 xmlsec==1.3.13


### PR DESCRIPTION
## Problem

We are still not heartbeatting even after #17642 and #17670. I believe this is because the heartbeat is spawning an async task, but since our code is not doing any `await`-ing, we never yield the main thread for it to run the async task.

By swapping to aioboto3 we now await on each upload part which should allow us to heartbeat while the part is uploaded.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

aioboto3 is mostly compatible with the boto3 interface with 1 big difference: client must be initialized as a context manager. Besides that, I mostly added `async`/`await` in every call.

In order for aioboto3 to be compatible with our existing boto3 dependency, I've had to bump it slightly to 1.26.76 from 1.26.66. We are taking steps to split up the temporal bits of code to avoid conflicting with the django monolith. In the meantime, I hope this bump won't cause issues. Reviewing the [changelog](https://github.com/boto/boto3/blob/develop/CHANGELOG.rst#12666) reveals no significant changes between versions.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## Next steps

Add heartbeating to every destination
Use asyncio (aiofiles) for `BatchExportTemporaryFile`.

## How did you test this code?

Updated unit tests to use async code, which is just more of the same: Use context manager, and add `async`/`await` everywhere.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
