### PR TITLE
fix: allow more sentry headers

### DIFF
--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1143,10 +1143,7 @@ class TestCapture(BaseTest):
         for headers in [
             (
                 "sentry",
-                [
-                    "traceparent",
-                    "request-id",
-                ],
+                ["traceparent", "request-id", "Sentry-Trace", "Baggage"],
             ),
             (
                 "aws",
@@ -1171,8 +1168,8 @@ class TestCapture(BaseTest):
             HTTP_ACCESS_CONTROL_REQUEST_HEADERS=presented_headers,
             HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
         )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.headers["Access-Control-Allow-Headers"], expected_headers)
+        assert response.status_code == 200
+        assert response.headers["Access-Control-Allow-Headers"] == expected_headers
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_legacy_recording_ingestion_data_sent_to_kafka(self, kafka_produce) -> None:

--- a/posthog/api/test/test_element.py
+++ b/posthog/api/test/test_element.py
@@ -7,7 +7,6 @@ from freezegun import freeze_time
 from rest_framework import status
 
 from posthog.models import Element, ElementGroup, Organization
-from posthog.settings import CORS_ALLOW_HEADERS
 from posthog.test.base import (
     APIBaseTest,
     ClickhouseTestMixin,
@@ -273,21 +272,6 @@ class TestElement(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         assert response_json["next"] is None
         limit_to_one_results = response_json["results"]
         assert limit_to_one_results == [expected_all_data_response_results[1]]
-
-    def test_element_stats_cors_headers(self) -> None:
-        # Azure App Insights sends the same tracing headers as Sentry
-        # _and_ a request-context header
-        # this is added by the cors headers package so should apply to any endpoint
-
-        response = self.client.generic(
-            "OPTIONS",
-            "/api/element/stats/",
-            HTTP_ORIGIN="https://localhost",
-            HTTP_ACCESS_CONTROL_REQUEST_HEADERS="traceparent,request-id,someotherrandomheader,request-context",
-            HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
-        )
-
-        assert response.headers["Access-Control-Allow-Headers"] == ", ".join(CORS_ALLOW_HEADERS)
 
     def test_element_stats_does_not_allow_non_numeric_limit(self) -> None:
         response = self.client.get(f"/api/element/stats/?limit=not-a-number")

--- a/posthog/utils_cors.py
+++ b/posthog/utils_cors.py
@@ -6,6 +6,8 @@ CORS_ALLOWED_TRACING_HEADERS = (
     "request-context",
     "x-amzn-trace-id",
     "x-cloud-trace-context",
+    "Sentry-Trace",
+    "Baggage",
 )
 
 


### PR DESCRIPTION
see: https://posthoghelp.zendesk.com/agent/tickets/6145 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/9057)

This customer could not use the toolbar for heatmaps because some Sentry tracing headers were being refused by our API. 

They can probably configure their way around this, but we also have a mechanism to ignore/allow tracing headers. So, this PR extends that.