### PR TITLE
feat: Duplicate dynamic cohorts

### DIFF
--- a/cypress/e2e/cohorts.cy.ts
+++ b/cypress/e2e/cohorts.cy.ts
@@ -52,5 +52,26 @@ describe('Cohorts', () => {
             cy.url().should('include', '/cohorts/')
             cy.get('[data-attr="cohort-name"]').should('have.value', 'Test Cohort')
         })
+
+        // back into cohort
+        cy.get('tbody').contains('Test Cohort').click()
+
+        // duplicate cohort (dynamic)
+        cy.get('[data-attr="more-button"]').click()
+        cy.get('.Popover__content').contains('Duplicate as dynamic cohort').click()
+        cy.wait(500)
+        cy.get('.Toastify__toast-body').contains('View cohort').click()
+
+        // duplicate cohort (static)
+        cy.get('[data-attr="more-button"]').click()
+        cy.get('.Popover__content').contains('Duplicate as static cohort').click()
+        cy.wait(500)
+        cy.get('.Toastify__toast-body').contains('View cohort').click()
+
+        // delete cohort
+        cy.get('[data-attr="more-button"]').click()
+        cy.get('.Popover__content').contains('Delete').click()
+        cy.clickNavMenu('cohorts')
+        cy.get('tbody').should('not.have.text', 'Test Cohort (dynamic copy) (static copy)')
     })
 })

--- a/cypress/e2e/cohorts.cy.ts
+++ b/cypress/e2e/cohorts.cy.ts
@@ -59,13 +59,11 @@ describe('Cohorts', () => {
         // duplicate cohort (dynamic)
         cy.get('[data-attr="more-button"]').click()
         cy.get('.Popover__content').contains('Duplicate as dynamic cohort').click()
-        cy.wait(500)
         cy.get('.Toastify__toast-body').contains('View cohort').click()
 
         // duplicate cohort (static)
         cy.get('[data-attr="more-button"]').click()
         cy.get('.Popover__content').contains('Duplicate as static cohort').click()
-        cy.wait(500)
         cy.get('.Toastify__toast-body').contains('View cohort').click()
 
         // delete cohort

--- a/cypress/e2e/cohorts.cy.ts
+++ b/cypress/e2e/cohorts.cy.ts
@@ -68,7 +68,7 @@ describe('Cohorts', () => {
 
         // delete cohort
         cy.get('[data-attr="more-button"]').click()
-        cy.get('.Popover__content').contains('Delete').click()
+        cy.get('.Popover__content').contains('Delete cohort').click()
         cy.clickNavMenu('cohorts')
         cy.get('tbody').should('not.have.text', 'Test Cohort (dynamic copy) (static copy)')
     })

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -30,8 +30,16 @@ import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilte
 export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
     const logicProps = { id }
     const logic = cohortEditLogic(logicProps)
-    const { deleteCohort, setOuterGroupsType, setQuery, duplicateToStaticCohort } = useActions(logic)
-    const { cohort, cohortLoading, cohortMissing, query, duplicatedStaticCohortLoading } = useValues(logic)
+    const { deleteCohort, setOuterGroupsType, setQuery, duplicateToStaticCohort, duplicateToDynamicCohort } =
+        useActions(logic)
+    const {
+        cohort,
+        cohortLoading,
+        cohortMissing,
+        query,
+        duplicatedStaticCohortLoading,
+        duplicatedDynamicCohortLoading,
+    } = useValues(logic)
     const { hasAvailableFeature } = useValues(userLogic)
     const isNewCohort = cohort.id === 'new' || cohort.id === undefined
 
@@ -72,6 +80,16 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                             {!isNewCohort && !cohort.is_static && (
                                 <>
                                     <LemonDivider vertical />
+                                    <LemonButton
+                                        onClick={duplicateToDynamicCohort}
+                                        type="secondary"
+                                        disabledReason={
+                                            cohort.is_calculating ? 'Cohort is still calculating' : undefined
+                                        }
+                                        loading={duplicatedDynamicCohortLoading}
+                                    >
+                                        Duplicate as dynamic cohort
+                                    </LemonButton>
                                     <LemonButton
                                         onClick={duplicateToStaticCohort}
                                         type="secondary"

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -87,7 +87,7 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                                     >
                                                         Duplicate as static cohort
                                                     </LemonButton>
-                                                    <LemonDivider vertical />
+                                                    <LemonDivider />
                                                 </>
                                             )}
                                             <LemonButton

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -98,7 +98,7 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                                     deleteCohort()
                                                 }}
                                             >
