### PR TITLE
feat(batch-exports): Add include_events option to all destinations

### DIFF
--- a/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
@@ -247,6 +247,13 @@ export function BatchExportsEditForm(props: BatchExportsEditLogicProps): JSX.Ele
                                             }
                                         />
                                     </Field>
+                                    <Field name="include_events" label="Events to include" className="flex-1">
+                                        <LemonSelectMultiple
+                                            mode="multiple-custom"
+                                            options={[]}
+                                            placeholder={'Input one or more events to include in the export (optional)'}
+                                        />
+                                    </Field>
                                 </>
                             ) : batchExportConfigForm.destination === 'Snowflake' ? (
                                 <>
@@ -280,6 +287,23 @@ export function BatchExportsEditForm(props: BatchExportsEditLogicProps): JSX.Ele
 
                                     <Field name="role" label="Role" showOptional>
                                         <LemonInput placeholder="my-role" />
+                                    </Field>
+
+                                    <Field name="exclude_events" label="Events to exclude" className="flex-1">
+                                        <LemonSelectMultiple
+                                            mode="multiple-custom"
+                                            options={[]}
+                                            placeholder={
+                                                'Input one or more events to exclude from the export (optional)'
+                                            }
+                                        />
+                                    </Field>
+                                    <Field name="include_events" label="Events to include" className="flex-1">
+                                        <LemonSelectMultiple
+                                            mode="multiple-custom"
+                                            options={[]}
+                                            placeholder={'Input one or more events to include in the export (optional)'}
+                                        />
                                     </Field>
                                 </>
                             ) : batchExportConfigForm.destination === 'Postgres' ? (
@@ -327,6 +351,23 @@ export function BatchExportsEditForm(props: BatchExportsEditLogicProps): JSX.Ele
                                             }
                                         />
                                     </Field>
