### PR TITLE
perf(Persons): Use optimize_aggregation_in_order for person queries

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -20,7 +20,7 @@
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND ((((has(['something'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))
-           AND ((has(['something'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$another_prop'), '^"|"$', ''))))))) as person
+           AND ((has(['something'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$another_prop'), '^"|"$', '')))))) SETTINGS optimize_aggregation_in_order = 1) as person
   UNION ALL
   SELECT person_id,
          cohort_id,
@@ -54,7 +54,7 @@
             AND ((has(['something1'], replaceRegexpAll(JSONExtractRaw(properties, '$some_prop'), '^"|"$', '')))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND ((has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))) as person
+     AND ((has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1) as person
   UNION ALL
   SELECT person_id,
          cohort_id,
@@ -111,7 +111,7 @@
                   AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(properties, '$some_prop'), '^"|"$', ''))))))) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
+           AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))) SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
      WHERE 1 = 1
        AND ((((performed_event_condition_15_level_level_0_level_0_level_0_0)))) ) as person
   UNION ALL
@@ -176,7 +176,7 @@
                               AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(properties, '$some_prop'), '^"|"$', ''))))))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
-                       AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))) person ON person.person_id = behavior_query.person_id
+                       AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))) SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
                  WHERE 1 = 1
                    AND ((((performed_event_condition_17_level_level_0_level_0_level_0_0)))) ) ))
   '

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -170,7 +170,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = funnel_actors.actor_id) aggregation_target_with_props
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = funnel_actors.actor_id) aggregation_target_with_props
   GROUP BY prop.1,
                prop.2
   HAVING prop.1 NOT IN []
@@ -242,7 +242,7 @@
                               AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
-                       AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
+                       AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -326,7 +326,7 @@
                               AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
-                       AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
+                       AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -410,7 +410,7 @@
                               AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
-                       AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
+                       AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -494,7 +494,7 @@
                               AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
-                       AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
+                       AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -594,7 +594,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = funnel_actors.actor_id) aggregation_target_with_props
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = funnel_actors.actor_id) aggregation_target_with_props
   GROUP BY prop.1,
                prop.2
   HAVING prop.1 NOT IN []
@@ -666,7 +666,7 @@
                               AND (has(['Positive'], "pmat_$browser")) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
-                       AND (has(['Positive'], argMax(person."pmat_$browser", version)))) person ON person.id = pdi.person_id
+                       AND (has(['Positive'], argMax(person."pmat_$browser", version))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -750,7 +750,7 @@
                               AND (has(['Positive'], "pmat_$browser")) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
-                       AND (has(['Positive'], argMax(person."pmat_$browser", version)))) person ON person.id = pdi.person_id
+                       AND (has(['Positive'], argMax(person."pmat_$browser", version))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -834,7 +834,7 @@
                               AND (has(['Negative'], "pmat_$browser")) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
-                       AND (has(['Negative'], argMax(person."pmat_$browser", version)))) person ON person.id = pdi.person_id
+                       AND (has(['Negative'], argMax(person."pmat_$browser", version))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -918,7 +918,7 @@
                               AND (has(['Negative'], "pmat_$browser")) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
-                       AND (has(['Negative'], argMax(person."pmat_$browser", version)))) person ON person.id = pdi.person_id
+                       AND (has(['Negative'], argMax(person."pmat_$browser", version))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -445,7 +445,7 @@
                               AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(properties, 'foo'), '^"|"$', ''))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
-                       AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id
+                       AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'foo'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                     WHERE team_id = 2
                       AND event IN ['$pageview', 'insight analyzed']
                       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
@@ -579,7 +579,7 @@
                               AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(properties, 'foo'), '^"|"$', ''))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
-                       AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id
+                       AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'foo'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                     WHERE team_id = 2
                       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
                       AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC')
@@ -711,7 +711,7 @@
                               AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(properties, 'foo'), '^"|"$', ''))) )
                        GROUP BY id
                        HAVING max(is_deleted) = 0
-                       AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id
+                       AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'foo'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                     WHERE team_id = 2
                       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
                       AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC')

--- a/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
@@ -73,7 +73,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = '$pageview'
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2019-12-21 00:00:00', 'UTC')
@@ -105,7 +105,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = '$pageview'
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2019-12-21 00:00:00', 'UTC')
@@ -143,7 +143,7 @@
                AND ((replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '') ILIKE '%test%')) )
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '') ILIKE '%test%'))) person ON pdi.person_id = person.id
+        AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '') ILIKE '%test%')) SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = '$pageview'
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2019-12-21 00:00:00', 'UTC')
@@ -204,7 +204,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      INNER JOIN
        (SELECT "$session_id",
                dateDiff('second', min(timestamp), max(timestamp)) as session_duration
@@ -245,7 +245,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      INNER JOIN
        (SELECT "$session_id",
                dateDiff('second', min(timestamp), max(timestamp)) as session_duration

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -39,7 +39,7 @@
                AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
+        AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', ''))))) SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
     AND ((((performed_event_condition_None_level_level_0_level_0_level_0_0)
            OR (performed_event_condition_None_level_level_0_level_0_level_1_0))
@@ -111,7 +111,7 @@
                AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', ''))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))))) person ON person.person_id = funnel_query.person_id
+        AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))) SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
     AND ((((steps_0))
           AND (steps_1)))
@@ -153,7 +153,7 @@
                AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', '')))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))))))) person ON person.person_id = behavior_query.person_id
+        AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))))) SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
     AND (((performed_event_condition_None_level_level_0_level_0_0)))
   '
