### PR TITLE
feat: added session duration as a breakdown option

### DIFF
--- a/posthog/hogql/database/schema/events.py
+++ b/posthog/hogql/database/schema/events.py
@@ -63,6 +63,7 @@ class EventsTable(Table):
         "distinct_id": StringDatabaseField(name="distinct_id"),
         "elements_chain": StringDatabaseField(name="elements_chain"),
         "created_at": DateTimeDatabaseField(name="created_at"),
+        "$session_id": StringDatabaseField(name="$session_id"),
         # Lazy table that adds a join to the persons table
         "pdi": LazyJoin(
             from_field="distinct_id",

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -31,6 +31,10 @@
               "type": "datetime"
           },
           {
+              "key": "$session_id",
+              "type": "string"
+          },
+          {
               "key": "pdi",
               "type": "lazy_table",
               "table": "person_distinct_ids",
@@ -811,6 +815,10 @@
           {
               "key": "created_at",
               "type": "datetime"
+          },
+          {
+              "key": "$session_id",
+              "type": "string"
           },
           {
               "key": "pdi",

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -779,6 +779,7 @@ class TestResolver(BaseTest):
                     chain=["elements_chain"], type=ast.FieldType(name="elements_chain", table_type=events_table_type)
                 ),
                 ast.Field(chain=["created_at"], type=ast.FieldType(name="created_at", table_type=events_table_type)),
+                ast.Field(chain=["$session_id"], type=ast.FieldType(name="$session_id", table_type=events_table_type)),
                 ast.Field(chain=["$group_0"], type=ast.FieldType(name="$group_0", table_type=events_table_type)),
                 ast.Field(chain=["$group_1"], type=ast.FieldType(name="$group_1", table_type=events_table_type)),
                 ast.Field(chain=["$group_2"], type=ast.FieldType(name="$group_2", table_type=events_table_type)),
@@ -815,6 +816,9 @@ class TestResolver(BaseTest):
                 ),
                 ast.Field(
                     chain=["created_at"], type=ast.FieldType(name="created_at", table_type=events_table_alias_type)
+                ),
+                ast.Field(
+                    chain=["$session_id"], type=ast.FieldType(name="$session_id", table_type=events_table_alias_type)
                 ),
                 ast.Field(chain=["$group_0"], type=ast.FieldType(name="$group_0", table_type=events_table_alias_type)),
                 ast.Field(chain=["$group_1"], type=ast.FieldType(name="$group_1", table_type=events_table_alias_type)),
@@ -892,6 +896,7 @@ class TestResolver(BaseTest):
                 "distinct_id": ast.FieldType(name="distinct_id", table_type=events_table_type),
                 "elements_chain": ast.FieldType(name="elements_chain", table_type=events_table_type),
                 "created_at": ast.FieldType(name="created_at", table_type=events_table_type),
+                "$session_id": ast.FieldType(name="$session_id", table_type=events_table_type),
                 "$group_0": ast.FieldType(name="$group_0", table_type=events_table_type),
                 "$group_1": ast.FieldType(name="$group_1", table_type=events_table_type),
                 "$group_2": ast.FieldType(name="$group_2", table_type=events_table_type),
@@ -913,6 +918,7 @@ class TestResolver(BaseTest):
                     type=ast.FieldType(name="elements_chain", table_type=inner_select_type),
                 ),
                 ast.Field(chain=["created_at"], type=ast.FieldType(name="created_at", table_type=inner_select_type)),
+                ast.Field(chain=["$session_id"], type=ast.FieldType(name="$session_id", table_type=inner_select_type)),
                 ast.Field(chain=["$group_0"], type=ast.FieldType(name="$group_0", table_type=inner_select_type)),
                 ast.Field(chain=["$group_1"], type=ast.FieldType(name="$group_1", table_type=inner_select_type)),
                 ast.Field(chain=["$group_2"], type=ast.FieldType(name="$group_2", table_type=inner_select_type)),
@@ -950,6 +956,7 @@ class TestResolver(BaseTest):
                         "distinct_id": ast.FieldType(name="distinct_id", table_type=events_table_type),
                         "elements_chain": ast.FieldType(name="elements_chain", table_type=events_table_type),
                         "created_at": ast.FieldType(name="created_at", table_type=events_table_type),
