### PR TITLE
chore: update experiment types

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentPreview.tsx
+++ b/frontend/src/scenes/experiments/ExperimentPreview.tsx
@@ -142,7 +142,10 @@ export function ExperimentPreview({
                                     value={minimumDetectableChange}
                                     onChange={(value) => {
                                         setExperiment({
-                                            parameters: { ...experiment.parameters, minimum_detectable_effect: value },
+                                            parameters: {
+                                                ...experiment.parameters,
+                                                minimum_detectable_effect: value ?? undefined,
+                                            },
                                         })
                                     }}
                                 />

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -226,12 +226,14 @@ export function Experiments(): JSX.Element {
                                                 setSearchStatus(status as ProgressStatus | 'all')
                                             }
                                         }}
-                                        options={[
-                                            { label: 'All', value: 'all' },
-                                            { label: 'Draft', value: ProgressStatus.Draft },
-                                            { label: 'Running', value: ProgressStatus.Running },
-                                            { label: 'Complete', value: ProgressStatus.Complete },
-                                        ]}
+                                        options={
+                                            [
+                                                { label: 'All', value: 'all' },
+                                                { label: 'Draft', value: ProgressStatus.Draft },
+                                                { label: 'Running', value: ProgressStatus.Running },
+                                                { label: 'Complete', value: ProgressStatus.Complete },
+                                            ] as { label: string; value: string }[]
+                                        }
                                         value="all"
                                         dropdownMaxContentWidth
                                     />


### PR DESCRIPTION
## Problem

The [React 18 upgrade](https://github.com/PostHog/posthog/pull/17731/files?diff=unified&w=0) is (rightly) throwing more Typescript errors. Most of which can be seen here: https://github.com/PostHog/posthog/actions/runs/6392211358/job/17349015734?pr=17731#step:10:1094

## Changes

Fix some of the typings ahead of the upgrade so there as few changes as possible

## How did you test this code?

None. Just type improvements