### PR TITLE
fix: Check for the event generally being truthy

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -310,9 +310,9 @@ export class SessionRecordingIngester {
             })
         }
 
-        const invalidEvents: RRWebEvent[] = []
+        const invalidEvents: any[] = []
         const events: RRWebEvent[] = $snapshot_items.filter((event: any) => {
-            if (!event.timestamp) {
+            if (!event || !event.timestamp) {
                 invalidEvents.push(event)
                 return false
             }

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -309,6 +309,9 @@ describe('ingester', () => {
                     },
                 ],
             })
+
+            const parsedMessage3 = await ingester.parseKafkaMessage(createMessage([null]), () => Promise.resolve(1))
+            expect(parsedMessage3).toEqual(undefined)
         })
     })
 


### PR DESCRIPTION
## Problem

Somehow a seemingly null event got through 🤔 Given that clients can do weird, I guess we have to handle that too

[Sentry issue](https://posthog.sentry.io/issues/4542689860/?project=6423401)

## Changes

* Check the event is generally truthy.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
