### PR TITLE
feat(batch-exports): Partition created table by timestamp

### DIFF
--- a/posthog/temporal/workflows/bigquery_batch_export.py
+++ b/posthog/temporal/workflows/bigquery_batch_export.py
@@ -47,6 +47,7 @@ def create_table_in_bigquery(
     """Create a table in BigQuery."""
     fully_qualified_name = f"{project_id}.{dataset_id}.{table_id}"
     table = bigquery.Table(fully_qualified_name, schema=table_schema)
+    table.time_partitioning = bigquery.TimePartitioning(type_=bigquery.TimePartitioningType.DAY, field="timestamp")
     table = bigquery_client.create_table(table, exists_ok=exists_ok)
 
     return table


### PR DESCRIPTION
## Problem

BigQuery export plugin created tables with DAY partitioning based on `timestamp`. We should do the same. Eventually, we could offer users the option to choose a partition key. For now, let's support what was already available.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add time partitioning when creating table.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Ran unit tests manually.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