+
+                                    <Field name="exclude_events" label="Events to exclude" className="flex-1">
+                                        <LemonSelectMultiple
+                                            mode="multiple-custom"
+                                            options={[]}
+                                            placeholder={
+                                                'Input one or more events to exclude from the export (optional)'
+                                            }
+                                        />
+                                    </Field>
+                                    <Field name="include_events" label="Events to include" className="flex-1">
+                                        <LemonSelectMultiple
+                                            mode="multiple-custom"
+                                            options={[]}
+                                            placeholder={'Input one or more events to include in the export (optional)'}
+                                        />
+                                    </Field>
                                 </>
                             ) : batchExportConfigForm.destination === 'BigQuery' ? (
                                 <>
@@ -349,6 +390,13 @@ export function BatchExportsEditForm(props: BatchExportsEditLogicProps): JSX.Ele
                                             placeholder={
                                                 'Input one or more events to exclude from the export (optional)'
                                             }
+                                        />
+                                    </Field>
+                                    <Field name="include_events" label="Events to include" className="flex-1">
+                                        <LemonSelectMultiple
+                                            mode="multiple-custom"
+                                            options={[]}
+                                            placeholder={'Input one or more events to include in the export (optional)'}
                                         />
                                     </Field>
                                 </>

--- a/frontend/src/scenes/batch_exports/BatchExports.stories.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExports.stories.tsx
@@ -34,6 +34,7 @@ export default {
                             aws_secret_access_key: '',
                             compression: null,
                             exclude_events: [],
+                            include_events: [],
                             encryption: null,
                             kms_key_id: null,
                         },

--- a/frontend/src/scenes/batch_exports/batchExportEditLogic.ts
+++ b/frontend/src/scenes/batch_exports/batchExportEditLogic.ts
@@ -61,6 +61,8 @@ const formFields = (
                   schema: !config.schema ? 'This field is required' : '',
                   table_name: !config.table_name ? 'This field is required' : '',
                   has_self_signed_cert: false,
+                  exclude_events: '',
+                  include_evnts: '',
               }
             : destination === 'S3'
             ? {
@@ -73,6 +75,7 @@ const formFields = (
                   encryption: '',
                   kms_key_id: !config.kms_key_id && config.encryption == 'aws:kms' ? 'This field is required' : '',
                   exclude_events: '',
+                  include_evnts: '',
               }
             : destination === 'BigQuery'
             ? {
@@ -90,6 +93,7 @@ const formFields = (
                   dataset_id: !config.dataset_id ? 'This field is required' : '',
                   table_id: !config.table_id ? 'This field is required' : '',
                   exclude_events: '',
+                  include_evnts: '',
               }
             : destination === 'Snowflake'
             ? {
@@ -101,6 +105,8 @@ const formFields = (
                   schema: !config.schema ? 'This field is required' : '',
                   table_name: !config.table_name ? 'This field is required' : '',
                   role: '',
+                  exclude_events: '',
+                  include_evnts: '',
               }
             : {}),
     }

--- a/frontend/src/scenes/batch_exports/batchExportEditLogic.ts
+++ b/frontend/src/scenes/batch_exports/batchExportEditLogic.ts
@@ -62,7 +62,7 @@ const formFields = (
                   table_name: !config.table_name ? 'This field is required' : '',
                   has_self_signed_cert: false,
                   exclude_events: '',
-                  include_evnts: '',
+                  include_events: '',
               }
             : destination === 'S3'
             ? {
@@ -75,7 +75,7 @@ const formFields = (
                   encryption: '',
                   kms_key_id: !config.kms_key_id && config.encryption == 'aws:kms' ? 'This field is required' : '',
                   exclude_events: '',
-                  include_evnts: '',
+                  include_events: '',
               }
             : destination === 'BigQuery'
             ? {
@@ -93,7 +93,7 @@ const formFields = (
                   dataset_id: !config.dataset_id ? 'This field is required' : '',
                   table_id: !config.table_id ? 'This field is required' : '',
                   exclude_events: '',
-                  include_evnts: '',
+                  include_events: '',
               }
             : destination === 'Snowflake'
             ? {
@@ -106,7 +106,7 @@ const formFields = (
                   table_name: !config.table_name ? 'This field is required' : '',
                   role: '',
                   exclude_events: '',
-                  include_evnts: '',
+                  include_events: '',
               }
             : {}),
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3125,6 +3125,7 @@ export type BatchExportDestinationS3 = {
         aws_access_key_id: string
         aws_secret_access_key: string
         exclude_events: string[]
+        include_events: string[]
         compression: string | null
         encryption: string | null
         kms_key_id: string | null
@@ -3142,6 +3143,8 @@ export type BatchExportDestinationPostgres = {
         schema: string
         table_name: string
         has_self_signed_cert: boolean
+        exclude_events: string[]
+        include_events: string[]
     }
 }
 
@@ -3156,6 +3159,8 @@ export type BatchExportDestinationSnowflake = {
         schema: string
         table_name: string
         role: string | null
+        exclude_events: string[]
+        include_events: string[]
     }
 }
 
@@ -3170,6 +3175,7 @@ export type BatchExportDestinationBigQuery = {
         dataset_id: string
         table_id: string
         exclude_events: string[]
+        include_events: string[]
     }
 }
 

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -57,6 +57,7 @@ class S3BatchExportInputs:
     data_interval_end: str | None = None
     compression: str | None = None
     exclude_events: list[str] | None = None
+    include_events: list[str] | None = None
     encryption: str | None = None
     kms_key_id: str | None = None
 
@@ -77,6 +78,8 @@ class SnowflakeBatchExportInputs:
     table_name: str = "events"
     data_interval_end: str | None = None
     role: str | None = None
+    exclude_events: list[str] | None = None
+    include_events: list[str] | None = None
 
 
 @dataclass
@@ -95,6 +98,8 @@ class PostgresBatchExportInputs:
     table_name: str = "events"
     port: int = 5432
     data_interval_end: str | None = None
+    exclude_events: list[str] | None = None
+    include_events: list[str] | None = None
 
 
 @dataclass
@@ -113,6 +118,7 @@ class BigQueryBatchExportInputs:
     table_id: str = "events"
     data_interval_end: str | None = None
     exclude_events: list[str] | None = None
+    include_events: list[str] | None = None
 
 
 DESTINATION_WORKFLOWS = {

--- a/posthog/temporal/tests/batch_exports/test_batch_exports.py
+++ b/posthog/temporal/tests/batch_exports/test_batch_exports.py
@@ -252,7 +252,58 @@ async def test_get_rows_count_can_exclude_events(client):
 
     # Exclude the latter half of events.
     exclude_events = (f"test-{i}" for i in range(5000, 10000))
-    row_count = await get_rows_count(client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", exclude_events)
+    row_count = await get_rows_count(
+        client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", exclude_events=exclude_events
+    )
+    assert row_count == 5000
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_get_rows_count_can_include_events(client):
+    """Test the count of rows returned by get_rows_count can include events."""
+    team_id = randint(1, 1000000)
+
+    events: list[EventValues] = [
+        {
+            "uuid": str(uuid4()),
+            "event": f"test-{i}",
+            "_timestamp": "2023-04-20 14:30:00",
+            "timestamp": f"2023-04-20 14:30:00.{i:06d}",
+            "inserted_at": f"2023-04-20 14:30:00.{i:06d}",
+            "created_at": "2023-04-20 14:30:00.000000",
+            "distinct_id": str(uuid4()),
+            "person_id": str(uuid4()),
+            "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "team_id": team_id,
+            "properties": {
+                "$browser": "Chrome",
+                "$os": "Mac OS X",
+                "$ip": "127.0.0.1",
+                "$current_url": "http://localhost.com",
+            },
+            "elements_chain": "this that and the other",
+            "elements": json.dumps("this that and the other"),
+            "ip": "127.0.0.1",
+            "site_url": "http://localhost.com",
+            "set": None,
+            "set_once": None,
+        }
+        for i in range(10000)
+    ]
+    # Duplicate everything
+    duplicate_events = events * 2
+
+    await insert_events(
+        ch_client=client,
+        events=duplicate_events,
+    )
+
+    # Include the latter half of events.
+    include_events = (f"test-{i}" for i in range(5000, 10000))
+    row_count = await get_rows_count(
+        client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", include_events=include_events
+    )
     assert row_count == 5000
 
 
@@ -415,10 +466,76 @@ async def test_get_results_iterator_can_exclude_events(client):
 
     # Exclude the latter half of events.
     exclude_events = (f"test-{i}" for i in range(5000, 10000))
-    iter_ = get_results_iterator(client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", exclude_events)
+    iter_ = get_results_iterator(
+        client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", exclude_events=exclude_events
+    )
     rows = [row for row in iter_]
 
     all_expected = sorted(events[:5000], key=operator.itemgetter("event"))
+    all_result = sorted(rows, key=operator.itemgetter("event"))
+
+    assert len(all_expected) == len(all_result)
+    assert len([row["uuid"] for row in all_result]) == len(set(row["uuid"] for row in all_result))
+
+    for expected, result in zip(all_expected, all_result):
+        for key, value in result.items():
+            if key in ("timestamp", "inserted_at", "created_at"):
+                expected_value = to_isoformat(expected[key])
+            else:
+                expected_value = expected[key]
+
+            # Some keys will be missing from result, so let's only check the ones we have.
+            assert value == expected_value, f"{key} value in {result} didn't match value in {expected}"
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_get_results_iterator_can_include_events(client):
+    """Test the rows returned by get_results_iterator can include events."""
+    team_id = randint(1, 1000000)
+
+    events: list[EventValues] = [
+        {
+            "uuid": str(uuid4()),
+            "event": f"test-{i}",
+            "_timestamp": "2023-04-20 14:30:00",
+            "timestamp": f"2023-04-20 14:30:00.{i:06d}",
+            "inserted_at": f"2023-04-20 14:30:00.{i:06d}",
+            "created_at": "2023-04-20 14:30:00.000000",
+            "distinct_id": str(uuid4()),
+            "person_id": str(uuid4()),
+            "person_properties": {"$browser": "Chrome", "$os": "Mac OS X"},
+            "team_id": team_id,
+            "properties": {
+                "$browser": "Chrome",
+                "$os": "Mac OS X",
+                "$ip": "127.0.0.1",
+                "$current_url": "http://localhost.com",
+            },
+            "elements_chain": "this that and the other",
+            "elements": json.dumps("this that and the other"),
+            "ip": "127.0.0.1",
+            "site_url": "",
+            "set": None,
+            "set_once": None,
+        }
+        for i in range(10000)
+    ]
+    duplicate_events = events * 2
+
+    await insert_events(
+        ch_client=client,
+        events=duplicate_events,
+    )
+
+    # Include the latter half of events.
+    include_events = (f"test-{i}" for i in range(5000, 10000))
+    iter_ = get_results_iterator(
+        client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", include_events=include_events
+    )
+    rows = [row for row in iter_]
+
+    all_expected = sorted(events[5000:], key=operator.itemgetter("event"))
     all_result = sorted(rows, key=operator.itemgetter("event"))
 
     assert len(all_expected) == len(all_result)

--- a/posthog/temporal/workflows/bigquery_batch_export.py
+++ b/posthog/temporal/workflows/bigquery_batch_export.py
@@ -67,6 +67,7 @@ class BigQueryInsertInputs:
     data_interval_start: str
     data_interval_end: str
     exclude_events: list[str] | None = None
+    include_events: list[str] | None = None
 
 
 @contextlib.contextmanager
@@ -113,6 +114,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs):
             interval_start=inputs.data_interval_start,
             interval_end=inputs.data_interval_end,
             exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
         )
 
         if count == 0:
@@ -131,6 +133,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs):
             interval_start=inputs.data_interval_start,
             interval_end=inputs.data_interval_end,
             exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
         )
         table_schema = [
             bigquery.SchemaField("uuid", "STRING"),
@@ -244,6 +247,7 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
             data_interval_start=data_interval_start.isoformat(),
             data_interval_end=data_interval_end.isoformat(),
             exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
         )
 
         try:

--- a/posthog/temporal/workflows/postgres_batch_export.py
+++ b/posthog/temporal/workflows/postgres_batch_export.py
@@ -81,6 +81,8 @@ class PostgresInsertInputs:
     has_self_signed_cert: bool = False
     schema: str = "public"
     port: int = 5432
+    exclude_events: list[str] | None = None
+    include_events: list[str] | None = None
 
 
 @activity.defn
@@ -102,6 +104,8 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs):
             team_id=inputs.team_id,
             interval_start=inputs.data_interval_start,
             interval_end=inputs.data_interval_end,
