### PR TITLE
feat: Create Notebook from dashboard

### DIFF
--- a/frontend/src/models/notebooksModel.ts
+++ b/frontend/src/models/notebooksModel.ts
@@ -176,7 +176,7 @@ export const notebooksModel = kea<notebooksModelType>([
                         query: {
                             kind: NodeKind.InsightVizNode,
                             source: node,
-                        } as InsightVizNode,
+                        },
                     },
                 ]
             }, [] as { title: string; query: InsightVizNode | Node }[])

--- a/frontend/src/models/notebooksModel.ts
+++ b/frontend/src/models/notebooksModel.ts
@@ -1,7 +1,7 @@
-import { actions, BuiltLogic, connect, kea, path, reducers } from 'kea'
+import { actions, BuiltLogic, connect, kea, listeners, path, reducers } from 'kea'
 
 import { loaders } from 'kea-loaders'
-import { NotebookListItemType, NotebookTarget, NotebookType } from '~/types'
+import { DashboardType, NotebookListItemType, NotebookNodeType, NotebookTarget, NotebookType } from '~/types'
 
 import api from 'lib/api'
 import posthog from 'posthog-js'
@@ -16,6 +16,8 @@ import { notebookLogicType } from 'scenes/notebooks/Notebook/notebookLogicType'
 import { urls } from 'scenes/urls'
 import { notebookLogic } from 'scenes/notebooks/Notebook/notebookLogic'
 import { router } from 'kea-router'
+import { filtersToQueryNode } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
+import { NodeKind } from '~/queries/schema'
 
 export const SCRATCHPAD_NOTEBOOK: NotebookListItemType = {
     short_id: 'scratchpad',
@@ -74,6 +76,7 @@ export const notebooksModel = kea<notebooksModelType>([
         receiveNotebookUpdate: (notebook: NotebookListItemType) => ({ notebook }),
         loadNotebooks: true,
         deleteNotebook: (shortId: NotebookListItemType['short_id'], title?: string) => ({ shortId, title }),
+        createNotebookFromDashboard: (dashboard: DashboardType) => ({ dashboard }),
     }),
     connect({
         values: [teamLogic, ['currentTeamId']],
@@ -143,5 +146,50 @@ export const notebooksModel = kea<notebooksModelType>([
                 // In the future we can load these from remote
             },
         ],
+    })),
+
+    listeners(({ actions }) => ({
+        createNotebookFromDashboard: async ({ dashboard }) => {
+            const queries = dashboard.tiles.reduce((acc, tile) => {
+                if (!tile.insight) {
+                    return acc
+                }
+                if (tile.insight.query) {
+                    return [
+                        ...acc,
+                        {
+                            title: tile.insight.name,
+                            query: tile.insight.query,
+                        },
+                    ]
+                }
+                const node = filtersToQueryNode(tile.insight.filters)
+
+                if (!node) {
+                    return acc
+                }
+
+                return [
+                    ...acc,
+                    {
+                        title: tile.insight.name,
+                        query: {
+                            kind: NodeKind.InsightVizNode,
+                            source: node,
+                        },
+                    },
+                ]
+            }, [] as { title: string; query: Node }[])
+
+            const resources = queries.map((x) => ({
+                type: NotebookNodeType.Query,
+                attrs: {
+                    title: x.title,
+                    query: x.query,
+                },
+            }))
+
+            await actions.createNotebook(dashboard.name + ' (copied)', NotebookTarget.Auto, resources)
+        },
     })),
 ])

--- a/frontend/src/models/notebooksModel.ts
+++ b/frontend/src/models/notebooksModel.ts
@@ -17,7 +17,7 @@ import { urls } from 'scenes/urls'
 import { notebookLogic } from 'scenes/notebooks/Notebook/notebookLogic'
 import { router } from 'kea-router'
 import { filtersToQueryNode } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