@@ -189,7 +189,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
     AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
           OR ((performed_event_condition_None_level_level_0_level_1_level_0_0))))

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -341,7 +341,7 @@
                AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '')))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))))) person ON person.person_id = funnel_query.person_id
+        AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
     AND (((steps_0)
           AND (performed_event_multiple_condition_None_level_level_0_level_1_0)))
@@ -378,7 +378,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
     AND (((performed_event_condition_None_level_level_0_level_0_0)
           OR (has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person_props, '$sample_field'), '^"|"$', '')))))
@@ -415,7 +415,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
     AND (((performed_event_condition_None_level_level_0_level_0_0)
           OR (has(['test@posthog.com'], "pmat_$sample_field"))))
@@ -463,7 +463,7 @@
                AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
+        AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', ''))))) SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
     AND ((((performed_event_condition_None_level_level_0_level_0_level_0_0)
            OR (performed_event_condition_None_level_level_0_level_0_level_1_0)
@@ -490,7 +490,7 @@
   AND (((has(['test1@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))
         OR (has(['test2@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', ''))))
        OR ((has(['test3'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))
-           AND (has(['test3@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))))
+           AND (has(['test3@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', ''))))) SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestCohortQuery.test_precalculated_cohort_filter_with_extra_filters
@@ -528,7 +528,7 @@
   GROUP BY id
   HAVING max(is_deleted) = 0
   AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))))
-       OR (has(['test2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))
+       OR (has(['test2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestCohortQuery.test_static_cohort_filter
@@ -552,7 +552,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person
   WHERE 1 = 1
     AND (((id IN
              (SELECT person_id as id
@@ -600,7 +600,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
     AND (((id IN
              (SELECT person_id as id
@@ -640,7 +640,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
     AND ((((id IN
               (SELECT person_id as id
@@ -692,7 +692,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
     AND ((((performed_event_condition_None_level_level_0_level_0_level_0_0)
            AND (id NOT IN

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -41,7 +41,7 @@
             AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', ''))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
+     AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
   WHERE team_id = 2
     AND event = 'event_name'
     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-01-14 00:00:00', 'UTC')), 'UTC')
@@ -75,7 +75,7 @@
      FROM person
      WHERE team_id = 2
      GROUP BY id
-     HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
   WHERE team_id = 2
     AND event = 'viewed'
     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
@@ -91,7 +91,7 @@
                    AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', '')))) )
             GROUP BY id
             HAVING max(is_deleted) = 0
-            AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))))
+            AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1))
   '
 ---
 # name: TestEventQuery.test_denormalised_props
@@ -146,7 +146,7 @@
      FROM person
      WHERE team_id = 2
      GROUP BY id
-     HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
   WHERE team_id = 2
     AND event = '$pageview'
     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
@@ -162,7 +162,7 @@
                    AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', '')))) )
             GROUP BY id
             HAVING max(is_deleted) = 0
-            AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))))
+            AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1))
   '
 ---
 # name: TestEventQuery.test_entity_filtered_by_multiple_session_duration_filters
@@ -282,7 +282,7 @@
             AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', ''))))) person ON person.id = pdi.person_id
+     AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
   LEFT JOIN
     (SELECT group_key,
             argMax(group_properties, _timestamp) AS group_properties_0
@@ -314,7 +314,7 @@
      FROM person
      WHERE team_id = 2
      GROUP BY id
-     HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
   WHERE team_id = 2
     AND event = 'viewed'
     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -55,7 +55,7 @@
               FROM person
               WHERE team_id = 2
               GROUP BY id
-              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE team_id = 2
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
@@ -128,7 +128,7 @@
               FROM person
               WHERE team_id = 2
               GROUP BY id
-              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE team_id = 2
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('month', toDateTime('2021-02-04 00:00:00', 'UTC'))) - INTERVAL 1 month
@@ -201,7 +201,7 @@
               FROM person
               WHERE team_id = 2
               GROUP BY id
-              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE team_id = 2
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('week', toDateTime('2021-04-06 00:00:00', 'UTC'))) - INTERVAL 1 week
@@ -274,7 +274,7 @@
               FROM person
               WHERE team_id = 2
               GROUP BY id
-              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE team_id = 2
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-11 00:00:00', 'UTC'))) - INTERVAL 1 day
@@ -347,7 +347,7 @@
               FROM person
               WHERE team_id = 2
               GROUP BY id
-              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE team_id = 2
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
@@ -421,7 +421,7 @@
               FROM person
               WHERE team_id = 2
               GROUP BY id
-              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE team_id = 2
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
@@ -496,7 +496,7 @@
               FROM person
               WHERE team_id = 2
               GROUP BY id
-              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE team_id = 2
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
@@ -571,7 +571,7 @@
               FROM person
               WHERE team_id = 2
               GROUP BY id
-              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE team_id = 2
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
@@ -645,7 +645,7 @@
               FROM person
               WHERE team_id = 2
               GROUP BY id
-              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            LEFT JOIN
              (SELECT group_key,
                      argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
@@ -14,6 +14,7 @@
                
               
               
+              SETTINGS optimize_aggregation_in_order = 1
               
   '
 ---
@@ -40,6 +41,7 @@
                
               
               
+              SETTINGS optimize_aggregation_in_order = 1
               
   '
 ---
@@ -66,6 +68,7 @@
                
               
               
+              SETTINGS optimize_aggregation_in_order = 1
               
   '
 ---
@@ -92,6 +95,7 @@
                
               
               
+              SETTINGS optimize_aggregation_in_order = 1
               
   '
 ---
@@ -111,6 +115,7 @@
                
               
               
+              SETTINGS optimize_aggregation_in_order = 1
               
   '
 ---
@@ -137,6 +142,7 @@
                
               
               
+              SETTINGS optimize_aggregation_in_order = 1
               
   '
 ---
@@ -163,6 +169,7 @@
                
               
               
+              SETTINGS optimize_aggregation_in_order = 1
               
   '
 ---
@@ -189,6 +196,7 @@
                
               
               
+              SETTINGS optimize_aggregation_in_order = 1
               
   '
 ---
@@ -215,6 +223,7 @@
                
               
               
+              SETTINGS optimize_aggregation_in_order = 1
               
   '
 ---
@@ -241,6 +250,7 @@
                
               
               
+              SETTINGS optimize_aggregation_in_order = 1
               
   '
 ---
@@ -267,6 +277,7 @@
                
               
               
+              SETTINGS optimize_aggregation_in_order = 1
               
   '
 ---
@@ -297,6 +308,7 @@
                
               
               
+              SETTINGS optimize_aggregation_in_order = 1
               
   '
 ---
@@ -316,6 +328,7 @@
                
               
               
+              SETTINGS optimize_aggregation_in_order = 1
               
   '
 ---
@@ -335,6 +348,7 @@
                
               
               
+              SETTINGS optimize_aggregation_in_order = 1
               
   '
 ---

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -229,7 +229,7 @@
                   AND (NOT (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
+           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%')) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND e.event = 'target event'
           AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -265,7 +265,7 @@
                   AND (NOT (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
+           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%')) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND e.event = 'target event'
         GROUP BY target
@@ -329,7 +329,7 @@
                   AND (NOT (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
+           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%')) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND e.event = 'target event'
           AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -365,7 +365,7 @@
                   AND (NOT (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
+           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%')) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND e.event = 'target event'
         GROUP BY target
@@ -425,7 +425,7 @@
                   AND (NOT (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
+           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%')) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND e.event = 'target event'
           AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -461,7 +461,7 @@
                   AND (NOT (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
+           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%posthog.com%')) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND e.event = 'target event'
         GROUP BY target

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -512,7 +512,7 @@
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'key'), '^"|"$', '')))
-             AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'key'), '^"|"$', ''))))) person ON pdi.person_id = person.id
+             AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'key'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = '$pageview'
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
@@ -589,7 +589,7 @@
                     GROUP BY id
                     HAVING max(is_deleted) = 0
                     AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'key'), '^"|"$', '')))
-                         AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'key'), '^"|"$', ''))))) person ON person.id = pdi.person_id
+                         AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'key'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                  WHERE e.team_id = 2
                    AND event = '$pageview'
                    AND toDateTime(timestamp, 'UTC') >= toDateTime('2011-12-25 00:00:00', 'UTC')
@@ -644,7 +644,7 @@
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'key'), '^"|"$', ''))))
-             AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'key'), '^"|"$', ''))))) person ON person.id = pdi.person_id
+             AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'key'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND event = '$pageview'
        AND toDateTime(timestamp, 'UTC') >= toDateTime('2011-12-25 00:00:00', 'UTC')

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -75,7 +75,7 @@
                           FROM person
                           WHERE team_id = 2
                           GROUP BY id
