### PR TITLE
fix: do not offer file upload when logged out

### DIFF
--- a/frontend/src/lib/components/Support/SupportModal.tsx
+++ b/frontend/src/lib/components/Support/SupportModal.tsx
@@ -12,6 +12,7 @@ import { LemonFileInput } from 'lib/lemon-ui/LemonFileInput/LemonFileInput'
 import { useRef } from 'react'
 import { LemonInput, lemonToast } from '@posthog/lemon-ui'
 import { useUploadFiles } from 'lib/hooks/useUploadFiles'
+import { userLogic } from 'scenes/userLogic'
 
 const SUPPORT_TICKET_OPTIONS: LemonSelectOptions<SupportTicketKind> = [
     {
@@ -45,6 +46,8 @@ export function SupportModal({ loggedIn = true }: { loggedIn?: boolean }): JSX.E
     const { sendSupportRequest, isSupportFormOpen, sendSupportLoggedOutRequest } = useValues(supportLogic)
     const { setSendSupportRequestValue, closeSupportForm } = useActions(supportLogic)
     const { objectStorageAvailable } = useValues(preflightLogic)
+    // the support model can be shown when logged out, file upload is not offered to anonymous users
+    const { user } = useValues(userLogic)
 
     if (!preflightLogic.values.preflight?.cloud) {
         if (isSupportFormOpen) {
@@ -124,7 +127,7 @@ export function SupportModal({ loggedIn = true }: { loggedIn?: boolean }): JSX.E
                                 data-attr="support-form-content-input"
                                 {...props}
                             />
-                            {objectStorageAvailable && (
+                            {objectStorageAvailable && !!user && (
                                 <LemonFileInput
                                     accept="image/*"
                                     multiple={false}


### PR DESCRIPTION
## Problem

When someone launches the support modal on the login page we offer them file upload. But we don't accept file uploads from anonymous users - no bueno

## Changes

Check if the user is logged in and hide the file upload option if they are not

|logged in|logged out|
|--|--|
|<img width="400" alt="Screenshot 2023-09-29 at 18 42 02" src="https://github.com/PostHog/posthog/assets/984817/06fcf61b-a00b-4be6-b929-300f9d9ad748">|<img width="400" alt="Screenshot 2023-09-29 at 18 45 52" src="https://github.com/PostHog/posthog/assets/984817/5907b3f5-f5ba-463a-b804-057fe7937b0a">|

closes https://github.com/PostHog/posthog/issues/17653

## How did you test this code?

👀 locally