### PR TITLE
feat(css): Add tailwind size breakpoints

### DIFF
--- a/frontend/src/styles/mixins.scss
+++ b/frontend/src/styles/mixins.scss
@@ -28,7 +28,11 @@
 }
 
 @mixin screen($breakpoint) {
-    @media screen and (min-width: $breakpoint) {
+    @if $breakpoint == null {
         @content;
+    } @else {
+        @media screen and (min-width: $breakpoint) {
+            @content;
+        }
     }
 }

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -12,1175 +12,1190 @@
     custom naming conventions 🙌
 */
 
-// TODO: Wrap all of this in a catch for the screen breakpoints like md:foo
-@each $space in $tiny_spaces {
-    .space-y-#{escape-number($space)} {
-        & > * + * {
-            margin-top: #{$space * 0.25}rem;
-        }
-    }
+@each $name,
+    $size
+        in map-merge(
+            (
+                'base': null,
+            ),
+            $screens
+        )
+{
+    $prefix: if($name == 'base', '', $name + '\\:');
 
-    .space-x-#{escape-number($space)} {
-        & > * + * {
-            margin-left: #{$space * 0.25}rem;
-        }
-    }
+    @include screen($size) {
+        @debug 'Name: #{$name}, Size: #{$size}, Prefix: #{$prefix}';
 
-    .gap-#{escape-number($space)} {
-        gap: #{$space * 0.25}rem;
-    }
+        @each $space in $tiny_spaces {
+            .#{$prefix}space-y-#{escape-number($space)} {
+                & > * + * {
+                    margin-top: #{$space * 0.25}rem;
+                }
+            }
 
-    .gap-x-#{escape-number($space)} {
-        column-gap: #{$space * 0.25}rem;
-    }
+            .#{$prefix}space-x-#{escape-number($space)} {
+                & > * + * {
+                    margin-left: #{$space * 0.25}rem;
+                }
+            }
 
-    .gap-y-#{escape-number($space)} {
-        row-gap: #{$space * 0.25}rem;
-    }
+            .#{$prefix}gap-#{escape-number($space)} {
+                gap: #{$space * 0.25}rem;
+            }
 
-    .m-#{escape-number($space)} {
-        margin: #{$space * 0.25}rem;
-    }
+            .#{$prefix}gap-x-#{escape-number($space)} {
+                column-gap: #{$space * 0.25}rem;
+            }
 
-    .-m-#{escape-number($space)} {
-        margin: #{-$space * 0.25}rem;
-    }
+            .#{$prefix}gap-y-#{escape-number($space)} {
+                row-gap: #{$space * 0.25}rem;
+            }
 
-    .mx-#{escape-number($space)} {
-        margin-left: #{$space * 0.25}rem;
-        margin-right: #{$space * 0.25}rem;
-    }
+            .#{$prefix}m-#{escape-number($space)} {
+                margin: #{$space * 0.25}rem;
+            }
 
-    .-mx-#{escape-number($space)} {
-        margin-left: #{-$space * 0.25}rem;
-        margin-right: #{-$space * 0.25}rem;
-    }
+            .#{$prefix}-m-#{escape-number($space)} {
+                margin: #{-$space * 0.25}rem;
+            }
 
-    .my-#{escape-number($space)} {
-        margin-top: #{$space * 0.25}rem;
-        margin-bottom: #{$space * 0.25}rem;
-    }
+            .#{$prefix}mx-#{escape-number($space)} {
+                margin-left: #{$space * 0.25}rem;
+                margin-right: #{$space * 0.25}rem;
+            }
 
-    .-my-#{escape-number($space)} {
-        margin-top: #{-$space * 0.25}rem;
-        margin-bottom: #{-$space * 0.25}rem;
-    }
+            .#{$prefix}-mx-#{escape-number($space)} {
+                margin-left: #{-$space * 0.25}rem;
+                margin-right: #{-$space * 0.25}rem;
+            }
 
-    .px-#{escape-number($space)} {
-        padding-left: #{$space * 0.25}rem;
-        padding-right: #{$space * 0.25}rem;
-    }
+            .#{$prefix}my-#{escape-number($space)} {
+                margin-top: #{$space * 0.25}rem;
+                margin-bottom: #{$space * 0.25}rem;
+            }
 
-    .py-#{escape-number($space)} {
-        padding-top: #{$space * 0.25}rem;
-        padding-bottom: #{$space * 0.25}rem;
-    }
+            .#{$prefix}-my-#{escape-number($space)} {
+                margin-top: #{-$space * 0.25}rem;
+                margin-bottom: #{-$space * 0.25}rem;
+            }
 
-    .p-#{escape-number($space)} {
-        padding: #{$space * 0.25}rem;
-    }
+            .#{$prefix}px-#{escape-number($space)} {
+                padding-left: #{$space * 0.25}rem;
+                padding-right: #{$space * 0.25}rem;
+            }
 
-    .inset-#{escape-number($space)} {
-        top: #{$space * 0.25}rem;
-        right: #{$space * 0.25}rem;
-        bottom: #{$space * 0.25}rem;
-        left: #{$space * 0.25}rem;
-    }
+            .#{$prefix}py-#{escape-number($space)} {
+                padding-top: #{$space * 0.25}rem;
+                padding-bottom: #{$space * 0.25}rem;
+            }
 
-    .inset-x-#{escape-number($space)} {
-        left: #{$space * 0.25}rem;
-        right: #{$space * 0.25}rem;
-    }
+            .#{$prefix}p-#{escape-number($space)} {
+                padding: #{$space * 0.25}rem;
+            }
 
-    .inset-y-#{escape-number($space)} {
-        top: #{$space * 0.25}rem;
-        bottom: #{$space * 0.25}rem;
-    }
-    .top-#{escape-number($space)} {
-        top: #{$space * 0.25}rem;
-    }
+            .#{$prefix}inset-#{escape-number($space)} {
+                top: #{$space * 0.25}rem;
+                right: #{$space * 0.25}rem;
+                bottom: #{$space * 0.25}rem;
+                left: #{$space * 0.25}rem;
+            }
 
-    .bottom-#{escape-number($space)} {
-        bottom: #{$space * 0.25}rem;
-    }
+            .#{$prefix}inset-x-#{escape-number($space)} {
+                left: #{$space * 0.25}rem;
+                right: #{$space * 0.25}rem;
+            }
 
-    .right-#{escape-number($space)} {
-        right: #{$space * 0.25}rem;
-    }
+            .#{$prefix}inset-y-#{escape-number($space)} {
+                top: #{$space * 0.25}rem;
+                bottom: #{$space * 0.25}rem;
+            }
+            .#{$prefix}top-#{escape-number($space)} {
+                top: #{$space * 0.25}rem;
+            }
 
-    .left-#{escape-number($space)} {
-        left: #{$space * 0.25}rem;
-    }
+            .#{$prefix}bottom-#{escape-number($space)} {
+                bottom: #{$space * 0.25}rem;
+            }
 
-    @each $side in $sides {
-        .m#{str-slice($side, 0, 1)}-#{escape-number($space)} {
-            margin-#{$side}: #{$space * 0.25}rem;
-        }
+            .#{$prefix}right-#{escape-number($space)} {
+                right: #{$space * 0.25}rem;
+            }
 
-        .-m#{str-slice($side, 0, 1)}-#{escape-number($space)} {
-            margin-#{$side}: #{-$space * 0.25}rem;
-        }
+            .#{$prefix}left-#{escape-number($space)} {
+                left: #{$space * 0.25}rem;
+            }
 
-        .p#{str-slice($side, 0, 1)}-#{escape-number($space)} {
-            padding-#{$side}: #{$space * 0.25}rem;
-        }
-    }
-}
+            @each $side in $sides {
+                .#{$prefix}m#{str-slice($side, 0, 1)}-#{escape-number($space)} {
+                    margin-#{$side}: #{$space * 0.25}rem;
+                }
 
-@each $name, $size in $screens {
-    .w-#{$name} {
-        width: $size;
-    }
-    .h-#{$name} {
-        height: $size;
-    }
-    .min-w-#{$name} {
-        min-width: $size;
-    }
-    .max-w-#{$name} {
-        max-width: $size;
-    }
-    .min-h-#{$name} {
-        min-height: $size;
-    }
-    .max-h-#{$name} {
-        max-height: $size;
-    }
-}
+                .#{$prefix}-m#{str-slice($side, 0, 1)}-#{escape-number($space)} {
+                    margin-#{$side}: #{-$space * 0.25}rem;
+                }
 
-// TODO: Wrap all of this in a catch for the screen breakpoints like md:foo
-@each $space in $all_spaces {
-    .w-#{escape-number($space)} {
-        width: #{$space * 0.25}rem;
-    }
-
-    .h-#{escape-number($space)} {
-        height: #{$space * 0.25}rem;
-    }
-
-    .max-w-#{escape-number($space)} {
-        max-width: #{$space * 0.25}rem;
-    }
-    .max-h-#{escape-number($space)} {
-        max-height: #{$space * 0.25}rem;
-    }
-
-    .min-w-#{escape-number($space)} {
-        min-width: #{$space * 0.25}rem;
-    }
-    .min-h-#{escape-number($space)} {
-        min-height: #{$space * 0.25}rem;
-    }
-}
-
-.space-y-px {
-    & > * + * {
-        margin-top: 1px;
-    }
-}
-
-.space-x-px {
-    & > * + * {
-        margin-left: 1px;
-    }
-}
-
-.border {
-    border-width: 1px;
-}
-
-// Margins/padding
-@each $kind in ('margin', 'padding') {
-    $char: str-slice($kind, 0, 1);
-
-    .#{$char}-auto {
-        #{$kind}: auto;
-    }
-    .#{$char}x-auto {
-        #{$kind}-left: auto;
-        #{$kind}-right: auto;
-    }
-
-    .#{$char}y-auto {
-        #{$kind}-top: auto;
-        #{$kind}-bottom: auto;
-    }
-    .#{$char}-px {
-        #{$kind}: 1px;
-    }
-
-    .#{$char}x-px {
-        #{$kind}-left: 1px;
-        #{$kind}-right: 1px;
-    }
-
-    .#{$char}y-px {
-        #{$kind}-top: 1px;
-        #{$kind}-bottom: 1px;
-    }
-
-    @each $side in $sides {
-        .#{$char}#{str-slice($side, 0, 1)}-auto {
-            #{$kind}-#{$side}: auto;
+                .#{$prefix}p#{str-slice($side, 0, 1)}-#{escape-number($space)} {
+                    padding-#{$side}: #{$space * 0.25}rem;
+                }
+            }
         }
 
-        .#{$char}#{str-slice($side, 0, 1)}-px {
-            #{$kind}-#{$side}: 1px;
-        }
-    }
-}
-
-.-mt-px {
-    margin-top: -1px;
-}
-
-// Border
-.border-0 {
-    border-width: 0px;
-}
-.border-2 {
-    border-width: 2px;
-}
-.border-4 {
-    border-width: 4px;
-}
-.border-6 {
-    border-width: 6px;
-}
-.border-8 {
-    border-width: 8px;
-}
-.border-t-0 {
-    border-top-width: 0px;
-}
-.border-t-2 {
-    border-top-width: 2px;
-}
-.border-t-4 {
-    border-top-width: 4px;
-}
-.border-t-6 {
-    border-top-width: 6px;
-}
-.border-t-8 {
-    border-top-width: 8px;
-}
-.border-t {
-    border-top-width: 1px;
-}
-.border-r-0 {
-    border-right-width: 0px;
-}
-.border-r-2 {
-    border-right-width: 2px;
-}
-.border-r-4 {
-    border-right-width: 4px;
-}
-.border-r-6 {
-    border-right-width: 6px;
-}
-.border-r-8 {
-    border-right-width: 8px;
-}
-.border-r {
-    border-right-width: 1px;
-}
-.border-b-0 {
-    border-bottom-width: 0px;
-}
-.border-b-2 {
-    border-bottom-width: 2px;
-}
-.border-b-4 {
-    border-bottom-width: 4px;
-}
-.border-b-6 {
-    border-bottom-width: 6px;
-}
-.border-b-8 {
-    border-bottom-width: 8px;
-}
-.border-b {
-    border-bottom-width: 1px;
-}
-.border-l-0 {
-    border-left-width: 0px;
-}
-.border-l-2 {
-    border-left-width: 2px;
-}
-.border-l-4 {
-    border-left-width: 4px;
-}
-.border-l-6 {
-    border-left-width: 6px;
-}
-.border-l-8 {
-    border-left-width: 8px;
-}
-.border-l {
-    border-left-width: 1px;
-}
-
-.border-solid {
-    border-style: solid;
-}
-.border-dashed {
-    border-style: dashed;
-}
-.border-dotted {
-    border-style: dotted;
-}
-.border-double {
-    border-style: double;
-}
-.border-hidden {
-    border-style: hidden;
-}
-.border-none {
-    border-style: none;
-}
-
-$decorations: underline, overline, line-through, no-underline;
-@each $decoration in $decorations {
-    .#{$decoration} {
-        text-decoration-line: $decoration;
-    }
-    .hover\:#{$decoration}:hover {
-        text-decoration-line: $decoration;
-    }
-}
-
-.decoration-inherit {
-    text-decoration-color: inherit;
-}
-.decoration-current {
-    text-decoration-color: currentColor;
-}
-.decoration-transparent {
-    text-decoration-color: transparent;
-}
-
-@each $name, $hex in $colors {
-    .text-#{$name} {
-        color: var(--#{$name});
-    }
-    .bg-#{$name} {
-        background-color: var(--#{$name});
-    }
-    .border-#{$name} {
-        border-color: var(--#{$name});
-    }
-    .border-x-#{$name} {
-        border-left-color: var(--#{$name});
-        border-right-color: var(--#{$name});
-    }
-    .border-y-#{$name} {
-        border-top-color: var(--#{$name});
-        border-bottom-color: var(--#{$name});
-    }
-    .decoration-#{$name} {
-        text-decoration-color: var(--#{$name});
-    }
-}
-
-@each $name, $hex in $colors {
-    .hover\:text-#{$name}:hover {
-        color: $hex;
-    }
-    .hover\:bg-#{$name}:hover {
-        background-color: $hex;
-    }
-    .hover\:border-#{$name}:hover {
-        border-color: $hex;
-    }
-}
-
-// Widths / heights
-
-@each $kind in ('width', 'height') {
-    $char: str-slice($kind, 1, 1);
-    .#{$char}-auto {
-        #{$kind}: auto;
-    }
-    .#{$char}-full {
-        #{$kind}: 100%;
-    }
-    .#{$char}-screen {
-        #{$kind}: unquote('100v' + $char);
-    }
-    .#{$char}-min {
-        #{$kind}: min-content;
-    }
-    .#{$char}-max {
-        #{$kind}: max-content;
-    }
-    .#{$char}-fit {
-        #{$kind}: fit-content;
-    }
-
-    .min-#{$char}-full {
-        min-#{$kind}: 100%;
-    }
-    .min-#{$char}-screen {
-        min-#{$kind}: unquote('100v' + $char);
-    }
-
-    .max-#{$char}-full {
-        max-#{$kind}: 100%;
-    }
-    .max-#{$char}-screen {
-        max-#{$kind}: unquote('100v' + $char);
-    }
-
-    @each $variant in ('', 'max-', 'min-') {
-        .#{$variant}#{$char}-1\/2 {
-            #{$variant}#{$kind}: 50%;
+        @each $name, $size in $screens {
+            .#{$prefix}w-#{$name} {
+                width: $size;
+            }
+            .#{$prefix}h-#{$name} {
+                height: $size;
+            }
+            .#{$prefix}min-w-#{$name} {
+                min-width: $size;
+            }
+            .#{$prefix}max-w-#{$name} {
+                max-width: $size;
+            }
+            .#{$prefix}min-h-#{$name} {
+                min-height: $size;
+            }
+            .#{$prefix}max-h-#{$name} {
+                max-height: $size;
+            }
         }
 
