### PR TITLE
fix: console log query

### DIFF
--- a/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
@@ -50,13 +50,12 @@ def _get_filter_by_log_text_session_ids_clause(
     if not recording_filters.console_search_query:
         return "", {}
 
-    log_query = LogQuery(team=team, filter=recording_filters).get_query()
-    matching_session_ids = sync_execute(log_query[0], log_query[1])
+    log_query, log_params = LogQuery(team=team, filter=recording_filters).get_query()
 
     # we return this _even_ if there are no matching ids since if there are no matching ids
     # then no sessions can match...
     # sorted so that snapshots are consistent
-    return f'AND "{column_name}" in %(session_ids)s', {"session_ids": sorted([x[0] for x in matching_session_ids])}
+    return f'AND "{column_name}" in ({log_query}) as log_text_matching', log_params
 
 
 def _get_filter_by_provided_session_ids_clause(
@@ -123,7 +122,7 @@ class LogQuery:
             else ("", {})
         )
 
-    def get_query(self):
+    def get_query(self) -> Tuple[str, Dict]:
         if not self._filter.console_search_query:
             return "", {}
 
@@ -565,11 +564,16 @@ class SessionRecordingListFromReplaySummary(EventQuery):
         return SessionRecordingQueryResult(session_recordings, more_recordings_available)
 
     def run(self) -> SessionRecordingQueryResult:
-        self._filter.hogql_context.modifiers.personsOnEventsMode = PersonOnEventsMode.DISABLED
-        query, query_params = self.get_query()
-        query_results = sync_execute(query, {**query_params, **self._filter.hogql_context.values})
-        session_recordings = self._data_to_return(query_results)
-        return self._paginate_results(session_recordings)
+        try:
+            self._filter.hogql_context.modifiers.personsOnEventsMode = PersonOnEventsMode.DISABLED
+            query, query_params = self.get_query()
+            query_results = sync_execute(query, {**query_params, **self._filter.hogql_context.values})
+            session_recordings = self._data_to_return(query_results)
+            return self._paginate_results(session_recordings)
+        except Exception as ex:
+            # error here weren't making it to sentry, let's be explicit
+            capture_exception(ex, tags={"team_id": self._team.pk})
+            raise ex
 
     @property
     def limit(self):
@@ -590,15 +594,10 @@ class SessionRecordingListFromReplaySummary(EventQuery):
             recording_filters=self._filter
         )
 
-        try:
-            (
-                log_matching_session_ids_clause,
-                log_matching_session_ids_params,
-            ) = _get_filter_by_log_text_session_ids_clause(team=self._team, recording_filters=self._filter)
-        except Exception as ex:
-            # error here weren't making it to sentry, let's be explicit
-            capture_exception(ex, tags={"team_id": self._team.pk})
-            raise ex
+        (
+            log_matching_session_ids_clause,
+            log_matching_session_ids_params,
+        ) = _get_filter_by_log_text_session_ids_clause(team=self._team, recording_filters=self._filter)
 
         duration_clause, duration_params = self.duration_clause(self._filter.duration_type_filter)
         console_log_clause = self._get_console_log_clause(self._filter.console_logs_filter)

--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -2701,15 +2701,43 @@
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_filter_for_recordings_by_console_text
   '
   
-  SELECT distinct log_source_id as session_id
-  FROM log_entries PREWHERE team_id = 2
-  AND timestamp >= '2020-12-31 20:00:00'
-  AND timestamp <= now()
-  AND timestamp >= '2021-01-13 12:00:00'
-  AND timestamp <= '2021-01-22 08:00:00'
-  WHERE 1=1
-    AND level in ['warn', 'error']
-    AND positionCaseInsensitive(message, 'message 4') > 0
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND "session_id" in
+      (SELECT distinct log_source_id as session_id
+       FROM log_entries PREWHERE team_id = 2
+       AND timestamp >= '2020-12-31 20:00:00'
+       AND timestamp <= now()
+       AND timestamp >= '2021-01-13 12:00:00'
+       AND timestamp <= '2021-01-22 08:00:00'
+       WHERE 1=1
+         AND level in ['warn', 'error']
+         AND positionCaseInsensitive(message, 'message 4') > 0 ) as log_text_matching
+  GROUP BY session_id
+  HAVING 1=1
+  AND (console_warn_count > 0
+       OR console_error_count > 0)
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
   '
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_filter_for_recordings_by_console_text.1
@@ -2735,7 +2763,16 @@
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
     AND s.max_last_timestamp <= '2021-01-21 20:00:00'
