### PR TITLE
Enabled control of CSRF_TRUSTED_ORIGINS

### DIFF
--- a/posthog/settings/access.py
+++ b/posthog/settings/access.py
@@ -72,3 +72,6 @@ if not DEBUG and not TEST and SECRET_KEY == DEFAULT_SECRET_KEY:
 
 INTERNAL_IPS = ["127.0.0.1", "172.18.0.1"]  # Docker IP
 CORS_ORIGIN_ALLOW_ALL = True
+
+# CSRF Trusted origins setting
+CSRF_TRUSTED_ORIGINS = get_list(os.getenv("CSRF_TRUSTED_ORIGINS", ""))


### PR DESCRIPTION
## Problem

When self hosting and serving behind a proxy you are met with CSRF issues when posting to the API.

## Changes

Introduced the possibility to set CSRF_TRUSTED_ORIGINS through environment var.

This improves the experience when attempting to serve the application through a proxy, when using self-hosting.

Simply passes command onwards to Django using established posthog syntax


## How did you test this code?

Patched the file in docker-image by adding the new one as a volume, and saw that it resolved the CSRF issues.
Note that this simply allows an admin to use a default Django feature.