### PR TITLE
feat: Make onEvent skip other plugins

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
@@ -26,7 +26,7 @@ export async function eachMessageAppsOnEventHandlers(
         )?.capabilities?.methods?.includes('onEvent')
     )
 
-    if (pluginConfigs) {
+    if (pluginConfigs && pluginConfigs.length > 0) {
         // Elements parsing can be extremely slow, so we skip it for some plugins
         // # SKIP_ELEMENTS_PARSING_PLUGINS
         const skipElementsChain = pluginConfigs.every((pluginConfig) =>

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
@@ -17,7 +17,12 @@ export async function eachMessageAppsOnEventHandlers(
     clickHouseEvent: RawClickHouseEvent,
     queue: KafkaJSIngestionConsumer
 ): Promise<void> {
-    const pluginConfigs = queue.pluginsServer.pluginConfigsPerTeam.get(clickHouseEvent.team_id)
+    let pluginConfigs = queue.pluginsServer.pluginConfigsPerTeam.get(clickHouseEvent.team_id)
+    // filter out plugins that don't have onEvent handlers
+    pluginConfigs = pluginConfigs?.filter((pluginConfig) =>
+        pluginConfig.plugin?.capabilities?.methods?.includes('onEvent')
+    )
+
     if (pluginConfigs) {
         // Elements parsing can be extremely slow, so we skip it for some plugins
         // # SKIP_ELEMENTS_PARSING_PLUGINS

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
@@ -19,8 +19,11 @@ export async function eachMessageAppsOnEventHandlers(
 ): Promise<void> {
     let pluginConfigs = queue.pluginsServer.pluginConfigsPerTeam.get(clickHouseEvent.team_id)
     // filter out plugins that don't have onEvent handlers
+    // TODO: ideally we'd do this when we load pluginConfigsPerTeam in the first place ... one step at a time
     pluginConfigs = pluginConfigs?.filter((pluginConfig) =>
-        pluginConfig.plugin?.capabilities?.methods?.includes('onEvent')
+        (
+            pluginConfig.plugin || queue.pluginsServer.plugins.get(pluginConfig.plugin_id)
+        )?.capabilities?.methods?.includes('onEvent')
     )
 
     if (pluginConfigs) {

--- a/plugin-server/tests/helpers/plugins.ts
+++ b/plugin-server/tests/helpers/plugins.ts
@@ -55,6 +55,14 @@ export const pluginConfig39: PluginConfig = {
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
 }
+export const plugin22: Plugin = {
+    id: 22,
+    organization_id: commonOrganizationId,
+    plugin_type: 'custom',
+    name: 'test-plugin',
+    is_global: true,
+    capabilities: {},
+}
 
 function mockSourceFileFields(
     name: string,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Noticed that we get all the plugin-configs and then do event conversions even if that plugin isn't an onEvent plugin. That's very wasteful.
This filtering currently happens much later: https://github.com/PostHog/posthog/blob/731504fa0a3a05f8d0c061975b6ecb62399da653/plugin-server/src/worker/plugins/run.ts#L59 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
