### PR TITLE
fix: Insight tooltip overscrolling issue

### DIFF
--- a/frontend/src/scenes/funnels/useFunnelTooltip.tsx
+++ b/frontend/src/scenes/funnels/useFunnelTooltip.tsx
@@ -111,6 +111,9 @@ export function useFunnelTooltip(showPersonsModal: boolean): React.RefObject<HTM
         const svgRect = vizRef.current?.getBoundingClientRect()
         const tooltipEl = ensureTooltipElement()
         tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
+        if (isTooltipShown) {
+            tooltipEl.style.display = 'initial'
+        }
         const tooltipRect = tooltipEl.getBoundingClientRect()
         if (tooltipOrigin) {
             ReactDOM.render(

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -41,6 +41,9 @@ function useBoldNumberTooltip({
         const divRect = divRef.current?.getBoundingClientRect()
         const tooltipEl = ensureTooltipElement()
         tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
+        if (isTooltipShown) {
+            tooltipEl.style.display = 'initial'
+        }
 
         const seriesResult = insightData?.result?.[0]
 
@@ -66,10 +69,10 @@ function useBoldNumberTooltip({
             () => {
                 const tooltipRect = tooltipEl.getBoundingClientRect()
                 if (divRect) {
-                    tooltipEl.style.top = `${
-                        window.scrollY + divRect.top - tooltipRect.height - BOLD_NUMBER_TOOLTIP_OFFSET_PX
-                    }px`
-                    tooltipEl.style.left = `${divRect.left + divRect.width / 2 - tooltipRect.width / 2}px`
+                    const desiredTop = window.scrollY + divRect.top - tooltipRect.height - BOLD_NUMBER_TOOLTIP_OFFSET_PX
+                    const desiredLeft = divRect.left + divRect.width / 2 - tooltipRect.width / 2
+                    tooltipEl.style.top = `${Math.min(desiredTop, window.innerHeight)}px`
+                    tooltipEl.style.left = `${Math.min(desiredLeft, window.innerWidth)}px`
                 }
             }
         )

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -44,6 +44,7 @@ export function ensureTooltipElement(): HTMLElement {
         tooltipEl = document.createElement('div')
         tooltipEl.id = 'InsightTooltipWrapper'
         tooltipEl.classList.add('InsightTooltipWrapper')
+        tooltipEl.style.display = 'none'
         document.body.appendChild(tooltipEl)
     }
     return tooltipEl
@@ -432,6 +433,7 @@ export function LineGraph_({
                         tooltipEl.classList.remove('above', 'below', 'no-transform')
                         tooltipEl.classList.add(tooltip.yAlign || 'no-transform')
                         tooltipEl.style.opacity = '1'
+                        tooltipEl.style.display = 'initial'
 
                         if (tooltip.body) {
                             const referenceDataPoint = tooltip.dataPoints[0] // Use this point as reference to get the date
@@ -520,8 +522,8 @@ export function LineGraph_({
                                 ? chartClientLeft + tooltip.caretX - tooltipEl.clientWidth - 8 // If tooltip is too large (or close to the edge), show it to the left of the data point instead
                                 : defaultOffsetLeft
 
-                        tooltipEl.style.top = tooltipClientTop + 'px'
-                        tooltipEl.style.left = tooltipClientLeft + 'px'
+                        tooltipEl.style.top = Math.min(tooltipClientTop, window.innerHeight) + 'px'
+                        tooltipEl.style.left = Math.min(tooltipClientLeft, window.innerWidth) + 'px'
                     },
                 },
                 ...(!isBar

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -181,6 +181,7 @@ export function PieChart({
                             tooltipEl.classList.remove('above', 'below', 'no-transform')
                             tooltipEl.classList.add(tooltip.yAlign || 'no-transform')
                             tooltipEl.style.opacity = '1'
+                            tooltipEl.style.display = 'initial'
 
                             if (tooltip.body) {
                                 const referenceDataPoint = tooltip.dataPoints[0] // Use this point as reference to get the date

--- a/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
@@ -33,6 +33,9 @@ function useWorldMapTooltip(showPersonsModal: boolean): React.RefObject<SVGSVGEl
         const svgRect = svgRef.current?.getBoundingClientRect()
         const tooltipEl = ensureTooltipElement()
         tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
+        if (isTooltipShown) {
+            tooltipEl.style.display = 'initial'
+        }
 
         if (tooltipCoordinates) {
             ReactDOM.render(


### PR DESCRIPTION
## Problem

The tooltip can get rendered offscreen and because it is a child of the root it causes a big over-scroll.

This is partly because we changed the scroll so that the root is no longer a truly scrollable element but if a hover element is placed off screen that triggers the scroll

## Changes

* Don't display the tooltip until it is first actually used (stops it flowing the DOM)
* Fix the bounds of the problematic tooltip (so that it doesn't suddenly jump from off screen when it gets displayed)

Really that tooltip needs a re-think. Lots of duplicated code everywhere but this at least fixes the issue for now

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
