### PR TITLE
fix(queries): export limit

### DIFF
--- a/frontend/src/models/cohortsModel.ts
+++ b/frontend/src/models/cohortsModel.ts
@@ -85,7 +85,6 @@ export const cohortsModel = kea<cohortsModelType>({
                 export_format: ExporterFormat.CSV,
                 export_context: {
                     path: `/api/cohort/${id}/persons`,
-                    max_limit: 10000,
                 },
             }
             if (columns && columns.length > 0) {

--- a/frontend/src/queries/nodes/DataTable/DataTableExport.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableExport.tsx
@@ -39,6 +39,10 @@ function startDownload(query: DataTableNode, onlySelectedColumns: boolean): void
             exportContext['columns'] = exportContext['columns'].map((c: string) =>
                 removeExpressionComment(c) === 'person' ? 'person.properties.email' : c
             )
+        } else if (isPersonsNode(query.source)) {
+            exportContext['columns'] = exportContext['columns'].map((c: string) =>
+                removeExpressionComment(c) === 'person' ? 'properties.email' : c
+            )
         }
     }
     triggerExport({

--- a/frontend/src/queries/nodes/DataTable/DataTableExport.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableExport.tsx
@@ -22,8 +22,8 @@ const EXPORT_MAX_LIMIT = 10000
 
 function startDownload(query: DataTableNode, onlySelectedColumns: boolean): void {
     const exportContext = isPersonsNode(query.source)
-        ? { path: getPersonsEndpoint(query.source), max_limit: EXPORT_MAX_LIMIT }
-        : { source: query.source, max_limit: EXPORT_MAX_LIMIT }
+        ? { path: getPersonsEndpoint(query.source) }
+        : { source: query.source }
     if (!exportContext) {
         throw new Error('Unsupported node type')
     }

--- a/frontend/src/queries/nodes/DataTable/DataTableExport.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableExport.tsx
@@ -4,7 +4,11 @@ import { IconExport } from 'lib/lemon-ui/icons'
 import { triggerExport } from 'lib/components/ExportButton/exporter'
 import { ExporterFormat } from '~/types'
 import { DataNode, DataTableNode, NodeKind } from '~/queries/schema'
-import { defaultDataTableColumns, extractExpressionComment } from '~/queries/nodes/DataTable/utils'
+import {
+    defaultDataTableColumns,
+    extractExpressionComment,
+    removeExpressionComment,
+} from '~/queries/nodes/DataTable/utils'
 import { isEventsQuery, isHogQLQuery, isPersonsNode } from '~/queries/utils'
 import { getPersonsEndpoint } from '~/queries/query'
 import { ExportWithConfirmation } from '~/queries/nodes/DataTable/ExportWithConfirmation'
@@ -24,20 +28,18 @@ function startDownload(query: DataTableNode, onlySelectedColumns: boolean): void
         throw new Error('Unsupported node type')
     }
 
-    const columnMapping = {
-        url: ['properties.$current_url', 'properties.$screen_name'],
-        time: 'timestamp',
-        event: 'event',
-        source: 'properties.$lib',
-        person: isPersonsNode(query.source)
-            ? ['distinct_ids.0', 'properties.email']
-            : ['person.distinct_ids.0', 'person.properties.email'],
-    }
-
     if (onlySelectedColumns) {
-        exportContext['columns'] = (query.columns ?? defaultDataTableColumns(query.source.kind))
-            ?.flatMap((c) => columnMapping[c] || c)
-            .filter((c) => c !== 'person.$delete')
+        exportContext['columns'] = (
+            (isEventsQuery(query.source) ? query.source.select : null) ??
+            query.columns ??
+            defaultDataTableColumns(query.source.kind)
+        )?.filter((c) => c !== 'person.$delete')
+
+        if (isEventsQuery(query.source)) {
+            exportContext['columns'] = exportContext['columns'].map((c: string) =>
+                removeExpressionComment(c) === 'person' ? 'person.properties.email' : c
+            )
+        }
     }
     triggerExport({
         export_format: ExporterFormat.CSV,
@@ -185,7 +187,7 @@ export function DataTableExport({ query }: DataTableExportProps): JSX.Element | 
         (isEventsQuery(source) || isPersonsNode(source) ? source.properties?.length || 0 : 0) +
         (isEventsQuery(source) && source.event ? 1 : 0) +
         (isPersonsNode(source) && source.search ? 1 : 0)
-    const canExportAllColumns = isEventsQuery(source) || isPersonsNode(source)
+    const canExportAllColumns = (isEventsQuery(source) && source.select.includes('*')) || isPersonsNode(source)
     const showExportClipboardButtons = isPersonsNode(source) || isEventsQuery(source) || isHogQLQuery(source)
 
     return (

--- a/frontend/src/queries/query.test.ts
+++ b/frontend/src/queries/query.test.ts
@@ -67,7 +67,6 @@ describe('query', () => {
                     'timestamp',
                 ],
             },
-            max_limit: 10000,
         })
     })
 

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -32,8 +32,6 @@ import { currentSessionId } from 'lib/internalMetrics'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 
-const EXPORT_MAX_LIMIT = 10000
-
 //get export context for a given query
 export function queryExportContext<N extends DataNode = DataNode>(
     query: N,
@@ -47,7 +45,6 @@ export function queryExportContext<N extends DataNode = DataNode>(
     } else if (isEventsQuery(query) || isPersonsQuery(query)) {
         return {
             source: query,
-            max_limit: EXPORT_MAX_LIMIT,
         }
     } else if (isHogQLQuery(query)) {
         return { source: query }

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -170,7 +170,6 @@ export const personsLogic = kea<personsLogicType>({
                         path: cohort
                             ? api.cohorts.determineListUrl(cohort, listFilters)
                             : api.persons.determineListUrl(listFilters),
-                        max_limit: 10000,
                     },
                 },
             ],

--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -47,7 +47,6 @@ export function RetentionModal(): JSX.Element | null {
                                 export_format: ExporterFormat.CSV,
                                 export_context: {
                                     path: row?.people_url,
-                                    max_limit: 10000,
                                 },
                             })
                         }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2911,13 +2911,11 @@ export type OnlineExportContext = {
     query?: any
     body?: any
     filename?: string
-    max_limit?: number
 }
 
 export type QueryExportContext = {
     source: Record<string, any>
     filename?: string
-    max_limit?: number
 }
 
 export type ExportContext = OnlineExportContext | LocalExportContext | QueryExportContext

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -411,7 +411,6 @@ class TestExportMixin(APIBaseTest):
                     f"/api/projects/{self.team.pk}/exports/",
                     {
                         "export_context": {
-                            "max_limit": 10000,
                             "path": path,
                         },
                         "export_format": "text/csv",

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -421,7 +421,8 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
 
     @patch("posthog.hogql.constants.DEFAULT_RETURNED_ROWS", 10)
-    def test_full_hogql_query_limit(self, DEFAULT_RETURNED_ROWS=10):
+    @patch("posthog.hogql.constants.MAX_SELECT_RETURNED_ROWS", 15)
+    def test_full_hogql_query_limit(self, MAX_SELECT_RETURNED_ROWS=15, DEFAULT_RETURNED_ROWS=10):
         random_uuid = str(UUIDT())
         with freeze_time("2020-01-10 12:00:00"):
             for _ in range(20):
@@ -439,7 +440,28 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(len(response.get("results", [])), 10)
 
     @patch("posthog.hogql.constants.DEFAULT_RETURNED_ROWS", 10)
-    def test_full_events_query_limit(self, DEFAULT_RETURNED_ROWS=10):
+    @patch("posthog.hogql.constants.MAX_SELECT_RETURNED_ROWS", 15)
+    def test_full_hogql_query_limit_exported(self, MAX_SELECT_RETURNED_ROWS=15, DEFAULT_RETURNED_ROWS=10):
+        random_uuid = str(UUIDT())
+        with freeze_time("2020-01-10 12:00:00"):
+            for _ in range(20):
+                _create_event(team=self.team, event="sign up", distinct_id=random_uuid, properties={"key": "test_val1"})
+        flush_persons_and_events()
+
+        with freeze_time("2020-01-10 12:14:00"):
+            response = process_query(
+                team=self.team,
+                query_json={
+                    "kind": "HogQLQuery",
+                    "query": f"select event from events where distinct_id='{random_uuid}'",
+                },
+                in_export_context=True,  # This is the only difference
+            )
+            self.assertEqual(len(response.get("results", [])), 15)
+
+    @patch("posthog.hogql.constants.DEFAULT_RETURNED_ROWS", 10)
+    @patch("posthog.hogql.constants.MAX_SELECT_RETURNED_ROWS", 15)
+    def test_full_events_query_limit(self, MAX_SELECT_RETURNED_ROWS=15, DEFAULT_RETURNED_ROWS=10):
         random_uuid = str(UUIDT())
         with freeze_time("2020-01-10 12:00:00"):
             for _ in range(20):
@@ -450,6 +472,24 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             response = process_query(
                 team=self.team,
                 query_json={"kind": "EventsQuery", "select": ["event"], "where": [f"distinct_id = '{random_uuid}'"]},
+            )
+
+        self.assertEqual(len(response.get("results", [])), 10)
+
+    @patch("posthog.hogql.constants.DEFAULT_RETURNED_ROWS", 10)
+    @patch("posthog.hogql.constants.MAX_SELECT_RETURNED_ROWS", 15)
+    def test_full_events_query_limit_exported(self, MAX_SELECT_RETURNED_ROWS=15, DEFAULT_RETURNED_ROWS=10):
+        random_uuid = str(UUIDT())
+        with freeze_time("2020-01-10 12:00:00"):
+            for _ in range(20):
+                _create_event(team=self.team, event="sign up", distinct_id=random_uuid, properties={"key": "test_val1"})
+        flush_persons_and_events()
+
+        with freeze_time("2020-01-10 12:14:00"):
+            response = process_query(
+                team=self.team,
+                query_json={"kind": "EventsQuery", "select": ["event"], "where": [f"distinct_id = '{random_uuid}'"]},
+                in_export_context=True,
             )
 
         self.assertEqual(len(response.get("results", [])), 10)

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -492,7 +492,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 in_export_context=True,
             )
 
