### PR TITLE
feat: Added lazy joins for groups on events

### DIFF
--- a/posthog/hogql/database/schema/events.py
+++ b/posthog/hogql/database/schema/events.py
@@ -11,6 +11,7 @@ from posthog.hogql.database.models import (
     FieldTraverser,
     FieldOrTable,
 )
+from posthog.hogql.database.schema.groups import GroupsTable, join_with_group_n_table
 from posthog.hogql.database.schema.person_distinct_ids import (
     PersonDistinctIdsTable,
     join_with_person_distinct_ids_table,
@@ -85,6 +86,16 @@ class EventsTable(Table):
         # These are swapped out if the user has PoE enabled
         "person": FieldTraverser(chain=["pdi", "person"]),
         "person_id": FieldTraverser(chain=["pdi", "person_id"]),
+        "$group_0": StringDatabaseField(name="$group_0"),
+        "group_0": LazyJoin(from_field="$group_0", join_table=GroupsTable(), join_function=join_with_group_n_table(0)),
+        "$group_1": StringDatabaseField(name="$group_1"),
+        "group_1": LazyJoin(from_field="$group_1", join_table=GroupsTable(), join_function=join_with_group_n_table(1)),
+        "$group_2": StringDatabaseField(name="$group_2"),
+        "group_2": LazyJoin(from_field="$group_2", join_table=GroupsTable(), join_function=join_with_group_n_table(2)),
+        "$group_3": StringDatabaseField(name="$group_3"),
+        "group_3": LazyJoin(from_field="$group_3", join_table=GroupsTable(), join_function=join_with_group_n_table(3)),
+        "$group_4": StringDatabaseField(name="$group_4"),
+        "group_4": LazyJoin(from_field="$group_4", join_table=GroupsTable(), join_function=join_with_group_n_table(4)),
     }
 
     def to_printed_clickhouse(self, context):

--- a/posthog/hogql/database/schema/groups.py
+++ b/posthog/hogql/database/schema/groups.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from posthog.hogql.database.argmax import argmax_select
 from posthog.hogql.database.models import (
@@ -10,6 +10,7 @@ from posthog.hogql.database.models import (
     Table,
     FieldOrTable,
 )
+from posthog.hogql.errors import HogQLException
 
 GROUPS_TABLE_FIELDS = {
     "index": IntegerDatabaseField(name="group_type_index"),
@@ -28,6 +29,34 @@ def select_from_groups_table(requested_fields: Dict[str, List[str]]):
         group_fields=["index", "key"],
         argmax_field="updated_at",
     )
+
+
+def join_with_group_n_table(group_index: int):
+    def join_with_group_table(from_table: str, to_table: str, requested_fields: Dict[str, Any]):
+        from posthog.hogql import ast
+
+        if not requested_fields:
+            raise HogQLException("No fields requested from person_distinct_ids")
+
+        select_query = select_from_groups_table(requested_fields)
+        select_query.where = ast.CompareOperation(
+            left=ast.Field(chain=["index"]), op=ast.CompareOperationOp.Eq, right=ast.Constant(value=group_index)
+        )
+
+        join_expr = ast.JoinExpr(table=select_query)
+        join_expr.join_type = "LEFT JOIN"
+        join_expr.alias = to_table
+        join_expr.constraint = ast.JoinConstraint(
+            expr=ast.CompareOperation(
+                op=ast.CompareOperationOp.Eq,
+                left=ast.Field(chain=[from_table, f"$group_{group_index}"]),
+                right=ast.Field(chain=[to_table, "key"]),
+            )
+        )
+
+        return join_expr
+
+    return join_with_group_table
 
 
 class RawGroupsTable(Table):

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -137,6 +137,91 @@
                   "pdi",
                   "person_id"
               ]
