### PR TITLE
fix: popover edits out of sync

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/NotebookPopover.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookPopover.tsx
@@ -17,13 +17,14 @@ import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
 import { openNotebookShareDialog } from './NotebookShare'
 
 export function NotebookPopoverCard(): JSX.Element | null {
-    const { visibility, shownAtLeastOnce, fullScreen, selectedNotebook, initialAutofocus, droppedResource } =
+    const { visibility, fullScreen, selectedNotebook, initialAutofocus, droppedResource } =
         useValues(notebookPopoverLogic)
     const { setVisibility, setFullScreen, selectNotebook } = useActions(notebookPopoverLogic)
     const { createNotebook } = useActions(notebooksModel)
     const { notebook } = useValues(notebookLogic({ shortId: selectedNotebook }))
 
-    const editable = visibility !== 'hidden' && !notebook?.is_template
+    const visible = visibility !== 'hidden'
+    const editable = visible && !notebook?.is_template
 
     const { ref, size } = useResizeBreakpoints({
         0: 'small',
@@ -91,7 +92,7 @@ export function NotebookPopoverCard(): JSX.Element | null {
             </header>
 
             <div className="flex flex-col flex-1 overflow-y-auto px-4 py-2">
-                {shownAtLeastOnce && (
+                {visible && (
                     <Notebook
                         key={selectedNotebook}
                         shortId={selectedNotebook}

--- a/frontend/src/scenes/notebooks/Notebook/NotebookPopover.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookPopover.tsx
@@ -15,16 +15,19 @@ import { urls } from 'scenes/urls'
 import { NotebookPopoverDropzone } from './NotebookPopoverDropzone'
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
 import { openNotebookShareDialog } from './NotebookShare'
+import { sceneLogic } from 'scenes/sceneLogic'
+import { Scene } from 'scenes/sceneTypes'
 
 export function NotebookPopoverCard(): JSX.Element | null {
-    const { visibility, fullScreen, selectedNotebook, initialAutofocus, droppedResource } =
+    const { visibility, shownAtLeastOnce, fullScreen, selectedNotebook, initialAutofocus, droppedResource } =
         useValues(notebookPopoverLogic)
     const { setVisibility, setFullScreen, selectNotebook } = useActions(notebookPopoverLogic)
     const { createNotebook } = useActions(notebooksModel)
     const { notebook } = useValues(notebookLogic({ shortId: selectedNotebook }))
+    const { activeScene } = useValues(sceneLogic)
 
-    const visible = visibility !== 'hidden'
-    const editable = visible && !notebook?.is_template
+    const showEditor = activeScene === Scene.Notebook ? visibility !== 'hidden' : shownAtLeastOnce
+    const editable = visibility !== 'hidden' && !notebook?.is_template
 
     const { ref, size } = useResizeBreakpoints({
         0: 'small',
@@ -92,7 +95,7 @@ export function NotebookPopoverCard(): JSX.Element | null {
             </header>
 
             <div className="flex flex-col flex-1 overflow-y-auto px-4 py-2">
-                {visible && (
+                {showEditor && (
                     <Notebook
                         key={selectedNotebook}
                         shortId={selectedNotebook}

--- a/frontend/src/scenes/notebooks/Notebook/notebookPopoverLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookPopoverLogic.ts
@@ -57,12 +57,6 @@ export const notebookPopoverLogic = kea<notebookPopoverLogicType>([
                 setElementRef: (_, { element }) => element,
             },
         ],
-        shownAtLeastOnce: [
-            false,
-            {
-                setVisibility: (state, { visibility }) => visibility !== 'hidden' || state,
-            },
-        ],
         dropMode: [
             false,
             {

--- a/frontend/src/scenes/notebooks/Notebook/notebookPopoverLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookPopoverLogic.ts
@@ -57,6 +57,12 @@ export const notebookPopoverLogic = kea<notebookPopoverLogicType>([
                 setElementRef: (_, { element }) => element,
             },
         ],
+        shownAtLeastOnce: [
+            false,
+            {
+                setVisibility: (state, { visibility }) => visibility !== 'hidden' || state,
+            },
+        ],
         dropMode: [
             false,
             {


### PR DESCRIPTION
## Problem

We only mount the TipTap editor in the popover a single time. This means that when it is "hidden" but open while editing a notebook on the notebook scene, it is not receiving updates to its content. And when it is open its changes override the existing content.

## Changes

- Only leave the editor loaded (using the `shownAtLeastOnce` caching) if not on a notebook scene. Otherwise, reload the TipTap editor every time the popover becomes visible.
    - Confirmed that reopening the popover does not cause a network request to fetch the content or immediately save 

## How did you test this code?

https://github.com/PostHog/posthog/assets/6685876/13532bcb-983a-4f1e-859d-222424e4b527

https://github.com/PostHog/posthog/assets/6685876/06e48cdb-c154-4d61-bd5d-e34b48569115