-        .#{$variant}#{$char}-1\/3 {
-            #{$variant}#{$kind}: 33.333333%;
+        // TODO: Wrap all of this in a catch for the screen breakpoints like md:foo
+        @each $space in $all_spaces {
+            .#{$prefix}w-#{escape-number($space)} {
+                width: #{$space * 0.25}rem;
+            }
+
+            .#{$prefix}h-#{escape-number($space)} {
+                height: #{$space * 0.25}rem;
+            }
+
+            .#{$prefix}max-w-#{escape-number($space)} {
+                max-width: #{$space * 0.25}rem;
+            }
+            .#{$prefix}max-h-#{escape-number($space)} {
+                max-height: #{$space * 0.25}rem;
+            }
+
+            .#{$prefix}min-w-#{escape-number($space)} {
+                min-width: #{$space * 0.25}rem;
+            }
+            .#{$prefix}min-h-#{escape-number($space)} {
+                min-height: #{$space * 0.25}rem;
+            }
         }
 
-        .#{$variant}#{$char}-2\/3 {
-            #{$variant}#{$kind}: 66.666667%;
+        .#{$prefix}space-y-px {
+            & > * + * {
+                margin-top: 1px;
+            }
         }
 
-        .#{$variant}#{$char}-1\/4 {
-            #{$variant}#{$kind}: 25%;
+        .#{$prefix}space-x-px {
+            & > * + * {
+                margin-left: 1px;
+            }
         }
 
-        .#{$variant}#{$char}-2\/4 {
-            #{$variant}#{$kind}: 50%;
+        .#{$prefix}border {
+            border-width: 1px;
         }
 
-        .#{$variant}#{$char}-3\/4 {
-            #{$variant}#{$kind}: 75%;
+        // Margins/padding
+        @each $kind in ('margin', 'padding') {
+            $char: str-slice($kind, 0, 1);
+
+            .#{$prefix}#{$char}-auto {
+                #{$kind}: auto;
+            }
+            .#{$prefix}#{$char}x-auto {
+                #{$kind}-left: auto;
+                #{$kind}-right: auto;
+            }
+
+            .#{$prefix}#{$char}y-auto {
+                #{$kind}-top: auto;
+                #{$kind}-bottom: auto;
+            }
+            .#{$prefix}#{$char}-px {
+                #{$kind}: 1px;
+            }
+
+            .#{$prefix}#{$char}x-px {
+                #{$kind}-left: 1px;
+                #{$kind}-right: 1px;
+            }
+
+            .#{$prefix}#{$char}y-px {
+                #{$kind}-top: 1px;
+                #{$kind}-bottom: 1px;
+            }
+
+            @each $side in $sides {
+                .#{$prefix}#{$char}#{str-slice($side, 0, 1)}-auto {
+                    #{$kind}-#{$side}: auto;
+                }
+
+                .#{$prefix}#{$char}#{str-slice($side, 0, 1)}-px {
+                    #{$kind}-#{$side}: 1px;
+                }
+            }
         }
 
-        .#{$variant}#{$char}-1\/5 {
-            #{$variant}#{$kind}: 20%;
+        .#{$prefix}-mt-px {
+            margin-top: -1px;
         }
 
-        .#{$variant}#{$char}-2\/5 {
-            #{$variant}#{$kind}: 40%;
+        // Border
+        .#{$prefix}border-0 {
+            border-width: 0px;
+        }
+        .#{$prefix}border-2 {
+            border-width: 2px;
+        }
+        .#{$prefix}border-4 {
+            border-width: 4px;
+        }
+        .#{$prefix}border-6 {
+            border-width: 6px;
+        }
+        .#{$prefix}border-8 {
+            border-width: 8px;
+        }
+        .#{$prefix}border-t-0 {
+            border-top-width: 0px;
+        }
+        .#{$prefix}border-t-2 {
+            border-top-width: 2px;
+        }
+        .#{$prefix}border-t-4 {
+            border-top-width: 4px;
+        }
+        .#{$prefix}border-t-6 {
+            border-top-width: 6px;
+        }
+        .#{$prefix}border-t-8 {
+            border-top-width: 8px;
+        }
+        .#{$prefix}border-t {
+            border-top-width: 1px;
+        }
+        .#{$prefix}border-r-0 {
+            border-right-width: 0px;
+        }
+        .#{$prefix}border-r-2 {
+            border-right-width: 2px;
+        }
+        .#{$prefix}border-r-4 {
+            border-right-width: 4px;
+        }
+        .#{$prefix}border-r-6 {
+            border-right-width: 6px;
+        }
+        .#{$prefix}border-r-8 {
+            border-right-width: 8px;
+        }
+        .#{$prefix}border-r {
+            border-right-width: 1px;
+        }
+        .#{$prefix}border-b-0 {
+            border-bottom-width: 0px;
+        }
+        .#{$prefix}border-b-2 {
+            border-bottom-width: 2px;
+        }
+        .#{$prefix}border-b-4 {
+            border-bottom-width: 4px;
+        }
+        .#{$prefix}border-b-6 {
+            border-bottom-width: 6px;
+        }
+        .#{$prefix}border-b-8 {
+            border-bottom-width: 8px;
+        }
+        .#{$prefix}border-b {
+            border-bottom-width: 1px;
+        }
+        .#{$prefix}border-l-0 {
+            border-left-width: 0px;
+        }
+        .#{$prefix}border-l-2 {
+            border-left-width: 2px;
+        }
+        .#{$prefix}border-l-4 {
+            border-left-width: 4px;
+        }
+        .#{$prefix}border-l-6 {
+            border-left-width: 6px;
+        }
+        .#{$prefix}border-l-8 {
+            border-left-width: 8px;
+        }
+        .#{$prefix}border-l {
+            border-left-width: 1px;
         }
 
-        .#{$variant}#{$char}-3\/5 {
-            #{$variant}#{$kind}: 60%;
+        .#{$prefix}border-solid {
+            border-style: solid;
+        }
+        .#{$prefix}border-dashed {
+            border-style: dashed;
+        }
+        .#{$prefix}border-dotted {
+            border-style: dotted;
+        }
+        .#{$prefix}border-double {
+            border-style: double;
+        }
+        .#{$prefix}border-hidden {
+            border-style: hidden;
+        }
+        .#{$prefix}border-none {
+            border-style: none;
         }
 
