### PR TITLE
fix: redirect properly after complete onboarding

### DIFF
--- a/frontend/src/scenes/onboarding/OnboardingOtherProductsStep.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingOtherProductsStep.tsx
@@ -2,7 +2,6 @@ import { LemonButton, LemonCard } from '@posthog/lemon-ui'
 import { OnboardingStep } from './OnboardingStep'
 import { onboardingLogic } from './onboardingLogic'
 import { useActions, useValues } from 'kea'
-import { urls } from 'scenes/urls'
 
 export const OnboardingOtherProductsStep = (): JSX.Element => {
     const { product, suggestedProducts } = useValues(onboardingLogic)
@@ -39,10 +38,7 @@ export const OnboardingOtherProductsStep = (): JSX.Element => {
                             </div>
                         </div>
                         <div className="justify-self-end min-w-30 flex justify-end">
-                            <LemonButton
-                                type="primary"
-                                onClick={() => completeOnboarding(urls.onboarding(suggestedProduct.type))}
-                            >
+                            <LemonButton type="primary" onClick={() => completeOnboarding(suggestedProduct.type)}>
                                 Get started
                             </LemonButton>
                         </div>


### PR DESCRIPTION
## Problem

It takes a minute to receive the new current team information, so we need to wait for that before we redirect after completing onboarding. This also still needs to work if we want to go to a different onboarding product but still complete the current onboarding flow.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

I think this will work in production... 🤞 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
