### PR TITLE
chore: track log entries lag along with other tables

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -456,7 +456,7 @@ def pg_row_count():
                     pass
 
 
-CLICKHOUSE_TABLES = ["events", "person", "person_distinct_id2", "session_replay_events"]
+CLICKHOUSE_TABLES = ["events", "person", "person_distinct_id2", "session_replay_events", "log_entries"]
 if not is_cloud():
     CLICKHOUSE_TABLES.append("session_recording_events")
 


### PR DESCRIPTION
ingesting console logs could maybe cause lag.... it will also mean we should expect pretty constant traffic into the log_entries table...

let's track it