### PR TITLE
chore: stop using piscina worker methods for runEventPipeline

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-webhooks.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-webhooks.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node'
 import { StatsD } from 'hot-shots'
 import { EachBatchPayload, KafkaMessage } from 'kafkajs'
+import { Counter } from 'prom-client'
 import { ActionMatcher } from 'worker/ingestion/action-matcher'
 
 import { PostIngestionEvent, RawClickHouseEvent } from '../../../types'
@@ -8,7 +9,6 @@ import { DependencyUnavailableError } from '../../../utils/db/error'
 import { convertToIngestionEvent, convertToProcessedPluginEvent } from '../../../utils/event'
 import { status } from '../../../utils/status'
 import { processWebhooksStep } from '../../../worker/ingestion/event-pipeline/runAsyncHandlersStep'
-import { silentFailuresAsyncHandlers } from '../../../worker/ingestion/event-pipeline/runner'
 import { HookCommander } from '../../../worker/ingestion/hooks'
 import { runInstrumentedFunction } from '../../utils'
 import { eventDroppedCounter, latestOffsetTimestampGauge } from '../metrics'
@@ -16,6 +16,10 @@ import { eventDroppedCounter, latestOffsetTimestampGauge } from '../metrics'
 // Must require as `tsc` strips unused `import` statements and just requiring this seems to init some globals
 require('@sentry/tracing')
 