-                          HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                          HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                        LEFT JOIN
                          (SELECT group_key,
                                  argMax(group_properties, _timestamp) AS group_properties_0

--- a/posthog/api/test/__snapshots__/test_cohort.ambr
+++ b/posthog/api/test/__snapshots__/test_cohort.ambr
@@ -46,7 +46,7 @@
            FROM person
            WHERE team_id = 2
            GROUP BY id
-           HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+           HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
      WHERE 1 = 1
        AND ((((has(['something'], replaceRegexpAll(JSONExtractRaw(person_props, '$some_prop'), '^"|"$', ''))))
              OR ((performed_event_condition_1_level_level_0_level_1_level_0_0)))) ) as person
@@ -131,7 +131,7 @@
             AND ((has(['something'], replaceRegexpAll(JSONExtractRaw(properties, '$some_prop'), '^"|"$', '')))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND ((has(['something'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))) as person
+     AND ((has(['something'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1) as person
   UNION ALL
   SELECT person_id,
          cohort_id,

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -13,7 +13,7 @@
             AND (has(['0', '1', '2', '3'], replaceRegexpAll(JSONExtractRaw(properties, 'group'), '^"|"$', ''))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND (has(['0', '1', '2', '3'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'group'), '^"|"$', ''))))
+     AND (has(['0', '1', '2', '3'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'group'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1)
   '
 ---
 # name: TestBlastRadius.test_user_blast_radius.1
@@ -25,7 +25,7 @@
      FROM person
      WHERE team_id = 2
      GROUP BY id
-     HAVING max(is_deleted) = 0)
+     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)
   '
 ---
 # name: TestBlastRadius.test_user_blast_radius_with_groups
@@ -138,7 +138,7 @@
             AND cohort_id = 2
             AND version = 0 )
      GROUP BY id
-     HAVING max(is_deleted) = 0)
+     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)
   '
 ---
 # name: TestBlastRadius.test_user_blast_radius_with_multiple_precalculated_cohorts.5
@@ -150,7 +150,7 @@
      FROM person
      WHERE team_id = 2
      GROUP BY id
-     HAVING max(is_deleted) = 0)
+     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)
   '
 ---
 # name: TestBlastRadius.test_user_blast_radius_with_multiple_static_cohorts
