### PR TITLE
fix: allow select dropdown item width to match content

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -157,6 +157,7 @@ export function PropertyValue({
                 selectClassName={clsx(className, 'property-filters-property-value', 'w-full')}
                 value={formattedValues}
                 mode="multiple-custom"
+                matchWidth={false}
                 onChange={(nextVal: string[]) => {
                     setValue(nextVal)
                 }}

--- a/frontend/src/lib/lemon-ui/LemonSelectMultiple/LemonSelectMultiple.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSelectMultiple/LemonSelectMultiple.tsx
@@ -19,6 +19,7 @@ export interface LemonSelectMultipleOptionItem extends LemonSelectMultipleOption
 export type LemonSelectMultipleOptions = Record<string, LemonSelectMultipleOption>
 
 export type LemonSelectMultipleProps = {
+    matchWidth?: boolean
     selectClassName?: string
     options?: LemonSelectMultipleOptions | LemonSelectMultipleOptionItem[]
     value?: string | string[] | null
@@ -51,6 +52,7 @@ export function LemonSelectMultiple({
     filterOption = true,
     mode = 'single',
     selectClassName,
+    matchWidth = true,
     ...props
 }: LemonSelectMultipleProps): JSX.Element {
     const optionsAsList: LemonSelectMultipleOptionItem[] = Array.isArray(options)
@@ -114,6 +116,7 @@ export function LemonSelectMultiple({
                 }
                 filterOption={filterOption}
                 tagRender={({ label, onClose }) => <LemonSnack onClose={onClose}>{label}</LemonSnack>}
+                dropdownMatchSelectWidth={matchWidth}
             />
         </div>
     )


### PR DESCRIPTION
## Problem

#17425 

## Changes

add `matchWidth` property (`dropdownMatchSelectWidth` in antd) and set default to `true` (previous behavior), when set to `false` dropdown now shows full content

<img width="1624" alt="Screenshot 2023-10-17 at 19 27 38" src="https://github.com/PostHog/posthog/assets/31130737/e0f9f888-281f-47a2-87e0-439849d5f9b3">

## How did you test this code?

manually, content was no longer truncated/hidden
