### PR TITLE
chore: time cypress commands

### DIFF
--- a/cypress/e2e/insights-duplication.cy.ts
+++ b/cypress/e2e/insights-duplication.cy.ts
@@ -14,19 +14,16 @@ describe('Insights', () => {
                 })
             )
         )
-
-        cy.visit(urls.insightNew())
     })
 
     describe('duplicating insights', () => {
         let insightName
         beforeEach(() => {
-            cy.visit(urls.savedInsights()) // make sure turbo mode has cached this page
             insightName = randomString('insight-name-')
             createInsight(insightName)
+            cy.visit(urls.savedInsights()) // make sure turbo mode has cached this page
         })
         it('can duplicate insights from the insights list view', () => {
-            cy.visit(urls.savedInsights())
             cy.contains('.saved-insights table tr', insightName).within(() => {
                 cy.get('[data-attr="more-button"]').click()
             })
@@ -35,7 +32,6 @@ describe('Insights', () => {
         })
 
         it('can duplicate insights from the insights card view', () => {
-            cy.visit(urls.savedInsights())
             cy.contains('.saved-insights .LemonSegmentedButton', 'Cards').click()
             cy.contains('.CardMeta', insightName).within(() => {
                 cy.get('[data-attr="more-button"]').click()

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -18,6 +18,63 @@ Cypress.on('window:before:load', (win) => {
     cy.spy(win.console, 'warn')
 })
 
+const commands = []
+
+Cypress.on('command:start', (c) => {
+    const detail =
+        c.attributes.name === 'visit'
+            ? c.attributes.args[0]
+            : c.attributes.name === 'get'
+            ? c.attributes.args[0]
+            : undefined
+    commands.push({
+        name: c.attributes.name,
+        detail: detail,
+        started: new Date().getTime(),
+    })
+})
+
+Cypress.on('command:end', (c) => {
+    const lastCommand = commands[commands.length - 1]
+
+    if (lastCommand.name !== c.attributes.name) {
+        cy.log('test timing code encountered unexpected command', c)
+    }
+
+    lastCommand.endedAt = new Date().getTime()
+    lastCommand.elapsed = lastCommand.endedAt - lastCommand.started
+})
+
+Cypress.on('test:after:run', (attributes) => {
+    // eslint-disable-next-line no-console
+    console.log('Test "%s" has finished in %dms', attributes.title, attributes.duration)
+    const total = commands.reduce((acc, { elapsed }) => acc + elapsed, 0)
+    // eslint-disable-next-line no-console
+    console.table(
+        commands.map(({ name, elapsed, detail }) => ({
+            name,
+            elapsed,
+            percentage: ((elapsed / total) * 100).toFixed(1),
+            detail,
+        }))
+    )
+
+    if (E2E_TESTING) {
+        cy.window().then((win) => {
+            commands.forEach((command) => {
+                ;(win as any).posthog?.capture(`cypress_command_timing`, {
+                    name: command.name,
+                    title: attributes.title,
+                    duration: command.elapsed,
+                    percentage: ((command.elapsed / total) * 100).toFixed(1),
+                    detail: command.detail,
+                })
+            })
+        })
+    }
+    commands.length = 0
+})
+
 beforeEach(() => {
     Cypress.env('POSTHOG_PROPERTY_CURRENT_TEST_TITLE', Cypress.currentTest.title)
     Cypress.env('POSTHOG_PROPERTY_CURRENT_TEST_FULL_TITLE', Cypress.currentTest.titlePath.join(' > '))


### PR DESCRIPTION
Cypress tests are _really_ slow in CI and we don't know, so we can't do anything about it

* adds timing of Cypress commands
* reports them in the console
* reports them to the E2E Testing PostHog project

(I don't think this slows them down further 🙈)

<img width="1491" alt="Screenshot 2023-10-16 at 23 03 37" src="https://github.com/PostHog/posthog/assets/984817/dd8a9d0b-d5b0-44f4-922f-4d83e1c6dd87">
