### PR TITLE
fix(hogql): fix edge cases when converting real world trends filters

### DIFF
--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -185,31 +185,34 @@ def _properties(filter: AnyInsightFilter):
         return {"properties": PropertyGroupFilter(**clean_properties(raw_properties))}
 
 
-def _breakdown_filter(filter: AnyInsightFilter):
-    if filter.insight != "TRENDS" and filter.insight != "FUNNELS":
+def _breakdown_filter(_filter: AnyInsightFilter):
+    if _filter.insight != "TRENDS" and _filter.insight != "FUNNELS":
         return {}
 
     # early return for broken breakdown filters
-    if filter.breakdown_type == "undefined" and not isinstance(filter.breakdown, str):
+    if _filter.breakdown_type == "undefined" and not isinstance(_filter.breakdown, str):
         return {}
 
     breakdownFilter = {
-        "breakdown_type": filter.breakdown_type,
-        "breakdown": filter.breakdown,
-        "breakdown_normalize_url": filter.breakdown_normalize_url,
-        "breakdown_group_type_index": filter.breakdown_group_type_index,
-        "breakdown_histogram_bin_count": filter.breakdown_histogram_bin_count if filter.insight == "TRENDS" else None,
+        "breakdown_type": _filter.breakdown_type,
+        "breakdown": _filter.breakdown,
+        "breakdown_normalize_url": _filter.breakdown_normalize_url,
+        "breakdown_group_type_index": _filter.breakdown_group_type_index,
+        "breakdown_histogram_bin_count": _filter.breakdown_histogram_bin_count if _filter.insight == "TRENDS" else None,
     }
 
-    if filter.breakdowns is not None:
-        if len(filter.breakdowns) == 1:
-            breakdownFilter["breakdown_type"] = filter.breakdowns[0].get("type", None)
-            breakdownFilter["breakdown"] = filter.breakdowns[0].get("property", None)
+    if _filter.breakdowns is not None:
+        if len(_filter.breakdowns) == 1:
+            breakdownFilter["breakdown_type"] = _filter.breakdowns[0].get("type", None)
+            breakdownFilter["breakdown"] = _filter.breakdowns[0].get("property", None)
         else:
             raise Exception("Could not convert multi-breakdown property `breakdowns` - found more than one breakdown")
 
     if breakdownFilter["breakdown"] is not None and breakdownFilter["breakdown_type"] is None:
         breakdownFilter["breakdown_type"] = "event"
+
+    if isinstance(breakdownFilter["breakdown"], list):
+        breakdownFilter["breakdown"] = list(filter(lambda x: x is not None, breakdownFilter["breakdown"]))
 
     return {"breakdown": BreakdownFilter(**breakdownFilter)}
 

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -153,7 +153,13 @@ def _series(filter: AnyInsightFilter):
         return {}
     elif filter.insight == "LIFECYCLE":
         include_math = False
-    return {"series": map(lambda entity: entity_to_node(entity, include_properties, include_math), filter.entities)}
+    return {
+        "series": [
+            entity_to_node(entity, include_properties, include_math)
+            for entity in filter.entities
+            if entity.id is not None
+        ]
+    }
 
 
 def _sampling_factor(filter: AnyInsightFilter):
@@ -222,7 +228,7 @@ def _insight_filter(filter: AnyInsightFilter):
                 aggregation_axis_prefix=filter.aggregation_axis_prefix,
                 aggregation_axis_postfix=filter.aggregation_axis_postfix,
                 formula=filter.formula,
-                shown_as=filter.shown_as,
+                # shown_as=filter.shown_as,
                 display=clean_display(filter.display),
                 # show_values_on_series=filter.show_values_on_series,
                 # show_percent_stack_view=filter.show_percent_stack_view,
