### PR TITLE
chore: replace textfit package

### DIFF
--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -1,7 +1,7 @@
 import { useValues } from 'kea'
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 import ReactDOM from 'react-dom'
-import { Textfit } from 'react-textfit'
+import Textfit from './Textfit'
 import clsx from 'clsx'
 
 import { insightLogic } from '../../insightLogic'
@@ -81,7 +81,6 @@ function useBoldNumberTooltip({
 export function BoldNumber({ showPersonsModal = true }: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { insightData, trendsFilter } = useValues(insightVizDataLogic(insightProps))
-    const [textFitTimer, setTextFitTimer] = useState<NodeJS.Timeout | null>(null)
 
     const [isTooltipShown, setIsTooltipShown] = useState(false)
     const valueRef = useBoldNumberTooltip({ showPersonsModal, isTooltipShown })
@@ -89,28 +88,9 @@ export function BoldNumber({ showPersonsModal = true }: ChartParams): JSX.Elemen
     const showComparison = !!trendsFilter?.compare && insightData?.result?.length > 1
     const resultSeries = insightData?.result?.[0] as TrendResult | undefined
 
-    useEffect(() => {
-        // sometimes text fit can get stuck and leave text too small
-        // force a resize after a small delay
-        const timer = setTimeout(() => window.dispatchEvent(new CustomEvent('resize')), 300)
-        setTextFitTimer(timer)
-        return () => clearTimeout(timer)
-    }, [])
-
     return resultSeries ? (
         <div className="BoldNumber">
-            <Textfit
-                mode="single"
-                min={32}
-                max={120}
-                onReady={() => {
-                    // if fontsize has calculated then no need for a resize event
-                    if (textFitTimer) {
-                        clearTimeout(textFitTimer)
-                    }
-                }}
-                style={{ lineHeight: 1 }}
-            >
+            <Textfit min={32} max={120}>
                 <div
                     className={clsx('BoldNumber__value', showPersonsModal ? 'cursor-pointer' : 'cursor-default')}
                     onClick={

--- a/frontend/src/scenes/insights/views/BoldNumber/Textfit.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/Textfit.tsx
@@ -1,0 +1,83 @@
+// Adapted from https://github.com/malte-wessel/react-textfit
+// which is no longer maintained and does not support React 18
+
+import { useEffect, useRef, useState } from 'react'
+
+// Calculate width without padding.
+const innerWidth = (el: HTMLDivElement): number => {
+    const style = window.getComputedStyle(el, null)
+    // Hidden iframe in Firefox returns null, https://github.com/malte-wessel/react-textfit/pull/34
+    if (!style) {
+        return el.clientWidth
+    }
+
+    return (
+        el.clientWidth -
+        parseInt(style.getPropertyValue('padding-left'), 10) -
+        parseInt(style.getPropertyValue('padding-right'), 10)
+    )
+}
+
+const assertElementFitsWidth = (el: HTMLDivElement, width: number): boolean => el.scrollWidth - 1 <= width
+
+const Textfit = ({ min, max, children }: { min: number; max: number; children: React.ReactNode }): JSX.Element => {
+    const parentRef = useRef<HTMLDivElement>(null)
+    const childRef = useRef<HTMLDivElement>(null)
+
+    const [fontSize, setFontSize] = useState<number>()
+
+    let resizeTimer: NodeJS.Timeout
+
+    const handleWindowResize = (): void => {
+        clearTimeout(resizeTimer)
+        resizeTimer = setTimeout(() => {
+            const el = parentRef.current
+            const wrapper = childRef.current
+
+            if (el && wrapper) {
+                const originalWidth = innerWidth(el)
+
+                let mid
+                let low = min
+                let high = max
+
+                while (low <= high) {
+                    mid = Math.floor((low + high) / 2)
+                    setFontSize(mid)
+
+                    if (assertElementFitsWidth(wrapper, originalWidth)) {
+                        low = mid + 1
+                    } else {
+                        high = mid - 1
+                    }
+                }
+                mid = Math.min(low, high)
+
+                // Ensure we hit the user-supplied limits
+                mid = Math.max(mid, min)
+                mid = Math.min(mid, max)
+
+                setFontSize(mid)
+            }
+        }, 10)
+    }
+
+    useEffect(() => {
+        window.addEventListener('resize', handleWindowResize)
+        return () => window.removeEventListener('resize', handleWindowResize)
+    }, [])
+
+    useEffect(() => handleWindowResize(), [parentRef, childRef])
+
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div ref={parentRef} style={{ lineHeight: 1, fontSize: fontSize }}>
+            {/* eslint-disable-next-line react/forbid-dom-props */}
+            <div ref={childRef} style={{ whiteSpace: 'nowrap', display: 'inline-block' }}>
+                {children}
+            </div>
+        </div>
+    )
+}
+
+export default Textfit


### PR DESCRIPTION
## Problem

[React Textfit](https://github.com/malte-wessel/react-textfit) is no longer maintained and does not support React 18. Towards https://github.com/PostHog/posthog/pull/16605

## Changes

- We are only using it in a single place so I reimplemented what functionality we needed from it. There is no obvious replacement package either
- Removed a tiny fix for the package for when it occasionally froze

## How did you test this code?
Continues to resize as expected:
https://github.com/PostHog/posthog/assets/6685876/feb477ec-8cc4-42d1-a1c7-e59e94c122fb
