### PR TITLE
feat(web-analytics): Fix source query views and uniques - remove blended source

### DIFF
--- a/posthog/hogql_queries/web_analytics/top_pages.py
+++ b/posthog/hogql_queries/web_analytics/top_pages.py
@@ -42,15 +42,15 @@ FROM
 LEFT OUTER JOIN
     (
         SELECT
-            session.entry_pathname,
+            session.$initial_pathname,
             avg(session.is_bounce) as bounce_rate
         FROM
             {session_query} AS session
         GROUP BY
-            session.entry_pathname
+            session.$initial_pathname
     ) AS bounce_rate
 ON
-    pathname.$pathname = bounce_rate.entry_pathname
+    pathname.$pathname = bounce_rate.$initial_pathname
 LEFT OUTER JOIN
     {pathname_scroll_query} AS scroll_data
 ON

--- a/posthog/hogql_queries/web_analytics/top_sources.py
+++ b/posthog/hogql_queries/web_analytics/top_sources.py
@@ -1,7 +1,7 @@
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
-from posthog.hogql_queries.web_analytics.ctes import SESSION_CTE
+from posthog.hogql_queries.web_analytics.ctes import SESSION_CTE, SOURCE_CTE
 from posthog.hogql_queries.web_analytics.web_analytics_query_runner import WebAnalyticsQueryRunner
 from posthog.schema import WebTopSourcesQuery, WebTopSourcesQueryResponse
 
@@ -17,25 +17,39 @@ class WebTopSourcesQueryRunner(WebAnalyticsQueryRunner):
                 timings=self.timings,
                 placeholders={"session_where": self.session_where(), "session_having": self.session_having()},
             )
+        with self.timings.measure("sources_query"):
+            source_query = parse_select(
+                SOURCE_CTE,
+                timings=self.timings,
+                placeholders={"source_where": self.events_where()},
+            )
         with self.timings.measure("top_sources_query"):
             top_sources_query = parse_select(
                 """
 SELECT
-    blended_source as "Source",
-    count(num_pageviews) as "context.columns.views",
-    count(DISTINCT person_id) as "context.columns.visitors",
-    avg(is_bounce) AS "context.columns.bounce_rate"
+    source_query.$initial_utm_source as "Initial UTM Source",
+    source_query.total_pageviews as "context.columns.views",
+    source_query.unique_visitors as "context.columns.visitors",
+    bounce_rate.bounce_rate AS "context.columns.bounce_rate"
 FROM
-    {session_query}
+    {source_query} AS source_query
+LEFT JOIN  (
+        SELECT
+            session.$initial_utm_source,
+            avg(session.is_bounce) as bounce_rate
+        FROM
+            {session_query} AS session
+        GROUP BY
+            session.$initial_utm_source
+    ) AS bounce_rate
+ON source_query.$initial_utm_source = bounce_rate.$initial_utm_source
 WHERE
-    "Source" IS NOT NULL
-GROUP BY "Source"
-
+    "Initial UTM Source" IS NOT NULL
 ORDER BY "context.columns.views" DESC
 LIMIT 10
                 """,
                 timings=self.timings,
-                placeholders={"session_query": session_query},
+                placeholders={"session_query": session_query, "source_query": source_query},
             )
         return top_sources_query
 


### PR DESCRIPTION
## Problem
The query for pageviews/uniques for sources when filtered by pageview was comparing against the initial pageview of a session and then adding the pageviews/uniques in those sessions, rather than counting the pageview events of that specific pathname by source.

Blended source also needed to go, as it doesn't make sense to do it in the query. Probably it will need to be a plugin or in the new web pipeline, but I don't need it for now.

## Changes

Tweak the query to fix the above, remove blended source

## How did you test this code?

(Behind FF) ran it