+          },
+          {
+              "key": "$group_0",
+              "type": "string"
+          },
+          {
+              "key": "group_0",
+              "type": "lazy_table",
+              "table": "groups",
+              "fields": [
+                  "index",
+                  "team_id",
+                  "key",
+                  "created_at",
+                  "updated_at",
+                  "properties"
+              ]
+          },
+          {
+              "key": "$group_1",
+              "type": "string"
+          },
+          {
+              "key": "group_1",
+              "type": "lazy_table",
+              "table": "groups",
+              "fields": [
+                  "index",
+                  "team_id",
+                  "key",
+                  "created_at",
+                  "updated_at",
+                  "properties"
+              ]
+          },
+          {
+              "key": "$group_2",
+              "type": "string"
+          },
+          {
+              "key": "group_2",
+              "type": "lazy_table",
+              "table": "groups",
+              "fields": [
+                  "index",
+                  "team_id",
+                  "key",
+                  "created_at",
+                  "updated_at",
+                  "properties"
+              ]
+          },
+          {
+              "key": "$group_3",
+              "type": "string"
+          },
+          {
+              "key": "group_3",
+              "type": "lazy_table",
+              "table": "groups",
+              "fields": [
+                  "index",
+                  "team_id",
+                  "key",
+                  "created_at",
+                  "updated_at",
+                  "properties"
+              ]
+          },
+          {
+              "key": "$group_4",
+              "type": "string"
+          },
+          {
+              "key": "group_4",
+              "type": "lazy_table",
+              "table": "groups",
+              "fields": [
+                  "index",
+                  "team_id",
+                  "key",
+                  "created_at",
+                  "updated_at",
+                  "properties"
+              ]
           }
       ],
       "groups": [
@@ -829,6 +914,91 @@
           {
               "key": "person_id",
               "type": "string"
+          },
+          {
+              "key": "$group_0",
+              "type": "string"
+          },
+          {
+              "key": "group_0",
+              "type": "lazy_table",
+              "table": "groups",
+              "fields": [
+                  "index",
+                  "team_id",
+                  "key",
+                  "created_at",
+                  "updated_at",
+                  "properties"
+              ]
+          },
+          {
+              "key": "$group_1",
+              "type": "string"
+          },
+          {
+              "key": "group_1",
+              "type": "lazy_table",
+              "table": "groups",
+              "fields": [
+                  "index",
+                  "team_id",
+                  "key",
+                  "created_at",
+                  "updated_at",
+                  "properties"
+              ]
+          },
+          {
+              "key": "$group_2",
+              "type": "string"
+          },
+          {
+              "key": "group_2",
+              "type": "lazy_table",
+              "table": "groups",
+              "fields": [
+                  "index",
+                  "team_id",
+                  "key",
+                  "created_at",
+                  "updated_at",
+                  "properties"
+              ]
+          },
+          {
+              "key": "$group_3",
+              "type": "string"
+          },
+          {
+              "key": "group_3",
+              "type": "lazy_table",
+              "table": "groups",
+              "fields": [
+                  "index",
+                  "team_id",
+                  "key",
+                  "created_at",
+                  "updated_at",
+                  "properties"
+              ]
+          },
+          {
+              "key": "$group_4",
+              "type": "string"
+          },
+          {
+              "key": "group_4",
+              "type": "lazy_table",
+              "table": "groups",
+              "fields": [
+                  "index",
+                  "team_id",
+                  "key",
+                  "created_at",
+                  "updated_at",
+                  "properties"
+              ]
           }
       ],
       "groups": [

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -779,6 +779,11 @@ class TestResolver(BaseTest):
                     chain=["elements_chain"], type=ast.FieldType(name="elements_chain", table_type=events_table_type)
                 ),
                 ast.Field(chain=["created_at"], type=ast.FieldType(name="created_at", table_type=events_table_type)),
+                ast.Field(chain=["$group_0"], type=ast.FieldType(name="$group_0", table_type=events_table_type)),
+                ast.Field(chain=["$group_1"], type=ast.FieldType(name="$group_1", table_type=events_table_type)),
+                ast.Field(chain=["$group_2"], type=ast.FieldType(name="$group_2", table_type=events_table_type)),
+                ast.Field(chain=["$group_3"], type=ast.FieldType(name="$group_3", table_type=events_table_type)),
+                ast.Field(chain=["$group_4"], type=ast.FieldType(name="$group_4", table_type=events_table_type)),
             ],
         )
 
@@ -811,6 +816,11 @@ class TestResolver(BaseTest):
                 ast.Field(
                     chain=["created_at"], type=ast.FieldType(name="created_at", table_type=events_table_alias_type)
                 ),
