### PR TITLE
Fix/overlap taxonomic filter popup with scroll

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -23,6 +23,10 @@ import { pluralize } from 'lib/utils'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { useState } from 'react'
 
+export interface InfiniteListProps {
+    popupAnchorElement: HTMLDivElement | null
+}
+
 const staleIndicator = (parsedLastSeen: dayjs.Dayjs | null): JSX.Element => {
     return (
         <Tooltip
@@ -148,7 +152,7 @@ const selectedItemHasPopover = (
     )
 }
 
-export function InfiniteList(): JSX.Element {
+export function InfiniteList({ popupAnchorElement }: InfiniteListProps): JSX.Element {
     const { mouseInteractionsEnabled, activeTab, searchQuery, value, groupType, eventNames } =
         useValues(taxonomicFilterLogic)
     const { selectItem } = useActions(taxonomicFilterLogic)
@@ -191,7 +195,11 @@ export function InfiniteList(): JSX.Element {
             // if the popover is not enabled then don't leave the row selected when the mouse leaves it
             onMouseLeave: () => (mouseInteractionsEnabled && !showPopover ? setIndex(NO_ITEM_SELECTED) : null),
             style: style,
-            ref: isHighlighted ? (element) => setHighlightedItemElement(element) : null,
+            ref: isHighlighted
+                ? (element) => {
+                      setHighlightedItemElement(element && popupAnchorElement ? popupAnchorElement : element)
+                  }
+                : null,
         }
 
         return item && group ? (

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
@@ -9,6 +9,7 @@ import clsx from 'clsx'
 export interface InfiniteSelectResultsProps {
     focusInput: () => void
     taxonomicFilterLogicProps: TaxonomicFilterLogicProps
+    popupAnchorElement: HTMLDivElement | null
 }
 
 function CategoryPill({
@@ -53,6 +54,7 @@ function CategoryPill({
 export function InfiniteSelectResults({
     focusInput,
     taxonomicFilterLogicProps,
+    popupAnchorElement,
 }: InfiniteSelectResultsProps): JSX.Element {
     const { activeTab, taxonomicGroups, taxonomicGroupTypes, activeTaxonomicGroup, value } =
         useValues(taxonomicFilterLogic)
@@ -66,7 +68,7 @@ export function InfiniteSelectResults({
             onChange={(newValue) => selectItem(activeTaxonomicGroup, newValue, newValue)}
         />
     ) : (
-        <InfiniteList />
+        <InfiniteList popupAnchorElement={popupAnchorElement} />
     )
 
     if (taxonomicGroupTypes.length === 1) {

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -69,9 +69,12 @@ export function TaxonomicFilter({
         ...(height ? { height } : {}),
     }
 
+    const taxonomicFilterRef = useRef<HTMLInputElement | null>(null)
+
     return (
         <BindLogic logic={taxonomicFilterLogic} props={taxonomicFilterLogicProps}>
             <div
+                ref={taxonomicFilterRef}
                 className={clsx(
                     'taxonomic-filter',
                     taxonomicGroupTypes.length === 1 && 'one-taxonomic-tab',
@@ -136,7 +139,11 @@ export function TaxonomicFilter({
                         />
                     </div>
                 ) : null}
-                <InfiniteSelectResults focusInput={focusInput} taxonomicFilterLogicProps={taxonomicFilterLogicProps} />
+                <InfiniteSelectResults
+                    focusInput={focusInput}
+                    taxonomicFilterLogicProps={taxonomicFilterLogicProps}
+                    popupAnchorElement={taxonomicFilterRef.current}
+                />
             </div>
         </BindLogic>
     )

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -107,30 +107,28 @@ export function TaxonomicFilter({
                                 </Tooltip>
                             }
                             onKeyDown={(e) => {
-                                if (e.key === 'ArrowUp') {
-                                    e.preventDefault()
-                                    moveUp()
+                                let shouldPreventDefault = true
+                                switch (e.key) {
+                                    case 'ArrowUp':
+                                        moveUp()
+                                        break
+                                    case 'ArrowDown':
+                                        moveDown()
+                                        break
+                                    case 'Tab':
+                                        e.shiftKey ? tabLeft() : tabRight()
+                                        break
+                                    case 'Enter':
+                                        selectSelected()
+                                        break
+                                    case 'Escape':
+                                        onClose?.()
+                                        break
+                                    default:
+                                        shouldPreventDefault = false
                                 }
-                                if (e.key === 'ArrowDown') {
+                                if (shouldPreventDefault) {
                                     e.preventDefault()
-                                    moveDown()
-                                }
-                                if (e.key === 'Tab') {
-                                    e.preventDefault()
-                                    if (e.shiftKey) {
-                                        tabLeft()
-                                    } else {
-                                        tabRight()
-                                    }
-                                }
-
-                                if (e.key === 'Enter') {
-                                    e.preventDefault()
-                                    selectSelected()
-                                }
-                                if (e.key === 'Escape') {
-                                    e.preventDefault()
-                                    onClose?.()
                                 }
                             }}
                             ref={searchInputRef}


### PR DESCRIPTION
## Problem
I created this issue: [Taxonomic filter help overlaps with scroll and not properly visualized at the bottom #17986](https://github.com/PostHog/posthog/issues/17986)

This is the two bugs that are solved by this PR:
![posthog-position-and-overlap-bug](https://github.com/PostHog/posthog/assets/11620411/68a345ca-a328-4f35-bc07-a55534d318f2)


## Changes
The changes introduced render the popup next to the taxonomic filter.

Here you can see the behaviour introduced in this pull request:
![posthog-filter-proposal](https://github.com/PostHog/posthog/assets/11620411/b1368535-5720-436c-b37a-cebd95127fd7)

Note:  There is also a small commit where I cleaned up a little bit the logic for key shortcuts. Same logic, but hopefully slightly cleaner (switch instead of muiltiple ifs and multiple preventDefault calls)

## How did you test this code?

Manually tested in multiple filter components throught PostHog. It seems to continue to work properly.

In order to test, I followed the steps to reproduce that I provided on [the issue I created](https://github.com/PostHog/posthog/issues/17986).


