### PR TITLE
fix(insights): loading in saved insights card view

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -52,6 +52,7 @@ import { filtersToQueryNode } from '~/queries/nodes/InsightQuery/utils/filtersTo
 import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { getCachedResults } from '~/queries/nodes/InsightViz/utils'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 
 type DisplayedType = ChartDisplayType | 'RetentionContainer' | 'FunnelContainer' | 'PathsContainer'
 
@@ -271,10 +272,10 @@ function InsightCardInternal(
         dashboardItemId: insight.short_id,
         dashboardId: dashboardId,
         cachedInsight: insight,
-        doNotLoad: true,
     }
 
     const { insightLoading } = useValues(insightLogic(insightLogicProps))
+    const { insightDataLoading } = useValues(insightDataLogic(insightLogicProps))
     const { isFunnelWithEnoughSteps, hasFunnelResults, areExclusionFiltersValid } = useValues(
         funnelDataLogic(insightLogicProps)
     )
@@ -292,7 +293,7 @@ function InsightCardInternal(
             empty = true
         }
     }
-    if (insightLoading) {
+    if (insightLoading || insightDataLoading) {
         loading = true
     }
 

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -45,7 +45,7 @@ import {
 import { Resizeable } from 'lib/components/Cards/CardMeta'
 import { Query } from '~/queries/Query/Query'
 import { QueriesUnsupportedHere } from 'lib/components/Cards/InsightCard/QueriesUnsupportedHere'
-import { QueryContext } from '~/queries/schema'
+import { InsightQueryNode, QueryContext } from '~/queries/schema'
 import { InsightMeta } from './InsightMeta'
 import { dataNodeLogic, DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { filtersToQueryNode } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
@@ -186,7 +186,7 @@ export function FilterBasedCardContent({
 }: FilterBasedCardContentProps): JSX.Element {
     const displayedType = getDisplayedType(insight.filters)
     const VizComponent = displayMap[displayedType]?.element || VizComponentFallback
-    const query = filtersToQueryNode(insight.filters)
+    const query: InsightQueryNode = filtersToQueryNode(insight.filters)
     const dataNodeLogicProps: DataNodeLogicProps = {
         query,
         key: insightVizDataNodeKey(insightProps),
@@ -351,7 +351,7 @@ function InsightCardInternal(
                             <QueriesUnsupportedHere />
                         )}
                     </div>
-                ) : (
+                ) : insight.filters?.insight ? (
                     <FilterBasedCardContent
                         insight={insight}
                         insightProps={insightLogicProps}
@@ -370,7 +370,7 @@ function InsightCardInternal(
                         }
                         setAreDetailsShown={setAreDetailsShown}
                     />
-                )}
+                ) : null}
             </BindLogic>
             {showResizeHandles && (
                 <>

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -370,7 +370,14 @@ function InsightCardInternal(
                         }
                         setAreDetailsShown={setAreDetailsShown}
                     />
-                ) : null}
+                ) : (
+                    <div className="flex justify-between items-center h-full">
+                        <InsightErrorState
+                            excludeDetail
+                            title="Missing 'filters.insight' property, can't display insight"
+                        />
+                    </div>
+                )}
             </BindLogic>
             {showResizeHandles && (
                 <>


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/17869

Old (filter-based) insights do not load on the saved insights card view:

![2023-10-10 11 19 15](https://github.com/PostHog/posthog/assets/53387/195b5402-74ca-469d-be30-b41f264f11dd)

## Changes

![2023-10-10 11 19 47](https://github.com/PostHog/posthog/assets/53387/35e85df6-2182-496f-a89e-b5f27e739cd5)

This seems to work, but I'm not sure of the validity of the fix.

## How did you test this code?

Looked at the saved insights card view. It now loaded. It did make many queries in parallel, but the main problem was fixed. I also opened a random dashboard and saw no difference there. Granted, I only had the default one locally.