### PR TITLE
removes created/modified by "unknown user" from the usage tab of feature flag

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -331,7 +331,7 @@ function InsightDetailsInternal({ insight }: { insight: InsightModel }, ref: Rea
                     <h5>Created by</h5>
                     <section>
                         <ProfilePicture
-                            name={created_by?.first_name || 'PostHog via feature flag'}
+                            name={created_by?.first_name || 'PostHog'}
                             email={created_by?.email}
                             showName
                             size="md"

--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -330,22 +330,29 @@ function InsightDetailsInternal({ insight }: { insight: InsightModel }, ref: Rea
                 <div>
                     <h5>Created by</h5>
                     <section>
-                        <ProfilePicture name={created_by?.first_name} email={created_by?.email} showName size="md" />{' '}
-                        <TZLabel time={created_at} />
-                    </section>
-                </div>
-                <div>
-                    <h5>Last modified by</h5>
-                    <section>
                         <ProfilePicture
-                            name={insight.last_modified_by?.first_name}
-                            email={insight.last_modified_by?.email}
+                            name={created_by?.first_name || 'PostHog via feature flag'}
+                            email={created_by?.email}
                             showName
                             size="md"
                         />{' '}
-                        <TZLabel time={insight.last_modified_at} />
+                        <TZLabel time={created_at} />
                     </section>
                 </div>
+                {insight.last_modified_by && (
+                    <div>
+                        <h5>Last modified by</h5>
+                        <section>
+                            <ProfilePicture
+                                name={insight.last_modified_by?.first_name}
+                                email={insight.last_modified_by?.email}
+                                showName
+                                size="md"
+                            />{' '}
+                            <TZLabel time={insight.last_modified_at} />
+                        </section>
+                    </div>
+                )}
             </div>
         </div>
     )


### PR DESCRIPTION
## Problem

When viewing the Usage tab for a feature flag where the insights were auto-generated, it shows as created/modified by an unknown user.  #17617 

## Changes
![image](https://github.com/PostHog/posthog/assets/79001785/8e66b856-e24b-4579-867f-50dad86ae6b9)

