### PR TITLE
feat(database): persons.pdi.distinct_id lazy join

### DIFF
--- a/posthog/hogql/database/schema/persons.py
+++ b/posthog/hogql/database/schema/persons.py
@@ -9,9 +9,11 @@ from posthog.hogql.database.models import (
     StringJSONDatabaseField,
     BooleanDatabaseField,
     LazyTable,
+    LazyJoin,
     FieldOrTable,
 )
 from posthog.hogql.errors import HogQLException
+from posthog.hogql.database.schema.persons_pdi import PersonsPDITable, persons_pdi_join
 
 PERSONS_FIELDS: Dict[str, FieldOrTable] = {
     "id": StringDatabaseField(name="id"),
@@ -19,6 +21,11 @@ PERSONS_FIELDS: Dict[str, FieldOrTable] = {
     "team_id": IntegerDatabaseField(name="team_id"),
     "properties": StringJSONDatabaseField(name="properties"),
     "is_identified": BooleanDatabaseField(name="is_identified"),
+    "pdi": LazyJoin(
+        from_field="id",
+        join_table=PersonsPDITable(),
+        join_function=persons_pdi_join,
+    ),
 }
 
 

--- a/posthog/hogql/database/schema/persons_pdi.py
+++ b/posthog/hogql/database/schema/persons_pdi.py
@@ -1,0 +1,63 @@
+from typing import Dict, List
+
+from posthog.hogql.database.argmax import argmax_select
+from posthog.hogql.database.models import (
+    IntegerDatabaseField,
+    StringDatabaseField,
+    LazyTable,
+    FieldOrTable,
+)
+from posthog.hogql.errors import HogQLException
+
+# :NOTE: We already have person_distinct_ids.py, which most tables link to. This persons_pdi.py is a hack to
+# make "select persons.pdi.distinct_id from persons" work while avoiding circular imports. Don't use directly.
+def persons_pdi_select(requested_fields: Dict[str, List[str]]):
+    # Always include "person_id", as it's the key we use to make further joins, and it'd be great if it's available
+    if "person_id" not in requested_fields:
+        requested_fields = {**requested_fields, "person_id": ["person_id"]}
+    return argmax_select(
+        table_name="raw_person_distinct_ids",
+        select_fields=requested_fields,
+        group_fields=["distinct_id"],
+        argmax_field="version",
+        deleted_field="is_deleted",
+    )
+
+
+# :NOTE: We already have person_distinct_ids.py, which most tables link to. This persons_pdi.py is a hack to
+# make "select persons.pdi.distinct_id from persons" work while avoiding circular imports. Don't use directly.
+def persons_pdi_join(from_table: str, to_table: str, requested_fields: Dict[str, List[str]]):
+    from posthog.hogql import ast
+
+    if not requested_fields:
+        raise HogQLException("No fields requested from person_distinct_ids")
+    join_expr = ast.JoinExpr(table=persons_pdi_select(requested_fields))
+    join_expr.join_type = "INNER JOIN"
+    join_expr.alias = to_table
+    join_expr.constraint = ast.JoinConstraint(
+        expr=ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq,
+            left=ast.Field(chain=[from_table, "id"]),
+            right=ast.Field(chain=[to_table, "person_id"]),
+        )
+    )
+    return join_expr
+
+
+# :NOTE: We already have person_distinct_ids.py, which most tables link to. This persons_pdi.py is a hack to
+# make "select persons.pdi.distinct_id from persons" work while avoiding circular imports. Don't use directly.
+class PersonsPDITable(LazyTable):
+    fields: Dict[str, FieldOrTable] = {
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "distinct_id": StringDatabaseField(name="distinct_id"),
+        "person_id": StringDatabaseField(name="person_id"),
+    }
+
+    def lazy_select(self, requested_fields: Dict[str, List[str]]):
+        return persons_pdi_select(requested_fields)
+
+    def to_printed_clickhouse(self, context):
+        return "person_distinct_id2"
+
+    def to_printed_hogql(self):
+        return "person_distinct_ids"

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -177,6 +177,16 @@
           {
               "key": "is_identified",
               "type": "boolean"
+          },
+          {
+              "key": "pdi",
+              "type": "lazy_table",
+              "table": "person_distinct_ids",
+              "fields": [
+                  "team_id",
+                  "distinct_id",
+                  "person_id"
+              ]
           }
       ],
       "person_distinct_ids": [
@@ -197,7 +207,8 @@
                   "created_at",
                   "team_id",
                   "properties",
-                  "is_identified"
+                  "is_identified",
+                  "pdi"
               ]
           }
       ],
