### PR TITLE
chore: update wait-on-action

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -212,7 +212,10 @@ jobs:
             - name: Wait for PostHog
               # these are required checks so, we can't skip entire sections
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
-              uses: iFaxity/wait-on-action@v1
+              # this action might be abandoned - but v1 doesn't point to latest of v1 (which it should)
+              # so pointing to v1.1.0 to remove warnings about node version with v1
+              # todo check https://github.com/iFaxity/wait-on-action/releases for new releases
+              uses: iFaxity/wait-on-action@v1.1.0
               timeout-minutes: 3
               with:
                   verbose: true

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -69,9 +69,7 @@ afterEach(function () {
     const event = state === 'passed' ? 'e2e_testing_test_passed' : 'e2e_testing_test_failed'
 
     if (E2E_TESTING) {
-        cy.log(`E2E_TESTING: ${event} ${Cypress.spec.name}`, { state, duration })
         cy.window().then((win) => {
-            cy.log('has posthog on window', { window, posthog: (win as any).posthog })
             ;(win as any).posthog?.capture(event, { state, duration })
         })
     }


### PR DESCRIPTION
wait-on-action hasn't followed the recommendation that the vN tag always points to the latest release for vN

in this case v1 does not point to v1.1.0

that older tag uses a deprecated version of node... let's manually update it