### PR TITLE
feat(web-analytics): Fix top pages sql and add some extra insights

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -2,6 +2,7 @@ import { actions, connect, kea, listeners, path, reducers, selectors, sharedList
 
 import type { webAnalyticsLogicType } from './webAnalyticsLogicType'
 import { NodeKind, QuerySchema } from '~/queries/schema'
+import { BaseMathType, ChartDisplayType } from '~/types'
 
 interface Layout {
     colSpan?: number
@@ -56,6 +57,62 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         source: {
                             kind: NodeKind.WebTopSourcesQuery,
                             filters: {},
+                        },
+                    },
+                },
+                {
+                    layout: {
+                        colSpan: 6,
+                    },
+                    query: {
+                        kind: NodeKind.InsightVizNode,
+                        source: {
+                            filterTestAccounts: false,
+                            interval: 'day',
+                            kind: NodeKind.TrendsQuery,
+                            series: [
+                                {
+                                    event: '$pageview',
+                                    kind: NodeKind.EventsNode,
+                                    math: BaseMathType.UniqueUsers,
+                                    name: '$pageview',
+                                },
+                            ],
+                            trendsFilter: {
+                                compare: true,
+                                display: ChartDisplayType.ActionsLineGraph,
+                            },
+                        },
+                    },
+                },
+                {
+                    layout: {
+                        colSpan: 6,
+                    },
+                    query: {
+                        kind: NodeKind.InsightVizNode,
+                        source: {
+                            breakdown: {
+                                breakdown: '$geoip_country_code',
+                                breakdown_type: 'person',
+                            },
+                            dateRange: {
+                                date_from: '-7d',
+                                date_to: null,
+                            },
+                            filterTestAccounts: true,
+                            kind: NodeKind.TrendsQuery,
+                            series: [
+                                {
+                                    event: '$pageview',
+                                    kind: NodeKind.EventsNode,
+                                    math: BaseMathType.UniqueUsers,
+                                    name: '$pageview',
+                                },
+                            ],
+                            trendsFilter: {
+                                display: ChartDisplayType.WorldMap,
+                            },
                         },
                     },
                 },

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -67,9 +67,12 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     query: {
                         kind: NodeKind.InsightVizNode,
                         source: {
-                            filterTestAccounts: false,
-                            interval: 'day',
                             kind: NodeKind.TrendsQuery,
+                            dateRange: {
+                                date_from: '-7d',
+                                date_to: '-1d',
+                            },
+                            interval: 'day',
                             series: [
                                 {
                                     event: '$pageview',
@@ -82,6 +85,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 compare: true,
                                 display: ChartDisplayType.ActionsLineGraph,
                             },
+                            filterTestAccounts: true,
                         },
                     },
                 },
@@ -92,27 +96,25 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     query: {
                         kind: NodeKind.InsightVizNode,
                         source: {
+                            kind: NodeKind.TrendsQuery,
                             breakdown: {
                                 breakdown: '$geoip_country_code',
                                 breakdown_type: 'person',
                             },
                             dateRange: {
                                 date_from: '-7d',
-                                date_to: null,
                             },
-                            filterTestAccounts: true,
-                            kind: NodeKind.TrendsQuery,
                             series: [
                                 {
                                     event: '$pageview',
                                     kind: NodeKind.EventsNode,
                                     math: BaseMathType.UniqueUsers,
-                                    name: '$pageview',
                                 },
                             ],
                             trendsFilter: {
                                 display: ChartDisplayType.WorldMap,
                             },
+                            filterTestAccounts: true,
                         },
                     },
                 },

--- a/posthog/hogql_queries/web_analytics/ctes.py
+++ b/posthog/hogql_queries/web_analytics/ctes.py
@@ -62,7 +62,7 @@ PATHNAME_CTE = """
 SELECT
     events.properties.`$pathname` AS pathname,
     count() as total_pageviews,
-    uniq(events.properties.person_id) as unique_visitors -- might want to use person id? have seen a small number of pages where unique > total
+    uniq(events.person_id) as unique_visitors -- might want to use person id? have seen a small number of pages where unique > total
 FROM
     events
 WHERE

--- a/posthog/hogql_queries/web_analytics/ctes.py
+++ b/posthog/hogql_queries/web_analytics/ctes.py
@@ -62,7 +62,7 @@ PATHNAME_CTE = """
 SELECT
     events.properties.`$pathname` AS pathname,
     count() as total_pageviews,
-    uniq(events.properties.distinct_id) as unique_visitors -- might want to use person id? have seen a small number of pages where unique > total
+    uniq(events.properties.person_id) as unique_visitors -- might want to use person id? have seen a small number of pages where unique > total
 FROM
     events
 WHERE

--- a/posthog/hogql_queries/web_analytics/ctes.py
+++ b/posthog/hogql_queries/web_analytics/ctes.py
@@ -60,9 +60,20 @@ HAVING
 
 PATHNAME_CTE = """
 SELECT
+    events.properties.`$pathname` AS pathname,
+    count() as total_pageviews,
+    uniq(events.properties.distinct_id) as unique_visitors -- might want to use person id? have seen a small number of pages where unique > total
+FROM
+    events
+WHERE
+    (event = '$pageview')
+    AND events.timestamp >= now() - INTERVAL 7 DAY
+GROUP BY pathname
+"""
+
+PATHNAME_SCROLL_CTE = """
+SELECT
     events.properties.`$prev_pageview_pathname` AS pathname,
-    countIf(events.event == '$pageview') as total_pageviews,
-    COUNT(DISTINCT events.properties.distinct_id) as unique_visitors, -- might want to use person id? have seen a small number of pages where unique > total
     avg(CASE
         WHEN toFloat(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage')) IS NULL THEN NULL
         WHEN toFloat(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage')) > 0.8 THEN 100

--- a/posthog/hogql_queries/web_analytics/overview_stats.py
+++ b/posthog/hogql_queries/web_analytics/overview_stats.py
@@ -22,8 +22,8 @@ class WebOverviewStatsQueryRunner(WebAnalyticsQueryRunner):
             overview_stats_query = parse_select(
                 """
 SELECT