-import { NodeKind } from '~/queries/schema'
+import { InsightVizNode, Node, NodeKind } from '~/queries/schema'
 
 export const SCRATCHPAD_NOTEBOOK: NotebookListItemType = {
     short_id: 'scratchpad',
@@ -176,10 +176,10 @@ export const notebooksModel = kea<notebooksModelType>([
                         query: {
                             kind: NodeKind.InsightVizNode,
                             source: node,
-                        },
+                        } as InsightVizNode,
                     },
                 ]
-            }, [] as { title: string; query: Node }[])
+            }, [] as { title: string; query: InsightVizNode | Node }[])
 
             const resources = queries.map((x) => ({
                 type: NotebookNodeType.Query,

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -31,6 +31,7 @@ import { duplicateDashboardLogic } from 'scenes/dashboard/duplicateDashboardLogi
 import { tagsModel } from '~/models/tagsModel'
 import { DashboardTemplateEditor } from './DashboardTemplateEditor'
 import { dashboardTemplateEditorLogic } from './dashboardTemplateEditorLogic'
+import { notebooksModel } from '~/models/notebooksModel'
 
 export const DASHBOARD_CANNOT_EDIT_MESSAGE =
     "You don't have edit permissions for this dashboard. Ask a dashboard collaborator with edit access to add you."
@@ -50,6 +51,7 @@ export function DashboardHeader(): JSX.Element | null {
     const { setDashboardMode, triggerDashboardUpdate } = useActions(dashboardLogic)
     const { asDashboardTemplate } = useValues(dashboardLogic)
     const { updateDashboard, pinDashboard, unpinDashboard } = useActions(dashboardsModel)
+    const { createNotebookFromDashboard } = useActions(notebooksModel)
 
     const { setDashboardTemplate, openDashboardTemplateEditor } = useActions(dashboardTemplateEditorLogic)
 
@@ -260,6 +262,13 @@ export function DashboardHeader(): JSX.Element | null {
                                                 fullWidth
                                             >
                                                 Duplicate dashboard
+                                            </LemonButton>
+                                            <LemonButton
+                                                onClick={() => createNotebookFromDashboard(dashboard)}
+                                                status="stealth"
+                                                fullWidth
+                                            >
+                                                Create notebook from dashboard
                                             </LemonButton>
                                             {canEditDashboard && (
                                                 <LemonButton

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -32,6 +32,7 @@ import { tagsModel } from '~/models/tagsModel'
 import { DashboardTemplateEditor } from './DashboardTemplateEditor'
 import { dashboardTemplateEditorLogic } from './dashboardTemplateEditorLogic'
 import { notebooksModel } from '~/models/notebooksModel'
+import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 
 export const DASHBOARD_CANNOT_EDIT_MESSAGE =
     "You don't have edit permissions for this dashboard. Ask a dashboard collaborator with edit access to add you."
@@ -263,13 +264,15 @@ export function DashboardHeader(): JSX.Element | null {
                                             >
                                                 Duplicate dashboard
                                             </LemonButton>
-                                            <LemonButton
-                                                onClick={() => createNotebookFromDashboard(dashboard)}
-                                                status="stealth"
-                                                fullWidth
-                                            >
-                                                Create notebook from dashboard
-                                            </LemonButton>
+                                            <FlaggedFeature flag={'notebooks'}>
+                                                <LemonButton
+                                                    onClick={() => createNotebookFromDashboard(dashboard)}
+                                                    status="stealth"
+                                                    fullWidth
+                                                >
+                                                    Create notebook from dashboard
+                                                </LemonButton>
+                                            </FlaggedFeature>
                                             {canEditDashboard && (
                                                 <LemonButton
                                                     onClick={() => {


### PR DESCRIPTION
## Problem

Was thinking about how a more dashboard-like view might look like in notebooks and wanted to test it out...
Made me think of pulling in insights from a dashboard...

## Changes

* Adds a button to take all the tiles of a dashboard and clone them into a Notebook

![2023-10-13 14 36 34](https://github.com/PostHog/posthog/assets/2536520/32bd5b93-87c8-42a4-a545-d1b3af578120)

## TODO
* Big number seems to be broken...

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