+export const silentFailuresAsyncHandlers = new Counter({
+    name: 'async_handlers_silent_failure',
+    help: 'Number silent failures from async handlers.',
+})
 // exporting only for testing
 export function groupIntoBatchesByUsage(
     array: KafkaMessage[],

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -6,7 +6,7 @@ import { Counter } from 'prom-client'
 
 import { BatchConsumer, startBatchConsumer } from '../../kafka/batch-consumer'
 import { createRdConnectionConfigFromEnvVars } from '../../kafka/config'
-import { Hub, PipelineEvent, WorkerMethods } from '../../types'
+import { Hub } from '../../types'
 import { KafkaConfig } from '../../utils/db/hub'
 import { timeoutGuard } from '../../utils/db/utils'
 import { status } from '../../utils/status'
@@ -23,7 +23,6 @@ type KafkaJSBatchFunction = (payload: EachBatchPayload, queue: KafkaJSIngestionC
 
 export class KafkaJSIngestionConsumer {
     public pluginsServer: Hub
-    public workerMethods: WorkerMethods
     public consumerReady: boolean
     public topic: string
     public consumerGroupId: string
@@ -54,17 +53,6 @@ export class KafkaJSIngestionConsumer {
         )
         this.wasConsumerRan = false
 
-        // TODO: remove `this.workerMethods` and just rely on
-        // `this.batchHandler`. At the time of writing however, there are some
-        // references to queue.workerMethods buried deep in the codebase
-        // #onestepatatime
-        this.workerMethods = {
-            runEventPipeline: (event: PipelineEvent) => {
-                this.pluginsServer.lastActivity = new Date().valueOf()
-                this.pluginsServer.lastActivityType = 'runEventPipeline'
-                return piscina.run({ task: 'runEventPipeline', args: { event } })
-            },
-        }
         this.consumerGroupMemberId = null
         this.consumerReady = false
 
@@ -198,7 +186,6 @@ type EachBatchFunction = (messages: Message[], queue: IngestionConsumer) => Prom
 
 export class IngestionConsumer {
     public pluginsServer: Hub
-    public workerMethods: WorkerMethods
     public consumerReady: boolean
     public topic: string
     public consumerGroupId: string
@@ -216,17 +203,6 @@ export class IngestionConsumer {
         this.topic = topic
         this.consumerGroupId = consumerGroupId
 
-        // TODO: remove `this.workerMethods` and just rely on
-        // `this.batchHandler`. At the time of writing however, there are some
-        // references to queue.workerMethods buried deep in the codebase
-        // #onestepatatime
-        this.workerMethods = {
-            runEventPipeline: (event: PipelineEvent) => {
-                this.pluginsServer.lastActivity = new Date().valueOf()
-                this.pluginsServer.lastActivityType = 'runEventPipeline'
-                return piscina.run({ task: 'runEventPipeline', args: { event } })
-            },
-        }
         this.consumerReady = false
 
         this.eachBatch = batchHandler

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -24,7 +24,6 @@ import { KafkaProducerWrapper } from './utils/db/kafka-producer-wrapper'
 import { PostgresRouter } from './utils/db/postgres'
 import { UUID } from './utils/utils'
 import { AppMetrics } from './worker/ingestion/app-metrics'
-import { EventPipelineResult } from './worker/ingestion/event-pipeline/runner'
 import { OrganizationManager } from './worker/ingestion/organization-manager'
 import { EventsProcessor } from './worker/ingestion/process-event'
 import { TeamManager } from './worker/ingestion/team-manager'
@@ -475,10 +474,6 @@ export interface PluginTask {
     exec: (payload?: Record<string, any>) => Promise<any>
 
     __ignoreForAppMetrics?: boolean
-}
-
-export type WorkerMethods = {
-    runEventPipeline: (event: PipelineEvent) => Promise<EventPipelineResult>
 }
 
 export type VMMethods = {

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -1,7 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
 
-import { EnqueuedPluginJob, Hub, PipelineEvent, PluginTaskType } from '../types'
-import { EventPipelineRunner } from './ingestion/event-pipeline/runner'
+import { EnqueuedPluginJob, Hub, PluginTaskType } from '../types'
 import { loadSchedule } from './plugins/loadSchedule'
 import { runPluginTask, runProcessEvent } from './plugins/run'
 import { setupPlugins } from './plugins/setup'
@@ -27,10 +26,6 @@ export const workerTasks: Record<string, TaskRunner> = {
     },
     pluginScheduleReady: (hub) => {
         return hub.pluginSchedule !== null
-    },
-    runEventPipeline: async (hub, args: { event: PipelineEvent }) => {
-        const runner = new EventPipelineRunner(hub, args.event)
-        return await runner.runEventPipeline(args.event)
     },
     reloadPlugins: async (hub) => {
         await setupPlugins(hub)

--- a/plugin-server/src/worker/worker.ts
+++ b/plugin-server/src/worker/worker.ts
@@ -100,12 +100,8 @@ export const createTaskRunner =
                 }
                 return response
             },
-            (transactionDuration: number) => {
-                if (task === 'runEventPipeline') {
-                    return transactionDuration > 0.5 ? 1 : 0.01
-                } else {
-                    return 1
-                }
+            (_) => {
+                return 1
             }
         )
 

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
@@ -7,6 +7,10 @@ import { captureIngestionWarning } from './../../../src/worker/ingestion/utils'
 
 jest.mock('../../../src/utils/status')
 jest.mock('./../../../src/worker/ingestion/utils')
+jest.mock('./../../../src/worker/ingestion/event-pipeline/runner', () => ({
+    runEventPipeline: jest.fn().mockResolvedValue('default value'),
+}))
+import { runEventPipeline } from './../../../src/worker/ingestion/event-pipeline/runner'
 
 const captureEndpointEvent = {
     uuid: 'uuid1',
@@ -53,9 +57,6 @@ describe('eachBatchParallelIngestion with overflow consume', () => {
                 },
                 db: 'database',
             },
-            workerMethods: {
-                runEventPipeline: jest.fn(() => Promise.resolve({})),
-            },
         }
     })
 
@@ -81,7 +82,7 @@ describe('eachBatchParallelIngestion with overflow consume', () => {
         )
 
         // Event is processed
-        expect(queue.workerMethods.runEventPipeline).toHaveBeenCalled()
+        expect(runEventPipeline).toHaveBeenCalled()
     })
 
     it('does not raise ingestion warning when under threshold', async () => {
@@ -99,6 +100,6 @@ describe('eachBatchParallelIngestion with overflow consume', () => {
         expect(queue.pluginsServer.kafkaProducer.queueMessage).not.toHaveBeenCalled()
 
         // Event is processed
-        expect(queue.workerMethods.runEventPipeline).toHaveBeenCalled()
+        expect(runEventPipeline).toHaveBeenCalled()
     })
 })

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -34,6 +34,11 @@ jest.mock('../../../src/worker/ingestion/event-pipeline/runAsyncHandlersStep', (
 })
 jest.mock('../../../src/utils/status')
 jest.mock('./../../../src/worker/ingestion/utils')
+jest.mock('./../../../src/worker/ingestion/event-pipeline/runner', () => ({
+    runEventPipeline: jest.fn().mockResolvedValue('default value'),
+    // runEventPipeline: jest.fn().mockRejectedValue('default value'),
+}))
+import { runEventPipeline } from './../../../src/worker/ingestion/event-pipeline/runner'
 
 const event: PostIngestionEvent = {
     eventUuid: 'uuid1',
@@ -135,9 +140,6 @@ describe('eachBatchX', () => {
                     queueMessage: jest.fn(),
                 },
                 pluginConfigsPerTeam: new Map(),
-            },
-            workerMethods: {
-                runEventPipeline: jest.fn(() => Promise.resolve({})),
             },
         }
     })
