### PR TITLE
feat(hogql-debug): add explain

### DIFF
--- a/frontend/src/queries/examples.ts
+++ b/frontend/src/queries/examples.ts
@@ -308,9 +308,10 @@ const HogQLRaw: HogQLQuery = {
           person.properties.email
  order by count() desc
     limit 100`,
+    explain: true,
     filters: {
         dateRange: {
-            date_from: '-24h',
+            date_from: '-34h',
         },
     },
 }

--- a/frontend/src/queries/examples.ts
+++ b/frontend/src/queries/examples.ts
@@ -311,7 +311,7 @@ const HogQLRaw: HogQLQuery = {
     explain: true,
     filters: {
         dateRange: {
-            date_from: '-34h',
+            date_from: '-24h',
         },
     },
 }

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1209,6 +1209,9 @@
         "HogQLQuery": {
             "additionalProperties": false,
             "properties": {
+                "explain": {
+                    "type": "boolean"
+                },
                 "filters": {
                     "$ref": "#/definitions/HogQLFilters"
                 },
@@ -1257,6 +1260,12 @@
                 },
                 "columns": {
                     "items": {},
+                    "type": "array"
+                },
+                "explain": {
+                    "items": {
+                        "type": "string"
+                    },
                     "type": "array"
                 },
                 "hogql": {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -144,6 +144,7 @@ export interface HogQLQueryResponse {
     types?: any[]
     columns?: any[]
     timings?: QueryTiming[]
+    explain?: string[]
     modifiers?: HogQLQueryModifiers
 }
 
@@ -160,6 +161,7 @@ export interface HogQLQuery extends DataNode {
     /** Constant values that can be referenced with the {placeholder} syntax in the query */
     values?: Record<string, any>
     modifiers?: HogQLQueryModifiers
+    explain?: boolean
     response?: HogQLQueryResponse
 }
 

--- a/frontend/src/scenes/debug/HogQLDebug.tsx
+++ b/frontend/src/scenes/debug/HogQLDebug.tsx
@@ -98,9 +98,7 @@ export function HogQLDebug({ query, setQuery, queryKey }: HogQLDebugProps): JSX.
                         {response?.explain ? (
                             <>
                                 <h2>Explained ClickHouseSQL</h2>
-                                <CodeSnippet language={Language.SQL} wrap>
-                                    {response.explain.join('\n')}
-                                </CodeSnippet>
+                                <CodeSnippet wrap>{response.explain.join('\n')}</CodeSnippet>
                             </>
                         ) : null}
                         {response?.timings && elapsedTime !== null ? (

--- a/frontend/src/scenes/debug/HogQLDebug.tsx
+++ b/frontend/src/scenes/debug/HogQLDebug.tsx
@@ -1,5 +1,5 @@
 import { HogQLQueryEditor } from '~/queries/nodes/HogQLQuery/HogQLQueryEditor'
-import { DataNode, HogQLQuery } from '~/queries/schema'
+import { DataNode, HogQLQuery, HogQLQueryResponse } from '~/queries/schema'
 import { DateRange } from '~/queries/nodes/DataNode/DateRange'
 import { EventPropertyFilters } from '~/queries/nodes/EventsNode/EventPropertyFilters'
 import { BindLogic, useValues } from 'kea'
@@ -19,6 +19,8 @@ interface HogQLDebugProps {
 export function HogQLDebug({ query, setQuery, queryKey }: HogQLDebugProps): JSX.Element {
     const dataNodeLogicProps: DataNodeLogicProps = { query, key: queryKey }
     const { dataLoading, response, responseErrorObject, elapsedTime } = useValues(dataNodeLogic(dataNodeLogicProps))
+    const clickHouseTime = (response as HogQLQueryResponse)?.timings?.find(({ k }) => k === './clickhouse_execute')?.t
+
     return (
         <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
             <div className="space-y-2">
@@ -82,9 +84,22 @@ export function HogQLDebug({ query, setQuery, queryKey }: HogQLDebugProps): JSX.
                         ) : null}
                         {response?.clickhouse ? (
                             <>
-                                <h2>Executed ClickHouse SQL</h2>
+                                <h2>
+                                    Executed ClickHouse SQL
+                                    {clickHouseTime !== undefined
+                                        ? ` (${Math.floor(clickHouseTime * 1000) / 1000}s)`
+                                        : ''}
+                                </h2>
                                 <CodeSnippet language={Language.SQL} wrap>
                                     {response.clickhouse}
+                                </CodeSnippet>
+                            </>
+                        ) : null}
+                        {response?.explain ? (
+                            <>
+                                <h2>Explained ClickHouseSQL</h2>
+                                <CodeSnippet language={Language.SQL} wrap>
+                                    {response.explain.join('\n')}
                                 </CodeSnippet>
                             </>
                         ) : null}

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -240,6 +240,7 @@ def process_query(
             modifiers=hogql_query.modifiers,
             placeholders=values,
             default_limit=default_limit,
+            explain=hogql_query.explain,
         )
         return _unwrap_pydantic_dict(hogql_response)
     elif query_kind == "HogQLMetadata":

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -664,6 +664,7 @@ class HogQLQueryResponse(BaseModel):
     )
     clickhouse: Optional[str] = None
     columns: Optional[List] = None
+    explain: Optional[List[str]] = None
     hogql: Optional[str] = None
     modifiers: Optional[HogQLQueryModifiers] = None
     query: Optional[str] = None
@@ -937,6 +938,7 @@ class HogQLQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    explain: Optional[bool] = None
     filters: Optional[HogQLFilters] = None
     kind: Literal["HogQLQuery"] = "HogQLQuery"
     modifiers: Optional[HogQLQueryModifiers] = None


### PR DESCRIPTION
## Problem

The /debug page is missing useful things.

## Changes

Adds a query explainer

<img width="1523" alt="image" src="https://github.com/PostHog/posthog/assets/53387/7fac7b7c-1146-496e-82d1-53f6fc1e2d36">

I'm still not sure if this should default to on or not. It might make every query a bit slower here, but keeping it just on for everyone for now.

## How did you test this code?

Ran things locally.