### PR TITLE
chore: set Sentry release using commit.txt

### DIFF
--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -122,9 +122,20 @@ def sentry_init() -> None:
         sentry_logging = LoggingIntegration(level=sentry_logging_level, event_level=None)
         profiles_sample_rate = get_from_env("SENTRY_PROFILES_SAMPLE_RATE", type_cast=float, default=0.0)
 
+        release = None
+        try:
+            # Docker containers should have a commit.txt file in the base directory with the git
+            # commit hash used to generate them.
+            with open("commit.txt") as f:
+                release = f.read()
+        except:
+            # The release isn't required, it's just nice to have.
+            pass
+
         sentry_sdk.init(
             send_default_pii=send_pii,
             dsn=os.environ["SENTRY_DSN"],
+            release=release,
             integrations=[DjangoIntegration(), CeleryIntegration(), RedisIntegration(), sentry_logging],
             request_bodies="always" if send_pii else "never",
             sample_rate=1.0,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Sentry events aren't tied to a release.

## Changes

Use new `commit.txt` file (falling back to old behavior of no release on any error).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally with and without `commit.txt`

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
