### PR TITLE
chore: investigate delivery report

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import dataclasses
 import datetime
@@ -1194,8 +1195,15 @@ def wait_for_parallel_celery_group(task: Any, max_timeout: Optional[datetime.tim
 
     while not task.ready():
         if timezone.now() - start_time > max_timeout:
+            logger.error(
+                "Timed out waiting for celery task to finish",
+                methods=dir(task),
+                task=task,
+                timeout=max_timeout,
+                start_time=start_time,
+            )
             raise TimeoutError("Timed out waiting for celery task to finish")
-        time.sleep(0.1)
+        asyncio.sleep(0.1)
     return task
 
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import dataclasses
 import datetime
@@ -11,6 +10,7 @@ import re
 import secrets
 import string
 import subprocess
+import threading
 import time
 import uuid
 import zlib
@@ -1193,17 +1193,22 @@ def wait_for_parallel_celery_group(task: Any, max_timeout: Optional[datetime.tim
 
     start_time = timezone.now()
 
-    while not task.ready():
-        if timezone.now() - start_time > max_timeout:
-            logger.error(
-                "Timed out waiting for celery task to finish",
-                methods=dir(task),
-                task=task,
-                timeout=max_timeout,
-                start_time=start_time,
-            )
-            raise TimeoutError("Timed out waiting for celery task to finish")
-        asyncio.sleep(0.1)
+    event = threading.Event()
+
+    while not event.is_set():
+        if task.ready():
+            event.set()
+        else:
+            if timezone.now() - start_time > max_timeout:
+                logger.error(
+                    "Timed out waiting for celery task to finish",
+                    methods=dir(task),
+                    task=task,
+                    timeout=max_timeout,
+                    start_time=start_time,
+                )
+                raise TimeoutError("Timed out waiting for celery task to finish")
+            event.wait(0.1)
     return task
 
 


### PR DESCRIPTION
Since the upgrade to Celery 5 most tasks are running better but the deliver subscription report task is really struggling

This adds some logging and moves to a non-blocking sleep