-        .#{$variant}#{$char}-4\/5 {
-            #{$variant}#{$kind}: 80%;
+        $decorations: underline, overline, line-through, no-underline;
+        @each $decoration in $decorations {
+            .#{$prefix}#{$decoration} {
+                text-decoration-line: $decoration;
+            }
+            .#{$prefix}hover\:#{$decoration}:hover {
+                text-decoration-line: $decoration;
+            }
+        }
+
+        .#{$prefix}decoration-inherit {
+            text-decoration-color: inherit;
+        }
+        .#{$prefix}decoration-current {
+            text-decoration-color: currentColor;
+        }
+        .#{$prefix}decoration-transparent {
+            text-decoration-color: transparent;
+        }
+
+        @each $name, $hex in $colors {
+            .#{$prefix}text-#{$name} {
+                color: var(--#{$name});
+            }
+            .#{$prefix}bg-#{$name} {
+                background-color: var(--#{$name});
+            }
+            .#{$prefix}border-#{$name} {
+                border-color: var(--#{$name});
+            }
+            .#{$prefix}border-x-#{$name} {
+                border-left-color: var(--#{$name});
+                border-right-color: var(--#{$name});
+            }
+            .#{$prefix}border-y-#{$name} {
+                border-top-color: var(--#{$name});
+                border-bottom-color: var(--#{$name});
+            }
+            .#{$prefix}decoration-#{$name} {
+                text-decoration-color: var(--#{$name});
+            }
+        }
+
+        @each $name, $hex in $colors {
+            .#{$prefix}hover\:text-#{$name}:hover {
+                color: $hex;
+            }
+            .#{$prefix}hover\:bg-#{$name}:hover {
+                background-color: $hex;
+            }
+            .#{$prefix}hover\:border-#{$name}:hover {
+                border-color: $hex;
+            }
+        }
+
+        // Widths / heights
+
+        @each $kind in ('width', 'height') {
+            $char: str-slice($kind, 1, 1);
+            .#{$prefix}#{$char}-auto {
+                #{$kind}: auto;
+            }
+            .#{$prefix}#{$char}-full {
+                #{$kind}: 100%;
+            }
+            .#{$prefix}#{$char}-screen {
+                #{$kind}: unquote('100v' + $char);
+            }
+            .#{$prefix}#{$char}-min {
+                #{$kind}: min-content;
+            }
+            .#{$prefix}#{$char}-max {
+                #{$kind}: max-content;
+            }
+            .#{$prefix}#{$char}-fit {
+                #{$kind}: fit-content;
+            }
+
+            .#{$prefix}min-#{$char}-full {
+                min-#{$kind}: 100%;
+            }
+            .#{$prefix}min-#{$char}-screen {
+                min-#{$kind}: unquote('100v' + $char);
+            }
+
+            .#{$prefix}max-#{$char}-full {
+                max-#{$kind}: 100%;
+            }
+            .#{$prefix}max-#{$char}-screen {
+                max-#{$kind}: unquote('100v' + $char);
+            }
+
+            @each $variant in ('', 'max-', 'min-') {
+                .#{$prefix}#{$variant}#{$char}-1\/2 {
+                    #{$variant}#{$kind}: 50%;
+                }
+
+                .#{$prefix}#{$variant}#{$char}-1\/3 {
+                    #{$variant}#{$kind}: 33.333333%;
+                }
+
+                .#{$prefix}#{$variant}#{$char}-2\/3 {
+                    #{$variant}#{$kind}: 66.666667%;
+                }
+
+                .#{$prefix}#{$variant}#{$char}-1\/4 {
+                    #{$variant}#{$kind}: 25%;
+                }
+
+                .#{$prefix}#{$variant}#{$char}-2\/4 {
+                    #{$variant}#{$kind}: 50%;
+                }
+
+                .#{$prefix}#{$variant}#{$char}-3\/4 {
+                    #{$variant}#{$kind}: 75%;
+                }
+
+                .#{$prefix}#{$variant}#{$char}-1\/5 {
+                    #{$variant}#{$kind}: 20%;
+                }
+
+                .#{$prefix}#{$variant}#{$char}-2\/5 {
+                    #{$variant}#{$kind}: 40%;
+                }
+
+                .#{$prefix}#{$variant}#{$char}-3\/5 {
+                    #{$variant}#{$kind}: 60%;
+                }
+
+                .#{$prefix}#{$variant}#{$char}-4\/5 {
+                    #{$variant}#{$kind}: 80%;
+                }
+            }
+        }
+
+        // One-off utilities
+
+        .#{$prefix}text-right {
+            text-align: right;
+        }
+
+        .#{$prefix}text-left {
+            text-align: left;
+        }
+
+        .#{$prefix}text-center {
+            text-align: center;
+        }
+
+        .#{$prefix}uppercase {
+            text-transform: uppercase;
+        }
+
+        .#{$prefix}float-right {
+            float: right;
+        }
+
+        .#{$prefix}float-left {
+            float: left;
+        }
+
+        .#{$prefix}align-middle {
+            vertical-align: middle;
+        }
+
+        // Display
+
+        .#{$prefix}block {
+            display: block;
+        }
+
+        .#{$prefix}inline-block {
+            display: inline-block;
+        }
+
+        .#{$prefix}inline {
+            display: inline;
+        }
+
+        .#{$prefix}grid {
+            display: grid;
+        }
+
+        .#{$prefix}inline-grid {
+            display: inline-grid;
+        }
+
+        .#{$prefix}hidden {
+            display: none;
+        }
+
+        // Flex
+        .#{$prefix}flex {
+            display: flex;
+        }
+
+        .#{$prefix}inline-flex {
+            display: inline-flex;
+        }
+
+        @each $size in $flex_sizes {
+            .#{$prefix}flex-#{escape-number($size)} {
+                flex: $size;
+            }
+        }
+
+        .#{$prefix}flex-auto {
+            flex: auto;
+        }
+
+        .#{$prefix}flex-col {
+            flex-direction: column;
+        }
+
+        .#{$prefix}flex-row {
+            flex-direction: row;
+        }
+
+        .#{$prefix}flex-wrap {
+            flex-wrap: wrap;
+        }
+
+        .#{$prefix}flex-wrap-reverse {
+            flex-wrap: wrap-reverse;
+        }
+
+        .#{$prefix}flex-nowrap {
+            flex-wrap: nowrap;
+        }
+
+        .#{$prefix}shrink {
+            flex-shrink: 1;
+        }
+
+        .#{$prefix}shrink-0 {
+            flex-shrink: 0;
+        }
+
+        .#{$prefix}grow {
+            flex-grow: 1;
+        }
+
+        .#{$prefix}grow-0 {
+            flex-grow: 0;
+        }
+
+        .#{$prefix}justify-start {
+            justify-content: flex-start;
+        }
+        .#{$prefix}justify-end {
+            justify-content: flex-end;
+        }
+        .#{$prefix}justify-center {
+            justify-content: center;
+        }
+        .#{$prefix}justify-between {
+            justify-content: space-between;
+        }
+        .#{$prefix}justify-around {
+            justify-content: space-around;
+        }
+        .#{$prefix}justify-evenly {
+            justify-content: space-evenly;
+        }
+
+        .#{$prefix}items-start {
+            align-items: flex-start;
+        }
+        .#{$prefix}items-end {
+            align-items: flex-end;
+        }
+        .#{$prefix}items-center {
+            align-items: center;
+        }
+        .#{$prefix}items-baseline {
+            align-items: baseline;
+        }
+        .#{$prefix}items-stretch {
+            align-items: stretch;
+        }
+
+        .#{$prefix}self-auto {
+            align-self: auto;
+        }
+        .#{$prefix}self-start {
+            align-self: flex-start;
+        }
+        .#{$prefix}self-end {
+            align-self: flex-end;
+        }
+        .#{$prefix}self-center {
+            align-self: center;
+        }
+        .#{$prefix}self-stretch {
+            align-self: stretch;
+        }
+        .#{$prefix}self-baseline {
+            align-self: baseline;
+        }
+
+        // Grid Template Columns
+        @for $i from 1 through 12 {
+            .#{$prefix}grid-cols-#{$i} {
+                grid-template-columns: repeat(#{$i}, minmax(0, 1fr));
+            }
+        }
+        .#{$prefix}grid-cols-none {
+            grid-template-columns: none;
+        }
+
+        // Grid Column Start/End
+        .#{$prefix}col-auto {
+            grid-column: auto;
+        }
+
+        @for $i from 1 through 12 {
+            .#{$prefix}col-span-#{$i} {
+                grid-column: span #{$i} / span #{$i};
+            }
+        }
+        .#{$prefix}col-span-full {
+            grid-column: 1 / -1;
+        }
+
+        @for $i from 1 through 13 {
+            .#{$prefix}col-start-#{$i} {
+                grid-column-start: #{$i};
+            }
+        }
+        .#{$prefix}col-start-auto {
+            grid-column-start: auto;
+        }
+
+        @for $i from 1 through 13 {
+            .#{$prefix}col-end-#{$i} {
+                grid-column-end: #{$i};
+            }
+        }
+        .#{$prefix}col-end-auto {
+            grid-column-end: auto;
+        }
+
+        // Grid Row Start/End
+        .#{$prefix}row-auto {
+            grid-row: auto;
+        }
+
+        @for $i from 1 through 6 {
+            .#{$prefix}row-span-#{$i} {
+                grid-row: span #{$i} / span #{$i};
+            }
+        }
+        .#{$prefix}row-span-full {
+            grid-row: 1 / -1;
+        }
+
+        @for $i from 1 through 7 {
+            .#{$prefix}row-start-#{$i} {
+                grid-row-start: #{$i};
+            }
+        }
+        .#{$prefix}row-start-auto {
+            grid-row-start: auto;
+        }
+
+        @for $i from 1 through 7 {
+            .#{$prefix}row-end-#{$i} {
+                grid-row-end: #{$i};
+            }
+        }
+        .#{$prefix}row-end-auto {
+            grid-row-end: auto;
+        }
+
+        // Gap
+        @each $space in $all_spaces {
+            .#{$prefix}gap-#{escape-number($space)} {
+                gap: #{$space * 0.25}rem;
+            }
+            .#{$prefix}gap-x-#{escape-number($space)} {
+                column-gap: #{$space * 0.25}rem;
+            }
+            .#{$prefix}gap-y-#{escape-number($space)} {
+                row-gap: #{$space * 0.25}rem;
+            }
+        }
+        .#{$prefix}gap-px {
+            gap: 1px;
+        }
+        .#{$prefix}gap-x-px {
+            column-gap: 1px;
+        }
+        .#{$prefix}gap-y-px {
+            row-gap: 1px;
+        }
+
+        // Typography
+        .#{$prefix}font-thin {
+            font-weight: 100;
+        }
+        .#{$prefix}font-extralight {
+            font-weight: 200;
+        }
+        .#{$prefix}font-light {
+            font-weight: 300;
+        }
+        .#{$prefix}font-normal {
+            font-weight: 400;
+        }
+        .#{$prefix}font-medium {
+            font-weight: 500;
+        }
+        .#{$prefix}font-semibold {
+            font-weight: 600;
+        }
+        .#{$prefix}font-bold {
+            font-weight: 700;
+        }
+        .#{$prefix}font-extrabold {
+            font-weight: 800;
+        }
+        .#{$prefix}font-black {
+            font-weight: 900;
+        }
+        .#{$prefix}italic {
+            font-style: italic;
+        }
+        .#{$prefix}not-italic {
+            font-style: normal;
+        }
+
+        .#{$prefix}break-normal {
+            overflow-wrap: normal;
+            word-break: normal;
+        }
+
+        .#{$prefix}break-words {
+            overflow-wrap: break-word;
+        }
+
+        .#{$prefix}break-all {
+            word-break: break-all;
+        }
+
+        .#{$prefix}whitespace-normal {
+            white-space: normal;
+        }
+        .#{$prefix}whitespace-nowrap {
+            white-space: nowrap;
+        }
+        .#{$prefix}whitespace-pre {
+            white-space: pre;
+        }
+        .#{$prefix}whitespace-pre-line {
+            white-space: pre-line;
+        }
+        .#{$prefix}whitespace-pre-wrap {
+            white-space: pre-wrap;
+        }
+
+        .#{$prefix}text-xxs {
+            font-size: 0.625rem; /* 10px */
+            line-height: 0.75rem; /* 12px */
+        }
+        .#{$prefix}text-xs {
+            font-size: 0.75rem; /* 12px */
+            line-height: 1rem; /* 16px */
+        }
+        .#{$prefix}text-sm {
+            font-size: 0.875rem; /* 14px */
+            line-height: 1.25rem; /* 20px */
+        }
+        .#{$prefix}text-base {
+            font-size: 1rem; /* 16px */
+            line-height: 1.5rem; /* 24px */
+        }
+        .#{$prefix}text-lg {
+            font-size: 1.125rem; /* 18px */
+            line-height: 1.75rem; /* 28px */
+        }
+        .#{$prefix}text-xl {
+            font-size: 1.25rem; /* 20px */
+            line-height: 1.75rem; /* 28px */
+        }
+        .#{$prefix}text-2xl {
+            font-size: 1.5rem; /* 24px */
+            line-height: 2rem; /* 32px */
+        }
+        .#{$prefix}text-3xl {
+            font-size: 1.875rem; /* 30px */
+            line-height: 2.25rem; /* 36px */
+        }
+        .#{$prefix}text-4xl {
+            font-size: 2.25rem; /* 36px */
+            line-height: 2.5rem; /* 40px */
+        }
+        .#{$prefix}text-5xl {
+            font-size: 3rem; /* 48px */
+            line-height: 1;
+        }
+        .#{$prefix}text-6xl {
+            font-size: 3.75rem; /* 60px */
+            line-height: 1;
+        }
+        .#{$prefix}text-7xl {
+            font-size: 4.5rem; /* 72px */
+            line-height: 1;
+        }
+        .#{$prefix}text-8xl {
+            font-size: 6rem; /* 96px */
+            line-height: 1;
+        }
+        .#{$prefix}text-9xl {
+            font-size: 8rem; /* 128px */
+            line-height: 1;
+        }
+
+        @each $space in $tiny_spaces {
+            .#{$prefix}leading-#{escape-number($space)} {
+                line-height: #{$space * 0.25}rem;
+            }
+        }
+
+        .#{$prefix}rounded {
+            border-radius: var(--radius); /* 4px */
+        }
+        .#{$prefix}rounded-l {
+            border-top-left-radius: var(--radius); /* 4px */
+            border-bottom-left-radius: var(--radius); /* 4px */
+        }
+        .#{$prefix}rounded-r {
+            border-top-right-radius: var(--radius); /* 4px */
+            border-bottom-right-radius: var(--radius); /* 4px */
+        }
+        .#{$prefix}rounded-t {
+            border-top-left-radius: var(--radius); /* 4px */
+            border-top-right-radius: var(--radius); /* 4px */
+        }
+        .#{$prefix}rounded-b {
+            border-bottom-left-radius: var(--radius); /* 4px */
+            border-bottom-right-radius: var(--radius); /* 4px */
+        }
+
+        .#{$prefix}rounded-none {
+            border-radius: 0;
+        }
+        .#{$prefix}rounded-r-none {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+        }
+        .#{$prefix}rounded-l-none {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+        }
+
+        .#{$prefix}rounded-sm {
+            border-radius: calc(var(--radius) / 2); /* 2px */
+        }
+
+        .#{$prefix}rounded-md {
+            border-radius: calc(var(--radius) * 1.5); /* 6px */
+        }
+        .#{$prefix}rounded-lg {
+            border-radius: calc(var(--radius) * 2); /* 8px */
+        }
+        .#{$prefix}rounded-xl {
+            border-radius: calc(var(--radius) * 3); /* 12px */
+        }
+        .#{$prefix}rounded-2xl {
+            border-radius: calc(var(--radius) * 4); /* 16px */
+        }
+        .#{$prefix}rounded-3xl {
+            border-radius: calc(var(--radius) * 6); /* 24px */
+        }
+        .#{$prefix}rounded-4xl {
+            border-radius: calc(var(--radius) * 8); /* 32px */
+        }
+        .#{$prefix}rounded-full {
+            border-radius: 1000rem;
+        }
+
+        .#{$prefix}overflow-auto {
+            overflow: auto;
+        }
+        .#{$prefix}overflow-hidden {
+            overflow: hidden;
+        }
+        .#{$prefix}overflow-clip {
+            overflow: clip;
+        }
+        .#{$prefix}overflow-visible {
+            overflow: visible;
+        }
+        .#{$prefix}overflow-scroll {
+            overflow: scroll;
+        }
+        .#{$prefix}overflow-x-scroll {
+            overflow-x: scroll;
+        }
+        .#{$prefix}overflow-y-scroll {
+            overflow-y: scroll;
+        }
+        .#{$prefix}overflow-x-auto {
+            overflow-x: auto;
+        }
+        .#{$prefix}overflow-y-auto {
+            overflow-y: auto;
+        }
+        .#{$prefix}overflow-x-hidden {
+            overflow-x: hidden;
+        }
+
+        .#{$prefix}font-sans {
+            font-family: var(--font-sans);
+        }
+
+        .#{$prefix}font-mono {
+            font-family: var(--font-mono);
+        }
+
+        .#{$prefix}opacity-0 {
+            opacity: 0;
+        }
+        .#{$prefix}opacity-5 {
+            opacity: 0.05;
+        }
+        .#{$prefix}opacity-10 {
+            opacity: 0.1;
+        }
+        .#{$prefix}opacity-20 {
+            opacity: 0.2;
+        }
+        .#{$prefix}opacity-25 {
+            opacity: 0.25;
+        }
+        .#{$prefix}opacity-30 {
+            opacity: 0.3;
+        }
+        .#{$prefix}opacity-40 {
+            opacity: 0.4;
+        }
+        .#{$prefix}opacity-50 {
+            opacity: 0.5;
+        }
+        .#{$prefix}opacity-60 {
+            opacity: 0.6;
+        }
+        .#{$prefix}opacity-70 {
+            opacity: 0.7;
+        }
+        .#{$prefix}opacity-75 {
+            opacity: 0.75;
+        }
+        .#{$prefix}opacity-80 {
+            opacity: 0.8;
+        }
+        .#{$prefix}opacity-90 {
+            opacity: 0.9;
+        }
+        .#{$prefix}opacity-95 {
+            opacity: 0.95;
+        }
+        .#{$prefix}opacity-100 {
+            opacity: 1;
+        }
+
+        .#{$prefix}pointer-events-none {
+            pointer-events: none;
+        }
+        .#{$prefix}pointer-events-auto {
+            pointer-events: auto;
+        }
+
+        .#{$prefix}truncate {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .#{$prefix}text-ellipsis {
+            text-overflow: ellipsis;
+        }
+        .#{$prefix}text-clip {
+            text-overflow: clip;
+        }
+
+        @each $cursor in $cursors {
+            .#{$prefix}cursor-#{$cursor} {
+                cursor: #{$cursor};
+            }
+        }
+
+        @each $list_style_type in $list_style_types {
+            .#{$prefix}list-#{$list_style_type} {
+                list-style-type: #{$list_style_type};
+            }
+        }
+
+        .#{$prefix}list-inside {
+            list-style-position: inside;
+        }
+        .#{$prefix}list-outside {
+            list-style-position: outside;
+        }
+
+        .#{$prefix}shadow {
+            box-shadow: var(--shadow-elevation);
+        }
+
+        @each $fitOption in ('contain', 'cover', 'fill', 'none', 'scale-down') {
+            .#{$prefix}object-#{$fitOption} {
+                object-fit: string.unquote($fitOption);
+            }
+            hover\:object-#{$fitOption}:hover {
+                object-fit: string.unquote($fitOption);
+            }
+        }
+
+        .#{$prefix}tracking-tighter {
+            letter-spacing: -0.05em;
+        }
+        .#{$prefix}tracking-tight {
+            letter-spacing: -0.025em;
+        }
+        .#{$prefix}tracking-normal {
+            letter-spacing: 0em;
+        }
+        .#{$prefix}tracking-wide {
+            letter-spacing: 0.025em;
+        }
+        .#{$prefix}tracking-wider {
+            letter-spacing: 0.05em;
+        }
+        .#{$prefix}tracking-widest {
+            letter-spacing: 0.1em;
+        }
+
+        .#{$prefix}select-none {
+            user-select: none;
+        }
+        .#{$prefix}select-text {
+            user-select: text;
+        }
+        .#{$prefix}select-all {
+            user-select: all;
+        }
+        .#{$prefix}select-auto {
+            user-select: auto;
+        }
+
+        .#{$prefix}rotate-90 {
+            transform: rotate(90deg);
+        }
+        .#{$prefix}rotate-180 {
+            transform: rotate(180deg);
+        }
+
+        .#{$prefix}rotate-270 {
+            transform: rotate(270deg);
+        }
+
+        .#{$prefix}z-0 {
+            z-index: 0;
+        }
+
+        .#{$prefix}z-10 {
+            z-index: 10;
+        }
+
+        .#{$prefix}z-20 {
+            z-index: 20;
+        }
+
+        .#{$prefix}z-30 {
+            z-index: 30;
+        }
+
+        .#{$prefix}z-40 {
+            z-index: 40;
+        }
+
+        .#{$prefix}z-50 {
+            z-index: 50;
+        }
+
+        .#{$prefix}z-auto {
+            z-index: auto;
+        }
+
+        .#{$prefix}invisible {
+            visibility: hidden;
+        }
+
+        .#{$prefix}resize-y {
+            resize: vertical;
+        }
+
+        // Position
+
+        .#{$prefix}static {
+            position: static;
+        }
+
+        .#{$prefix}relative {
+            position: relative;
+        }
+
+        .#{$prefix}absolute {
+            position: absolute;
+        }
+
+        .#{$prefix}fixed {
+            position: fixed;
+        }
+
+        .#{$prefix}sticky {
+            position: sticky;
+        }
+
+        .#{$prefix}line-clamp-2 {
+            overflow: hidden;
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 2;
+        }
+
+        .#{$prefix}transition-all {
+            transition-property: all;
+            transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+            transition-duration: 150ms;
+        }
+
+        .#{$prefix}aspect-auto {
+            aspect-ratio: auto;
+        }
+
+        .#{$prefix}aspect-square {
+            aspect-ratio: 1 / 1;
+        }
+
+        .#{$prefix}aspect-video {
+            aspect-ratio: 16 / 9;
         }
     }
