### PR TITLE
test: Increase playwright timeouts

### DIFF
--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -63,17 +63,22 @@ const LOADER_SELECTORS = [
 
 const customSnapshotsDir = `${process.cwd()}/frontend/__snapshots__`
 
+const TEST_TIMEOUT_MS = 10000
+const BROWSER_DEFAULT_TIMEOUT_MS = 9000
+const SCREENSHOT_TIMEOUT_MS = 9000
+
 module.exports = {
     setup() {
         expect.extend({ toMatchImageSnapshot })
         jest.retryTimes(RETRY_TIMES, { logErrorsBeforeRetry: true })
+        jest.setTimeout(TEST_TIMEOUT_MS)
     },
     async postRender(page, context) {
         const browserContext = page.context()
         const storyContext = (await getStoryContext(page, context)) as StoryContext
         const { skip = false, snapshotBrowsers = ['chromium'] } = storyContext.parameters?.testOptions ?? {}
 
-        browserContext.setDefaultTimeout(5000) // Reduce the default timeout from 30 s to 5 s to pre-empt Jest timeouts
+        browserContext.setDefaultTimeout(BROWSER_DEFAULT_TIMEOUT_MS) // Reduce the default timeout from 30 s to 5 s to pre-empt Jest timeouts
         if (!skip) {
             const currentBrowser = browserContext.browser()!.browserType().name() as SupportedBrowserName
             if (snapshotBrowsers.includes(currentBrowser)) {
@@ -198,7 +203,7 @@ async function expectLocatorToMatchStorySnapshot(
     browser: SupportedBrowserName,
     options?: LocatorScreenshotOptions
 ): Promise<void> {
-    const image = await locator.screenshot({ timeout: 3000, ...options })
+    const image = await locator.screenshot({ timeout: SCREENSHOT_TIMEOUT_MS, ...options })
     let customSnapshotIdentifier = context.id
     if (browser !== 'chromium') {
         customSnapshotIdentifier += `--${browser}`

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -64,7 +64,7 @@ const LOADER_SELECTORS = [
 const customSnapshotsDir = `${process.cwd()}/frontend/__snapshots__`
 
 const TEST_TIMEOUT_MS = 10000
-const BROWSER_DEFAULT_TIMEOUT_MS = 9000
+const BROWSER_DEFAULT_TIMEOUT_MS = 9000 // Reduce the default timeout down from 30s, to pre-empt Jest timeouts
 const SCREENSHOT_TIMEOUT_MS = 9000
 
 module.exports = {
@@ -78,7 +78,7 @@ module.exports = {
         const storyContext = (await getStoryContext(page, context)) as StoryContext
         const { skip = false, snapshotBrowsers = ['chromium'] } = storyContext.parameters?.testOptions ?? {}
 
-        browserContext.setDefaultTimeout(BROWSER_DEFAULT_TIMEOUT_MS) // Reduce the default timeout from 30 s to 5 s to pre-empt Jest timeouts
+        browserContext.setDefaultTimeout(BROWSER_DEFAULT_TIMEOUT_MS)
         if (!skip) {
             const currentBrowser = browserContext.browser()!.browserType().name() as SupportedBrowserName
             if (snapshotBrowsers.includes(currentBrowser)) {


### PR DESCRIPTION
## Problem

Some playright screenshot tests are flaky, see https://posthog.slack.com/archives/C0368RPHLQH/p1696921922837369

## Changes

Increase the timeouts
<img width="374" alt="Screenshot 2023-10-10 at 09 21 11" src="https://github.com/PostHog/posthog/assets/2056078/ca42e63e-ca26-4efc-b691-a2ca06f6e037">

## How did you test this code?
Ran CI twice via this PR, checked that all tests passed both times.
