### PR TITLE
chore: deflake a test

### DIFF
--- a/cypress/e2e/insights-unsaved-confirmation.cy.ts
+++ b/cypress/e2e/insights-unsaved-confirmation.cy.ts
@@ -1,4 +1,3 @@
-import { urls } from 'scenes/urls'
 import { randomString } from '../support/random'
 import { decideResponse } from '../fixtures/api/decide'
 import { insight } from '../productAnalytics'
@@ -20,7 +19,10 @@ describe('Insights', () => {
             return true
         })
 
-        cy.visit(urls.insightNew())
+        cy.visit('/insights')
+        cy.wait('@getInsights').then(() => {
+            cy.get('.saved-insights tr').should('exist')
+        })
     })
 
     describe('unsaved insights confirmation', () => {


### PR DESCRIPTION
the flakey test when failing starts on the edit insight page, and when passing starts on the saved insights page.

let's really, really try to reset the test in before each