### PR TITLE
feat(persons): rename urls.person(id) to urls.personDistinctId(id)

### DIFF
--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -246,7 +246,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>({
                                 display: `View person ${input}`,
                                 executor: () => {
                                     const { push } = router.actions
-                                    push(urls.personDistinctId(person.distinct_ids[0]))
+                                    push(urls.personByDistinctId(person.distinct_ids[0]))
                                 },
                             },
                         ],

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -246,7 +246,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>({
                                 display: `View person ${input}`,
                                 executor: () => {
                                     const { push } = router.actions
-                                    push(urls.person(person.distinct_ids[0]))
+                                    push(urls.personDistinctId(person.distinct_ids[0]))
                                 },
                             },
                         ],

--- a/frontend/src/lib/components/UniversalSearch/UniversalSearchPopover.tsx
+++ b/frontend/src/lib/components/UniversalSearch/UniversalSearchPopover.tsx
@@ -91,7 +91,7 @@ function redirectOnSelectItems(
     } else if (groupType === TaxonomicFilterGroupType.Cohorts) {
         router.actions.push(urls.cohort(value))
     } else if (groupType === TaxonomicFilterGroupType.Persons) {
-        router.actions.push(urls.person(String(value)))
+        router.actions.push(urls.personDistinctId(String(value)))
     } else if (groupType.startsWith(TaxonomicFilterGroupType.GroupNamesPrefix)) {
         router.actions.push(urls.group((item as Group).group_type_index, String(value)))
     } else if (groupType === TaxonomicFilterGroupType.Insights) {

--- a/frontend/src/lib/components/UniversalSearch/UniversalSearchPopover.tsx
+++ b/frontend/src/lib/components/UniversalSearch/UniversalSearchPopover.tsx
@@ -91,7 +91,7 @@ function redirectOnSelectItems(
     } else if (groupType === TaxonomicFilterGroupType.Cohorts) {
         router.actions.push(urls.cohort(value))
     } else if (groupType === TaxonomicFilterGroupType.Persons) {
-        router.actions.push(urls.personDistinctId(String(value)))
+        router.actions.push(urls.personByDistinctId(String(value)))
     } else if (groupType.startsWith(TaxonomicFilterGroupType.GroupNamesPrefix)) {
         router.actions.push(urls.group((item as Group).group_type_index, String(value)))
     } else if (groupType === TaxonomicFilterGroupType.Insights) {

--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -205,7 +205,7 @@ export function renderColumn(
     } else if (key === 'person' && isPersonsNode(query.source)) {
         const personRecord = record as PersonType
         return (
-            <Link to={urls.person(personRecord.distinct_ids[0])}>
+            <Link to={urls.personDistinctId(personRecord.distinct_ids[0])}>
                 <PersonDisplay noLink withIcon person={personRecord} noPopover />
             </Link>
         )

--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -205,7 +205,7 @@ export function renderColumn(
     } else if (key === 'person' && isPersonsNode(query.source)) {
         const personRecord = record as PersonType
         return (
-            <Link to={urls.personDistinctId(personRecord.distinct_ids[0])}>
+            <Link to={urls.personByDistinctId(personRecord.distinct_ids[0])}>
                 <PersonDisplay noLink withIcon person={personRecord} noPopover />
             </Link>
         )

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -26,7 +26,7 @@ export const appScenes: Record<Scene, () => any> = {
     [Scene.Replay]: () => import('./session-recordings/SessionRecordings'),
     [Scene.ReplaySingle]: () => import('./session-recordings/detail/SessionRecordingDetail'),
     [Scene.ReplayPlaylist]: () => import('./session-recordings/playlist/SessionRecordingsPlaylistScene'),
-    [Scene.Person]: () => import('./persons/Person'),
+    [Scene.Person]: () => import('./persons/PersonScene'),
     [Scene.Persons]: () => import('./persons/PersonsScene'),
     [Scene.Groups]: () => import('./groups/Groups'),
     [Scene.Group]: () => import('./groups/Group'),

--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -36,9 +36,10 @@ const WARNING_TYPE_RENDERER = {
         return (
             <>
                 Refused to merge already identified person{' '}
-                <Link to={urls.person(details.sourcePersonDistinctId)}>{details.sourcePersonDistinctId}</Link> into{' '}
-                <Link to={urls.person(details.targetPersonDistinctId)}>{details.targetPersonDistinctId}</Link> via an
-                $identify or $create_alias call (event uuid: <code>{details.eventUuid}</code>).
+                <Link to={urls.personDistinctId(details.sourcePersonDistinctId)}>{details.sourcePersonDistinctId}</Link>{' '}
+                into{' '}
+                <Link to={urls.personDistinctId(details.targetPersonDistinctId)}>{details.targetPersonDistinctId}</Link>{' '}
+                via an $identify or $create_alias call (event uuid: <code>{details.eventUuid}</code>).
             </>
         )
     },
@@ -51,9 +52,9 @@ const WARNING_TYPE_RENDERER = {
         return (
             <>
                 Refused to merge an illegal distinct_id{' '}
-                <Link to={urls.person(details.illegalDistinctId)}>{details.illegalDistinctId}</Link> with{' '}
-                <Link to={urls.person(details.otherDistinctId)}>{details.otherDistinctId}</Link> via an $identify or
-                $create_alias call (event uuid: <code>{details.eventUuid}</code>).
+                <Link to={urls.personDistinctId(details.illegalDistinctId)}>{details.illegalDistinctId}</Link> with{' '}
+                <Link to={urls.personDistinctId(details.otherDistinctId)}>{details.otherDistinctId}</Link> via an
+                $identify or $create_alias call (event uuid: <code>{details.eventUuid}</code>).
             </>
         )
     },
@@ -116,8 +117,8 @@ const WARNING_TYPE_RENDERER = {
         return (
             <>
                 Event ingestion has overflowed capacity for distinct_id{' '}
-                <Link to={urls.person(details.overflowDistinctId)}>{details.overflowDistinctId}</Link>. Events will
-                still be processed, but are likely to be delayed longer than usual.
+                <Link to={urls.personDistinctId(details.overflowDistinctId)}>{details.overflowDistinctId}</Link>. Events
+                will still be processed, but are likely to be delayed longer than usual.
             </>
         )
     },

--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -36,9 +36,13 @@ const WARNING_TYPE_RENDERER = {
         return (
             <>
                 Refused to merge already identified person{' '}
-                <Link to={urls.personDistinctId(details.sourcePersonDistinctId)}>{details.sourcePersonDistinctId}</Link>{' '}
+                <Link to={urls.personByDistinctId(details.sourcePersonDistinctId)}>
+                    {details.sourcePersonDistinctId}
+                </Link>{' '}
                 into{' '}
-                <Link to={urls.personDistinctId(details.targetPersonDistinctId)}>{details.targetPersonDistinctId}</Link>{' '}
+                <Link to={urls.personByDistinctId(details.targetPersonDistinctId)}>
+                    {details.targetPersonDistinctId}
+                </Link>{' '}
                 via an $identify or $create_alias call (event uuid: <code>{details.eventUuid}</code>).
             </>
         )
@@ -52,8 +56,8 @@ const WARNING_TYPE_RENDERER = {
         return (
             <>
                 Refused to merge an illegal distinct_id{' '}
-                <Link to={urls.personDistinctId(details.illegalDistinctId)}>{details.illegalDistinctId}</Link> with{' '}
-                <Link to={urls.personDistinctId(details.otherDistinctId)}>{details.otherDistinctId}</Link> via an
+                <Link to={urls.personByDistinctId(details.illegalDistinctId)}>{details.illegalDistinctId}</Link> with{' '}
+                <Link to={urls.personByDistinctId(details.otherDistinctId)}>{details.otherDistinctId}</Link> via an
                 $identify or $create_alias call (event uuid: <code>{details.eventUuid}</code>).
             </>
         )
@@ -117,8 +121,8 @@ const WARNING_TYPE_RENDERER = {
         return (
             <>
                 Event ingestion has overflowed capacity for distinct_id{' '}
-                <Link to={urls.personDistinctId(details.overflowDistinctId)}>{details.overflowDistinctId}</Link>. Events
-                will still be processed, but are likely to be delayed longer than usual.
+                <Link to={urls.personByDistinctId(details.overflowDistinctId)}>{details.overflowDistinctId}</Link>.
+                Events will still be processed, but are likely to be delayed longer than usual.
             </>
         )
     },

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeBacklink.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeBacklink.tsx
@@ -68,7 +68,7 @@ function backlinkHref(id: string, type: TaxonomicFilterGroupType): string {
     } else if (type === TaxonomicFilterGroupType.Cohorts) {
         return urls.cohort(id)
     } else if (type === TaxonomicFilterGroupType.Persons) {
-        return urls.person(id)
+        return urls.personDistinctId(id)
     } else if (type === TaxonomicFilterGroupType.Insights) {
         return urls.insightView(id as InsightModel['short_id'])
     } else if (type === TaxonomicFilterGroupType.FeatureFlags) {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeBacklink.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeBacklink.tsx
@@ -68,7 +68,7 @@ function backlinkHref(id: string, type: TaxonomicFilterGroupType): string {
     } else if (type === TaxonomicFilterGroupType.Cohorts) {
         return urls.cohort(id)
     } else if (type === TaxonomicFilterGroupType.Persons) {
-        return urls.personDistinctId(id)
+        return urls.personByDistinctId(id)
     } else if (type === TaxonomicFilterGroupType.Insights) {
         return urls.insightView(id as InsightModel['short_id'])
     } else if (type === TaxonomicFilterGroupType.FeatureFlags) {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
@@ -94,13 +94,13 @@ export const NotebookNodePerson = createPostHogWidgetNode<NotebookNodePersonAttr
     Component,
     heightEstimate: 300,
     minHeight: 100,
-    href: (attrs) => urls.person(attrs.id),
+    href: (attrs) => urls.personDistinctId(attrs.id),
     resizeable: true,
     attributes: {
         id: {},
     },
     pasteOptions: {
-        find: urls.person('(.+)', false),
+        find: urls.personDistinctId('(.+)', false),
         getAttributes: async (match) => {
             return { id: match[1] }
         },

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
@@ -94,13 +94,13 @@ export const NotebookNodePerson = createPostHogWidgetNode<NotebookNodePersonAttr
     Component,
     heightEstimate: 300,
     minHeight: 100,
-    href: (attrs) => urls.personDistinctId(attrs.id),
+    href: (attrs) => urls.personByDistinctId(attrs.id),
     resizeable: true,
     attributes: {
         id: {},
     },
     pasteOptions: {
-        find: urls.personDistinctId('(.+)', false),
+        find: urls.personByDistinctId('(.+)', false),
         getAttributes: async (match) => {
             return { id: match[1] }
         },

--- a/frontend/src/scenes/persons/PersonPreview.tsx
+++ b/frontend/src/scenes/persons/PersonPreview.tsx
@@ -32,7 +32,7 @@ export function PersonPreview(props: PersonPreviewProps): JSX.Element | null {
     }
 
     const display = asDisplay(person)
-    const url = urls.personDistinctId(person?.distinct_ids[0])
+    const url = urls.personByDistinctId(person?.distinct_ids[0])
 
     return (
         <div className="flex flex-col overflow-hidden max-h-80 max-w-160 gap-2">
@@ -54,7 +54,7 @@ export function PersonPreview(props: PersonPreviewProps): JSX.Element | null {
                 <LemonButton
                     size="small"
                     icon={<IconOpenInNew />}
-                    to={urls.personDistinctId(person?.distinct_ids[0])}
+                    to={urls.personByDistinctId(person?.distinct_ids[0])}
                 />
             </div>
 

--- a/frontend/src/scenes/persons/PersonPreview.tsx
+++ b/frontend/src/scenes/persons/PersonPreview.tsx
@@ -32,7 +32,7 @@ export function PersonPreview(props: PersonPreviewProps): JSX.Element | null {
     }
 
     const display = asDisplay(person)
-    const url = urls.person(person?.distinct_ids[0])
+    const url = urls.personDistinctId(person?.distinct_ids[0])
 
     return (
         <div className="flex flex-col overflow-hidden max-h-80 max-w-160 gap-2">
@@ -51,7 +51,11 @@ export function PersonPreview(props: PersonPreviewProps): JSX.Element | null {
                     onNotebookOpened={() => props.onClose?.()}
                     size="small"
                 />
-                <LemonButton size="small" icon={<IconOpenInNew />} to={urls.person(person?.distinct_ids[0])} />
+                <LemonButton
+                    size="small"
+                    icon={<IconOpenInNew />}
+                    to={urls.personDistinctId(person?.distinct_ids[0])}
+                />
             </div>
 
             <div className="flex-1 overflow-y-auto border-t">

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -127,7 +127,7 @@ export function PersonScene(): JSX.Element | null {
         return personLoading ? <SpinnerOverlay sceneLevel /> : <NotFound object="Person" />
     }
 
-    const url = urls.personDistinctId(urlId || person.distinct_ids[0] || String(person.id))
+    const url = urls.personByDistinctId(urlId || person.distinct_ids[0] || String(person.id))
 
     return (
         <>

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -36,7 +36,7 @@ import { PersonDashboard } from './PersonDashboard'
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
 
 export const scene: SceneExport = {
-    component: Person,
+    component: PersonScene,
     logic: personsLogic,
     paramsToProps: ({ params: { _: rawUrlId } }): (typeof personsLogic)['props'] => ({
         syncWithUrl: true,
@@ -106,7 +106,7 @@ function PersonCaption({ person }: { person: PersonType }): JSX.Element {
     )
 }
 
-export function Person(): JSX.Element | null {
+export function PersonScene(): JSX.Element | null {
     const {
         showCustomerSuccessDashboards,
         person,
@@ -127,7 +127,7 @@ export function Person(): JSX.Element | null {
         return personLoading ? <SpinnerOverlay sceneLevel /> : <NotFound object="Person" />
     }
 
-    const url = urls.person(urlId || person.distinct_ids[0] || String(person.id))
+    const url = urls.personDistinctId(urlId || person.distinct_ids[0] || String(person.id))
 
     return (
         <>

--- a/frontend/src/scenes/persons/activityDescriptions.tsx
+++ b/frontend/src/scenes/persons/activityDescriptions.tsx
@@ -68,7 +68,7 @@ export function personActivityDescriber(logItem: ActivityLogItem): HumanizedChan
                         }
                         listParts={distinctIds.map((di) => (
                             <span key={di} className="highlighted-activity">
-                                <Link to={urls.personDistinctId(di)}>{di}</Link>
+                                <Link to={urls.personByDistinctId(di)}>{di}</Link>
                             </span>
                         ))}
                     />

--- a/frontend/src/scenes/persons/activityDescriptions.tsx
+++ b/frontend/src/scenes/persons/activityDescriptions.tsx
@@ -68,7 +68,7 @@ export function personActivityDescriber(logItem: ActivityLogItem): HumanizedChan
                         }
                         listParts={distinctIds.map((di) => (
                             <span key={di} className="highlighted-activity">
-                                <Link to={urls.person(di)}>{di}</Link>
+                                <Link to={urls.personDistinctId(di)}>{di}</Link>
                             </span>
                         ))}
                     />

--- a/frontend/src/scenes/persons/person-utils.test.ts
+++ b/frontend/src/scenes/persons/person-utils.test.ts
@@ -6,10 +6,10 @@ import { asLink, asDisplay } from './person-utils'
 describe('the person header', () => {
     describe('linking to a person', () => {
         const personLinksTestCases = [
-            { distinctIds: ['a uuid'], expectedLink: urls.personDistinctId('a uuid'), name: 'with one id' },
+            { distinctIds: ['a uuid'], expectedLink: urls.personByDistinctId('a uuid'), name: 'with one id' },
             {
                 distinctIds: ['the first uuid', 'a uuid'],
-                expectedLink: urls.personDistinctId('the first uuid'),
+                expectedLink: urls.personByDistinctId('the first uuid'),
                 name: 'with more than one id',
             },
             {
@@ -19,7 +19,7 @@ describe('the person header', () => {
             },
             {
                 distinctIds: ['a+dicey/@!'],
-                expectedLink: urls.personDistinctId('a+dicey/@!'),
+                expectedLink: urls.personByDistinctId('a+dicey/@!'),
                 name: 'with no ids',
             },
         ]

--- a/frontend/src/scenes/persons/person-utils.test.ts
+++ b/frontend/src/scenes/persons/person-utils.test.ts
@@ -6,10 +6,10 @@ import { asLink, asDisplay } from './person-utils'
 describe('the person header', () => {
     describe('linking to a person', () => {
         const personLinksTestCases = [
-            { distinctIds: ['a uuid'], expectedLink: urls.person('a uuid'), name: 'with one id' },
+            { distinctIds: ['a uuid'], expectedLink: urls.personDistinctId('a uuid'), name: 'with one id' },
             {
                 distinctIds: ['the first uuid', 'a uuid'],
-                expectedLink: urls.person('the first uuid'),
+                expectedLink: urls.personDistinctId('the first uuid'),
                 name: 'with more than one id',
             },
             {
@@ -19,7 +19,7 @@ describe('the person header', () => {
             },
             {
                 distinctIds: ['a+dicey/@!'],
-                expectedLink: urls.person('a+dicey/@!'),
+                expectedLink: urls.personDistinctId('a+dicey/@!'),
                 name: 'with no ids',
             },
         ]

--- a/frontend/src/scenes/persons/person-utils.ts
+++ b/frontend/src/scenes/persons/person-utils.ts
@@ -60,7 +60,7 @@ export function asDisplay(person: PersonPropType | null | undefined, maxLength?:
 
 export const asLink = (person?: PersonPropType | null): string | undefined =>
     person?.distinct_id
-        ? urls.person(person.distinct_id)
+        ? urls.personDistinctId(person.distinct_id)
         : person?.distinct_ids?.length
-        ? urls.person(person.distinct_ids[0])
+        ? urls.personDistinctId(person.distinct_ids[0])
         : undefined

--- a/frontend/src/scenes/persons/person-utils.ts
+++ b/frontend/src/scenes/persons/person-utils.ts
@@ -60,7 +60,7 @@ export function asDisplay(person: PersonPropType | null | undefined, maxLength?:
 
 export const asLink = (person?: PersonPropType | null): string | undefined =>
     person?.distinct_id
-        ? urls.personDistinctId(person.distinct_id)
+        ? urls.personByDistinctId(person.distinct_id)
         : person?.distinct_ids?.length
-        ? urls.personDistinctId(person.distinct_ids[0])
+        ? urls.personByDistinctId(person.distinct_ids[0])
         : undefined

--- a/frontend/src/scenes/project-homepage/NewlySeenPersons.tsx
+++ b/frontend/src/scenes/project-homepage/NewlySeenPersons.tsx
@@ -17,7 +17,7 @@ function PersonRow({ person }: { person: PersonType }): JSX.Element {
 
     return (
         <ProjectHomePageCompactListItem
-            to={urls.personDistinctId(person.distinct_ids[0])}
+            to={urls.personByDistinctId(person.distinct_ids[0])}
             title={asDisplay(person)}
             subtitle={`First seen ${dayjs(person.created_at).fromNow()}`}
             prefix={<ProfilePicture name={asDisplay(person)} />}

--- a/frontend/src/scenes/project-homepage/NewlySeenPersons.tsx
+++ b/frontend/src/scenes/project-homepage/NewlySeenPersons.tsx
@@ -17,7 +17,7 @@ function PersonRow({ person }: { person: PersonType }): JSX.Element {
 
     return (
         <ProjectHomePageCompactListItem
-            to={urls.person(person.distinct_ids[0])}
+            to={urls.personDistinctId(person.distinct_ids[0])}
             title={asDisplay(person)}
             subtitle={`First seen ${dayjs(person.created_at).fromNow()}`}
             prefix={<ProfilePicture name={asDisplay(person)} />}

--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -110,7 +110,7 @@ export function RetentionModal(): JSX.Element | null {
                                                 ) : (
                                                     <LemonButton
                                                         size="small"
-                                                        to={urls.personDistinctId(
+                                                        to={urls.personByDistinctId(
                                                             personAppearances.person.distinct_ids[0]
                                                         )}
                                                         data-attr="retention-person-link"

--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -110,7 +110,9 @@ export function RetentionModal(): JSX.Element | null {
                                                 ) : (
                                                     <LemonButton
                                                         size="small"
-                                                        to={urls.person(personAppearances.person.distinct_ids[0])}
+                                                        to={urls.personDistinctId(
+                                                            personAppearances.person.distinct_ids[0]
+                                                        )}
                                                         data-attr="retention-person-link"
                                                     >
                                                         {asDisplay(personAppearances.person)}

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -415,7 +415,7 @@ export const routes: Record<string, Scene> = {
     }, {} as Record<string, Scene>),
     [urls.replaySingle(':id')]: Scene.ReplaySingle,
     [urls.replayPlaylist(':id')]: Scene.ReplayPlaylist,
-    [urls.personDistinctId('*', false)]: Scene.Person,
+    [urls.personByDistinctId('*', false)]: Scene.Person,
     [urls.persons()]: Scene.Persons,
     [urls.groups(':groupTypeIndex')]: Scene.Groups,
     [urls.group(':groupTypeIndex', ':groupKey', false)]: Scene.Group,

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -415,7 +415,7 @@ export const routes: Record<string, Scene> = {
     }, {} as Record<string, Scene>),
     [urls.replaySingle(':id')]: Scene.ReplaySingle,
     [urls.replayPlaylist(':id')]: Scene.ReplayPlaylist,
-    [urls.person('*', false)]: Scene.Person,
+    [urls.personDistinctId('*', false)]: Scene.Person,
     [urls.persons()]: Scene.Persons,
     [urls.groups(':groupTypeIndex')]: Scene.Groups,
     [urls.group(':groupTypeIndex', ':groupKey', false)]: Scene.Group,

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -88,7 +88,7 @@ export const urls = {
         combineUrl(`/replay/playlists/${id}`, filters ? { filters } : {}).url,
     replaySingle: (id: string, filters?: Partial<FilterType>): string =>
         combineUrl(`/replay/${id}`, filters ? { filters } : {}).url,
-    personDistinctId: (id: string, encode: boolean = true): string =>
+    personByDistinctId: (id: string, encode: boolean = true): string =>
         encode ? `/person/${encodeURIComponent(id)}` : `/person/${id}`,
     persons: (): string => '/persons',
     groups: (groupTypeIndex: string | number): string => `/groups/${groupTypeIndex}`,

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -88,7 +88,7 @@ export const urls = {
         combineUrl(`/replay/playlists/${id}`, filters ? { filters } : {}).url,
     replaySingle: (id: string, filters?: Partial<FilterType>): string =>
         combineUrl(`/replay/${id}`, filters ? { filters } : {}).url,
-    person: (id: string, encode: boolean = true): string =>
+    personDistinctId: (id: string, encode: boolean = true): string =>
         encode ? `/person/${encodeURIComponent(id)}` : `/person/${id}`,
     persons: (): string => '/persons',
     groups: (groupTypeIndex: string | number): string => `/groups/${groupTypeIndex}`,


### PR DESCRIPTION
## Problem

Splitting out work from https://github.com/PostHog/posthog/pull/17470

## Changes

- Renames `urls.person(id)` to `urls.personDistinctId(id)`
- This makes a future `urls.personUUID(id)` unambiguous.

## How did you test this code?

CI, and nothing broke in the big PR.