### PR TITLE
fix: stop propagation in the toolbar

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
@@ -44,6 +44,8 @@ interface LemonInputPropsBase
     onPressEnter?: (event: React.KeyboardEvent<HTMLInputElement>) => void
     'data-attr'?: string
     'aria-label'?: string
+    /** Whether to stop propagation of events from the input */
+    stopPropagation?: boolean
 }
 
 export interface LemonInputPropsText extends LemonInputPropsBase {
@@ -80,6 +82,7 @@ export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(fu
         value,
         transparentBackground = false,
         size = 'medium',
+        stopPropagation = false,
         ...textProps
     },
     ref
@@ -160,6 +163,9 @@ export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(fu
                 type={(type === 'password' && passwordVisible ? 'text' : type) || 'text'}
                 value={value}
                 onChange={(event) => {
+                    if (stopPropagation) {
+                        event.stopPropagation()
+                    }
                     if (type === 'number') {
                         onChange?.(
                             !isNaN(event.currentTarget.valueAsNumber) ? event.currentTarget.valueAsNumber : undefined
@@ -169,14 +175,23 @@ export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(fu
                     }
                 }}
                 onFocus={(event) => {
+                    if (stopPropagation) {
+                        event.stopPropagation()
+                    }
                     setFocused(true)
                     onFocus?.(event)
                 }}
                 onBlur={(event) => {
+                    if (stopPropagation) {
+                        event.stopPropagation()
+                    }
                     setFocused(false)
                     onBlur?.(event)
                 }}
                 onKeyDown={(event) => {
+                    if (stopPropagation) {
+                        event.stopPropagation()
+                    }
                     if (onPressEnter && event.key === 'Enter') {
                         onPressEnter(event)
                     }

--- a/frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.tsx
@@ -34,11 +34,13 @@ export interface LemonTextAreaProps
     minRows?: number
     maxRows?: number
     rows?: number
+    /** Whether to stop propagation of events from the input */
+    stopPropagation?: boolean
 }
 
 /** A `textarea` component for multi-line text. */
 export const LemonTextArea = React.forwardRef<HTMLTextAreaElement, LemonTextAreaProps>(function _LemonTextArea(
-    { className, onChange, onPressCmdEnter: onPressEnter, minRows = 3, onKeyDown, ...textProps },
+    { className, onChange, onPressCmdEnter: onPressEnter, minRows = 3, onKeyDown, stopPropagation, ...textProps },
     ref
 ): JSX.Element {
     const _ref = useRef<HTMLTextAreaElement | null>(null)
@@ -50,13 +52,21 @@ export const LemonTextArea = React.forwardRef<HTMLTextAreaElement, LemonTextArea
             ref={textRef}
             className={clsx('LemonTextArea', className)}
             onKeyDown={(e) => {
+                if (stopPropagation) {
+                    e.stopPropagation()
+                }
                 if (onPressEnter && e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                     onPressEnter(textProps.value?.toString() ?? '')
                 }
 
                 onKeyDown?.(e)
             }}
-            onChange={(event) => onChange?.(event.currentTarget.value ?? '')}
+            onChange={(event) => {
+                if (stopPropagation) {
+                    event.stopPropagation()
+                }
+                return onChange?.(event.currentTarget.value ?? '')
+            }}
             {...textProps}
         />
     )

--- a/frontend/src/toolbar/actions/EditAction.tsx
+++ b/frontend/src/toolbar/actions/EditAction.tsx
@@ -64,7 +64,11 @@ export function EditAction(): JSX.Element {
                 <div className="mb-4">
                     <p>What did your user do?</p>
                     <Field name="name">
-                        <LemonInput placeholder="E.g: Clicked Sign Up" className="action-title-field" />
+                        <LemonInput
+                            placeholder="E.g: Clicked Sign Up"
+                            className="action-title-field"
+                            stopPropagation={true}
+                        />
                     </Field>
                 </div>
 

--- a/frontend/src/toolbar/actions/StepField.tsx
+++ b/frontend/src/toolbar/actions/StepField.tsx
@@ -63,12 +63,14 @@ export function StepField({ step, item, label, caption }: StepFieldProps): JSX.E
                                 className={clsx(!selected && 'opacity-50')}
                                 onChange={onChange}
                                 value={value ?? ''}
+                                stopPropagation={true}
                             />
                         ) : (
                             <LemonInput
                                 className={clsx(!selected && 'opacity-50')}
                                 onChange={onChange}
                                 value={value ?? ''}
+                                stopPropagation={true}
                             />
                         )
                     }}


### PR DESCRIPTION
see: https://posthoghelp.zendesk.com/agent/tickets/5665 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/9358)

The toolbar floats above other people's sites. And (on the edit action form) lets you type. This can clash with desired behavior. E.g. if you open a floating menu on your site and then want to create an action, it's not uncommon for other interactions with the site to cause the floating menu to close.

So, let's swallow events in the inputs in the toolbar