### PR TITLE
fix(surveys): survey titles with apostrophe should not break query

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -360,7 +360,7 @@ export const surveyLogic = kea<surveyLogicType>([
                         kind: NodeKind.EventsQuery,
                         select: ['*', `properties.${SURVEY_RESPONSE_PROPERTY}`, 'timestamp', 'person'],
                         orderBy: ['timestamp DESC'],
-                        where: [`event == 'survey sent' or event == '${survey.name} survey sent'`],
+                        where: [`event == 'survey sent'`],
                         after: createdAt,
                         properties: [
                             {


### PR DESCRIPTION
## Problem

Survey names with an apostrophe in it was breaking the query due to single/double quotes issue. Removed the second half of the query entirely since it shouldn't be supported anymore, will deal with any "deprecation" issues as it comes up from users. 

<img width="1014" alt="Screen Shot 2023-10-01 at 3 41 39 PM" src="https://github.com/PostHog/posthog/assets/25164963/d6189e03-a09c-42ce-8d13-ddb975695034">

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
