### PR TITLE
feat(surveys): survey results summary

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -169,6 +169,7 @@ export const FEATURE_FLAGS = {
     WEBHOOKS_DENYLIST: 'webhooks-denylist', // owner: #team-pipeline
     SURVEYS_SITE_APP_DEPRECATION: 'surveys-site-app-deprecation', // owner: @neilkakkar
     SURVEYS_MULTIPLE_QUESTIONS: 'surveys-multiple-questions', // owner: @liyiy
+    SURVEYS_RESULTS_VISUALIZATIONS: 'surveys-results-visualizations', // owner: @jurajmajerik
     CONSOLE_RECORDING_SEARCH: 'console-recording-search', // owner: #team-monitoring
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -32,11 +32,10 @@ import { dayjs } from 'lib/dayjs'
 import { defaultSurveyAppearance, SURVEY_EVENT_NAME } from './constants'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { Summary } from './surveyViewViz'
 
 export function SurveyView({ id }: { id: string }): JSX.Element {
     const { survey, surveyLoading, surveyPlugin, showSurveyAppWarning } = useValues(surveyLogic)
-    // TODO: survey results logic
-    // const { surveyImpressionsCount, surveyStartedCount, surveyCompletedCount } = useValues(surveyResultsLogic)
     const { editingSurvey, updateSurvey, launchSurvey, stopSurvey, archiveSurvey, resumeSurvey } =
         useActions(surveyLogic)
     const { deleteSurvey } = useActions(surveysLogic)
@@ -289,12 +288,17 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
         surveyRatingQuery,
         surveyMultipleChoiceQuery,
         currentQuestionIndexAndType,
+        surveyUserStats,
+        surveyUserStatsLoading,
     } = useValues(surveyLogic)
     const { setCurrentQuestionIndexAndType } = useActions(surveyLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     return (
         <>
+            {featureFlags[FEATURE_FLAGS.SURVEYS_RESULTS_VISUALIZATIONS] && (
+                <Summary surveyUserStatsLoading={surveyUserStatsLoading} surveyUserStats={surveyUserStats} />
+            )}
             {surveyMetricsQueries && (
                 <div className="flex flex-row gap-4 mb-4">
                     <div className="flex-1">

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -10,10 +10,6 @@ const formatCount = (count: number, total: number): string => {
 }
 
 export function UsersCount({ surveyUserStats }: { surveyUserStats: SurveyUserStats }): JSX.Element {
-    if (!surveyUserStats) {
-        return <></>
-    }
-
     const { seen, dismissed, sent } = surveyUserStats
     const total = seen + dismissed + sent
     const labelTotal = total === 1 ? 'Unique user viewed' : 'Unique users viewed'
@@ -36,10 +32,6 @@ export function UsersCount({ surveyUserStats }: { surveyUserStats: SurveyUserSta
 }
 
 export function UsersStackedBar({ surveyUserStats }: { surveyUserStats: SurveyUserStats }): JSX.Element {
-    if (!surveyUserStats) {
-        return <></>
-    }
-
     const { seen, dismissed, sent } = surveyUserStats
 
     const total = seen + dismissed + sent
@@ -127,6 +119,10 @@ export function Summary({
     surveyUserStats: SurveyUserStats
     surveyUserStatsLoading: boolean
 }): JSX.Element {
+    if (!surveyUserStats) {
+        return <></>
+    }
+
     return (
         <div className="mb-4">
             {surveyUserStatsLoading ? (

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -1,0 +1,108 @@
+import { LemonTable } from '@posthog/lemon-ui'
+import { SurveyUserStats } from './surveyLogic'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+
+const formatPercentageValue = (value: number): string => {
+    if (value < 5) {
+        return ''
+    }
+    return `${value.toFixed(1)}%`
+}
+
+export function UsersCount({ surveyUserStats }: { surveyUserStats: SurveyUserStats }): JSX.Element {
+    if (!surveyUserStats) {
+        return <></>
+    }
+
+    const { seen, dismissed, sent } = surveyUserStats
+    const total = seen + dismissed + sent
+    const label = total === 1 ? 'Unique user viewed' : 'Unique users viewed'
+
+    return (
+        <div className="mb-4">
+            <div className="text-4xl font-bold">{total}</div>
+            <div className="font-semibold text-muted-alt">{label}</div>
+        </div>
+    )
+}
+
+export function UsersStackedBar({ surveyUserStats }: { surveyUserStats: SurveyUserStats }): JSX.Element {
+    const { seen, dismissed, sent } = surveyUserStats
+
+    const total = seen + dismissed + sent
+    const seenPercentage = (seen / total) * 100
+    const dismissedPercentage = (dismissed / total) * 100
+    const sentPercentage = (sent / total) * 100
+
+    return (
+        <div className="mb-6">
+            <div className="w-full mx-auto h-8 mb-4">
+                {[
+                    {
+                        label: 'Seen',
+                        classes: 'bg-primary rounded-l',
+                        style: { width: `${seenPercentage}%` },
+                    },
+                    {
+                        label: 'Dismissed',
+                        classes: 'bg-warning',
+                        style: { width: `${dismissedPercentage}%`, left: `${seenPercentage}%` },
+                    },
+                    {
+                        label: 'Submitted',
+                        classes: 'bg-success rounded-r',
+                        style: { width: `${sentPercentage}%`, left: `${seenPercentage + dismissedPercentage}%` },
+                    },
+                ].map(({ label, classes, style }) => (
+                    <Tooltip
+                        key={`survey-summary-chart-${label}`}
+                        title={`Seen surveys: ${seenPercentage.toFixed(1)}%`}
+                        delayMs={0}
+                        placement="top"
+                    >
+                        <div className={`h-8 text-white text-center absolute cursor-pointer ${classes}`} style={style}>
+                            <span className="inline-flex font-semibold leading-8">
+                                {formatPercentageValue(seenPercentage)}
+                            </span>
+                        </div>
+                    </Tooltip>
+                ))}
+            </div>
+            <div className="w-full flex justify-center">
+                <div className="flex items-center">
+                    {[
+                        { label: 'Seen', color: 'bg-primary' },
+                        { label: 'Dismissed', color: 'bg-warning' },
+                        { label: 'Submitted', color: 'bg-success' },
+                    ].map(({ label, color }) => (
+                        <div key={`survey-summary-legend-${label}`} className="flex items-center mr-6">
+                            <div className={`w-2 h-2 rounded-full mr-2 ${color}`} />
+                            <span className="font-semibold text-muted-alt">{label}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export function Summary({
+    surveyUserStats,
+    surveyUserStatsLoading,
+}: {
+    surveyUserStats: SurveyUserStats
+    surveyUserStatsLoading: boolean
+}): JSX.Element {
+    return (
+        <div className="mb-4">
+            {surveyUserStatsLoading ? (
+                <LemonTable dataSource={[]} columns={[]} loading={true} />
+            ) : (
+                <>
+                    <UsersCount surveyUserStats={surveyUserStats} />
+                    <UsersStackedBar surveyUserStats={surveyUserStats} />
+                </>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -2,6 +2,13 @@ import { LemonTable } from '@posthog/lemon-ui'
 import { SurveyUserStats } from './surveyLogic'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
+const formatCount = (count: number, total: number): string => {
+    if ((count / total) * 100 < 3) {
+        return ''
+    }
+    return `${count}`
+}
+
 export function UsersCount({ surveyUserStats }: { surveyUserStats: SurveyUserStats }): JSX.Element {
     if (!surveyUserStats) {
         return <></>
@@ -9,21 +16,23 @@ export function UsersCount({ surveyUserStats }: { surveyUserStats: SurveyUserSta
 
     const { seen, dismissed, sent } = surveyUserStats
     const total = seen + dismissed + sent
-    const label = total === 1 ? 'Unique user viewed' : 'Unique users viewed'
+    const labelTotal = total === 1 ? 'Unique user viewed' : 'Unique users viewed'
+    const labelSent = sent === 1 ? 'Response submitted' : 'Responses submitted'
 
     return (
-        <div className="mb-4">
-            <div className="text-4xl font-bold">{total}</div>
-            <div className="font-semibold text-muted-alt">{label}</div>
+        <div className="inline-flex mb-4">
+            <div>
+                <div className="text-4xl font-bold">{total}</div>
+                <div className="font-semibold text-muted-alt">{labelTotal}</div>
+            </div>
+            {sent > 0 && (
+                <div className="ml-10">
+                    <div className="text-4xl font-bold">{sent}</div>
+                    <div className="font-semibold text-muted-alt">{labelSent}</div>
+                </div>
+            )}
         </div>
     )
-}
-
-const formatCount = (count: number, total: number): string => {
-    if ((count / total) * 100 < 3) {
-        return ''
-    }
-    return `${count}`
 }
 
 export function UsersStackedBar({ surveyUserStats }: { surveyUserStats: SurveyUserStats }): JSX.Element {
@@ -38,71 +47,76 @@ export function UsersStackedBar({ surveyUserStats }: { surveyUserStats: SurveyUs
     const dismissedPercentage = (dismissed / total) * 100
     const sentPercentage = (sent / total) * 100
 
-    return total === 0 ? (
-        <></>
-    ) : (
-        <div className="mb-6">
-            <div className="w-full mx-auto h-10 mb-4">
-                {[
-                    {
-                        count: seen,
-                        label: 'Viewed',
-                        classes: `bg-primary rounded-l ${dismissed === 0 && sent === 0 ? 'rounded-r' : ''}`,
-                        style: { width: `${seenPercentage}%` },
-                    },
-                    {
-                        count: dismissed,
-                        label: 'Dismissed',
-                        classes: `${seen === 0 ? 'rounded-l' : ''} ${sent === 0 ? 'rounded-r' : ''}`,
-                        style: {
-                            backgroundColor: '#E3A506',
-                            width: `${dismissedPercentage}%`,
-                            left: `${seenPercentage}%`,
-                        },
-                    },
-                    {
-                        count: sent,
-                        label: 'Submitted',
-                        classes: `rounded-r ${seen === 0 && dismissed === 0 ? 'rounded-l' : ''}`,
-                        style: {
-                            backgroundColor: '#529B08',
-                            width: `${sentPercentage}%`,
-                            left: `${seenPercentage + dismissedPercentage}%`,
-                        },
-                    },
-                ].map(({ count, label, classes, style }) => (
-                    <Tooltip
-                        key={`survey-summary-chart-${label}`}
-                        title={`${label} surveys: ${count}`}
-                        delayMs={0}
-                        placement="top"
-                    >
-                        <div className={`h-10 text-white text-center absolute cursor-pointer ${classes}`} style={style}>
-                            <span className="inline-flex font-semibold max-w-full px-1 truncate leading-10">
-                                {formatCount(count, total)}
-                            </span>
+    return (
+        <>
+            {total > 0 && (
+                <div className="mb-6">
+                    <div className="w-full mx-auto h-10 mb-4">
+                        {[
+                            {
+                                count: seen,
+                                label: 'Viewed',
+                                classes: `bg-primary rounded-l ${dismissed === 0 && sent === 0 ? 'rounded-r' : ''}`,
+                                style: { width: `${seenPercentage}%` },
+                            },
+                            {
+                                count: dismissed,
+                                label: 'Dismissed',
+                                classes: `${seen === 0 ? 'rounded-l' : ''} ${sent === 0 ? 'rounded-r' : ''}`,
+                                style: {
+                                    backgroundColor: '#E3A506',
+                                    width: `${dismissedPercentage}%`,
+                                    left: `${seenPercentage}%`,
+                                },
+                            },
+                            {
+                                count: sent,
+                                label: 'Submitted',
+                                classes: `rounded-r ${seen === 0 && dismissed === 0 ? 'rounded-l' : ''}`,
+                                style: {
+                                    backgroundColor: '#529B08',
+                                    width: `${sentPercentage}%`,
+                                    left: `${seenPercentage + dismissedPercentage}%`,
+                                },
+                            },
+                        ].map(({ count, label, classes, style }) => (
+                            <Tooltip
+                                key={`survey-summary-chart-${label}`}
+                                title={`${label} surveys: ${count}`}
+                                delayMs={0}
+                                placement="top"
+                            >
+                                <div
+                                    className={`h-10 text-white text-center absolute cursor-pointer ${classes}`}
+                                    style={style}
+                                >
+                                    <span className="inline-flex font-semibold max-w-full px-1 truncate leading-10">
+                                        {formatCount(count, total)}
+                                    </span>
+                                </div>
+                            </Tooltip>
+                        ))}
+                    </div>
+                    <div className="w-full flex justify-center">
+                        <div className="flex items-center">
+                            {[
+                                { count: seen, label: 'Viewed', color: 'bg-primary' },
+                                { count: dismissed, label: 'Dismissed', color: 'bg-warning' },
+                                { count: sent, label: 'Submitted', color: 'bg-success' },
+                            ].map(({ count, label, color }) => (
+                                <div key={`survey-summary-legend-${label}`} className="flex items-center mr-6">
+                                    <div className={`w-3 h-3 rounded-full mr-2 ${color}`} />
+                                    <span className="font-semibold text-muted-alt">{`${label} (${(
+                                        (count / total) *
+                                        100
+                                    ).toFixed(1)}%)`}</span>
+                                </div>
+                            ))}
                         </div>
-                    </Tooltip>
-                ))}
-            </div>
-            <div className="w-full flex justify-center">
-                <div className="flex items-center">
-                    {[
-                        { count: seen, label: 'Viewed', color: 'bg-primary' },
-                        { count: dismissed, label: 'Dismissed', color: 'bg-warning' },
-                        { count: sent, label: 'Submitted', color: 'bg-success' },
-                    ].map(({ count, label, color }) => (
-                        <div key={`survey-summary-legend-${label}`} className="flex items-center mr-6">
-                            <div className={`w-3 h-3 rounded-full mr-2 ${color}`} />
-                            <span className="font-semibold text-muted-alt">{`${label} (${(
-                                (count / total) *
-                                100
-                            ).toFixed(1)}%)`}</span>
-                        </div>
-                    ))}
+                    </div>
                 </div>
-            </div>
-        </div>
+            )}
+        </>
     )
 }
 

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -34,7 +34,9 @@ export function UsersStackedBar({ surveyUserStats }: { surveyUserStats: SurveyUs
     const dismissedPercentage = (dismissed / total) * 100
     const sentPercentage = (sent / total) * 100
 
-    return (
+    return total === 0 ? (
+        <></>
+    ) : (
         <div className="mb-6">
             <div className="w-full mx-auto h-8 mb-4">
                 {[

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -59,7 +59,7 @@ export function UsersStackedBar({ surveyUserStats }: { surveyUserStats: SurveyUs
                 ].map(({ value, label, classes, style }) => (
                     <Tooltip
                         key={`survey-summary-chart-${label}`}
-                        title={`Seen surveys: ${seenPercentage.toFixed(1)}%`}
+                        title={`${label} surveys: ${seenPercentage.toFixed(1)}%`}
                         delayMs={0}
                         placement="top"
                     >

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -39,21 +39,24 @@ export function UsersStackedBar({ surveyUserStats }: { surveyUserStats: SurveyUs
             <div className="w-full mx-auto h-8 mb-4">
                 {[
                     {
+                        value: seenPercentage,
                         label: 'Seen',
                         classes: 'bg-primary rounded-l',
                         style: { width: `${seenPercentage}%` },
                     },
                     {
+                        value: dismissedPercentage,
                         label: 'Dismissed',
                         classes: 'bg-warning',
                         style: { width: `${dismissedPercentage}%`, left: `${seenPercentage}%` },
                     },
                     {
+                        value: sentPercentage,
                         label: 'Submitted',
                         classes: 'bg-success rounded-r',
                         style: { width: `${sentPercentage}%`, left: `${seenPercentage + dismissedPercentage}%` },
                     },
-                ].map(({ label, classes, style }) => (
+                ].map(({ value, label, classes, style }) => (
                     <Tooltip
                         key={`survey-summary-chart-${label}`}
                         title={`Seen surveys: ${seenPercentage.toFixed(1)}%`}
@@ -61,9 +64,7 @@ export function UsersStackedBar({ surveyUserStats }: { surveyUserStats: SurveyUs
                         placement="top"
                     >
                         <div className={`h-8 text-white text-center absolute cursor-pointer ${classes}`} style={style}>
-                            <span className="inline-flex font-semibold leading-8">
-                                {formatPercentageValue(seenPercentage)}
-                            </span>
+                            <span className="inline-flex font-semibold leading-8">{formatPercentageValue(value)}</span>
                         </div>
                     </Tooltip>
                 ))}


### PR DESCRIPTION
feature flag: `surveys-results-visualizations`
Implemented a stacked bar showing survey status per user

<img width="1512" alt="Screenshot 2023-10-05 at 17 33 18" src="https://github.com/PostHog/posthog/assets/22996112/b531c5ef-9899-4328-af45-7878af6015b8">

Edge case - when a sub-bar is too small, the value will overflow. In that case, I don't render the value, but there's always a tooltip available. Happy to hear feedback @corywatilo.

<img width="1512" alt="Screenshot 2023-10-05 at 17 34 10" src="https://github.com/PostHog/posthog/assets/22996112/156cddba-1fcf-4b36-bae8-38799a151ed3">

## Testing
Manually in the browser.