### PR TITLE
fix: spacing for "Addons" text on billing product screen 

### DIFF
--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -528,7 +528,7 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                     )}
                     {!isOnboarding && product.addons?.length > 0 && (
                         <div className="pb-8">
-                            <h4 className="mb-4">Addons</h4>
+                            <h4 className="my-4">Addons</h4>
                             <div className="gap-y-4 flex flex-col">
                                 {product.addons.map((addon, i) => {
                                     return <BillingProductAddon key={i} addon={addon} />


### PR DESCRIPTION
## Problem

non-symmetric spacing for `Addons` text on the Billing Screen

## Changes

Before: 

<img width="1624" alt="Screenshot 2023-10-18 at 07 41 07" src="https://github.com/PostHog/posthog/assets/31130737/0f5c5bc5-24f1-4f1a-b34c-df242321a648">

After:

<img width="1624" alt="Screenshot 2023-10-18 at 07 44 18" src="https://github.com/PostHog/posthog/assets/31130737/cff84bf2-5499-4211-b0fc-7fd678958101">

## How did you test this code?

👀