### PR TITLE
feat(temporal-worker): Add steps to trigger deployment

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -126,7 +126,7 @@ jobs:
             - name: Check for changes that affect temporal worker
               id: check_changes_temporal_worker
               run: |
-                  echo "::set-output name=changed::$(git diff --name-only HEAD^ HEAD | grep '^posthog/temporal/|^posthog/batch_exports/|^posthog/management/commands/start_temporal_worker.py$' || true)"
+                  echo "::set-output name=changed::$(git diff --name-only HEAD^ HEAD | grep -E '^posthog/temporal/|^posthog/batch_exports/|^posthog/management/commands/start_temporal_worker.py$' || true)"
 
             - name: Trigger Temporal Worker Cloud deployment
               if: steps.check_changes_temporal_worker.outputs.changed != ''

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -122,3 +122,21 @@ jobs:
                       {
                         "image_tag": "${{ steps.build.outputs.digest }}"
                       }
+
+            - name: Check for changes that affect temporal worker
+              id: check_changes_temporal_worker
+              run: |
+                  echo "::set-output name=changed::$(git diff --name-only HEAD^ HEAD | grep '^posthog/temporal/|^posthog/batch_exports/' || true)"
+
+            - name: Trigger Temporal Worker Cloud deployment
+              if: steps.check_changes_temporal_worker.outputs.changed != ''
+              uses: mvasigh/dispatch-action@main
+              with:
+                  token: ${{ steps.deployer.outputs.token }}
+                  repo: charts
+                  owner: PostHog
+                  event_type: temporal_worker_deploy
+                  message: |
+                      {
+                        "image_tag": "${{ steps.build.outputs.digest }}"
+                      }

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -126,7 +126,7 @@ jobs:
             - name: Check for changes that affect temporal worker
               id: check_changes_temporal_worker
               run: |
-                  echo "::set-output name=changed::$(git diff --name-only HEAD^ HEAD | grep '^posthog/temporal/|^posthog/batch_exports/' || true)"
+                  echo "::set-output name=changed::$(git diff --name-only HEAD^ HEAD | grep '^posthog/temporal/|^posthog/batch_exports/|^posthog/management/commands/start_temporal_worker.py$' || true)"
 
             - name: Trigger Temporal Worker Cloud deployment
               if: steps.check_changes_temporal_worker.outputs.changed != ''


### PR DESCRIPTION
## Problem

Temporal workers should be deployed separately from the PostHog monolith for a few of reasons:
* Deployments disrupt on-going batch exports, even if the changes don't affect batch exports.
* The changes that do affect the temporal worker are contained to a small subset of known paths.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

We trigger a temporal worker deploy when changes are detected under posthog/temporal or posthog/batch_exports. This may change in the future, but we'll update this workflow when that happens.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
