### PR TITLE
fix: show play button on paused recording when public

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrameOverlay.tsx
@@ -10,6 +10,7 @@ import './PlayerFrameOverlay.scss'
 import { PlayerUpNext } from './PlayerUpNext'
 import { useState } from 'react'
 import clsx from 'clsx'
+import { getCurrentExporterData } from '~/exporter/exporterViewLogic'
 
 export interface PlayerFrameOverlayProps extends SessionRecordingPlayerLogicProps {
     nextSessionRecording?: Partial<SessionRecordingType>
@@ -23,6 +24,7 @@ const PlayerFrameOverlayContent = ({
     let content = null
     const pausedState =
         currentPlayerState === SessionPlayerState.PAUSE || currentPlayerState === SessionPlayerState.READY
+    const isInExportContext = !!getCurrentExporterData()
 
     if (currentPlayerState === SessionPlayerState.ERROR) {
         content = (
@@ -68,7 +70,10 @@ const PlayerFrameOverlayContent = ({
     }
     return content ? (
         <div
-            className={clsx('PlayerFrameOverlay__content', pausedState && 'PlayerFrameOverlay__content--only-hover')}
+            className={clsx(
+                'PlayerFrameOverlay__content',
+                pausedState && !isInExportContext && 'PlayerFrameOverlay__content--only-hover'
+            )}
             aria-busy={currentPlayerState === SessionPlayerState.BUFFER}
         >
             {content}


### PR DESCRIPTION
see #17681 

people wanted no play button overlay when a replay was paused so they could take screenshots

but in a public link that makes it hard to see that you should interact with the recording to load it...

so, if it's in a public link -> show the play button (which is what the world would have been like before #17676)

# when paused logged in

<img width="600" alt="Screenshot 2023-09-29 at 15 02 33" src="https://github.com/PostHog/posthog/assets/984817/5d137353-aa90-4407-afef-0dd132abc6f7">


# when loaded shared state
<img width="600" alt="Screenshot 2023-09-29 at 15 01 45" src="https://github.com/PostHog/posthog/assets/984817/abdbfd46-1797-4bb0-9ff4-2146cabc3209">
