### PR TITLE
chore: add commit hash file to the built docker image

### DIFF
--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -33,6 +33,7 @@ runs:
               load: ${{ inputs.load }}
               tags: ${{ steps.emit.outputs.tag }}
               platforms: linux/amd64,linux/arm64
+              build-args: COMMIT_HASH=${{ github.sha }}
           env:
               ACTIONS_ID_TOKEN_REQUEST_URL: ${{ inputs.actions-id-token-request-url }}
 
@@ -45,5 +46,6 @@ runs:
               file: production-unit.Dockerfile
               tags: ${{ steps.emit.outputs.tag }}
               platforms: linux/amd64
+              build-args: COMMIT_HASH=${{ github.sha }}
           env:
               ACTIONS_ID_TOKEN_REQUEST_URL: ${{ inputs.actions-id-token-request-url }}

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -70,6 +70,7 @@ jobs:
                   push: true
                   tags: posthog/posthog:${{ github.sha }},posthog/posthog:latest,${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:master
                   platforms: linux/arm64,linux/amd64
+                  build-args: COMMIT_HASH=${{ github.sha }}
 
             - name: Build and push unit container image
               id: build-unit
@@ -80,6 +81,7 @@ jobs:
                   file: production-unit.Dockerfile
                   tags: ${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:unit
                   platforms: linux/amd64
+                  build-args: COMMIT_HASH=${{ github.sha }}
 
             - name: get deployer token
               id: deployer

--- a/production-unit.Dockerfile
+++ b/production-unit.Dockerfile
@@ -168,6 +168,10 @@ RUN groupadd -g 1000 posthog && \
     chown posthog:posthog /code
 USER posthog
 
+# Add the commit hash
+ARG COMMIT_HASH
+RUN echo $COMMIT_HASH > /code/commit.txt
+
 # Add in the compiled plugin-server & its runtime dependencies from the plugin-server-build stage.
 COPY --from=plugin-server-build --chown=posthog:posthog /code/plugin-server/dist /code/plugin-server/dist
 COPY --from=plugin-server-build --chown=posthog:posthog /code/plugin-server/node_modules /code/plugin-server/node_modules

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -1,7 +1,7 @@
 #
 # This Dockerfile is used for self-hosted production builds.
 #
-# PostHog has sunset support for self-hosted K8s deployments. 
+# PostHog has sunset support for self-hosted K8s deployments.
 # See: https://posthog.com/blog/sunsetting-helm-support-posthog
 #
 # Note: for PostHog Cloud remember to update ‘Dockerfile.cloud’ as appropriate.
@@ -167,6 +167,10 @@ RUN groupadd -g 1000 posthog && \
     useradd -u 999 -r -g posthog posthog && \
     chown posthog:posthog /code
 USER posthog
+
+# Add the commit hash
+ARG COMMIT_HASH
+RUN echo $COMMIT_HASH > /code/commit.txt
 
 # Add in the compiled plugin-server & its runtime dependencies from the plugin-server-build stage.
 COPY --from=plugin-server-build --chown=posthog:posthog /code/plugin-server/dist /code/plugin-server/dist


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
plugin-server Sentry doesn't configure the `release`, which is the git hash. I'd like to read this file to set the `release` on startup. It doesn't hurt to have it available for other uses, either.

## Changes

Add `commit.txt` to `/code` in Docker images

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
