### PR TITLE
feat: Add django command for geoip

### DIFF
--- a/posthog/management/commands/run_geoip.py
+++ b/posthog/management/commands/run_geoip.py
@@ -1,4 +1,5 @@
 import logging
+from pprint import pprint
 
 from django.contrib.gis.geoip2 import GeoIP2
 from django.core.management.base import BaseCommand
@@ -13,7 +14,7 @@ class Command(BaseCommand):
         parser.add_argument("ip", type=str, help="IP Address")
 
     def handle(self, *args, **options):
-        geoip = GeoIP2(cache=8)
+        geoip = GeoIP2(cache=GeoIP2.MODE_MMAP)
         ip_arg = options.get("ip")
         if not isinstance(ip_arg, str):
             raise ValueError("ip not a string")
@@ -22,7 +23,6 @@ class Command(BaseCommand):
 
         for ip in ips:
             ip = ip.strip()
-            print("----")  # noqa: T201
+            print("----------------------------------------")  # noqa: T201
             print(ip)  # noqa: T201
-            print("Country: ", geoip.country(ip))  # noqa: T201
-            print("City: ", geoip.city(ip))  # noqa: T201
+            pprint(geoip.city(ip))  # noqa: T203

--- a/posthog/management/commands/run_geoip.py
+++ b/posthog/management/commands/run_geoip.py
@@ -14,6 +14,15 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         geoip = GeoIP2(cache=8)
-        ip = options.get("ip")
-        print("Country: ", geoip.country(ip))  # noqa: T201
-        print("City: ", geoip.city(ip))  # noqa: T201
+        ip_arg = options.get("ip")
+        if not isinstance(ip_arg, str):
+            raise ValueError("ip not a string")
+
+        ips = ip_arg.split(",")
+
+        for ip in ips:
+            ip = ip.strip()
+            print("----")  # noqa: T201
+            print(ip)  # noqa: T201
+            print("Country: ", geoip.country(ip))  # noqa: T201
+            print("City: ", geoip.city(ip))  # noqa: T201

--- a/posthog/management/commands/run_geoip.py
+++ b/posthog/management/commands/run_geoip.py
@@ -1,0 +1,19 @@
+import logging
+
+from django.contrib.gis.geoip2 import GeoIP2
+from django.core.management.base import BaseCommand
+
+logging.getLogger("kafka").setLevel(logging.ERROR)  # Hide kafka-python's logspam
+
+
+class Command(BaseCommand):
+    help = "Run geoip2 for an ip address, try `DEBUG=1 ./manage.py run_geoip 138.84.47.0`"
+
+    def add_arguments(self, parser):
+        parser.add_argument("ip", type=str, help="IP Address")
+
+    def handle(self, *args, **options):
+        geoip = GeoIP2(cache=8)
+        ip = options.get("ip")
+        print("Country: ", geoip.country(ip))  # noqa: T201
+        print("City: ", geoip.city(ip))  # noqa: T201


### PR DESCRIPTION
## Problem
I needed to run geoip on an ip address

## Changes

Add a django command. The config to sert the db path is done in django settings, so making a django command was easier than a simple script

## How did you test this code?

Ran manually, it's not used in prod anyway


```bash
(env) ➜  posthog git:(add-djano-command-for-geoip) DEBUG=1 ./manage.py run_geoip 138.84.47.0
2023-10-12 12:17.38 [warning  ] ['️Environment variable DEBUG is set - PostHog is running in DEVELOPMENT MODE!', 'Be sure to unset DEBUG if this is supposed to be a PRODUCTION ENVIRONMENT!']
ERROR: Unable to check license Apps aren't loaded yet.
2023-10-12T11:17:39.191393Z [warning  ] Skipping async migrations setup. This is unsafe in production! [posthog.apps] pid=42083 tid=8138265344
2023-10-12T11:17:39.194352Z [info     ] AXES: BEGIN LOG                [axes.apps] pid=42083 tid=8138265344
2023-10-12T11:17:39.194555Z [info     ] AXES: Using django-axes version 5.9.0 [axes.apps] pid=42083 tid=8138265344
2023-10-12T11:17:39.194596Z [info     ] AXES: blocking by IP only.     [axes.apps] pid=42083 tid=8138265344
Country:  {'country_code': 'GF', 'country_name': 'French Guiana'}
City:  {'city': 'Cayenne', 'continent_code': 'SA', 'continent_name': 'South America', 'country_code': 'GF', 'country_name': 'French Guiana', 'dma_code': None, 'is_in_european_union': True, 'latitude': 4.9324, 'longitude': -52.3373, 'postal_code': None, 'region': None, 'time_zone': 'America/Cayenne'}
```
