### PR TITLE
fix(dev): do not sync the cloud announcement flag

### DIFF
--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -36,7 +36,10 @@ class Command(BaseCommand):
             deleted_flags = FeatureFlag.objects.filter(team=team, deleted=True).values_list("key", flat=True)
             for flag in flags.keys():
                 flag_type = flags[flag]
-                if flag in deleted_flags:
+                # do not sync the cloud announcement flag for in-app banners
+                if flag == "cloud-announcement":
+                    continue
+                elif flag in deleted_flags:
                     ff = FeatureFlag.objects.filter(team=team, key=flag)[0]
                     ff.deleted = False
                     ff.save()


### PR DESCRIPTION
## Problem

Running `DEBUG=1 python3 manage.py sync_feature_flags` adds the in-app banner with the latest message.

## Changes

This PR excludes the `cloud-announcement` flag from the sync comman.

## How did you test this code?

Deleted the flag and ran the command