### PR TITLE
fix(s3-batch-exports): Do not abort s3 upload

### DIFF
--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -230,10 +230,6 @@ class S3MultiPartUpload:
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback) -> bool:
-        if exc_type == asyncio.CancelledError:
-            # Ensure we clean-up the cancelled upload.
-            await self.abort()
-
         return False
 
 


### PR DESCRIPTION
## Problem

We are aborting and/or completing s3 uploads too eagerly. Let's remove them from the context manager while we investigate. This should aid users that have long running exports.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Do not abort s3 upload on exiting context manager.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