-        self.assertEqual(len(response.get("results", [])), 10)
+        self.assertEqual(len(response.get("results", [])), 15)
 
     def test_property_definition_annotation_does_not_break_things(self):
         PropertyDefinition.objects.create(team=self.team, name="$browser", property_type=PropertyType.String)

--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -20,7 +20,7 @@ RESERVED_KEYWORDS = KEYWORDS + ["team_id"]
 # Limit applied to SELECT statements without LIMIT clause when queried via the API
 DEFAULT_RETURNED_ROWS = 100
 # Max limit for all SELECT queries, and the default for CSV exports.
-MAX_SELECT_RETURNED_ROWS = 10000
+MAX_SELECT_RETURNED_ROWS = 10000  # sync with CSV_EXPORT_LIMIT
 
 
 # Settings applied at the SELECT level

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -27,7 +27,7 @@ def execute_hogql_query(
     workload: Workload = Workload.ONLINE,
     settings: Optional[HogQLGlobalSettings] = None,
     modifiers: Optional[HogQLQueryModifiers] = None,
-    default_limit: Optional[int] = None,
+    in_export_context: Optional[bool] = False,
     timings: Optional[HogQLTimings] = None,
     explain: Optional[bool] = False,
 ) -> HogQLQueryResponse:
@@ -61,15 +61,17 @@ def execute_hogql_query(
             select_query = replace_placeholders(select_query, placeholders)
 
     with timings.measure("max_limit"):
-        from posthog.hogql.constants import DEFAULT_RETURNED_ROWS
+        from posthog.hogql.constants import DEFAULT_RETURNED_ROWS, MAX_SELECT_RETURNED_ROWS
 
         select_queries = (
             select_query.select_queries if isinstance(select_query, ast.SelectUnionQuery) else [select_query]
         )
         for one_query in select_queries:
             if one_query.limit is None:
-                # One more "max" of MAX_SELECT_RETURNED_ROWS (100k) in applied in the query printer.
-                one_query.limit = ast.Constant(value=default_limit or DEFAULT_RETURNED_ROWS)
+                # One more "max" of MAX_SELECT_RETURNED_ROWS (10k) in applied in the query printer.
+                one_query.limit = ast.Constant(
+                    value=MAX_SELECT_RETURNED_ROWS if in_export_context else DEFAULT_RETURNED_ROWS
+                )
 
     # Get printed HogQL query, and returned columns. Using a cloned query.
     with timings.measure("hogql"):

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -43,14 +43,13 @@ class EventsQueryRunner(QueryRunner):
         query: EventsQuery | Dict[str, Any],
         team: Team,
         timings: Optional[HogQLTimings] = None,
-        default_limit: Optional[int] = None,
+        in_export_context: Optional[bool] = False,
     ):
