### PR TITLE
fix: Additional parsing of incoming messages

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
@@ -329,6 +329,15 @@ export class SessionRecordingIngesterV2 {
             })
         }
 
+        if (!events.length) {
+            status.warn('🙈', 'Event contained no valid rrweb events, ignoring')
+
+            return statusWarn('invalid_rrweb_events', {
+                token: messagePayload.token,
+                teamId: messagePayload.team_id,
+            })
+        }
+
         const recordingMessage: IncomingRecordingMessage = {
             metadata: {
                 partition: message.partition,

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
@@ -9,7 +9,7 @@ import { KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS } from '../../../config/ka
 import { BatchConsumer, startBatchConsumer } from '../../../kafka/batch-consumer'
 import { createRdConnectionConfigFromEnvVars } from '../../../kafka/config'
 import { runInstrumentedFunction } from '../../../main/utils'
-import { PipelineEvent, PluginsServerConfig, RRWebEvent, RawEventMessage, RedisPool, TeamId } from '../../../types'
+import { PipelineEvent, PluginsServerConfig, RawEventMessage, RedisPool, RRWebEvent, TeamId } from '../../../types'
 import { BackgroundRefresher } from '../../../utils/background-refresher'
 import { PostgresRouter } from '../../../utils/db/postgres'
 import { status } from '../../../utils/status'

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v2.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/node'
-import { captureException } from '@sentry/node'
+import { captureException, captureMessage } from '@sentry/node'
 import { mkdirSync, rmSync } from 'node:fs'
 import { CODES, features, librdkafkaVersion, Message, TopicPartition } from 'node-rdkafka'
 import { Counter, Gauge, Histogram } from 'prom-client'
@@ -9,7 +9,7 @@ import { KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS } from '../../../config/ka
 import { BatchConsumer, startBatchConsumer } from '../../../kafka/batch-consumer'
 import { createRdConnectionConfigFromEnvVars } from '../../../kafka/config'
 import { runInstrumentedFunction } from '../../../main/utils'
-import { PipelineEvent, PluginsServerConfig, RawEventMessage, RedisPool, TeamId } from '../../../types'
+import { PipelineEvent, PluginsServerConfig, RRWebEvent, RawEventMessage, RedisPool, TeamId } from '../../../types'
 import { BackgroundRefresher } from '../../../utils/background-refresher'
 import { PostgresRouter } from '../../../utils/db/postgres'
 import { status } from '../../../utils/status'
@@ -276,7 +276,10 @@ export class SessionRecordingIngesterV2 {
             return statusWarn('invalid_json', { error })
         }
 
-        if (event.event !== '$snapshot_items' || !event.properties?.$snapshot_items?.length) {
+        const { $snapshot_items, $session_id, $window_id } = event.properties || {}
+
+        // NOTE: This is simple validation - ideally we should do proper schema based validation
+        if (event.event !== '$snapshot_items' || !$snapshot_items || !$session_id) {
             status.warn('🙈', 'Received non-snapshot message, ignoring')
             return
         }
@@ -307,6 +310,25 @@ export class SessionRecordingIngesterV2 {
             })
         }
 
+        const invalidEvents: RRWebEvent[] = []
+        const events: RRWebEvent[] = $snapshot_items.filter((event: any) => {
+            if (!event.timestamp) {
+                invalidEvents.push(event)
+                return false
+            }
+            return true
+        })
+
+        if (invalidEvents.length) {
+            captureMessage('[session-manager]: invalid rrweb events filtered out from message', {
+                extra: { events: invalidEvents },
+                tags: {
+                    team_id: teamId,
+                    session_id: $session_id,
+                },
+            })
+        }
+
         const recordingMessage: IncomingRecordingMessage = {
             metadata: {
                 partition: message.partition,
@@ -317,9 +339,9 @@ export class SessionRecordingIngesterV2 {
 
             team_id: teamId,
             distinct_id: messagePayload.distinct_id,
-            session_id: event.properties?.$session_id,
-            window_id: event.properties?.$window_id,
-            events: event.properties.$snapshot_items,
+            session_id: $session_id,
+            window_id: $window_id,
+            events: events,
         }
 
         return recordingMessage


### PR DESCRIPTION
## Problem

We don't check too much about the incoming message. This can lead us to a state where we end up with a SessionManager that can't be flushed as the timestamp range is invalid, which in turn leads to it blocking forever.

## Changes

* Add better validation to check the right properties are set and somewhat valid (more todo here in the future)
* Capture sentry message for those that fail for debugging

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