-}
-
-// One-off utilities
-
-.text-right {
-    text-align: right;
-}
-
-.text-left {
-    text-align: left;
-}
-
-.text-center {
-    text-align: center;
-}
-
-.uppercase {
-    text-transform: uppercase;
-}
-
-.float-right {
-    float: right;
-}
-
-.float-left {
-    float: left;
-}
-
-.align-middle {
-    vertical-align: middle;
-}
-
-// Display
-
-.block {
-    display: block;
-}
-
-.inline-block {
-    display: inline-block;
-}
-
-.inline {
-    display: inline;
-}
-
-.grid {
-    display: grid;
-}
-
-.inline-grid {
-    display: inline-grid;
-}
-
-.hidden {
-    display: none;
-}
-
-// Flex
-.flex {
-    display: flex;
-}
-
-.inline-flex {
-    display: inline-flex;
-}
-
-@each $size in $flex_sizes {
-    .flex-#{escape-number($size)} {
-        flex: $size;
-    }
-}
-
-.flex-auto {
-    flex: auto;
-}
-
-.flex-col {
-    flex-direction: column;
-}
-
-.flex-row {
-    flex-direction: row;
-}
-
-.flex-wrap {
-    flex-wrap: wrap;
-}
-
-.flex-wrap-reverse {
-    flex-wrap: wrap-reverse;
-}
-
-.flex-nowrap {
-    flex-wrap: nowrap;
-}
-
-.shrink {
-    flex-shrink: 1;
-}
-
-.shrink-0 {
-    flex-shrink: 0;
-}
-
-.grow {
-    flex-grow: 1;
-}
-
-.grow-0 {
-    flex-grow: 0;
-}
-
-.justify-start {
-    justify-content: flex-start;
-}
-.justify-end {
-    justify-content: flex-end;
-}
-.justify-center {
-    justify-content: center;
-}
-.justify-between {
-    justify-content: space-between;
-}
-.justify-around {
-    justify-content: space-around;
-}
-.justify-evenly {
-    justify-content: space-evenly;
-}
-
-.items-start {
-    align-items: flex-start;
-}
-.items-end {
-    align-items: flex-end;
-}
-.items-center {
-    align-items: center;
-}
-.items-baseline {
-    align-items: baseline;
-}
-.items-stretch {
-    align-items: stretch;
-}
-
-.self-auto {
-    align-self: auto;
-}
-.self-start {
-    align-self: flex-start;
-}
-.self-end {
-    align-self: flex-end;
-}
-.self-center {
-    align-self: center;
-}
-.self-stretch {
-    align-self: stretch;
-}
-.self-baseline {
-    align-self: baseline;
-}
-
-// Grid Template Columns
-@for $i from 1 through 12 {
-    .grid-cols-#{$i} {
-        grid-template-columns: repeat(#{$i}, minmax(0, 1fr));
-    }
-}
-.grid-cols-none {
-    grid-template-columns: none;
-}
-
-// Grid Column Start/End
-.col-auto {
-    grid-column: auto;
-}
-
-@for $i from 1 through 12 {
-    .col-span-#{$i} {
-        grid-column: span #{$i} / span #{$i};
-    }
-}
-.col-span-full {
-    grid-column: 1 / -1;
-}
-
-@for $i from 1 through 13 {
-    .col-start-#{$i} {
-        grid-column-start: #{$i};
-    }
-}
-.col-start-auto {
-    grid-column-start: auto;
-}
-
-@for $i from 1 through 13 {
-    .col-end-#{$i} {
-        grid-column-end: #{$i};
-    }
-}
-.col-end-auto {
-    grid-column-end: auto;
-}
-
-// Grid Row Start/End
-.row-auto {
-    grid-row: auto;
-}
-
-@for $i from 1 through 6 {
-    .row-span-#{$i} {
-        grid-row: span #{$i} / span #{$i};
-    }
-}
-.row-span-full {
-    grid-row: 1 / -1;
-}
-
-@for $i from 1 through 7 {
-    .row-start-#{$i} {
-        grid-row-start: #{$i};
-    }
-}
-.row-start-auto {
-    grid-row-start: auto;
-}
-
-@for $i from 1 through 7 {
-    .row-end-#{$i} {
-        grid-row-end: #{$i};
-    }
-}
-.row-end-auto {
-    grid-row-end: auto;
-}
-
-// Gap
-@each $space in $all_spaces {
-    .gap-#{escape-number($space)} {
-        gap: #{$space * 0.25}rem;
-    }
-    .gap-x-#{escape-number($space)} {
-        column-gap: #{$space * 0.25}rem;
-    }
-    .gap-y-#{escape-number($space)} {
-        row-gap: #{$space * 0.25}rem;
-    }
-}
-.gap-px {
-    gap: 1px;
-}
-.gap-x-px {
-    column-gap: 1px;
-}
-.gap-y-px {
-    row-gap: 1px;
-}
-
-// Typography
-.font-thin {
-    font-weight: 100;
-}
-.font-extralight {
-    font-weight: 200;
-}
-.font-light {
-    font-weight: 300;
-}
-.font-normal {
-    font-weight: 400;
-}
-.font-medium {
-    font-weight: 500;
-}
-.font-semibold {
-    font-weight: 600;
-}
-.font-bold {
-    font-weight: 700;
-}
-.font-extrabold {
-    font-weight: 800;
-}
-.font-black {
-    font-weight: 900;
-}
-.italic {
-    font-style: italic;
-}
-.not-italic {
-    font-style: normal;
-}
-
-.break-normal {
-    overflow-wrap: normal;
-    word-break: normal;
-}
-
-.break-words {
-    overflow-wrap: break-word;
-}
-
-.break-all {
-    word-break: break-all;
-}
-
-.whitespace-normal {
-    white-space: normal;
-}
-.whitespace-nowrap {
-    white-space: nowrap;
-}
-.whitespace-pre {
-    white-space: pre;
-}
-.whitespace-pre-line {
-    white-space: pre-line;
-}
-.whitespace-pre-wrap {
-    white-space: pre-wrap;
-}
-
-.text-xxs {
-    font-size: 0.625rem; /* 10px */
-    line-height: 0.75rem; /* 12px */
-}
-.text-xs {
-    font-size: 0.75rem; /* 12px */
-    line-height: 1rem; /* 16px */
-}
-.text-sm {
-    font-size: 0.875rem; /* 14px */
-    line-height: 1.25rem; /* 20px */
-}
-.text-base {
-    font-size: 1rem; /* 16px */
-    line-height: 1.5rem; /* 24px */
-}
-.text-lg {
-    font-size: 1.125rem; /* 18px */
-    line-height: 1.75rem; /* 28px */
-}
-.text-xl {
-    font-size: 1.25rem; /* 20px */
-    line-height: 1.75rem; /* 28px */
-}
-.text-2xl {
-    font-size: 1.5rem; /* 24px */
-    line-height: 2rem; /* 32px */
-}
-.text-3xl {
-    font-size: 1.875rem; /* 30px */
-    line-height: 2.25rem; /* 36px */
-}
-.text-4xl {
-    font-size: 2.25rem; /* 36px */
-    line-height: 2.5rem; /* 40px */
-}
-.text-5xl {
-    font-size: 3rem; /* 48px */
-    line-height: 1;
-}
-.text-6xl {
-    font-size: 3.75rem; /* 60px */
-    line-height: 1;
-}
-.text-7xl {
-    font-size: 4.5rem; /* 72px */
-    line-height: 1;
-}
-.text-8xl {
-    font-size: 6rem; /* 96px */
-    line-height: 1;
-}
-.text-9xl {
-    font-size: 8rem; /* 128px */
-    line-height: 1;
-}
-
-@each $space in $tiny_spaces {
-    .leading-#{escape-number($space)} {
-        line-height: #{$space * 0.25}rem;
-    }
-}
-
-.rounded {
-    border-radius: var(--radius); /* 4px */
-}
-.rounded-l {
-    border-top-left-radius: var(--radius); /* 4px */
-    border-bottom-left-radius: var(--radius); /* 4px */
-}
-.rounded-r {
-    border-top-right-radius: var(--radius); /* 4px */
-    border-bottom-right-radius: var(--radius); /* 4px */
-}
-.rounded-t {
-    border-top-left-radius: var(--radius); /* 4px */
-    border-top-right-radius: var(--radius); /* 4px */
-}
-.rounded-b {
-    border-bottom-left-radius: var(--radius); /* 4px */
-    border-bottom-right-radius: var(--radius); /* 4px */
-}
-
-.rounded-none {
-    border-radius: 0;
-}
-.rounded-r-none {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-}
-.rounded-l-none {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-}
-
-.rounded-sm {
-    border-radius: calc(var(--radius) / 2); /* 2px */
-}
-
-.rounded-md {
-    border-radius: calc(var(--radius) * 1.5); /* 6px */
-}
-.rounded-lg {
-    border-radius: calc(var(--radius) * 2); /* 8px */
-}
-.rounded-xl {
-    border-radius: calc(var(--radius) * 3); /* 12px */
-}
-.rounded-2xl {
-    border-radius: calc(var(--radius) * 4); /* 16px */
-}
-.rounded-3xl {
-    border-radius: calc(var(--radius) * 6); /* 24px */
-}
-.rounded-4xl {
-    border-radius: calc(var(--radius) * 8); /* 32px */
-}
-.rounded-full {
-    border-radius: 1000rem;
-}
-
-.overflow-auto {
-    overflow: auto;
-}
-.overflow-hidden {
-    overflow: hidden;
-}
-.overflow-clip {
-    overflow: clip;
-}
-.overflow-visible {
-    overflow: visible;
-}
-.overflow-scroll {
-    overflow: scroll;
-}
-.overflow-x-scroll {
-    overflow-x: scroll;
-}
-.overflow-y-scroll {
-    overflow-y: scroll;
-}
-.overflow-x-auto {
-    overflow-x: auto;
-}
-.overflow-y-auto {
-    overflow-y: auto;
-}
-.overflow-x-hidden {
-    overflow-x: hidden;
-}
-
-.font-sans {
-    font-family: var(--font-sans);
-}
-
-.font-mono {
-    font-family: var(--font-mono);
-}
-
-.opacity-0 {
-    opacity: 0;
-}
-.opacity-5 {
-    opacity: 0.05;
-}
-.opacity-10 {
-    opacity: 0.1;
-}
-.opacity-20 {
-    opacity: 0.2;
-}
-.opacity-25 {
-    opacity: 0.25;
-}
-.opacity-30 {
-    opacity: 0.3;
-}
-.opacity-40 {
-    opacity: 0.4;
-}
-.opacity-50 {
-    opacity: 0.5;
-}
-.opacity-60 {
-    opacity: 0.6;
-}
-.opacity-70 {
-    opacity: 0.7;
-}
-.opacity-75 {
-    opacity: 0.75;
-}
-.opacity-80 {
-    opacity: 0.8;
-}
-.opacity-90 {
-    opacity: 0.9;
-}
-.opacity-95 {
-    opacity: 0.95;
-}
-.opacity-100 {
-    opacity: 1;
-}
-
-.pointer-events-none {
-    pointer-events: none;
-}
-.pointer-events-auto {
-    pointer-events: auto;
-}
-
-.truncate {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-.text-ellipsis {
-    text-overflow: ellipsis;
-}
-.text-clip {
-    text-overflow: clip;
-}
-
-@each $cursor in $cursors {
-    .cursor-#{$cursor} {
-        cursor: #{$cursor};
-    }
-}
-
-@each $list_style_type in $list_style_types {
-    .list-#{$list_style_type} {
-        list-style-type: #{$list_style_type};
-    }
-}
-
-.list-inside {
-    list-style-position: inside;
-}
-.list-outside {
-    list-style-position: outside;
-}
-
-.shadow {
-    box-shadow: var(--shadow-elevation);
-}
-
-@each $fitOption in ('contain', 'cover', 'fill', 'none', 'scale-down') {
-    .object-#{$fitOption} {
-        object-fit: string.unquote($fitOption);
-    }
-    hover\:object-#{$fitOption}:hover {
-        object-fit: string.unquote($fitOption);
-    }
-}
-
-.tracking-tighter {
-    letter-spacing: -0.05em;
-}
-.tracking-tight {
-    letter-spacing: -0.025em;
-}
-.tracking-normal {
-    letter-spacing: 0em;
-}
-.tracking-wide {
-    letter-spacing: 0.025em;
-}
-.tracking-wider {
-    letter-spacing: 0.05em;
-}
-.tracking-widest {
-    letter-spacing: 0.1em;
-}
-
-.select-none {
-    user-select: none;
-}
-.select-text {
-    user-select: text;
-}
-.select-all {
-    user-select: all;
-}
-.select-auto {
-    user-select: auto;
-}
-
-.rotate-90 {
-    transform: rotate(90deg);
-}
-.rotate-180 {
-    transform: rotate(180deg);
-}
-
-.rotate-270 {
-    transform: rotate(270deg);
-}
-
-.z-0 {
-    z-index: 0;
-}
-
-.z-10 {
-    z-index: 10;
-}
-
-.z-20 {
-    z-index: 20;
-}
-
-.z-30 {
-    z-index: 30;
-}
-
-.z-40 {
-    z-index: 40;
-}
-
-.z-50 {
-    z-index: 50;
-}
-
-.z-auto {
-    z-index: auto;
-}
-
-.invisible {
-    visibility: hidden;
-}
-
-.resize-y {
-    resize: vertical;
-}
-
-// Position
-
-.static {
-    position: static;
-}
-
-.relative {
-    position: relative;
-}
-
-.absolute {
-    position: absolute;
-}
-
-.fixed {
-    position: fixed;
-}
-
-.sticky {
-    position: sticky;
-}
-
-.line-clamp-2 {
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
-}
-
-.transition-all {
-    transition-property: all;
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    transition-duration: 150ms;
-}
-
-.aspect-auto {
-    aspect-ratio: auto;
-}
-
-.aspect-square {
-    aspect-ratio: 1 / 1;
-}
-
-.aspect-video {
-    aspect-ratio: 16 / 9;
 }

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -12,6 +12,639 @@
     custom naming conventions 🙌
 */
 