-                                                Delete
+                                                Delete cohort
                                             </LemonButton>
                                         </>
                                     }

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -26,6 +26,7 @@ import { Query } from '~/queries/Query/Query'
 import { pluralize } from 'lib/utils'
 import { LemonDivider } from '@posthog/lemon-ui'
 import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilters/AndOrFilterSelect'
+import { More } from 'lib/lemon-ui/LemonButton/More'
 
 export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
     const logicProps = { id }
@@ -57,42 +58,51 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                     Cancel
                                 </LemonButton>
                             ) : (
-                                <LemonButton
-                                    data-attr="delete-cohort"
-                                    status="danger"
-                                    type="secondary"
-                                    onClick={() => {
-                                        deleteCohort()
-                                    }}
-                                    disabled={cohortLoading}
-                                >
-                                    Delete
-                                </LemonButton>
-                            )}
-                            {!isNewCohort && !cohort.is_static && (
-                                <>
-                                    <LemonDivider vertical />
-                                    <LemonButton
-                                        onClick={() => duplicateCohort(false)}
-                                        type="secondary"
-                                        disabledReason={
-                                            cohort.is_calculating ? 'Cohort is still calculating' : undefined
-                                        }
-                                        loading={duplicatedCohortLoading}
-                                    >
-                                        Duplicate as dynamic cohort
-                                    </LemonButton>
-                                    <LemonButton
-                                        onClick={() => duplicateCohort(true)}
-                                        type="secondary"
-                                        disabledReason={
-                                            cohort.is_calculating ? 'Cohort is still calculating' : undefined
-                                        }
-                                        loading={duplicatedCohortLoading}
-                                    >
-                                        Duplicate as static cohort
-                                    </LemonButton>
-                                </>
+                                <More
+                                    overlay={
+                                        <>
+                                            {!cohort.is_static && (
+                                                <>
+                                                    <LemonButton
+                                                        onClick={() => duplicateCohort(false)}
+                                                        fullWidth
+                                                        disabledReason={
+                                                            cohort.is_calculating
+                                                                ? 'Cohort is still calculating'
+                                                                : undefined
+                                                        }
+                                                        loading={duplicatedCohortLoading}
+                                                    >
+                                                        Duplicate as dynamic cohort
+                                                    </LemonButton>
+                                                    <LemonButton
+                                                        onClick={() => duplicateCohort(true)}
+                                                        fullWidth
+                                                        disabledReason={
+                                                            cohort.is_calculating
+                                                                ? 'Cohort is still calculating'
+                                                                : undefined
+                                                        }
+                                                        loading={duplicatedCohortLoading}
+                                                    >
+                                                        Duplicate as static cohort
+                                                    </LemonButton>
+                                                    <LemonDivider vertical />
+                                                </>
+                                            )}
+                                            <LemonButton
+                                                data-attr="delete-cohort"
+                                                fullWidth
+                                                status="danger"
+                                                onClick={() => {
+                                                    deleteCohort()
+                                                }}
+                                            >
+                                                Delete
+                                            </LemonButton>
+                                        </>
+                                    }
+                                />
                             )}
                             <LemonButton
                                 type="primary"

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -104,6 +104,7 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                     }
                                 />
                             )}
+                            <LemonDivider vertical />
                             <LemonButton
                                 type="primary"
                                 data-attr="save-cohort"

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -30,16 +30,8 @@ import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilte
 export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
     const logicProps = { id }
     const logic = cohortEditLogic(logicProps)
-    const { deleteCohort, setOuterGroupsType, setQuery, duplicateToStaticCohort, duplicateToDynamicCohort } =
-        useActions(logic)
-    const {
-        cohort,
-        cohortLoading,
-        cohortMissing,
-        query,
-        duplicatedStaticCohortLoading,
-        duplicatedDynamicCohortLoading,
-    } = useValues(logic)
+    const { deleteCohort, setOuterGroupsType, setQuery, duplicateCohort } = useActions(logic)
+    const { cohort, cohortLoading, cohortMissing, query, duplicatedCohortLoading } = useValues(logic)
     const { hasAvailableFeature } = useValues(userLogic)
     const isNewCohort = cohort.id === 'new' || cohort.id === undefined
 
