### PR TITLE
chore: default to ingesting console logs as searchable logs

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -155,8 +155,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_PARALLEL_CONSUMPTION: false,
         POSTHOG_SESSION_RECORDING_REDIS_HOST: undefined,
         POSTHOG_SESSION_RECORDING_REDIS_PORT: undefined,
-        // by default a very restricted list of teams, so we can slowly roll out
-        MAX_TEAM_TO_ALLOW_SESSION_RECORDING_CONSOLE_LOGS_INGESTION: 2,
+        SESSION_RECORDING_CONSOLE_LOGS_INGESTION_ENABLED: true,
     }
 }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -222,8 +222,7 @@ export interface PluginsServerConfig {
     SESSION_RECORDING_REDIS_PREFIX: string
     SESSION_RECORDING_PARTITION_REVOKE_OPTIMIZATION: boolean
     SESSION_RECORDING_PARALLEL_CONSUMPTION: boolean
-    // team ids greater than this won't ingest console logs separately, allows controlled rollout by team
-    MAX_TEAM_TO_ALLOW_SESSION_RECORDING_CONSOLE_LOGS_INGESTION: number
+    SESSION_RECORDING_CONSOLE_LOGS_INGESTION_ENABLED: boolean
 
     // Dedicated infra values
     SESSION_RECORDING_KAFKA_HOSTS: string | undefined


### PR DESCRIPTION
I've slowly increased console log ingestion and all is bueno.

Let's default to it being on, with a toggle to turn it off just in case the next few days act as a smoke test for an unforeseen problem