-    uniq(if(timestamp >= {mid} AND timestamp < {end}, events.distinct_id, NULL)) AS current_week_unique_users,
-    uniq(if(timestamp >= {start} AND timestamp < {mid}, events.distinct_id, NULL)) AS previous_week_unique_users,
+    uniq(if(timestamp >= {mid} AND timestamp < {end}, events.person_id, NULL)) AS current_week_unique_users,
+    uniq(if(timestamp >= {start} AND timestamp < {mid}, events.person_id, NULL)) AS previous_week_unique_users,
 
     uniq(if(timestamp >= {mid} AND timestamp < {end}, events.properties.$session_id, NULL)) AS current_week_unique_sessions,
     uniq(if(timestamp >= {start} AND timestamp < {mid}, events.properties.$session_id, NULL)) AS previous_week_unique_sessions,

--- a/posthog/hogql_queries/web_analytics/top_clicks.py
+++ b/posthog/hogql_queries/web_analytics/top_clicks.py
@@ -31,6 +31,7 @@ AND el_text IS NOT NULL
 GROUP BY
     el_text
 ORDER BY total_clicks DESC
+LIMIT 10
                 """,
                 timings=self.timings,
             )

--- a/posthog/hogql_queries/web_analytics/top_pages.py
+++ b/posthog/hogql_queries/web_analytics/top_pages.py
@@ -3,7 +3,7 @@ from django.utils.timezone import datetime
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
-from posthog.hogql_queries.web_analytics.ctes import SESSION_CTE, PATHNAME_CTE
+from posthog.hogql_queries.web_analytics.ctes import SESSION_CTE, PATHNAME_CTE, PATHNAME_SCROLL_CTE
 from posthog.hogql_queries.web_analytics.web_analytics_query_runner import WebAnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models.filters.mixins.utils import cached_property
@@ -19,6 +19,8 @@ class WebTopPagesQueryRunner(WebAnalyticsQueryRunner):
             session_query = parse_select(SESSION_CTE, timings=self.timings)
         with self.timings.measure("pathname_query"):
             pathname_query = parse_select(PATHNAME_CTE, timings=self.timings)
+        with self.timings.measure("pathname_scroll_query"):
+            pathname_scroll_query = parse_select(PATHNAME_SCROLL_CTE, timings=self.timings)
         with self.timings.measure("top_pages_query"):
             top_sources_query = parse_select(
                 """
@@ -26,9 +28,9 @@ SELECT
     pathname.pathname as pathname,
     pathname.total_pageviews as total_pageviews,
     pathname.unique_visitors as unique_visitors,
-    pathname.scroll_gt80_percentage as scroll_gt80_percentage,
-    pathname.average_scroll_percentage as average_scroll_percentage,
-    bounce_rate.bounce_rate as bounce_rate
+    bounce_rate.bounce_rate as bounce_rate,
+    scroll_data.scroll_gt80_percentage as scroll_gt80_percentage,
+    scroll_data.average_scroll_percentage as average_scroll_percentage
 FROM
     {pathname_query} AS pathname
 LEFT OUTER JOIN
@@ -43,11 +45,19 @@ LEFT OUTER JOIN
     ) AS bounce_rate
 ON
     pathname.pathname = bounce_rate.earliest_pathname
+LEFT OUTER JOIN
+    {pathname_scroll_query} AS scroll_data
+ON
+    pathname.pathname = scroll_data.pathname
 ORDER BY
     total_pageviews DESC
                 """,
                 timings=self.timings,
-                placeholders={"pathname_query": pathname_query, "session_query": session_query},
+                placeholders={
+                    "pathname_query": pathname_query,
+                    "session_query": session_query,
+                    "pathname_scroll_query": pathname_scroll_query,
+                },
             )
         return top_sources_query
 

--- a/posthog/hogql_queries/web_analytics/top_pages.py
+++ b/posthog/hogql_queries/web_analytics/top_pages.py
@@ -51,6 +51,7 @@ ON
     pathname.pathname = scroll_data.pathname
 ORDER BY
     total_pageviews DESC
+LIMIT 10
                 """,
                 timings=self.timings,
                 placeholders={

--- a/posthog/hogql_queries/web_analytics/top_sources.py
+++ b/posthog/hogql_queries/web_analytics/top_sources.py
@@ -32,7 +32,7 @@ WHERE
 GROUP BY blended_source
 
 ORDER BY total_pageviews DESC
-LIMIT 100
+LIMIT 10
                 """,
                 timings=self.timings,
                 placeholders={"session_query": session_query},


### PR DESCRIPTION
## Problem

More web analytics!

## Changes

Apologies for the 2-for-1-special.

* Found a flaw in my SQL, split out scroll depth into a separate CTE from pathname. Now pathname doesn't undercount, previously it did not count the first $pageview of a visit, as it did not have a previous pathname
* Added some other insights to the dashboard.
<img width="2002" alt="Screenshot 2023-10-06 at 16 03 27" src="https://github.com/PostHog/posthog/assets/2056078/a6fc5537-4c07-4a3c-8442-6731a1b8acfb">

Not solved yet:
* The UI for the tables is a bit janky
* The world map has a load more button which I'd like to hide

## How did you test this code?
(Behind FF) Ran it locally
