### PR TITLE
chore: remove title expand toggle

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.scss
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.scss
@@ -17,9 +17,9 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
-            font-size: 0.75rem;
-            font-weight: 700;
-            color: var(--muted-alt-3000);
+            font-size: 0.875rem;
+            font-weight: 500;
+            color: var(--primary-alt);
             padding: var(--notebook-node-meta-padding);
             border-bottom: 1px solid var(--border);
             height: var(--notebook-node-meta-height);

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -158,7 +158,7 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>({
                                                 {isEditable && (
                                                     <IconDragHandle className="cursor-move text-base shrink-0" />
                                                 )}
-                                                <span className="flex-1 cursor-pointer">{title}</span>
+                                                <span>{title}</span>
                                             </div>
 
                                             <div className="flex space-x-1">

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -154,19 +154,12 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>({
                                 ) : (
                                     <>
                                         <div className="NotebookNode__meta" data-drag-handle>
-                                            <LemonButton
-                                                onClick={() => setExpanded(!expanded)}
-                                                size="small"
-                                                status="primary-alt"
-                                                className="flex-1"
-                                                icon={
-                                                    isEditable ? (
-                                                        <IconDragHandle className="cursor-move text-base shrink-0" />
-                                                    ) : undefined
-                                                }
-                                            >
+                                            <div className="flex items-center gap-1">
+                                                {isEditable && (
+                                                    <IconDragHandle className="cursor-move text-base shrink-0" />
+                                                )}
                                                 <span className="flex-1 cursor-pointer">{title}</span>
-                                            </LemonButton>
+                                            </div>
 
                                             <div className="flex space-x-1">
                                                 {parsedHref && (


### PR DESCRIPTION
## Problem

Discussed in https://posthog.slack.com/archives/C05N9R3HT7V/p1696434032219059

## Changes

Remove the toggle to expand from the title because we have a dedicated button for it

## How did you test this code?

By eye