### PR TITLE
chore(surveys): add surveys opt in to onboarding ingestion

### DIFF
--- a/frontend/src/scenes/ingestion/panels/SuperpowersPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/SuperpowersPanel.tsx
@@ -12,6 +12,7 @@ export function SuperpowersPanel(): JSX.Element {
     const { completeOnboarding } = useActions(ingestionLogic)
     const [sessionRecordingsChecked, setSessionRecordingsChecked] = useState(true)
     const [autocaptureChecked, setAutocaptureChecked] = useState(true)
+    const [surveysChecked, setSurveysChecked] = useState(true)
 
     return (
         <CardContainer
@@ -22,6 +23,7 @@ export function SuperpowersPanel(): JSX.Element {
                     capture_console_log_opt_in: sessionRecordingsChecked,
                     capture_performance_opt_in: sessionRecordingsChecked,
                     autocapture_opt_out: !autocaptureChecked,
+                    surveys_opt_in: surveysChecked,
                 })
                 if (!showBillingStep) {
                     completeOnboarding()
@@ -80,6 +82,25 @@ export function SuperpowersPanel(): JSX.Element {
                         Fine-tune what you capture
                     </Link>{' '}
                     directly in your code snippet.
+                </p>
+            </div>
+            <div>
+                <LemonSwitch
+                    data-attr="opt-in-surveys-switch"
+                    onChange={(checked) => {
+                        setSurveysChecked(checked)
+                    }}
+                    label="Get qualitative feedback from your users"
+                    fullWidth={true}
+                    labelClassName={'text-base font-semibold'}
+                    checked={surveysChecked}
+                />
+                <p className="prompt-text ml-0">
+                    Collect feedback from your users directly in your product.{' '}
+                    <Link to={'https://posthog.com/docs/surveys'} target="blank">
+                        Learn more
+                    </Link>{' '}
+                    about Surveys.
                 </p>
             </div>
         </CardContainer>


### PR DESCRIPTION
## Problem

Add surveys snippet to onboarding ingestion so we can have it default on

## Changes

<img width="830" alt="Screen Shot 2023-10-17 at 2 12 21 PM" src="https://github.com/PostHog/posthog/assets/25164963/609ae30d-0137-4503-99a0-ce96767ea412">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
