### PR TITLE
fix(batch-exports): Include properties in feature_enabled call

### DIFF
--- a/frontend/src/scenes/batch_exports/utils.ts
+++ b/frontend/src/scenes/batch_exports/utils.ts
@@ -4,6 +4,7 @@ export function intervalToFrequency(interval: BatchExportConfiguration['interval
     return {
         day: 'daily',
         hour: 'hourly',
+        'every 5 minutes': 'every 5 minutes',
     }[interval]
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3211,7 +3211,7 @@ export type BatchExportConfiguration = {
     id: string
     name: string
     destination: BatchExportDestination
-    interval: 'hour' | 'day'
+    interval: 'hour' | 'day' | 'every 5 minutes'
     created_at: string
     start_at: string | null
     end_at: string | null

--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -65,7 +65,15 @@ def test_create_batch_export_with_interval_schedule(client: HttpClient, interval
             )
 
         if interval == "every 5 minutes":
-            feature_enabled.assert_called_once_with("high-frequency-batch-exports", str(team.uuid))
+            feature_enabled.assert_called_once_with(
+                "high-frequency-batch-exports",
+                str(team.uuid),
+                groups={"organization": str(team.organization.id)},
+                group_properties={
+                    "organization": {"id": str(team.organization.id), "created_at": team.organization.created_at}
+                },
+                send_feature_flag_events=False,
+            )
 
         assert response.status_code == status.HTTP_201_CREATED, response.json()
 
@@ -179,4 +187,12 @@ def test_cannot_create_a_batch_export_with_higher_frequencies_if_not_enabled(cli
                 batch_export_data,
             )
             assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
-            feature_enabled.assert_called_once_with("high-frequency-batch-exports", str(team.uuid))
+            feature_enabled.assert_called_once_with(
+                "high-frequency-batch-exports",
+                str(team.uuid),
+                groups={"organization": str(team.organization.id)},
+                group_properties={
+                    "organization": {"id": str(team.organization.id), "created_at": team.organization.created_at}
+                },
+                send_feature_flag_events=False,
+            )

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -180,7 +180,6 @@ class BatchExportSerializer(serializers.ModelSerializer):
                 group_properties={
                     "organization": {"id": str(team.organization.id), "created_at": team.organization.created_at}
                 },
-                only_evaluate_locally=True,
                 send_feature_flag_events=False,
             ):
                 raise PermissionDenied("Higher frequency exports are not enabled for this team.")

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -170,11 +170,20 @@ class BatchExportSerializer(serializers.ModelSerializer):
         destination_data = validated_data.pop("destination")
         team_id = self.context["team_id"]
 
-        if validated_data["interval"] not in ("hour", "day", "week") and not posthoganalytics.feature_enabled(
-            "high-frequency-batch-exports",
-            str(Team.objects.get(id=team_id).uuid),
-        ):
-            raise PermissionDenied("Higher frequency exports are not enabled for this team.")
+        if validated_data["interval"] not in ("hour", "day", "week"):
+            team = Team.objects.get(id=team_id)
+
+            if not posthoganalytics.feature_enabled(
+                "high-frequency-batch-exports",
+                str(team.uuid),
+                groups={"organization": str(team.organization.id)},
+                group_properties={
+                    "organization": {"id": str(team.organization.id), "created_at": team.organization.created_at}
+                },
+                only_evaluate_locally=True,
+                send_feature_flag_events=False,
+            ):
+                raise PermissionDenied("Higher frequency exports are not enabled for this team.")
 
         destination = BatchExportDestination(**destination_data)
         batch_export = BatchExport(team_id=team_id, destination=destination, **validated_data)


### PR DESCRIPTION
## Problem

The backend is returning a 403, even though the flag is enabled for a specific team. Maybe the call is missing properties used in other similar calls?  

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds arguments to `feature_enabled` call when creating high frequency batch exports.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