-        super().__init__(query, team, timings)
+        super().__init__(query, team, timings, in_export_context)
         if isinstance(query, EventsQuery):
             self.query = query
         else:
             self.query = EventsQuery.model_validate(query)
-        self.default_limit = default_limit
 
     def to_query(self) -> ast.SelectQuery:
         # Note: This code is inefficient and problematic, see https://github.com/PostHog/posthog/issues/13485 for details.
@@ -193,6 +192,7 @@ class EventsQueryRunner(QueryRunner):
             workload=Workload.ONLINE,
             query_type="EventsQuery",
             timings=self.timings,
+            in_export_context=self.in_export_context,
         )
 
         # Convert star field from tuple to dict in each result
@@ -267,7 +267,9 @@ class EventsQueryRunner(QueryRunner):
         return (
             min(
                 MAX_SELECT_RETURNED_ROWS,
-                self.default_limit or DEFAULT_RETURNED_ROWS if self.query.limit is None else self.query.limit,
+                (MAX_SELECT_RETURNED_ROWS if self.in_export_context else DEFAULT_RETURNED_ROWS)
+                if self.query.limit is None
+                else self.query.limit,
             )
             + 1
         )

--- a/posthog/hogql_queries/insights/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle_query_runner.py
@@ -27,7 +27,7 @@ class LifecycleQueryRunner(QueryRunner):
         query: LifecycleQuery | Dict[str, Any],
         team: Team,
         timings: Optional[HogQLTimings] = None,
