### PR TITLE
fix: debug frontend from vscode with launch configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ pnpm-error.log
 yalc.lock
 .vscode/*
 !.vscode/launch.json
+!.vscode/tasks.json
 cypress/screenshots/
 cypress/downloads/
 cypress/**/*.diff.png

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -48,12 +48,11 @@
             }
         },
         {
-            "name": "Frontend",
-            "command": "npm start",
+            "name": "Launch Chrome",
+            "type": "chrome",
             "request": "launch",
-            "type": "node-terminal",
-            "cwd": "${workspaceFolder}",
-            "localRoot": "${workspaceFolder}/frontend"
+            "url": "http://localhost:8000",
+            "webRoot": "${workspaceFolder}/frontend"
         },
         {
             "name": "Backend",
@@ -127,7 +126,7 @@
     "compounds": [
         {
             "name": "PostHog",
-            "configurations": ["Backend", "Celery", "Frontend", "Plugin Server", "Temporal Worker"],
+            "configurations": ["Backend", "Celery", "Launch Chrome", "Plugin Server", "Temporal Worker"],
             "stopAll": true
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,7 +52,8 @@
             "command": "npm start",
             "request": "launch",
             "type": "node-terminal",
-            "cwd": "${workspaceFolder}"
+            "cwd": "${workspaceFolder}",
+            "localRoot": "${workspaceFolder}/frontend"
         },
         {
             "name": "Backend",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Frontend",
+            "type": "npm",
+            "script": "start",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "test:visual-regression:stories:docker": "NODE_OPTIONS=--max-old-space-size=6144 test-storybook -u --no-index-json --browsers chromium webkit --url http://host.docker.internal:6006",
         "test:visual-regression:stories:ci:update": "test-storybook -u --no-index-json --maxWorkers=2",
         "test:visual-regression:stories:ci:verify": "test-storybook --ci --no-index-json --maxWorkers=2",
-        "start": "concurrently -n ESBUILD,TYPEGEN -c yellow,green \"pnpm start-http\"",
+        "start": "concurrently -n ESBUILD,TYPEGEN -c yellow,green \"pnpm start-http\" \"pnpm run typegen:watch\"",
         "start-http": "pnpm clean && pnpm copy-scripts && node frontend/build.mjs --dev",
         "start-docker": "pnpm start-http --host 0.0.0.0",
         "clean": "rm -rf frontend/dist && mkdir frontend/dist",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "test:visual-regression:stories:docker": "NODE_OPTIONS=--max-old-space-size=6144 test-storybook -u --no-index-json --browsers chromium webkit --url http://host.docker.internal:6006",
         "test:visual-regression:stories:ci:update": "test-storybook -u --no-index-json --maxWorkers=2",
         "test:visual-regression:stories:ci:verify": "test-storybook --ci --no-index-json --maxWorkers=2",
-        "start": "concurrently -n ESBUILD,TYPEGEN -c yellow,green \"pnpm start-http\" \"pnpm run typegen:watch\"",
+        "start": "concurrently -n ESBUILD,TYPEGEN -c yellow,green \"pnpm start-http\"",
         "start-http": "pnpm clean && pnpm copy-scripts && node frontend/build.mjs --dev",
         "start-docker": "pnpm start-http --host 0.0.0.0",
         "clean": "rm -rf frontend/dist && mkdir frontend/dist",


### PR DESCRIPTION
## Problem

unable to set breakpoints when debugging frontend on vscode via launch configuration

## Changes

replace `Frontend` launch config with `Launch Chrome`, and set `webRoot` to enable breakpoints

developers need to run task `Frontend` then run `Launch Configuration: PostHog`

## How did you test this code?

successfully ran launch config and was able to set breakpoints
