### PR TITLE
chore: Make pluginConfigs be keyed over config id not plugin id

### DIFF
--- a/frontend/src/scenes/apps/frontendAppsLogic.tsx
+++ b/frontend/src/scenes/apps/frontendAppsLogic.tsx
@@ -31,7 +31,7 @@ export const frontendAppsLogic = kea<frontendAppsLogicType>([
             loadFrontendApp: async ({ id, pluginId, reload, attempt }) => {
                 if (!values.appConfigs[id]) {
                     if (pluginsLogic.findMounted()) {
-                        const pluginConfig = Object.values(pluginsLogic.values.pluginConfigs).find((c) => c.id === id)
+                        const pluginConfig = pluginsLogic.values.getPluginConfig(id)
                         const plugin = pluginConfig ? pluginsLogic.values.plugins[pluginConfig.plugin] : undefined
                         if (!plugin && !pluginConfig) {
                             throw Error(`Could not load metadata for app with ID ${id}`)

--- a/frontend/src/scenes/apps/frontendAppsLogic.tsx
+++ b/frontend/src/scenes/apps/frontendAppsLogic.tsx
@@ -2,7 +2,7 @@ import { actions, afterMount, connect, defaults, kea, path, reducers } from 'kea
 import type { frontendAppsLogicType } from './frontendAppsLogicType'
 import { getAppContext } from 'lib/utils/getAppContext'
 import { loaders } from 'kea-loaders'
-import { FrontendApp, FrontendAppConfig } from '~/types'
+import { FrontendApp, FrontendAppConfig, PluginConfigType } from '~/types'
 import { frontendAppRequire } from './frontendAppRequire'
 import { lemonToast } from 'lib/lemon-ui/lemonToast'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
@@ -31,7 +31,7 @@ export const frontendAppsLogic = kea<frontendAppsLogicType>([
             loadFrontendApp: async ({ id, pluginId, reload, attempt }) => {
                 if (!values.appConfigs[id]) {
                     if (pluginsLogic.findMounted()) {
-                        const pluginConfig = pluginsLogic.values.getPluginConfig(id)
+                        const pluginConfig: PluginConfigType | undefined = pluginsLogic.values.getPluginConfig(id)
                         const plugin = pluginConfig ? pluginsLogic.values.plugins[pluginConfig.plugin] : undefined
                         if (!plugin && !pluginConfig) {
                             throw Error(`Could not load metadata for app with ID ${id}`)

--- a/frontend/src/scenes/plugins/types.ts
+++ b/frontend/src/scenes/plugins/types.ts
@@ -17,7 +17,7 @@ export enum PluginRepositoryEntryType {
 }
 
 export interface PluginTypeWithConfig extends PluginType {
-    pluginConfig: PluginConfigType
+    pluginConfig: Omit<PluginConfigType, 'id'> & { id?: number }
     updateStatus: PluginUpdateStatusType
     hasMoved?: boolean
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1466,7 +1466,7 @@ export interface JobSpec {
 }
 
 export interface PluginConfigType {
-    id?: number
+    id: number
     plugin: number
     team_id: number
     enabled: boolean


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
This is step 1 towards being able to install multiples of an app/plugin.
Making the pluginConfigs be keyed over config ID not plugin ID (the latter implying 1 - 0/1 mapping ; the former 1 - n).

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
