### PR TITLE
chore: remove unused prop and CSS

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -205,7 +205,7 @@ export function InsightContainer({
             ) : null}
             {/* These are filters that are reused between insight features. They each have generic logic that updates the url */}
             <Card
-                title={disableHeader ? null : <InsightDisplayConfig disableTable={!!disableTable} />}
+                title={disableHeader ? null : <InsightDisplayConfig />}
                 data-attr="insights-graph"
                 className="insights-graph-container"
                 bordered={!embedded}

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -24,11 +24,7 @@ import { axisLabel } from 'scenes/insights/aggregationAxisFormat'
 import { ChartDisplayType } from '~/types'
 import { ShowLegendFilter } from 'scenes/insights/EditorFilters/ShowLegendFilter'
 
-interface InsightDisplayConfigProps {
-    disableTable: boolean
-}
-
-export function InsightDisplayConfig({ disableTable }: InsightDisplayConfigProps): JSX.Element {
+export function InsightDisplayConfig(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const {
         showDateRange,
@@ -90,7 +86,7 @@ export function InsightDisplayConfig({ disableTable }: InsightDisplayConfigProps
     return (
         <div className="flex justify-between items-center flex-wrap" data-attr="insight-filters">
             <div className="flex items-center space-x-2 flex-wrap my-2 gap-y-2">
-                {showDateRange && !disableTable && (
+                {showDateRange && (
                     <ConfigFilter>
                         <InsightDateFilter disabled={disableDateRange} />
                     </ConfigFilter>

--- a/frontend/src/scenes/experiments/Experiment.scss
+++ b/frontend/src/scenes/experiments/Experiment.scss
@@ -17,29 +17,6 @@
     .insights-graph-container {
         margin-bottom: 1rem;
 
-        .ant-card-head {
-            border-bottom: 1px solid var(--border);
-            min-height: unset;
-            background-color: var(--bg-light);
-            padding-left: 1rem;
-            padding-right: 1rem;
-
-            .ant-card-head-title {
-                padding: 0.5rem 0;
-
-                span.filter {
-                    font-size: 14px;
-
-                    &:not(:last-child) {
-                        margin-right: 0.5rem;
-                    }
-
-                    span.head-title-item {
-                        margin-right: 0.5rem;
-                    }
-                }
-            }
-        }
         .display-config-inner {
             display: flex;
             align-items: center;


### PR DESCRIPTION
## Problem

We are conditionally showing the date filter based on the presence of the detailed results table which means it does not show when the header is rendered in notebooks. Based on https://github.com/PostHog/posthog/pull/7606#discussion_r768620964 and from chatting with @neilkakkar 

## Changes

- The header is never rendered in Experiments so this prop was redundant
- Removing some custom CSS that only applies to headers then too

## How did you test this code?

Insights on experiments have not changed

Before
<img width="1345" alt="before" src="https://github.com/PostHog/posthog/assets/6685876/b035f2d7-a794-4313-9527-b727857d9788">
<img width="1048" alt="before2" src="https://github.com/PostHog/posthog/assets/6685876/4abcb5ae-0fce-49ef-a8ee-1339155749df">

After
<img width="1349" alt="after" src="https://github.com/PostHog/posthog/assets/6685876/f5dce51b-fe0e-4bdc-b316-38f56fb01429">
<img width="1048" alt="after2" src="https://github.com/PostHog/posthog/assets/6685876/b0529a81-16be-43c7-a58d-175df93fa46c">
