### PR TITLE
fix: retry subscriptions

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1200,6 +1200,10 @@ def sleep_time_generator() -> Generator[float, None, None]:
         yield 3.0
 
 
+class ParallelWaitTimeout(Exception):
+    pass
+
+
 @async_to_sync
 async def wait_for_parallel_celery_group(task: Any, max_timeout: Optional[datetime.timedelta] = None) -> Any:
     """
@@ -1224,7 +1228,7 @@ async def wait_for_parallel_celery_group(task: Any, max_timeout: Optional[dateti
                 timeout=max_timeout,
                 start_time=start_time,
             )
-            raise TimeoutError("Timed out waiting for celery task to finish")
+            raise ParallelWaitTimeout("Timed out waiting for celery task to finish")
 
         await asyncio.sleep(next(sleep_generator))
     return task

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1200,7 +1200,7 @@ def sleep_time_generator() -> Generator[float, None, None]:
         yield 3.0
 
 
-class ParallelWaitTimeout(Exception):
+class ParallelWaitTimeout(TimeoutError):
     pass
 
 


### PR DESCRIPTION
Subscriptions are scheduled at 55 minutes past the hour.
They check for subscriptions due to be delivered in the next 15 minutes.

If that task times out or fails, those subscriptions won't be delivered.

Inside the scheduler task we can wait for the timeout error and retry the individual subscriptions