+            exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
         )
 
         if count == 0:
@@ -119,6 +123,8 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs):
             team_id=inputs.team_id,
             interval_start=inputs.data_interval_start,
             interval_end=inputs.data_interval_end,
+            exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
         )
         with postgres_connection(inputs) as connection:
             with connection.cursor() as cursor:
@@ -239,6 +245,8 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
             has_self_signed_cert=inputs.has_self_signed_cert,
             data_interval_start=data_interval_start.isoformat(),
             data_interval_end=data_interval_end.isoformat(),
+            exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
         )
 
         try:

--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -272,6 +272,7 @@ class S3InsertInputs:
     aws_secret_access_key: str | None = None
     compression: str | None = None
     exclude_events: list[str] | None = None
+    include_events: list[str] | None = None
     encryption: str | None = None
     kms_key_id: str | None = None
 
@@ -353,6 +354,8 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
             team_id=inputs.team_id,
             interval_start=inputs.data_interval_start,
             interval_end=inputs.data_interval_end,
+            exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
         )
 
         if count == 0:
@@ -379,6 +382,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
             interval_start=interval_start,
             interval_end=inputs.data_interval_end,
             exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
         )
 
         result = None
@@ -496,6 +500,7 @@ class S3BatchExportWorkflow(PostHogWorkflow):
             data_interval_end=data_interval_end.isoformat(),
             compression=inputs.compression,
             exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
             encryption=inputs.encryption,
             kms_key_id=inputs.kms_key_id,
         )

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -61,6 +61,8 @@ class SnowflakeInsertInputs:
     data_interval_start: str
     data_interval_end: str
     role: str | None = None