-    AND "session_id" in ['with-errors-session', 'with-two-session', 'with-warns-session']
+    AND "session_id" in
+      (SELECT distinct log_source_id as session_id
+       FROM log_entries PREWHERE team_id = 2
+       AND timestamp >= '2020-12-31 20:00:00'
+       AND timestamp <= now()
+       AND timestamp >= '2021-01-13 12:00:00'
+       AND timestamp <= '2021-01-22 08:00:00'
+       WHERE 1=1
+         AND level in ['warn', 'error']
+         AND positionCaseInsensitive(message, 'message 5') > 0 ) as log_text_matching
   GROUP BY session_id
   HAVING 1=1
   AND (console_warn_count > 0
@@ -2748,15 +2785,43 @@
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_filter_for_recordings_by_console_text.2
   '
   
-  SELECT distinct log_source_id as session_id
-  FROM log_entries PREWHERE team_id = 2
-  AND timestamp >= '2020-12-31 20:00:00'
-  AND timestamp <= now()
-  AND timestamp >= '2021-01-13 12:00:00'
-  AND timestamp <= '2021-01-22 08:00:00'
-  WHERE 1=1
-    AND level in ['warn', 'error']
-    AND positionCaseInsensitive(message, 'message 5') > 0
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND "session_id" in
+      (SELECT distinct log_source_id as session_id
+       FROM log_entries PREWHERE team_id = 2
+       AND timestamp >= '2020-12-31 20:00:00'
+       AND timestamp <= now()
+       AND timestamp >= '2021-01-13 12:00:00'
+       AND timestamp <= '2021-01-22 08:00:00'
+       WHERE 1=1
+         AND level in ['warn', 'error']
+         AND positionCaseInsensitive(message, 'MESSAGE 5') > 0 ) as log_text_matching
+  GROUP BY session_id
+  HAVING 1=1
+  AND (console_warn_count > 0
+       OR console_error_count > 0)
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
   '
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_filter_for_recordings_by_console_text.3
@@ -2782,11 +2847,19 @@
     AND s.min_first_timestamp >= '2020-12-31 20:00:00'
     AND s.min_first_timestamp >= '2021-01-14 00:00:00'
     AND s.max_last_timestamp <= '2021-01-21 20:00:00'
-    AND "session_id" in ['with-warns-session']
+    AND "session_id" in
+      (SELECT distinct log_source_id as session_id
+       FROM log_entries PREWHERE team_id = 2
+       AND timestamp >= '2020-12-31 20:00:00'
+       AND timestamp <= now()
+       AND timestamp >= '2021-01-13 12:00:00'
+       AND timestamp <= '2021-01-22 08:00:00'
+       WHERE 1=1
+         AND level in ['log']
+         AND positionCaseInsensitive(message, 'message 5') > 0 ) as log_text_matching
   GROUP BY session_id
   HAVING 1=1
-  AND (console_warn_count > 0
-       OR console_error_count > 0)
+  AND (console_log_count > 0)
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0
@@ -2795,15 +2868,42 @@
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_filter_for_recordings_by_console_text.4
   '
   
-  SELECT distinct log_source_id as session_id
-  FROM log_entries PREWHERE team_id = 2
-  AND timestamp >= '2020-12-31 20:00:00'
-  AND timestamp <= now()
-  AND timestamp >= '2021-01-13 12:00:00'
-  AND timestamp <= '2021-01-22 08:00:00'
-  WHERE 1=1
-    AND level in ['warn', 'error']
-    AND positionCaseInsensitive(message, 'MESSAGE 5') > 0
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND "session_id" in
+      (SELECT distinct log_source_id as session_id
+       FROM log_entries PREWHERE team_id = 2
+       AND timestamp >= '2020-12-31 20:00:00'
+       AND timestamp <= now()
+       AND timestamp >= '2021-01-13 12:00:00'
+       AND timestamp <= '2021-01-22 08:00:00'
+       WHERE 1=1
+         AND level in ['log']
+         AND positionCaseInsensitive(message, 'message 5') > 0 ) as log_text_matching
+  GROUP BY session_id
+  HAVING 1=1
+  AND (console_log_count > 0)
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
   '
 ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_filter_for_recordings_by_console_text.5


### PR DESCRIPTION
passing console log matching session ids into the filter query is failing because when a lot of session ids match then the resulting query is too big

use a subquery instead