### PR TITLE
feat: Person node changes

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/NotebookPopover.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookPopover.tsx
@@ -24,16 +24,16 @@ export function NotebookPopoverCard(): JSX.Element | null {
 
     const editable = visibility !== 'hidden' && !notebook?.is_template
 
-    if (droppedResource) {
-        return null
-    }
-
     const { ref, size } = useResizeBreakpoints({
         0: 'small',
         832: 'medium',
     })
 
     const contentWidthHasEffect = useMemo(() => fullScreen && size === 'medium', [fullScreen, size])
+
+    if (droppedResource) {
+        return null
+    }
 
     return (
         <div ref={ref} className="NotebookPopover__content__card">

--- a/frontend/src/scenes/persons/PersonDisplay.tsx
+++ b/frontend/src/scenes/persons/PersonDisplay.tsx
@@ -20,10 +20,11 @@ export interface PersonDisplayProps {
     noPopover?: boolean
 }
 
-export function PersonDisplay({ person, withIcon, noEllipsis, noPopover, noLink }: PersonDisplayProps): JSX.Element {
-    const href = asLink(person)
+export function PersonIcon({
+    person,
+    ...props
+}: Pick<PersonDisplayProps, 'person'> & Omit<ProfilePictureProps, 'name' | 'email'>): JSX.Element {
     const display = asDisplay(person)
-    const [visible, setVisible] = useState(false)
 
     const email: string | undefined = useMemo(() => {
         // The email property could be correct but it could also be set strangely such as an array or not even a string
@@ -33,11 +34,17 @@ export function PersonDisplay({ person, withIcon, noEllipsis, noPopover, noLink 
         return typeof possibleEmail === 'string' ? possibleEmail : undefined
     }, [person?.properties?.email])
 
+    return <ProfilePicture {...props} name={display} email={email} />
+}
+
+export function PersonDisplay({ person, withIcon, noEllipsis, noPopover, noLink }: PersonDisplayProps): JSX.Element {
+    const href = asLink(person)
+    const display = asDisplay(person)
+    const [visible, setVisible] = useState(false)
+
     let content = (
         <span className="flex items-center">
-            {withIcon && (
-                <ProfilePicture name={display} email={email} size={typeof withIcon === 'string' ? withIcon : 'md'} />
-            )}
+            {withIcon && <PersonIcon person={person} size={typeof withIcon === 'string' ? withIcon : 'md'} />}
             <span className={clsx('ph-no-capture', !noEllipsis && 'truncate')}>{display}</span>
         </span>
     )


### PR DESCRIPTION
## Problem

Person Node was a bit half-done.

Now it is 3/4 done 😅 

## Changes

* Adds property icons like we have in recordings
* Adds events action to add related events
* Adds cursor pointer when not expanded
* Pulls our the PersonIcon from the PersonDisplay

|Before|After|
|----|----|
| <img width="849" alt="Screenshot 2023-10-10 at 12 11 40" src="https://github.com/PostHog/posthog/assets/2536520/17ed558f-0a32-4e70-a583-437d1f0a872b"> | <img width="889" alt="Screenshot 2023-10-10 at 12 11 22" src="https://github.com/PostHog/posthog/assets/2536520/5fc2d1be-fc40-47e8-a55d-6d914f6e9fa7"> |




👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
