### PR TITLE
feat: clarify experiments usage in FFs onboarding

### DIFF
--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -96,9 +96,9 @@ const FeatureFlagsOnboarding = (): JSX.Element => {
     return (
         <OnboardingWrapper>
             <SDKs
-                usersAction="loading flags"
+                usersAction="loading flags & experiments"
                 sdkInstructionMap={FeatureFlagsSDKInstructions}
-                subtitle="Choose the framework where you want to use feature flags, or use our all-purpose JavaScript library. If you already have the snippet installed, you can skip this step!"
+                subtitle="Choose the framework where you want to use feature flags and/or run experiments, or use our all-purpose JavaScript library. If you already have the snippet installed, you can skip this step!"
                 stepKey={OnboardingStepKey.SDKS}
             />
         </OnboardingWrapper>

--- a/frontend/src/scenes/onboarding/sdks/feature-flags/flagImplementationSnippet.tsx
+++ b/frontend/src/scenes/onboarding/sdks/feature-flags/flagImplementationSnippet.tsx
@@ -5,13 +5,18 @@ import { SDKKey } from '~/types'
 export const FlagImplementationSnippet = ({ sdkKey }: { sdkKey: SDKKey }): JSX.Element => {
     return (
         <>
-            <h3>Basic implementation</h3>
+            <h3>Basic flag implementation</h3>
             <CodeInstructions
                 options={OPTIONS}
                 selectedLanguage={sdkKey}
                 showAdvancedOptions={false}
                 showFooter={false}
             />
+            <h3>Running experiments</h3>
+            <p>
+                Experiments run on top of our feature flags. Once you've implemented the flag in your code, you you'll
+                run an A/B test by creating a new experiment in the PostHog dashboard.
+            </p>
         </>
     )
 }


### PR DESCRIPTION
## Problem

I noticed in a [recording](https://app.posthog.com/replay/018b163c-0617-7dc9-8024-1d53067fb4da) that someone wanted experimentation instructions so was looking at our docs, but seemed confused because "Feature flags & A/B testing" onboarding flow didn't mention much about experiments. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds experiments language to sdks heading:

<img width="862" alt="image" src="https://github.com/PostHog/posthog/assets/18598166/30957e95-8529-46e6-b077-98a4d90f19ff">

And a blurb at the bottom about running experiments. 

<img width="582" alt="image" src="https://github.com/PostHog/posthog/assets/18598166/1d2ce42b-4507-44dd-b79c-9dd897adcf4d">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
