### PR TITLE
feat(insights): edit as sql

### DIFF
--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -137,10 +137,10 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                 }
                 buttons={
                     <div className="flex justify-between items-center gap-2">
-                        {hasDashboardItemId && (
-                            <>
-                                <More
-                                    overlay={
+                        <More
+                            overlay={
+                                <>
+                                    {hasDashboardItemId && (
                                         <>
                                             <LemonButton
                                                 status="stealth"
@@ -181,80 +181,78 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                             >
                                                 Share or embed
                                             </LemonButton>
-                                            {insight.short_id && (
-                                                <>
-                                                    <SubscribeButton insightShortId={insight.short_id} />
-                                                    {exporterResourceParams ? (
-                                                        <ExportButton
-                                                            fullWidth
-                                                            items={[
-                                                                {
-                                                                    export_format: ExporterFormat.PNG,
-                                                                    insight: insight.id,
-                                                                },
-                                                                {
-                                                                    export_format: ExporterFormat.CSV,
-                                                                    export_context: exporterResourceParams,
-                                                                },
-                                                            ]}
-                                                        />
-                                                    ) : null}
-                                                    {isInsightVizNode(query) ? (
-                                                        <LemonButton
-                                                            data-attr={`${
-                                                                showQueryEditor ? 'hide' : 'show'
-                                                            }-insight-source`}
-                                                            status="stealth"
-                                                            onClick={() => {
-                                                                // for an existing insight in view mode
-                                                                if (
-                                                                    hasDashboardItemId &&
-                                                                    insightMode !== ItemMode.Edit
-                                                                ) {
-                                                                    // enter edit mode
-                                                                    setInsightMode(ItemMode.Edit, null)
+                                        </>
+                                    )}
+                                    {insight.short_id && (
+                                        <>
+                                            <SubscribeButton insightShortId={insight.short_id} />
+                                            {exporterResourceParams ? (
+                                                <ExportButton
+                                                    fullWidth
+                                                    items={[
+                                                        {
+                                                            export_format: ExporterFormat.PNG,
+                                                            insight: insight.id,
+                                                        },
+                                                        {
+                                                            export_format: ExporterFormat.CSV,
+                                                            export_context: exporterResourceParams,
+                                                        },
+                                                    ]}
+                                                />
+                                            ) : null}
+                                        </>
+                                    )}
+                                    {isInsightVizNode(query) ? (
+                                        <LemonButton
+                                            data-attr={`${showQueryEditor ? 'hide' : 'show'}-insight-source`}
+                                            status="stealth"
+                                            onClick={() => {
+                                                // for an existing insight in view mode
+                                                if (hasDashboardItemId && insightMode !== ItemMode.Edit) {
+                                                    // enter edit mode
+                                                    setInsightMode(ItemMode.Edit, null)
 
-                                                                    // exit early if query editor doesn't need to be toggled
-                                                                    if (showQueryEditor !== false) {
-                                                                        return
-                                                                    }
-                                                                }
-                                                                toggleQueryEditorPanel()
-                                                            }}
-                                                            fullWidth
-                                                        >
-                                                            {showQueryEditor ? 'Hide source' : 'View source'}
-                                                        </LemonButton>
-                                                    ) : null}
-                                                    {hogQL && (
-                                                        <LemonButton
-                                                            data-attr={`edit-insight-sql`}
-                                                            status="stealth"
-                                                            onClick={() => {
-                                                                router.actions.push(
-                                                                    urls.insightNew(
-                                                                        undefined,
-                                                                        undefined,
-                                                                        JSON.stringify({
-                                                                            kind: NodeKind.DataTableNode,
-                                                                            source: {
-                                                                                kind: NodeKind.HogQLQuery,
-                                                                                query: hogQL,
-                                                                            },
-                                                                            full: true,
-                                                                        } as DataTableNode)
-                                                                    )
-                                                                )
-                                                            }}
-                                                            fullWidth
-                                                        >
-                                                            Edit SQL directly
-                                                        </LemonButton>
-                                                    )}
-                                                    <LemonDivider />
-                                                </>
-                                            )}
-
+                                                    // exit early if query editor doesn't need to be toggled
+                                                    if (showQueryEditor !== false) {
+                                                        return
+                                                    }
+                                                }
+                                                toggleQueryEditorPanel()
+                                            }}
+                                            fullWidth
+                                        >
+                                            {showQueryEditor ? 'Hide source' : 'View source'}
+                                        </LemonButton>
+                                    ) : null}
+                                    {hogQL && (
+                                        <LemonButton
+                                            data-attr={`edit-insight-sql`}
+                                            status="stealth"
+                                            onClick={() => {
+                                                router.actions.push(
+                                                    urls.insightNew(
+                                                        undefined,
+                                                        undefined,
+                                                        JSON.stringify({
+                                                            kind: NodeKind.DataTableNode,
+                                                            source: {
+                                                                kind: NodeKind.HogQLQuery,
+                                                                query: hogQL,
+                                                            },
+                                                            full: true,
+                                                        } as DataTableNode)
+                                                    )
+                                                )
+                                            }}
+                                            fullWidth
+                                        >
+                                            Edit SQL directly
+                                        </LemonButton>
+                                    )}
+                                    {hasDashboardItemId && (
+                                        <>
+                                            <LemonDivider />
                                             <LemonButton
                                                 status="danger"
                                                 onClick={() =>
@@ -272,11 +270,11 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                 Delete insight
                                             </LemonButton>
                                         </>
-                                    }
-                                />
-                                <LemonDivider vertical />
-                            </>
-                        )}
+                                    )}
+                                </>
+                            }
+                        />
+                        <LemonDivider vertical />
 
                         {insightMode === ItemMode.Edit && hasDashboardItemId && (
                             <LemonButton type="secondary" onClick={() => setInsightMode(ItemMode.View, null)}>

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -68,11 +68,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
 
     // insightDataLogic
     const { query, queryChanged, showQueryEditor, hogQL } = useValues(insightDataLogic(insightProps))
-    const {
-        saveInsight: saveQueryBasedInsight,
-        toggleQueryEditorPanel,
-        setQuery,
-    } = useActions(insightDataLogic(insightProps))
+    const { saveInsight: saveQueryBasedInsight, toggleQueryEditorPanel } = useActions(insightDataLogic(insightProps))
 
     // other logics
     useMountedLogic(insightCommandLogic(insightProps))
@@ -235,15 +231,20 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                             data-attr={`edit-insight-sql`}
                                                             status="stealth"
                                                             onClick={() => {
-                                                                setQuery({
-                                                                    kind: NodeKind.DataTableNode,
-                                                                    source: {
-                                                                        kind: NodeKind.HogQLQuery,
-                                                                        query: hogQL,
-                                                                    },
-                                                                    full: true,
-                                                                } as DataTableNode)
-                                                                setInsightMode(ItemMode.Edit, null)
+                                                                router.actions.push(
+                                                                    urls.insightNew(
+                                                                        undefined,
+                                                                        undefined,
+                                                                        JSON.stringify({
+                                                                            kind: NodeKind.DataTableNode,
+                                                                            source: {
+                                                                                kind: NodeKind.HogQLQuery,
+                                                                                query: hogQL,
+                                                                            },
+                                                                            full: true,
+                                                                        } as DataTableNode)
+                                                                    )
+                                                                )
                                                             }}
                                                             fullWidth
                                                         >

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -42,7 +42,7 @@ import { AddToDashboardModal } from 'lib/components/AddToDashboard/AddToDashboar
 import { useState } from 'react'
 import { NewDashboardModal } from 'scenes/dashboard/NewDashboardModal'
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
-import { NodeKind } from '~/queries/schema'
+import { DataTableNode, NodeKind } from '~/queries/schema'
 
 export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: InsightLogicProps }): JSX.Element {
     // insightSceneLogic
@@ -67,8 +67,12 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     const { duplicateInsight, loadInsights } = useActions(savedInsightsLogic)
 
     // insightDataLogic
-    const { query, queryChanged, showQueryEditor } = useValues(insightDataLogic(insightProps))
-    const { saveInsight: saveQueryBasedInsight, toggleQueryEditorPanel } = useActions(insightDataLogic(insightProps))
+    const { query, queryChanged, showQueryEditor, hogQL } = useValues(insightDataLogic(insightProps))
+    const {
+        saveInsight: saveQueryBasedInsight,
+        toggleQueryEditorPanel,
+        setQuery,
+    } = useActions(insightDataLogic(insightProps))
 
     // other logics
     useMountedLogic(insightCommandLogic(insightProps))
@@ -226,6 +230,26 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                             {showQueryEditor ? 'Hide source' : 'View source'}
                                                         </LemonButton>
                                                     ) : null}
+                                                    {hogQL && (
+                                                        <LemonButton
+                                                            data-attr={`edit-insight-sql`}
+                                                            status="stealth"
+                                                            onClick={() => {
+                                                                setQuery({
+                                                                    kind: NodeKind.DataTableNode,
+                                                                    source: {
+                                                                        kind: NodeKind.HogQLQuery,
+                                                                        query: hogQL,
+                                                                    },
+                                                                    full: true,
+                                                                } as DataTableNode)
+                                                                setInsightMode(ItemMode.Edit, null)
+                                                            }}
+                                                            fullWidth
+                                                        >
+                                                            Edit SQL directly
+                                                        </LemonButton>
+                                                    )}
                                                     <LemonDivider />
                                                 </>
                                             )}

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -155,6 +155,16 @@ export const insightDataLogic = kea<insightDataLogicType>([
                 return { ...insightDataRaw, result: insightDataRaw?.results ?? insightDataRaw?.result }
             },
         ],
