### PR TITLE
fix(plugin-server): applyEventPropertyUpdates returns whether it did …

### DIFF
--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -244,16 +244,24 @@ describe('PersonState.update()', () => {
 
     describe('on person update', () => {
         it('updates person properties', async () => {
-            await hub.db.createPerson(timestamp, { b: 3, c: 4 }, {}, {}, teamId, null, false, uuid.toString(), [
-                'new-user',
-            ])
+            await hub.db.createPerson(
+                timestamp,
+                { b: 3, c: 4, toString: {} },
+                {},
+                {},
+                teamId,
+                null,
+                false,
+                uuid.toString(),
+                ['new-user']
+            )
 
             const person = await personState({
                 event: '$pageview',
                 distinct_id: 'new-user',
                 properties: {
                     $set_once: { c: 3, e: 4 },
-                    $set: { b: 4 },
+                    $set: { b: 4, toString: 1 },
                 },
             }).updateProperties()
             await hub.db.kafkaProducer.flush()
@@ -262,7 +270,7 @@ describe('PersonState.update()', () => {
                 expect.objectContaining({
                     id: expect.any(Number),
                     uuid: uuid.toString(),
-                    properties: { b: 4, c: 4, e: 4 },
+                    properties: { b: 4, c: 4, e: 4, toString: 1 },
                     created_at: timestamp,
                     version: 1,
                     is_identified: false,


### PR DESCRIPTION
…an update, rather than needing to use deep-equals

## Problem

Our use of `fast-deep-equal` trips up on some types: https://posthog.sentry.io/issues/4524975934/?alert_rule_id=12777331&alert_type=issue&notification_uuid=b1b2d9cd-208d-437a-9189-0d1106fb732a&project=6423401&referrer=slack

It turns out that event is trying to `$set` a field to an object that literally contains a `toString` key. This trips up `fast-deep-equal`.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

The object copy and `fast-deep-equal` comparison wasn't getting us anything that a simple bool doesn't, so just use a bool.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Existing behavior/tests are expected.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
