### PR TITLE
fix: event is sometimes null

### DIFF
--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -359,7 +359,9 @@ export const gatherConsoleLogEvents = (
     const consoleLogEntries: ConsoleLogEntry[] = []
 
     events.forEach((event) => {
-        if (event.type === RRWebEventType.Plugin && event.data?.plugin === 'rrweb/console@1') {
+        // it should be unnecessary to check for truthiness of event here,
+        // but we've seen null in production so 🤷
+        if (!!event && event.type === RRWebEventType.Plugin && event.data?.plugin === 'rrweb/console@1') {
             const level = event.data.payload?.level
             const message = safeString(event.data.payload?.payload)
             consoleLogEntries.push({

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1497,6 +1497,7 @@ test('simple console log processing', () => {
                 },
             },
         },
+        null as unknown as RRWebEvent, // see https://posthog.sentry.io/issues/4525043303
     ])
     expect(consoleLogEntries).toEqual([
         {


### PR DESCRIPTION
We've seen errors because event is null... 

But not any more!

