### PR TITLE
feat(hogql): support constant values in HogQLQuery

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1201,6 +1201,10 @@
                 "response": {
                     "$ref": "#/definitions/HogQLQueryResponse",
                     "description": "Cached query response"
+                },
+                "values": {
+                    "description": "Constant values that can be referenced with the {placeholder} syntax in the query",
+                    "type": "object"
                 }
             },
             "required": ["kind", "query"],

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -144,6 +144,8 @@ export interface HogQLQuery extends DataNode {
     kind: NodeKind.HogQLQuery
     query: string
     filters?: HogQLFilters
+    /** Constant values that can be referenced with the {placeholder} syntax in the query */
+    values?: Record<string, any>
     response?: HogQLQueryResponse
 }
 

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -540,4 +540,4 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 },
             )
 
-        self.assertEqual(len(response.get("results", [])), 20)
+        self.assertEqual(response.get("results", [])[0][0], 20)

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -522,3 +522,22 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                     ["sign out", "4", "test_val3"],
                 ],
             )
+
+    def test_full_hogql_query_values(self):
+        random_uuid = str(UUIDT())
+        with freeze_time("2020-01-10 12:00:00"):
+            for _ in range(20):
+                _create_event(team=self.team, event="sign up", distinct_id=random_uuid, properties={"key": "test_val1"})
+        flush_persons_and_events()
+
+        with freeze_time("2020-01-10 12:14:00"):
+            response = process_query(
+                team=self.team,
+                query_json={
+                    "kind": "HogQLQuery",
+                    "query": "select count() from events where distinct_id = {random_uuid}",
+                    "values": {"random_uuid": random_uuid},
+                },
+            )
+
+        self.assertEqual(len(response.get("results", [])), 20)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -882,6 +882,9 @@ class HogQLQuery(BaseModel):
     kind: Literal["HogQLQuery"] = "HogQLQuery"
     query: str
     response: Optional[HogQLQueryResponse] = Field(default=None, description="Cached query response")
+    values: Optional[Dict[str, Any]] = Field(
+        default=None, description="Constant values that can be referenced with the {placeholder} syntax in the query"
+    )
 
 
 class PersonsNode(BaseModel):


### PR DESCRIPTION
## Problem

Splitting out work from https://github.com/PostHog/posthog/pull/17470

## Changes

Updates the `HogQLQuery` node and adds `values: Record<string, any>`. 

This allows you to pass in any constant like `uuid: '123'`, and reference it in your query with `id = {uuid}`. 

Note: 
- This is used in the new persons scene to load just one person in a query. It'll likely be replaced with a dedicated query node, but this is still useful.
- I had forgotten about our [hogql tag](https://github.com/PostHog/posthog/blob/ed07aacb1e2c59470649c7cb664815d478eaa617/frontend/src/queries/utils.test.ts#L10-L53) when writing this. That would work fine for my PersonsQuery usecase, but will likely not be enough for people actually making API calls who don't want to reimplement our sanitization in their backend language of choice.
- If the base query stays the same, and only a few variables/placeholders change, we can cahce the AST generation much better. If we want to, is another question.

## How did you test this code?

Wrote a test.