+    exclude_events: list[str] | None = None
+    include_events: list[str] | None = None
 
 
 def put_file_to_snowflake_table(cursor: SnowflakeCursor, file_name: str, table_name: str):
@@ -112,6 +114,8 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs):
             team_id=inputs.team_id,
             interval_start=inputs.data_interval_start,
             interval_end=inputs.data_interval_end,
+            exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
         )
 
         if count == 0:
@@ -165,6 +169,8 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs):
                 team_id=inputs.team_id,
                 interval_start=inputs.data_interval_start,
                 interval_end=inputs.data_interval_end,
+                exclude_events=inputs.exclude_events,
+                include_events=inputs.include_events,
             )
             result = None
             local_results_file = tempfile.NamedTemporaryFile(suffix=".jsonl")
@@ -326,6 +332,8 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
             data_interval_start=data_interval_start.isoformat(),
             data_interval_end=data_interval_end.isoformat(),
             role=inputs.role,
+            exclude_events=inputs.exclude_events,
+            include_events=inputs.include_events,
         )
         try:
             await workflow.execute_activity(


### PR DESCRIPTION
## Problem

We allow users to set events to exclude in a batch export, but some users require the inverse: The option to select a subset of events to include in a batch export.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Add an `include_events` argument to all batch exports.
* All batch export destinations expose `exclude_events` and `include_events` (perhaps this should be moved to a batch export property, which would require a migration).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added unit tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
