### PR TITLE
fix: we can receive strings that ClickHouse can't receive

### DIFF
--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -321,7 +321,7 @@ function safeString(payload: (string | null)[]) {
     // the individual strings are sometimes wrapped in quotes... we want to strip those
     return payload
         .filter((item): item is string => !!item && typeof item === 'string')
-        .map((item) => sanitizeForUTF8(item))
+        .map((item) => sanitizeForUTF8(item.substring(0, 1999)))
         .join(' ')
 }
 

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -306,21 +306,21 @@ export type ConsoleLogEntry = {
     timestamp: ClickHouseTimestamp
 }
 
+function sanitizeForUTF8(input: string): string {
+    // the JS console truncates some logs...
+    // when it does that it doesn't check if the output is valid UTF-8
+    // and so it can truncate half way through a UTF-16 pair 🤷
+    // the simplest way to fix this is to convert to a buffer and back
+    // annoyingly Node 20 has `toWellFormed` which might have been useful
+    const buffer = Buffer.from(input)
+    return buffer.toString()
+}
+
 function safeString(payload: (string | null)[]) {
     // the individual strings are sometimes wrapped in quotes... we want to strip those
     return payload
         .filter((item): item is string => !!item && typeof item === 'string')
-        .map((item) => {
-            let candidate = item
-            if (candidate.startsWith('"') || candidate.startsWith("'")) {
-                candidate = candidate.substring(1)
-            }
-
-            if (candidate.endsWith('"') || candidate.endsWith("'")) {
-                candidate = candidate.substring(0, candidate.length - 1)
-            }
-            return candidate
-        })
+        .map((item) => sanitizeForUTF8(item))
         .join(' ')
 }
 

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -321,7 +321,7 @@ function safeString(payload: (string | null)[]) {
     // the individual strings are sometimes wrapped in quotes... we want to strip those
     return payload
         .filter((item): item is string => !!item && typeof item === 'string')
-        .map((item) => sanitizeForUTF8(item.substring(0, 1999)))
+        .map((item) => sanitizeForUTF8(item.substring(0, 2999)))
         .join(' ')
 }
 

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1515,8 +1515,8 @@ test.each([
     },
     {
         // let's not accept arbitrary length content
-        payload: [new Array(2001).join('a')],
-        expectedMessage: new Array(2000).join('a'),
+        payload: [new Array(3001).join('a')],
+        expectedMessage: new Array(3000).join('a'),
     },
 ])('simple console log processing', ({ payload, expectedMessage }) => {
     const consoleLogEntries = gatherConsoleLogEvents(team.id, 'session_id', [

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1513,6 +1513,11 @@ test.each([
         payload: ['"test"'],
         expectedMessage: '"test"',
     },
+    {
+        // let's not accept arbitrary length content
+        payload: [new Array(2001).join('a')],
+        expectedMessage: new Array(2000).join('a'),
+    },
 ])('simple console log processing', ({ payload, expectedMessage }) => {
     const consoleLogEntries = gatherConsoleLogEvents(team.id, 'session_id', [
         consoleMessageFor(payload),

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1484,20 +1484,41 @@ test(`snapshot event with no event summary timestamps is ignored`, () => {
     }).toThrowError()
 })
 
-test('simple console log processing', () => {
-    const consoleLogEntries = gatherConsoleLogEvents(team.id, 'session_id', [
-        {
-            timestamp: 1682449093469,
-            type: 6,
-            data: {
-                plugin: 'rrweb/console@1',
-                payload: {
-                    level: 'info',
-                    payload: ['the message', 'more strings', '', null, false, 0, { blah: 'wat' }],
-                },
+function consoleMessageFor(payload: any[]) {
+    return {
+        timestamp: 1682449093469,
+        type: 6,
+        data: {
+            plugin: 'rrweb/console@1',
+            payload: {
+                level: 'info',
+                payload: payload,
             },
         },
-        null as unknown as RRWebEvent, // see https://posthog.sentry.io/issues/4525043303
+    }
+}
+
+test.each([
+    {
+        payload: ['the message', 'more strings', '', null, false, 0, { blah: 'wat' }],
+        expectedMessage: 'the message more strings',
+    },
+    {
+        // lone surrogate pairs are replaced with the "unknown" character
+        payload: ['\\\\\\",\\\\\\"emoji_flag\\\\\\":\\\\\\"\ud83c...[truncated]'],
+        expectedMessage: '\\\\\\",\\\\\\"emoji_flag\\\\\\":\\\\\\"\ufffd...[truncated]',
+    },
+    {
+        // sometimes the strings are wrapped in quotes...
+        payload: ['"test"'],
+        expectedMessage: '"test"',
+    },
+])('simple console log processing', ({ payload, expectedMessage }) => {
+    const consoleLogEntries = gatherConsoleLogEvents(team.id, 'session_id', [
+        consoleMessageFor(payload),
+        // see https://posthog.sentry.io/issues/4525043303
+        // null events always ignored
+        null as unknown as RRWebEvent,
     ])
     expect(consoleLogEntries).toEqual([
         {
@@ -1507,7 +1528,7 @@ test('simple console log processing', () => {
             log_source_id: 'session_id',
             instance_id: null,
             timestamp: castTimestampToClickhouseFormat(DateTime.fromMillis(1682449093469), TimestampFormat.ClickHouse),
-            message: 'the message more strings',
+            message: expectedMessage,
         } satisfies ConsoleLogEntry,
     ])
 })


### PR DESCRIPTION
see https://posthog.slack.com/archives/C0185UNBSJZ/p1696439181538489

the browser console truncated a string and managed to do that half way through a UTF16 surrogate pair. All of our processing either didn't try to process the string or didn't care when it did. until we tried to ingest to the ClickHouse kafka table and CH was unhappy and could not ingest

converting to a buffer and back again forces the string to UTF-8 and removes any lone surrogate pairs

let's truncate very long strings while we're at it