-        in_export_context: Optional[int] = None,
+        in_export_context: Optional[bool] = False,
     ):
         super().__init__(query, team, timings, in_export_context)
 

--- a/posthog/hogql_queries/insights/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle_query_runner.py
@@ -22,8 +22,14 @@ class LifecycleQueryRunner(QueryRunner):
     query: LifecycleQuery
     query_type = LifecycleQuery
 
-    def __init__(self, query: LifecycleQuery | Dict[str, Any], team: Team, timings: Optional[HogQLTimings] = None):
-        super().__init__(query, team, timings)
+    def __init__(
+        self,
+        query: LifecycleQuery | Dict[str, Any],
+        team: Team,
+        timings: Optional[HogQLTimings] = None,
+        in_export_context: Optional[int] = None,
+    ):
+        super().__init__(query, team, timings, in_export_context)
 
     def to_query(self) -> ast.SelectQuery | ast.SelectUnionQuery:
         placeholders = {

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -28,8 +28,14 @@ class TrendsQueryRunner(QueryRunner):
     query_type = TrendsQuery
     series: List[SeriesWithExtras]
 
-    def __init__(self, query: TrendsQuery | Dict[str, Any], team: Team, timings: Optional[HogQLTimings] = None):
-        super().__init__(query, team, timings)
+    def __init__(
+        self,
+        query: TrendsQuery | Dict[str, Any],
+        team: Team,
+        timings: Optional[HogQLTimings] = None,
+        in_export_context: Optional[int] = None,
+    ):
+        super().__init__(query, team, timings, in_export_context)
         self.series = self.setup_series()
 
     def _is_stale(self, cached_result_package):

--- a/posthog/hogql_queries/persons_query_runner.py
+++ b/posthog/hogql_queries/persons_query_runner.py
@@ -19,8 +19,14 @@ class PersonsQueryRunner(QueryRunner):
     query: PersonsQuery
     query_type = PersonsQuery
 
-    def __init__(self, query: PersonsQuery | Dict[str, Any], team: Team, timings: Optional[HogQLTimings] = None):
-        super().__init__(query, team, timings)
+    def __init__(
+        self,
+        query: PersonsQuery | Dict[str, Any],
+        team: Team,
+        timings: Optional[HogQLTimings] = None,
+        in_export_context: Optional[int] = None,
+    ):
+        super().__init__(query=query, team=team, timings=timings, in_export_context=in_export_context)
         if isinstance(query, PersonsQuery):
             self.query = query
         else:

--- a/posthog/hogql_queries/persons_query_runner.py
+++ b/posthog/hogql_queries/persons_query_runner.py
@@ -24,7 +24,7 @@ class PersonsQueryRunner(QueryRunner):
         query: PersonsQuery | Dict[str, Any],
         team: Team,
         timings: Optional[HogQLTimings] = None,
-        in_export_context: Optional[int] = None,
+        in_export_context: Optional[bool] = False,
     ):
         super().__init__(query=query, team=team, timings=timings, in_export_context=in_export_context)
         if isinstance(query, PersonsQuery):

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -150,7 +150,7 @@ class QueryRunner(ABC):
         query: RunnableQueryNode | Dict[str, Any],
         team: Team,
         timings: Optional[HogQLTimings] = None,
