### PR TITLE
fix: safe string even safer

### DIFF
--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -302,13 +302,14 @@ export type ConsoleLogEntry = {
     // in practice console log timestamps are pretty precise: 2023-10-04 07:53:29.586
     // so, this is unlikely enough that we can avoid filling the DB with UUIDs only to avoid losing
     // a very, very small proportion of console logs.
-    instance_id: string
+    instance_id: string | null
     timestamp: ClickHouseTimestamp
 }
 
-function safeString(payload: string[]) {
+function safeString(payload: (string | null)[]) {
     // the individual strings are sometimes wrapped in quotes... we want to strip those
     return payload
+        .filter((item): item is string => !!item && typeof item === 'string')
         .map((item) => {
             let candidate = item
             if (candidate.startsWith('"') || candidate.startsWith("'")) {
@@ -368,7 +369,7 @@ export const gatherConsoleLogEvents = (
                 log_level: level,
                 log_source: 'session_replay',
                 log_source_id: session_id,
-                instance_id: event.data.instanceId,
+                instance_id: null,
                 timestamp: castTimestampOrNow(DateTime.fromMillis(event.timestamp), TimestampFormat.ClickHouse),
             })
         }

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -21,18 +21,21 @@ import {
     PropertyDefinitionTypeEnum,
     RRWebEvent,
     Team,
+    TimestampFormat,
 } from '../../src/types'
 import { createHub } from '../../src/utils/db/hub'
 import { PostgresUse } from '../../src/utils/db/postgres'
 import { personInitialAndUTMProperties } from '../../src/utils/db/utils'
 import { posthog } from '../../src/utils/posthog'
-import { UUIDT } from '../../src/utils/utils'
+import { castTimestampToClickhouseFormat, UUIDT } from '../../src/utils/utils'
 import { EventPipelineRunner } from '../../src/worker/ingestion/event-pipeline/runner'
 import {
+    ConsoleLogEntry,
     createPerformanceEvent,
     createSessionRecordingEvent,
     createSessionReplayEvent,
     EventsProcessor,
+    gatherConsoleLogEvents,
     SummarizedSessionRecordingEvent,
 } from '../../src/worker/ingestion/process-event'
 import { delayUntilEventIngested, resetTestDatabaseClickhouse } from '../helpers/clickhouse'
@@ -1479,6 +1482,33 @@ test(`snapshot event with no event summary timestamps is ignored`, () => {
             },
         ] as any[])
     }).toThrowError()
+})
+
+test('simple console log processing', () => {
+    const consoleLogEntries = gatherConsoleLogEvents(team.id, 'session_id', [
+        {
+            timestamp: 1682449093469,
+            type: 6,
+            data: {
+                plugin: 'rrweb/console@1',
+                payload: {
+                    level: 'info',
+                    payload: ['the message', 'more strings', '', null, false, 0, { blah: 'wat' }],
+                },
+            },
+        },
+    ])
+    expect(consoleLogEntries).toEqual([
+        {
+            team_id: team.id,
+            log_level: 'info',
+            log_source: 'session_replay',
+            log_source_id: 'session_id',
+            instance_id: null,
+            timestamp: castTimestampToClickhouseFormat(DateTime.fromMillis(1682449093469), TimestampFormat.ClickHouse),
+            message: 'the message more strings',
+        } satisfies ConsoleLogEntry,
+    ])
 })
 
 test('performance event stored as performance_event', () => {


### PR DESCRIPTION
see https://posthog.sentry.io/issues/4524658915/?notification_uuid=40de87e2-3249-4ae8-a377-0c0e9a89773c&project=6423401&referrer=assigned_activity-email

The format of the console log payload is fuzzier than I thought... let's be safer when reading it