### PR TITLE
fix(plugin-server): consumer loop throwing trigger a shutdown

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node'
 import fs from 'fs'
 import { Server } from 'http'
+import { BatchConsumer } from 'kafka/batch-consumer'
 import { CompressionCodecs, CompressionTypes, Consumer, KafkaJSProtocolError } from 'kafkajs'
 // @ts-expect-error no type definitions
 import SnappyCodec from 'kafkajs-snappy'
@@ -99,10 +100,7 @@ export async function startPluginsServer(
     // (default 60 seconds) to allow for the person to be created in the
     // meantime.
     let bufferConsumer: Consumer | undefined
-    let stopSessionRecordingEventsConsumer: (() => void) | undefined
     let stopSessionRecordingBlobConsumer: (() => void) | undefined
-    let joinSessionRecordingEventsConsumer: ((timeout?: number) => Promise<void>) | undefined
-    let joinSessionRecordingBlobConsumer: ((timeout?: number) => Promise<void>) | undefined
     let jobsConsumer: Consumer | undefined
     let schedulerTasksConsumer: Consumer | undefined
 
@@ -142,7 +140,6 @@ export async function startPluginsServer(
             stopWebhooksHandlerConsumer?.(),
             bufferConsumer?.disconnect(),
             jobsConsumer?.disconnect(),
-            stopSessionRecordingEventsConsumer?.(),
             stopSessionRecordingBlobConsumer?.(),
             schedulerTasksConsumer?.disconnect(),
         ])
@@ -152,8 +149,19 @@ export async function startPluginsServer(
         }
 
         await closeHub?.()
+    }
 
-        status.info('👋', 'Over and out!')
+    // If join resolves, then the consumer has stopped and we should shut down everything else.
+    // Ideally we would also join all the other background tasks as well to ensure we stop the
+    // server if we hit any errors and don't end up with zombie instances, but I'll leave that
+    // refactoring for another time. Note that we have the liveness health checks already, so in K8s
+    // cases zombies should be reaped anyway, albeit not in the most efficient way.
+    function shutdownOnConsumerExit(consumer: BatchConsumer) {
+        consumer.join().catch(async (error) => {
+            status.error('💥', 'Unexpected task joined!', { error: error.stack ?? error })
+            await closeJobs()
+            process.exit(1)
+        })
     }
 
     for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
@@ -164,6 +172,7 @@ export async function startPluginsServer(
         // This makes async exit possible with the process waiting until jobs are closed
         status.info('👋', 'process handling beforeExit event. Closing jobs...')
         await closeJobs()
+        status.info('👋', 'Over and out!')
         process.exit(0)
     })
 
@@ -285,6 +294,7 @@ export async function startPluginsServer(
             )
 
             analyticsEventsIngestionConsumer = queue
+            shutdownOnConsumerExit(analyticsEventsIngestionConsumer.consumer!)
             healthChecks['analytics-ingestion'] = isAnalyticsEventsIngestionHealthy
         }
 
@@ -299,6 +309,7 @@ export async function startPluginsServer(
                 })
 
             analyticsEventsIngestionHistoricalConsumer = queue
+            shutdownOnConsumerExit(analyticsEventsIngestionHistoricalConsumer.consumer!)
             healthChecks['analytics-ingestion-historical'] = isAnalyticsEventsIngestionHistoricalHealthy
         }
 
@@ -307,9 +318,12 @@ export async function startPluginsServer(
             serverInstance = serverInstance ? serverInstance : { hub }
 
             piscina = piscina ?? (await makePiscina(serverConfig, hub))
-            analyticsEventsIngestionOverflowConsumer = await startAnalyticsEventsIngestionOverflowConsumer({
+            const queue = await startAnalyticsEventsIngestionOverflowConsumer({
                 hub: hub,
             })
+
+            analyticsEventsIngestionOverflowConsumer = queue
+            shutdownOnConsumerExit(analyticsEventsIngestionOverflowConsumer.consumer!)
         }
 
         if (capabilities.processAsyncOnEventHandlers) {
@@ -414,38 +428,13 @@ export async function startPluginsServer(
 
             if (batchConsumer) {
                 stopSessionRecordingBlobConsumer = () => ingester.stop()
-                joinSessionRecordingBlobConsumer = () => batchConsumer.join()
+                shutdownOnConsumerExit(batchConsumer)
                 healthChecks['session-recordings-blob'] = () => ingester.isHealthy() ?? false
             }
         }
 
         if (capabilities.http) {
             httpServer = createHttpServer(serverConfig.HTTP_SERVER_PORT, healthChecks, analyticsEventsIngestionConsumer)
-        }
-
-        // If session recordings consumer is defined, then join it. If join
-        // resolves, then the consumer has stopped and we should shut down
-        // everything else. Ideally we would also join all the other background
-        // tasks as well to ensure we stop the server if we hit any errors and
-        // don't end up with zombie instances, but I'll leave that refactoring
-        // for another time. Note that we have the liveness health checks
-        // already, so in K8s cases zombies should be reaped anyway, albeit not
-        // in the most efficient way.
-        //
-        // When extending to other consumers, we would want to do something like
-        //
-        // ```
-        // try {
-        //      await Promise.race([sessionConsumer.join(), analyticsConsumer.join(), ...])
-        // } finally {
-        //      await closeJobs()
-        // }
-        // ```
-        if (joinSessionRecordingEventsConsumer) {
-            joinSessionRecordingEventsConsumer().catch(closeJobs)
-        }
-        if (joinSessionRecordingBlobConsumer) {
-            joinSessionRecordingBlobConsumer().catch(closeJobs)
         }
 
         return serverInstance ?? { stop: closeJobs }

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -151,7 +151,7 @@ export async function startPluginsServer(
         await closeHub?.()
     }
 
-    // If join resolves, then the consumer has stopped and we should shut down everything else.
+    // If join rejects or throws, then the consumer is unhealthy and we should shut down the process.
     // Ideally we would also join all the other background tasks as well to ensure we stop the
     // server if we hit any errors and don't end up with zombie instances, but I'll leave that
     // refactoring for another time. Note that we have the liveness health checks already, so in K8s


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We had nothing at the toplevel watching the `join` (i.e. `mainLoop`) promise for the analytics consumer(s). An exception thrown by the `main_loop` would effectively go nowhere.


## Changes

Watch the `join` promises for analytics ingestion like blob recording does. Do a little cleanup of the related code (`*SessionRecordingEventsConsumer` were unused).


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
