### PR TITLE
fix: removed old feedback URL

### DIFF
--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -731,13 +731,6 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>({
                                 }),
                             },
                             {
-                                icon: IconRecording,
-                                display: 'Schedule Quick Call',
-                                executor: () => {
-                                    open('https://calendly.com/posthog-feedback')
-                                },
-                            },
-                            {
                                 icon: IconGithub,
                                 display: 'Create GitHub Issue',
                                 executor: () => {


### PR DESCRIPTION
## Problem

Command palette had an old Calendly link in it that 404s

<img width="634" alt="image" src="https://github.com/PostHog/posthog/assets/154479/3a7cfda3-e603-4ac0-af40-0da25fa7bd5d">

## Changes

Removed this option