### PR TITLE
feat: Webhook metrics API

### DIFF
--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -128,6 +128,7 @@ app_metrics_router.register(
     "historical_exports",
     ["team_id", "plugin_config_id"],
 )
+webhooks_metrics_router = projects_router.register("webhooks", app_metrics.WebhooksViewSet, "webhooks", ["team_id"])
 
 batch_exports_router = projects_router.register(
     r"batch_exports", batch_exports.BatchExportViewSet, "batch_exports", ["team_id"]

--- a/posthog/api/app_metrics.py
+++ b/posthog/api/app_metrics.py
@@ -2,25 +2,29 @@ from typing import Any
 
 from rest_framework import mixins, request, response, viewsets
 from rest_framework.decorators import action
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.models.plugin import PluginConfig
 from posthog.queries.app_metrics.app_metrics import AppMetricsErrorDetailsQuery, AppMetricsErrorsQuery, AppMetricsQuery
 from posthog.queries.app_metrics.historical_exports import historical_export_metrics, historical_exports_activity
-from posthog.queries.app_metrics.serializers import AppMetricsErrorsRequestSerializer, AppMetricsRequestSerializer
+from posthog.queries.app_metrics.serializers import (
+    AppMetricsErrorsRequestSerializer,
+    AppMetricsRequestSerializer,
+    WebhooksMetricsRequestSerializer,
+)
 
 
-class AppMetricsViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
-    queryset = PluginConfig.objects.all()
-
-    def retrieve(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
-        plugin_config = self.get_object()
-
-        filter = AppMetricsRequestSerializer(data=request.query_params)
+class WebhooksViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        filter = WebhooksMetricsRequestSerializer(data=request.query_params)
         filter.is_valid(raise_exception=True)
+        ch_id = filter.validated_data.get("ch_id")
+        date_from = filter.validated_data.get("date_from")
 
-        metric_results = AppMetricsQuery(self.team, plugin_config.pk, filter).run()
-        errors = AppMetricsErrorsQuery(self.team, plugin_config.pk, filter).run()
+        metric_results = AppMetricsQuery(self.team, ch_id, "webhook", date_from).run()
+        errors = AppMetricsErrorsQuery(self.team, ch_id, "webhook", date_from).run()
         return response.Response({"metrics": metric_results, "errors": errors})
 
     @action(methods=["GET"], detail=True)
@@ -31,6 +35,37 @@ class AppMetricsViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, views
         filter.is_valid(raise_exception=True)
 
         error_details = AppMetricsErrorDetailsQuery(self.team, plugin_config.pk, filter).run()
+        return response.Response({"result": error_details})
+
+
+class AppMetricsViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    queryset = PluginConfig.objects.all()
+
+    def retrieve(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
+        plugin_config = self.get_object()
+
+        filter = AppMetricsRequestSerializer(data=request.query_params)
+        filter.is_valid(raise_exception=True)
+        job_id = filter.validated_data.get("job_id")
+        category = filter.validated_data.get("category")
+        date_from = filter.validated_data.get("date_from")
+        date_to = filter.validated_data.get("date_to")
+
+        metric_results = AppMetricsQuery(self.team, plugin_config.pk, category, date_from, date_to, job_id).run()
+        errors = AppMetricsErrorsQuery(self.team, plugin_config.pk, category, date_from, date_to, job_id).run()
+        return response.Response({"metrics": metric_results, "errors": errors})
+
+    @action(methods=["GET"], detail=True)
+    def error_details(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
+        plugin_config = self.get_object()
+
+        filter = AppMetricsErrorsRequestSerializer(data=request.query_params)
+        filter.is_valid(raise_exception=True)
+        category = filter.validated_data.get("category")
+        error_type = filter.validated_data.get("error_type")
+        job_id = filter.validated_data.get("job_id")
+
+        error_details = AppMetricsErrorDetailsQuery(self.team, plugin_config.pk, category, error_type, job_id).run()
         return response.Response({"result": error_details})
 
 

--- a/posthog/queries/app_metrics/historical_exports.py
+++ b/posthog/queries/app_metrics/historical_exports.py
@@ -74,8 +74,9 @@ def historical_export_metrics(team: Team, plugin_config_id: int, job_id: str):
 
     filter = AppMetricsRequestSerializer(data=filter_data)
     filter.is_valid(raise_exception=True)
-    metric_results = AppMetricsQuery(team, plugin_config_id, filter).run()
-    errors = AppMetricsErrorsQuery(team, plugin_config_id, filter).run()
+    job_id = filter.validated_data.get("job_id")
+    metric_results = AppMetricsQuery(team, plugin_config_id, filter, job_id).run()
+    errors = AppMetricsErrorsQuery(team, plugin_config_id, filter, job_id).run()
 
     return {"summary": export_summary, "metrics": metric_results, "errors": errors}
 

--- a/posthog/queries/app_metrics/serializers.py
+++ b/posthog/queries/app_metrics/serializers.py
@@ -1,6 +1,14 @@
 from rest_framework import serializers
 
 
+class WebhooksMetricsRequestSerializer(serializers.Serializer):
+    date_from = serializers.CharField(
+        default="-30d",
+        help_text="What date to filter the results from. Can either be a date `2021-01-01`, or a relative date, like `-7d` for last seven days, `-1m` for last month, `mStart` for start of the month or `yStart` for the start of the year.",
+    )
+    ch_id = serializers.IntegerField(help_text="What ClickHouse plugin_config_id to filter the results to.")
+
+
 class AppMetricsRequestSerializer(serializers.Serializer):
     category = serializers.ChoiceField(
         # Keep in sync with plugin-server/src/worker/ingestion/app-metrics.ts


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We have app metrics for webhooks now, would be cool to show them to the users too, so step (1) is api to be able to query.
Note that we're using -2 = webhooks, -1 = resthooks as hardcoded values.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

I'm not sure why I need to provide the second number to the api requests, even though it's not used.

<img width="594" alt="Screenshot 2023-10-05 at 21 39 37" src="https://github.com/PostHog/posthog/assets/890921/02ce54a3-c8db-44d1-8333-234d888e6a48">

