### PR TITLE
fix(hogql): fix edge cases when converting real world lifecycle filters

### DIFF
--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -35,6 +35,10 @@ def is_property_with_operator(property: Dict):
 def clean_property(property: Dict):
     cleaned_property = {**property}
 
+    # convert precalculated cohorts to cohorts
+    if cleaned_property.get("type") == "precalculated-cohort":
+        cleaned_property["type"] = "cohort"
+
     # set a default operator for properties that support it, but don't have an operator set
     if is_property_with_operator(cleaned_property) and cleaned_property.get("operator") is None:
         cleaned_property["operator"] = "exact"

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -32,6 +32,10 @@ def clean_entity_property(property: Dict):
     cleaned_property = {**property}
     if cleaned_property.get("operator", None) is None and cleaned_property.get("type", None) not in ("cohort", "hogql"):
         cleaned_property["operator"] = "exact"
+
+    # remove keys without concrete value
+    cleaned_property = {key: value for key, value in cleaned_property.items() if value is not None}
+
     return cleaned_property
 
 

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -28,12 +28,20 @@ from posthog.schema import (
 from posthog.types import InsightQueryNode
 
 
+def is_property_with_operator(property: Dict):
+    return property.get("type") not in ("cohort", "hogql")
+
+
 def clean_property(property: Dict):
     cleaned_property = {**property}
 
     # set a default operator for properties that support it, but don't have an operator set
-    if cleaned_property.get("operator", None) is None and cleaned_property.get("type", None) not in ("cohort", "hogql"):
+    if is_property_with_operator(cleaned_property) and cleaned_property.get("operator") is None:
         cleaned_property["operator"] = "exact"
+
+    # remove the operator for properties that don't support it, but have it set
+    if not is_property_with_operator(cleaned_property) and cleaned_property.get("operator") is not None:
+        del cleaned_property["operator"]
 
     # remove keys without concrete value
     cleaned_property = {key: value for key, value in cleaned_property.items() if value is not None}

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -446,6 +446,7 @@ properties_9 = {
         {"type": "OR", "values": [{}]},
     ],
 }
+properties_10 = [{"key": "id", "type": "cohort", "value": 71, "operator": None}]
 
 test_properties = [
     properties_0,
@@ -458,6 +459,7 @@ test_properties = [
     properties_7,
     properties_8,
     properties_9,
+    properties_10,
 ]
 
 

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -339,6 +339,25 @@ insight_19 = {
     "shown_as": "Lifecycle",
 }
 
+insight_20 = {
+    "events": [
+        {
+            "id": "$pageview",
+            "math": "total",
+            "name": "$pageview",
+            "type": "events",
+            "order": 0,
+            "properties": [],
+            "math_property": None,
+        }
+    ],
+    "display": "ActionsLineGraph",
+    "insight": "LIFECYCLE",
+    "interval": "day",
+    "shown_as": "Lifecycle",
+    "properties": [{"key": "id", "type": "cohort", "value": 929, "operator": "exact"}],
+}
+
 test_insights = [
     insight_0,
     insight_1,
@@ -360,6 +379,7 @@ test_insights = [
     insight_17,
     insight_18,
     insight_19,
+    insight_20,
 ]
 
 

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -320,6 +320,25 @@ insight_18 = {
     "shown_as": "Lifecycle",
 }
 
+insight_19 = {
+    "events": [
+        {
+            "id": "created change",
+            "math": "total",
+            "name": "created change",
+            "type": "events",
+            "order": 0,
+            "properties": [{"key": "id", "type": "cohort", "value": 2208, "operator": None}],
+            "custom_name": None,
+            "math_property": None,
+        }
+    ],
+    "display": "ActionsLineGraph",
+    "insight": "LIFECYCLE",
+    "interval": "day",
+    "shown_as": "Lifecycle",
+}
+
 test_insights = [
     insight_0,
     insight_1,
@@ -340,6 +359,7 @@ test_insights = [
     insight_16,
     insight_17,
     insight_18,
+    insight_19,
 ]
 
 

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -300,6 +300,26 @@ insight_17 = {
     "filter_test_accounts": True,
 }
 
+# real world regression tests
+
+insight_18 = {
+    "actions": [
+        {
+            "id": 2760,
+            "math": "total",
+            "name": "Pageviews",
+            "type": "actions",
+            "order": 0,
+            "properties": [{"key": "$browser", "type": "event", "value": "Chrome", "operator": None}],
+            "math_property": None,
+        }
+    ],
+    "display": "ActionsBar",
+    "insight": "LIFECYCLE",
+    "interval": "day",
+    "shown_as": "Lifecycle",
+}
+
 test_insights = [
     insight_0,
     insight_1,
@@ -319,6 +339,7 @@ test_insights = [
     insight_15,
     insight_16,
     insight_17,
+    insight_18,
 ]
 
 

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -358,6 +358,27 @@ insight_20 = {
     "properties": [{"key": "id", "type": "cohort", "value": 929, "operator": "exact"}],
 }
 
+insight_21 = {
+    "actions": [
+        {
+            "id": 4317,
+            "math": "total",
+            "name": "Used newer version of the app",
+            "type": "actions",
+            "order": 0,
+            "properties": [],
+            "custom_name": None,
+            "math_property": None,
+        }
+    ],
+    "display": "ActionsLineGraph",
+    "insight": "LIFECYCLE",
+    "interval": "day",
+    "shown_as": "Lifecycle",
+    "properties": [{"key": "id", "type": "precalculated-cohort", "value": 760, "operator": None}],
+    "funnel_window_days": 14,
+}
+
 test_insights = [
     insight_0,
     insight_1,
@@ -380,6 +401,7 @@ test_insights = [
     insight_18,
     insight_19,
     insight_20,
+    insight_21,
 ]
 
 


### PR DESCRIPTION
## Problem

We need to make the backend side `filter_to_query` conversion function robust against real-world edge cases.

## Changes

This PR fixes problems in the conversion for all existing **lifecycle** filters. The filters were obtained via metabase:

```sql
SELECT DISTINCT filters
FROM posthog_dashboarditem 
WHERE filters->>'insight' = 'LIFECYCLE'
```

## How did you test this code?

Added test examples that were then fixed