-        in_export_context: Optional[int] = None,
+        in_export_context: Optional[bool] = False,
     ):
         self.team = team
         self.timings = timings or HogQLTimings()

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -78,7 +78,7 @@ def get_query_runner(
     query: Dict[str, Any] | RunnableQueryNode,
     team: Team,
     timings: Optional[HogQLTimings] = None,
-    default_limit: Optional[int] = None,
+    in_export_context: Optional[bool] = False,
 ) -> "QueryRunner":
     kind = None
     if isinstance(query, dict):
@@ -89,21 +89,39 @@ def get_query_runner(
     if kind == "LifecycleQuery":
         from .insights.lifecycle_query_runner import LifecycleQueryRunner
 
-        return LifecycleQueryRunner(query=cast(LifecycleQuery | Dict[str, Any], query), team=team, timings=timings)
+        return LifecycleQueryRunner(
+            query=cast(LifecycleQuery | Dict[str, Any], query),
+            team=team,
+            timings=timings,
+            in_export_context=in_export_context,
+        )
     if kind == "TrendsQuery":
         from .insights.trends.trends_query_runner import TrendsQueryRunner
 
-        return TrendsQueryRunner(query=cast(TrendsQuery | Dict[str, Any], query), team=team, timings=timings)
+        return TrendsQueryRunner(
+            query=cast(TrendsQuery | Dict[str, Any], query),
+            team=team,
+            timings=timings,
+            in_export_context=in_export_context,
+        )
     if kind == "EventsQuery":
         from .events_query_runner import EventsQueryRunner
 
         return EventsQueryRunner(
-            query=cast(EventsQuery | Dict[str, Any], query), team=team, timings=timings, default_limit=default_limit
+            query=cast(EventsQuery | Dict[str, Any], query),
+            team=team,
+            timings=timings,
+            in_export_context=in_export_context,
         )
     if kind == "PersonsQuery":
         from .persons_query_runner import PersonsQueryRunner
 
-        return PersonsQueryRunner(query=cast(PersonsQuery | Dict[str, Any], query), team=team, timings=timings)
+        return PersonsQueryRunner(
+            query=cast(PersonsQuery | Dict[str, Any], query),
+            team=team,
+            timings=timings,
+            in_export_context=in_export_context,
+        )
     if kind == "WebOverviewStatsQuery":
         from .web_analytics.overview_stats import WebOverviewStatsQueryRunner
 
@@ -125,10 +143,18 @@ class QueryRunner(ABC):
     query_type: Type[RunnableQueryNode]
     team: Team
     timings: HogQLTimings
+    in_export_context: bool
 
-    def __init__(self, query: RunnableQueryNode | Dict[str, Any], team: Team, timings: Optional[HogQLTimings] = None):
+    def __init__(
+        self,
+        query: RunnableQueryNode | Dict[str, Any],
+        team: Team,
+        timings: Optional[HogQLTimings] = None,
+        in_export_context: Optional[int] = None,
+    ):
         self.team = team
         self.timings = timings or HogQLTimings()
+        self.in_export_context = in_export_context or False
         if isinstance(query, self.query_type):
             self.query = query  # type: ignore
         else:
@@ -141,7 +167,7 @@ class QueryRunner(ABC):
         raise NotImplementedError()
 
     def run(self, refresh_requested: Optional[bool] = None) -> CachedQueryResponse:
-        cache_key = self._cache_key()
+        cache_key = self._cache_key() + ("_export" if self.in_export_context else "")
         tag_queries(cache_key=cache_key)
 
         if not refresh_requested:

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -47,8 +47,7 @@ def export_asset(exported_asset_id: int, limit: Optional[int] = None) -> None:
 
     is_csv_export = exported_asset.export_format == ExportedAsset.ExportFormat.CSV
     if is_csv_export:
-        max_limit = exported_asset.export_context.get("max_limit", 10000)
-        csv_exporter.export_csv(exported_asset, limit=limit, max_limit=max_limit)
+        csv_exporter.export_csv(exported_asset, limit=limit)
         EXPORT_QUEUED_COUNTER.labels(type="csv").inc()
     else:
         image_exporter.export_image(exported_asset)

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -168,16 +168,11 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
     resource = exported_asset.export_context
 
     columns: List[str] = resource.get("columns", [])
-
     all_csv_rows: List[Any] = []
 
     if resource.get("source"):
-        from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS
-
         query = resource.get("source")
-        query_response = process_query(
-            team=exported_asset.team, query_json=query, default_limit=MAX_SELECT_RETURNED_ROWS
-        )
+        query_response = process_query(team=exported_asset.team, query_json=query, in_export_context=True)
         all_csv_rows = _convert_response_to_csv_data(query_response)
 
     else:

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -280,8 +280,9 @@ class TestCSVExporter(APIBaseTest):
             csv_exporter.export_csv(self._create_asset())
 
     @patch("posthog.hogql.constants.MAX_SELECT_RETURNED_ROWS", 10)
+    @patch("posthog.hogql.constants.DEFAULT_RETURNED_ROWS", 5)
     @patch("posthog.models.exported_asset.UUIDT")
-    def test_csv_exporter_hogql_query(self, mocked_uuidt, MAX_SELECT_RETURNED_ROWS=10) -> None:
+    def test_csv_exporter_hogql_query(self, mocked_uuidt, DEFAULT_RETURNED_ROWS=5, MAX_SELECT_RETURNED_ROWS=10) -> None:
         random_uuid = str(UUIDT())
         for i in range(15):
             _create_event(


### PR DESCRIPTION
## Problem

After a recent refactor, the csv export limit got dropped to 100.

## Changes

- Fixes this regression.
- Shows the "export all columns" export option only when it makes sense: events query with a `*` column, or old persons API.
- Removes the ambiguous `default_limit` that was passed between queries, and introduces `self.in_export_context` into the query runners, letting them pick the limits as needed.
- Removes the `max_limit` that you could set on the frontend, but never did.
- Now it's very simple: each query runner knows if it's in an export context, and updates the default limit accordingly.

## How did you test this code?

Manually for now.

## Coming up in the next PR:

The ability to boost the export limits per team and/or per query type.