### PR TITLE
fix: tiers show incorrect volumes if denominator differs

### DIFF
--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -1,4 +1,10 @@
-import { convertAmountToUsage, convertUsageToAmount, projectUsage, summarizeUsage } from './billing-utils'
+import {
+    convertAmountToUsage,
+    convertLargeNumberToWords,
+    convertUsageToAmount,
+    projectUsage,
+    summarizeUsage,
+} from './billing-utils'
 import tk from 'timekeeper'
 import { dayjs } from 'lib/dayjs'
 import billingJson from '~/mocks/fixtures/_billing_v2.json'
@@ -158,4 +164,14 @@ describe('convertAmountToUsageWithPercentDiscount', () => {
             }
         }
     )
+})
+
+describe('convertLargeNumberToWords', () => {
+    it('should convert large numbers to words', () => {
+        expect(convertLargeNumberToWords(250, null, true, 'survey')).toEqual('First 250 surveys/mo')
+        expect(convertLargeNumberToWords(500, 250, true, 'survey')).toEqual('251-500')
+        expect(convertLargeNumberToWords(1000, 500, true, 'survey')).toEqual('501-1k')
+        expect(convertLargeNumberToWords(10000, 1000, true, 'survey')).toEqual('1-10k')
+        expect(convertLargeNumberToWords(10000000, 1000000, true, 'survey')).toEqual('1-10 million')
+    })
 })

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -185,14 +185,20 @@ export const convertLargeNumberToWords = (
     }
 
     let denominator = 1
-
     if (num >= 1000000) {
         denominator = 1000000
     } else if (num >= 1000) {
         denominator = 1000
     }
 
-    return `${previousNum ? `${(previousNum / denominator).toFixed(0)}-` : multipleTiers ? 'First ' : ''}${(
+    let prevDenominator = 1
+    if (previousNum && previousNum >= 1000000) {
+        prevDenominator = 1000000
+    } else if (previousNum && previousNum >= 1000) {
+        prevDenominator = 1000
+    }
+
+    return `${previousNum ? `${((previousNum + 1) / prevDenominator).toFixed(0)}-` : multipleTiers ? 'First ' : ''}${(
         num / denominator
     ).toFixed(0)}${denominator === 1000000 ? ' million' : denominator === 1000 ? 'k' : ''}${
         !previousNum && multipleTiers ? ` ${productType}s/mo` : ''


### PR DESCRIPTION
## Problem

The pricing tiers showed the wrong numbers, third tier shows `1-1k`:

![image](https://github.com/PostHog/posthog/assets/18598166/cec6e546-98af-4526-bdb0-d7109b18b336)


<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Uses a different denominator for previous and current tier, and adds 1 to previous tier so that the correct number is displayed. 

<img width="284" alt="image" src="https://github.com/PostHog/posthog/assets/18598166/8eedf8d3-0995-40d3-a42a-c97b2eb24994">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a test

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
