### PR TITLE
feat: Persist Notebook pinned recordings

### DIFF
--- a/cypress/fixtures/api/session-recordings/recording.json
+++ b/cypress/fixtures/api/session-recordings/recording.json
@@ -31,6 +31,5 @@
         "created_at": "2023-07-11T14:21:33.883000Z",
         "uuid": "01894554-925a-0000-11d9-a44d69b426d7"
     },
-    "storage": "clickhouse",
-    "pinned_count": 0
+    "storage": "clickhouse"
 }

--- a/ee/session_recordings/test/test_session_recording_playlist.py
+++ b/ee/session_recordings/test/test_session_recording_playlist.py
@@ -207,7 +207,6 @@ class TestSessionRecordingPlaylist(APILicensedTest):
         ).json()
         assert len(result["results"]) == 2
         assert {x["id"] for x in result["results"]} == {session_one, session_two}
-        assert {x["pinned_count"] for x in result["results"]} == {1, 1}
 
     @patch("ee.session_recordings.session_recording_extensions.object_storage.list_objects")
     @patch("ee.session_recordings.session_recording_extensions.object_storage.copy_objects")
@@ -313,11 +312,9 @@ class TestSessionRecordingPlaylist(APILicensedTest):
 
         session_recording_obj_1 = SessionRecording.get_or_build(team=self.team, session_id=recording1_session_id)
         assert session_recording_obj_1
-        assert session_recording_obj_1.pinned_count == 1
 
         session_recording_obj_2 = SessionRecording.get_or_build(team=self.team, session_id=recording2_session_id)
         assert session_recording_obj_2
-        assert session_recording_obj_2.pinned_count == 2
 
         # Delete playlist items
         result = self.client.delete(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1306,6 +1306,10 @@ const api = {
             return await new ApiRequest().recording(recordingId).withQueryString(toParams(params)).get()
         },
 
+        async persist(recordingId: SessionRecordingType['id']): Promise<{ success: boolean }> {
+            return await new ApiRequest().recording(recordingId).withAction('persist').create()
+        },
+
         async delete(recordingId: SessionRecordingType['id']): Promise<{ success: boolean }> {
             return await new ApiRequest().recording(recordingId).delete()
         },

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.stories.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.stories.tsx
@@ -336,7 +336,6 @@ const meta: Meta = {
                                 uuid: '018a8a51-a3d3-0000-e8fa-94621f9ddd48',
                             },
                             storage: 'clickhouse',
-                            pinned_count: 0,
                         },
                     ],
                     has_next: false,

--- a/frontend/src/scenes/session-recordings/__mocks__/recording_meta.json
+++ b/frontend/src/scenes/session-recordings/__mocks__/recording_meta.json
@@ -19,6 +19,5 @@
         "created_at": "2023-05-01T14:46:20.838000Z",
         "uuid": "0187d7c7-61b7-0000-d6a1-59b207080ac0"
     },
-    "storage": "clickhouse",
-    "pinned_count": 0
+    "storage": "clickhouse"
 }

--- a/frontend/src/scenes/session-recordings/file-playback/sessionRecordingFilePlaybackLogic.ts
+++ b/frontend/src/scenes/session-recordings/file-playback/sessionRecordingFilePlaybackLogic.ts
@@ -149,7 +149,6 @@ export const sessionRecordingFilePlaybackLogic = kea<sessionRecordingFilePlaybac
                 person: values.sessionRecording.person || undefined,
                 start_time: dayjs(snapshots[0].timestamp).toISOString(),
                 end_time: dayjs(snapshots[snapshots.length - 1].timestamp).toISOString(),
-                pinned_count: 0,
             })
         },
     })),

