### PR TITLE
fix(experiments): Dont show exposure for all property math except sum

### DIFF
--- a/ee/clickhouse/queries/experiments/secondary_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/secondary_experiment_result.py
@@ -3,10 +3,7 @@ from typing import Dict, Optional
 from zoneinfo import ZoneInfo
 
 from rest_framework.exceptions import ValidationError
-from ee.clickhouse.queries.experiments.trend_experiment_result import (
-    uses_count_per_property_value_aggregation,
-    uses_count_per_user_aggregation,
-)
+from ee.clickhouse.queries.experiments.trend_experiment_result import uses_math_aggregation_by_user_or_property_value
 
 from posthog.constants import INSIGHT_FUNNELS, INSIGHT_TRENDS, TRENDS_CUMULATIVE
 from posthog.models.feature_flag import FeatureFlag
@@ -59,7 +56,7 @@ class ClickhouseSecondaryExperimentResult:
 
         self.team = team
         if query_filter.insight == INSIGHT_TRENDS and not (
-            uses_count_per_user_aggregation(query_filter) or uses_count_per_property_value_aggregation(query_filter)
+            uses_math_aggregation_by_user_or_property_value(query_filter)
         ):
             query_filter = query_filter.shallow_clone({"display": TRENDS_CUMULATIVE})
 
@@ -99,9 +96,7 @@ class ClickhouseSecondaryExperimentResult:
             count = result["count"]
             breakdown_value = result["breakdown_value"]
 
-            if uses_count_per_user_aggregation(self.query_filter) or uses_count_per_property_value_aggregation(
-                self.query_filter
-            ):
+            if uses_math_aggregation_by_user_or_property_value(self.query_filter):
                 count = result["count"] / len(result.get("data", [0]))
 
             if breakdown_value in self.variants:

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -1505,7 +1505,7 @@ class ClickhouseTestFunnelExperimentResults(ClickhouseTestMixin, APILicensedTest
         self.assertAlmostEqual(response_data["expected_loss"], 1, places=2)
 
 
-@flaky(max_runs=10, min_passes=1)
+# @flaky(max_runs=10, min_passes=1)
 class ClickhouseTestTrendExperimentResults(ClickhouseTestMixin, APILicensedTest):
     @snapshot_clickhouse_queries
     def test_experiment_flow_with_event_results(self):
@@ -2439,4 +2439,129 @@ class ClickhouseTestTrendExperimentResults(ClickhouseTestMixin, APILicensedTest)
         # Variant with test: Gamma(7, 1) and control: Gamma(4, 1) distribution
         # The variant has high probability of being better. (effectively Gamma(10,1))
         self.assertAlmostEqual(response_data["probability"]["test"], 0.805, places=2)
+        self.assertFalse(response_data["significant"])
+
+    def test_experiment_flow_with_sum_count_per_property_value_results(self):
+        journeys_for(
+            {
+                "person1": [
+                    # 5 counts, single person
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2020-01-02",
+                        "properties": {"$feature/a-b-test": "test", "mathable": 1},
+                    },
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2020-01-02",
+                        "properties": {"$feature/a-b-test": "test", "mathable": 1},
+                    },
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2020-01-02",
+                        "properties": {"$feature/a-b-test": "test", "mathable": 3},
+                    },
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2020-01-02",
+                        "properties": {"$feature/a-b-test": "test", "mathable": 3},
+                    },
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2020-01-02",
+                        "properties": {"$feature/a-b-test": "test", "mathable": 10},
+                    },
+                ],
+                "person2": [
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2020-01-03",
+                        "properties": {"$feature/a-b-test": "control", "mathable": 1},
+                    },
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2020-01-04",
+                        "properties": {"$feature/a-b-test": "control", "mathable": 1},
+                    },
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2020-01-05",
+                        "properties": {"$feature/a-b-test": "control", "mathable": 1},
+                    },
+                ],
+                "person3": [
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2020-01-04",
+                        "properties": {"$feature/a-b-test": "control", "mathable": 2},
+                    },
+                ],
+                "person4": [
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2020-01-05",
+                        "properties": {"$feature/a-b-test": "test", "mathable": 1},
+                    },
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2020-01-05",
+                        "properties": {"$feature/a-b-test": "test", "mathable": 1.5},
+                    },
+                ],
+                # doesn't have feature set
+                "person_out_of_control": [
+                    {"event": "$pageview", "timestamp": "2020-01-03"},
+                ],
+                "person_out_of_end_date": [
+                    {"event": "$pageview", "timestamp": "2020-08-03", "properties": {"$feature/a-b-test": "control"}},
+                ],
+            },
+            self.team,
+        )
+
+        ff_key = "a-b-test"
+        # generates the FF which should result in the above events^
+        creation_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Test Experiment",
+                "description": "",
+                "start_date": "2020-01-01T00:00",
+                "end_date": "2020-01-06T00:00",
+                "feature_flag_key": ff_key,
+                "parameters": {
+                    "custom_exposure_filter": {
+                        "events": [
+                            {
+                                "id": "$pageview",  # exposure is total pageviews
+                                "order": 0,
+                            }
+                        ],
+                    }
+                },
+                "filters": {
+                    "insight": "TRENDS",
+                    "events": [{"order": 0, "id": "$pageview", "math": "sum", "math_property": "mathable"}],
+                    "properties": [],
+                },
+            },
+        )
+
+        id = creation_response.json()["id"]
+
+        response = self.client.get(f"/api/projects/{self.team.id}/experiments/{id}/results")
+        self.assertEqual(200, response.status_code)
+
+        response_data = response.json()["result"]
+        result = sorted(response_data["insight"], key=lambda x: x["breakdown_value"])
+
+        self.assertEqual(result[0]["data"], [0.0, 0.0, 1.0, 4.0, 5.0, 5.0])
+        self.assertEqual("control", result[0]["breakdown_value"])
+
+        self.assertEqual(result[1]["data"], [0.0, 18.0, 18.0, 18.0, 20.5, 20.5])
+        self.assertEqual("test", result[1]["breakdown_value"])
+
+        # Variant with test: Gamma(7, 1) and control: Gamma(4, 1) distribution
+        # The variant has high probability of being better. (effectively Gamma(10,1))
+        self.assertAlmostEqual(response_data["probability"]["test"], 0.9513, places=2)
         self.assertFalse(response_data["significant"])

