### PR TITLE
chore: Keep ip only within properties

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -651,7 +651,6 @@ export interface ClickHouseEvent extends BaseEvent {
 interface BaseIngestionEvent {
     eventUuid: string
     event: string
-    ip: string | null
     teamId: TeamId
     distinctId: string
     properties: Properties

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -15,7 +15,7 @@ import {
 export function convertToProcessedPluginEvent(event: PostIngestionEvent): ProcessedPluginEvent {
     return {
         distinct_id: event.distinctId,
-        ip: event.ip,
+        ip: null, // deprecated : within properties[$ip] now
         team_id: event.teamId,
         event: event.event,
         properties: event.properties,
@@ -67,7 +67,6 @@ export function convertToIngestionEvent(event: RawClickHouseEvent, skipElementsC
     return {
         eventUuid: event.uuid,
         event: event.event!,
-        ip: properties['$ip'],
         teamId: event.team_id,
         distinctId: event.distinct_id,
         properties,
@@ -95,6 +94,13 @@ export function normalizeEvent(event: PluginEvent): PluginEvent {
     if (event['$set_once']) {
         properties['$set_once'] = { ...properties['$set_once'], ...event['$set_once'] }
     }
+    if (!properties['$ip'] && event.ip) {
+        // if $ip wasn't sent with the event, then add what we got from capture
+        properties['$ip'] = event.ip
+    }
+    // For safety while PluginEvent still has an `ip` field
+    event.ip = null
+
     if (!['$snapshot', '$performance_event'].includes(event.event)) {
         properties = personInitialAndUTMProperties(properties)
     }
@@ -113,7 +119,6 @@ export function formPipelineEvent(message: Message): PipelineEvent {
     const event: PipelineEvent = normalizeEvent({
         ...combinedEvent,
         site_url: combinedEvent.site_url || null,
-        ip: combinedEvent.ip || null,
     })
     return event
 }
@@ -122,7 +127,7 @@ export function formPluginEvent(event: RawClickHouseEvent): PluginEvent {
     const postIngestionEvent = convertToIngestionEvent(event)
     return {
         distinct_id: postIngestionEvent.distinctId,
-        ip: postIngestionEvent.properties['$ip'],
+        ip: null, // deprecated : within properties[$ip] now
         site_url: '',
         team_id: postIngestionEvent.teamId,
         now: DateTime.now().toISO(),

--- a/plugin-server/src/worker/ingestion/event-pipeline/prepareEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/prepareEventStep.ts
@@ -6,7 +6,7 @@ import { captureIngestionWarning } from '../utils'
 import { EventPipelineRunner } from './runner'
 
 export async function prepareEventStep(runner: EventPipelineRunner, event: PluginEvent): Promise<PreIngestionEvent> {
-    const { ip, team_id, uuid } = event
+    const { team_id, uuid } = event
     const invalidTimestampCallback = function (type: string, details: Record<string, any>) {
         // TODO: make that metric name more generic when transitionning to prometheus
         runner.hub.statsd?.increment('process_event_invalid_timestamp', { teamId: String(team_id), type: type })
@@ -15,7 +15,6 @@ export async function prepareEventStep(runner: EventPipelineRunner, event: Plugi
     }
     const preIngestionEvent = await runner.hub.eventsProcessor.processEvent(
         String(event.distinct_id),
-        ip,
         event,
         team_id,
         parseEventTimestamp(event, invalidTimestampCallback),

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -39,7 +39,6 @@ jest.mock('./../../../src/worker/ingestion/utils')
 const event: PostIngestionEvent = {
     eventUuid: 'uuid1',
     distinctId: 'my_id',
-    ip: '127.0.0.1',
     teamId: 2,
     timestamp: '2020-02-23T02:15:00.000Z' as ISOTimestamp,
     event: '$pageview',

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -834,7 +834,6 @@ test('capture bad team', async () => {
     await expect(
         eventsProcessor.processEvent(
             'asdfasdfasdf',
-            '',
             {
                 event: '$pageview',
                 properties: { distinct_id: 'asdfasdfasdf', token: team.api_token },
@@ -2367,7 +2366,6 @@ test('throws with bad uuid', async () => {
     await expect(
         eventsProcessor.processEvent(
             'xxx',
-            '',
             { event: 'E', properties: { price: 299.99, name: 'AirPods Pro' } } as any as PluginEvent,
             team.id,
             DateTime.utc(),
@@ -2378,7 +2376,6 @@ test('throws with bad uuid', async () => {
     await expect(
         eventsProcessor.processEvent(
             'xxx',
-            '',
             { event: 'E', properties: { price: 299.99, name: 'AirPods Pro' } } as any as PluginEvent,
             team.id,
             DateTime.utc(),

--- a/plugin-server/tests/worker/dead-letter-queue.test.ts
+++ b/plugin-server/tests/worker/dead-letter-queue.test.ts
@@ -75,12 +75,11 @@ describe('events dead letter queue', () => {
 
         const dlqEvent = deadLetterQueueEvents[0]
         expect(dlqEvent.event).toEqual('default event')
-        expect(dlqEvent.ip).toEqual('127.0.0.1')
         expect(dlqEvent.team_id).toEqual(2)
         expect(dlqEvent.team_id).toEqual(2)
         expect(dlqEvent.error_location).toEqual('plugin_server_ingest_event:prepareEventStep')
         expect(dlqEvent.error).toEqual('ingestEvent failed. Error: database unavailable')
-        expect(dlqEvent.properties).toEqual(JSON.stringify({ key: 'value' }))
+        expect(dlqEvent.properties).toEqual(JSON.stringify({ key: 'value', $ip: '127.0.0.1' }))
         expect(dlqEvent.event_uuid).toEqual(EVENT_UUID)
     })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/prepareEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/prepareEventStep.test.ts
@@ -11,13 +11,15 @@ jest.mock('../../../../src/utils/status')
 
 const pluginEvent: PluginEvent = {
     distinct_id: 'my_id',
-    ip: '127.0.0.1',
+    ip: null,
     site_url: 'http://localhost',
     team_id: 2,
     now: '2020-02-23T02:15:00Z',
     timestamp: '2020-02-23T02:15:00Z',
     event: 'default event',
-    properties: {},
+    properties: {
+        $ip: '127.0.0.1',
+    },
     uuid: '017ef865-19da-0000-3b60-1506093bf40f',
 }
 
@@ -84,7 +86,6 @@ describe('prepareEventStep()', () => {
             elementsList: [],
             event: 'default event',
             eventUuid: '017ef865-19da-0000-3b60-1506093bf40f',
-            ip: '127.0.0.1',
             properties: {
                 $ip: '127.0.0.1',
             },
@@ -106,7 +107,6 @@ describe('prepareEventStep()', () => {
             elementsList: [],
             event: 'default event',
             eventUuid: '017ef865-19da-0000-3b60-1506093bf40f',
-            ip: null,
             properties: {},
             teamId: 2,
             timestamp: '2020-02-23T02:15:00.000Z',

--- a/plugin-server/tests/worker/ingestion/event-pipeline/processPersonsStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/processPersonsStep.test.ts
@@ -29,7 +29,7 @@ describe.each([[true], [false]])('processPersonsStep()', (poEEmbraceJoin) => {
 
         pluginEvent = {
             distinct_id: 'my_id',
-            ip: '127.0.0.1',
+            ip: null,
             site_url: 'http://localhost',
             team_id: teamId,
             now: '2020-02-23T02:15:00Z',

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runAsyncHandlersStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runAsyncHandlersStep.test.ts
@@ -12,7 +12,6 @@ const testElements: any = ['element1', 'element2']
 const ingestionEvent: PostIngestionEvent = {
     eventUuid: 'uuid1',
     distinctId: 'my_id',
-    ip: '127.0.0.1',
     teamId: 2,
     timestamp: '2020-02-23T02:15:00.000Z' as ISOTimestamp,
     event: '$pageview',


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Trying to clean up our types. See also https://github.com/PostHog/plugin-scaffold/pull/56
We don't need ip to be separate and it just creates confusion. 
This is safe because the only apps that (should be) using ip are geoIP and advanced geoIP, both of which check both `event.ip` and `event.properties.$ip`
https://github.com/PostHog/posthog-plugin-geoip/blob/main/index.ts#L42 & https://github.com/paolodamico/posthog-app-advanced-geoip/blob/91b845841859fe8ec5a6f27c07df4ee3b43b0bde/index.ts#L87 respectively

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

There are already existing tests e.g. https://github.com/PostHog/posthog/blob/ecd47719e3b95547f268aef94aa104e32c0bfa1c/plugin-server/tests/main/process-event.test.ts#L908

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
