### PR TITLE
fix(batch-exports): Account for jitter when backfilling

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -258,6 +258,11 @@ def backfill_export(
 async def backfill_schedule(temporal: Client, schedule_id: str, schedule_backfill: ScheduleBackfill):
     """Async call the Temporal client to execute a backfill on the given schedule."""
     handle = temporal.get_schedule_handle(schedule_id)
+    description = await handle.describe()
+
+    if description.schedule.spec.jitter is not None:
+        schedule_backfill.end_at += description.schedule.spec.jitter
+
     await handle.backfill(schedule_backfill)
 
 


### PR DESCRIPTION
## Problem

Our Schedules now come with jitter, but this breaks backfilling.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Account for jitter when backfilling.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually testing:
* Setting jitter to `None` and triggering a backfill between `03:00:00` and `04:00:00` treats end time as inclusive, backfilling the batch `03:00:00-04:00:00` with run id `<schedule_id>-04:00:00`
* Setting jitter to 5 minutes and triggering a backfill between `03:00:00` and `04:00:00` treats end time as exclusive, and nothing is triggered.
* Setting jitter to 5 minutes and triggering a backfill between `03:00:00` and `04:05:00` works as the first case backfilling the batch `03:00:00-04:00:00` with run id `<schedule_id>-04:00:00`

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