+// TODO: Support the screen breakpoint versions like md:foo
+// The problem is CSS file size, which could be solved by using Tailwind directly.
+// See the Grid section, which has breakpoint support, to add it for something in this file.
+@each $space in $tiny_spaces {
+    .space-y-#{escape-number($space)} {
+        & > * + * {
+            margin-top: #{$space * 0.25}rem;
+        }
+    }
+
+    .space-x-#{escape-number($space)} {
+        & > * + * {
+            margin-left: #{$space * 0.25}rem;
+        }
+    }
+
+    .gap-#{escape-number($space)} {
+        gap: #{$space * 0.25}rem;
+    }
+
+    .gap-x-#{escape-number($space)} {
+        column-gap: #{$space * 0.25}rem;
+    }
+
+    .gap-y-#{escape-number($space)} {
+        row-gap: #{$space * 0.25}rem;
+    }
+
+    .m-#{escape-number($space)} {
+        margin: #{$space * 0.25}rem;
+    }
+
+    .-m-#{escape-number($space)} {
+        margin: #{-$space * 0.25}rem;
+    }
+
+    .mx-#{escape-number($space)} {
+        margin-left: #{$space * 0.25}rem;
+        margin-right: #{$space * 0.25}rem;
+    }
+
+    .-mx-#{escape-number($space)} {
+        margin-left: #{-$space * 0.25}rem;
+        margin-right: #{-$space * 0.25}rem;
+    }
+
+    .my-#{escape-number($space)} {
+        margin-top: #{$space * 0.25}rem;
+        margin-bottom: #{$space * 0.25}rem;
+    }
+
+    .-my-#{escape-number($space)} {
+        margin-top: #{-$space * 0.25}rem;
+        margin-bottom: #{-$space * 0.25}rem;
+    }
+
+    .px-#{escape-number($space)} {
+        padding-left: #{$space * 0.25}rem;
+        padding-right: #{$space * 0.25}rem;
+    }
+
+    .py-#{escape-number($space)} {
+        padding-top: #{$space * 0.25}rem;
+        padding-bottom: #{$space * 0.25}rem;
+    }
+
+    .p-#{escape-number($space)} {
+        padding: #{$space * 0.25}rem;
+    }
+
+    .inset-#{escape-number($space)} {
+        top: #{$space * 0.25}rem;
+        right: #{$space * 0.25}rem;
+        bottom: #{$space * 0.25}rem;
+        left: #{$space * 0.25}rem;
+    }
+
+    .inset-x-#{escape-number($space)} {
+        left: #{$space * 0.25}rem;
+        right: #{$space * 0.25}rem;
+    }
+
+    .inset-y-#{escape-number($space)} {
+        top: #{$space * 0.25}rem;
+        bottom: #{$space * 0.25}rem;
+    }
+    .top-#{escape-number($space)} {
+        top: #{$space * 0.25}rem;
+    }
+
+    .bottom-#{escape-number($space)} {
+        bottom: #{$space * 0.25}rem;
+    }
+
+    .right-#{escape-number($space)} {
+        right: #{$space * 0.25}rem;
+    }
+
+    .left-#{escape-number($space)} {
+        left: #{$space * 0.25}rem;
+    }
+
+    @each $side in $sides {
+        .m#{str-slice($side, 0, 1)}-#{escape-number($space)} {
+            margin-#{$side}: #{$space * 0.25}rem;
+        }
+
+        .-m#{str-slice($side, 0, 1)}-#{escape-number($space)} {
+            margin-#{$side}: #{-$space * 0.25}rem;
+        }
+
+        .p#{str-slice($side, 0, 1)}-#{escape-number($space)} {
+            padding-#{$side}: #{$space * 0.25}rem;
+        }
+    }
+}
+
+@each $name, $size in $screens {
+    .w-#{$name} {
+        width: $size;
+    }
+    .h-#{$name} {
+        height: $size;
+    }
+    .min-w-#{$name} {
+        min-width: $size;
+    }
+    .max-w-#{$name} {
+        max-width: $size;
+    }
+    .min-h-#{$name} {
+        min-height: $size;
+    }
+    .max-h-#{$name} {
+        max-height: $size;
+    }
+}
+
+// TODO: Wrap all of this in a catch for the screen breakpoints like md:foo
+@each $space in $all_spaces {
+    .w-#{escape-number($space)} {
+        width: #{$space * 0.25}rem;
+    }
+
+    .h-#{escape-number($space)} {
+        height: #{$space * 0.25}rem;
+    }
+
+    .max-w-#{escape-number($space)} {
+        max-width: #{$space * 0.25}rem;
+    }
+    .max-h-#{escape-number($space)} {
+        max-height: #{$space * 0.25}rem;
+    }
+
+    .min-w-#{escape-number($space)} {
+        min-width: #{$space * 0.25}rem;
+    }
+    .min-h-#{escape-number($space)} {
+        min-height: #{$space * 0.25}rem;
+    }
+}
+
+.space-y-px {
+    & > * + * {
+        margin-top: 1px;
+    }
+}
+
+.space-x-px {
+    & > * + * {
+        margin-left: 1px;
+    }
+}
+
+.border {
+    border-width: 1px;
+}
+
+// Margins/padding
+@each $kind in ('margin', 'padding') {
+    $char: str-slice($kind, 0, 1);
+
+    .#{$char}-auto {
+        #{$kind}: auto;
+    }
+    .#{$char}x-auto {
+        #{$kind}-left: auto;
+        #{$kind}-right: auto;
+    }
+
+    .#{$char}y-auto {
+        #{$kind}-top: auto;
+        #{$kind}-bottom: auto;
+    }
+    .#{$char}-px {
+        #{$kind}: 1px;
+    }
+
+    .#{$char}x-px {
+        #{$kind}-left: 1px;
+        #{$kind}-right: 1px;
+    }
+
+    .#{$char}y-px {
+        #{$kind}-top: 1px;
+        #{$kind}-bottom: 1px;
+    }
+
+    @each $side in $sides {
+        .#{$char}#{str-slice($side, 0, 1)}-auto {
+            #{$kind}-#{$side}: auto;
+        }
+
+        .#{$char}#{str-slice($side, 0, 1)}-px {
+            #{$kind}-#{$side}: 1px;
+        }
+    }
+}
+
+.-mt-px {
+    margin-top: -1px;
+}
+
+// Border
+.border-0 {
+    border-width: 0px;
+}
+.border-2 {
+    border-width: 2px;
+}
+.border-4 {
+    border-width: 4px;
+}
+.border-6 {
+    border-width: 6px;
+}
+.border-8 {
+    border-width: 8px;
+}
+.border-t-0 {
+    border-top-width: 0px;
+}
+.border-t-2 {
+    border-top-width: 2px;
+}
+.border-t-4 {
+    border-top-width: 4px;
+}
+.border-t-6 {
+    border-top-width: 6px;
+}
+.border-t-8 {
+    border-top-width: 8px;
+}
+.border-t {
+    border-top-width: 1px;
+}
+.border-r-0 {
+    border-right-width: 0px;
+}
+.border-r-2 {
+    border-right-width: 2px;
+}
+.border-r-4 {
+    border-right-width: 4px;
+}
+.border-r-6 {
+    border-right-width: 6px;
+}
+.border-r-8 {
+    border-right-width: 8px;
+}
+.border-r {
+    border-right-width: 1px;
+}
+.border-b-0 {
+    border-bottom-width: 0px;
+}
+.border-b-2 {
+    border-bottom-width: 2px;
+}
+.border-b-4 {
+    border-bottom-width: 4px;
+}
+.border-b-6 {
+    border-bottom-width: 6px;
+}
+.border-b-8 {
+    border-bottom-width: 8px;
+}
+.border-b {
+    border-bottom-width: 1px;
+}
+.border-l-0 {
+    border-left-width: 0px;
+}
+.border-l-2 {
+    border-left-width: 2px;
+}
+.border-l-4 {
+    border-left-width: 4px;
+}
+.border-l-6 {
+    border-left-width: 6px;
+}
+.border-l-8 {
+    border-left-width: 8px;
+}
+.border-l {
+    border-left-width: 1px;
+}
+
+.border-solid {
+    border-style: solid;
+}
+.border-dashed {
+    border-style: dashed;
+}
+.border-dotted {
+    border-style: dotted;
+}
+.border-double {
+    border-style: double;
+}
+.border-hidden {
+    border-style: hidden;
+}
+.border-none {
+    border-style: none;
+}
+
+$decorations: underline, overline, line-through, no-underline;
+@each $decoration in $decorations {
+    .#{$decoration} {
+        text-decoration-line: $decoration;
+    }
+    .hover\:#{$decoration}:hover {
+        text-decoration-line: $decoration;
+    }
+}
+
+.decoration-inherit {
+    text-decoration-color: inherit;
+}
+.decoration-current {
+    text-decoration-color: currentColor;
+}
+.decoration-transparent {
+    text-decoration-color: transparent;
+}
+
+@each $name, $hex in $colors {
+    .text-#{$name} {
+        color: var(--#{$name});
+    }
+    .bg-#{$name} {
+        background-color: var(--#{$name});
+    }
+    .border-#{$name} {
+        border-color: var(--#{$name});
+    }
+    .border-x-#{$name} {
+        border-left-color: var(--#{$name});
+        border-right-color: var(--#{$name});
+    }
+    .border-y-#{$name} {
+        border-top-color: var(--#{$name});
+        border-bottom-color: var(--#{$name});
+    }
+    .decoration-#{$name} {
+        text-decoration-color: var(--#{$name});
+    }
+}
+
+@each $name, $hex in $colors {
+    .hover\:text-#{$name}:hover {
+        color: $hex;
+    }
+    .hover\:bg-#{$name}:hover {
+        background-color: $hex;
+    }
+    .hover\:border-#{$name}:hover {
+        border-color: $hex;
+    }
+}
+
+// Widths / heights
+
+@each $kind in ('width', 'height') {
+    $char: str-slice($kind, 1, 1);
+    .#{$char}-auto {
+        #{$kind}: auto;
+    }
+    .#{$char}-full {
+        #{$kind}: 100%;
+    }
+    .#{$char}-screen {
+        #{$kind}: unquote('100v' + $char);
+    }
+    .#{$char}-min {
+        #{$kind}: min-content;
+    }
+    .#{$char}-max {
+        #{$kind}: max-content;
+    }
+    .#{$char}-fit {
+        #{$kind}: fit-content;
+    }
+
+    .min-#{$char}-full {
+        min-#{$kind}: 100%;
+    }
+    .min-#{$char}-screen {
+        min-#{$kind}: unquote('100v' + $char);
+    }
+
+    .max-#{$char}-full {
+        max-#{$kind}: 100%;
+    }
+    .max-#{$char}-screen {
+        max-#{$kind}: unquote('100v' + $char);
+    }
+
+    @each $variant in ('', 'max-', 'min-') {
+        .#{$variant}#{$char}-1\/2 {
+            #{$variant}#{$kind}: 50%;
+        }
+
+        .#{$variant}#{$char}-1\/3 {
+            #{$variant}#{$kind}: 33.333333%;
+        }
+
+        .#{$variant}#{$char}-2\/3 {
+            #{$variant}#{$kind}: 66.666667%;
+        }
+
+        .#{$variant}#{$char}-1\/4 {
+            #{$variant}#{$kind}: 25%;
+        }
+
+        .#{$variant}#{$char}-2\/4 {
+            #{$variant}#{$kind}: 50%;
+        }
+
+        .#{$variant}#{$char}-3\/4 {
+            #{$variant}#{$kind}: 75%;
+        }
+
+        .#{$variant}#{$char}-1\/5 {
+            #{$variant}#{$kind}: 20%;
+        }
+
+        .#{$variant}#{$char}-2\/5 {
+            #{$variant}#{$kind}: 40%;
+        }
+
+        .#{$variant}#{$char}-3\/5 {
+            #{$variant}#{$kind}: 60%;
+        }
+
+        .#{$variant}#{$char}-4\/5 {
+            #{$variant}#{$kind}: 80%;
+        }
+    }
+}
+
+// One-off utilities
+
+.text-right {
+    text-align: right;
+}
+
+.text-left {
+    text-align: left;
+}
+
+.text-center {
+    text-align: center;
+}
+
+.uppercase {
+    text-transform: uppercase;
+}
+
+.float-right {
+    float: right;
+}
+
+.float-left {
+    float: left;
+}
+
+.align-middle {
+    vertical-align: middle;
+}
+
+// Display
+
+.block {
+    display: block;
+}
+
+.inline-block {
+    display: inline-block;
+}
+
+.inline {
+    display: inline;
+}
+
+.grid {
+    display: grid;
+}
+
+.inline-grid {
+    display: inline-grid;
+}
+
+.hidden {
+    display: none;
+}
+
+// Flex
+.flex {
+    display: flex;
+}
+
+.inline-flex {
+    display: inline-flex;
+}
+
+@each $size in $flex_sizes {
+    .flex-#{escape-number($size)} {
+        flex: $size;
+    }
+}
+
+.flex-auto {
+    flex: auto;
+}
+
+.flex-col {
+    flex-direction: column;
+}
+
+.flex-row {
+    flex-direction: row;
+}
+
+.flex-wrap {
+    flex-wrap: wrap;
+}
+
+.flex-wrap-reverse {
+    flex-wrap: wrap-reverse;
+}
+
+.flex-nowrap {
+    flex-wrap: nowrap;
+}
+
+.shrink {
+    flex-shrink: 1;
+}
+
+.shrink-0 {
+    flex-shrink: 0;
+}
+
+.grow {
+    flex-grow: 1;
+}
+
+.grow-0 {
+    flex-grow: 0;
+}
+
+.justify-start {
+    justify-content: flex-start;
+}
+.justify-end {
+    justify-content: flex-end;
+}
+.justify-center {
+    justify-content: center;
+}
+.justify-between {
+    justify-content: space-between;
+}
+.justify-around {
+    justify-content: space-around;
+}
+.justify-evenly {
+    justify-content: space-evenly;
+}
+
+.items-start {
+    align-items: flex-start;
+}
+.items-end {
+    align-items: flex-end;
+}
+.items-center {
+    align-items: center;
+}
+.items-baseline {
+    align-items: baseline;
+}
+.items-stretch {
+    align-items: stretch;
+}
+
+.self-auto {
+    align-self: auto;
+}
+.self-start {
+    align-self: flex-start;
+}
+.self-end {
+    align-self: flex-end;
+}
+.self-center {
+    align-self: center;
+}
+.self-stretch {
+    align-self: stretch;
+}
+.self-baseline {
+    align-self: baseline;
+}
+
+// Grid Template Columns
 @each $name,
     $size
         in map-merge(
@@ -24,638 +657,6 @@
     $prefix: if($name == 'base', '', $name + '\\:');
 
     @include screen($size) {
-        @debug 'Name: #{$name}, Size: #{$size}, Prefix: #{$prefix}';
-
-        @each $space in $tiny_spaces {
-            .#{$prefix}space-y-#{escape-number($space)} {
-                & > * + * {
-                    margin-top: #{$space * 0.25}rem;
-                }
-            }
-
-            .#{$prefix}space-x-#{escape-number($space)} {
-                & > * + * {
-                    margin-left: #{$space * 0.25}rem;
-                }
-            }
-
-            .#{$prefix}gap-#{escape-number($space)} {
-                gap: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}gap-x-#{escape-number($space)} {
-                column-gap: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}gap-y-#{escape-number($space)} {
-                row-gap: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}m-#{escape-number($space)} {
-                margin: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}-m-#{escape-number($space)} {
-                margin: #{-$space * 0.25}rem;
-            }
-
-            .#{$prefix}mx-#{escape-number($space)} {
-                margin-left: #{$space * 0.25}rem;
-                margin-right: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}-mx-#{escape-number($space)} {
-                margin-left: #{-$space * 0.25}rem;
-                margin-right: #{-$space * 0.25}rem;
-            }
-
-            .#{$prefix}my-#{escape-number($space)} {
-                margin-top: #{$space * 0.25}rem;
-                margin-bottom: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}-my-#{escape-number($space)} {
-                margin-top: #{-$space * 0.25}rem;
-                margin-bottom: #{-$space * 0.25}rem;
-            }
-
-            .#{$prefix}px-#{escape-number($space)} {
-                padding-left: #{$space * 0.25}rem;
-                padding-right: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}py-#{escape-number($space)} {
-                padding-top: #{$space * 0.25}rem;
-                padding-bottom: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}p-#{escape-number($space)} {
-                padding: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}inset-#{escape-number($space)} {
-                top: #{$space * 0.25}rem;
-                right: #{$space * 0.25}rem;
-                bottom: #{$space * 0.25}rem;
-                left: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}inset-x-#{escape-number($space)} {
-                left: #{$space * 0.25}rem;
-                right: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}inset-y-#{escape-number($space)} {
-                top: #{$space * 0.25}rem;
-                bottom: #{$space * 0.25}rem;
-            }
-            .#{$prefix}top-#{escape-number($space)} {
-                top: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}bottom-#{escape-number($space)} {
-                bottom: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}right-#{escape-number($space)} {
-                right: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}left-#{escape-number($space)} {
-                left: #{$space * 0.25}rem;
-            }
-
-            @each $side in $sides {
-                .#{$prefix}m#{str-slice($side, 0, 1)}-#{escape-number($space)} {
-                    margin-#{$side}: #{$space * 0.25}rem;
-                }
-
-                .#{$prefix}-m#{str-slice($side, 0, 1)}-#{escape-number($space)} {
-                    margin-#{$side}: #{-$space * 0.25}rem;
-                }
-
-                .#{$prefix}p#{str-slice($side, 0, 1)}-#{escape-number($space)} {
-                    padding-#{$side}: #{$space * 0.25}rem;
-                }
-            }
-        }
-
-        @each $name, $size in $screens {
-            .#{$prefix}w-#{$name} {
-                width: $size;
-            }
-            .#{$prefix}h-#{$name} {
-                height: $size;
-            }
-            .#{$prefix}min-w-#{$name} {
-                min-width: $size;
-            }
-            .#{$prefix}max-w-#{$name} {
-                max-width: $size;
-            }
-            .#{$prefix}min-h-#{$name} {
-                min-height: $size;
-            }
-            .#{$prefix}max-h-#{$name} {
-                max-height: $size;
-            }
-        }
-
-        // TODO: Wrap all of this in a catch for the screen breakpoints like md:foo
-        @each $space in $all_spaces {
-            .#{$prefix}w-#{escape-number($space)} {
-                width: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}h-#{escape-number($space)} {
-                height: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}max-w-#{escape-number($space)} {
-                max-width: #{$space * 0.25}rem;
-            }
-            .#{$prefix}max-h-#{escape-number($space)} {
-                max-height: #{$space * 0.25}rem;
-            }
-
-            .#{$prefix}min-w-#{escape-number($space)} {
-                min-width: #{$space * 0.25}rem;
-            }
-            .#{$prefix}min-h-#{escape-number($space)} {
-                min-height: #{$space * 0.25}rem;
-            }
-        }
-
-        .#{$prefix}space-y-px {
-            & > * + * {
-                margin-top: 1px;
-            }
-        }
-
-        .#{$prefix}space-x-px {
-            & > * + * {
-                margin-left: 1px;
-            }
-        }
-
-        .#{$prefix}border {
-            border-width: 1px;
-        }
-
-        // Margins/padding
-        @each $kind in ('margin', 'padding') {
-            $char: str-slice($kind, 0, 1);
-
-            .#{$prefix}#{$char}-auto {
-                #{$kind}: auto;
-            }
-            .#{$prefix}#{$char}x-auto {
-                #{$kind}-left: auto;
-                #{$kind}-right: auto;
-            }
-
-            .#{$prefix}#{$char}y-auto {
-                #{$kind}-top: auto;
-                #{$kind}-bottom: auto;
-            }
-            .#{$prefix}#{$char}-px {
-                #{$kind}: 1px;
-            }
-
-            .#{$prefix}#{$char}x-px {
-                #{$kind}-left: 1px;
-                #{$kind}-right: 1px;
-            }
-
-            .#{$prefix}#{$char}y-px {
-                #{$kind}-top: 1px;
-                #{$kind}-bottom: 1px;
-            }
-
-            @each $side in $sides {
-                .#{$prefix}#{$char}#{str-slice($side, 0, 1)}-auto {
-                    #{$kind}-#{$side}: auto;
-                }
-
-                .#{$prefix}#{$char}#{str-slice($side, 0, 1)}-px {
-                    #{$kind}-#{$side}: 1px;
-                }
-            }
-        }
-
-        .#{$prefix}-mt-px {
-            margin-top: -1px;
-        }
-
-        // Border
-        .#{$prefix}border-0 {
-            border-width: 0px;
-        }
-        .#{$prefix}border-2 {
-            border-width: 2px;
-        }
-        .#{$prefix}border-4 {
-            border-width: 4px;
-        }
-        .#{$prefix}border-6 {
-            border-width: 6px;
-        }
-        .#{$prefix}border-8 {
-            border-width: 8px;
-        }
-        .#{$prefix}border-t-0 {
-            border-top-width: 0px;
-        }
-        .#{$prefix}border-t-2 {
-            border-top-width: 2px;
-        }
-        .#{$prefix}border-t-4 {
-            border-top-width: 4px;
-        }
-        .#{$prefix}border-t-6 {
-            border-top-width: 6px;
-        }
-        .#{$prefix}border-t-8 {
-            border-top-width: 8px;
-        }
-        .#{$prefix}border-t {
-            border-top-width: 1px;
-        }
-        .#{$prefix}border-r-0 {
-            border-right-width: 0px;
-        }
-        .#{$prefix}border-r-2 {
-            border-right-width: 2px;
-        }
-        .#{$prefix}border-r-4 {
-            border-right-width: 4px;
-        }
-        .#{$prefix}border-r-6 {
-            border-right-width: 6px;
-        }
-        .#{$prefix}border-r-8 {
-            border-right-width: 8px;
-        }
-        .#{$prefix}border-r {
-            border-right-width: 1px;
-        }
-        .#{$prefix}border-b-0 {
-            border-bottom-width: 0px;
-        }
-        .#{$prefix}border-b-2 {
-            border-bottom-width: 2px;
-        }
-        .#{$prefix}border-b-4 {
-            border-bottom-width: 4px;
-        }
-        .#{$prefix}border-b-6 {
-            border-bottom-width: 6px;
-        }
-        .#{$prefix}border-b-8 {
-            border-bottom-width: 8px;
-        }
-        .#{$prefix}border-b {
-            border-bottom-width: 1px;
-        }
-        .#{$prefix}border-l-0 {
-            border-left-width: 0px;
-        }
-        .#{$prefix}border-l-2 {
-            border-left-width: 2px;
-        }
-        .#{$prefix}border-l-4 {
-            border-left-width: 4px;
-        }
-        .#{$prefix}border-l-6 {
-            border-left-width: 6px;
-        }
-        .#{$prefix}border-l-8 {
-            border-left-width: 8px;
-        }
-        .#{$prefix}border-l {
-            border-left-width: 1px;
-        }
-
-        .#{$prefix}border-solid {
-            border-style: solid;
-        }
-        .#{$prefix}border-dashed {
-            border-style: dashed;
-        }
-        .#{$prefix}border-dotted {
-            border-style: dotted;
-        }
-        .#{$prefix}border-double {
-            border-style: double;
-        }
-        .#{$prefix}border-hidden {
-            border-style: hidden;
-        }
-        .#{$prefix}border-none {
-            border-style: none;
-        }
-
-        $decorations: underline, overline, line-through, no-underline;
-        @each $decoration in $decorations {
-            .#{$prefix}#{$decoration} {
-                text-decoration-line: $decoration;
-            }
-            .#{$prefix}hover\:#{$decoration}:hover {
-                text-decoration-line: $decoration;
-            }
-        }
-
-        .#{$prefix}decoration-inherit {
-            text-decoration-color: inherit;
-        }
-        .#{$prefix}decoration-current {
-            text-decoration-color: currentColor;
-        }
-        .#{$prefix}decoration-transparent {
-            text-decoration-color: transparent;
-        }
-
-        @each $name, $hex in $colors {
-            .#{$prefix}text-#{$name} {
-                color: var(--#{$name});
-            }
-            .#{$prefix}bg-#{$name} {
-                background-color: var(--#{$name});
-            }
-            .#{$prefix}border-#{$name} {
-                border-color: var(--#{$name});
-            }
-            .#{$prefix}border-x-#{$name} {
-                border-left-color: var(--#{$name});
-                border-right-color: var(--#{$name});
-            }
-            .#{$prefix}border-y-#{$name} {
-                border-top-color: var(--#{$name});
-                border-bottom-color: var(--#{$name});
-            }
-            .#{$prefix}decoration-#{$name} {
-                text-decoration-color: var(--#{$name});
-            }
-        }
-
-        @each $name, $hex in $colors {
-            .#{$prefix}hover\:text-#{$name}:hover {
-                color: $hex;
-            }
-            .#{$prefix}hover\:bg-#{$name}:hover {
-                background-color: $hex;
-            }
-            .#{$prefix}hover\:border-#{$name}:hover {
-                border-color: $hex;
-            }
-        }
-
-        // Widths / heights
-
-        @each $kind in ('width', 'height') {
-            $char: str-slice($kind, 1, 1);
-            .#{$prefix}#{$char}-auto {
-                #{$kind}: auto;
-            }
-            .#{$prefix}#{$char}-full {
-                #{$kind}: 100%;
-            }
-            .#{$prefix}#{$char}-screen {
-                #{$kind}: unquote('100v' + $char);
-            }
-            .#{$prefix}#{$char}-min {
-                #{$kind}: min-content;
-            }
-            .#{$prefix}#{$char}-max {
-                #{$kind}: max-content;
-            }
-            .#{$prefix}#{$char}-fit {
-                #{$kind}: fit-content;
-            }
-
-            .#{$prefix}min-#{$char}-full {
-                min-#{$kind}: 100%;
-            }
-            .#{$prefix}min-#{$char}-screen {
-                min-#{$kind}: unquote('100v' + $char);
-            }
-
-            .#{$prefix}max-#{$char}-full {
-                max-#{$kind}: 100%;
-            }
-            .#{$prefix}max-#{$char}-screen {
-                max-#{$kind}: unquote('100v' + $char);
-            }
-
-            @each $variant in ('', 'max-', 'min-') {
-                .#{$prefix}#{$variant}#{$char}-1\/2 {
-                    #{$variant}#{$kind}: 50%;
-                }
-
-                .#{$prefix}#{$variant}#{$char}-1\/3 {
-                    #{$variant}#{$kind}: 33.333333%;
-                }
-
-                .#{$prefix}#{$variant}#{$char}-2\/3 {
-                    #{$variant}#{$kind}: 66.666667%;
-                }
-
-                .#{$prefix}#{$variant}#{$char}-1\/4 {
-                    #{$variant}#{$kind}: 25%;
-                }
-
-                .#{$prefix}#{$variant}#{$char}-2\/4 {
-                    #{$variant}#{$kind}: 50%;
-                }
-
-                .#{$prefix}#{$variant}#{$char}-3\/4 {
-                    #{$variant}#{$kind}: 75%;
-                }
-
-                .#{$prefix}#{$variant}#{$char}-1\/5 {
-                    #{$variant}#{$kind}: 20%;
-                }
-
-                .#{$prefix}#{$variant}#{$char}-2\/5 {
-                    #{$variant}#{$kind}: 40%;
-                }
-
-                .#{$prefix}#{$variant}#{$char}-3\/5 {
-                    #{$variant}#{$kind}: 60%;
-                }
-
-                .#{$prefix}#{$variant}#{$char}-4\/5 {
-                    #{$variant}#{$kind}: 80%;
-                }
-            }
-        }
-
-        // One-off utilities
-
-        .#{$prefix}text-right {
-            text-align: right;
-        }
-
-        .#{$prefix}text-left {
-            text-align: left;
-        }
-
-        .#{$prefix}text-center {
-            text-align: center;
-        }
-
-        .#{$prefix}uppercase {
-            text-transform: uppercase;
-        }
-
-        .#{$prefix}float-right {
-            float: right;
-        }
-
-        .#{$prefix}float-left {
-            float: left;
-        }
-
-        .#{$prefix}align-middle {
-            vertical-align: middle;
-        }
-
-        // Display
-
-        .#{$prefix}block {
-            display: block;
-        }
-
-        .#{$prefix}inline-block {
-            display: inline-block;
-        }
-
-        .#{$prefix}inline {
-            display: inline;
-        }
-
-        .#{$prefix}grid {
-            display: grid;
-        }
-
-        .#{$prefix}inline-grid {
-            display: inline-grid;
-        }
-
-        .#{$prefix}hidden {
-            display: none;
-        }
-
-        // Flex
-        .#{$prefix}flex {
-            display: flex;
-        }
-
-        .#{$prefix}inline-flex {
-            display: inline-flex;
-        }
-
-        @each $size in $flex_sizes {
-            .#{$prefix}flex-#{escape-number($size)} {
-                flex: $size;
-            }
-        }
-
-        .#{$prefix}flex-auto {
-            flex: auto;
-        }
-
-        .#{$prefix}flex-col {
-            flex-direction: column;
-        }
-
-        .#{$prefix}flex-row {
-            flex-direction: row;
-        }
-
-        .#{$prefix}flex-wrap {
-            flex-wrap: wrap;
-        }
-
-        .#{$prefix}flex-wrap-reverse {
-            flex-wrap: wrap-reverse;
-        }
-
-        .#{$prefix}flex-nowrap {
-            flex-wrap: nowrap;
-        }
-
-        .#{$prefix}shrink {
-            flex-shrink: 1;
-        }
-
-        .#{$prefix}shrink-0 {
-            flex-shrink: 0;
-        }
-
-        .#{$prefix}grow {
-            flex-grow: 1;
-        }
-
-        .#{$prefix}grow-0 {
-            flex-grow: 0;
-        }
-
-        .#{$prefix}justify-start {
-            justify-content: flex-start;
-        }
-        .#{$prefix}justify-end {
-            justify-content: flex-end;
-        }
-        .#{$prefix}justify-center {
-            justify-content: center;
-        }
-        .#{$prefix}justify-between {
-            justify-content: space-between;
-        }
-        .#{$prefix}justify-around {
-            justify-content: space-around;
-        }
-        .#{$prefix}justify-evenly {
-            justify-content: space-evenly;
-        }
-
-        .#{$prefix}items-start {
-            align-items: flex-start;
-        }
-        .#{$prefix}items-end {
-            align-items: flex-end;
-        }
-        .#{$prefix}items-center {
-            align-items: center;
-        }
-        .#{$prefix}items-baseline {
-            align-items: baseline;
-        }
-        .#{$prefix}items-stretch {
-            align-items: stretch;
-        }
-
-        .#{$prefix}self-auto {
-            align-self: auto;
-        }
-        .#{$prefix}self-start {
-            align-self: flex-start;
-        }
-        .#{$prefix}self-end {
-            align-self: flex-end;
-        }
-        .#{$prefix}self-center {
-            align-self: center;
-        }
-        .#{$prefix}self-stretch {
-            align-self: stretch;
-        }
-        .#{$prefix}self-baseline {
-            align-self: baseline;
-        }
-
-        // Grid Template Columns
         @for $i from 1 through 12 {
             .#{$prefix}grid-cols-#{$i} {
                 grid-template-columns: repeat(#{$i}, minmax(0, 1fr));
@@ -750,452 +751,452 @@
         .#{$prefix}gap-y-px {
             row-gap: 1px;
         }
-
-        // Typography
-        .#{$prefix}font-thin {
-            font-weight: 100;
-        }
-        .#{$prefix}font-extralight {
-            font-weight: 200;
-        }
-        .#{$prefix}font-light {
-            font-weight: 300;
-        }
-        .#{$prefix}font-normal {
-            font-weight: 400;
-        }
-        .#{$prefix}font-medium {
-            font-weight: 500;
-        }
-        .#{$prefix}font-semibold {
-            font-weight: 600;
-        }
-        .#{$prefix}font-bold {
-            font-weight: 700;
-        }
-        .#{$prefix}font-extrabold {
-            font-weight: 800;
-        }
-        .#{$prefix}font-black {
-            font-weight: 900;
-        }
-        .#{$prefix}italic {
-            font-style: italic;
-        }
-        .#{$prefix}not-italic {
-            font-style: normal;
-        }
-
-        .#{$prefix}break-normal {
-            overflow-wrap: normal;
-            word-break: normal;
-        }
-
-        .#{$prefix}break-words {
-            overflow-wrap: break-word;
-        }
-
-        .#{$prefix}break-all {
-            word-break: break-all;
-        }
-
-        .#{$prefix}whitespace-normal {
-            white-space: normal;
-        }
-        .#{$prefix}whitespace-nowrap {
-            white-space: nowrap;
-        }
-        .#{$prefix}whitespace-pre {
-            white-space: pre;
-        }
-        .#{$prefix}whitespace-pre-line {
-            white-space: pre-line;
-        }
-        .#{$prefix}whitespace-pre-wrap {
-            white-space: pre-wrap;
-        }
-
-        .#{$prefix}text-xxs {
-            font-size: 0.625rem; /* 10px */
-            line-height: 0.75rem; /* 12px */
-        }
-        .#{$prefix}text-xs {
-            font-size: 0.75rem; /* 12px */
-            line-height: 1rem; /* 16px */
-        }
-        .#{$prefix}text-sm {
-            font-size: 0.875rem; /* 14px */
-            line-height: 1.25rem; /* 20px */
-        }
-        .#{$prefix}text-base {
-            font-size: 1rem; /* 16px */
-            line-height: 1.5rem; /* 24px */
-        }
-        .#{$prefix}text-lg {
-            font-size: 1.125rem; /* 18px */
-            line-height: 1.75rem; /* 28px */
-        }
-        .#{$prefix}text-xl {
-            font-size: 1.25rem; /* 20px */
-            line-height: 1.75rem; /* 28px */
-        }
-        .#{$prefix}text-2xl {
-            font-size: 1.5rem; /* 24px */
-            line-height: 2rem; /* 32px */
-        }
-        .#{$prefix}text-3xl {
-            font-size: 1.875rem; /* 30px */
-            line-height: 2.25rem; /* 36px */
-        }
-        .#{$prefix}text-4xl {
-            font-size: 2.25rem; /* 36px */
-            line-height: 2.5rem; /* 40px */
-        }
-        .#{$prefix}text-5xl {
-            font-size: 3rem; /* 48px */
-            line-height: 1;
-        }
-        .#{$prefix}text-6xl {
-            font-size: 3.75rem; /* 60px */
-            line-height: 1;
-        }
-        .#{$prefix}text-7xl {
-            font-size: 4.5rem; /* 72px */
-            line-height: 1;
-        }
-        .#{$prefix}text-8xl {
-            font-size: 6rem; /* 96px */
-            line-height: 1;
-        }
-        .#{$prefix}text-9xl {
-            font-size: 8rem; /* 128px */
-            line-height: 1;
-        }
-
-        @each $space in $tiny_spaces {
-            .#{$prefix}leading-#{escape-number($space)} {
-                line-height: #{$space * 0.25}rem;
-            }
-        }
-
-        .#{$prefix}rounded {
-            border-radius: var(--radius); /* 4px */
-        }
-        .#{$prefix}rounded-l {
-            border-top-left-radius: var(--radius); /* 4px */
-            border-bottom-left-radius: var(--radius); /* 4px */
-        }
-        .#{$prefix}rounded-r {
-            border-top-right-radius: var(--radius); /* 4px */
-            border-bottom-right-radius: var(--radius); /* 4px */
-        }
-        .#{$prefix}rounded-t {
-            border-top-left-radius: var(--radius); /* 4px */
-            border-top-right-radius: var(--radius); /* 4px */
-        }
-        .#{$prefix}rounded-b {
-            border-bottom-left-radius: var(--radius); /* 4px */
-            border-bottom-right-radius: var(--radius); /* 4px */
-        }
-
-        .#{$prefix}rounded-none {
-            border-radius: 0;
-        }
-        .#{$prefix}rounded-r-none {
-            border-top-right-radius: 0;
-            border-bottom-right-radius: 0;
-        }
-        .#{$prefix}rounded-l-none {
-            border-top-left-radius: 0;
-            border-bottom-left-radius: 0;
-        }
-
-        .#{$prefix}rounded-sm {
-            border-radius: calc(var(--radius) / 2); /* 2px */
-        }
-
-        .#{$prefix}rounded-md {
-            border-radius: calc(var(--radius) * 1.5); /* 6px */
-        }
-        .#{$prefix}rounded-lg {
-            border-radius: calc(var(--radius) * 2); /* 8px */
-        }
-        .#{$prefix}rounded-xl {
-            border-radius: calc(var(--radius) * 3); /* 12px */
-        }
-        .#{$prefix}rounded-2xl {
-            border-radius: calc(var(--radius) * 4); /* 16px */
-        }
-        .#{$prefix}rounded-3xl {
-            border-radius: calc(var(--radius) * 6); /* 24px */
-        }
-        .#{$prefix}rounded-4xl {
-            border-radius: calc(var(--radius) * 8); /* 32px */
-        }
-        .#{$prefix}rounded-full {
-            border-radius: 1000rem;
-        }
-
-        .#{$prefix}overflow-auto {
-            overflow: auto;
-        }
-        .#{$prefix}overflow-hidden {
-            overflow: hidden;
-        }
-        .#{$prefix}overflow-clip {
-            overflow: clip;
-        }
-        .#{$prefix}overflow-visible {
-            overflow: visible;
-        }
-        .#{$prefix}overflow-scroll {
-            overflow: scroll;
-        }
-        .#{$prefix}overflow-x-scroll {
-            overflow-x: scroll;
-        }
-        .#{$prefix}overflow-y-scroll {
-            overflow-y: scroll;
-        }
-        .#{$prefix}overflow-x-auto {
-            overflow-x: auto;
-        }
-        .#{$prefix}overflow-y-auto {
-            overflow-y: auto;
-        }
-        .#{$prefix}overflow-x-hidden {
-            overflow-x: hidden;
-        }
-
-        .#{$prefix}font-sans {
-            font-family: var(--font-sans);
-        }
-
-        .#{$prefix}font-mono {
-            font-family: var(--font-mono);
-        }
-
-        .#{$prefix}opacity-0 {
-            opacity: 0;
-        }
-        .#{$prefix}opacity-5 {
-            opacity: 0.05;
-        }
-        .#{$prefix}opacity-10 {
-            opacity: 0.1;
-        }
-        .#{$prefix}opacity-20 {
-            opacity: 0.2;
-        }
-        .#{$prefix}opacity-25 {
-            opacity: 0.25;
-        }
-        .#{$prefix}opacity-30 {
-            opacity: 0.3;
-        }
-        .#{$prefix}opacity-40 {
-            opacity: 0.4;
-        }
-        .#{$prefix}opacity-50 {
-            opacity: 0.5;
-        }
-        .#{$prefix}opacity-60 {
-            opacity: 0.6;
-        }
-        .#{$prefix}opacity-70 {
-            opacity: 0.7;
-        }
-        .#{$prefix}opacity-75 {
-            opacity: 0.75;
-        }
-        .#{$prefix}opacity-80 {
-            opacity: 0.8;
-        }
-        .#{$prefix}opacity-90 {
-            opacity: 0.9;
-        }
-        .#{$prefix}opacity-95 {
-            opacity: 0.95;
-        }
-        .#{$prefix}opacity-100 {
-            opacity: 1;
-        }
-
-        .#{$prefix}pointer-events-none {
-            pointer-events: none;
-        }
-        .#{$prefix}pointer-events-auto {
-            pointer-events: auto;
-        }
-
-        .#{$prefix}truncate {
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-        .#{$prefix}text-ellipsis {
-            text-overflow: ellipsis;
-        }
-        .#{$prefix}text-clip {
-            text-overflow: clip;
-        }
-
-        @each $cursor in $cursors {
-            .#{$prefix}cursor-#{$cursor} {
-                cursor: #{$cursor};
-            }
-        }
-
-        @each $list_style_type in $list_style_types {
-            .#{$prefix}list-#{$list_style_type} {
-                list-style-type: #{$list_style_type};
-            }
-        }
-
-        .#{$prefix}list-inside {
-            list-style-position: inside;
-        }
-        .#{$prefix}list-outside {
-            list-style-position: outside;
-        }
-
-        .#{$prefix}shadow {
-            box-shadow: var(--shadow-elevation);
-        }
-
-        @each $fitOption in ('contain', 'cover', 'fill', 'none', 'scale-down') {
-            .#{$prefix}object-#{$fitOption} {
-                object-fit: string.unquote($fitOption);
-            }
-            hover\:object-#{$fitOption}:hover {
-                object-fit: string.unquote($fitOption);
-            }
-        }
-
-        .#{$prefix}tracking-tighter {
-            letter-spacing: -0.05em;
-        }
-        .#{$prefix}tracking-tight {
-            letter-spacing: -0.025em;
-        }
-        .#{$prefix}tracking-normal {
-            letter-spacing: 0em;
-        }
-        .#{$prefix}tracking-wide {
-            letter-spacing: 0.025em;
-        }
-        .#{$prefix}tracking-wider {
-            letter-spacing: 0.05em;
-        }
-        .#{$prefix}tracking-widest {
-            letter-spacing: 0.1em;
-        }
-
-        .#{$prefix}select-none {
-            user-select: none;
-        }
-        .#{$prefix}select-text {
-            user-select: text;
-        }
-        .#{$prefix}select-all {
-            user-select: all;
-        }
-        .#{$prefix}select-auto {
-            user-select: auto;
-        }
-
-        .#{$prefix}rotate-90 {
-            transform: rotate(90deg);
-        }
-        .#{$prefix}rotate-180 {
-            transform: rotate(180deg);
-        }
-
-        .#{$prefix}rotate-270 {
-            transform: rotate(270deg);
-        }
-
-        .#{$prefix}z-0 {
-            z-index: 0;
-        }
-
-        .#{$prefix}z-10 {
-            z-index: 10;
-        }
-
-        .#{$prefix}z-20 {
-            z-index: 20;
-        }
-
-        .#{$prefix}z-30 {
-            z-index: 30;
-        }
-
-        .#{$prefix}z-40 {
-            z-index: 40;
-        }
-
-        .#{$prefix}z-50 {
-            z-index: 50;
-        }
-
-        .#{$prefix}z-auto {
-            z-index: auto;
-        }
-
-        .#{$prefix}invisible {
-            visibility: hidden;
-        }
-
-        .#{$prefix}resize-y {
-            resize: vertical;
-        }
-
-        // Position
-
-        .#{$prefix}static {
-            position: static;
-        }
-
-        .#{$prefix}relative {
-            position: relative;
-        }
-
-        .#{$prefix}absolute {
-            position: absolute;
-        }
-
-        .#{$prefix}fixed {
-            position: fixed;
-        }
-
-        .#{$prefix}sticky {
-            position: sticky;
-        }
-
-        .#{$prefix}line-clamp-2 {
-            overflow: hidden;
-            display: -webkit-box;
-            -webkit-box-orient: vertical;
-            -webkit-line-clamp: 2;
-        }
-
-        .#{$prefix}transition-all {
-            transition-property: all;
-            transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-            transition-duration: 150ms;
-        }
-
-        .#{$prefix}aspect-auto {
-            aspect-ratio: auto;
-        }
-
-        .#{$prefix}aspect-square {
-            aspect-ratio: 1 / 1;
-        }
-
-        .#{$prefix}aspect-video {
-            aspect-ratio: 16 / 9;
-        }
     }
