### PR TITLE
fix(surveys): bypass HogQL coercion + UI fixes

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -50,6 +50,14 @@ export function ensureTooltipElement(): HTMLElement {
     return tooltipEl
 }
 
+function truncateString(str: string, num: number): string {
+    if (str.length > num) {
+        return str.slice(0, num) + ' ...'
+    } else {
+        return str
+    }
+}
+
 export function onChartClick(
     event: ChartEvent,
     chart: Chart,
@@ -654,6 +662,13 @@ export function LineGraph_({
                     display: true,
                     beforeFit: (scale) => {
                         if (inSurveyView) {
+                            scale.ticks = scale.ticks.map((tick) => {
+                                if (typeof tick.label === 'string') {
+                                    return { ...tick, label: truncateString(tick.label, 50) }
+                                }
+                                return tick
+                            })
+
                             const ROW_HEIGHT = 60
                             const dynamicHeight = scale.ticks.length * ROW_HEIGHT
                             const height = dynamicHeight

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -408,6 +408,9 @@ export function LineGraph_({
                     },
                     display: (context) => {
                         const datum = context.dataset.data[context.dataIndex]
+                        if (showValueOnSeries && inSurveyView) {
+                            return true
+                        }
                         return showValueOnSeries === true && typeof datum === 'number' && datum !== 0 ? 'auto' : false
                     },
                     formatter: (value: number, context) => {
@@ -570,6 +573,9 @@ export function LineGraph_({
         }
 
         if (type === GraphType.Bar) {
+            if (hideXAxis || hideYAxis) {
+                options.layout = { padding: 20 }
+            }
             options.scales = {
                 x: {
                     display: !hideXAxis,
@@ -597,6 +603,9 @@ export function LineGraph_({
                 },
             }
         } else if (type === GraphType.Line) {
+            if (hideXAxis || hideYAxis) {
+                options.layout = { padding: 20 }
+            }
             options.scales = {
                 x: {
                     display: !hideXAxis,
@@ -624,6 +633,9 @@ export function LineGraph_({
                 },
             }
         } else if (isHorizontal) {
+            if (hideXAxis || hideYAxis) {
+                options.layout = { padding: 20 }
+            }
             options.scales = {
                 x: {
                     display: !hideXAxis,

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -592,8 +592,9 @@ export function LineGraph_({
                     ticks: {
                         ...tickOptions,
                         precision,
+                        ...(inSurveyView ? { padding: 10 } : {}),
                     },
-                    grid: gridOptions,
+                    grid: inSurveyView ? { display: false } : gridOptions,
                 },
                 y: {
                     display: !hideYAxis,

--- a/frontend/src/scenes/surveys/SurveyView.scss
+++ b/frontend/src/scenes/surveys/SurveyView.scss
@@ -3,6 +3,12 @@
     column-gap: 10px;
 }
 
+@media screen and (max-width: 1024px) {
+    .masonry-container {
+        column-count: 2;
+    }
+}
+
 .masonry-item {
     margin: 0;
     display: grid;

--- a/frontend/src/scenes/surveys/SurveyView.scss
+++ b/frontend/src/scenes/surveys/SurveyView.scss
@@ -16,7 +16,7 @@
 
 .masonry-item-text {
     max-height: 305px;
-    overflow: scroll;
+    overflow-y: scroll;
 }
 
 .masonry-item-link {

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -225,7 +225,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 const query: HogQLQuery = {
                     kind: NodeKind.HogQLQuery,
                     query: `
-                        SELECT properties.${surveyResponseField} AS survey_response, COUNT(survey_response)
+                        SELECT JSONExtractString(properties, '${surveyResponseField}') AS survey_response, COUNT(survey_response)
                         FROM events
                         WHERE event = 'survey sent' 
                             AND properties.$survey_id = '${props.id}'
@@ -266,7 +266,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 const query: HogQLQuery = {
                     kind: NodeKind.HogQLQuery,
                     query: `
-                        SELECT properties.${surveyResponseField} AS survey_response, COUNT(survey_response)
+                        SELECT JSONExtractString(properties, '${surveyResponseField}') AS survey_response, COUNT(survey_response)
                         FROM events
                         WHERE event = 'survey sent' 
                             AND properties.$survey_id = '${props.id}'
@@ -303,10 +303,13 @@ export const surveyLogic = kea<surveyLogicType>([
                     ? dayjs(survey.end_date).add(1, 'day').format('YYYY-MM-DD')
                     : dayjs().add(1, 'day').format('YYYY-MM-DD')
 
+                const surveyResponseField =
+                    questionIndex === 0 ? '$survey_response' : `$survey_response_${questionIndex}`
+
                 const query: HogQLQuery = {
                     kind: NodeKind.HogQLQuery,
                     query: `
-                        SELECT count(), arrayJoin(JSONExtractArrayRaw(properties, '$survey_response')) AS choice
+                        SELECT count(), arrayJoin(JSONExtractArrayRaw(properties, '${surveyResponseField}')) AS choice
                         FROM events
                         WHERE event == 'survey sent'
                             AND properties.$survey_id == '${survey.id}'

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -465,7 +465,7 @@ export function OpenTextViz({
                     <div className="mt-4 mb-8 masonry-container">
                         {surveyOpenTextResults[questionIndex].events.map((event, i) => (
                             <div key={`open-text-${questionIndex}-${i}`} className="masonry-item border rounded">
-                                <div className="masonry-item-text italic font-semibold px-5 py-4">
+                                <div className="masonry-item-text text-center italic font-semibold px-5 py-4">
                                     {event.properties[surveyResponseField]}
                                 </div>
                                 <div className="masonry-item-link items-center px-5 py-4 border-t rounded-b truncate w-full">

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -191,7 +191,7 @@ export function RatingQuestionBarChart({
                         question.scale === 10 ? '0 - 10' : '1 - 5'
                     } rating`}</div>
                     <div className="text-xl font-bold mb-2">{question.question}</div>
-                    <div className=" h-50 border rounded pt-6 pb-2 px-2">
+                    <div className=" h-50 border rounded pt-6 pb-2">
                         <div className="relative h-full w-full">
                             <BindLogic logic={insightLogic} props={insightProps}>
                                 <LineGraph

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -197,7 +197,6 @@ export function RatingQuestionBarChart({
                                 <LineGraph
                                     inSurveyView={true}
                                     hideYAxis={true}
-                                    hideXAxis={true}
                                     showValueOnSeries={true}
                                     labelGroupType={1}
                                     data-attr="survey-rating"


### PR DESCRIPTION
## Changes
- use JsonExtractString to prevent HogQL type coercion
- truncate multi-choice labels to 50 chars
- open text boxes - only allow y-scroll
- open text boxes - use 2 cols on smaller screens
- add data labels for 0-valued bars

<img width="955" alt="Screenshot 2023-10-18 at 14 41 00" src="https://github.com/PostHog/posthog/assets/22996112/8b0d8ca4-6d03-48b8-b9b2-0e1af5464659">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
Manually