### PR TITLE
chore: capture more to sentry

### DIFF
--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -141,9 +141,9 @@ def _screenshot_asset(
         driver.set_window_size(screenshot_width, height)
         driver.save_screenshot(image_path)
     except Exception as e:
-        if driver:
-            # To help with debugging, add a screenshot and any chrome logs
-            with configure_scope() as scope:
+        # To help with debugging, add a screenshot and any chrome logs
+        with configure_scope() as scope:
+            if driver:
                 # If we encounter issues getting extra info we should silenty fail rather than creating a new exception
                 try:
                     all_logs = [x for x in driver.get_log("browser")]
@@ -155,7 +155,7 @@ def _screenshot_asset(
                     scope.add_attachment(None, None, image_path)
                 except Exception:
                     pass
-                capture_exception(e)
+        capture_exception(e)
 
         raise e
     finally:

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -143,8 +143,9 @@ def _screenshot_asset(
     except Exception as e:
         # To help with debugging, add a screenshot and any chrome logs
         with configure_scope() as scope:
+            scope.set_extra("url_to_render", url_to_render)
             if driver:
-                # If we encounter issues getting extra info we should silenty fail rather than creating a new exception
+                # If we encounter issues getting extra info we should silently fail rather than creating a new exception
                 try:
                     all_logs = [x for x in driver.get_log("browser")]
                     scope.add_attachment(json.dumps(all_logs).encode("utf-8"), "logs.txt")


### PR DESCRIPTION
we only capture errors to Sentry when image exports fail if the driver is still around

let's capture more often