### PR TITLE
fix(flags): set selector value

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -279,7 +279,7 @@ export function OverViewTab({
                                                 { label: 'Multiple variants', value: 'multivariant' },
                                                 { label: 'Experiment', value: 'experiment' },
                                             ]}
-                                            value="all"
+                                            value={filters.type ?? 'all'}
                                         />
                                     </>
                                 )}
@@ -304,7 +304,7 @@ export function OverViewTab({
                                         { label: 'Enabled', value: 'true' },
                                         { label: 'Disabled', value: 'false' },
                                     ]}
-                                    value="all"
+                                    value={filters.active ?? 'all'}
                                 />
                                 <span className="ml-1">
                                     <b>Created by</b>
@@ -323,7 +323,7 @@ export function OverViewTab({
                                         }
                                     }}
                                     options={uniqueCreators}
-                                    value="any"
+                                    value={filters.created_by ?? 'any'}
                                 />
                             </div>
                         </div>


### PR DESCRIPTION
## Problem
The filter selectors remain at their default values when manipulated (even though filtering works correctly on change).

![image](https://github.com/PostHog/posthog/assets/22996112/51f2eff9-b4b2-4bf2-959a-b603ea27df77)

## Changes
Set the selector value to the current state or fall back to the default value.

## How did you test this code?
Manually in the browser.