### PR TITLE
feat: Add env var to skip migration checks

### DIFF
--- a/bin/migrate-check
+++ b/bin/migrate-check
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
-python manage.py migrate --check
-python manage.py migrate_clickhouse --check
-python manage.py run_async_migrations --check
+if [ -z "$POSTHOG_SKIP_MIGRATION_CHECKS" ]; then
+	python manage.py migrate --check
+	python manage.py migrate_clickhouse --check
+	python manage.py run_async_migrations --check
+fi


### PR DESCRIPTION
## Problem
This will allow us to skip the checks in kubernetes pods that use initContainers but without effecting existing deploys or docker-compose

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