--- a/frontend/src/scenes/session-recordings/player/PlayerMetaLinks.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMetaLinks.tsx
@@ -14,7 +14,7 @@ import { useNotebookNode } from 'scenes/notebooks/Nodes/notebookNodeLogic'
 
 export function PlayerMetaLinks(): JSX.Element {
     const { sessionRecordingId, logicProps } = useValues(sessionRecordingPlayerLogic)
-    const { setPause, deleteRecording } = useActions(sessionRecordingPlayerLogic)
+    const { setPause, deleteRecording, maybePersistRecording } = useActions(sessionRecordingPlayerLogic)
     const nodeLogic = useNotebookNode()
 
     const getCurrentPlayerTime = (): number => {
@@ -98,7 +98,14 @@ export function PlayerMetaLinks(): JSX.Element {
 
                     {logicProps.setPinned ? (
                         <LemonButton
-                            onClick={() => logicProps.setPinned?.(!logicProps.pinned)}
+                            onClick={() => {
+                                if (nodeLogic && !logicProps.pinned) {
+                                    // If we are in a node, then pinning should persist the recording
+                                    maybePersistRecording()
+                                }
+
+                                logicProps.setPinned?.(!logicProps.pinned)
+                            }}
                             size="small"
                             tooltip={logicProps.pinned ? 'Unpin from this list' : 'Pin to this list'}
                             icon={logicProps.pinned ? <IconPinFilled /> : <IconPinOutline />}

--- a/frontend/src/scenes/session-recordings/player/__snapshots__/sessionRecordingPlayerLogic.test.ts.snap
+++ b/frontend/src/scenes/session-recordings/player/__snapshots__/sessionRecordingPlayerLogic.test.ts.snap
@@ -18,7 +18,6 @@ exports[`sessionRecordingPlayerLogic loading session core loads metadata and sna
     },
     "uuid": "0187d7c7-61b7-0000-d6a1-59b207080ac0",
   },
-  "pinnedCount": 0,
   "segments": [
     {
       "durationMs": 11868,
@@ -51,7 +50,6 @@ exports[`sessionRecordingPlayerLogic loading session core loads metadata and sna
     },
     "uuid": "0187d7c7-61b7-0000-d6a1-59b207080ac0",
   },
-  "pinnedCount": 0,
   "segments": [
     {
       "durationMs": 7255,
@@ -2131,7 +2129,6 @@ exports[`sessionRecordingPlayerLogic loading session core loads metadata only by
     },
     "uuid": "0187d7c7-61b7-0000-d6a1-59b207080ac0",
   },
-  "pinnedCount": 0,
   "segments": [
     {
       "durationMs": 11868,

--- a/frontend/src/scenes/session-recordings/player/playlist-popover/PlaylistPopover.tsx
+++ b/frontend/src/scenes/session-recordings/player/playlist-popover/PlaylistPopover.tsx
@@ -13,7 +13,7 @@ import { sessionRecordingPlayerLogic } from '../sessionRecordingPlayerLogic'
 import { playlistPopoverLogic } from './playlistPopoverLogic'
 
 export function PlaylistPopoverButton(props: LemonButtonProps): JSX.Element {
-    const { sessionRecordingId, logicProps, sessionPlayerData } = useValues(sessionRecordingPlayerLogic)
+    const { sessionRecordingId, logicProps } = useValues(sessionRecordingPlayerLogic)
     const logic = playlistPopoverLogic(logicProps)
     const {
         playlistsLoading,
@@ -23,12 +23,13 @@ export function PlaylistPopoverButton(props: LemonButtonProps): JSX.Element {
         allPlaylists,
         currentPlaylistsLoading,
         modifyingPlaylist,
+        pinnedCount,
     } = useValues(logic)
     const { setSearchQuery, setNewFormShowing, setShowPlaylistPopover, addToPlaylist, removeFromPlaylist } =
         useActions(logic)
 
     return (
-        <IconWithCount count={sessionPlayerData.pinnedCount ?? 0} showZero={false}>
+        <IconWithCount showZero={false} count={pinnedCount}>
             <Popover
                 visible={showPlaylistPopover}
                 onClickOutside={() => setShowPlaylistPopover(false)}
@@ -97,10 +98,6 @@ export function PlaylistPopoverButton(props: LemonButtonProps): JSX.Element {
                                             }
                                         >
                                             {playlist.name || playlist.derived_name}
-
-                                            {/* {logicProps.playlistLogic?.values.logicProps === playlist.short_id && (
-                                                <span className="text-muted-alt italic text-sm ml-1">(current)</span>
-                                            )} */}
                                         </LemonButton>
 
                                         <LemonButton

--- a/frontend/src/scenes/session-recordings/player/playlist-popover/playlistPopoverLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playlist-popover/playlistPopoverLogic.ts
@@ -1,4 +1,4 @@
-import { kea, props, path, key, actions, reducers, selectors, listeners, connect } from 'kea'
+import { kea, props, path, key, actions, reducers, selectors, listeners, connect, afterMount } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { toParams } from 'lib/utils'
@@ -13,8 +13,6 @@ import { forms } from 'kea-forms'
 import { addRecordingToPlaylist, removeRecordingFromPlaylist } from 'scenes/session-recordings/player/utils/playerUtils'
 import { createPlaylist } from 'scenes/session-recordings/playlist/playlistUtils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { sessionRecordingDataLogic } from 'scenes/session-recordings/player/sessionRecordingDataLogic'
-import { sessionRecordingsPlaylistSceneLogic } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistSceneLogic'
 
 export const playlistPopoverLogic = kea<playlistPopoverLogicType>([
     path((key) => ['scenes', 'session-recordings', 'player', 'playlist-popover', 'playlistPopoverLogic', key]),
@@ -24,8 +22,6 @@ export const playlistPopoverLogic = kea<playlistPopoverLogicType>([
         actions: [
             sessionRecordingPlayerLogic(props),
             ['setPause'],
-            sessionRecordingDataLogic(props),
-            ['addDiffToRecordingMetaPinnedCount'],
             eventUsageLogic,
             ['reportRecordingPinnedToList', 'reportRecordingPlaylistCreated'],
         ],
@@ -38,10 +34,6 @@ export const playlistPopoverLogic = kea<playlistPopoverLogicType>([
         removeFromPlaylist: (playlist: SessionRecordingPlaylistType) => ({ playlist }),
         setNewFormShowing: (show: boolean) => ({ show }),
         setShowPlaylistPopover: (show: boolean) => ({ show }),
-        updateRecordingsPinnedCounts: (
-            diffCount: number,
-            playlistShortId?: SessionRecordingPlaylistType['short_id']
-        ) => ({ diffCount, playlistShortId }),
     })),
     loaders(({ values, props, actions }) => ({
         playlists: {
@@ -144,22 +136,6 @@ export const playlistPopoverLogic = kea<playlistPopoverLogicType>([
                 actions.setPause()
             }
         },
-
-        addToPlaylistSuccess: ({ payload }) => {
-            actions.updateRecordingsPinnedCounts(1, payload?.playlist?.short_id)
-        },
-
-        removeFromPlaylistSuccess: ({ payload }) => {
-            actions.updateRecordingsPinnedCounts(-1, payload?.playlist?.short_id)
-        },
-
-        updateRecordingsPinnedCounts: ({ diffCount, playlistShortId }) => {
-            actions.addDiffToRecordingMetaPinnedCount(diffCount)
-            // Handles locally updating recordings sidebar so that we don't have to call expensive load recordings every time.
-            if (!!playlistShortId && sessionRecordingsPlaylistSceneLogic.isMounted({ shortId: playlistShortId })) {
-                sessionRecordingsPlaylistSceneLogic({ shortId: playlistShortId }).actions.loadPinnedRecordings()
-            }
-        },
     })),
     selectors(() => ({
         allPlaylists: [
@@ -185,16 +161,13 @@ export const playlistPopoverLogic = kea<playlistPopoverLogicType>([
                     })),
                 ]
 
-                // TODO: Do we care about this...
-                // // If props.playlistShortId exists put it at the beginning of the list
-                // if (playlistShortId) {
-                //     results = results.sort((a, b) =>
-                //         a.playlist.short_id == playlistShortId ? -1 : b.playlist.short_id == playlistShortId ? 1 : 0
-                //     )
-                // }
-
                 return results
             },
         ],
+        pinnedCount: [(s) => [s.currentPlaylists], (currentPlaylists) => currentPlaylists.length],
     })),
+
+    afterMount(({ actions }) => {
+        actions.loadPlaylistsForRecording()
+    }),
 ])

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
@@ -129,7 +129,6 @@ describe('sessionRecordingDataLogic', () => {
                         start: undefined,
                         end: undefined,
                         durationMs: 0,
-                        pinnedCount: 0,
                         segments: [],
                         person: null,
                         snapshotsByWindowId: {},

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -151,7 +151,6 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
         setFilters: (filters: Partial<RecordingEventsFilters>) => ({ filters }),
         loadRecordingMeta: true,
         maybeLoadRecordingMeta: true,
-        addDiffToRecordingMetaPinnedCount: (diffCount: number) => ({ diffCount }),
         loadRecordingSnapshotsV1: (nextUrl?: string) => ({ nextUrl }),
         loadRecordingSnapshotsV2: (source?: SessionRecordingSnapshotSource) => ({ source }),
         loadRecordingSnapshots: true,
@@ -328,16 +327,6 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                 breakpoint()
 
                 return response
-            },
-            addDiffToRecordingMetaPinnedCount: ({ diffCount }) => {
-                if (!values.sessionPlayerMetaData) {
-                    return null
-                }
-
-                return {
-                    ...values.sessionPlayerMetaData,
-                    pinned_count: Math.max(values.sessionPlayerMetaData.pinned_count ?? 0 + diffCount, 0),
-                }
             },
         },
         sessionPlayerSnapshotData: [
@@ -589,7 +578,6 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                 durationMs,
                 fullyLoaded
             ): SessionPlayerData => ({
-                pinnedCount: meta?.pinned_count ?? 0,
                 person: meta?.person ?? null,
                 start,
                 end,

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -122,6 +122,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 'loadRecordingSnapshotsSuccess',
                 'loadRecordingSnapshotsFailure',
                 'loadRecordingMetaSuccess',
+                'maybePersistRecording',
             ],
             playerSettingsLogic,
             ['setSpeed', 'setSkipInactivitySetting'],

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
@@ -153,7 +153,7 @@ function FirstURL(props: { startUrl: string | undefined }): JSX.Element {
 
 function PinnedIndicator(): JSX.Element | null {
     return (
-        <Tooltip placement="topRight" title={`This recording is pinned to this list`}>
+        <Tooltip placement="topRight" title={`This recording is pinned to this list.`}>
             <IconPinFilled className="text-sm text-orange shrink-0" />
         </Tooltip>
     )

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1034,7 +1034,7 @@ export interface SessionRecordingType {
     console_warn_count?: number
     console_error_count?: number
     /** Where this recording information was loaded from  */
-    storage?: 'object_storage_lts' | 'clickhouse' | 'object_storage'
+    storage?: 'object_storage_lts' | 'object_storage'
 }
 
 export interface SessionRecordingPropertiesType {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -689,7 +689,6 @@ export interface SessionPlayerSnapshotData {
 }
 
 export interface SessionPlayerData {
-    pinnedCount: number
     person: PersonType | null
     segments: RecordingSegment[]
     bufferedToTime: number | null
@@ -1031,8 +1030,6 @@ export interface SessionRecordingType {
     /** count of all mouse activity in the recording, not just clicks */
     mouse_activity_count?: number
     start_url?: string
-    /** Count of number of playlists this recording is pinned to. **/
-    pinned_count?: number
     console_log_count?: number
     console_warn_count?: number
     console_error_count?: number

--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -59,7 +59,6 @@ class SessionRecording(UUIDModel):
     viewed: Optional[bool] = False
     person: Optional[Person] = None
     matching_events: Optional[RecordingMatchingEvents] = None
-    pinned_count: int = 0
 
     # Metadata can be loaded from Clickhouse or S3
     _metadata: Optional[RecordingMetadata] = None
@@ -195,9 +194,7 @@ class SessionRecording(UUIDModel):
     @staticmethod
     def get_or_build(session_id: str, team: Team) -> "SessionRecording":
         try:
-            return SessionRecording.objects.annotate(pinned_count=Count("playlist_items")).get(
-                session_id=session_id, team=team
-            )
+            return SessionRecording.objects.get(session_id=session_id, team=team)
         except SessionRecording.DoesNotExist:
             return SessionRecording(session_id=session_id, team=team)
 
@@ -207,9 +204,7 @@ class SessionRecording(UUIDModel):
 
         recordings_by_id = {
             recording.session_id: recording
-            for recording in SessionRecording.objects.filter(session_id__in=session_ids, team=team)
-            .annotate(pinned_count=Count("playlist_items"))
-            .all()
+            for recording in SessionRecording.objects.filter(session_id__in=session_ids, team=team).all()
         }
 
         recordings = []

--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -147,7 +147,10 @@ class SessionRecording(UUIDModel):
 
     @property
     def storage(self):
-        return "object_storage_lts" if self.object_storage_path else "clickhouse"
+        if self._state.adding:
+            return "object_storage"
+
+        return "object_storage_lts"
 
     def load_person(self) -> Optional[Person]:
         if self.person:

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -93,7 +93,6 @@ class SessionRecordingSerializer(serializers.ModelSerializer):
             "start_url",
             "person",
             "storage",
-            "pinned_count",
         ]
 
         read_only_fields = [
@@ -113,7 +112,6 @@ class SessionRecordingSerializer(serializers.ModelSerializer):
             "console_error_count",
             "start_url",
             "storage",
-            "pinned_count",
         ]
 
 
@@ -525,11 +523,9 @@ def list_recordings(filter: SessionRecordingsFilter, request: request.Request, c
         # If we specify the session ids (like from pinned recordings) we can optimise by only going to Postgres
         sorted_session_ids = sorted(all_session_ids)
 
-        persisted_recordings_queryset = (
-            SessionRecording.objects.filter(team=team, session_id__in=sorted_session_ids)
-            .exclude(object_storage_path=None)
-            .annotate(pinned_count=Count("playlist_items"))
-        )
+        persisted_recordings_queryset = SessionRecording.objects.filter(
+            team=team, session_id__in=sorted_session_ids
+        ).exclude(object_storage_path=None)
 
         persisted_recordings = persisted_recordings_queryset.all()
 

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -248,6 +248,18 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
 
         return Response({"success": True}, status=204)
 
+    @action(methods=["POST"], detail=True)
+    def persist(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
+        recording = self.get_object()
+
+        if recording.deleted:
+            raise exceptions.NotFound("Recording not found")
+
+        recording.deleted = True
+        recording.save()
+
+        return Response({"success": True}, status=204)
+
     def _snapshots_v2(self, request: request.Request):
         """
         This will eventually replace the snapshots endpoint below.

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -345,7 +345,6 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             "id": "session_1",
             "distinct_id": "d1",
             "viewed": False,
-            "pinned_count": 0,
             "recording_duration": 30,
             "start_time": base_time.replace(tzinfo=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "end_time": (base_time + relativedelta(seconds=30)).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -525,7 +524,6 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             self.assertEqual(len(response_data["results"]), 0)
 
     def test_regression_encoded_emojis_dont_crash(self):
-
         Person.objects.create(
             team=self.team, distinct_ids=["user"], properties={"$some_prop": "something", "email": "bob@bob.com"}
         )


### PR DESCRIPTION
## Problem

Currently pinning a recording to a playlist persists it to LTS storage. We should have the same for notebooks

I think we should also have the same if you add an individual recording to a Notebook as well but that should be a follow up where we make sure that really makes sense

## Changes

* Adds a persist endpoint
* Calls it if pinned within a notebook (doesn't need to be called when pinned to a normal playlist as that does it for us)
* Removes the `pinned_count` stuff as it was overly complicated.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

* API tests but no frontend as the logic is a little fiddley