@@ -338,7 +349,8 @@
                   "created_at",
                   "team_id",
                   "properties",
-                  "is_identified"
+                  "is_identified",
+                  "pdi"
               ]
           }
       ],
@@ -360,7 +372,8 @@
                   "created_at",
                   "team_id",
                   "properties",
-                  "is_identified"
+                  "is_identified",
+                  "pdi"
               ]
           }
       ],
@@ -467,7 +480,8 @@
                   "created_at",
                   "team_id",
                   "properties",
-                  "is_identified"
+                  "is_identified",
+                  "pdi"
               ]
           },
           {
@@ -495,6 +509,16 @@
           {
               "key": "is_identified",
               "type": "boolean"
+          },
+          {
+              "key": "pdi",
+              "type": "lazy_table",
+              "table": "person_distinct_ids",
+              "fields": [
+                  "team_id",
+                  "distinct_id",
+                  "person_id"
+              ]
           },
           {
               "key": "is_deleted",
@@ -545,7 +569,8 @@
                   "created_at",
                   "team_id",
                   "properties",
-                  "is_identified"
+                  "is_identified",
+                  "pdi"
               ]
           },
           {
@@ -766,6 +791,16 @@
           {
               "key": "is_identified",
               "type": "boolean"
+          },
+          {
+              "key": "pdi",
+              "type": "lazy_table",
+              "table": "person_distinct_ids",
+              "fields": [
+                  "team_id",
+                  "distinct_id",
+                  "person_id"
+              ]
           }
       ],
       "person_distinct_ids": [
@@ -786,7 +821,8 @@
                   "created_at",
                   "team_id",
                   "properties",
-                  "is_identified"
+                  "is_identified",
+                  "pdi"
               ]
           }
       ],
@@ -927,7 +963,8 @@
                   "created_at",
                   "team_id",
                   "properties",
-                  "is_identified"
+                  "is_identified",
+                  "pdi"
               ]
           }
       ],
@@ -949,7 +986,8 @@
                   "created_at",
                   "team_id",
                   "properties",
-                  "is_identified"
+                  "is_identified",
+                  "pdi"
               ]
           }
       ],
@@ -1056,7 +1094,8 @@
                   "created_at",
                   "team_id",
                   "properties",
-                  "is_identified"
+                  "is_identified",
+                  "pdi"
               ]
           },
           {
@@ -1084,6 +1123,16 @@
           {
               "key": "is_identified",
               "type": "boolean"
+          },
+          {
+              "key": "pdi",
+              "type": "lazy_table",
+              "table": "person_distinct_ids",
+              "fields": [
+                  "team_id",
+                  "distinct_id",
+                  "person_id"
+              ]
           },
           {
               "key": "is_deleted",
@@ -1134,7 +1183,8 @@
                   "created_at",
                   "team_id",
                   "properties",
-                  "is_identified"
+                  "is_identified",
+                  "pdi"
               ]
           },
           {


### PR DESCRIPTION
## Problem

Splitting out work from https://github.com/PostHog/posthog/pull/17470

## Changes

Adds a link from the `persons` table to the `person_distinct_ids` table. 
We had links from events and other tables to pdi, but to get the distinct id-s if selecting a person, you had to make a manual join. No longer!

```sql
select id, pdi.distinct_id from persons
```

I considered adding `distinct_id` as an alias on persons directly, but this messes up `count()` and other aggregations, so best to keep it simple for now.

I also considered `groupArray(pdi.distinct_id) as distinct_ids`, but that requires me to `group by` a lot of things magically, and messes up the counts as well. So no.

## How did you test this code?

Queries ran locally. Database snapshot will be updated by CI.

<img width="1286" alt="image" src="https://github.com/PostHog/posthog/assets/53387/dda6eaf3-fad8-417a-b578-a13d59261f2b">
