### PR TITLE
chore(plugin-server): switch console.log usage to status

### DIFF
--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -6,6 +6,7 @@ import { DateTime } from 'luxon'
 import { defaultConfig } from '../../config/config'
 import { KAFKA_PERSON } from '../../config/kafka-topics'
 import { BasePerson, Person, RawPerson, TimestampFormat } from '../../types'
+import { status } from '../../utils/status'
 import { castTimestampOrNow } from '../../utils/utils'
 import { PluginLogEntrySource, PluginLogEntryType, PluginLogLevel } from './../../types'
 
@@ -35,7 +36,7 @@ export function timeoutGuard(
 ): NodeJS.Timeout {
     return setTimeout(() => {
         const ctx = typeof context === 'function' ? context() : context
-        console.log(`⌛⌛⌛ ${message}`, ctx)
+        status.warn('⌛', message, ctx)
         Sentry.captureMessage(message, ctx ? { extra: ctx } : undefined)
     }, timeout)
 }

--- a/plugin-server/src/worker/ingestion/app-metrics.ts
+++ b/plugin-server/src/worker/ingestion/app-metrics.ts
@@ -136,7 +136,7 @@ export class AppMetrics {
     }
 
     async flush(): Promise<void> {
-        console.log(`Flushing app metrics`)
+        status.debug('🚽', `Flushing app metrics`)
         const startTime = Date.now()
         this.lastFlushTime = startTime
         if (Object.keys(this.queuedData).length === 0) {
@@ -170,7 +170,7 @@ export class AppMetrics {
             topic: KAFKA_APP_METRICS,
             messages: kafkaMessages,
         })
-        console.log(`Finisehd flushing app metrics, took ${Date.now() - startTime}ms`)
+        status.debug('🚽', `Finished flushing app metrics, took ${Date.now() - startTime}ms`)
     }
 
     _metricErrorParameters(errorWithContext: ErrorWithContext): Partial<AppMetric> {

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -359,8 +359,9 @@ export class HookCommander {
         end()
 
         const timeout = setTimeout(() => {
-            console.log(
-                `⌛⌛⌛ Posting Webhook slow. Timeout warning after 5 sec! url=${webhookUrl} team_id=${team.id} event_id=${event.eventUuid}`
+            status.warn(
+                '⌛',
+                `Posting Webhook slow. Timeout warning after 5 sec! url=${webhookUrl} team_id=${team.id} event_id=${event.eventUuid}`
             )
         }, 5000)
         const relevantFetch =
@@ -404,8 +405,9 @@ export class HookCommander {
         }
 
         const timeout = setTimeout(() => {
-            console.log(
-                `⌛⌛⌛ Posting RestHook slow. Timeout warning after 5 sec! url=${hook.target} team_id=${event.teamId} event_id=${event.eventUuid}`
+            status.warn(
+                '⌛',
+                `Posting RestHook slow. Timeout warning after 5 sec! url=${hook.target} team_id=${event.teamId} event_id=${event.eventUuid}`
             )
         }, 5000)
         const relevantFetch =

--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -13,9 +13,7 @@ async function runSingleTeamPluginOnEvent(
     onEvent: any
 ): Promise<void> {
     const timeout = setTimeout(() => {
-        console.log(
-            `⌛⌛⌛ Still running single onEvent plugin for team ${event.team_id} for plugin ${pluginConfig.id}`
-        )
+        status.warn('⌛', `Still running single onEvent plugin for team ${event.team_id} for plugin ${pluginConfig.id}`)
     }, 10 * 1000) // 10 seconds
     try {
         // Runs onEvent for a single plugin without any retries


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Some things in plugin-server are directly logging, rather than using our JSON structured logger. It's better to use the same format everywhere.

## Changes

`console.log` -> `status.$LEVEL`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

N/A
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