@@ -185,7 +185,7 @@
             AND ((has(['1', '2', '4', '5', '6'], replaceRegexpAll(JSONExtractRaw(properties, 'group'), '^"|"$', '')))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND ((has(['1', '2', '4', '5', '6'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'group'), '^"|"$', '')))))
+     AND ((has(['1', '2', '4', '5', '6'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'group'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1)
   '
 ---
 # name: TestBlastRadius.test_user_blast_radius_with_multiple_static_cohorts.2
@@ -197,7 +197,7 @@
      FROM person
      WHERE team_id = 2
      GROUP BY id
-     HAVING max(is_deleted) = 0)
+     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)
   '
 ---
 # name: TestBlastRadius.test_user_blast_radius_with_multiple_static_cohorts.3
@@ -260,7 +260,7 @@
             AND cohort_id = 2
             AND version = 0 )
      GROUP BY id
-     HAVING max(is_deleted) = 0)
+     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)
   '
 ---
 # name: TestBlastRadius.test_user_blast_radius_with_single_cohort
@@ -280,7 +280,7 @@
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND ((has(['none'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'group'), '^"|"$', ''))
-           OR has(['1', '2', '3'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'group'), '^"|"$', '')))))
+           OR has(['1', '2', '3'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'group'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1)
   '
 ---
 # name: TestBlastRadius.test_user_blast_radius_with_single_cohort.1
@@ -292,7 +292,7 @@
      FROM person
      WHERE team_id = 2
      GROUP BY id
-     HAVING max(is_deleted) = 0)
+     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)
   '
 ---
 # name: TestBlastRadius.test_user_blast_radius_with_single_cohort.2
@@ -331,7 +331,7 @@
         ORDER BY person_id) cohort_persons ON cohort_persons.person_id = person.id
      WHERE team_id = 2
      GROUP BY id
-     HAVING max(is_deleted) = 0)
+     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)
   '
 ---
 # name: TestResiliency.test_feature_flags_v3_with_experience_continuity_working_slow_db

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -19,7 +19,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event IN ['user did things', 'user signed up']
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
@@ -96,7 +96,7 @@
                        FROM person
                        WHERE team_id = 2
                        GROUP BY id
-                       HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                       HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                     WHERE team_id = 2
                       AND event IN ['user did things', 'user signed up']
                       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
@@ -164,7 +164,7 @@
                     FROM person
                     WHERE team_id = 2
                     GROUP BY id
-                    HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                    HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                  WHERE team_id = 2
                    AND event IN ['user did things', 'user signed up']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
@@ -235,7 +235,7 @@
                     FROM person
                     WHERE team_id = 2
                     GROUP BY id
-                    HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                    HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                  WHERE team_id = 2
                    AND event IN ['user did things', 'user signed up']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
@@ -432,7 +432,7 @@
            FROM person
            WHERE team_id = 2
            GROUP BY id
