### PR TITLE
fix(plugin-server): wrap a few ingestion/consumer calls in simple ret…

### DIFF
--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -190,6 +190,12 @@ export const findOffsetsToCommit = (messages: TopicPartitionOffset[]): TopicPart
     return highestOffsets
 }
 
+/**
+ * Updates the offsets that will be committed on the next call to commit() (without offsets
+ * specified) or the next auto commit.
+ *
+ * This is a local (in-memory) operation and does not talk to the Kafka broker.
+ */
 export const storeOffsetsForMessages = (messages: Message[], consumer: RdKafkaConsumer) => {
     const topicPartitionOffsets = findOffsetsToCommit(messages).map((message) => {
         return {

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -4,6 +4,7 @@ import { Message, MessageHeader } from 'node-rdkafka'
 import { KAFKA_EVENTS_PLUGIN_INGESTION_DLQ, KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW } from '../../../config/kafka-topics'
 import { Hub, PipelineEvent } from '../../../types'
 import { formPipelineEvent } from '../../../utils/event'
+import { retryIfRetriable } from '../../../utils/retries'
 import { status } from '../../../utils/status'
 import { ConfiguredLimiter, LoggingLimiter, WarningLimiter } from '../../../utils/token-bucket'
 import { EventPipelineResult, runEventPipeline } from '../../../worker/ingestion/event-pipeline/runner'
@@ -98,10 +99,6 @@ export async function eachBatchParallelIngestion(
     queue: IngestionConsumer,
     overflowMode: IngestionOverflowMode
 ): Promise<void> {
-    async function eachMessage(event: PipelineEvent, queue: IngestionConsumer): Promise<IngestResult> {
-        return ingestEvent(queue.pluginsServer, event)
-    }
-
     const batchStartTimer = new Date()
     const metricKey = 'ingestion'
     const loggingKey = `each_batch_parallel_ingestion`
@@ -154,15 +151,17 @@ export async function eachBatchParallelIngestion(
                 // Process every message sequentially, stash promises to await on later
                 for (const { message, pluginEvent } of currentBatch) {
                     try {
-                        const result = await eachMessage(pluginEvent, queue)
+                        const result = (await retryIfRetriable(async () => {
+                            return await ingestEvent(queue.pluginsServer, pluginEvent)
+                        })) as IngestResult
 
-                        for (const promise of result.promises ?? []) {
+                        result.promises?.forEach((promise) =>
                             processingPromises.push(
                                 promise.catch(async (error) => {
                                     await handleProcessingError(error, message, pluginEvent, queue)
                                 })
                             )
-                        }
+                        )
                     } catch (error) {
                         await handleProcessingError(error, message, pluginEvent, queue)
                     }

--- a/plugin-server/src/utils/retries.ts
+++ b/plugin-server/src/utils/retries.ts
@@ -4,6 +4,7 @@ import { runInTransaction } from '../sentry'
 import { Hub } from '../types'
 import { status } from '../utils/status'
 import { AppMetricIdentifier, ErrorWithContext } from '../worker/ingestion/app-metrics'
+import { sleep } from './utils'
 
 // Simple retries in our code
 export const defaultRetryConfig = {
@@ -152,4 +153,26 @@ export async function runRetriableFunction(retriableFunctionPayload: RetriableFu
             hub.statsd?.timing(`${metricName}`, timer, metricTags)
         },
     })
+}
+
+/**
+ * Retry a function, respecting `error.isRetriable`.
+ */
+export async function retryIfRetriable<T>(fn: () => Promise<T>, retries = 3, sleepMs = 500): Promise<T> {
+    for (let i = 0; i < retries; i++) {
+        try {
+            return await fn()
+        } catch (error) {
+            if (error?.isRetriable === false || i === retries - 1) {
+                // Throw if the error is not retryable or if we're out of retries.
+                throw error
+            }
+
+            // Fall through, `fn` will retry after sleep.
+            await sleep(sleepMs)
+        }
+    }
+
+    // This should never happen, but TypeScript doesn't know that.
+    throw new Error('Unreachable error in retry')
 }

--- a/plugin-server/src/utils/utils.ts
+++ b/plugin-server/src/utils/utils.ts
@@ -606,3 +606,7 @@ export function getPropertyValueByPath(properties: Properties, [firstKey, ...nes
     }
     return value
 }
+
+export async function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
…ries

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We lack retries for analytics ingestion under rdkafka. We also don't retry on any rdkafka issue (which may be intermittent). 

## Changes

Add a simple `retryIfRetriable` helper that respects `error.isRetriable`.

Includes some minor code cleanup.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
