### PR TITLE
fix(autocapture): add taxonomic filter key as data-attr

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -77,6 +77,7 @@ export function TaxonomicFilter({
                     taxonomicGroupTypes.length === 1 && 'one-taxonomic-tab',
                     !width && 'force-minimum-width'
                 )}
+                data-attr={taxonomicFilterLogicKey}
                 // eslint-disable-next-line react/forbid-dom-props
                 style={style}
             >


### PR DESCRIPTION
## Problem

I want to find out what people are searching for with the "universal search". Since we don't capture user input, it would be helpful to at least see the categories people click on to know wether they primarily search metadata (Insights, Dashboards, Feature Flags) or data (Events, Persons).

**At the moment we can distinguish between the various taxonomic filters in autocapture events**

## Changes

This PR adds the autocapture key as data-attr.

## How did you test this code?

Verified locally that the search taxonomic filter has a data-attr set