-           HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+           HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND event = '$pageview'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
@@ -500,7 +500,7 @@
            FROM person
            WHERE team_id = 2
            GROUP BY id
-           HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+           HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND event = '$pageview'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
@@ -542,7 +542,7 @@
            FROM person
            WHERE team_id = 2
            GROUP BY id
-           HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+           HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND event = '$pageview'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
@@ -584,7 +584,7 @@
            FROM person
            WHERE team_id = 2
            GROUP BY id
-           HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+           HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND event = '$pageview'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')

--- a/posthog/api/test/__snapshots__/test_person.ambr
+++ b/posthog/api/test/__snapshots__/test_person.ambr
@@ -9,7 +9,7 @@
   AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
   AND has(['another@gmail.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_filter_person_email_materialized
@@ -23,7 +23,7 @@
   AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
   AND has(['another@gmail.com'], "pmat_email")
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_filter_person_list
@@ -46,7 +46,7 @@
         HAVING argMax(is_deleted, version) = 0)
      where distinct_id = 'distinct_id' )
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_filter_person_list.1
@@ -69,7 +69,7 @@
         HAVING argMax(is_deleted, version) = 0)
      where distinct_id = 'another_one' )
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_filter_person_list.2
@@ -83,7 +83,7 @@
   AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
   AND has(['another@gmail.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_filter_person_list.3
@@ -97,7 +97,7 @@
   AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
   AND has(['inexistent'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_filter_person_list.4
@@ -120,7 +120,7 @@
         HAVING argMax(is_deleted, version) = 0)
      where distinct_id = 'inexistent' )
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_filter_person_prop
@@ -139,7 +139,7 @@
   AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
   AND (has(['some_value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'some_prop'), '^"|"$', '')))
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_person_property_values
@@ -232,7 +232,7 @@
   AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
   AND (JSONHas(argMax(person.properties, version), 'email'))
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_properties.1
@@ -251,7 +251,7 @@
   AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
   AND (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%another@gm%')
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_properties_materialized
@@ -270,7 +270,7 @@
   AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
   AND (notEmpty(argMax(person."pmat_email", version)))
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_properties_materialized.1
@@ -289,7 +289,7 @@
   AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
   AND (argMax(person."pmat_email", version) ILIKE '%another@gm%')
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_search
@@ -328,7 +328,7 @@
              HAVING argMax(is_deleted, version) = 0)
           WHERE distinct_id = 'another@gm' ))
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_search.1
@@ -367,7 +367,7 @@
              HAVING argMax(is_deleted, version) = 0)
           WHERE distinct_id = 'distinct_id_3' ))
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_search_materialized
@@ -406,7 +406,7 @@
              HAVING argMax(is_deleted, version) = 0)
           WHERE distinct_id = 'another@gm' ))
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_search_materialized.1
@@ -445,7 +445,7 @@
              HAVING argMax(is_deleted, version) = 0)
           WHERE distinct_id = 'distinct_id_3' ))
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_search_person_id
@@ -486,7 +486,7 @@
                  HAVING argMax(is_deleted, version) = 0)
               WHERE distinct_id = '00000000-0000-4000-8000-000000000000' )))
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPerson.test_search_person_id_materialized
@@ -527,7 +527,7 @@
                  HAVING argMax(is_deleted, version) = 0)
               WHERE distinct_id = '00000000-0000-4000-8000-000000000000' )))
   ORDER BY argMax(person.created_at, version) DESC, id DESC
-  LIMIT 100
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '
 ---
 # name: TestPersonFromClickhouse.test_filter_person_email
@@ -547,7 +547,7 @@
      AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
      AND has(['another@gmail.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -577,7 +577,7 @@
      AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
      AND has(['another@gmail.com'], "pmat_email")
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -616,7 +616,7 @@
            HAVING argMax(is_deleted, version) = 0)
         where distinct_id = 'distinct_id' )
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -655,7 +655,7 @@
            HAVING argMax(is_deleted, version) = 0)
         where distinct_id = 'another_one' )
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -685,7 +685,7 @@
      AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
      AND has(['another@gmail.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -715,7 +715,7 @@
      AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
      AND has(['inexistent'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -754,7 +754,7 @@
            HAVING argMax(is_deleted, version) = 0)
         where distinct_id = 'inexistent' )
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -789,7 +789,7 @@
      AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
      AND (has(['some_value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'some_prop'), '^"|"$', '')))
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -898,7 +898,7 @@
      AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
      AND (JSONHas(argMax(person.properties, version), 'email'))
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -933,7 +933,7 @@
      AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
      AND (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%another@gm%')
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -968,7 +968,7 @@
      AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
      AND (notEmpty(argMax(person."pmat_email", version)))
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -1003,7 +1003,7 @@
      AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
      AND (argMax(person."pmat_email", version) ILIKE '%another@gm%')
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -1058,7 +1058,7 @@
                 HAVING argMax(is_deleted, version) = 0)
              WHERE distinct_id = 'another@gm' ))
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -1113,7 +1113,7 @@
                 HAVING argMax(is_deleted, version) = 0)
              WHERE distinct_id = 'distinct_id_3' ))
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -1168,7 +1168,7 @@
                 HAVING argMax(is_deleted, version) = 0)
              WHERE distinct_id = 'another@gm' ))
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -1223,7 +1223,7 @@
                 HAVING argMax(is_deleted, version) = 0)
              WHERE distinct_id = 'distinct_id_3' ))
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -1280,7 +1280,7 @@
                     HAVING argMax(is_deleted, version) = 0)
                  WHERE distinct_id = '00000000-0000-4000-8000-000000000000' )))
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -1337,7 +1337,7 @@
                     HAVING argMax(is_deleted, version) = 0)
                  WHERE distinct_id = '00000000-0000-4000-8000-000000000000' )))
      ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100) person