+}
+
+// Typography
+.font-thin {
+    font-weight: 100;
+}
+.font-extralight {
+    font-weight: 200;
+}
+.font-light {
+    font-weight: 300;
+}
+.font-normal {
+    font-weight: 400;
+}
+.font-medium {
+    font-weight: 500;
+}
+.font-semibold {
+    font-weight: 600;
+}
+.font-bold {
+    font-weight: 700;
+}
+.font-extrabold {
+    font-weight: 800;
+}
+.font-black {
+    font-weight: 900;
+}
+.italic {
+    font-style: italic;
+}
+.not-italic {
+    font-style: normal;
+}
+
+.break-normal {
+    overflow-wrap: normal;
+    word-break: normal;
+}
+
+.break-words {
+    overflow-wrap: break-word;
+}
+
+.break-all {
+    word-break: break-all;
+}
+
+.whitespace-normal {
+    white-space: normal;
+}
+.whitespace-nowrap {
+    white-space: nowrap;
+}
+.whitespace-pre {
+    white-space: pre;
+}
+.whitespace-pre-line {
+    white-space: pre-line;
+}
+.whitespace-pre-wrap {
+    white-space: pre-wrap;
+}
+
+.text-xxs {
+    font-size: 0.625rem; /* 10px */
+    line-height: 0.75rem; /* 12px */
+}
+.text-xs {
+    font-size: 0.75rem; /* 12px */
+    line-height: 1rem; /* 16px */
+}
+.text-sm {
+    font-size: 0.875rem; /* 14px */
+    line-height: 1.25rem; /* 20px */
+}
+.text-base {
+    font-size: 1rem; /* 16px */
+    line-height: 1.5rem; /* 24px */
+}
+.text-lg {
+    font-size: 1.125rem; /* 18px */
+    line-height: 1.75rem; /* 28px */
+}
+.text-xl {
+    font-size: 1.25rem; /* 20px */
+    line-height: 1.75rem; /* 28px */
+}
+.text-2xl {
+    font-size: 1.5rem; /* 24px */
+    line-height: 2rem; /* 32px */
+}
+.text-3xl {
+    font-size: 1.875rem; /* 30px */
+    line-height: 2.25rem; /* 36px */
+}
+.text-4xl {
+    font-size: 2.25rem; /* 36px */
+    line-height: 2.5rem; /* 40px */
+}
+.text-5xl {
+    font-size: 3rem; /* 48px */
+    line-height: 1;
+}
+.text-6xl {
+    font-size: 3.75rem; /* 60px */
+    line-height: 1;
+}
+.text-7xl {
+    font-size: 4.5rem; /* 72px */
+    line-height: 1;
+}
+.text-8xl {
+    font-size: 6rem; /* 96px */
+    line-height: 1;
+}
+.text-9xl {
+    font-size: 8rem; /* 128px */
+    line-height: 1;
+}
+
+@each $space in $tiny_spaces {
+    .leading-#{escape-number($space)} {
+        line-height: #{$space * 0.25}rem;
+    }
+}
+
+.rounded {
+    border-radius: var(--radius); /* 4px */
+}
+.rounded-l {
+    border-top-left-radius: var(--radius); /* 4px */
+    border-bottom-left-radius: var(--radius); /* 4px */
+}
+.rounded-r {
+    border-top-right-radius: var(--radius); /* 4px */
+    border-bottom-right-radius: var(--radius); /* 4px */
+}
+.rounded-t {
+    border-top-left-radius: var(--radius); /* 4px */
+    border-top-right-radius: var(--radius); /* 4px */
+}
+.rounded-b {
+    border-bottom-left-radius: var(--radius); /* 4px */
+    border-bottom-right-radius: var(--radius); /* 4px */
+}
+
+.rounded-none {
+    border-radius: 0;
+}
+.rounded-r-none {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+.rounded-l-none {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
+.rounded-sm {
+    border-radius: calc(var(--radius) / 2); /* 2px */
+}
+
+.rounded-md {
+    border-radius: calc(var(--radius) * 1.5); /* 6px */
+}
+.rounded-lg {
+    border-radius: calc(var(--radius) * 2); /* 8px */
+}
+.rounded-xl {
+    border-radius: calc(var(--radius) * 3); /* 12px */
+}
+.rounded-2xl {
+    border-radius: calc(var(--radius) * 4); /* 16px */
+}
+.rounded-3xl {
+    border-radius: calc(var(--radius) * 6); /* 24px */
+}
+.rounded-4xl {
+    border-radius: calc(var(--radius) * 8); /* 32px */
+}
+.rounded-full {
+    border-radius: 1000rem;
+}
+
+.overflow-auto {
+    overflow: auto;
+}
+.overflow-hidden {
+    overflow: hidden;
+}
+.overflow-clip {
+    overflow: clip;
+}
+.overflow-visible {
+    overflow: visible;
+}
+.overflow-scroll {
+    overflow: scroll;
+}
+.overflow-x-scroll {
+    overflow-x: scroll;
+}
+.overflow-y-scroll {
+    overflow-y: scroll;
+}
+.overflow-x-auto {
+    overflow-x: auto;
+}
+.overflow-y-auto {
+    overflow-y: auto;
+}
+.overflow-x-hidden {
+    overflow-x: hidden;
+}
+
+.font-sans {
+    font-family: var(--font-sans);
+}
+
+.font-mono {
+    font-family: var(--font-mono);
+}
+
+.opacity-0 {
+    opacity: 0;
+}
+.opacity-5 {
+    opacity: 0.05;
+}
+.opacity-10 {
+    opacity: 0.1;
+}
+.opacity-20 {
+    opacity: 0.2;
+}
+.opacity-25 {
+    opacity: 0.25;
+}
+.opacity-30 {
+    opacity: 0.3;
+}
+.opacity-40 {
+    opacity: 0.4;
+}
+.opacity-50 {
+    opacity: 0.5;
+}
+.opacity-60 {
+    opacity: 0.6;
+}
+.opacity-70 {
+    opacity: 0.7;
+}
+.opacity-75 {
+    opacity: 0.75;
+}
+.opacity-80 {
+    opacity: 0.8;
+}
+.opacity-90 {
+    opacity: 0.9;
+}
+.opacity-95 {
+    opacity: 0.95;
+}
+.opacity-100 {
+    opacity: 1;
+}
+
+.pointer-events-none {
+    pointer-events: none;
+}
+.pointer-events-auto {
+    pointer-events: auto;
+}
+
+.truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.text-ellipsis {
+    text-overflow: ellipsis;
+}
+.text-clip {
+    text-overflow: clip;
+}
+
+@each $cursor in $cursors {
+    .cursor-#{$cursor} {
+        cursor: #{$cursor};
+    }
+}
+
+@each $list_style_type in $list_style_types {
+    .list-#{$list_style_type} {
+        list-style-type: #{$list_style_type};
+    }
+}
+
+.list-inside {
+    list-style-position: inside;
+}
+.list-outside {
+    list-style-position: outside;
+}
+
+.shadow {
+    box-shadow: var(--shadow-elevation);
+}
+
+@each $fitOption in ('contain', 'cover', 'fill', 'none', 'scale-down') {
+    .object-#{$fitOption} {
+        object-fit: string.unquote($fitOption);
+    }
+    hover\:object-#{$fitOption}:hover {
+        object-fit: string.unquote($fitOption);
+    }
+}
+
+.tracking-tighter {
+    letter-spacing: -0.05em;
+}
+.tracking-tight {
+    letter-spacing: -0.025em;
+}
+.tracking-normal {
+    letter-spacing: 0em;
+}
+.tracking-wide {
+    letter-spacing: 0.025em;
+}
+.tracking-wider {
+    letter-spacing: 0.05em;
+}
+.tracking-widest {
+    letter-spacing: 0.1em;
+}
+
+.select-none {
+    user-select: none;
+}
+.select-text {
+    user-select: text;
+}
+.select-all {
+    user-select: all;
+}
+.select-auto {
+    user-select: auto;
+}
+
+.rotate-90 {
+    transform: rotate(90deg);
+}
+.rotate-180 {
+    transform: rotate(180deg);
+}
+
+.rotate-270 {
+    transform: rotate(270deg);
+}
+
+.z-0 {
+    z-index: 0;
+}
+
+.z-10 {
+    z-index: 10;
+}
+
+.z-20 {
+    z-index: 20;
+}
+
+.z-30 {
+    z-index: 30;
+}
+
+.z-40 {
+    z-index: 40;
+}
+
+.z-50 {
+    z-index: 50;
+}
+
+.z-auto {
+    z-index: auto;
+}
+
+.invisible {
+    visibility: hidden;
+}
+
+.resize-y {
+    resize: vertical;
+}
+
+// Position
+
+.static {
+    position: static;
+}
+
+.relative {
+    position: relative;
+}
+
+.absolute {
+    position: absolute;
+}
+
+.fixed {
+    position: fixed;
+}
+
+.sticky {
+    position: sticky;
+}
+
+.line-clamp-2 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.transition-all {
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 150ms;
+}
+
+.aspect-auto {
+    aspect-ratio: auto;
+}
+
+.aspect-square {
+    aspect-ratio: 1 / 1;
+}
+
+.aspect-video {
+    aspect-ratio: 16 / 9;
 }


### PR DESCRIPTION
FYI - you can disable whitespace in the github diff by clicking the cog icon.

## Problem

I'd like to use class like`md:grid-cols-12` in tailwind to make nice responsive designs

## Changes

Use a loop in utilities.css to create classes for all the different breakpoints, handling the base case (no breakpoint) elegantly too.

## How did you test this code?

Visual regressions tests would fail pretty dramatically if this didn't work
Added some of the classes to one of my components and testing with browser sizes