@@ -81,22 +73,22 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                 <>
                                     <LemonDivider vertical />
                                     <LemonButton
-                                        onClick={duplicateToDynamicCohort}
+                                        onClick={() => duplicateCohort(false)}
                                         type="secondary"
                                         disabledReason={
                                             cohort.is_calculating ? 'Cohort is still calculating' : undefined
                                         }
-                                        loading={duplicatedDynamicCohortLoading}
+                                        loading={duplicatedCohortLoading}
                                     >
                                         Duplicate as dynamic cohort
                                     </LemonButton>
                                     <LemonButton
-                                        onClick={duplicateToStaticCohort}
+                                        onClick={() => duplicateCohort(true)}
                                         type="secondary"
                                         disabledReason={
                                             cohort.is_calculating ? 'Cohort is still calculating' : undefined
                                         }
-                                        loading={duplicatedStaticCohortLoading}
+                                        loading={duplicatedCohortLoading}
                                     >
                                         Duplicate as static cohort
                                     </LemonButton>

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -270,7 +270,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                         lemonToast.success(
                             'Cohort duplicated. Please wait up to a few minutes for it to be calculated',
                             {
-                                toastId: `cohort-duplicated-${values.cohort.id}`,
+                                toastId: `cohort-duplicated-${cohort.id}`,
                                 button: {
                                     label: 'View cohort',
                                     action: () => {

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -59,6 +59,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
         }),
         setQuery: (query: Node) => ({ query }),
         duplicateToStaticCohort: true,
+        duplicateToDynamicCohort: true,
     }),
 
     reducers(({ props }) => ({
@@ -256,14 +257,44 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
         duplicatedStaticCohort: [
             null as CohortType | null,
             {
+                duplicateToDynamicCohort: async (_, breakpoint) => {
+                    try {
+                        await breakpoint(200)
+                        const data = { ...values.cohort }
+                        data.name += ' (dynamic copy)'
+                        const cohort = await api.cohorts.create(data)
+
+                        lemonToast.success(
+                            'Cohort duplicated dynamically. Please wait up to a few minutes for it to be calculated',
+                            {
+                                toastId: `cohort-dynamically-duplicated-${values.cohort.id}`,
+                                button: {
+                                    label: 'View cohort',
+                                    action: () => {
+                                        router.actions.push(urls.cohort(cohort.id))
+                                    },
+                                },
+                            }
+                        )
+                        return cohort
+                    } catch (error: any) {
+                        lemonToast.error(error.detail || 'Failed to duplicate cohort')
+                        return null
+                    }
+                },
+            },
+        ],
+        duplicatedDynamicCohort: [
+            null as CohortType | null,
+            {
                 duplicateToStaticCohort: async (_, breakpoint) => {
                     try {
                         await breakpoint(200)
                         const cohort = await api.cohorts.duplicate(values.cohort.id)
                         lemonToast.success(
-                            'Cohort duplicated. Please wait up to a few minutes for it to be calculated',
+                            'Cohort duplicated statically. Please wait up to a few minutes for it to be calculated',
                             {
-                                toastId: `cohort-duplicated-${values.cohort.id}`,
+                                toastId: `cohort-statically-duplicated-${values.cohort.id}`,
                                 button: {
                                     label: 'View cohort',
                                     action: () => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Adds ability to duplicate a dynamic cohort, as per https://github.com/PostHog/posthog/issues/16935.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
Duplicate buttons in dropdown:

<img width="366" alt="image" src="https://github.com/PostHog/posthog/assets/3529318/bc58ccbd-e3e7-41b7-a0c0-b45758850fa8">

New cohort state:

<img width="222" alt="image" src="https://github.com/PostHog/posthog/assets/3529318/544bab8f-6f75-4a62-b9bd-c37cd1234c7e">

Static cohort, with only delete in dropdown:

<img width="266" alt="image" src="https://github.com/PostHog/posthog/assets/3529318/30545b34-c7ee-48aa-a811-f3794eaa9cac">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
Didn't see any automated frontend tests related to this functionality, perhaps because this functionality is considered sufficiently covered by API tests, though it's my first PR so I may have missed something. Still ran unit tests, and manually validated the feature by duplicating dynamic cohorts in my local test environment.

Added cypress e2e tests covering the new feature, plus ones for delete and the existing static duplicate button since they weren't there.