### PR TITLE
chore: fix test snapshot flapping

### DIFF
--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -2735,7 +2735,7 @@
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
     AND s.max_last_timestamp <= '2021-01-21 20:00:00'
-    AND "session_id" in ['with-errors-session-497cfe26-1ce1-4a2d-b81d-1b8e171b6564', 'with-two-session-52d93c81-84c8-490d-92fe-cd80ee9a2483', 'with-warns-session-20fe20bd-4364-4376-b221-9a284b53c7b7']
+    AND "session_id" in ['with-errors-session', 'with-two-session', 'with-warns-session']
   GROUP BY session_id
   HAVING 1=1
   AND (console_warn_count > 0
@@ -2782,7 +2782,7 @@
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
     AND s.max_last_timestamp <= '2021-01-21 20:00:00'
-    AND "session_id" in ['with-warns-session-20fe20bd-4364-4376-b221-9a284b53c7b7']
+    AND "session_id" in ['with-warns-session']
   GROUP BY session_id
   HAVING 1=1
   AND (console_warn_count > 0
@@ -2829,7 +2829,7 @@
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
     AND s.max_last_timestamp <= '2021-01-21 20:00:00'
-    AND "session_id" in ['with-warns-session-20fe20bd-4364-4376-b221-9a284b53c7b7']
+    AND "session_id" in ['with-warns-session']
   GROUP BY session_id
   HAVING 1=1
   AND (console_warn_count > 0

--- a/posthog/session_recordings/queries/test/test_session_recording_list_from_session_replay.py
+++ b/posthog/session_recordings/queries/test/test_session_recording_list_from_session_replay.py
@@ -1979,10 +1979,10 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
     def test_filter_for_recordings_by_console_text(self):
         Person.objects.create(team=self.team, distinct_ids=["user"], properties={"email": "bla"})
 
-        with_logs_session_id = f"with-logs-session-{str(uuid4())}"
-        with_warns_session_id = f"with-warns-session-{str(uuid4())}"
-        with_errors_session_id = f"with-errors-session-{str(uuid4())}"
-        with_two_session_id = f"with-two-session-{str(uuid4())}"
+        with_logs_session_id = "with-logs-session"
+        with_warns_session_id = "with-warns-session"
+        with_errors_session_id = "with-errors-session"
+        with_two_session_id = "with-two-session"
 
         produce_replay_summary(
             distinct_id="user",


### PR DESCRIPTION
I added a test that has a query snapshot and ids that vary in each run... so the snapshot will start to flap over time.

The IDs don't need to vary