+                ast.Field(chain=["$group_0"], type=ast.FieldType(name="$group_0", table_type=events_table_alias_type)),
+                ast.Field(chain=["$group_1"], type=ast.FieldType(name="$group_1", table_type=events_table_alias_type)),
+                ast.Field(chain=["$group_2"], type=ast.FieldType(name="$group_2", table_type=events_table_alias_type)),
+                ast.Field(chain=["$group_3"], type=ast.FieldType(name="$group_3", table_type=events_table_alias_type)),
+                ast.Field(chain=["$group_4"], type=ast.FieldType(name="$group_4", table_type=events_table_alias_type)),
             ],
         )
 
@@ -882,6 +892,11 @@ class TestResolver(BaseTest):
                 "distinct_id": ast.FieldType(name="distinct_id", table_type=events_table_type),
                 "elements_chain": ast.FieldType(name="elements_chain", table_type=events_table_type),
                 "created_at": ast.FieldType(name="created_at", table_type=events_table_type),
+                "$group_0": ast.FieldType(name="$group_0", table_type=events_table_type),
+                "$group_1": ast.FieldType(name="$group_1", table_type=events_table_type),
+                "$group_2": ast.FieldType(name="$group_2", table_type=events_table_type),
+                "$group_3": ast.FieldType(name="$group_3", table_type=events_table_type),
+                "$group_4": ast.FieldType(name="$group_4", table_type=events_table_type),
             },
         )
 
@@ -898,6 +913,11 @@ class TestResolver(BaseTest):
                     type=ast.FieldType(name="elements_chain", table_type=inner_select_type),
                 ),
                 ast.Field(chain=["created_at"], type=ast.FieldType(name="created_at", table_type=inner_select_type)),
+                ast.Field(chain=["$group_0"], type=ast.FieldType(name="$group_0", table_type=inner_select_type)),
+                ast.Field(chain=["$group_1"], type=ast.FieldType(name="$group_1", table_type=inner_select_type)),
+                ast.Field(chain=["$group_2"], type=ast.FieldType(name="$group_2", table_type=inner_select_type)),
+                ast.Field(chain=["$group_3"], type=ast.FieldType(name="$group_3", table_type=inner_select_type)),
+                ast.Field(chain=["$group_4"], type=ast.FieldType(name="$group_4", table_type=inner_select_type)),
             ],
         )
 
@@ -930,6 +950,11 @@ class TestResolver(BaseTest):
                         "distinct_id": ast.FieldType(name="distinct_id", table_type=events_table_type),
                         "elements_chain": ast.FieldType(name="elements_chain", table_type=events_table_type),
                         "created_at": ast.FieldType(name="created_at", table_type=events_table_type),
+                        "$group_0": ast.FieldType(name="$group_0", table_type=events_table_type),
+                        "$group_1": ast.FieldType(name="$group_1", table_type=events_table_type),
+                        "$group_2": ast.FieldType(name="$group_2", table_type=events_table_type),
+                        "$group_3": ast.FieldType(name="$group_3", table_type=events_table_type),
+                        "$group_4": ast.FieldType(name="$group_4", table_type=events_table_type),
                     },
                 )
             ]
@@ -949,6 +974,11 @@ class TestResolver(BaseTest):
                     type=ast.FieldType(name="elements_chain", table_type=inner_select_type),
                 ),
                 ast.Field(chain=["created_at"], type=ast.FieldType(name="created_at", table_type=inner_select_type)),
+                ast.Field(chain=["$group_0"], type=ast.FieldType(name="$group_0", table_type=inner_select_type)),
+                ast.Field(chain=["$group_1"], type=ast.FieldType(name="$group_1", table_type=inner_select_type)),
+                ast.Field(chain=["$group_2"], type=ast.FieldType(name="$group_2", table_type=inner_select_type)),
+                ast.Field(chain=["$group_3"], type=ast.FieldType(name="$group_3", table_type=inner_select_type)),
+                ast.Field(chain=["$group_4"], type=ast.FieldType(name="$group_4", table_type=inner_select_type)),
             ],
         )
 


### PR DESCRIPTION
## Problem
- In the trends insights HogQL conversion work, we need to pull `group` properties when dealing with trend breakdowns
- Instead of adding in manual joins to the HogQL queries, it's much nicer to get HogQL to do this for us instead

## Changes
- Adds `LazyJoin`'s for each of the `$group_n` fields on `events`

<img width="1219" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/7c8802f8-b29f-43c1-ad6d-fa727086d88a">

## How did you test this code?
- Manually via query debugging