### PR TITLE
ci(hogql): Don't run parser build workflow on forks

### DIFF
--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
     check-version:
         name: Check version legitimacy
+        if: github.repository == 'posthog/posthog'
         runs-on: ubuntu-22.04
         outputs:
             parser_any_changed: ${{ steps.changed-files-yaml.outputs.parser_any_changed }}

--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     check-version:
         name: Check version legitimacy
-        if: github.repository == 'posthog/posthog'
+        if: github.repository == 'PostHog/posthog'
         runs-on: ubuntu-22.04
         outputs:
             parser_any_changed: ${{ steps.changed-files-yaml.outputs.parser_any_changed }}


### PR DESCRIPTION
## Problem

When developing on a fork, the hogql parser workflow runs and fails on step `Notify about release needed`.

## Changes

added `if: github.repository == 'posthog/posthog'` to workflow

## How did you test this code?

pushed change to fork and the workflow did not run/fail
