### PR TITLE
feat: Set keepalive to 60 on gunicorn

### DIFF
--- a/bin/docker-server
+++ b/bin/docker-server
@@ -20,6 +20,7 @@ exec gunicorn posthog.wsgi \
     --worker-tmp-dir /dev/shm \
     --workers=2 \
     --threads=8 \
+    --keep-alive=60 \
     --backlog=${GUNICORN_BACKLOG:-1000} \
     --worker-class=gthread \
     ${STATSD_HOST:+--statsd-host $STATSD_HOST:$STATSD_PORT} \


### PR DESCRIPTION
## Problem

The default is 2 seconds, the default for ALBs is 30 seconds

This can cause a race condition where gunicorn closes the connection as the ALB sends a request, resulting in a 502.
<img width="730" alt="image" src="https://github.com/PostHog/posthog/assets/2088870/7accf7e2-99e4-4f6b-b110-f9ab2606a1b5">

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
