### PR TITLE
chore: log slow warnings relative to external request timeout

### DIFF
--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -364,12 +364,15 @@ export class HookCommander {
         const message = this.formatMessage(webhookUrl, action, event, team)
         end()
 
+        const slowWarningTimeout = this.EXTERNAL_REQUEST_TIMEOUT * 0.7
         const timeout = setTimeout(() => {
             status.warn(
                 '⌛',
-                `Posting Webhook slow. Timeout warning after 5 sec! url=${webhookUrl} team_id=${team.id} event_id=${event.eventUuid}`
+                `Posting Webhook slow. Timeout warning after ${
+                    slowWarningTimeout / 1000
+                } sec! url=${webhookUrl} team_id=${team.id} event_id=${event.eventUuid}`
             )
-        }, 5000)
+        }, slowWarningTimeout)
         const relevantFetch =
             isCloud() && (!this.fetchHostnameGuardTeams || this.fetchHostnameGuardTeams.has(team.id))
                 ? safeTrackedFetch
@@ -443,12 +446,15 @@ export class HookCommander {
             data: { ...data, person: sendablePerson },
         }
 
+        const slowWarningTimeout = this.EXTERNAL_REQUEST_TIMEOUT * 0.7
         const timeout = setTimeout(() => {
             status.warn(
                 '⌛',
-                `Posting RestHook slow. Timeout warning after 5 sec! url=${hook.target} team_id=${event.teamId} event_id=${event.eventUuid}`
+                `Posting RestHook slow. Timeout warning after ${slowWarningTimeout / 1000} sec! url=${
+                    hook.target
+                } team_id=${event.teamId} event_id=${event.eventUuid}`
             )
-        }, 5000)
+        }, slowWarningTimeout)
         const relevantFetch =
             isCloud() && (!this.fetchHostnameGuardTeams || this.fetchHostnameGuardTeams.has(hook.team_id))
                 ? safeTrackedFetch


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Forgot about this, if we're chaning the timeout to 3s, then 5s slow warning would be useless

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
