### PR TITLE
fix: subscriptions revoke child exports

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
@@ -1,6 +1,6 @@
 # name: ClickhouseTestExperimentSecondaryResults.test_basic_secondary_metric_results
   '
-  /* user_id:128 celery:posthog.celery.sync_insight_caching_state */
+  /* user_id:125 celery:posthog.celery.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/ee/tasks/test/subscriptions/test_subscriptions_utils.py
+++ b/ee/tasks/test/subscriptions/test_subscriptions_utils.py
@@ -71,3 +71,22 @@ class TestSubscriptionsTasksUtils(APIBaseTest):
             assert len(insights) == 1
             assert len(assets) == 1
             assert mock_export_task.s.call_count == 1
+
+    def test_cancels_children_if_timed_out(self, _mock_export_task: MagicMock, mock_group: MagicMock) -> None:
+        # mock the group so that its children are never ready,
+        # and we capture calls to revoke
+        mock_running_exports = MagicMock()
+        mock_ready = MagicMock()
+        running_export_task = MagicMock()
+
+        mock_ready.return_value = False
+        mock_group.return_value.apply_async.return_value = mock_running_exports
+
+        mock_running_exports.children = [running_export_task]
+        mock_running_exports.ready = mock_ready
+
+        with self.settings(ASSET_GENERATION_MAX_TIMEOUT_MINUTES=0.1), pytest.raises(Exception) as e:
+            generate_assets(self.subscription)
+
+        assert str(e.value) == "Timed out waiting for celery task to finish"
+        running_export_task.revoke.assert_called()

--- a/ee/tasks/test/subscriptions/test_subscriptions_utils.py
+++ b/ee/tasks/test/subscriptions/test_subscriptions_utils.py
@@ -79,13 +79,15 @@ class TestSubscriptionsTasksUtils(APIBaseTest):
         mock_ready = MagicMock()
         running_export_task = MagicMock()
 
+        running_export_task.state = "PENDING"
+
         mock_ready.return_value = False
         mock_group.return_value.apply_async.return_value = mock_running_exports
 
         mock_running_exports.children = [running_export_task]
         mock_running_exports.ready = mock_ready
 
-        with self.settings(ASSET_GENERATION_MAX_TIMEOUT_MINUTES=0.1), pytest.raises(Exception) as e:
+        with self.settings(ASSET_GENERATION_MAX_TIMEOUT_MINUTES=0.01), pytest.raises(Exception) as e:
             generate_assets(self.subscription)
 
         assert str(e.value) == "Timed out waiting for celery task to finish"

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1221,7 +1221,6 @@ async def wait_for_parallel_celery_group(task: Any, max_timeout: Optional[dateti
             for child in task.children:
                 child_states.append(child.state)
                 # this child should not be retried...
-                # but the subscription should be!
                 child.revoke(terminate=True)
 
             logger.error(


### PR DESCRIPTION
Since upgrading to Celery 5 the subscription delivery is intermittently timing out... when it times out we see its child export tasks are pending.

Those export tasks have retry set... but once the parent subscription has timed out any retries of the children tasks are ignored

If the subscription times out, and any children tasks are either pending or started we should revoke and terminate those tasks to make sure the task is tidied up