+     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
   LEFT JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id

--- a/posthog/api/test/__snapshots__/test_persons_trends.ambr
+++ b/posthog/api/test/__snapshots__/test_persons_trends.ambr
@@ -77,7 +77,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND event = '$pageview'
        AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-08 00:00:00', 'UTC')), 'UTC')

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -326,7 +326,7 @@
                                           AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%')) )
                                    GROUP BY id
                                    HAVING max(is_deleted) = 0
-                                   AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.com%')))), 1, 0) as step_0,
+                                   AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.com%')) SETTINGS optimize_aggregation_in_order = 1)), 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
@@ -343,7 +343,7 @@
                     FROM person
                     WHERE team_id = 2
                     GROUP BY id
-                    HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                    HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                  WHERE team_id = 2
                    AND event IN ['paid', 'user signed up']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -432,7 +432,7 @@
                     FROM person
                     WHERE team_id = 2
                     GROUP BY id
-                    HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                    HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                  WHERE team_id = 2
                    AND event IN ['paid', 'user signed up']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -540,7 +540,7 @@
                           AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.com%'
                                 AND has(['20'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'age'), '^"|"$', '')))
                                OR (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.org%'
-                                   OR has(['28'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'age'), '^"|"$', ''))))) person ON person.id = pdi.person_id
+                                   OR has(['28'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'age'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                        WHERE team_id = 2
                          AND event IN ['$pageview', 'user signed up']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -643,7 +643,7 @@
                           AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.com%'
                                 AND has(['20'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'age'), '^"|"$', '')))
                                OR (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.org%'
-                                   OR has(['28'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'age'), '^"|"$', ''))))) person ON person.id = pdi.person_id
+                                   OR has(['28'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'age'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                        WHERE team_id = 2
                          AND event IN ['$pageview', 'user signed up']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -750,7 +750,7 @@
                           AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.com%'
                                 AND has(['20'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'age'), '^"|"$', '')))
                                OR (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.org%'
-                                   OR has(['28'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'age'), '^"|"$', ''))))) person ON person.id = pdi.person_id
+                                   OR has(['28'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'age'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                        WHERE team_id = 2
                          AND event IN ['$pageview', 'user signed up']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -857,7 +857,7 @@
                           AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.com%'
                                 AND has(['20'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'age'), '^"|"$', '')))
                                OR (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%.org%'
-                                   OR has(['28'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'age'), '^"|"$', ''))))) person ON person.id = pdi.person_id
+                                   OR has(['28'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'age'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                        WHERE team_id = 2
                          AND event IN ['$pageview', 'user signed up']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -939,7 +939,7 @@
                     FROM person
                     WHERE team_id = 2
                     GROUP BY id
-                    HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                    HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                  WHERE team_id = 2
                    AND event IN ['paid', 'user signed up']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -144,6 +144,7 @@ class PersonQuery:
             {distinct_id_condition} {email_condition}
             {order}
             {limit_offset}
+            SETTINGS optimize_aggregation_in_order = 1
             """,
             {
                 **updated_after_params,

--- a/posthog/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/posthog/queries/test/__snapshots__/test_lifecycle.ambr
@@ -55,7 +55,7 @@
               FROM person
               WHERE team_id = 2
               GROUP BY id
-              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE team_id = 2
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-12 00:00:00', 'UTC'))) - INTERVAL 1 day
@@ -128,7 +128,7 @@
               FROM person
               WHERE team_id = 2
               GROUP BY id
-              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE team_id = 2
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-12 00:00:00', 'UTC'))) - INTERVAL 1 day
@@ -201,7 +201,7 @@
               FROM person
               WHERE team_id = 2
               GROUP BY id
-              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE team_id = 2
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-12 00:00:00', 'US/Pacific'))) - INTERVAL 1 day

--- a/posthog/queries/test/__snapshots__/test_retention.ambr
+++ b/posthog/queries/test/__snapshots__/test_retention.ambr
@@ -251,7 +251,7 @@
            FROM person
            WHERE team_id = 2
            GROUP BY id
-           HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+           HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 00:00:00', 'UTC')
@@ -282,7 +282,7 @@
            FROM person
            WHERE team_id = 2
            GROUP BY id
-           HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+           HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND ((event = '$pageview'
                 AND (has(['person1@test.com'], replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '')))))

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -63,7 +63,7 @@
                   AND (has(['x'], replaceRegexpAll(JSONExtractRaw(properties, '$bool_prop'), '^"|"$', ''))) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (has(['x'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$bool_prop'), '^"|"$', '')))) person ON person.id = pdi.person_id
+           AND (has(['x'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$bool_prop'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND ((event = 'sign up'
                 AND (pdi.person_id IN
@@ -560,7 +560,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND ((event = '$pageview'
              AND (has(['p1', 'p2', 'p3'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))
@@ -575,7 +575,7 @@
                             AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', '')))) )
                      GROUP BY id
                      HAVING max(is_deleted) = 0
-                     AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))))))
+                     AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1))))
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
      GROUP BY value
@@ -643,7 +643,7 @@
                     FROM person
                     WHERE team_id = 2
                     GROUP BY id
-                    HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                    HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                  WHERE e.team_id = 2
                    AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-25 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
@@ -660,7 +660,7 @@
                                         AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', '')))) )
                                  GROUP BY id
                                  HAVING max(is_deleted) = 0
-                                 AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))))))
+                                 AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1))))
                  GROUP BY timestamp, person_id,
                                      breakdown_value) e
               WHERE e.timestamp <= d.timestamp
@@ -1065,7 +1065,7 @@
                   AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', ''))) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
+           AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND event = 'event_name'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-26 00:00:00', 'UTC')), 'UTC')
@@ -1268,7 +1268,7 @@
                AND (has(['filter_val'], replaceRegexpAll(JSONExtractRaw(properties, 'filter_prop'), '^"|"$', ''))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND (has(['filter_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'filter_prop'), '^"|"$', '')))) person ON pdi.person_id = person.id
+        AND (has(['filter_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'filter_prop'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = 'sign up'
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
@@ -1344,7 +1344,7 @@
                            AND (has(['filter_val'], replaceRegexpAll(JSONExtractRaw(properties, 'filter_prop'), '^"|"$', ''))) )
                     GROUP BY id
                     HAVING max(is_deleted) = 0
-                    AND (has(['filter_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'filter_prop'), '^"|"$', '')))) person ON person.id = pdi.person_id
+                    AND (has(['filter_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'filter_prop'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
                  WHERE e.team_id = 2
                    AND event = 'sign up'
                    AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-28 00:00:00', 'UTC')
@@ -1524,7 +1524,7 @@
                             AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, '$some_prop'), '^"|"$', '')))) )
                      GROUP BY id
                      HAVING max(is_deleted) = 0
-                     AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))
+                     AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1))))
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
      GROUP BY value
@@ -1587,7 +1587,7 @@
                                   AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, '$some_prop'), '^"|"$', '')))) )
                            GROUP BY id
                            HAVING max(is_deleted) = 0
-                           AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))
+                           AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1))))
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,
@@ -1625,7 +1625,7 @@
                             AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, '$some_prop'), '^"|"$', '')))) )
                      GROUP BY id
                      HAVING max(is_deleted) = 0
-                     AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))
+                     AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1))))
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
        AND notEmpty(e.person_id)
@@ -1689,7 +1689,7 @@
                                   AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, '$some_prop'), '^"|"$', '')))) )
                            GROUP BY id
                            HAVING max(is_deleted) = 0
-                           AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))))
+                           AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1))))
              AND notEmpty(e.person_id)
            GROUP BY day_start,
                     breakdown_value))
@@ -1736,7 +1736,7 @@
                   AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', ''))) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
+           AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND event = 'watched movie'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
@@ -1781,7 +1781,7 @@
                   AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', ''))) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
+           AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND event = 'watched movie'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
@@ -1853,7 +1853,7 @@
                   AND (has(['person1'], "pmat_name")) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (has(['person1'], argMax(person."pmat_name", version)))) person ON person.id = pdi.person_id
+           AND (has(['person1'], argMax(person."pmat_name", version))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND event = 'watched movie'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
@@ -1925,7 +1925,7 @@
                   AND (has(['person1'], "pmat_name")) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (has(['person1'], argMax(person."pmat_name", version)))) person ON person.id = pdi.person_id
+           AND (has(['person1'], argMax(person."pmat_name", version))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND event = 'watched movie'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
@@ -3338,7 +3338,7 @@
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$os'), '^"|"$', '')))
-              OR (has(['safari'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '')))))) person ON pdi.person_id = person.id
+              OR (has(['safari'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', ''))))) SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = 'sign up'
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -3403,7 +3403,7 @@
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$os'), '^"|"$', '')))
-                    OR (has(['safari'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '')))))) person ON person.id = pdi.person_id
+                    OR (has(['safari'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', ''))))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE e.team_id = 2
              AND event = 'sign up'
              AND (((NOT (replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))
@@ -3452,7 +3452,7 @@
         HAVING max(is_deleted) = 0
         AND ((((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$os'), '^"|"$', '')))
                AND (has(['chrome'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '')))))
-             AND (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))) person ON pdi.person_id = person.id
+             AND (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%@posthog.com%')) SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = 'sign up'
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -3518,7 +3518,7 @@
               HAVING max(is_deleted) = 0
               AND ((((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$os'), '^"|"$', '')))
                      AND (has(['chrome'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$browser'), '^"|"$', '')))))
-                   AND (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))) person ON person.id = pdi.person_id
+                   AND (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%@posthog.com%')) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE e.team_id = 2
              AND event = 'sign up'
              AND ((has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', ''))))
@@ -3596,7 +3596,7 @@
                   AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, '$some_prop'), '^"|"$', ''))) )
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))) person ON person.id = pdi.person_id
+           AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND event = 'sign up'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), 'UTC')
@@ -3627,7 +3627,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = 'sign up'
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2019-12-24 00:00:00', 'UTC')
@@ -3682,7 +3682,7 @@
               FROM person
               WHERE team_id = 2
               GROUP BY id
-              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE e.team_id = 2
              AND event = 'sign up'
              AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), 'UTC')
@@ -4326,7 +4326,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
      WHERE team_id = 2
        AND event = 'viewed video'
        AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
@@ -4375,7 +4375,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = 'viewed video'
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
@@ -4408,7 +4408,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
      WHERE e.team_id = 2
        AND event = 'viewed video'
        AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
@@ -4451,7 +4451,7 @@
               FROM person
               WHERE team_id = 2
               GROUP BY id
-              HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+              HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
            WHERE team_id = 2
              AND event = 'viewed video'
              AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
@@ -4577,7 +4577,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      INNER JOIN
        (SELECT "$session_id",
                dateDiff('second', min(timestamp), max(timestamp)) as session_duration
@@ -4623,7 +4623,7 @@
            FROM person
            WHERE team_id = 2
            GROUP BY id
-           HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+           HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         INNER JOIN
           (SELECT "$session_id",
                   dateDiff('second', min(timestamp), max(timestamp)) as session_duration
@@ -5225,7 +5225,7 @@
                         AND (has(['person-1', 'person-2'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', ''))) )
                  GROUP BY id
                  HAVING max(is_deleted) = 0
-                 AND (has(['person-1', 'person-2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
+                 AND (has(['person-1', 'person-2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
               WHERE team_id = 2
                 AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-25 00:00:00', 'UTC')
@@ -5286,7 +5286,7 @@
                         AND (has(['person-1', 'person-2'], "pmat_name")) )
                  GROUP BY id
                  HAVING max(is_deleted) = 0
-                 AND (has(['person-1', 'person-2'], argMax(person."pmat_name", version)))) person ON person.id = pdi.person_id
+                 AND (has(['person-1', 'person-2'], argMax(person."pmat_name", version))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
               WHERE team_id = 2
                 AND event = '$pageview'
                 AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-25 00:00:00', 'UTC')

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -267,7 +267,7 @@
                              AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, '$some_prop'), '^"|"$', '')))) )
                       GROUP BY id
                       HAVING max(is_deleted) = 0
-                      AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))))
+                      AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1)
                  UNION ALL SELECT DISTINCT distinct_id,
                                            0 as value
                  FROM events all_events
@@ -336,7 +336,7 @@
                              AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, '$some_prop'), '^"|"$', '')))) )
                       GROUP BY id
                       HAVING max(is_deleted) = 0
-                      AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))))
+                      AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1)
                  UNION ALL SELECT DISTINCT distinct_id,
                                            0 as value
                  FROM events all_events
@@ -378,7 +378,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = 'session start'
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
@@ -410,7 +410,7 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
+        HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = 'session start'
        AND toTimeZone(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
@@ -469,7 +469,7 @@
                  FROM person
                  WHERE team_id = 2
                  GROUP BY id
-                 HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                 HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
               WHERE e.team_id = 2
                 AND event = 'session start'
                 AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
@@ -525,7 +525,7 @@
                  FROM person
                  WHERE team_id = 2
                  GROUP BY id
-                 HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                 HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
               WHERE e.team_id = 2
                 AND event = 'session start'
                 AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Hits to the api/persons endpoint are slow. Hopefully we'll replace this code with Marius' HogQL work, but do this in the meantime.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Make them _fast_ using https://clickhouse.com/docs/en/sql-reference/statements/select/group-by#group-by-optimization-depending-on-table-sorting-key

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
