### PR TITLE
fix(plugin-server): update kafkaAbsolutePartitionCount even on empty …

### DIFF
--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -181,13 +181,13 @@ export const startBatchConsumer = async ({
                 // protocol. If we never manage to consume, we don't want our health checks to pass.
                 lastConsumeTime = Date.now()
 
+                for (const [topic, count] of countPartitionsPerTopic(consumer.assignments())) {
+                    kafkaAbsolutePartitionCount.labels({ topic }).set(count)
+                }
+
                 if (!messages) {
                     status.debug('🔁', 'main_loop_empty_batch', { cause: 'undefined' })
                     continue
-                }
-
-                for (const [topic, count] of countPartitionsPerTopic(consumer.assignments())) {
-                    kafkaAbsolutePartitionCount.labels({ topic }).set(count)
                 }
 
                 status.debug('🔁', 'main_loop_consumed', { messagesLength: messages.length })


### PR DESCRIPTION
…consume loop

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We're failing to update this metric if we have no partitions assigned.

## Changes

Update in on every loop iteration.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

N/A
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
