### PR TITLE
chore: simpler again for subscription task

### DIFF
--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -21,7 +21,7 @@ DEFAULT_MAX_ASSET_COUNT = 6
 SUBSCRIPTION_ASSET_GENERATION_TIMER = Histogram(
     "subscription_asset_generation_duration_seconds",
     "Time spent generating assets for a subscription",
-    buckets=(1, 5, 10, 30, 60, 120, 240, 300, 360, 420, 480, 540, 600, 1200, 1800, 3600, float("inf")),
+    buckets=(1, 5, 10, 30, 60, 120, 240, 300, 360, 420, 480, 540, 600, float("inf")),
 )
 
 

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -21,6 +21,7 @@ DEFAULT_MAX_ASSET_COUNT = 6
 SUBSCRIPTION_ASSET_GENERATION_TIMER = Histogram(
     "subscription_asset_generation_duration_seconds",
     "Time spent generating assets for a subscription",
+    buckets=(1, 5, 10, 30, 60, 120, 240, 300, 360, 420, 480, 540, 600, 1200, 1800, 3600, float("inf")),
 )
 
 

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -11,22 +11,22 @@ EXPORT_QUEUED_COUNTER = Counter(
     labelnames=["type"],
 )
 EXPORT_SUCCEEDED_COUNTER = Counter(
-    "exporter_task_csv_succeeded",
+    "exporter_task_succeeded",
     "An export task succeeded",
     labelnames=["type"],
 )
 EXPORT_ASSET_UNKNOWN_COUNTER = Counter(
-    "exporter_task_csv_unknown_asset",
+    "exporter_task_unknown_asset",
     "An export task was for an unknown asset",
     labelnames=["type"],
 )
 EXPORT_FAILED_COUNTER = Counter(
-    "exporter_task_csv_failed",
+    "exporter_task_failed",
     "An export task failed",
     labelnames=["type"],
 )
 EXPORT_TIMER = Histogram(
-    "exporter_task_csv_duration_seconds",
+    "exporter_task_duration_seconds",
     "Time spent exporting an asset",
     labelnames=["type"],
 )

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -32,7 +32,8 @@ EXPORT_TIMER = Histogram(
 )
 
 
-@app.task(autoretry_for=(Exception,), max_retries=5, retry_backoff=True, acks_late=True)
+# export_asset is used in chords/groups and so must not ignore its results
+@app.task(autoretry_for=(Exception,), max_retries=5, retry_backoff=True, acks_late=True, ignore_result=False)
 def export_asset(exported_asset_id: int, limit: Optional[int] = None) -> None:
     from posthog.tasks.exports import csv_exporter, image_exporter
 

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -29,7 +29,7 @@ EXPORT_TIMER = Histogram(
     "exporter_task_duration_seconds",
     "Time spent exporting an asset",
     labelnames=["type"],
-    buckets=(1, 5, 10, 30, 60, 120, 240, 300, 360, 420, 480, 540, 600, 1200, 1800, 3600, float("inf")),
+    buckets=(1, 5, 10, 30, 60, 120, 240, 300, 360, 420, 480, 540, 600, float("inf")),
 )
 
 

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -29,6 +29,7 @@ EXPORT_TIMER = Histogram(
     "exporter_task_duration_seconds",
     "Time spent exporting an asset",
     labelnames=["type"],
+    buckets=(1, 5, 10, 30, 60, 120, 240, 300, 360, 420, 480, 540, 600, 1200, 1800, 3600, float("inf")),
 )
 
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -10,7 +10,6 @@ import re
 import secrets
 import string
 import subprocess
-import threading
 import time
 import uuid
 import zlib
@@ -1193,21 +1192,18 @@ def wait_for_parallel_celery_group(task: Any, max_timeout: Optional[datetime.tim
 
     start_time = timezone.now()
 
-    event = threading.Event()
-    task.on_ready(event.set)
-
-    while not event.is_set():
+    while not task.ready():
         if timezone.now() - start_time > max_timeout:
             logger.error(
                 "Timed out waiting for celery task to finish",
                 ready=task.ready(),
                 successful=task.successful(),
-                task=task,
+                failed=task.failed(),
                 timeout=max_timeout,
                 start_time=start_time,
             )
             raise TimeoutError("Timed out waiting for celery task to finish")
-        event.wait(0.1)
+        time.sleep(0.1)
     return task
 
 


### PR DESCRIPTION
* trying to avoid a blocking wait was more complicated code and didn't actually help
* also follow the documentation advice and ensure that a task used in a group does not ignore its result