### PR TITLE
feat(feature-flags): calculate variant in hogql

### DIFF
--- a/posthog/hogql/functions/__init__.py
+++ b/posthog/hogql/functions/__init__.py
@@ -9,6 +9,7 @@ from .mapping import (
 )
 from .cohort import cohort
 from .sparkline import sparkline
+from .flag_variant import flag_variant
 
 __all__ = [
     "validate_function_args",
@@ -20,4 +21,5 @@ __all__ = [
     "FIRST_ARG_DATETIME_FUNCTIONS",
     "cohort",
     "sparkline",
+    "flag_variant",
 ]

--- a/posthog/hogql/functions/flag_variant.py
+++ b/posthog/hogql/functions/flag_variant.py
@@ -39,7 +39,9 @@ def flag_variant(node: ast.Expr, args: List[ast.Expr], context: HogQLContext) ->
                     "{v} < {max}",
                     placeholders={
                         "v": variant_uint64,
-                        "max": ast.Constant(value=variant_min + variant["rollout_percentage"] / 100),
+                        "max": ast.Constant(
+                            value=(variant_min + variant["rollout_percentage"] / 100) * float(0xFFFFFFFFFFFFFFF)
+                        ),
                     },
                 )
                 variant_min = variant_min + variant["rollout_percentage"] / 100

--- a/posthog/hogql/functions/flag_variant.py
+++ b/posthog/hogql/functions/flag_variant.py
@@ -1,0 +1,53 @@
+from typing import List
+
+from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.errors import HogQLException
+from posthog.hogql.parser import parse_expr
+
+
+def flag_variant(node: ast.Expr, args: List[ast.Expr], context: HogQLContext) -> ast.Expr:
+    flag_key = args[0]
+    distinct_id = args[1]
+    if not isinstance(flag_key, ast.Constant):
+        raise HogQLException("flag_variant(flag_key, distinct_id) takes only a constant for flag_key", node=flag_key)
+
+    from posthog.models import FeatureFlag
+
+    if isinstance(flag_key.value, str):
+        feature_flags = FeatureFlag.objects.filter(key=flag_key.value, team_id=context.team_id)
+        if len(feature_flags) == 1:
+            feature_flag = feature_flags[0]
+            variants = feature_flag.variants
+
+            if len(variants) == 0:
+                return ast.Constant(value=None)
+
+            variant_uint64 = parse_expr(
+                "reinterpretAsUInt64(reverse(unhex(substring(SHA1(concat({key}, '.', {distinct_id}, {salt})), 1, 15))))",
+                placeholders={
+                    "key": ast.Constant(value=feature_flag.key),
+                    "distinct_id": distinct_id,
+                    "salt": ast.Constant(value=""),
+                },
+            )
+
+            variant_min = 0
+            args = []
+            for variant in variants:
+                condition = parse_expr(
+                    "{v} < {max}",
+                    placeholders={
+                        "v": variant_uint64,
+                        "max": ast.Constant(value=variant_min + variant["rollout_percentage"] / 100),
+                    },
+                )
+                variant_min = variant_min + variant["rollout_percentage"] / 100
+                args.append(condition)
+                args.append(ast.Constant(value=variant["key"]))
+
+            return ast.Call(name="multiIf", args=[*args, ast.Constant(value=None)])
+
+        raise HogQLException(f"Could not find feature flag with key '{flag_key.value}'", node=flag_key)
+
+    raise HogQLException("The first argument to flag_variant() must be a string", node=flag_key)

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -156,6 +156,8 @@ HOGQL_CLICKHOUSE_FUNCTIONS: Dict[str, HogQLFunctionMeta] = {
     "toJSONString": HogQLFunctionMeta("toJSONString", 1, 1),
     "parseDateTime": HogQLFunctionMeta("parseDateTimeOrNull", 2, 2, tz_aware=True),
     "parseDateTimeBestEffort": HogQLFunctionMeta("parseDateTime64BestEffortOrNull", 1, 1, tz_aware=True),
+    "unhex": HogQLFunctionMeta("unhex", 1, 1),
+    "reinterpretAsUInt64": HogQLFunctionMeta("reinterpretAsUInt64", 1, 1),
     # dates and times
     "toTimeZone": HogQLFunctionMeta("toTimeZone", 2, 2),
     "timeZoneOf": HogQLFunctionMeta("timeZoneOf", 1, 1),
@@ -547,6 +549,8 @@ HOGQL_CLICKHOUSE_FUNCTIONS: Dict[str, HogQLFunctionMeta] = {
     "nth_value": HogQLFunctionMeta("nth_value", 2, 2),
     "lagInFrame": HogQLFunctionMeta("lagInFrame", 1, 1),
     "leadInFrame": HogQLFunctionMeta("leadInFrame", 1, 1),
+    # misc
+    "SHA1": HogQLFunctionMeta("SHA1", 1, 1),
 }
 # Permitted HogQL aggregations
 HOGQL_AGGREGATIONS: Dict[str, HogQLFunctionMeta] = {
@@ -721,6 +725,7 @@ HOGQL_AGGREGATIONS: Dict[str, HogQLFunctionMeta] = {
 }
 HOGQL_POSTHOG_FUNCTIONS: Dict[str, HogQLFunctionMeta] = {
     "sparkline": HogQLFunctionMeta("sparkline", 1, 1),
+    "flag_variant": HogQLFunctionMeta("flag_variant", 2, 2),
 }
 
 # TODO: Make the below details part of function meta

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -9,6 +9,7 @@ from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import StringJSONDatabaseField, FunctionCallTable, LazyTable, SavedQuery
 from posthog.hogql.errors import ResolverException
 from posthog.hogql.functions.cohort import cohort
+from posthog.hogql.functions.flag_variant import flag_variant
 from posthog.hogql.functions.mapping import validate_function_args
 from posthog.hogql.functions.sparkline import sparkline
 from posthog.hogql.parser import parse_select
@@ -315,6 +316,8 @@ class Resolver(CloningVisitor):
             validate_function_args(node.args, func_meta.min_args, func_meta.max_args, node.name)
             if node.name == "sparkline":
                 return self.visit(sparkline(node=node, args=node.args))
+            if node.name == "flag_variant":
+                return self.visit(flag_variant(node=node, args=node.args, context=self.context))
 
         node = super().visit_call(node)
         arg_types: List[ast.ConstantType] = []


### PR DESCRIPTION
## Problem

A user wants to see the feature flag's variant for a distinct_id in HogQL for further analysis.

## Changes

Adds a `flag_variant(flag_key: str, distinct_id: ast.Expr)` function that does just that

## How did you test this code?

I didn't. I need multivariate flags locally to test this.