+                        "$session_id": ast.FieldType(name="$session_id", table_type=events_table_type),
                         "$group_0": ast.FieldType(name="$group_0", table_type=events_table_type),
                         "$group_1": ast.FieldType(name="$group_1", table_type=events_table_type),
                         "$group_2": ast.FieldType(name="$group_2", table_type=events_table_type),
@@ -974,6 +981,7 @@ class TestResolver(BaseTest):
                     type=ast.FieldType(name="elements_chain", table_type=inner_select_type),
                 ),
                 ast.Field(chain=["created_at"], type=ast.FieldType(name="created_at", table_type=inner_select_type)),
+                ast.Field(chain=["$session_id"], type=ast.FieldType(name="$session_id", table_type=inner_select_type)),
                 ast.Field(chain=["$group_0"], type=ast.FieldType(name="$group_0", table_type=inner_select_type)),
                 ast.Field(chain=["$group_1"], type=ast.FieldType(name="$group_1", table_type=inner_select_type)),
                 ast.Field(chain=["$group_2"], type=ast.FieldType(name="$group_2", table_type=inner_select_type)),

--- a/posthog/hogql_queries/insights/trends/breakdown_session.py
+++ b/posthog/hogql_queries/insights/trends/breakdown_session.py
@@ -1,0 +1,52 @@
+from typing import List
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+
+
+class BreakdownSession:
+    query_date_range: QueryDateRange
+
+    def __init__(self, query_date_range: QueryDateRange):
+        self.query_date_range = query_date_range
+
+    def session_inner_join(self) -> ast.JoinExpr:
+        join = ast.JoinExpr(
+            table=ast.Field(chain=["events"]),
+            alias="e",
+            next_join=ast.JoinExpr(
+                join_type="INNER JOIN",
+                alias="sessions",
+                table=self._session_select_query(),
+                constraint=ast.JoinConstraint(
+                    expr=ast.CompareOperation(
+                        left=ast.Field(chain=["sessions", "$session_id"]),
+                        op=ast.CompareOperationOp.Eq,
+                        right=ast.Field(chain=["e", "$session_id"]),
+                    )
+                ),
+            ),
+        )
+
+        return join
+
+    def session_duration_property_chain(self) -> List[str]:
+        return ["sessions", "session_duration"]
+
+    def session_duration_field(self) -> ast.Field:
+        return ast.Field(chain=self.session_duration_property_chain())
+
+    def _session_select_query(self) -> ast.SelectQuery:
+        return parse_select(
+            """
+                SELECT
+                    "$session_id", dateDiff('second', min(timestamp), max(timestamp)) as session_duration
+                FROM events
+                WHERE
+                    "$session_id" != '' AND
+                    timestamp >= {date_from} - INTERVAL 24 HOUR AND
+                    timestamp <= {date_to} + INTERVAL 24 HOUR
+                GROUP BY "$session_id"
+            """,
+            placeholders=self.query_date_range.to_placeholders(),
+        )

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -246,7 +246,11 @@ class TrendsQueryRunner(QueryRunner):
         return [new_result]
 
     def _is_breakdown_field_boolean(self):
-        if self.query.breakdown.breakdown_type == "hogql" or self.query.breakdown.breakdown_type == "cohort":
+        if (
+            self.query.breakdown.breakdown_type == "hogql"
+            or self.query.breakdown.breakdown_type == "cohort"
+            or self.query.breakdown.breakdown_type == "session"
+        ):
             return False
 
         if self.query.breakdown.breakdown_type == "person":
@@ -286,10 +290,10 @@ class TrendsQueryRunner(QueryRunner):
             "interval": self.query.interval,
         }
 
-        if self.query.breakdown is not None:
-            filter_dict.update(self.query.breakdown.__dict__)
-
         if self.query.trendsFilter is not None:
             filter_dict.update(self.query.trendsFilter.__dict__)
+
+        if self.query.breakdown is not None:
+            filter_dict.update(**self.query.breakdown.__dict__)
 
         return {k: v for k, v in filter_dict.items() if v is not None}


### PR DESCRIPTION
## Problem
- Continuation of https://github.com/PostHog/meta/issues/130 
- Adds support for breaking down trends queries by `session duration`

## Changes
- Requires an extra `join` to achieve this
- Looked at adding `$session_duration` as a lazy join on `events`, but, because we filter the subquery by date, it wouldn't work I think - but I may dig deeper into this and see, it would be a lot nicer letting HogQL take care of this for us

## How did you test this code?
Browser clicky clicks 🙃  