### PR TITLE
refactor(insights): separate insight data and insight viz logics

### DIFF
--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -14,14 +14,14 @@ import {
 import { ChartDisplayType } from '~/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 export function ChartFilter(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { chartFilter } = useValues(chartFilterLogic(insightProps))
     const { setChartFilter } = useActions(chartFilterLogic(insightProps))
 
-    const { isTrends, isSingleSeries, formula, breakdown } = useValues(insightVizDataLogic(insightProps))
+    const { isTrends, isSingleSeries, formula, breakdown } = useValues(insightVizLogic(insightProps))
 
     const trendsOnlyDisabledReason = !isTrends ? 'This type is only available in Trends.' : undefined
     const singleSeriesOnlyDisabledReason = !isSingleSeries

--- a/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
+++ b/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
@@ -2,15 +2,15 @@ import { kea } from 'kea'
 import type { chartFilterLogicType } from './chartFilterLogicType'
 import { ChartDisplayType, InsightLogicProps } from '~/types'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 export const chartFilterLogic = kea<chartFilterLogicType>({
     props: {} as InsightLogicProps,
     key: keyForInsightLogicProps('new'),
     path: (key) => ['lib', 'components', 'ChartFilter', 'chartFilterLogic', key],
     connect: (props: InsightLogicProps) => ({
-        actions: [insightVizDataLogic(props), ['updateInsightFilter', 'updateBreakdown']],
-        values: [insightVizDataLogic(props), ['isTrends', 'isStickiness', 'display', 'series']],
+        actions: [insightVizLogic(props), ['updateInsightFilter', 'updateBreakdown']],
+        values: [insightVizLogic(props), ['isTrends', 'isStickiness', 'display', 'series']],
     }),
 
     actions: () => ({

--- a/frontend/src/lib/components/CompareFilter/compareFilterLogic.ts
+++ b/frontend/src/lib/components/CompareFilter/compareFilterLogic.ts
@@ -3,7 +3,7 @@ import { ChartDisplayType, InsightLogicProps } from '~/types'
 import type { compareFilterLogicType } from './compareFilterLogicType'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 export const compareFilterLogic = kea<compareFilterLogicType>({
     props: {} as InsightLogicProps,
@@ -13,10 +13,10 @@ export const compareFilterLogic = kea<compareFilterLogicType>({
         values: [
             insightLogic(props),
             ['canEditInsight'],
-            insightVizDataLogic(props),
+            insightVizLogic(props),
             ['compare', 'display', 'insightFilter', 'isLifecycle', 'dateRange'],
         ],
-        actions: [insightVizDataLogic(props), ['updateInsightFilter']],
+        actions: [insightVizLogic(props), ['updateInsightFilter']],
     }),
 
     actions: () => ({

--- a/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
@@ -8,15 +8,15 @@ import { dayjs } from 'lib/dayjs'
 import { InsightQueryNode, TrendsQuery } from '~/queries/schema'
 import { lemonToast } from 'lib/lemon-ui/lemonToast'
 import { BASE_MATH_DEFINITIONS } from 'scenes/trends/mathsLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 export const intervalFilterLogic = kea<intervalFilterLogicType>({
     props: {} as InsightLogicProps,
     key: keyForInsightLogicProps('new'),
     path: (key) => ['lib', 'components', 'IntervalFilter', 'intervalFilterLogic', key],
     connect: (props: InsightLogicProps) => ({
-        actions: [insightVizDataLogic(props), ['updateQuerySource']],
-        values: [insightVizDataLogic(props), ['interval', 'querySource']],
+        actions: [insightVizLogic(props), ['updateQuerySource']],
+        values: [insightVizLogic(props), ['interval', 'querySource']],
     }),
     actions: () => ({
         setInterval: (interval: IntervalKeyType) => ({ interval }),

--- a/frontend/src/lib/components/SmoothingFilter/SmoothingFilter.tsx
+++ b/frontend/src/lib/components/SmoothingFilter/SmoothingFilter.tsx
@@ -3,13 +3,13 @@ import { FundOutlined } from '@ant-design/icons'
 import { smoothingOptions } from './smoothings'
 import { useActions, useValues } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 
 export function SmoothingFilter(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { isTrends, interval, trendsFilter } = useValues(trendsDataLogic(insightProps))
-    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizLogic(insightProps))
 
     if (!isTrends || !interval) {
         return null

--- a/frontend/src/lib/components/UnitPicker/UnitPicker.tsx
+++ b/frontend/src/lib/components/UnitPicker/UnitPicker.tsx
@@ -7,7 +7,7 @@ import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { CustomUnitModal } from 'lib/components/UnitPicker/CustomUnitModal'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 const aggregationDisplayMap = INSIGHT_UNIT_OPTIONS.reduce((acc, option) => {
     acc[option.value] = option.label
@@ -23,8 +23,8 @@ export interface HandleUnitChange {
 
 export function UnitPicker(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const { trendsFilter, display } = useValues(insightVizDataLogic(insightProps))
-    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { trendsFilter, display } = useValues(insightVizLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizLogic(insightProps))
 
     const { reportAxisUnitsChanged } = useActions(eventUsageLogic)
 

--- a/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
+++ b/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
@@ -1,11 +1,11 @@
 import { useActions, useValues } from 'kea'
 import { EditorFilterProps } from '~/types'
 import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 export function Breakdown({ insightProps }: EditorFilterProps): JSX.Element {
-    const { breakdown, display, isTrends } = useValues(insightVizDataLogic(insightProps))
-    const { updateBreakdown, updateDisplay } = useActions(insightVizDataLogic(insightProps))
+    const { breakdown, display, isTrends } = useValues(insightVizLogic(insightProps))
+    const { updateBreakdown, updateDisplay } = useActions(insightVizLogic(insightProps))
 
     return (
         <TaxonomicBreakdownFilter

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -35,7 +35,7 @@ import { RetentionSummary } from 'scenes/insights/EditorFilters/RetentionSummary
 import { SamplingFilter } from 'scenes/insights/EditorFilters/SamplingFilter'
 
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 import './EditorFilters.scss'
 import { PathsHogQL } from 'scenes/insights/EditorFilters/PathsHogQL'
@@ -62,7 +62,7 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
         breakdown,
         pathsFilter,
         querySource,
-    } = useValues(insightVizDataLogic(insightProps))
+    } = useValues(insightVizLogic(insightProps))
     const { isStepsFunnel } = useValues(funnelDataLogic(insightProps))
 
     if (!querySource) {

--- a/frontend/src/queries/nodes/InsightViz/GlobalAndOrFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/GlobalAndOrFilters.tsx
@@ -4,15 +4,15 @@ import { useActions, useValues } from 'kea'
 import { groupsModel } from '~/models/groupsModel'
 import { actionsModel } from '~/models/actionsModel'
 import { getAllEventNames } from './utils'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { EditorFilterProps } from '~/types'
 import { StickinessQuery, TrendsQuery } from '~/queries/schema'
 
 export function GlobalAndOrFilters({ insightProps }: EditorFilterProps): JSX.Element {
     const { actions: allActions } = useValues(actionsModel)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
-    const { isTrends, querySource } = useValues(insightVizDataLogic(insightProps))
-    const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
+    const { isTrends, querySource } = useValues(insightVizLogic(insightProps))
+    const { updateQuerySource } = useActions(insightVizLogic(insightProps))
 
     const taxonomicGroupTypes = [
         TaxonomicFilterGroupType.EventProperties,

--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -85,9 +85,8 @@ export function InsightContainer({
         samplingFactor,
         insightDataLoading,
         erroredQueryId,
-        timedOutQueryId,
     } = useValues(insightVizDataLogic(insightProps))
-    const { exportContext } = useValues(insightDataLogic(insightProps))
+    const { exportContext, timedOutQueryId } = useValues(insightDataLogic(insightProps))
 
     // Empty states that completely replace the graph
     const BlockingEmptyState = (() => {

--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -83,10 +83,10 @@ export function InsightContainer({
         supportsDisplay,
         isUsingSessionAnalysis,
         samplingFactor,
-        insightDataLoading,
-        erroredQueryId,
     } = useValues(insightVizDataLogic(insightProps))
-    const { exportContext, timedOutQueryId } = useValues(insightDataLogic(insightProps))
+    const { exportContext, timedOutQueryId, insightDataLoading, erroredQueryId } = useValues(
+        insightDataLogic(insightProps)
+    )
 
     // Empty states that completely replace the graph
     const BlockingEmptyState = (() => {

--- a/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightContainer.tsx
@@ -31,7 +31,7 @@ import { InsightLegend } from 'lib/components/InsightLegend/InsightLegend'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { FunnelInsight } from 'scenes/insights/views/Funnels/FunnelInsight'
 import { FunnelStepsTable } from 'scenes/insights/views/Funnels/FunnelStepsTable'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { FunnelCorrelation } from 'scenes/insights/views/Funnels/FunnelCorrelation'
 import { InsightResultMetadata } from './InsightResultMetadata'
 
@@ -83,7 +83,7 @@ export function InsightContainer({
         supportsDisplay,
         isUsingSessionAnalysis,
         samplingFactor,
-    } = useValues(insightVizDataLogic(insightProps))
+    } = useValues(insightVizLogic(insightProps))
     const { exportContext, timedOutQueryId, insightDataLoading, erroredQueryId } = useValues(
         insightDataLogic(insightProps)
     )

--- a/frontend/src/queries/nodes/InsightViz/InsightResultMetadata.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightResultMetadata.tsx
@@ -1,7 +1,7 @@
 import { useValues } from 'kea'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 import { ComputationTimeWithRefresh } from './ComputationTimeWithRefresh'
 
@@ -15,7 +15,7 @@ export const InsightResultMetadata = ({
     disableLastComputationRefresh,
 }: InsightResultMetadataProps): JSX.Element => {
     const { insightProps } = useValues(insightLogic)
-    const { samplingFactor } = useValues(insightVizDataLogic(insightProps))
+    const { samplingFactor } = useValues(insightVizLogic(insightProps))
     return (
         <>
             {!disableLastComputation && <ComputationTimeWithRefresh disableRefresh={disableLastComputationRefresh} />}

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -16,7 +16,7 @@ import { getCachedResults } from './utils'
 import { useState } from 'react'
 
 import './Insight.scss'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 /** The key for the dataNodeLogic mounted by an InsightViz for insight of insightProps */
 export const insightVizDataNodeKey = (insightProps: InsightLogicProps): string => {
@@ -69,7 +69,7 @@ export function InsightViz({ uniqueKey, query, setQuery, context, readOnly }: In
     return (
         <BindLogic logic={insightLogic} props={insightProps}>
             <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
-                <BindLogic logic={insightVizDataLogic} props={insightProps}>
+                <BindLogic logic={insightVizLogic} props={insightProps}>
                     <div
                         className={clsx('insight-wrapper', {
                             'insight-wrapper--singlecolumn': isFunnels,

--- a/frontend/src/queries/nodes/InsightViz/LifecycleToggles.tsx
+++ b/frontend/src/queries/nodes/InsightViz/LifecycleToggles.tsx
@@ -2,7 +2,7 @@ import { LifecycleFilter } from '~/queries/schema'
 import { EditorFilterProps, LifecycleToggle } from '~/types'
 import { LemonCheckbox, LemonLabel } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 const lifecycles: { name: LifecycleToggle; tooltip: string; color: string }[] = [
     {
@@ -32,8 +32,8 @@ const lifecycles: { name: LifecycleToggle; tooltip: string; color: string }[] = 
 const DEFAULT_LIFECYCLE_TOGGLES: LifecycleToggle[] = ['new', 'returning', 'resurrecting', 'dormant']
 
 export function LifecycleToggles({ insightProps }: EditorFilterProps): JSX.Element {
-    const { insightFilter } = useValues(insightVizDataLogic(insightProps))
-    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { insightFilter } = useValues(insightVizLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizLogic(insightProps))
 
     const toggledLifecycles = (insightFilter as LifecycleFilter)?.toggledLifecycles || DEFAULT_LIFECYCLE_TOGGLES
     const toggleLifecycle = (name: LifecycleToggle): void => {

--- a/frontend/src/queries/nodes/InsightViz/TrendsFormula.tsx
+++ b/frontend/src/queries/nodes/InsightViz/TrendsFormula.tsx
@@ -2,14 +2,14 @@ import { useEffect, useState } from 'react'
 import { EditorFilterProps } from '~/types'
 import { useActions, useValues } from 'kea'
 import { LemonInput } from '@posthog/lemon-ui'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 // When updating this regex, remember to update the regex with the same name in mixins/common.py
 const ALLOWED_FORMULA_CHARACTERS = /^[a-zA-Z \-*^0-9+/().]+$/
 
 export function TrendsFormula({ insightProps }: EditorFilterProps): JSX.Element | null {
-    const { formula, hasFormula } = useValues(insightVizDataLogic(insightProps))
-    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { formula, hasFormula } = useValues(insightVizLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizLogic(insightProps))
 
     const [value, setValue] = useState(formula ? formula : undefined)
 

--- a/frontend/src/queries/nodes/InsightViz/TrendsFormulaLabel.tsx
+++ b/frontend/src/queries/nodes/InsightViz/TrendsFormulaLabel.tsx
@@ -1,8 +1,8 @@
 import { useValues } from 'kea'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { EditorFilterProps } from '~/types'
 
 export function TrendsFormulaLabel({ insightProps }: EditorFilterProps): JSX.Element | null {
-    const { hasFormula } = useValues(insightVizDataLogic(insightProps))
+    const { hasFormula } = useValues(insightVizLogic(insightProps))
     return hasFormula ? <>Formula</> : null
 }

--- a/frontend/src/queries/nodes/InsightViz/TrendsSeries.tsx
+++ b/frontend/src/queries/nodes/InsightViz/TrendsSeries.tsx
@@ -11,11 +11,11 @@ import { isInsightQueryNode } from '~/queries/utils'
 import { queryNodeToFilter } from '../InsightQuery/utils/queryNodeToFilter'
 import { actionsAndEventsToSeries } from '../InsightQuery/utils/filtersToQueryNode'
 
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 export function TrendsSeries(): JSX.Element | null {
-    const { querySource, isTrends, isLifecycle, isStickiness, display, hasFormula } = useValues(insightVizDataLogic)
-    const { updateQuerySource } = useActions(insightVizDataLogic)
+    const { querySource, isTrends, isLifecycle, isStickiness, display, hasFormula } = useValues(insightVizLogic)
+    const { updateQuerySource } = useActions(insightVizLogic)
 
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 

--- a/frontend/src/queries/nodes/InsightViz/TrendsSeriesLabel.tsx
+++ b/frontend/src/queries/nodes/InsightViz/TrendsSeriesLabel.tsx
@@ -4,11 +4,11 @@ import { SINGLE_SERIES_DISPLAY_TYPES } from 'lib/constants'
 import { LemonButton } from '@posthog/lemon-ui'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { IconCalculate } from 'lib/lemon-ui/icons'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 export function TrendsSeriesLabel({ insightProps }: EditorFilterProps): JSX.Element {
-    const { hasFormula, isTrends, display, series } = useValues(insightVizDataLogic(insightProps))
-    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { hasFormula, isTrends, display, series } = useValues(insightVizLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizLogic(insightProps))
 
     const canDisableFormula: boolean =
         !isTrends || !display || !SINGLE_SERIES_DISPLAY_TYPES.includes(display) || series?.length === 1

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayConfigLogic.ts
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayConfigLogic.ts
@@ -7,7 +7,7 @@ import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { FEATURE_FLAGS, NON_TIME_SERIES_DISPLAY_TYPES, NON_VALUES_ON_SERIES_DISPLAY_TYPES } from 'lib/constants'
 
 import type { insightDisplayConfigLogicType } from './insightDisplayConfigLogicType'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 export const insightDisplayConfigLogic = kea<insightDisplayConfigLogicType>([
     props({} as InsightLogicProps),
@@ -18,7 +18,7 @@ export const insightDisplayConfigLogic = kea<insightDisplayConfigLogicType>([
         values: [
             featureFlagLogic,
             ['featureFlags'],
-            insightVizDataLogic(props),
+            insightVizLogic(props),
             [
                 'isTrends',
                 'isFunnels',

--- a/frontend/src/scenes/experiments/MetricSelector.tsx
+++ b/frontend/src/scenes/experiments/MetricSelector.tsx
@@ -2,7 +2,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { actionsAndEventsToSeries } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 
@@ -43,8 +43,8 @@ export function MetricSelector({
     // insightDataLogic
     const { query } = useValues(insightDataLogic(insightProps))
 
-    // insightVizDataLogic
-    const { isTrends } = useValues(insightVizDataLogic(insightProps))
+    // insightVizLogic
+    const { isTrends } = useValues(insightVizLogic(insightProps))
 
     return (
         <>
@@ -89,9 +89,8 @@ export function MetricSelector({
 }
 
 export function ExperimentInsightCreator({ insightProps }: { insightProps: InsightLogicProps }): JSX.Element {
-    // insightVizDataLogic
-    const { isTrends, series, querySource } = useValues(insightVizDataLogic(insightProps))
-    const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
+    const { isTrends, series, querySource } = useValues(insightVizLogic(insightProps))
+    const { updateQuerySource } = useActions(insightVizLogic(insightProps))
 
     // calculated properties
     const filterSteps = series || []

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -35,7 +35,7 @@ import { loaders } from 'kea-loaders'
 import { IconInfo } from 'lib/lemon-ui/icons'
 import { validateFeatureFlagKey } from 'scenes/feature-flags/featureFlagLogic'
 import { EXPERIMENT_EXPOSURE_INSIGHT_ID, EXPERIMENT_INSIGHT_ID } from './constants'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { filtersToQueryNode } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
@@ -95,11 +95,11 @@ export const experimentLogic = kea<experimentLogicType>([
             ],
             insightDataLogic({ dashboardItemId: EXPERIMENT_INSIGHT_ID }),
             ['setQuery'],
-            insightVizDataLogic({ dashboardItemId: EXPERIMENT_INSIGHT_ID }),
+            insightVizLogic({ dashboardItemId: EXPERIMENT_INSIGHT_ID }),
             ['updateQuerySource'],
             insightDataLogic({ dashboardItemId: EXPERIMENT_EXPOSURE_INSIGHT_ID }),
             ['setQuery as setExposureQuery'],
-            insightVizDataLogic({ dashboardItemId: EXPERIMENT_EXPOSURE_INSIGHT_ID }),
+            insightVizLogic({ dashboardItemId: EXPERIMENT_EXPOSURE_INSIGHT_ID }),
             ['updateQuerySource as updateExposureQuerySource'],
         ],
     })),

--- a/frontend/src/scenes/experiments/secondaryMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/secondaryMetricsLogic.ts
@@ -10,7 +10,7 @@ import { InsightVizNode } from '~/queries/schema'
 import { SECONDARY_METRIC_INSIGHT_ID } from './constants'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { filtersToQueryNode } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { teamLogic } from 'scenes/teamLogic'
@@ -59,7 +59,7 @@ export const secondaryMetricsLogic = kea<secondaryMetricsLogicType>([
         actions: [
             insightDataLogic({ dashboardItemId: SECONDARY_METRIC_INSIGHT_ID }),
             ['setQuery'],
-            insightVizDataLogic({ dashboardItemId: SECONDARY_METRIC_INSIGHT_ID }),
+            insightVizLogic({ dashboardItemId: SECONDARY_METRIC_INSIGHT_ID }),
             ['updateQuerySource'],
         ],
     })),

--- a/frontend/src/scenes/funnels/funnelCorrelationUsageLogic.ts
+++ b/frontend/src/scenes/funnels/funnelCorrelationUsageLogic.ts
@@ -7,12 +7,12 @@ import { visibilitySensorLogic } from 'lib/components/VisibilitySensor/visibilit
 
 import type { funnelCorrelationUsageLogicType } from './funnelCorrelationUsageLogicType'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { parseEventAndProperty } from './funnelUtils'
 import { funnelPersonsModalLogic } from './funnelPersonsModalLogic'
 import { funnelDataLogic } from './funnelDataLogic'
 import { funnelCorrelationLogic } from './funnelCorrelationLogic'
 import { funnelPropertyCorrelationLogic } from './funnelPropertyCorrelationLogic'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 
 export const funnelCorrelationUsageLogic = kea<funnelCorrelationUsageLogicType>([
     props({} as InsightLogicProps),
@@ -25,7 +25,7 @@ export const funnelCorrelationUsageLogic = kea<funnelCorrelationUsageLogicType>(
         values: [insightLogic(props), ['filters', 'isInDashboardContext']],
 
         actions: [
-            insightVizDataLogic(props),
+            insightDataLogic(props),
             ['loadDataSuccess'],
             funnelPersonsModalLogic(props),
             ['openCorrelationPersonsModal'],

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -40,6 +40,7 @@ import {
 } from './funnelUtils'
 import { BIN_COUNT_AUTO } from 'lib/constants'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 
 const DEFAULT_FUNNEL_LOGIC_KEY = 'default_funnel_key'
 
@@ -50,17 +51,10 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
 
     connect((props: InsightLogicProps) => ({
         values: [
+            insightDataLogic,
+            ['insightData', 'insightDataError'],
             insightVizDataLogic(props),
-            [
-                'querySource as vizQuerySource',
-                'insightFilter',
-                'funnelsFilter',
-                'breakdown',
-                'series',
-                'interval',
-                'insightData',
-                'insightDataError',
-            ],
+            ['querySource as vizQuerySource', 'insightFilter', 'funnelsFilter', 'breakdown', 'series', 'interval'],
             groupsModel,
             ['aggregationLabel'],
         ],

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -39,7 +39,7 @@ import {
     stepsWithConversionMetrics,
 } from './funnelUtils'
 import { BIN_COUNT_AUTO } from 'lib/constants'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 
 const DEFAULT_FUNNEL_LOGIC_KEY = 'default_funnel_key'
@@ -53,12 +53,12 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
         values: [
             insightDataLogic,
             ['insightData', 'insightDataError'],
-            insightVizDataLogic(props),
+            insightVizLogic(props),
             ['querySource as vizQuerySource', 'insightFilter', 'funnelsFilter', 'breakdown', 'series', 'interval'],
             groupsModel,
             ['aggregationLabel'],
         ],
-        actions: [insightVizDataLogic(props), ['updateInsightFilter', 'updateQuerySource']],
+        actions: [insightVizLogic(props), ['updateInsightFilter', 'updateQuerySource']],
     })),
 
     actions({

--- a/frontend/src/scenes/insights/EditorFilters/RetentionSummary.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/RetentionSummary.tsx
@@ -14,12 +14,12 @@ import { groupsModel } from '~/models/groupsModel'
 import { MathAvailability } from '../filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 import { Link } from 'lib/lemon-ui/Link'
 import { LemonInput, LemonSelect } from '@posthog/lemon-ui'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 export function RetentionSummary({ insightProps }: EditorFilterProps): JSX.Element {
     const { showGroupsOptions } = useValues(groupsModel)
-    const { retentionFilter } = useValues(insightVizDataLogic(insightProps))
-    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { retentionFilter } = useValues(insightVizLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizLogic(insightProps))
     const { target_entity, returning_entity, retention_type, total_intervals, period } = retentionFilter || {}
 
     return (

--- a/frontend/src/scenes/insights/EditorFilters/ShowLegendFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/ShowLegendFilter.tsx
@@ -1,14 +1,14 @@
 import { useValues, useActions } from 'kea'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightVizDataLogic } from '../insightVizDataLogic'
+import { insightVizLogic } from '../insightVizLogic'
 
 import { LemonCheckbox } from '@posthog/lemon-ui'
 
 export function ShowLegendFilter(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
-    const { showLegend } = useValues(insightVizDataLogic(insightProps))
-    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { showLegend } = useValues(insightVizLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizLogic(insightProps))
 
     const toggleShowLegend = (): void => {
         updateInsightFilter({ show_legend: !showLegend })

--- a/frontend/src/scenes/insights/EditorFilters/samplingFilterLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/samplingFilterLogic.ts
@@ -1,7 +1,7 @@
 import { kea, path, connect, actions, reducers, props, selectors, listeners } from 'kea'
 import { subscriptions } from 'kea-subscriptions'
 
-import { insightVizDataLogic } from '../insightVizDataLogic'
+import { insightVizLogic } from '../insightVizLogic'
 
 import { InsightLogicProps } from '~/types'
 
@@ -13,8 +13,8 @@ export const samplingFilterLogic = kea<samplingFilterLogicType>([
     path(['scenes', 'insights', 'EditorFilters', 'samplingFilterLogic']),
     props({} as InsightLogicProps),
     connect((props: InsightLogicProps) => ({
-        values: [insightVizDataLogic(props), ['querySource']],
-        actions: [insightVizDataLogic(props), ['updateQuerySource']],
+        values: [insightVizLogic(props), ['querySource']],
+        actions: [insightVizLogic(props), ['updateQuerySource']],
     })),
     actions(() => ({
         setSamplingPercentage: (samplingPercentage: number | null) => ({ samplingPercentage }),

--- a/frontend/src/scenes/insights/EditorFilters/valueOnSeriesFilterLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/valueOnSeriesFilterLogic.ts
@@ -1,6 +1,6 @@
 import { actions, connect, kea, key, listeners, path, props, selectors } from 'kea'
 import { ChartDisplayType, InsightLogicProps, TrendsFilterType } from '~/types'
-import { insightVizDataLogic } from '../insightVizDataLogic'
+import { insightVizLogic } from '../insightVizLogic'
 import { keyForInsightLogicProps } from '../sharedUtils'
 
 import type { valueOnSeriesFilterLogicType } from './valueOnSeriesFilterLogicType'
@@ -11,8 +11,8 @@ export const valueOnSeriesFilterLogic = kea<valueOnSeriesFilterLogicType>([
     path((key) => ['scenes', 'insights', 'EditorFilters', 'valueOnSeriesFilterLogic', key]),
 
     connect((props: InsightLogicProps) => ({
-        values: [insightVizDataLogic(props), ['isTrends', 'isStickiness', 'isLifecycle', 'insightFilter']],
-        actions: [insightVizDataLogic(props), ['updateInsightFilter']],
+        values: [insightVizLogic(props), ['isTrends', 'isStickiness', 'isLifecycle', 'insightFilter']],
+        actions: [insightVizLogic(props), ['updateInsightFilter']],
     })),
 
     actions({

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.stories.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.stories.tsx
@@ -7,7 +7,7 @@ import insight from '../../../mocks/fixtures/api/projects/:team_id/insights/tren
 import { InsightShortId } from '~/types'
 import { createInsightStory } from 'scenes/insights/__mocks__/createInsightScene'
 import { App } from 'scenes/App'
-import { insightVizDataLogic } from '../insightVizDataLogic'
+import { insightDataLogic } from '../insightDataLogic'
 
 type Story = StoryObj<typeof App>
 const meta: Meta = {
@@ -73,7 +73,7 @@ export function TimeoutState(): JSX.Element {
     useEffect(() => {
         router.actions.push(`/insights/${insight.short_id}`)
         window.setTimeout(() => {
-            const logic = insightVizDataLogic.findMounted({ dashboardItemId: insight.short_id as InsightShortId })
+            const logic = insightDataLogic.findMounted({ dashboardItemId: insight.short_id as InsightShortId })
             logic?.actions.setTimedOutQueryId('a-uuid-query-id')
         }, 150)
     }, [])

--- a/frontend/src/scenes/insights/RetentionDatePicker.tsx
+++ b/frontend/src/scenes/insights/RetentionDatePicker.tsx
@@ -3,12 +3,12 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { dayjs } from 'lib/dayjs'
 import { DatePicker } from 'lib/components/DatePicker'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 export function RetentionDatePicker(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const { dateRange, retentionFilter } = useValues(insightVizDataLogic(insightProps))
-    const { updateDateRange } = useActions(insightVizDataLogic(insightProps))
+    const { dateRange, retentionFilter } = useValues(insightVizLogic(insightProps))
+    const { updateDateRange } = useActions(insightVizLogic(insightProps))
 
     const period = retentionFilter?.period
     const date_to = dateRange?.date_to

--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -5,7 +5,7 @@ import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { GroupIntroductionFooter } from 'scenes/groups/GroupsIntroduction'
 import { InsightLogicProps } from '~/types'
 import { isFunnelsQuery, isInsightQueryNode } from '~/queries/utils'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { FunnelsQuery } from '~/queries/schema'
 import { HogQLEditor } from 'lib/components/HogQLEditor/HogQLEditor'
 
@@ -43,8 +43,8 @@ export function AggregationSelect({
     className,
     hogqlAvailable,
 }: AggregationSelectProps): JSX.Element | null {
-    const { querySource } = useValues(insightVizDataLogic(insightProps))
-    const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
+    const { querySource } = useValues(insightVizLogic(insightProps))
+    const { updateQuerySource } = useActions(insightVizLogic(insightProps))
 
     if (!isInsightQueryNode(querySource)) {
         return null

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/insightDateFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/insightDateFilterLogic.ts
@@ -2,15 +2,15 @@ import { kea, props, key, path, connect, actions, selectors, listeners } from 'k
 import type { insightDateFilterLogicType } from './insightDateFilterLogicType'
 import { InsightLogicProps } from '~/types'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 export const insightDateFilterLogic = kea<insightDateFilterLogicType>([
     props({} as InsightLogicProps),
     key(keyForInsightLogicProps('new')),
     path((key) => ['scenes', 'insights', 'InsightDateFilter', 'insightDateFilterLogic', key]),
     connect((props: InsightLogicProps) => ({
-        actions: [insightVizDataLogic(props), ['updateQuerySource']],
-        values: [insightVizDataLogic(props), ['dateRange']],
+        actions: [insightVizLogic(props), ['updateQuerySource']],
+        values: [insightVizLogic(props), ['dateRange']],
     })),
     actions(() => ({
         setDates: (dateFrom: string | undefined | null, dateTo: string | undefined | null) => ({

--- a/frontend/src/scenes/insights/filters/RetentionReferencePicker.tsx
+++ b/frontend/src/scenes/insights/filters/RetentionReferencePicker.tsx
@@ -2,12 +2,12 @@ import { Select } from 'antd'
 import { PercentageOutlined } from '@ant-design/icons'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { useActions, useValues } from 'kea'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 export function RetentionReferencePicker(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const { retentionFilter } = useValues(insightVizDataLogic(insightProps))
-    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { retentionFilter } = useValues(insightVizLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizLogic(insightProps))
 
     const { retention_reference } = retentionFilter || {}
     return (

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -166,6 +166,13 @@ export const insightDataLogic = kea<insightDataLogicType>([
                 return { ...insightDataRaw, result: insightDataRaw?.results ?? insightDataRaw?.result }
             },
         ],
+        timezone: [(s) => [s.insightData], (insightData) => insightData?.timezone || 'UTC'],
+        erroredQueryId: [
+            (s) => [s.insightDataError],
+            (insightDataError) => {
+                return insightDataError?.queryId || null
+            },
+        ],
     }),
 
     listeners(({ actions, values }) => ({

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -57,7 +57,6 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
     })),
 
     actions({
-        saveInsight: (redirectToViewMode = true) => ({ redirectToViewMode }),
         updateQuerySource: (querySource: Omit<Partial<InsightQueryNode>, 'kind'>) => ({ querySource }),
         updateInsightFilter: (insightFilter: InsightFilter) => ({ insightFilter }),
         updateDateRange: (dateRange: DateRange) => ({ dateRange }),

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -52,12 +52,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
     path((key) => ['scenes', 'insights', 'insightVizDataLogic', key]),
 
     connect(() => ({
-        values: [
-            insightDataLogic,
-            ['query', 'insightData', 'insightDataLoading', 'insightDataError'],
-            filterTestAccountsDefaultsLogic,
-            ['filterTestAccountsDefault'],
-        ],
+        values: [insightDataLogic, ['query'], filterTestAccountsDefaultsLogic, ['filterTestAccountsDefault']],
         actions: [insightLogic, ['setFilters'], insightDataLogic, ['setQuery']],
     })),
 
@@ -163,15 +158,6 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         ],
 
         hasFormula: [(s) => [s.formula], (formula) => formula !== undefined],
-
-        erroredQueryId: [
-            (s) => [s.insightDataError],
-            (insightDataError) => {
-                return insightDataError?.queryId || null
-            },
-        ],
-
-        timezone: [(s) => [s.insightData], (insightData) => insightData?.timezone || 'UTC'],
     }),
 
     listeners(({ actions, values, props }) => ({

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -54,7 +54,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
     connect(() => ({
         values: [
             insightDataLogic,
-            ['query', 'insightQuery', 'insightData', 'insightDataLoading', 'insightDataError'],
+            ['query', 'insightData', 'insightDataLoading', 'insightDataError'],
             filterTestAccountsDefaultsLogic,
             ['filterTestAccountsDefault'],
         ],

--- a/frontend/src/scenes/insights/insightVizLogic.test.ts
+++ b/frontend/src/scenes/insights/insightVizLogic.test.ts
@@ -5,7 +5,7 @@ import { ChartDisplayType, InsightShortId } from '~/types'
 
 import { insightDataLogic } from './insightDataLogic'
 import { useMocks } from '~/mocks/jest'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { trendsQueryDefault, funnelsQueryDefault } from '~/queries/nodes/InsightQuery/defaults'
 import { NodeKind } from '~/queries/schema'
@@ -14,7 +14,7 @@ import { FunnelLayout } from 'lib/constants'
 const Insight123 = '123' as InsightShortId
 
 describe('insightVizDataLogic', () => {
-    let builtInsightVizDataLogic: ReturnType<typeof insightVizDataLogic.build>
+    let builtInsightVizDataLogic: ReturnType<typeof insightVizLogic.build>
     let builtInsightDataLogic: ReturnType<typeof insightDataLogic.build>
     let builtFeatureFlagLogic: ReturnType<typeof featureFlagLogic.build>
 
@@ -31,7 +31,7 @@ describe('insightVizDataLogic', () => {
 
         const props = { dashboardItemId: Insight123 }
 
-        builtInsightVizDataLogic = insightVizDataLogic(props)
+        builtInsightVizDataLogic = insightVizLogic(props)
         builtInsightDataLogic = insightDataLogic(props)
 
         builtInsightDataLogic.mount()

--- a/frontend/src/scenes/insights/insightVizLogic.ts
+++ b/frontend/src/scenes/insights/insightVizLogic.ts
@@ -42,11 +42,12 @@ import {
 import { DISPLAY_TYPES_WITHOUT_LEGEND } from 'lib/components/InsightLegend/utils'
 import { insightDataLogic, queryFromKind } from 'scenes/insights/insightDataLogic'
 
-import type { insightVizDataLogicType } from './insightVizDataLogicType'
 import { parseProperties } from 'lib/components/PropertyFilters/utils'
 import { filterTestAccountsDefaultsLogic } from 'scenes/project/Settings/filterTestAccountDefaultsLogic'
 
-export const insightVizDataLogic = kea<insightVizDataLogicType>([
+import type { insightVizLogicType } from './insightVizLogicType'
+
+export const insightVizLogic = kea<insightVizLogicType>([
     props({} as InsightLogicProps),
     key(keyForInsightLogicProps('new')),
     path((key) => ['scenes', 'insights', 'insightVizDataLogic', key]),

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -5,6 +5,7 @@ import Textfit from './Textfit'
 import clsx from 'clsx'
 
 import { insightLogic } from '../../insightLogic'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 import { ChartParams, TrendResult } from '~/types'
@@ -32,7 +33,8 @@ function useBoldNumberTooltip({
     isTooltipShown: boolean
 }): React.RefObject<HTMLDivElement> {
     const { insightProps } = useValues(insightLogic)
-    const { series, insightData, trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { insightData } = useValues(insightDataLogic(insightProps))
+    const { series, trendsFilter } = useValues(insightVizDataLogic(insightProps))
     const { aggregationLabel } = useValues(groupsModel)
 
     const divRef = useRef<HTMLDivElement>(null)
@@ -83,7 +85,8 @@ function useBoldNumberTooltip({
 
 export function BoldNumber({ showPersonsModal = true }: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const { insightData, trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { insightData } = useValues(insightDataLogic(insightProps))
+    const { trendsFilter } = useValues(insightVizDataLogic(insightProps))
 
     const [isTooltipShown, setIsTooltipShown] = useState(false)
     const valueRef = useBoldNumberTooltip({ showPersonsModal, isTooltipShown })
@@ -125,7 +128,7 @@ export function BoldNumber({ showPersonsModal = true }: ChartParams): JSX.Elemen
 
 function BoldNumberComparison({ showPersonsModal }: Pick<ChartParams, 'showPersonsModal'>): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
-    const { insightData } = useValues(insightVizDataLogic(insightProps))
+    const { insightData } = useValues(insightDataLogic(insightProps))
 
     if (!insightData?.result) {
         return null

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx'
 
 import { insightLogic } from '../../insightLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 import { ChartParams, TrendResult } from '~/types'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
@@ -34,7 +34,7 @@ function useBoldNumberTooltip({
 }): React.RefObject<HTMLDivElement> {
     const { insightProps } = useValues(insightLogic)
     const { insightData } = useValues(insightDataLogic(insightProps))
-    const { series, trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { series, trendsFilter } = useValues(insightVizLogic(insightProps))
     const { aggregationLabel } = useValues(groupsModel)
 
     const divRef = useRef<HTMLDivElement>(null)
@@ -86,7 +86,7 @@ function useBoldNumberTooltip({
 export function BoldNumber({ showPersonsModal = true }: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { insightData } = useValues(insightDataLogic(insightProps))
-    const { trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { trendsFilter } = useValues(insightVizLogic(insightProps))
 
     const [isTooltipShown, setIsTooltipShown] = useState(false)
     const valueRef = useBoldNumberTooltip({ showPersonsModal, isTooltipShown })

--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
@@ -16,12 +16,12 @@ import { IconFlag } from 'lib/lemon-ui/icons'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { funnelPersonsModalLogic } from 'scenes/funnels/funnelPersonsModalLogic'
 
 export function FunnelStepsTable(): JSX.Element | null {
     const { insightProps, insightLoading } = useValues(insightLogic)
-    const { breakdown } = useValues(insightVizDataLogic(insightProps))
+    const { breakdown } = useValues(insightVizLogic(insightProps))
     const { steps, flattenedBreakdowns, funnelsFilter } = useValues(funnelDataLogic(insightProps))
     const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
     const { canOpenPersonModal } = useValues(funnelPersonsModalLogic(insightProps))

--- a/frontend/src/scenes/insights/views/InsightsTable/insightsTableDataLogic.test.ts
+++ b/frontend/src/scenes/insights/views/InsightsTable/insightsTableDataLogic.test.ts
@@ -5,7 +5,7 @@ import { BaseMathType, ChartDisplayType, InsightShortId, PropertyMathType } from
 import { NodeKind, TrendsQuery } from '~/queries/schema'
 
 import { insightsTableDataLogic, AggregationType } from './insightsTableDataLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 const Insight123 = '123' as InsightShortId
 
@@ -29,7 +29,7 @@ describe('insightsTableDataLogic', () => {
                 },
             }
 
-            insightVizDataLogic(props).actions.updateQuerySource(query)
+            insightVizLogic(props).actions.updateQuerySource(query)
 
             await expectLogic(logic).toMatchValues({
                 allowAggregation: true,
@@ -46,7 +46,7 @@ describe('insightsTableDataLogic', () => {
                 ],
             }
 
-            insightVizDataLogic(props).actions.updateQuerySource(query)
+            insightVizLogic(props).actions.updateQuerySource(query)
 
             await expectLogic(logic).toMatchValues({
                 allowAggregation: true,
@@ -59,7 +59,7 @@ describe('insightsTableDataLogic', () => {
                 series: [{ kind: NodeKind.EventsNode, event: '$pageview', math: BaseMathType.UniqueUsers }],
             }
 
-            insightVizDataLogic(props).actions.updateQuerySource(query)
+            insightVizLogic(props).actions.updateQuerySource(query)
 
             await expectLogic(logic).toMatchValues({
                 allowAggregation: false,
@@ -74,7 +74,7 @@ describe('insightsTableDataLogic', () => {
                 series: [{ kind: NodeKind.EventsNode, event: '$pageview', math: BaseMathType.UniqueUsers }],
             }
 
-            insightVizDataLogic(props).actions.updateQuerySource(query)
+            insightVizLogic(props).actions.updateQuerySource(query)
 
             await expectLogic(logic).toMatchValues({
                 aggregation: AggregationType.Average,
@@ -87,7 +87,7 @@ describe('insightsTableDataLogic', () => {
                 series: [{ kind: NodeKind.EventsNode, event: '$pageview', math: BaseMathType.TotalCount }],
             }
 
-            insightVizDataLogic(props).actions.updateQuerySource(query)
+            insightVizLogic(props).actions.updateQuerySource(query)
 
             await expectLogic(logic).toMatchValues({
                 aggregation: AggregationType.Total,
@@ -100,7 +100,7 @@ describe('insightsTableDataLogic', () => {
                 series: [{ kind: NodeKind.EventsNode, event: '$pageview', math: BaseMathType.TotalCount }],
             }
 
-            insightVizDataLogic(props).actions.updateQuerySource(query)
+            insightVizLogic(props).actions.updateQuerySource(query)
 
             await expectLogic(logic, () => {
                 logic.actions.setAggregationType(AggregationType.Median)

--- a/frontend/src/scenes/insights/views/InsightsTable/insightsTableDataLogic.ts
+++ b/frontend/src/scenes/insights/views/InsightsTable/insightsTableDataLogic.ts
@@ -5,7 +5,7 @@ import { ChartDisplayType, InsightLogicProps } from '~/types'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 
 import type { insightsTableDataLogicType } from './insightsTableDataLogicType'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 export enum AggregationType {
     Total = 'total',
@@ -19,7 +19,7 @@ export const insightsTableDataLogic = kea<insightsTableDataLogicType>([
     path((key) => ['scenes', 'insights', 'InsightsTable', 'insightsTableDataLogic', key]),
 
     connect((props: InsightLogicProps) => ({
-        values: [insightVizDataLogic(props), ['isTrends', 'display', 'series']],
+        values: [insightVizLogic(props), ['isTrends', 'display', 'series']],
     })),
 
     actions({

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -37,6 +37,7 @@ import { SeriesLetter } from 'lib/components/SeriesGlyph'
 import { TrendsFilter } from '~/queries/schema'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import ChartjsPluginStacked100, { ExtendedChartData } from 'chartjs-plugin-stacked100'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 
 export function ensureTooltipElement(): HTMLElement {
     let tooltipEl = document.getElementById('InsightTooltipWrapper')
@@ -261,7 +262,8 @@ export function LineGraph_({
     const { isDarkModeOn } = useValues(themeLogic)
 
     const { insightProps, insight } = useValues(insightLogic)
-    const { timezone, isTrends } = useValues(insightVizDataLogic(insightProps))
+    const { timezone } = useValues(insightDataLogic(insightProps))
+    const { isTrends } = useValues(insightVizDataLogic(insightProps))
 
     const { createTooltipData } = useValues(lineGraphLogic)
 

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -35,7 +35,7 @@ import { PieChart } from 'scenes/insights/views/LineGraph/PieChart'
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
 import { TrendsFilter } from '~/queries/schema'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import ChartjsPluginStacked100, { ExtendedChartData } from 'chartjs-plugin-stacked100'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 
@@ -263,7 +263,7 @@ export function LineGraph_({
 
     const { insightProps, insight } = useValues(insightLogic)
     const { timezone } = useValues(insightDataLogic(insightProps))
-    const { isTrends } = useValues(insightVizDataLogic(insightProps))
+    const { isTrends } = useValues(insightVizLogic(insightProps))
 
     const { createTooltipData } = useValues(lineGraphLogic)
 

--- a/frontend/src/scenes/insights/views/Trends/funnelsCueLogic.tsx
+++ b/frontend/src/scenes/insights/views/Trends/funnelsCueLogic.tsx
@@ -6,7 +6,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import posthog from 'posthog-js'
 import { FEATURE_FLAGS } from 'lib/constants'
 import type { funnelsCueLogicType } from './funnelsCueLogicType'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { isFunnelsQuery, isInsightVizNode, isTrendsQuery } from '~/queries/utils'
 import { InsightVizNode, NodeKind } from '~/queries/schema'
 
@@ -18,12 +18,12 @@ export const funnelsCueLogic = kea<funnelsCueLogicType>([
         values: [
             insightLogic(props),
             ['isFirstLoad'],
-            insightVizDataLogic(props),
+            insightVizLogic(props),
             ['query'],
             featureFlagLogic,
             ['featureFlags'],
         ],
-        actions: [insightVizDataLogic(props), ['setQuery'], featureFlagLogic, ['setFeatureFlags']],
+        actions: [insightVizLogic(props), ['setQuery'], featureFlagLogic, ['setFeatureFlags']],
     })),
     actions({
         optOut: (userOptedOut: boolean) => ({ userOptedOut }),

--- a/frontend/src/scenes/insights/views/WorldMap/worldMapLogic.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/worldMapLogic.tsx
@@ -1,4 +1,5 @@
 import { kea, props, key, path, connect, actions, reducers, selectors } from 'kea'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { InsightLogicProps, TrendResult } from '~/types'
 import { keyForInsightLogicProps } from '../../sharedUtils'
@@ -9,7 +10,7 @@ export const worldMapLogic = kea<worldMapLogicType>([
     key(keyForInsightLogicProps('new')),
     path((key) => ['scenes', 'insights', 'WorldMap', 'worldMapLogic', key]),
     connect((props: InsightLogicProps) => ({
-        values: [insightVizDataLogic(props), ['insightData', 'trendsFilter', 'series']],
+        values: [insightDataLogic(props), ['insightData'], insightVizDataLogic(props), ['trendsFilter', 'series']],
     })),
     actions({
         showTooltip: (countryCode: string, countrySeries: TrendResult | null) => ({ countryCode, countrySeries }),

--- a/frontend/src/scenes/insights/views/WorldMap/worldMapLogic.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/worldMapLogic.tsx
@@ -1,6 +1,6 @@
 import { kea, props, key, path, connect, actions, reducers, selectors } from 'kea'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { InsightLogicProps, TrendResult } from '~/types'
 import { keyForInsightLogicProps } from '../../sharedUtils'
 import type { worldMapLogicType } from './worldMapLogicType'
@@ -10,7 +10,7 @@ export const worldMapLogic = kea<worldMapLogicType>([
     key(keyForInsightLogicProps('new')),
     path((key) => ['scenes', 'insights', 'WorldMap', 'worldMapLogic', key]),
     connect((props: InsightLogicProps) => ({
-        values: [insightDataLogic(props), ['insightData'], insightVizDataLogic(props), ['trendsFilter', 'series']],
+        values: [insightDataLogic(props), ['insightData'], insightVizLogic(props), ['trendsFilter', 'series']],
     })),
     actions({
         showTooltip: (countryCode: string, countrySeries: TrendResult | null) => ({ countryCode, countrySeries }),

--- a/frontend/src/scenes/paths/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.ts
@@ -21,6 +21,7 @@ import { router } from 'kea-router'
 import { urls } from 'scenes/urls'
 import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { InsightQueryNode } from '~/queries/schema'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 
 export const DEFAULT_STEP_LIMIT = 5
 
@@ -39,10 +40,12 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
 
     connect((props: InsightLogicProps) => ({
         values: [
+            insightDataLogic(props),
+            ['insightQuery'],
             insightVizDataLogic(props),
             [
                 'querySource as vizQuerySource',
-                'insightQuery',
+
                 'insightData',
                 'insightDataLoading',
                 'insightDataError',

--- a/frontend/src/scenes/paths/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.ts
@@ -12,7 +12,7 @@ import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 import type { pathsDataLogicType } from './pathsDataLogicType'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { isPathsQuery } from '~/queries/utils'
 import { PathNodeData } from './pathUtils'
 import { buildPeopleUrl, pathsTitle } from 'scenes/trends/persons-modal/persons-modal-utils'
@@ -42,10 +42,10 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
         values: [
             insightDataLogic(props),
             ['insightQuery', 'insightData', 'insightDataLoading', 'insightDataError'],
-            insightVizDataLogic(props),
+            insightVizLogic(props),
             ['querySource as vizQuerySource', 'pathsFilter', 'dateRange'],
         ],
-        actions: [insightVizDataLogic(props), ['updateInsightFilter']],
+        actions: [insightVizLogic(props), ['updateInsightFilter']],
     })),
 
     actions({

--- a/frontend/src/scenes/paths/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.ts
@@ -41,17 +41,9 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
     connect((props: InsightLogicProps) => ({
         values: [
             insightDataLogic(props),
-            ['insightQuery'],
+            ['insightQuery', 'insightData', 'insightDataLoading', 'insightDataError'],
             insightVizDataLogic(props),
-            [
-                'querySource as vizQuerySource',
-
-                'insightData',
-                'insightDataLoading',
-                'insightDataError',
-                'pathsFilter',
-                'dateRange',
-            ],
+            ['querySource as vizQuerySource', 'pathsFilter', 'dateRange'],
         ],
         actions: [insightVizDataLogic(props), ['updateInsightFilter']],
     })),

--- a/frontend/src/scenes/retention/retentionLineGraphLogic.ts
+++ b/frontend/src/scenes/retention/retentionLineGraphLogic.ts
@@ -5,7 +5,7 @@ import { RetentionTrendPayload } from 'scenes/retention/types'
 import { InsightLogicProps, RetentionPeriod } from '~/types'
 import { dateOptionToTimeIntervalMap } from './constants'
 
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { retentionLogic } from './retentionLogic'
 
 import type { retentionLineGraphLogicType } from './retentionLineGraphLogicType'
@@ -18,7 +18,7 @@ export const retentionLineGraphLogic = kea<retentionLineGraphLogicType>({
     path: (key) => ['scenes', 'retention', 'retentionLineGraphLogic', key],
     connect: (props: InsightLogicProps) => ({
         values: [
-            insightVizDataLogic(props),
+            insightVizLogic(props),
             ['querySource', 'dateRange', 'retentionFilter'],
             retentionLogic(props),
             ['results'],

--- a/frontend/src/scenes/retention/retentionLogic.ts
+++ b/frontend/src/scenes/retention/retentionLogic.ts
@@ -1,4 +1,5 @@
 import { kea } from 'kea'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { RetentionTablePayload } from 'scenes/retention/types'
@@ -14,7 +15,7 @@ export const retentionLogic = kea<retentionLogicType>({
     key: keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY),
     path: (key) => ['scenes', 'retention', 'retentionLogic', key],
     connect: (props: InsightLogicProps) => ({
-        values: [insightVizDataLogic(props), ['insightQuery', 'insightData', 'querySource']],
+        values: [insightDataLogic(props), ['insightQuery'], insightVizDataLogic(props), ['insightData', 'querySource']],
     }),
     selectors: {
         results: [

--- a/frontend/src/scenes/retention/retentionLogic.ts
+++ b/frontend/src/scenes/retention/retentionLogic.ts
@@ -1,6 +1,6 @@
 import { kea } from 'kea'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { RetentionTablePayload } from 'scenes/retention/types'
 import { isRetentionQuery } from '~/queries/utils'
@@ -15,7 +15,7 @@ export const retentionLogic = kea<retentionLogicType>({
     key: keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY),
     path: (key) => ['scenes', 'retention', 'retentionLogic', key],
     connect: (props: InsightLogicProps) => ({
-        values: [insightDataLogic(props), ['insightQuery', 'insightData'], insightVizDataLogic(props), ['querySource']],
+        values: [insightDataLogic(props), ['insightQuery', 'insightData'], insightVizLogic(props), ['querySource']],
     }),
     selectors: {
         results: [

--- a/frontend/src/scenes/retention/retentionLogic.ts
+++ b/frontend/src/scenes/retention/retentionLogic.ts
@@ -15,7 +15,7 @@ export const retentionLogic = kea<retentionLogicType>({
     key: keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY),
     path: (key) => ['scenes', 'retention', 'retentionLogic', key],
     connect: (props: InsightLogicProps) => ({
-        values: [insightDataLogic(props), ['insightQuery'], insightVizDataLogic(props), ['insightData', 'querySource']],
+        values: [insightDataLogic(props), ['insightQuery', 'insightData'], insightVizDataLogic(props), ['querySource']],
     }),
     selectors: {
         results: [

--- a/frontend/src/scenes/retention/retentionModalLogic.ts
+++ b/frontend/src/scenes/retention/retentionModalLogic.ts
@@ -4,7 +4,7 @@ import { Noun, groupsModel } from '~/models/groupsModel'
 import { InsightLogicProps } from '~/types'
 import { retentionPeopleLogic } from './retentionPeopleLogic'
 
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 import type { retentionModalLogicType } from './retentionModalLogicType'
 
@@ -15,7 +15,7 @@ export const retentionModalLogic = kea<retentionModalLogicType>({
     key: keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY),
     path: (key) => ['scenes', 'retention', 'retentionModalLogic', key],
     connect: (props: InsightLogicProps) => ({
-        values: [insightVizDataLogic(props), ['querySource'], groupsModel, ['aggregationLabel']],
+        values: [insightVizLogic(props), ['querySource'], groupsModel, ['aggregationLabel']],
         actions: [retentionPeopleLogic(props), ['loadPeople']],
     }),
     actions: () => ({

--- a/frontend/src/scenes/retention/retentionPeopleLogic.ts
+++ b/frontend/src/scenes/retention/retentionPeopleLogic.ts
@@ -6,7 +6,7 @@ import { RetentionTablePeoplePayload } from 'scenes/retention/types'
 import { InsightLogicProps } from '~/types'
 import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 
 import type { retentionPeopleLogicType } from './retentionPeopleLogicType'
 
@@ -17,8 +17,8 @@ export const retentionPeopleLogic = kea<retentionPeopleLogicType>({
     key: keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY),
     path: (key) => ['scenes', 'retention', 'retentionPeopleLogic', key],
     connect: (props: InsightLogicProps) => ({
-        values: [insightVizDataLogic(props), ['querySource']],
-        actions: [insightVizDataLogic(props), ['loadDataSuccess']],
+        values: [insightVizLogic(props), ['querySource']],
+        actions: [insightVizLogic(props), ['loadDataSuccess']],
     }),
     actions: () => ({
         clearPeople: true,

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -4,7 +4,7 @@ import { range } from 'lib/utils'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { InsightLogicProps } from '~/types'
 
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { retentionLogic } from './retentionLogic'
 
 import type { retentionTableLogicType } from './retentionTableLogicType'
@@ -35,7 +35,7 @@ export const retentionTableLogic = kea<retentionTableLogicType>({
     path: (key) => ['scenes', 'retention', 'retentionTableLogic', key],
     connect: (props: InsightLogicProps) => ({
         values: [
-            insightVizDataLogic(props),
+            insightVizLogic(props),
             ['dateRange', 'retentionFilter', 'breakdown'],
             retentionLogic(props),
             ['results'],

--- a/frontend/src/scenes/trends/trendsDataLogic.test.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.test.ts
@@ -3,7 +3,7 @@ import { initKeaTests } from '~/test/init'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { trendsDataLogic } from './trendsDataLogic'
 
 import { ChartDisplayType, InsightLogicProps, InsightModel } from '~/types'
@@ -23,7 +23,7 @@ async function initTrendsDataLogic(): Promise<void> {
     await expectLogic(dataNodeLogic).toFinishAllListeners()
 
     insightDataLogic(insightProps).mount()
-    insightVizDataLogic(insightProps).mount()
+    insightVizLogic(insightProps).mount()
 
     logic = trendsDataLogic(insightProps)
     logic.mount()
@@ -77,7 +77,7 @@ describe('trendsDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    insightVizDataLogic.findMounted(insightProps)?.actions.updateQuerySource(query)
+                    insightVizLogic.findMounted(insightProps)?.actions.updateQuerySource(query)
                     builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     indexedResults: [
@@ -113,7 +113,7 @@ describe('trendsDataLogic', () => {
                 }
 
                 await expectLogic(logic, () => {
-                    insightVizDataLogic.findMounted(insightProps)?.actions.updateQuerySource(query)
+                    insightVizLogic.findMounted(insightProps)?.actions.updateQuerySource(query)
                     builtDataNodeLogic.actions.loadDataSuccess(insight)
                 }).toMatchValues({
                     indexedResults: [

--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -16,10 +16,10 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
 
     connect((props: InsightLogicProps) => ({
         values: [
+            insightDataLogic(props),
+            ['insightData', 'insightDataLoading'],
             insightVizDataLogic(props),
             [
-                'insightData',
-                'insightDataLoading',
                 'series',
                 'formula',
                 'display',

--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -7,6 +7,7 @@ import type { trendsDataLogicType } from './trendsDataLogicType'
 import { IndexedTrendResult } from './types'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { dayjs } from 'lib/dayjs'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 
 export const trendsDataLogic = kea<trendsDataLogicType>([
     props({} as InsightLogicProps),
@@ -38,7 +39,7 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
                 'hasLegend',
             ],
         ],
-        actions: [insightVizDataLogic(props), ['setInsightData', 'updateInsightFilter']],
+        actions: [insightDataLogic(props), ['setInsightData'], insightVizDataLogic(props), ['updateInsightFilter']],
     })),
 
     actions({

--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -5,7 +5,7 @@ import api from 'lib/api'
 
 import type { trendsDataLogicType } from './trendsDataLogicType'
 import { IndexedTrendResult } from './types'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { insightVizLogic } from 'scenes/insights/insightVizLogic'
 import { dayjs } from 'lib/dayjs'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 
@@ -18,7 +18,7 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
         values: [
             insightDataLogic(props),
             ['insightData', 'insightDataLoading'],
-            insightVizDataLogic(props),
+            insightVizLogic(props),
             [
                 'series',
                 'formula',
@@ -39,7 +39,7 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
                 'hasLegend',
             ],
         ],
-        actions: [insightDataLogic(props), ['setInsightData'], insightVizDataLogic(props), ['updateInsightFilter']],
+        actions: [insightDataLogic(props), ['setInsightData'], insightVizLogic(props), ['updateInsightFilter']],
     })),
 
     actions({


### PR DESCRIPTION
## Problem

The goal of this PR is to separate the responsibilities of the `insightDataLogic` and `insightViz(Data)Logic`. This is to make the flow of updates in a query more easily understandable.

## Changes

This PR refactors the `insightVizDataLogic`, so that it handles everything related to reading and updating the query source of a "regular" insight node. It also renames the `insightVizDataLogic` -> `insightVizLogic` accordingly.

## How did you test this code?

Clicked around