### PR TITLE
fix: hide errors and show project creation if no projects exist in org

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -23,6 +23,15 @@ const ERROR_FILTER_WHITELIST = [
     'loadLatestVersion',
     'loadBilling', // Gracefully handled if it fails
     'loadData', // Gracefully handled in the data table
+    // 'loadPersons',
+    // 'loadCustomEvents',
+    // 'loadAllGroupTypes',
+    // 'loadDashboards',
+    // 'loadInsights',
+    // 'loadRecentInsights',
+    // 'loadEarlyAccessFeatures',
+    // 'loadPluginConfigs',
+    // 'loadSessionRecordings',
 ]
 
 interface InitKeaProps {
@@ -81,7 +90,11 @@ export function initKea({ routerHistory, routerLocation, beforePlugins }: InitKe
                 if (
                     !ERROR_FILTER_WHITELIST.includes(actionKey) &&
                     (error?.message === 'Failed to fetch' || // Likely CORS headers errors (i.e. request failing without reaching Django)
-                        (error?.status !== undefined && ![200, 201, 204].includes(error.status)))
+                        (error?.status !== undefined && ![200, 201, 204].includes(error.status))) &&
+                    !(
+                        error?.detail.includes('project ID is unknown') || // hide errors for unknown project ID
+                        error?.detail.includes('endpoint requires a project')
+                    )
                 ) {
                     lemonToast.error(
                         `${identifierToHuman(actionKey)} failed: ${

--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -23,15 +23,6 @@ const ERROR_FILTER_WHITELIST = [
     'loadLatestVersion',
     'loadBilling', // Gracefully handled if it fails
     'loadData', // Gracefully handled in the data table
-    // 'loadPersons',
-    // 'loadCustomEvents',
-    // 'loadAllGroupTypes',
-    // 'loadDashboards',
-    // 'loadInsights',
-    // 'loadRecentInsights',
-    // 'loadEarlyAccessFeatures',
-    // 'loadPluginConfigs',
-    // 'loadSessionRecordings',
 ]
 
 interface InitKeaProps {

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -20,7 +20,6 @@ import { teamLogic } from '../teamLogic'
 import { createDefaultPluginSource } from 'scenes/plugins/source/createDefaultPluginSource'
 import { frontendAppsLogic } from 'scenes/apps/frontendAppsLogic'
 import { urls } from 'scenes/urls'
-import { lemonToast } from 'lib/lemon-ui/lemonToast'
 
 export type PluginForm = FormInstance
 
@@ -424,7 +423,8 @@ export const pluginsLogic = kea<pluginsLogicType>([
             (plugins, pluginConfigs, updateStatus): PluginTypeWithConfig[] => {
                 const { currentTeam } = teamLogic.values
                 if (!currentTeam) {
-                    lemonToast.error("Can't list installed plugins with no user or team!")
+                    // disable toast to prevent errors showing, allow user to create project if allowed
+                    // lemonToast.error("Can't list installed plugins with no user or team!")
                     return []
                 }
 

--- a/frontend/src/scenes/project/Create/index.tsx
+++ b/frontend/src/scenes/project/Create/index.tsx
@@ -15,7 +15,7 @@ export function ProjectCreate(): JSX.Element {
 
     return projectCreationForbiddenReason ? (
         <LemonBanner type="warning" className="mt-5">
-            {projectCreationForbiddenReason}
+            {`Switch to a project that you have access to. If you need a new project or access to an existing one that's private, ask a team member with administrator permissions. Reason: ${projectCreationForbiddenReason}`}
         </LemonBanner>
     ) : (
         <CreateProjectModal isVisible inline />

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -140,7 +140,7 @@ export const sceneLogic = kea<sceneLogicType>({
             (s) => [s.scene, teamLogic.selectors.isCurrentTeamUnavailable],
             (scene, isCurrentTeamUnavailable) => {
                 return isCurrentTeamUnavailable && scene && sceneConfigurations[scene]?.projectBased
-                    ? Scene.ErrorProjectUnavailable
+                    ? Scene.ProjectCreateFirst
                     : scene
             },
         ],

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -9,6 +9,7 @@ import { getDefaultEventsSceneQuery } from 'scenes/events/defaults'
 import { EventsQuery } from '~/queries/schema'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/lemonToast'
+import { ProjectCreate } from './project/Create'
 
 export const emptySceneParams = { params: {}, searchParams: {}, hashParams: {} }
 
@@ -26,6 +27,11 @@ export const preloadedScenes: Record<string, LoadedScene> = {
     [Scene.ErrorProjectUnavailable]: {
         name: Scene.ErrorProjectUnavailable,
         component: ErrorProjectUnavailableComponent,
+        sceneParams: emptySceneParams,
+    },
+    [Scene.ProjectCreateFirst]: {
+        name: Scene.ProjectCreateFirst,
+        component: ProjectCreate,
         sceneParams: emptySceneParams,
     },
 }


### PR DESCRIPTION
## Problem

attempts to resolve #17837, displays create project modal and hides errors when no projects exist in org

## Changes

hide errors when detail contains `project ID is unknown` and `endpoint requires a project`; and disable toast with content `Can't list installed plugins with no user or team!`

add project creation forbidden reason (similar to `ErrorProjectUnavailable` component) to `LemonBanner` in `ProjectCreate` component, and  add `ProjectCreate` component to `preloadedScenes`, set `sceneLogic` to display `ProjectCreate` instead of `ErrorProjectUnavailable`

<img width="1536" alt="Screenshot 2023-10-17 at 13 07 21" src="https://github.com/PostHog/posthog/assets/31130737/3fd5c0cd-5544-49ff-8fe6-a8f2f7123f6b">

## How did you test this code?

deleted all projects in org, refreshed page and made sure no errors display + create project modal is shown
