### PR TITLE
fix: e2e testing posthog capture

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -228,10 +228,10 @@ jobs:
                   config: retries=2
                   spec: ${{ matrix.chunk }}
                   install: false
-                  env:
-                      E2E_TESTING: 1
-                      OPT_OUT_CAPTURE: 0
-                      GITHUB_ACTION_RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+              env:
+                  E2E_TESTING: 1
+                  OPT_OUT_CAPTURE: 0
+                  GITHUB_ACTION_RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
             - name: Archive test screenshots
               uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -222,12 +222,16 @@ jobs:
             - name: Cypress run
               # these are required checks so, we can't skip entire sections
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
-              uses: cypress-io/github-action@v5
+              uses: cypress-io/github-action@v6
               with:
                   config-file: cypress.e2e.config.ts
                   config: retries=2
                   spec: ${{ matrix.chunk }}
                   install: false
+                  env:
+                      E2E_TESTING: 1
+                      OPT_OUT_CAPTURE: 0
+                      GITHUB_ACTION_RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
             - name: Archive test screenshots
               uses: actions/upload-artifact@v3

--- a/cypress.e2e.config.ts
+++ b/cypress.e2e.config.ts
@@ -37,6 +37,8 @@ export default defineConfig({
         // We've imported your old cypress plugins here.
         // You may want to clean this up later by importing these.
         setupNodeEvents(on, config) {
+            config.env.E2E_TESTING = !!process.env.E2E_TESTING
+
             const options = {
                 webpackOptions: createEntry('cypress'),
                 watchOptions: {},

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -69,7 +69,9 @@ afterEach(function () {
     const event = state === 'passed' ? 'e2e_testing_test_passed' : 'e2e_testing_test_failed'
 
     if (E2E_TESTING) {
+        cy.log(`E2E_TESTING: ${event} ${Cypress.spec.name}`, { state, duration })
         cy.window().then((win) => {
+            cy.log('has posthog on window', { window, posthog: (win as any).posthog })
             ;(win as any).posthog?.capture(event, { state, duration })
         })
     }


### PR DESCRIPTION
We added session replay to our Cypress tests but the event capture for test status isn't working so we can't filter for failing tests 

<img width="922" alt="Screenshot 2023-10-12 at 09 08 59" src="https://github.com/PostHog/posthog/assets/984817/c0b60620-ccf9-4ed8-b586-db13ede95d47">


Tries to fix that. Locally I see the test state and duration reported