### PR TITLE
chore: replace react-json-view

### DIFF
--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -11,7 +11,7 @@ import { isEventsQuery, isHogQLQuery, isPersonsNode, isTimeToSeeDataSessionsQuer
 import { combineUrl, router } from 'kea-router'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { DeletePersonButton } from '~/queries/nodes/PersonsNode/DeletePersonButton'
-import ReactJson from 'react-json-view'
+import ReactJson from '@microlink/react-json-view'
 import { errorColumn, loadingColumn } from '~/queries/nodes/DataTable/dataTableLogic'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'

--- a/frontend/src/scenes/events/EventDetails.tsx
+++ b/frontend/src/scenes/events/EventDetails.tsx
@@ -9,7 +9,7 @@ import { dayjs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { pluralize } from 'lib/utils'
 import { LemonTableProps } from 'lib/lemon-ui/LemonTable'
-import ReactJson from 'react-json-view'
+import ReactJson from '@microlink/react-json-view'
 import { ErrorDisplay } from 'lib/components/Errors/ErrorDisplay'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
         "react-draggable": "^4.2.0",
         "react-grid-layout": "^1.3.0",
         "react-intersection-observer": "^9.4.3",
-        "react-json-view": "^1.21.3",
+        "@microlink/react-json-view": "^1.21.3",
         "react-markdown": "^5.0.3",
         "react-modal": "^3.15.1",
         "react-resizable": "^3.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -29,6 +29,9 @@ dependencies:
   '@medv/finder':
     specifier: ^2.1.0
     version: 2.1.0
+  '@microlink/react-json-view':
+    specifier: ^1.21.3
+    version: 1.22.2(@types/react@16.14.34)(react-dom@16.14.0)(react@16.14.0)
   '@monaco-editor/react':
     specifier: 4.4.6
     version: 4.4.6(monaco-editor@0.39.0)(react-dom@16.14.0)(react@16.14.0)
@@ -242,9 +245,6 @@ dependencies:
   react-intersection-observer:
     specifier: ^9.4.3
     version: 9.4.3(react@16.14.0)
-  react-json-view:
-    specifier: ^1.21.3
-    version: 1.21.3(@types/react@16.14.34)(react-dom@16.14.0)(react@16.14.0)
   react-markdown:
     specifier: ^5.0.3
     version: 5.0.3(@types/react@16.14.34)(react@16.14.0)
@@ -3165,6 +3165,23 @@ packages:
 
   /@medv/finder@2.1.0:
     resolution: {integrity: sha512-Egrg5XO4kLol24b1Kv50HDfi5hW0yQ6aWSsO0Hea1eJ4rogKElIN0M86FdVnGF4XIGYyA7QWx0MgbOzVPA0qkA==}
+    dev: false
+
+  /@microlink/react-json-view@1.22.2(@types/react@16.14.34)(react-dom@16.14.0)(react@16.14.0):
+    resolution: {integrity: sha512-liJzdlbspT5GbEuPffw4jzZfXOypKLK1Er9br03T31bAaIi/WptZqpcJaXPi7OmwC7v/YYczCkmAS7WaEfItPQ==}
+    peerDependencies:
+      react: '>= 15'
+      react-dom: '>= 15'
+    dependencies:
+      flux: 4.0.3(react@16.14.0)
+      react: 16.14.0
+      react-base16-styling: 0.6.0
+      react-dom: 16.14.0(react@16.14.0)
+      react-lifecycles-compat: 3.0.4
+      react-textarea-autosize: 8.3.4(@types/react@16.14.34)(react@16.14.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - encoding
     dev: false
 
   /@monaco-editor/loader@1.3.3(monaco-editor@0.39.0):
@@ -13097,7 +13114,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
 
   /jsprim@2.0.2:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
@@ -16081,23 +16098,6 @@ packages:
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
-
-  /react-json-view@1.21.3(@types/react@16.14.34)(react-dom@16.14.0)(react@16.14.0):
-    resolution: {integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==}
-    peerDependencies:
-      react: ^17.0.0 || ^16.3.0 || ^15.5.4
-      react-dom: ^17.0.0 || ^16.3.0 || ^15.5.4
-    dependencies:
-      flux: 4.0.3(react@16.14.0)
-      react: 16.14.0
-      react-base16-styling: 0.6.0
-      react-dom: 16.14.0(react@16.14.0)
-      react-lifecycles-compat: 3.0.4
-      react-textarea-autosize: 8.3.4(@types/react@16.14.34)(react@16.14.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - encoding
-    dev: false
 
   /react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}


### PR DESCRIPTION
## Problem

`react-json-view` is no longer maintained and does not support React 18. Towards https://github.com/PostHog/posthog/pull/16605

## Changes

Looks like the original maintainer and [Docusaurus](https://github.com/facebook/docusaurus/pull/9116) have recommended / adopted this fork. Will use that for now because it's a direct replacement, might use something else in future

## How did you test this code?

Should be no changes