### PR TITLE
fix: only run benchmark workflow if running from upstream repo

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,7 @@ jobs:
         environment: clickhouse-benchmarks
 
         # Benchmarks are expensive to run so we only run them (periodically) against master branch and for PRs labeled `performance`
-        if: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'performance')  }}
+        if: ${{ github.repository == 'PostHog/posthog' && (github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'performance'))  }}
 
         env:
             DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'


### PR DESCRIPTION
Problem

When developing on a fork, the benchmark workflow is scheduled and fails on step `Check out PostHog/benchmarks-results repo`

Changes

added if: github.repository == 'posthog/posthog' to existing conditional

How did you test this code?

🤞