### PR TITLE
fix(surveys): see multiple question surveys in overview

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -12,7 +12,6 @@ import { surveyLogic } from './surveyLogic'
 import { surveysLogic } from './surveysLogic'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SurveyReleaseSummary } from './Survey'
-import { SurveyAppearance } from './SurveyAppearance'
 import {
     PropertyFilterType,
     PropertyOperator,
@@ -25,7 +24,7 @@ import {
 import { SurveyAPIEditor } from './SurveyAPIEditor'
 import { NodeKind } from '~/queries/schema'
 import { dayjs } from 'lib/dayjs'
-import { defaultSurveyAppearance, SURVEY_EVENT_NAME } from './constants'
+import { SURVEY_EVENT_NAME } from './constants'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import {
@@ -36,6 +35,7 @@ import {
     OpenTextViz,
 } from './surveyViewViz'
 import './SurveyView.scss'
+import { SurveyFormAppearance } from './SurveyFormAppearance'
 
 export function SurveyView({ id }: { id: string }): JSX.Element {
     const { survey, surveyLoading } = useValues(surveyLogic)
@@ -44,6 +44,8 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
     const { deleteSurvey } = useActions(surveysLogic)
 
     const [tabKey, setTabKey] = useState(survey.start_date ? 'results' : 'overview')
+    const [activePreview, setActivePreview] = useState(0)
+
     useEffect(() => {
         if (survey.start_date) {
             setTabKey('results')
@@ -221,17 +223,16 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                                             )}
                                             {survey.type !== SurveyType.API ? (
                                                 <div className="mt-6">
-                                                    <SurveyAppearance
-                                                        type={survey.questions[0].type}
-                                                        surveyQuestionItem={survey.questions[0]}
-                                                        appearance={survey.appearance || defaultSurveyAppearance}
-                                                        question={survey.questions[0].question}
-                                                        description={survey.questions[0].description}
-                                                        link={
-                                                            survey.questions[0].type === SurveyQuestionType.Link
-                                                                ? survey.questions[0].link
-                                                                : undefined
+                                                    <SurveyFormAppearance
+                                                        activePreview={activePreview}
+                                                        survey={survey}
+                                                        showThankYou={
+                                                            !!(
+                                                                survey.appearance.displayThankYouMessage &&
+                                                                activePreview >= survey.questions.length
+                                                            )
                                                         }
+                                                        setActivePreview={(preview) => setActivePreview(preview)}
                                                     />
                                                 </div>
                                             ) : (


### PR DESCRIPTION
## Problem

Previously were unable to view the different questions in a survey on the overview tab

## Changes

<img width="1083" alt="Screen Shot 2023-10-17 at 2 53 46 PM" src="https://github.com/PostHog/posthog/assets/25164963/d09c8fc6-46a6-416b-b6ab-cfc82083524b">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
