### PR TITLE
chore: add minimal retry config for emails

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -22,7 +22,11 @@ def send_message_to_all_staff_users(message: EmailMessage) -> None:
     message.send()
 
 
-@app.task(max_retries=1)
+@app.task(
+    autoretry_for=(Exception,),
+    max_retries=3,
+    retry_backoff=True,
+)
 def send_invite(invite_id: str) -> None:
     campaign_key: str = f"invite_email_{invite_id}"
     invite: OrganizationInvite = OrganizationInvite.objects.select_related("created_by", "organization").get(
@@ -42,7 +46,11 @@ def send_invite(invite_id: str) -> None:
     message.send()
 
 
-@app.task(max_retries=1)
+@app.task(
+    autoretry_for=(Exception,),
+    max_retries=3,
+    retry_backoff=True,
+)
 def send_member_join(invitee_uuid: str, organization_id: str) -> None:
     invitee: User = User.objects.get(uuid=invitee_uuid)
     organization: Organization = Organization.objects.get(id=organization_id)
@@ -61,7 +69,11 @@ def send_member_join(invitee_uuid: str, organization_id: str) -> None:
         message.send()
 
 
-@app.task(max_retries=1)
+@app.task(
+    autoretry_for=(Exception,),
+    max_retries=3,
+    retry_backoff=True,
+)
 def send_password_reset(user_id: int, token: str) -> None:
     user = User.objects.get(pk=user_id)
     message = EmailMessage(
@@ -80,7 +92,11 @@ def send_password_reset(user_id: int, token: str) -> None:
     message.send()
 
 
-@app.task(max_retries=1)
+@app.task(
+    autoretry_for=(Exception,),
+    max_retries=3,
+    retry_backoff=True,
+)
 def send_email_verification(user_id: int, token: str) -> None:
     user: User = User.objects.get(pk=user_id)
     message = EmailMessage(
@@ -97,7 +113,11 @@ def send_email_verification(user_id: int, token: str) -> None:
     message.send()
 
 
-@app.task(max_retries=1)
+@app.task(
+    autoretry_for=(Exception,),
+    max_retries=3,
+    retry_backoff=True,
+)
 def send_fatal_plugin_error(
     plugin_config_id: int, plugin_config_updated_at: Optional[str], error: str, is_system_error: bool
 ) -> None:
@@ -135,7 +155,11 @@ def send_fatal_plugin_error(
         message.send(send_async=False)
 
 
-@app.task(max_retries=1)
+@app.task(
+    autoretry_for=(Exception,),
+    max_retries=3,
+    retry_backoff=True,
+)
 def send_canary_email(user_email: str) -> None:
     message = EmailMessage(
         campaign_key=f"canary_email_{uuid.uuid4()}",
@@ -147,7 +171,11 @@ def send_canary_email(user_email: str) -> None:
     message.send()
 
 
-@app.task(max_retries=1)
+@app.task(
+    autoretry_for=(Exception,),
+    max_retries=3,
+    retry_backoff=True,
+)
 def send_email_change_emails(now_iso: str, user_name: str, old_address: str, new_address: str) -> None:
     message_old_address = EmailMessage(
         campaign_key=f"email_change_old_address_{now_iso}",
@@ -167,7 +195,11 @@ def send_email_change_emails(now_iso: str, user_name: str, old_address: str, new
     message_new_address.send(send_async=False)
 
 
-@app.task(max_retries=1)
+@app.task(
+    autoretry_for=(Exception,),
+    max_retries=3,
+    retry_backoff=True,
+)
 def send_async_migration_complete_email(migration_key: str, time: str) -> None:
     message = EmailMessage(
         campaign_key=f"async_migration_complete_{migration_key}",
@@ -181,7 +213,11 @@ def send_async_migration_complete_email(migration_key: str, time: str) -> None:
     send_message_to_all_staff_users(message)
 
 
-@app.task(max_retries=1)
+@app.task(
+    autoretry_for=(Exception,),
+    max_retries=3,
+    retry_backoff=True,
+)
 def send_async_migration_errored_email(migration_key: str, time: str, error: str) -> None:
     message = EmailMessage(
         campaign_key=f"async_migration_error_{migration_key}",


### PR DESCRIPTION
I noticed an email task fail and no retry followed it (yay for trustable metrics from Celery)

I believe (from reading the Celery source) that the only way to get retries is to manually fangle them or add the `autoretry_for` value to the `task` decorator

Adds that config for emails (and increases the number of retries because why not)