### PR TITLE
fix(s3-batch-exports): Call complete after uploading last part

### DIFF
--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -230,11 +230,6 @@ class S3MultiPartUpload:
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback) -> bool:
-        if exc_value is None:
-            # Succesfully completed the upload
-            await self.complete()
-            return True
-
         if exc_type == asyncio.CancelledError:
             # Ensure we clean-up the cancelled upload.
             await self.abort()
@@ -444,6 +439,8 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
 
                     last_uploaded_part_timestamp = result["inserted_at"]
                     activity.heartbeat(last_uploaded_part_timestamp, s3_upload.to_state())
+
+            await s3_upload.complete()
 
 
 @workflow.defn(name="s3-export")


### PR DESCRIPTION
## Problem

Timing out doesn't raise an exception, so we are calling complete before being done as the S3 upload context manager only looks for an exception to be raised to decide whether to call complete.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Instead, we now switch to manually calling complete after the last part is done.

Not ideal: The optimal solution involves parallelizing s3 uploads and moving the context manager to the workflow, where it will have visibility of the timeout exception. But that's a bigger refactoring.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Existing unit tests should cover any failures, as this doesn't affect activities that do not timeout.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
