### PR TITLE
feat: warn when not ingesting recordings

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -152,6 +152,7 @@ export function SessionsRecordings(): JSX.Element {
                             onClick: () => openSessionRecordingSettingsDialog(),
                             children: 'Configure',
                         }}
+                        dismissKey={`session-recordings-authorized-domains-warning/${suggestions.join(',')}`}
                     >
                         You have authorized domains configured for session recordings. Only recordings from these
                         domains will be allowed.


### PR DESCRIPTION
## Problem

If you set an authorized URL for recordings, and don't realise the impact, or don't realise it doesn't match all of your traffic. Then we do not record any non-matching domains. This could be confusing.

## Changes

* converts the authorized URL listing to HogQL
* Shows a warning on the replay page if appropriate

![2023-10-03 22 09 14](https://github.com/PostHog/posthog/assets/984817/fc48a75c-e337-473b-ad45-750c7ed8bcd3)

## How did you test this code?

👀 locally