### PR TITLE
fix: don't run exports in parallel for subscriptions

### DIFF
--- a/ee/tasks/test/subscriptions/test_subscriptions_utils.py
+++ b/ee/tasks/test/subscriptions/test_subscriptions_utils.py
@@ -12,7 +12,7 @@ from posthog.models.insight import Insight
 from posthog.test.base import APIBaseTest
 
 
-@patch("ee.tasks.subscriptions.subscription_utils.group")
+@patch("ee.tasks.subscriptions.subscription_utils.chain")
 @patch("ee.tasks.subscriptions.subscription_utils.exporter.export_asset")
 class TestSubscriptionsTasksUtils(APIBaseTest):
     dashboard: Dashboard
@@ -36,7 +36,7 @@ class TestSubscriptionsTasksUtils(APIBaseTest):
 
             assert insights == [self.insight]
             assert len(assets) == 1
-            assert mock_export_task.s.call_count == 1
+            assert mock_export_task.si.call_count == 1
 
     def test_generate_assets_for_dashboard(self, mock_export_task: MagicMock, _mock_group: MagicMock) -> None:
         subscription = create_subscription(team=self.team, dashboard=self.dashboard, created_by=self.user)
@@ -46,7 +46,7 @@ class TestSubscriptionsTasksUtils(APIBaseTest):
 
         assert len(insights) == len(self.tiles)
         assert len(assets) == DEFAULT_MAX_ASSET_COUNT
-        assert mock_export_task.s.call_count == DEFAULT_MAX_ASSET_COUNT
+        assert mock_export_task.si.call_count == DEFAULT_MAX_ASSET_COUNT
 
     def test_raises_if_missing_resource(self, _mock_export_task: MagicMock, _mock_group: MagicMock) -> None:
         subscription = create_subscription(team=self.team, created_by=self.user)
@@ -70,7 +70,7 @@ class TestSubscriptionsTasksUtils(APIBaseTest):
 
             assert len(insights) == 1
             assert len(assets) == 1
-            assert mock_export_task.s.call_count == 1
+            assert mock_export_task.si.call_count == 1
 
     def test_cancels_children_if_timed_out(self, _mock_export_task: MagicMock, mock_group: MagicMock) -> None:
         # mock the group so that its children are never ready,


### PR DESCRIPTION
The subscription delivery is blocking processing in Celery. 

Let's run the exports as a chain instead of a group and see if that helps