### PR TITLE
feat(plugin-server): add option to only require a single ack to succe…

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -59,6 +59,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_TOPIC_CREATION_TIMEOUT_MS: isDevEnv() ? 30_000 : 5_000, // rdkafka default is 5s, increased in devenv to resist to slow kafka
         KAFKA_PRODUCER_MAX_QUEUE_SIZE: isTestEnv() ? 0 : 1000,
         KAFKA_PRODUCER_WAIT_FOR_ACK: true, // Turning it off can lead to dropped data
+        KAFKA_PRODUCER_ONLY_REQUIRE_ONE_ACK: false, // Turning it on risks data loss if the single replica that acks goes down
         KAFKA_MAX_MESSAGE_BATCH_SIZE: isDevEnv() ? 0 : 900_000,
         KAFKA_FLUSH_FREQUENCY_MS: isTestEnv() ? 5 : 500,
         APP_METRICS_FLUSH_FREQUENCY_MS: isTestEnv() ? 5 : 20_000,

--- a/plugin-server/src/kafka/producer.ts
+++ b/plugin-server/src/kafka/producer.ts
@@ -6,40 +6,44 @@ import {
     MessageValue,
     NumberNullUndefined,
     ProducerGlobalConfig,
+    ProducerTopicConfig,
 } from 'node-rdkafka-acosom'
 
 import { getSpan } from '../sentry'
 import { status } from '../utils/status'
 
 // Kafka production related functions using node-rdkafka.
-export const createKafkaProducer = async (config: ProducerGlobalConfig) => {
-    const producer = new RdKafkaProducer({
-        // milliseconds to wait after the most recently added message before
-        // sending a batch. The default is 0, which means that messages are sent
-        // as soon as possible. This does not mean that there will only be one
-        // message per batch, as the producer will attempt to fill batches up to
-        // the batch size while the number of Kafka inflight requests is
-        // saturated, by default 5 inflight requests.
-        'linger.ms': 20,
-        // The default is 16kb. 1024kb also seems quite small for our use case
-        // but at least larger than the default.
-        'batch.size': 1024 * 1024,
-        'compression.codec': 'snappy',
-        // Ensure that librdkafka handled producer retries do not produce
-        // duplicates. Note this doesn't mean that if we manually retry a
-        // message that it will be idempotent. May reduce throughput. Note that
-        // at the time of writing the session recording events table in
-        // ClickHouse uses a `ReplicatedReplacingMergeTree` with a ver param of
-        // _timestamp i.e. when the event was added to the Kafka ingest topic.
-        // The sort key is `team_id, toHour(timestamp), session_id, timestamp,
-        // uuid` which means duplicate production of the same event _should_ be
-        // deduplicated when merges occur on the table. This isn't a guarantee
-        // on removing duplicates though and rather still requires deduplication
-        // either when querying the table or client side.
-        'enable.idempotence': true,
-        dr_cb: true,
-        ...config,
-    })
+export const createKafkaProducer = async (config: ProducerGlobalConfig, topicConfig?: ProducerTopicConfig) => {
+    const producer = new RdKafkaProducer(
+        {
+            // milliseconds to wait after the most recently added message before
+            // sending a batch. The default is 0, which means that messages are sent
+            // as soon as possible. This does not mean that there will only be one
+            // message per batch, as the producer will attempt to fill batches up to
+            // the batch size while the number of Kafka inflight requests is
+            // saturated, by default 5 inflight requests.
+            'linger.ms': 20,
+            // The default is 16kb. 1024kb also seems quite small for our use case
+            // but at least larger than the default.
+            'batch.size': 1024 * 1024,
+            'compression.codec': 'snappy',
+            // Ensure that librdkafka handled producer retries do not produce
+            // duplicates. Note this doesn't mean that if we manually retry a
+            // message that it will be idempotent. May reduce throughput. Note that
+            // at the time of writing the session recording events table in
+            // ClickHouse uses a `ReplicatedReplacingMergeTree` with a ver param of
+            // _timestamp i.e. when the event was added to the Kafka ingest topic.
+            // The sort key is `team_id, toHour(timestamp), session_id, timestamp,
+            // uuid` which means duplicate production of the same event _should_ be
+            // deduplicated when merges occur on the table. This isn't a guarantee
+            // on removing duplicates though and rather still requires deduplication
+            // either when querying the table or client side.
+            'enable.idempotence': true,
+            dr_cb: true,
+            ...config,
+        },
+        topicConfig
+    )
 
     producer.on('event.log', function (log) {
         status.info('📝', 'librdkafka log', { log: log })

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -142,6 +142,7 @@ export interface PluginsServerConfig {
     KAFKA_TOPIC_CREATION_TIMEOUT_MS: number
     KAFKA_PRODUCER_MAX_QUEUE_SIZE: number
     KAFKA_PRODUCER_WAIT_FOR_ACK: boolean
+    KAFKA_PRODUCER_ONLY_REQUIRE_ONE_ACK: boolean // sets request.required.acks rdkafka parameter to 1
     KAFKA_MAX_MESSAGE_BATCH_SIZE: number
     KAFKA_FLUSH_FREQUENCY_MS: number
     APP_METRICS_FLUSH_FREQUENCY_MS: number

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -102,7 +102,13 @@ export async function createHub(
 
     const kafka = createKafkaClient(serverConfig)
     const kafkaConnectionConfig = createRdConnectionConfigFromEnvVars(serverConfig)
-    const producer = await createKafkaProducer({ ...kafkaConnectionConfig, 'linger.ms': 0 })
+    const producer = await createKafkaProducer(
+        {
+            ...kafkaConnectionConfig,
+            'linger.ms': 0,
+        },
+        { 'request.required.acks': serverConfig.KAFKA_PRODUCER_ONLY_REQUIRE_ONE_ACK ? 1 : -1 }
+    )
 
     const kafkaProducer = new KafkaProducerWrapper(producer, serverConfig.KAFKA_PRODUCER_WAIT_FOR_ACK)
     status.info('👍', `Kafka ready`)


### PR DESCRIPTION
…ssfully produce

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We have some topics with a replication factor of 2 and an `min.insync.replicas` of 2. If one broker is down for maintenance, we can't produce with `request.required.acks=-1` (`-1` means `all`).

## Changes

Add option to allow for riskier produce, where only 1 ack is needed.

Note that this configuration is currently for the entire producer. I think we just want to enable it for analytics ingestion, and I don't see a reason to split it out per topic yet (and see below for other ways I'd prefer to fix this medium-term).

(Note, an alternative would to be manually configure `min.insync.replicas` on those topics to be `1`, or to increase their replication factor to `3`. Keeping it a configurable per producer is pretty nice, but hopefully we can get to replication factor of 3 everywhere as part of our move to a better Kafka provider? That's unrelated to this, though.)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
