### PR TITLE
fix: Editor initial content

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -42,13 +42,11 @@ export function Editor({
     onUpdate,
     onSelectionUpdate,
     placeholder,
-    initialContent,
 }: {
     onCreate: (editor: NotebookEditor) => void
     onUpdate: () => void
     onSelectionUpdate: () => void
     placeholder: ({ node }: { node: any }) => string
-    initialContent: JSONContent
 }): JSX.Element {
     const editorRef = useRef<TTEditor>()
     const logic = insertionSuggestionsLogic()
@@ -102,7 +100,6 @@ export function Editor({
             BacklinkCommandsExtension,
             NodeGapInsertionExtension,
         ],
-        content: initialContent,
         editorProps: {
             handleDrop: (view, event, _slice, moved) => {
                 const editor = editorRef.current

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -1,6 +1,6 @@
 import posthog from 'posthog-js'
-import { useActions } from 'kea'
-import { useCallback, useRef } from 'react'
+import { useActions, useValues } from 'kea'
+import { useCallback, useMemo, useRef } from 'react'
 
 import { Editor as TTEditor } from '@tiptap/core'
 import { EditorContent, useEditor } from '@tiptap/react'
@@ -25,32 +25,31 @@ import { lemonToast } from '@posthog/lemon-ui'
 import { NotebookNodeType } from '~/types'
 import { NotebookNodeImage } from '../Nodes/NotebookNodeImage'
 
-import { EditorFocusPosition, EditorRange, JSONContent, Node, NotebookEditor, textContent } from './utils'
+import { EditorFocusPosition, EditorRange, JSONContent, Node, textContent } from './utils'
 import { SlashCommandsExtension } from './SlashCommands'
 import { BacklinkCommandsExtension } from './BacklinkCommands'
 import { NotebookNodeEarlyAccessFeature } from '../Nodes/NotebookNodeEarlyAccessFeature'
 import { NotebookNodeSurvey } from '../Nodes/NotebookNodeSurvey'
 import { InlineMenu } from './InlineMenu'
 import NodeGapInsertionExtension from './Extensions/NodeGapInsertion'
+import { notebookLogic } from './notebookLogic'
+import { sampleOne } from 'lib/utils'
 
 const CustomDocument = ExtensionDocument.extend({
     content: 'heading block*',
 })
 
-export function Editor({
-    onCreate,
-    onUpdate,
-    onSelectionUpdate,
-    placeholder,
-}: {
-    onCreate: (editor: NotebookEditor) => void
-    onUpdate: () => void
-    onSelectionUpdate: () => void
-    placeholder: ({ node }: { node: any }) => string
-}): JSX.Element {
+const PLACEHOLDER_TITLES = ['Release notes', 'Product roadmap', 'Meeting notes', 'Bug analysis']
+
+export function Editor(): JSX.Element {
     const editorRef = useRef<TTEditor>()
-    const logic = insertionSuggestionsLogic()
-    const { resetSuggestions, setPreviousNode } = useActions(logic)
+
+    const { shortId } = useValues(notebookLogic)
+    const { setEditor, onEditorUpdate, onEditorSelectionUpdate } = useActions(notebookLogic)
+
+    const { resetSuggestions, setPreviousNode } = useActions(insertionSuggestionsLogic)
+
+    const headingPlaceholder = useMemo(() => sampleOne(PLACEHOLDER_TITLES), [shortId])
 
     const updatePreviousNode = useCallback(() => {
         const editor = editorRef.current
@@ -67,7 +66,17 @@ export function Editor({
                 gapcursor: false,
             }),
             ExtensionPlaceholder.configure({
-                placeholder: placeholder,
+                placeholder: ({ node }: { node: any }) => {
+                    if (node.type.name === 'heading' && node.attrs.level === 1) {
+                        return `Untitled - maybe.. "${headingPlaceholder}"`
+                    }
+
+                    if (node.type.name === 'heading') {
+                        return `Heading ${node.attrs.level}`
+                    }
+
+                    return ''
+                },
             }),
             FloatingMenu.extend({
                 onSelectionUpdate() {
@@ -181,7 +190,7 @@ export function Editor({
         onCreate: ({ editor }) => {
             editorRef.current = editor
 
-            onCreate({
+            setEditor({
                 getJSON: () => editor.getJSON(),
                 getText: () => textContent(editor.state.doc),
                 getEndPosition: () => editor.state.doc.content.size,
@@ -225,8 +234,8 @@ export function Editor({
                 },
             })
         },
-        onUpdate: onUpdate,
-        onSelectionUpdate: onSelectionUpdate,
+        onUpdate: onEditorUpdate,
+        onSelectionUpdate: onEditorSelectionUpdate,
     })
 
     return (

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
@@ -28,7 +28,7 @@ const PLACEHOLDER_TITLES = ['Release notes', 'Product roadmap', 'Meeting notes',
 
 export function Notebook({ shortId, editable = false, initialAutofocus = 'start' }: NotebookProps): JSX.Element {
     const logic = notebookLogic({ shortId })
-    const { notebook, content, notebookLoading, editor, conflictWarningVisible, isEditable } = useValues(logic)
+    const { notebook, notebookLoading, editor, conflictWarningVisible, isEditable } = useValues(logic)
     const { setEditor, onEditorUpdate, duplicateNotebook, loadNotebook, setEditable, onEditorSelectionUpdate } =
         useActions(logic)
     const { isExpanded } = useValues(notebookSettingsLogic)
@@ -44,7 +44,6 @@ export function Notebook({ shortId, editable = false, initialAutofocus = 'start'
         shortId,
         editable,
         initialAutofocus,
-        content,
     })
 
     useEffect(() => {
@@ -112,7 +111,6 @@ export function Notebook({ shortId, editable = false, initialAutofocus = 'start'
                     <NotebookSidebar />
                     <ErrorBoundary>
                         <Editor
-                            initialContent={content}
                             onCreate={setEditor}
                             onUpdate={onEditorUpdate}
                             onSelectionUpdate={onEditorSelectionUpdate}

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect } from 'react'
 import { notebookLogic } from 'scenes/notebooks/Notebook/notebookLogic'
 import { BindLogic, useActions, useValues } from 'kea'
 import './Notebook.scss'
 
-import { sampleOne } from 'lib/utils'
 import { NotFound } from 'lib/components/NotFound'
 import clsx from 'clsx'
 import { notebookSettingsLogic } from './notebookSettingsLogic'
@@ -24,16 +23,11 @@ export type NotebookProps = {
     initialAutofocus?: EditorFocusPosition
 }
 
-const PLACEHOLDER_TITLES = ['Release notes', 'Product roadmap', 'Meeting notes', 'Bug analysis']
-
 export function Notebook({ shortId, editable = false, initialAutofocus = 'start' }: NotebookProps): JSX.Element {
     const logic = notebookLogic({ shortId })
     const { notebook, notebookLoading, editor, conflictWarningVisible, isEditable } = useValues(logic)
-    const { setEditor, onEditorUpdate, duplicateNotebook, loadNotebook, setEditable, onEditorSelectionUpdate } =
-        useActions(logic)
+    const { duplicateNotebook, loadNotebook, setEditable } = useActions(logic)
     const { isExpanded } = useValues(notebookSettingsLogic)
-
-    const headingPlaceholder = useMemo(() => sampleOne(PLACEHOLDER_TITLES), [shortId])
 
     useWhyDidIRender('Notebook', {
         notebook,
@@ -110,22 +104,7 @@ export function Notebook({ shortId, editable = false, initialAutofocus = 'start'
                 <div className="flex flex-1 justify-center">
                     <NotebookSidebar />
                     <ErrorBoundary>
-                        <Editor
-                            onCreate={setEditor}
-                            onUpdate={onEditorUpdate}
-                            onSelectionUpdate={onEditorSelectionUpdate}
-                            placeholder={({ node }: { node: any }) => {
-                                if (node.type.name === 'heading' && node.attrs.level === 1) {
-                                    return `Untitled - maybe.. "${headingPlaceholder}"`
-                                }
-
-                                if (node.type.name === 'heading') {
-                                    return `Heading ${node.attrs.level}`
-                                }
-
-                                return ''
-                            }}
-                        />
+                        <Editor />
                     </ErrorBoundary>
                 </div>
             </div>


### PR DESCRIPTION
## Problem

I was right in the first place! The content change, needlesssly re-renders the Editor which causes components to get re-rendered when you add new lines above them.

## Changes

* Removes it and relies on the logic setting the content.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