@@ -396,11 +398,18 @@ describe('eachBatchX', () => {
     })
 
     describe('eachBatchParallelIngestion', () => {
+        let runEventPipelineSpy
+        beforeEach(() => {
+            runEventPipelineSpy = jest.spyOn(
+                require('./../../../src/worker/ingestion/event-pipeline/runner'),
+                'runEventPipeline'
+            )
+        })
         it('calls runEventPipeline', async () => {
             const batch = createBatch(captureEndpointEvent)
             await eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Disabled)
 
-            expect(queue.workerMethods.runEventPipeline).toHaveBeenCalledWith({
+            expect(runEventPipeline).toHaveBeenCalledWith(expect.anything(), {
                 distinct_id: 'id',
                 event: 'event',
                 properties: {},
@@ -419,16 +428,16 @@ describe('eachBatchX', () => {
 
         it('fails the batch if runEventPipeline rejects', async () => {
             const batch = createBatch(captureEndpointEvent)
-            queue.workerMethods.runEventPipeline = jest.fn(() => Promise.reject('runEventPipeline nopes out'))
+            runEventPipelineSpy.mockImplementationOnce(() => Promise.reject('runEventPipeline nopes out'))
             await expect(eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Disabled)).rejects.toBe(
                 'runEventPipeline nopes out'
             )
-            expect(queue.workerMethods.runEventPipeline).toHaveBeenCalledTimes(1)
+            expect(runEventPipeline).toHaveBeenCalledTimes(1)
         })
 
         it('fails the batch if one deferred promise rejects', async () => {
             const batch = createBatch(captureEndpointEvent)
-            queue.workerMethods.runEventPipeline = jest.fn(() =>
+            runEventPipelineSpy.mockImplementationOnce(() =>
                 Promise.resolve({
                     promises: [Promise.resolve(), Promise.reject('deferred nopes out')],
                 })
@@ -436,7 +445,7 @@ describe('eachBatchX', () => {
             await expect(eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Disabled)).rejects.toBe(
                 'deferred nopes out'
             )
-            expect(queue.workerMethods.runEventPipeline).toHaveBeenCalledTimes(1)
+            expect(runEventPipeline).toHaveBeenCalledTimes(1)
         })
 
         it('batches events by team or token and distinct_id', () => {
@@ -510,7 +519,7 @@ describe('eachBatchX', () => {
             ])
 
             await eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Disabled)
-            expect(queue.workerMethods.runEventPipeline).toHaveBeenCalledTimes(14)
+            expect(runEventPipeline).toHaveBeenCalledTimes(14)
             expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith(
                 'ingest_event_batching.input_length',
                 14,

--- a/plugin-server/tests/main/ingestion-queues/run-ingestion-pipeline.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/run-ingestion-pipeline.test.ts
@@ -5,21 +5,18 @@ import { Hub } from '../../../src/types'
 import { DependencyUnavailableError } from '../../../src/utils/db/error'
 import { createHub } from '../../../src/utils/db/hub'
 import { PostgresUse } from '../../../src/utils/db/postgres'
-import { UUIDT } from '../../../src/utils/utils'
-import { createTaskRunner } from '../../../src/worker/worker'
+import { runEventPipeline } from '../../../src/worker/ingestion/event-pipeline/runner'
 import { createOrganization, createTeam, POSTGRES_DELETE_TABLES_QUERY } from '../../helpers/sql'
 
 describe('workerTasks.runEventPipeline()', () => {
     let hub: Hub
     let redis: Redis.Redis
     let closeHub: () => Promise<void>
-    let piscinaTaskRunner: ({ task, args }) => Promise<any>
     const OLD_ENV = process.env
 
     beforeAll(async () => {
         ;[hub, closeHub] = await createHub()
         redis = await hub.redisPool.acquire()
-        piscinaTaskRunner = createTaskRunner(hub)
         await hub.postgres.query(PostgresUse.COMMON_WRITE, POSTGRES_DELETE_TABLES_QUERY, undefined, '') // Need to clear the DB to avoid unique constraint violations on ids
         process.env = { ...OLD_ENV } // Make a copy
     })
@@ -52,18 +49,15 @@ describe('workerTasks.runEventPipeline()', () => {
         })
 
         await expect(
-            piscinaTaskRunner({
-                task: 'runEventPipeline',
-                args: {
-                    event: {
-                        distinctId: 'asdf',
-                        ip: '',
-                        team_id: teamId,
-                        event: 'some event',
-                        properties: {},
-                        eventUuid: new UUIDT().toString(),
-                    },
-                },
+            runEventPipeline(hub, {
+                distinct_id: 'asdf',
+                ip: '',
+                team_id: teamId,
+                event: 'some event',
+                properties: {},
+                site_url: 'https://example.com',
+                now: new Date().toISOString(),
+                uuid: 'uuid',
             })
         ).rejects.toEqual(new DependencyUnavailableError(errorMessage, 'Postgres', new Error(errorMessage)))
         pgQueryMock.mockRestore()

--- a/plugin-server/tests/worker/dead-letter-queue.test.ts
+++ b/plugin-server/tests/worker/dead-letter-queue.test.ts
@@ -3,8 +3,8 @@ import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
 import { Hub, LogLevel } from '../../src/types'
 import { createHub } from '../../src/utils/db/hub'
 import { UUIDT } from '../../src/utils/utils'
+import { runEventPipeline } from '../../src/worker/ingestion/event-pipeline/runner'
 import { generateEventDeadLetterQueueMessage } from '../../src/worker/ingestion/utils'
-import { workerTasks } from '../../src/worker/tasks'
 import { delayUntilEventIngested, resetTestDatabaseClickhouse } from '../helpers/clickhouse'
 import { resetTestDatabase } from '../helpers/sql'
 
@@ -59,7 +59,7 @@ describe('events dead letter queue', () => {
     })
 
     test('events get sent to dead letter queue on error', async () => {
-        const ingestResponse1 = await workerTasks.runEventPipeline(hub, { event: createEvent() })
+        const ingestResponse1 = await runEventPipeline(hub, createEvent())
         expect(ingestResponse1).toEqual({
             lastStep: 'prepareEventStep',
             error: 'database unavailable',


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We don't really need to use piscina here and it's creating unneccesary confusion reading the code

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
