### PR TITLE
fix(celery): celery compatibility with importlib

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -43,7 +43,7 @@ google-cloud-bigquery==3.11.4
 google-cloud-sqlcommenter==2.0.0
 gunicorn==20.1.0
 idna==2.8
-importlib-metadata==1.6.0
+importlib-metadata==6.8.0
 infi-clickhouse-orm@ git+https://github.com/PostHog/infi.clickhouse_orm@37722f350f3b449bbcd6564917c436b0d93e796f
 kafka-python==2.0.2
 kafka-helper==0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -256,7 +256,7 @@ idna==2.8
     #   trio
     #   urllib3
     #   yarl
-importlib-metadata==1.6.0
+importlib-metadata==6.8.0
     # via -r requirements.in
 infi-clickhouse-orm @ git+https://github.com/PostHog/infi.clickhouse_orm@37722f350f3b449bbcd6564917c436b0d93e796f
     # via -r requirements.in
@@ -557,7 +557,7 @@ xmlsec==1.3.13
     # via python3-saml
 yarl==1.7.2
     # via aiohttp
-zipp==3.1.0
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
## Problem

A Celery upgrade resulted in `cannot import name 'Celery' from 'celery` errors. This seems to be due to underlying changes in Celery's usage of `importlib`, see https://github.com/celery/celery/pull/7785.

## Changes

We've been on a really old version of importlib. This PR upgrades to the newest version, which fixes the Celery error.

## How did you test this code?

CI run