+
+        hogQL: [
+            (s) => [s.insightData],
+            (insightData): string | null => {
+                if (insightData && 'hogql' in insightData && insightData.hogql !== '') {
+                    return insightData.hogql
+                }
+                return null
+            },
+        ],
     }),
 
     listeners(({ actions, values }) => ({

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -33,7 +33,7 @@ from posthog.hogql.functions.mapping import validate_function_args
 from posthog.hogql.resolver import ResolverException, lookup_field_by_name, resolve_types
 from posthog.hogql.transforms.lazy_tables import resolve_lazy_tables
 from posthog.hogql.transforms.property_types import resolve_property_types
-from posthog.hogql.visitor import Visitor
+from posthog.hogql.visitor import Visitor, clone_expr
 from posthog.models.property import PropertyName, TableColumn
 from posthog.models.team.team import WeekStartDay
 from posthog.models.utils import UUIDT
@@ -50,6 +50,13 @@ def team_id_guard_for_table(table_type: Union[ast.TableType, ast.TableAliasType]
         left=ast.Field(chain=["team_id"], type=ast.FieldType(name="team_id", table_type=table_type)),
         right=ast.Constant(value=context.team_id),
         type=ast.BooleanType(),
+    )
+
+
+def to_printed_hogql(query: ast.Expr, team_id: int) -> str:
+    """Prints the HogQL query without mutating the node"""
+    return print_ast(
+        clone_expr(query), dialect="hogql", context=HogQLContext(team_id=team_id, enable_select_queries=True)
     )
 
 

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -10,7 +10,7 @@ from posthog.hogql.database.models import DateDatabaseField
 from posthog.hogql.errors import HogQLException
 from posthog.hogql.hogql import translate_hogql
 from posthog.hogql.parser import parse_select
-from posthog.hogql.printer import print_ast
+from posthog.hogql.printer import print_ast, to_printed_hogql
 from posthog.models.team.team import WeekStartDay
 from posthog.schema import HogQLQueryModifiers, PersonsArgMaxVersion
 from posthog.test.base import BaseTest
@@ -49,6 +49,11 @@ class TestPrinter(BaseTest):
         if expected_error not in str(context.exception):
             raise AssertionError(f"Expected '{expected_error}' in '{str(context.exception)}'")
         self.assertTrue(expected_error in str(context.exception))
+
+    def test_to_printed_hogql(self):
+        expr = parse_select("select 1 + 2, 3 from events")
+        repsponse = to_printed_hogql(expr, self.team.pk)
+        self.assertEqual(repsponse, "SELECT plus(1, 2), 3 FROM events LIMIT 10000")
 
     def test_literals(self):
         self.assertEqual(self._expr("1 + 2"), "plus(1, 2)")

--- a/posthog/hogql_queries/insights/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle_query_runner.py
@@ -8,6 +8,7 @@ from posthog.caching.utils import is_stale
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr, parse_select
+from posthog.hogql.printer import to_printed_hogql
 from posthog.hogql.property import property_to_expr, action_to_expr
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.timings import HogQLTimings
@@ -92,9 +93,12 @@ class LifecycleQueryRunner(QueryRunner):
             )
 
     def calculate(self):
+        query = self.to_query()
+        hogql = to_printed_hogql(query, self.team.pk)
+
         response = execute_hogql_query(
             query_type="LifecycleQuery",
-            query=self.to_query(),
+            query=query,
             team=self.team,
             timings=self.timings,
         )
@@ -130,7 +134,7 @@ class LifecycleQueryRunner(QueryRunner):
                 }
             )
 
