### PR TITLE
chore: metrics within tasks should have a registry

### DIFF
--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -30,14 +30,14 @@ def generate_assets(
     resource: Union[Subscription, SharingConfiguration], max_asset_count: int = DEFAULT_MAX_ASSET_COUNT
 ) -> Tuple[List[Insight], List[ExportedAsset]]:
     with pushed_metrics_registry("SUBSCRIPTION_ASSET_GENERATION_TIMER_registry") as registry:
-        REGISTRY_SUBSCRIPTION_ASSET_GENERATION_TIMER = Histogram(
+        registry_subscription_asset_generation_timer = Histogram(
             "subscription_asset_generation_duration_seconds",
             "Time spent generating assets for a subscription",
             buckets=(1, 5, 10, 30, 60, 120, 240, 300, 360, 420, 480, 540, 600, float("inf")),
             registry=registry,
         )
 
-        with REGISTRY_SUBSCRIPTION_ASSET_GENERATION_TIMER.time():
+        with registry_subscription_asset_generation_timer.time():
             with SUBSCRIPTION_ASSET_GENERATION_TIMER.time():
                 if resource.dashboard:
                     tiles = get_tiles_ordered_by_position(resource.dashboard)

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -31,7 +31,7 @@ def generate_assets(
 ) -> Tuple[List[Insight], List[ExportedAsset]]:
     with pushed_metrics_registry("SUBSCRIPTION_ASSET_GENERATION_TIMER_registry") as registry:
         registry_subscription_asset_generation_timer = Histogram(
-            "subscription_asset_generation_duration_seconds",
+            "registry_subscription_asset_generation_duration_seconds",
             "Time spent generating assets for a subscription",
             buckets=(1, 5, 10, 30, 60, 120, 240, 300, 360, 420, 480, 540, 600, float("inf")),
             registry=registry,

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -5,6 +5,7 @@ import structlog
 from celery import group
 from prometheus_client import Histogram
 
+from posthog.metrics import pushed_metrics_registry
 from posthog.models.dashboard_tile import get_tiles_ordered_by_position
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.insight import Insight
@@ -28,28 +29,39 @@ SUBSCRIPTION_ASSET_GENERATION_TIMER = Histogram(
 def generate_assets(
     resource: Union[Subscription, SharingConfiguration], max_asset_count: int = DEFAULT_MAX_ASSET_COUNT
 ) -> Tuple[List[Insight], List[ExportedAsset]]:
-    with SUBSCRIPTION_ASSET_GENERATION_TIMER.time():
-        if resource.dashboard:
-            tiles = get_tiles_ordered_by_position(resource.dashboard)
-            insights = [tile.insight for tile in tiles if tile.insight]
-        elif resource.insight:
-            insights = [resource.insight]
-        else:
-            raise Exception("There are no insights to be sent for this Subscription")
-
-        # Create all the assets we need
-        assets = [
-            ExportedAsset(team=resource.team, export_format="image/png", insight=insight, dashboard=resource.dashboard)
-            for insight in insights[:max_asset_count]
-        ]
-        ExportedAsset.objects.bulk_create(assets)
-
-        # Wait for all assets to be exported
-        tasks = [exporter.export_asset.s(asset.id) for asset in assets]
-        parallel_job = group(tasks).apply_async()
-
-        wait_for_parallel_celery_group(
-            parallel_job, max_timeout=timedelta(minutes=settings.ASSET_GENERATION_MAX_TIMEOUT_MINUTES)
+    with pushed_metrics_registry("SUBSCRIPTION_ASSET_GENERATION_TIMER_registry") as registry:
+        REGISTRY_SUBSCRIPTION_ASSET_GENERATION_TIMER = Histogram(
+            "subscription_asset_generation_duration_seconds",
+            "Time spent generating assets for a subscription",
+            buckets=(1, 5, 10, 30, 60, 120, 240, 300, 360, 420, 480, 540, 600, float("inf")),
+            registry=registry,
         )
 
-        return insights, assets
+        with REGISTRY_SUBSCRIPTION_ASSET_GENERATION_TIMER.time():
+            with SUBSCRIPTION_ASSET_GENERATION_TIMER.time():
+                if resource.dashboard:
+                    tiles = get_tiles_ordered_by_position(resource.dashboard)
+                    insights = [tile.insight for tile in tiles if tile.insight]
+                elif resource.insight:
+                    insights = [resource.insight]
+                else:
+                    raise Exception("There are no insights to be sent for this Subscription")
+
+                # Create all the assets we need
+                assets = [
+                    ExportedAsset(
+                        team=resource.team, export_format="image/png", insight=insight, dashboard=resource.dashboard
+                    )
+                    for insight in insights[:max_asset_count]
+                ]
+                ExportedAsset.objects.bulk_create(assets)
+
+                # Wait for all assets to be exported
+                tasks = [exporter.export_asset.s(asset.id) for asset in assets]
+                parallel_job = group(tasks).apply_async()
+
+                wait_for_parallel_celery_group(
+                    parallel_job, max_timeout=timedelta(minutes=settings.ASSET_GENERATION_MAX_TIMEOUT_MINUTES)
+                )
+
+                return insights, assets


### PR DESCRIPTION
see conversation at https://posthog.slack.com/archives/C045QJCUGQ4/p1696238318912939?thread_ts=1695067169.646429&cid=C045QJCUGQ4

We should be preferring/using pushed_metrics_registry inside Celery tasks. Particularly for `Gauges`

for a task that sends a gauge

* pod A would report 100
* then some processing happens
* and pod B next runs the task and reports 50
* but pod A hasn't run again so it is still reporting 100
* the grafana visualisation looks for max and continues reporting 100

This PR switches a Gauge to using a pushed metrics registry
~~And duplicates a histogram timer once with the registry and once without so I can compare~~