### PR TITLE
fix(hogql): fix edge cases when converting real world filters

### DIFF
--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -301,7 +301,6 @@ insight_17 = {
 }
 
 # real world regression tests
-
 insight_18 = {
     "actions": [
         {
@@ -319,7 +318,6 @@ insight_18 = {
     "interval": "day",
     "shown_as": "Lifecycle",
 }
-
 insight_19 = {
     "events": [
         {
@@ -338,7 +336,6 @@ insight_19 = {
     "interval": "day",
     "shown_as": "Lifecycle",
 }
-
 insight_20 = {
     "events": [
         {
@@ -357,7 +354,6 @@ insight_20 = {
     "shown_as": "Lifecycle",
     "properties": [{"key": "id", "type": "cohort", "value": 929, "operator": "exact"}],
 }
-
 insight_21 = {
     "actions": [
         {
@@ -378,7 +374,6 @@ insight_21 = {
     "properties": [{"key": "id", "type": "precalculated-cohort", "value": 760, "operator": None}],
     "funnel_window_days": 14,
 }
-
 insight_22 = {
     "actions": [
         {
@@ -396,7 +391,6 @@ insight_22 = {
     "interval": "day",
     "breakdown_type": "undefined",
 }
-
 insight_23 = {
     "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}],
     "display": "ActionsLineGraph",
@@ -407,7 +401,6 @@ insight_23 = {
     "properties": [{"key": "$current_url", "type": "event", "value": "https://example.com/", "operator": "icontains"}],
     "breakdown_type": "undefined",
 }
-
 insight_24 = {
     "events": [
         {
@@ -425,7 +418,6 @@ insight_24 = {
     "interval": "day",
     "date_from": "-90d",
 }
-
 insight_25 = {
     "events": [
         {
@@ -440,7 +432,6 @@ insight_25 = {
     ],
     "insight": "TRENDS",
 }
-
 insight_26 = {
     "events": [
         {
@@ -451,7 +442,6 @@ insight_26 = {
     ],
     "insight": "TRENDS",
 }
-
 insight_27 = {
     "actions": [
         {
@@ -466,7 +456,6 @@ insight_27 = {
     ],
     "insight": "TRENDS",
 }
-
 insight_28 = {
     "events": [
         {
@@ -478,7 +467,6 @@ insight_28 = {
     "breakdown": [None],
     "breakdown_type": "cohort",
 }
-
 insight_29 = {
     "events": [
         "{EXAMPLE_VARIABLE}",
@@ -496,7 +484,6 @@ insight_29 = {
     ],
     "insight": "TRENDS",
 }
-
 insight_30 = {
     "events": [
         {

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -619,6 +619,8 @@ properties_9 = {
 properties_10 = [{"key": "id", "type": "cohort", "value": 71, "operator": None}]
 properties_11 = [{"key": [498], "type": "cohort", "value": 498, "operator": None}]
 properties_12 = [{"key": "userId", "type": "event", "values": ["63ffaeae99ac3c4240976d60"], "operator": "exact"}]
+properties_13 = {"plan": "premium"}
+properties_14 = {"$current_url__icontains": "signin"}
 
 test_properties = [
     properties_0,
@@ -634,6 +636,8 @@ test_properties = [
     properties_10,
     properties_11,
     properties_12,
+    properties_13,
+    properties_14,
 ]
 
 


### PR DESCRIPTION
## Problem

We need to make the backend side `filter_to_query` conversion function robust against real-world edge cases.

## Changes

This PR fixes problems in the conversion for all remaining filter types filters. The filters were obtained via metabase:

```sql
SELECT DISTINCT filters
FROM posthog_dashboarditem 
WHERE filters->>'insight' = 'RETENTION'
OR filters->>'insight' = 'PATHS'
OR filters->>'insight' = 'STICKINESS'
```

## How did you test this code?

Added test examples that were then fixed