-        return LifecycleQueryResponse(results=res, timings=response.timings)
+        return LifecycleQueryResponse(results=res, timings=response.timings, hogql=hogql)
 
     @cached_property
     def query_date_range(self):


### PR DESCRIPTION
## Problem

The lifecycle insight is missing the "edit as sql" button change from [this large PR](https://github.com/PostHog/posthog/pull/17470).

## Changes

![2023-10-18 11 45 50](https://github.com/PostHog/posthog/assets/53387/5c7d0675-c3be-41b2-ab54-a358b6297c44)


* The unsaved "new insight" view now also gets a "..." menu, which exposes the "view source" / "hide source" button.
* Adds a "Edit SQL directly" option to the menu, in case the insight's response contains a `hogql` field.
* The flow for opening a new insight is a bit ugh, but I'd like to save it for a follow up PR. The ugh: this works on the "edit insight" or "show insight" pages, but is only ugh on the "new insight" page. When you click "edit sql directly", some logic mess is causing the "lifecycle" tab to remain open. I'm opening the canonical new insight URL, but it's not working as intended. Related: we should talk about putting the query inside the URL's hash params, as the back button otherwise won't really take you back to the previous insight... as the URLs are the same. 
* Note: this works if you click "edit sql" on a saved insight.
* Note 2: the lifecycle insight is feature flagged, so nothing is public now anyway.

## How did you test this code?

Clicked around in the interface.