--- a/frontend/src/scenes/experiments/ExperimentPreview.tsx
+++ b/frontend/src/scenes/experiments/ExperimentPreview.tsx
@@ -49,7 +49,7 @@ export function ExperimentPreview({
         isExperimentGoalModalOpen,
         isExperimentExposureModalOpen,
         experimentLoading,
-        experimentCountPerUserMath,
+        experimentMathAggregationForTrends,
     } = useValues(experimentLogic({ experimentId }))
     const {
         setExperiment,
@@ -290,48 +290,51 @@ export function ExperimentPreview({
                                             Change experiment goal
                                         </LemonButton>
                                     </div>
-                                    {experimentInsightType === InsightType.TRENDS && !experimentCountPerUserMath && (
-                                        <>
-                                            <div className="card-secondary mb-2 mt-4">
-                                                Exposure metric
-                                                <Tooltip
-                                                    title={`This metric determines how we calculate exposure for the experiment. Only users who have this event alongside the property '$feature/${experiment.feature_flag_key}' are included in exposure calculations.`}
-                                                >
-                                                    <IconInfo className="ml-1 text-muted text-sm" />
-                                                </Tooltip>
-                                            </div>
-                                            {experiment.parameters?.custom_exposure_filter ? (
-                                                <MetricDisplay filters={experiment.parameters.custom_exposure_filter} />
-                                            ) : (
-                                                <span className="description">
-                                                    Default via $feature_flag_called events
-                                                </span>
-                                            )}
-                                            <div className="mb-2 mt-2">
-                                                <span className="flex">
-                                                    <LemonButton
-                                                        type="secondary"
-                                                        size="small"
-                                                        onClick={openExperimentExposureModal}
-                                                        className="mr-2"
+                                    {experimentInsightType === InsightType.TRENDS &&
+                                        !experimentMathAggregationForTrends && (
+                                            <>
+                                                <div className="card-secondary mb-2 mt-4">
+                                                    Exposure metric
+                                                    <Tooltip
+                                                        title={`This metric determines how we calculate exposure for the experiment. Only users who have this event alongside the property '$feature/${experiment.feature_flag_key}' are included in exposure calculations.`}
                                                     >
-                                                        Change exposure metric
-                                                    </LemonButton>
-                                                    {experiment.parameters?.custom_exposure_filter && (
+                                                        <IconInfo className="ml-1 text-muted text-sm" />
+                                                    </Tooltip>
+                                                </div>
+                                                {experiment.parameters?.custom_exposure_filter ? (
+                                                    <MetricDisplay
+                                                        filters={experiment.parameters.custom_exposure_filter}
+                                                    />
+                                                ) : (
+                                                    <span className="description">
+                                                        Default via $feature_flag_called events
+                                                    </span>
+                                                )}
+                                                <div className="mb-2 mt-2">
+                                                    <span className="flex">
                                                         <LemonButton
                                                             type="secondary"
                                                             size="small"
-                                                            status="danger"
+                                                            onClick={openExperimentExposureModal}
                                                             className="mr-2"
-                                                            onClick={() => updateExperimentExposure(null)}
                                                         >
-                                                            Reset exposure
+                                                            Change exposure metric
                                                         </LemonButton>
-                                                    )}
-                                                </span>
-                                            </div>
-                                        </>
-                                    )}
+                                                        {experiment.parameters?.custom_exposure_filter && (
+                                                            <LemonButton
+                                                                type="secondary"
+                                                                size="small"
+                                                                status="danger"
+                                                                className="mr-2"
+                                                                onClick={() => updateExperimentExposure(null)}
+                                                            >
+                                                                Reset exposure
+                                                            </LemonButton>
+                                                        )}
+                                                    </span>
+                                                </div>
+                                            </>
+                                        )}
                                 </>
                             )}
                         </Col>

--- a/frontend/src/scenes/experiments/ExperimentResult.tsx
+++ b/frontend/src/scenes/experiments/ExperimentResult.tsx
@@ -26,7 +26,7 @@ export function ExperimentResult(): JSX.Element {
         areTrendResultsConfusing,
         experimentResultCalculationError,
         sortedExperimentResultVariants,
-        experimentCountPerUserMath,
+        experimentMathAggregationForTrends,
     } = useValues(experimentLogic)
 
     return (
@@ -116,7 +116,10 @@ export function ExperimentResult(): JSX.Element {
                                                                 />
                                                             )}
                                                             <span className="pl-1">
-                                                                {experimentCountPerUserMath ? 'metric' : 'count'}:
+                                                                {experimentMathAggregationForTrends
+                                                                    ? 'metric'
+                                                                    : 'count'}
+                                                                :
                                                             </span>
                                                         </Row>
                                                     </b>{' '}

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -19,6 +19,7 @@ import {
     CountPerActorMathType,
     ActionFilter as ActionFilterType,
     TrendExperimentVariant,
+    PropertyMathType,
 } from '~/types'
 import type { experimentLogicType } from './experimentLogicType'
 import { router, urlToAction } from 'kea-router'
@@ -642,11 +643,11 @@ export const experimentLogic = kea<experimentLogicType>([
                 return experiment?.parameters?.feature_flag_variants || []
             },
         ],
-        experimentCountPerUserMath: [
+        experimentMathAggregationForTrends: [
             (s) => [s.experiment],
-            (experiment): string | undefined => {
+            (experiment): PropertyMathType | CountPerActorMathType | undefined => {
                 // Find out if we're using count per actor math aggregates averages per user
-                const mathValue = (
+                const userMathValue = (
                     [
                         ...(experiment?.filters?.events || []),
                         ...(experiment?.filters?.actions || []),
@@ -655,7 +656,21 @@ export const experimentLogic = kea<experimentLogicType>([
                     Object.values(CountPerActorMathType).includes(entity?.math as CountPerActorMathType)
                 )[0]?.math
 
-                return mathValue
+                // alternatively, if we're using property math
+                // remove 'sum' property math from the list of math types
+                // since we can handle that as a regular case
+                const targetValues = Object.values(PropertyMathType).filter((value) => value !== PropertyMathType.Sum)
+                // sync with the backend at https://github.com/PostHog/posthog/blob/master/ee/clickhouse/queries/experiments/trend_experiment_result.py#L44
+                // the function uses_math_aggregation_by_user_or_property_value
+
+                const propertyMathValue = (
+                    [
+                        ...(experiment?.filters?.events || []),
+                        ...(experiment?.filters?.actions || []),
+                    ] as ActionFilterType[]
+                ).filter((entity) => targetValues.includes(entity?.math as PropertyMathType))[0]?.math
+
+                return (userMathValue ?? propertyMathValue) as PropertyMathType | CountPerActorMathType | undefined
             },
         ],
         minimumDetectableChange: [
@@ -803,8 +818,8 @@ export const experimentLogic = kea<experimentLogicType>([
                 },
         ],
         countDataForVariant: [
-            (s) => [s.experimentResults, s.experimentCountPerUserMath],
-            (experimentResults, experimentCountPerUserMath) =>
+            (s) => [s.experimentResults, s.experimentMathAggregationForTrends],
+            (experimentResults, experimentMathAggregationForTrends) =>
                 (variant: string): string => {
                     const errorResult = '--'
                     if (!experimentResults) {
@@ -819,8 +834,30 @@ export const experimentLogic = kea<experimentLogicType>([
 
                     let result = variantResults.count
 
-                    if (experimentCountPerUserMath) {
-                        result = variantResults.count / variantResults.data.length
+                    if (experimentMathAggregationForTrends) {
+                        // TODO: Aggregate end result appropriately for nth percentile
+                        if (
+                            [
+                                CountPerActorMathType.Average,
+                                CountPerActorMathType.Median,
+                                PropertyMathType.Average,
+                                PropertyMathType.Median,
+                            ].includes(experimentMathAggregationForTrends)
+                        ) {
+                            result = variantResults.count / variantResults.data.length
+                        } else if (
+                            [CountPerActorMathType.Maximum, PropertyMathType.Maximum].includes(
+                                experimentMathAggregationForTrends
+                            )
+                        ) {
+                            result = Math.max(...variantResults.data)
+                        } else if (
+                            [CountPerActorMathType.Minimum, PropertyMathType.Minimum].includes(
+                                experimentMathAggregationForTrends
+                            )
+                        ) {
+                            result = Math.min(...variantResults.data)
+                        }
                     }
 
                     if (result % 1 !== 0) {


### PR DESCRIPTION
## Problem

Fixes https://posthog.slack.com/archives/C02MHBYHS05/p1694693335276079

We weren't correctly handling property value aggregation for 'sum', and the UI was showing custom exposure for all property math aggregation when it shouldn't.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unit test, run locally, see on new experiment that exposure options shows up only for sum properties and not others

<img width="1198" alt="image" src="https://github.com/PostHog/posthog/assets/7115141/82d29bcf-4d30-4d2e-b3b0-3b2a560b7477">

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