@@ -288,7 +294,7 @@ def _insight_filter(filter: AnyInsightFilter):
     elif filter.insight == "LIFECYCLE":
         return {
             "lifecycleFilter": LifecycleFilter(
-                shown_as=filter.shown_as,
+                # shown_as=filter.shown_as,
                 # toggledLifecycles=filter.toggledLifecycles,
                 # show_values_on_series=filter.show_values_on_series,
             )
@@ -297,7 +303,7 @@ def _insight_filter(filter: AnyInsightFilter):
         return {
             "stickinessFilter": StickinessFilter(
                 compare=filter.compare,
-                shown_as=filter.shown_as,
+                # shown_as=filter.shown_as,
                 # show_legend=filter.show_legend,
                 # hidden_legend_indexes: cleanHiddenLegendIndexes(filters.hidden_legend_keys),
                 # show_values_on_series=filter.show_values_on_series,

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -44,6 +44,10 @@ def clean_property(property: Dict):
     if cleaned_property.get("type") == "precalculated-cohort":
         cleaned_property["type"] = "cohort"
 
+    # fix invalid property key for cohorts
+    if cleaned_property.get("type") == "cohort" and cleaned_property.get("key") != "id":
+        cleaned_property["key"] = "id"
+
     # set a default operator for properties that support it, but don't have an operator set
     if is_property_with_operator(cleaned_property) and cleaned_property.get("operator") is None:
         cleaned_property["operator"] = "exact"

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -151,12 +151,18 @@ def _interval(filter: AnyInsightFilter):
 
 
 def _series(filter: AnyInsightFilter):
-    include_math = True
-    include_properties = True
     if filter.insight == "RETENTION" or filter.insight == "PATHS":
         return {}
-    elif filter.insight == "LIFECYCLE":
+
+    # remove templates gone wrong
+    if filter._data.get("events") is not None:
+        filter._data["events"] = [event for event in filter._data.get("events") if not (isinstance(event, str))]
+
+    include_math = True
+    include_properties = True
+    if filter.insight == "LIFECYCLE":
         include_math = False
+
     return {
         "series": [
             entity_to_node(entity, include_properties, include_math)

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -48,6 +48,10 @@ def clean_property(property: Dict):
     if not is_property_with_operator(cleaned_property) and cleaned_property.get("operator") is not None:
         del cleaned_property["operator"]
 
+    # remove none from values
+    if isinstance(cleaned_property.get("value"), List):
+        cleaned_property["value"] = list(filter(lambda x: x is not None, cleaned_property.get("value")))
+
     # remove keys without concrete value
     cleaned_property = {key: value for key, value in cleaned_property.items() if value is not None}
 

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -40,6 +40,10 @@ def clean_property(property: Dict):
     if cleaned_property.get("type") == "events":
         cleaned_property["type"] = "event"
 
+    # fix value key typo
+    if cleaned_property.get("values") is not None and cleaned_property.get("value") is None:
+        cleaned_property["value"] = cleaned_property.pop("values")
+
     # convert precalculated cohorts to cohorts
     if cleaned_property.get("type") == "precalculated-cohort":
         cleaned_property["type"] = "cohort"

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -8,6 +8,7 @@ from posthog.models.filters.stickiness_filter import StickinessFilter as LegacyS
 from posthog.schema import (
     ActionsNode,
     BreakdownFilter,
+    ChartDisplayType,
     DateRange,
     EventsNode,
     FunnelExclusion,
@@ -71,6 +72,13 @@ def clean_property_group_filter_value(value: Dict):
 def clean_properties(properties: Dict):
     properties["values"] = map(clean_property_group_filter_value, properties.get("values"))
     return properties
+
+
+def clean_display(display: str):
+    if display not in ChartDisplayType.__members__:
+        return None
+    else:
+        return display
 
 
 def entity_to_node(entity: BackendEntity, include_properties: bool, include_math: bool) -> EventsNode | ActionsNode:
@@ -207,7 +215,7 @@ def _insight_filter(filter: AnyInsightFilter):
                 aggregation_axis_postfix=filter.aggregation_axis_postfix,
                 formula=filter.formula,
                 shown_as=filter.shown_as,
-                display=filter.display,
+                display=clean_display(filter.display),
                 # show_values_on_series=filter.show_values_on_series,
                 # show_percent_stack_view=filter.show_percent_stack_view,
             )

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -249,7 +249,7 @@ def _insight_filter(filter: AnyInsightFilter):
                 aggregation_axis_prefix=filter.aggregation_axis_prefix,
                 aggregation_axis_postfix=filter.aggregation_axis_postfix,
                 formula=filter.formula,
-                # shown_as=filter.shown_as,
+                shown_as=filter.shown_as,
                 display=clean_display(filter.display),
                 # show_values_on_series=filter.show_values_on_series,
                 # show_percent_stack_view=filter.show_percent_stack_view,
@@ -315,7 +315,7 @@ def _insight_filter(filter: AnyInsightFilter):
     elif filter.insight == "LIFECYCLE":
         return {
             "lifecycleFilter": LifecycleFilter(
-                # shown_as=filter.shown_as,
+                shown_as=filter.shown_as,
                 # toggledLifecycles=filter.toggledLifecycles,
                 # show_values_on_series=filter.show_values_on_series,
             )
@@ -324,7 +324,7 @@ def _insight_filter(filter: AnyInsightFilter):
         return {
             "stickinessFilter": StickinessFilter(
                 compare=filter.compare,
-                # shown_as=filter.shown_as,
+                shown_as=filter.shown_as,
                 # show_legend=filter.show_legend,
                 # hidden_legend_indexes: cleanHiddenLegendIndexes(filters.hidden_legend_keys),
                 # show_values_on_series=filter.show_values_on_series,

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -164,7 +164,7 @@ def _breakdown_filter(filter: AnyInsightFilter):
         return {}
 
     # early return for broken breakdown filters
-    if filter.breakdown_type == "undefined":
+    if filter.breakdown_type == "undefined" and not isinstance(filter.breakdown, str):
         return {}
 
     breakdownFilter = {

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -163,6 +163,10 @@ def _breakdown_filter(filter: AnyInsightFilter):
     if filter.insight != "TRENDS" and filter.insight != "FUNNELS":
         return {}
 
+    # early return for broken breakdown filters
+    if filter.breakdown_type == "undefined":
+        return {}
+
     breakdownFilter = {
         "breakdown_type": filter.breakdown_type,
         "breakdown": filter.breakdown,

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -211,6 +211,10 @@ def _breakdown_filter(_filter: AnyInsightFilter):
         "breakdown_histogram_bin_count": _filter.breakdown_histogram_bin_count if _filter.insight == "TRENDS" else None,
     }
 
+    # fix breakdown typo
+    if breakdownFilter["breakdown_type"] == "events":
+        breakdownFilter["breakdown_type"] = "event"
+
     if _filter.breakdowns is not None:
         if len(_filter.breakdowns) == 1:
             breakdownFilter["breakdown_type"] = _filter.breakdowns[0].get("type", None)

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -36,6 +36,10 @@ def is_property_with_operator(property: Dict):
 def clean_property(property: Dict):
     cleaned_property = {**property}
 
+    # fix type typo
+    if cleaned_property.get("type") == "events":
+        cleaned_property["type"] = "event"
+
     # convert precalculated cohorts to cohorts
     if cleaned_property.get("type") == "precalculated-cohort":
         cleaned_property["type"] = "cohort"

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -452,6 +452,21 @@ insight_26 = {
     "insight": "TRENDS",
 }
 
+insight_27 = {
+    "actions": [
+        {
+            "id": None,
+            "math": None,
+            "name": None,
+            "type": "actions",
+            "order": None,
+            "properties": [],
+            "math_property": None,
+        }
+    ],
+    "insight": "TRENDS",
+}
+
 
 test_insights = [
     insight_0,
@@ -481,6 +496,7 @@ test_insights = [
     insight_24,
     insight_25,
     insight_26,
+    insight_27,
 ]
 
 

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -408,6 +408,24 @@ insight_23 = {
     "breakdown_type": "undefined",
 }
 
+insight_24 = {
+    "events": [
+        {
+            "id": "$pageview",
+            "math": None,
+            "name": "$pageview",
+            "type": "events",
+            "order": 0,
+            "properties": [],
+            "math_property": None,
+        }
+    ],
+    "display": "ActionsLineGrap[…]ccounts=false",
+    "insight": "TRENDS",
+    "interval": "day",
+    "date_from": "-90d",
+}
+
 test_insights = [
     insight_0,
     insight_1,
@@ -433,6 +451,7 @@ test_insights = [
     insight_21,
     insight_22,
     insight_23,
+    insight_24,
 ]
 
 

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -441,6 +441,17 @@ insight_25 = {
     "insight": "TRENDS",
 }
 
+insight_26 = {
+    "events": [
+        {
+            "id": "$pageview",
+            "name": "$pageview",
+            "type": "events",
+        },
+    ],
+    "insight": "TRENDS",
+}
+
 
 test_insights = [
     insight_0,
@@ -469,6 +480,7 @@ test_insights = [
     insight_23,
     insight_24,
     insight_25,
+    insight_26,
 ]
 
 

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -479,6 +479,24 @@ insight_28 = {
     "breakdown_type": "cohort",
 }
 
+insight_29 = {
+    "events": [
+        "{EXAMPLE_VARIABLE}",
+        {
+            "id": "$pageview",
+            "math": "dau",
+            "name": "$pageview",
+            "type": "events",
+            "order": 1,
+            "properties": [
+                {"key": "$current_url", "type": "event", "value": "posthog.com/signup$", "operator": "regex"}
+            ],
+            "custom_name": "Views on signup page",
+        },
+    ],
+    "insight": "TRENDS",
+}
+
 
 test_insights = [
     insight_0,
@@ -510,6 +528,7 @@ test_insights = [
     insight_26,
     insight_27,
     insight_28,
+    insight_29,
 ]
 
 

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -363,7 +363,7 @@ insight_21 = {
         {
             "id": 4317,
             "math": "total",
-            "name": "Used newer version of the app",
+            "name": "Some name",
             "type": "actions",
             "order": 0,
             "properties": [],
@@ -384,7 +384,7 @@ insight_22 = {
         {
             "id": "10184",
             "math": None,
-            "name": "More Passive Candidates button",
+            "name": "Some name",
             "type": "actions",
             "order": 0,
             "properties": [],
@@ -394,6 +394,17 @@ insight_22 = {
     "display": "ActionsLineGraph",
     "insight": "TRENDS",
     "interval": "day",
+    "breakdown_type": "undefined",
+}
+
+insight_23 = {
+    "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}],
+    "display": "ActionsLineGraph",
+    "insight": "TRENDS",
+    "interval": "day",
+    "shown_as": "Volume",
+    "breakdown": False,
+    "properties": [{"key": "$current_url", "type": "event", "value": "https://example.com/", "operator": "icontains"}],
     "breakdown_type": "undefined",
 }
 
@@ -421,6 +432,7 @@ test_insights = [
     insight_20,
     insight_21,
     insight_22,
+    insight_23,
 ]
 
 

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -584,6 +584,7 @@ properties_9 = {
     ],
 }
 properties_10 = [{"key": "id", "type": "cohort", "value": 71, "operator": None}]
+properties_11 = [{"key": [498], "type": "cohort", "value": 498, "operator": None}]
 
 test_properties = [
     properties_0,
@@ -597,6 +598,7 @@ test_properties = [
     properties_8,
     properties_9,
     properties_10,
+    properties_11,
 ]
 
 

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -426,6 +426,22 @@ insight_24 = {
     "date_from": "-90d",
 }
 
+insight_25 = {
+    "events": [
+        {
+            "id": "$pageview",
+            "math": None,
+            "name": "$pageview",
+            "type": "events",
+            "order": 2,
+            "properties": [{"key": "$host", "type": "event", "value": [None], "operator": "exact"}],
+            "math_property": None,
+        },
+    ],
+    "insight": "TRENDS",
+}
+
+
 test_insights = [
     insight_0,
     insight_1,
@@ -452,6 +468,7 @@ test_insights = [
     insight_22,
     insight_23,
     insight_24,
+    insight_25,
 ]
 
 

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -497,6 +497,19 @@ insight_29 = {
     "insight": "TRENDS",
 }
 
+insight_30 = {
+    "events": [
+        {
+            "id": "$pageview",
+            "name": "$pageview",
+        }
+    ],
+    "insight": "TRENDS",
+    "breakdown": "$geoip_country_code",
+    "breakdown_type": "events",
+    "breakdown_group_type_index": 0,
+}
+
 
 test_insights = [
     insight_0,
@@ -529,6 +542,7 @@ test_insights = [
     insight_27,
     insight_28,
     insight_29,
+    insight_30,
 ]
 
 

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -379,6 +379,24 @@ insight_21 = {
     "funnel_window_days": 14,
 }
 
+insight_22 = {
+    "actions": [
+        {
+            "id": "10184",
+            "math": None,
+            "name": "More Passive Candidates button",
+            "type": "actions",
+            "order": 0,
+            "properties": [],
+            "math_property": None,
+        }
+    ],
+    "display": "ActionsLineGraph",
+    "insight": "TRENDS",
+    "interval": "day",
+    "breakdown_type": "undefined",
+}
+
 test_insights = [
     insight_0,
     insight_1,
@@ -402,6 +420,7 @@ test_insights = [
     insight_19,
     insight_20,
     insight_21,
+    insight_22,
 ]
 
 

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -617,6 +617,7 @@ properties_9 = {
 }
 properties_10 = [{"key": "id", "type": "cohort", "value": 71, "operator": None}]
 properties_11 = [{"key": [498], "type": "cohort", "value": 498, "operator": None}]
+properties_12 = [{"key": "userId", "type": "event", "values": ["63ffaeae99ac3c4240976d60"], "operator": "exact"}]
 
 test_properties = [
     properties_0,
@@ -631,6 +632,7 @@ test_properties = [
     properties_9,
     properties_10,
     properties_11,
+    properties_12,
 ]
 
 

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -467,6 +467,18 @@ insight_27 = {
     "insight": "TRENDS",
 }
 
+insight_28 = {
+    "events": [
+        {
+            "id": "$pageview",
+            "type": "events",
+        }
+    ],
+    "insight": "TRENDS",
+    "breakdown": [None],
+    "breakdown_type": "cohort",
+}
+
 
 test_insights = [
     insight_0,
@@ -497,6 +509,7 @@ test_insights = [
     insight_25,
     insight_26,
     insight_27,
+    insight_28,
 ]
 
 


### PR DESCRIPTION
## Problem

We need to make the backend side `filter_to_query` conversion function robust against real-world edge cases.

## Changes

This PR fixes problems in the conversion for all existing **trends** filters. The filters were obtained via metabase:

```sql
SELECT DISTINCT filters
FROM posthog_dashboarditem 
WHERE filters->>'insight' = 'TRENDS'
```

This PR does not fix problems relating to the `shown_as` filter, as this will be removed in a subsequent PR.

## How did you test this code?

Added test examples that were then fixed