### PR TITLE
feat: dedupe console logs

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
@@ -32,7 +32,7 @@ function deduplicateConsoleLogEvents(consoleLogEntries: ConsoleLogEntry[]): Cons
     for (const cle of consoleLogEntries) {
         if (!seen.has(cle.message)) {
             deduped.push(cle)
-            seen.add(cle.message)
+            seen.add(`${cle.log_level}-${cle.message}`)
         }
     }
     return deduped

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
@@ -21,6 +21,23 @@ const consoleLogEventsCounter = new Counter({
     help: 'Number of console log events successfully ingested',
 })
 
+function deduplicateConsoleLogEvents(consoleLogEntries: ConsoleLogEntry[]): ConsoleLogEntry[] {
+    // assuming that the console log entries are all for one team id (and they should be)
+    // because we only use these for search
+    // then we can deduplicate them by the message string
+
+    const seen = new Set<string>()
+    const deduped: ConsoleLogEntry[] = []
+
+    for (const cle of consoleLogEntries) {
+        if (!seen.has(cle.message)) {
+            deduped.push(cle)
+            seen.add(cle.message)
+        }
+    }
+    return deduped
+}
+
 // TODO this is an almost exact duplicate of the replay events ingester
 // am going to leave this duplication and then collapse it when/if we add a performance events ingester
 export class ConsoleLogsIngester {
@@ -124,7 +141,9 @@ export class ConsoleLogsIngester {
         }
 
         try {
-            const consoleLogEvents = gatherConsoleLogEvents(event.team_id, event.session_id, event.events)
+            const consoleLogEvents = deduplicateConsoleLogEvents(
+                gatherConsoleLogEvents(event.team_id, event.session_id, event.events)
+            )
 
             consoleLogEventsCounter.inc(consoleLogEvents.length)
 


### PR DESCRIPTION
We are ingesting console logs into log_entries only for search, as such we only really need to ingest each unique string once per session, but we had no checks on this at all

This deduplicates within each message to see if that is enough impact.

That impact can be tracked with 

```
select toStartOfMinute(timestamp), message, team_id, count(*) as c 
from log_entries
where timestamp >= now() - interval 2 day
group by toStartOfMinute(timestamp), message, team_id
order by c desc
```