### PR TITLE
fix: Performance issue with player logs

### DIFF
--- a/frontend/src/scenes/notebooks/NotebookSelectButton/NotebookSelectButton.stories.tsx
+++ b/frontend/src/scenes/notebooks/NotebookSelectButton/NotebookSelectButton.stories.tsx
@@ -13,9 +13,27 @@ const allNotebooks = [
     {
         title: 'my amazing notebook',
         short_id: 'abc',
+        created_by: {
+            first_name: 'Ben',
+            email: 'ben@posthog.com',
+        },
     },
-    { title: 'and another amazing notebook', short_id: 'def' },
-    { title: 'an empty notebook', short_id: 'ghi' },
+    {
+        title: 'and another amazing notebook',
+        short_id: 'def',
+        created_by: {
+            first_name: 'Paul',
+            email: 'paul@posthog.com',
+        },
+    },
+    {
+        title: 'an empty notebook',
+        short_id: 'ghi',
+        created_by: {
+            first_name: 'David',
+            email: 'david@posthog.com',
+        },
+    },
 ]
 
 const Template: StoryFn<typeof NotebookSelectButton> = (props) => {

--- a/frontend/src/scenes/notebooks/NotebookSelectButton/NotebookSelectButton.tsx
+++ b/frontend/src/scenes/notebooks/NotebookSelectButton/NotebookSelectButton.tsx
@@ -52,13 +52,15 @@ function NotebooksChoiceList(props: {
                     return (
                         <LemonButton
                             key={i}
-                            icon={
-                                <ProfilePicture
-                                    name={notebook.created_by?.first_name}
-                                    email={notebook.created_by?.email}
-                                    size="md"
-                                    title={`Created by ${notebook.created_by?.first_name} <${notebook.created_by?.email}>`}
-                                />
+                            sideIcon={
+                                notebook.created_by ? (
+                                    <ProfilePicture
+                                        name={notebook.created_by?.first_name}
+                                        email={notebook.created_by?.email}
+                                        size="md"
+                                        title={`Created by ${notebook.created_by?.first_name} <${notebook.created_by?.email}>`}
+                                    />
+                                ) : null
                             }
                             fullWidth
                             onClick={() => props.onClick(notebook.short_id)}

--- a/frontend/src/scenes/notebooks/NotebookSelectButton/NotebookSelectButton.tsx
+++ b/frontend/src/scenes/notebooks/NotebookSelectButton/NotebookSelectButton.tsx
@@ -17,8 +17,7 @@ import { notebookNodeLogicType } from '../Nodes/notebookNodeLogicType'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { ReactChild, useEffect } from 'react'
-import { LemonDivider, ProfilePicture, Tooltip } from '@posthog/lemon-ui'
-import { PersonIcon } from '@posthog/apps-common'
+import { LemonDivider, ProfilePicture } from '@posthog/lemon-ui'
 
 export type NotebookSelectProps = NotebookSelectButtonLogicProps & {
     newNotebookTitle?: string

--- a/frontend/src/scenes/notebooks/NotebookSelectButton/NotebookSelectButton.tsx
+++ b/frontend/src/scenes/notebooks/NotebookSelectButton/NotebookSelectButton.tsx
@@ -17,7 +17,8 @@ import { notebookNodeLogicType } from '../Nodes/notebookNodeLogicType'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { ReactChild, useEffect } from 'react'
-import { LemonDivider } from '@posthog/lemon-ui'
+import { LemonDivider, ProfilePicture, Tooltip } from '@posthog/lemon-ui'
+import { PersonIcon } from '@posthog/apps-common'
 
 export type NotebookSelectProps = NotebookSelectButtonLogicProps & {
     newNotebookTitle?: string
@@ -50,8 +51,20 @@ function NotebooksChoiceList(props: {
             ) : (
                 props.notebooks.map((notebook, i) => {
                     return (
-                        <LemonButton key={i} fullWidth onClick={() => props.onClick(notebook.short_id)}>
-                            {notebook.title || `Untitled (${notebook.short_id})`}
+                        <LemonButton
+                            key={i}
+                            icon={
+                                <ProfilePicture
+                                    name={notebook.created_by?.first_name}
+                                    email={notebook.created_by?.email}
+                                    size="md"
+                                    title={`Created by ${notebook.created_by?.first_name} <${notebook.created_by?.email}>`}
+                                />
+                            }
+                            fullWidth
+                            onClick={() => props.onClick(notebook.short_id)}
+                        >
+                            <span className="truncate">{notebook.title || `Untitled (${notebook.short_id})`}</span>
                         </LemonButton>
                     )
                 })

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -971,7 +971,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         cache.pausedMediaElements = []
         values.player?.replayer?.pause()
         actions.setPlayer(null)
-        cache.unmountConsoleWarns()
+        cache.unmountConsoleWarns?.()
 
         const playTimeMs = values.playingTimeTracking.watchTime || 0
         const summaryAnalytics: RecordingViewedSummaryAnalytics = {


### PR DESCRIPTION
## Problem

Long bit of debugging led me to find out something frustrating - the logging from the replayer is the source of a huge number of lock ups. Essentially the logged object can be so massive and full of getter proxies that simply serializing it takes such a long time that the browser locks up. 

Any recording with a lot of warnings suffered from this which is largely why some people had such bad experiences. 

## Changes

* Fixes it so we don't log, but rather just count and delay a message indicating to the viewer how they _could_ get to the error messages without actually logging them to the console
* Also accidentally includes some Notebook tidying - not too much there and I've checked it works so just going to lazily include it 🙈 


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
