### PR TITLE
chore(plugin-server): use existing INGESTION_BATCH_SIZE and KAFKA_CON…

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -240,11 +240,11 @@ export class IngestionConsumer {
             topic: this.topic,
             groupId: this.consumerGroupId,
             autoCommit: true,
-            sessionTimeout: 30000,
+            sessionTimeout: this.pluginsServer.KAFKA_CONSUMPTION_SESSION_TIMEOUT_MS,
             consumerMaxBytes: this.pluginsServer.KAFKA_CONSUMPTION_MAX_BYTES,
             consumerMaxBytesPerPartition: this.pluginsServer.KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION,
             consumerMaxWaitMs: this.pluginsServer.KAFKA_CONSUMPTION_MAX_WAIT_MS,
-            fetchBatchSize: 500,
+            fetchBatchSize: this.pluginsServer.INGESTION_BATCH_SIZE,
             topicCreationTimeoutMs: this.pluginsServer.KAFKA_TOPIC_CREATION_TIMEOUT_MS,
             eachBatch: (payload) => this.eachBatchConsumer(payload),
         })


### PR DESCRIPTION
…SUMPTION_SESSION_TIMEOUT_MS

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Existing envvars weren't wired up.

## Changes

Use existing envvars. They already default to the same values respectively, however `KAFKA_CONSUMPTION_SESSION_TIMEOUT_MS` is overridden to 60000 in charts.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
