### PR TITLE
fix(hogql): Use project default `mode` value in `toStartOfWeek`

### DIFF
--- a/posthog/hogql/metadata.py
+++ b/posthog/hogql/metadata.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.errors import HogQLException
 from posthog.hogql.filters import replace_filters
@@ -53,9 +54,9 @@ def get_hogql_metadata(
             if "mismatched input '<EOF>' expecting" in error:
                 error = "Unexpected end of query"
             response.errors.append(HogQLNotice(message=error, start=e.start, end=e.end))
-        else:
+        elif not settings.DEBUG:
             # We don't want to accidentally expose too much data via errors
-            response.errors.append(HogQLNotice(message=f"Unexpected f{e.__class__.__name__}"))
+            response.errors.append(HogQLNotice(message=f"Unexpected {e.__class__.__name__}"))
 
     return response
 

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -683,7 +683,7 @@ class _Printer(Visitor):
                 if node.name == "toStartOfWeek" and len(node.args) == 1:
                     # If week mode hasn't been specified, use the project's default.
                     # For Monday-based weeks mode 3 is used (which is ISO 8601), for Sunday-based mode 0 (CH default)
-                    args.insert(1, self._get_week_start_day().clickhouse_mode)
+                    args.insert(1, WeekStartDay(self._get_week_start_day()).clickhouse_mode)
 
                 params = [self.visit(param) for param in node.params] if node.params is not None else None
 

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -707,9 +707,15 @@ class TestPrinter(BaseTest):
         )
 
     def test_to_start_of_week_gets_mode(self):
-        sunday_week_context = HogQLContext(team_id=self.team.pk, database=Database(None, WeekStartDay.SUNDAY))
-        monday_week_context = HogQLContext(team_id=self.team.pk, database=Database(None, WeekStartDay.MONDAY))
+        # It's important we use ints and not WeekStartDay here, because it's the former that's actually in the DB
+        default_week_context = HogQLContext(team_id=self.team.pk, database=Database(None, None))
+        sunday_week_context = HogQLContext(team_id=self.team.pk, database=Database(None, 0))  # 0 == WeekStartDay.SUNDAY
+        monday_week_context = HogQLContext(team_id=self.team.pk, database=Database(None, 1))  # 1 == WeekStartDay.MONDAY
 
+        self.assertEqual(
+            self._expr("toStartOfWeek(timestamp)", default_week_context),  # Sunday is the default
+            f"toStartOfWeek(toTimeZone(events.timestamp, %(hogql_val_0)s), 0)",
+        )
         self.assertEqual(
             self._expr("toStartOfWeek(timestamp)"),  # Sunday is the default
             f"toStartOfWeek(toTimeZone(events.timestamp, %(hogql_val_0)s), 0)",

--- a/posthog/warehouse/api/saved_query.py
+++ b/posthog/warehouse/api/saved_query.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from posthog.permissions import OrganizationMemberPermissions
 from rest_framework.exceptions import NotAuthenticated
 from rest_framework.permissions import IsAuthenticated
@@ -69,8 +70,9 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
             if isinstance(err, ValueError) or isinstance(err, HogQLException):
                 error = str(err)
                 raise exceptions.ValidationError(detail=f"Invalid query: {error}")
-            else:
-                raise exceptions.ValidationError(detail=f"Unexpected f{err.__class__.__name__}")
+            elif not settings.DEBUG:
+                # We don't want to accidentally expose too much data via errors
+                raise exceptions.ValidationError(detail=f"Unexpected {err.__class__.__name__}")
 
         return query
 


### PR DESCRIPTION
## Problem

This HogQL query currently fails if you've specified the first day of the week in project settings:

```SQL
SELECT toStartOfWeek(timestamp) FROM events LIMIT 1
```

That's because the `visit_call` printer methods fails at adding the `mode` argument to `toStartOfWeek`.
The problem even came up in a Product Analytics standup metrics session.

## Changes

We now use `team.week_start_day` properly and don't fail at adding the arg.

## How did you test this code?

Updated tests to reflect the real world situation of integer results being selected from the database, instead of the `WeekStartDay` enum.