### PR TITLE
feat(hogql): mixed PoE mode

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1244,7 +1244,7 @@
                     "type": "string"
                 },
                 "personsOnEventsMode": {
-                    "enum": ["disabled", "v1_enabled", "v2_enabled", "v1_mixed"],
+                    "enum": ["disabled", "v1_enabled", "v1_mixed", "v2_enabled"],
                     "type": "string"
                 }
             },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1244,7 +1244,7 @@
                     "type": "string"
                 },
                 "personsOnEventsMode": {
-                    "enum": ["disabled", "v1_enabled", "v2_enabled"],
+                    "enum": ["disabled", "v1_enabled", "v2_enabled", "v1_mixed"],
                     "type": "string"
                 }
             },

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -131,7 +131,7 @@ export interface DataNode extends Node {
 
 /** HogQL Query Options are automatically set per team. However, they can be overriden in the query. */
 export interface HogQLQueryModifiers {
-    personsOnEventsMode?: 'disabled' | 'v1_enabled' | 'v2_enabled'
+    personsOnEventsMode?: 'disabled' | 'v1_enabled' | 'v1_mixed' | 'v2_enabled'
     personsArgMaxVersion?: 'auto' | 'v1' | 'v2'
     inCohortVia?: 'leftjoin' | 'subquery'
 }

--- a/frontend/src/scenes/debug/HogQLDebug.tsx
+++ b/frontend/src/scenes/debug/HogQLDebug.tsx
@@ -37,6 +37,7 @@ export function HogQLDebug({ query, setQuery, queryKey }: HogQLDebugProps): JSX.
                             options={[
                                 { value: 'disabled', label: 'Disabled' },
                                 { value: 'v1_enabled', label: 'V1 Enabled' },
+                                { value: 'v1_mixed', label: 'V1 Mixed' },
                                 { value: 'v2_enabled', label: 'V2 Enabled' },
                             ]}
                             onChange={(value) =>

--- a/posthog/hogql/test/test_modifiers.py
+++ b/posthog/hogql/test/test_modifiers.py
@@ -1,10 +1,9 @@
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.query import execute_hogql_query
 from posthog.models import Cohort
-from posthog.schema import HogQLQueryModifiers
+from posthog.schema import HogQLQueryModifiers, PersonsOnEventsMode
 from posthog.test.base import BaseTest
 from django.test import override_settings
-from posthog.utils import PersonOnEventsMode
 
 
 class TestModifiers(BaseTest):
@@ -12,30 +11,70 @@ class TestModifiers(BaseTest):
     def test_create_default_modifiers_for_team_init(self):
         assert self.team.person_on_events_mode == "disabled"
         modifiers = create_default_modifiers_for_team(self.team)
-        assert modifiers.personsOnEventsMode == PersonOnEventsMode.DISABLED  # NB! not a None
+        assert modifiers.personsOnEventsMode == PersonsOnEventsMode.disabled  # NB! not a None
         modifiers = create_default_modifiers_for_team(
-            self.team, HogQLQueryModifiers(personsOnEventsMode=PersonOnEventsMode.V1_ENABLED)
+            self.team, HogQLQueryModifiers(personsOnEventsMode=PersonsOnEventsMode.v1_enabled)
         )
-        assert modifiers.personsOnEventsMode == PersonOnEventsMode.V1_ENABLED
+        assert modifiers.personsOnEventsMode == PersonsOnEventsMode.v1_enabled
         modifiers = create_default_modifiers_for_team(
-            self.team, HogQLQueryModifiers(personsOnEventsMode=PersonOnEventsMode.V2_ENABLED)
+            self.team, HogQLQueryModifiers(personsOnEventsMode=PersonsOnEventsMode.v2_enabled)
         )
-        assert modifiers.personsOnEventsMode == PersonOnEventsMode.V2_ENABLED
+        assert modifiers.personsOnEventsMode == PersonsOnEventsMode.v2_enabled
 
     def test_modifiers_persons_on_events_mode_v1_enabled(self):
         query = "SELECT event, person_id FROM events"
 
         # Control
         response = execute_hogql_query(
-            query, team=self.team, modifiers=HogQLQueryModifiers(personsOnEventsMode=PersonOnEventsMode.DISABLED)
+            query, team=self.team, modifiers=HogQLQueryModifiers(personsOnEventsMode=PersonsOnEventsMode.disabled)
         )
         assert " JOIN " in response.clickhouse
 
         # Test
         response = execute_hogql_query(
-            query, team=self.team, modifiers=HogQLQueryModifiers(personsOnEventsMode=PersonOnEventsMode.V1_ENABLED)
+            query, team=self.team, modifiers=HogQLQueryModifiers(personsOnEventsMode=PersonsOnEventsMode.v1_enabled)
         )
         assert " JOIN " not in response.clickhouse
+
+    def test_modifiers_persons_on_events_mode_mapping(self):
+        query = "SELECT event, person.id, person.properties, person.created_at FROM events"
+
+        test_cases = [
+            (
+                PersonsOnEventsMode.disabled,
+                "events.event",
+                "events__pdi__person.id",
+                "events__pdi__person.properties",
+                "toTimeZone(events__pdi__person.created_at, %(hogql_val_0)s)",
+            ),
+            (
+                PersonsOnEventsMode.v1_enabled,
+                "events.event",
+                "events.person_id",
+                "events.person_properties",
+                "toTimeZone(events.person_created_at, %(hogql_val_0)s)",
+            ),
+            (
+                PersonsOnEventsMode.v1_mixed,
+                "events.event",
+                "events__pdi.person_id",
+                "events.person_properties",
+                "toTimeZone(events__pdi__person.created_at, %(hogql_val_0)s)",
+            ),
+            (
+                PersonsOnEventsMode.v2_enabled,
+                "events.event",
+                "events.person_id",
+                "events.person_properties",
+                "toTimeZone(events.person_created_at, %(hogql_val_0)s)",
+            ),
+        ]
+
+        for (mode, *expected) in test_cases:
+            response = execute_hogql_query(
+                query, team=self.team, modifiers=HogQLQueryModifiers(personsOnEventsMode=mode)
+            )
+            assert f"SELECT {', '.join(expected)} FROM" in response.clickhouse, f"PoE mode: {mode}"
 
     def test_modifiers_persons_argmax_version_v2(self):
         query = "SELECT * FROM persons"

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -9,7 +9,13 @@ from freezegun import freeze_time
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import create_hogql_database
-from posthog.hogql.database.models import LazyJoin
+from posthog.hogql.database.models import (
+    LazyJoin,
+    FieldTraverser,
+    StringJSONDatabaseField,
+    StringDatabaseField,
+    DateTimeDatabaseField,
+)
 from posthog.hogql.visitor import clone_expr
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import print_ast
@@ -992,3 +998,29 @@ class TestResolver(BaseTest):
         self.assertEqual(lambda_type.parent, node.type)
         self.assertEqual(list(lambda_type.aliases.keys()), ["x"])
         self.assertEqual(list(lambda_type.parent.columns.keys()), ["timestamp"])
+
+    def test_field_traverser_double_dot(self):
+        # Create a condition where we want to ".." out of "events.poe." to get to a higher level prop
+        self.database.events.fields["person"] = FieldTraverser(chain=["poe"])
+        self.database.events.fields["poe"].fields["id"] = FieldTraverser(chain=["..", "pdi", "person_id"])
+        self.database.events.fields["poe"].fields["created_at"] = FieldTraverser(
+            chain=["..", "pdi", "person", "created_at"]
+        )
+        self.database.events.fields["poe"].fields["properties"] = StringJSONDatabaseField(name="person_properties")
+
+        node = self._select("SELECT event, person.id, person.properties, person.created_at FROM events")
+        node = cast(ast.SelectQuery, resolve_types(node, self.context))
+
+        # all columns resolve to a type in the end
+        assert cast(ast.FieldType, node.select[0].type).resolve_database_field() == StringDatabaseField(
+            name="event", array=None, nullable=None
+        )
+        assert cast(ast.FieldType, node.select[1].type).resolve_database_field() == StringDatabaseField(
+            name="person_id", array=None, nullable=None
+        )
+        assert cast(ast.FieldType, node.select[2].type).resolve_database_field() == StringJSONDatabaseField(
+            name="person_properties"
+        )
+        assert cast(ast.FieldType, node.select[3].type).resolve_database_field() == DateTimeDatabaseField(
+            name="created_at", array=None, nullable=None
+        )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -242,8 +242,8 @@ class PersonsArgMaxVersion(str, Enum):
 class PersonsOnEventsMode(str, Enum):
     disabled = "disabled"
     v1_enabled = "v1_enabled"
-    v2_enabled = "v2_enabled"
     v1_mixed = "v1_mixed"
+    v2_enabled = "v2_enabled"
 
 
 class HogQLQueryModifiers(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -243,6 +243,7 @@ class PersonsOnEventsMode(str, Enum):
     disabled = "disabled"
     v1_enabled = "v1_enabled"
     v2_enabled = "v2_enabled"
+    v1_mixed = "v1_mixed"
 
 
 class HogQLQueryModifiers(BaseModel):


### PR DESCRIPTION
## Problem

I've been told we can speed up queries that rely on ingestion-time person properties without the full PoE rollout, by just exposing `person_properties`. 

## Changes

Introduces a `v1_mixed` PoE mode, where properties are taken from the event, but the other fields come via joins. 

This only works on HogQL queries.

```python
query = "SELECT event, person.id, person.properties, person.created_at FROM events"

test_cases = [
    (
        PersonsOnEventsMode.disabled, # all joined
        "events.event",
        "events__pdi__person.id",
        "events__pdi__person.properties",
        "toTimeZone(events__pdi__person.created_at, %(hogql_val_0)s)",
    ),
    (
        PersonsOnEventsMode.v1_enabled, # all direct
        "events.event",
        "events.person_id",
        "events.person_properties",
        "toTimeZone(events.person_created_at, %(hogql_val_0)s)",
    ),
    (
        PersonsOnEventsMode.v1_mixed,  # properties direct
        "events.event",
        "events__pdi.person_id",
        "events.person_properties",
        "toTimeZone(events__pdi__person.created_at, %(hogql_val_0)s)",
    ),
]
```

<img width="1461" alt="image" src="https://github.com/PostHog/posthog/assets/53387/23d79a07-a14a-490a-8195-27892415c9d4">


## How did you test this code?

Added tests to document the new behaviour. It's disabled by default, but we could play with it under `/debug` and try if it makes a difference for real clients.