### PR TITLE
feat(plugin-server): allow to configure the rdkafka producer queue size

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -60,6 +60,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         APP_METRICS_FLUSH_MAX_QUEUE_SIZE: isTestEnv() ? 5 : 1000,
         KAFKA_PRODUCER_LINGER_MS: 20, // rdkafka default is 5ms
         KAFKA_PRODUCER_BATCH_SIZE: 8 * 1024 * 1024, // rdkafka default is 1MiB
+        KAFKA_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES: 100_000, // rdkafka default is 100_000
         REDIS_URL: 'redis://127.0.0.1',
         POSTHOG_REDIS_PASSWORD: '',
         POSTHOG_REDIS_HOST: '',

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -144,9 +144,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_KAFKA_BATCH_SIZE: 500,
         SESSION_RECORDING_KAFKA_QUEUE_SIZE: 1500,
 
-        // DOUBLE the KAFKA_PRODUCER_BATCH_SIZE by default
-        CONSOLE_LOG_INGESTER_PRODUCER_BATCH_SIZE: 8 * 1024 * 1024 * 2,
-
         SESSION_RECORDING_LOCAL_DIRECTORY: '.tmp/sessions',
         // NOTE: 10 minutes
         SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: 60 * 10,

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -144,6 +144,9 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_KAFKA_BATCH_SIZE: 500,
         SESSION_RECORDING_KAFKA_QUEUE_SIZE: 1500,
 
+        // DOUBLE the KAFKA_PRODUCER_BATCH_SIZE by default
+        CONSOLE_LOG_INGESTER_PRODUCER_BATCH_SIZE: 8 * 1024 * 1024 * 2,
+
         SESSION_RECORDING_LOCAL_DIRECTORY: '.tmp/sessions',
         // NOTE: 10 minutes
         SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS: 60 * 10,

--- a/plugin-server/src/kafka/config.ts
+++ b/plugin-server/src/kafka/config.ts
@@ -49,5 +49,6 @@ export const createRdProducerConfigFromEnvVars = (producerConfig: KafkaProducerC
     return {
         KAFKA_PRODUCER_LINGER_MS: producerConfig.KAFKA_PRODUCER_LINGER_MS,
         KAFKA_PRODUCER_BATCH_SIZE: producerConfig.KAFKA_PRODUCER_BATCH_SIZE,
+        KAFKA_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES: producerConfig.KAFKA_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES,
     }
 }

--- a/plugin-server/src/kafka/producer.ts
+++ b/plugin-server/src/kafka/producer.ts
@@ -14,6 +14,7 @@ import { status } from '../utils/status'
 export type KafkaProducerConfig = {
     KAFKA_PRODUCER_LINGER_MS: number
     KAFKA_PRODUCER_BATCH_SIZE: number
+    KAFKA_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES: number
 }
 
 // Kafka production related functions using node-rdkafka.
@@ -26,6 +27,7 @@ export const createKafkaProducer = async (globalConfig: ProducerGlobalConfig, pr
         // default 5 inflight requests.
         'linger.ms': producerConfig.KAFKA_PRODUCER_LINGER_MS,
         'batch.size': producerConfig.KAFKA_PRODUCER_BATCH_SIZE,
+        'queue.buffering.max.messages': producerConfig.KAFKA_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES,
         'compression.codec': 'snappy',
         // Ensure that librdkafka handled producer retries do not produce duplicates. Note this
         // doesn't mean that if we manually retry a message that it will be idempotent. May reduce

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
@@ -145,9 +145,13 @@ export class ConsoleLogsIngester {
             })
         }
     }
+
     public async start(): Promise<void> {
         const connectionConfig = createRdConnectionConfigFromEnvVars(this.serverConfig)
+
         const producerConfig = createRdProducerConfigFromEnvVars(this.serverConfig)
+        producerConfig['KAFKA_PRODUCER_BATCH_SIZE'] = this.serverConfig.CONSOLE_LOG_INGESTER_PRODUCER_BATCH_SIZE
+
         this.producer = await createKafkaProducer(connectionConfig, producerConfig)
         this.producer.connect()
     }

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
@@ -150,7 +150,6 @@ export class ConsoleLogsIngester {
         const connectionConfig = createRdConnectionConfigFromEnvVars(this.serverConfig)
 
         const producerConfig = createRdProducerConfigFromEnvVars(this.serverConfig)
-        producerConfig['KAFKA_PRODUCER_BATCH_SIZE'] = this.serverConfig.CONSOLE_LOG_INGESTER_PRODUCER_BATCH_SIZE
 
         this.producer = await createKafkaProducer(connectionConfig, producerConfig)
         this.producer.connect()

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -230,8 +230,6 @@ export interface PluginsServerConfig {
     SESSION_RECORDING_KAFKA_BATCH_SIZE: number
     SESSION_RECORDING_KAFKA_QUEUE_SIZE: number
 
-    CONSOLE_LOG_INGESTER_PRODUCER_BATCH_SIZE: number
-
     POSTHOG_SESSION_RECORDING_REDIS_HOST: string | undefined
     POSTHOG_SESSION_RECORDING_REDIS_PORT: number | undefined
 }

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -139,6 +139,7 @@ export interface PluginsServerConfig {
     KAFKA_TOPIC_CREATION_TIMEOUT_MS: number
     KAFKA_PRODUCER_LINGER_MS: number // linger.ms rdkafka parameter
     KAFKA_PRODUCER_BATCH_SIZE: number // batch.size rdkafka parameter
+    KAFKA_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES: number // queue.buffering.max.messages rdkafka parameter
     KAFKA_FLUSH_FREQUENCY_MS: number
     APP_METRICS_FLUSH_FREQUENCY_MS: number
     APP_METRICS_FLUSH_MAX_QUEUE_SIZE: number

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -229,6 +229,9 @@ export interface PluginsServerConfig {
     SESSION_RECORDING_KAFKA_SECURITY_PROTOCOL: KafkaSecurityProtocol | undefined
     SESSION_RECORDING_KAFKA_BATCH_SIZE: number
     SESSION_RECORDING_KAFKA_QUEUE_SIZE: number
+
+    CONSOLE_LOG_INGESTER_PRODUCER_BATCH_SIZE: number
+
     POSTHOG_SESSION_RECORDING_REDIS_HOST: string | undefined
     POSTHOG_SESSION_RECORDING_REDIS_PORT: number | undefined
 }


### PR DESCRIPTION
see this private slack thread https://posthog.slack.com/archives/C04R8HGPACX/p1697448204786719

We're seeing kafka production queue fill up for console log ingestion. This is surprising but we do produce N messages per message received with a (relatively) unbounded N

We await production twice (using the standard plugin server ingestion code) so let's try a larger batch size