### PR TITLE
chore: launch celery by module in pycharm

### DIFF
--- a/.run/Celery.run.xml
+++ b/.run/Celery.run.xml
@@ -12,17 +12,16 @@
       <env name="SKIP_SERVICE_VERSION_REQUIREMENTS" value="1" />
     </envs>
     <option name="SDK_HOME" value="$PROJECT_DIR$/env/bin/python" />
-    <option name="SDK_NAME" value="Python 3.10 (posthog)" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/env/bin" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
-    <option name="SCRIPT_NAME" value="celery" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/env/bin/celery" />
     <option name="PARAMETERS" value="-A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle --loglevel=DEBUG" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
-    <option name="MODULE_MODE" value="true" />
+    <option name="MODULE_MODE" value="false" />
     <option name="REDIRECT_INPUT" value="false" />
     <option name="INPUT_FILE" value="" />
     <method v="2" />

--- a/.run/Celery.run.xml
+++ b/.run/Celery.run.xml
@@ -12,16 +12,17 @@
       <env name="SKIP_SERVICE_VERSION_REQUIREMENTS" value="1" />
     </envs>
     <option name="SDK_HOME" value="$PROJECT_DIR$/env/bin/python" />
+    <option name="SDK_NAME" value="Python 3.10 (posthog)" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/env/bin" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
-    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/env/bin/celery" />
+    <option name="SCRIPT_NAME" value="celery" />
     <option name="PARAMETERS" value="-A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle --loglevel=DEBUG" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
-    <option name="MODULE_MODE" value="false" />
+    <option name="MODULE_MODE" value="true" />
     <option name="REDIRECT_INPUT" value="false" />
     <option name="INPUT_FILE" value="" />
     <method v="2" />

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Celery",
             "type": "python",
             "request": "launch",
-            "module": "celery",
+            "program": "${workspaceFolder}/env/bin/celery",
             "console": "integratedTerminal",
             "python": "${workspaceFolder}/env/bin/python",
             "cwd": "${workspaceFolder}",


### PR DESCRIPTION
pairs with https://github.com/PostHog/posthog/pull/17874

Because we launch Celery differently in PyCharm and VSCode I didn't spot you couldn't run Celery locally **in VSCode** after https://github.com/PostHog/posthog/pull/17480

~~This shifts PyCharm to starting the same way as VSCode to (hopefully) avoid the same confusion in future~~

This shifts VSCode to run more like PyCharm  - because PyCharm ran more like production and the first time we tried to update to Python3.11 that was what caught that Celery 4 wouldn't start. 