### PR TITLE
feat(insights): Add dashboard filters to hogql insights

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -323,6 +323,17 @@
             ],
             "type": "string"
         },
+        "DashboardFilter": {
+            "properties": {
+                "date_from": {
+                    "type": ["string", "null"]
+                },
+                "date_to": {
+                    "type": ["string", "null"]
+                }
+            },
+            "type": "object"
+        },
         "DataNode": {
             "additionalProperties": false,
             "properties": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -330,6 +330,19 @@
                 },
                 "date_to": {
                     "type": ["string", "null"]
+                },
+                "properties": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/AnyPropertyFilter"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "type": "object"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -324,6 +324,7 @@
             "type": "string"
         },
         "DashboardFilter": {
+            "additionalProperties": false,
             "properties": {
                 "date_from": {
                     "type": ["string", "null"]

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -699,3 +699,9 @@ export interface BreakdownFilter {
     breakdown_group_type_index?: number | null
     breakdown_histogram_bin_count?: number // trends breakdown histogram bin count
 }
+
+export interface DashboardFilter {
+    date_from?: string | null
+    date_to?: string | null
+    [s: string]: any
+}

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -703,5 +703,6 @@ export interface BreakdownFilter {
 export interface DashboardFilter {
     date_from?: string | null
     date_to?: string | null
+    properties?: AnyPropertyFilter[] | null
     [s: string]: any
 }

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -704,5 +704,4 @@ export interface DashboardFilter {
     date_from?: string | null
     date_to?: string | null
     properties?: AnyPropertyFilter[] | null
-    [s: string]: any
 }

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -10,7 +10,6 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import {
     DashboardTile,
     DashboardType,
-    FilterType,
     InsightColor,
     InsightModel,
     InsightShortId,
@@ -24,6 +23,7 @@ import { dayjs, now } from 'lib/dayjs'
 import { teamLogic } from 'scenes/teamLogic'
 import { MOCK_TEAM_ID } from 'lib/api.mock'
 import api from 'lib/api'
+import { DashboardFilter } from '~/queries/schema'
 
 const dashboardJson = _dashboardJson as any as DashboardType
 
@@ -63,7 +63,7 @@ export const tileFromInsight = (insight: InsightModel, id: number = tileId++): D
 export const dashboardResult = (
     dashboardId: number,
     tiles: DashboardTile[],
-    filters: Partial<Pick<FilterType, 'date_from' | 'date_to' | 'properties'>> = {}
+    filters: Partial<DashboardFilter> = {}
 ): DashboardType => {
     return {
         ...dashboardJson,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -26,7 +26,13 @@ import { BehavioralFilterKey, BehavioralFilterType } from 'scenes/cohorts/Cohort
 import { LogicWrapper } from 'kea'
 import { AggregationAxisFormat } from 'scenes/insights/aggregationAxisFormat'
 import { Layout } from 'react-grid-layout'
-import { DatabaseSchemaQueryResponseField, HogQLQuery, InsightVizNode, Node } from './queries/schema'
+import type {
+    DashboardFilter,
+    DatabaseSchemaQueryResponseField,
+    HogQLQuery,
+    InsightVizNode,
+    Node,
+} from './queries/schema'
 import { QueryContext } from '~/queries/types'
 
 import { JSONContent } from 'scenes/notebooks/Notebook/utils'
@@ -1345,7 +1351,7 @@ export type DashboardTemplateScope = 'team' | 'global' | 'feature_flag'
 
 export interface DashboardType extends DashboardBasicType {
     tiles: DashboardTile[]
-    filters: Record<string, any>
+    filters: DashboardFilter
 }
 
 export interface DashboardTemplateType {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1360,7 +1360,7 @@ export interface DashboardTemplateType {
     created_at?: string
     template_name: string
     dashboard_description?: string
-    dashboard_filters?: Record<string, JsonType>
+    dashboard_filters?: DashboardFilter
     tiles: DashboardTile[]
     variables?: DashboardTemplateVariableType[]
     tags?: string[]

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -489,6 +489,7 @@ class InsightSerializer(InsightBasicSerializer, UserPermissionsSerializerMixin):
 
         dashboard: Optional[Dashboard] = self.context.get("dashboard")
         representation["filters"] = instance.dashboard_filters(dashboard=dashboard)
+        representation["query"] = instance.dashboard_query(dashboard=dashboard)
 
         if "insight" not in representation["filters"] and not representation["query"]:
             representation["filters"]["insight"] = "TRENDS"

--- a/posthog/hogql_queries/apply_dashboard_filters.py
+++ b/posthog/hogql_queries/apply_dashboard_filters.py
@@ -11,7 +11,10 @@ def apply_dashboard_filters(query: dict, filters: dict, team: Team) -> dict:
         source = apply_dashboard_filters(query["source"], filters, team)
         return {**query, "source": source}
 
-    query_runner = get_query_runner(query, team)
+    try:
+        query_runner = get_query_runner(query, team)
+    except ValueError:
+        return query
     try:
         return query_runner.apply_dashboard_filters(DashboardFilter(**filters)).dict()
     except NotImplementedError:

--- a/posthog/hogql_queries/apply_dashboard_filters.py
+++ b/posthog/hogql_queries/apply_dashboard_filters.py
@@ -1,0 +1,29 @@
+from posthog.schema import HogQLQuery, DashboardFilter, HogQLFilters, DateRange
+
+
+# Apply the filters from the django-style Dashboard object
+def apply_dashboard_filters(query: dict, filters: dict) -> dict:
+    kind = query.get("kind", None)
+
+    if kind == "DataTableNode":
+        source = apply_dashboard_filters(query["source"], filters)
+        return {**query, "source": source}
+
+    dashboard_filter = DashboardFilter(**filters)
+
+    if kind == "HogQLQuery":
+        node = HogQLQuery(**query)
+
+        hogql_filters = node.filters or HogQLFilters()
+        date_range = hogql_filters.dateRange or DateRange()
+        node.filters = hogql_filters
+        hogql_filters.dateRange = date_range
+
+        if dashboard_filter.date_to:
+            date_range.date_to = dashboard_filter.date_to
+        if dashboard_filter.date_from:
+            date_range.date_from = dashboard_filter.date_from
+
+        return node.dict()
+    else:
+        return query

--- a/posthog/hogql_queries/hogql_query_runner.py
+++ b/posthog/hogql_queries/hogql_query_runner.py
@@ -75,4 +75,7 @@ class HogQLQueryRunner(QueryRunner):
             self.query.filters.dateRange.date_to = dashboard_filter.date_to
             self.query.filters.dateRange.date_from = dashboard_filter.date_from
 
+        if dashboard_filter.properties:
+            self.query.filters.properties = (self.query.filters.properties or []) + dashboard_filter.properties
+
         return self.query

--- a/posthog/hogql_queries/hogql_query_runner.py
+++ b/posthog/hogql_queries/hogql_query_runner.py
@@ -10,7 +10,7 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.timings import HogQLTimings
 from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.models import Team
-from posthog.schema import HogQLQuery, HogQLQueryResponse
+from posthog.schema import HogQLQuery, HogQLQueryResponse, DashboardFilter, HogQLFilters, DateRange
 
 
 class HogQLQueryRunner(QueryRunner):
@@ -66,3 +66,13 @@ class HogQLQueryRunner(QueryRunner):
 
     def _refresh_frequency(self):
         return timedelta(minutes=1)
+
+    def apply_dashboard_filters(self, dashboard_filter: DashboardFilter) -> HogQLQuery:
+        self.query.filters = self.query.filters or HogQLFilters()
+        self.query.filters.dateRange = self.query.filters.dateRange or DateRange()
+
+        if dashboard_filter.date_to or dashboard_filter.date_from:
+            self.query.filters.dateRange.date_to = dashboard_filter.date_to
+            self.query.filters.dateRange.date_from = dashboard_filter.date_from
+
+        return self.query

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -25,6 +25,7 @@ from posthog.schema import (
     EventsQuery,
     WebStatsTableQuery,
     HogQLQuery,
+    DashboardFilter,
 )
 from posthog.utils import generate_cache_key, get_safe_cache
 
@@ -239,4 +240,7 @@ class QueryRunner(ABC):
 
     @abstractmethod
     def _refresh_frequency(self):
+        raise NotImplementedError()
+
+    def apply_dashboard_filters(self, dashboard_filter: DashboardFilter) -> RunnableQueryNode:
         raise NotImplementedError()

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -154,7 +154,7 @@ class Insight(models.Model):
         else:
             return self.filters
 
-    def dashboard_query(self, dashboard: Optional[Dashboard]):
+    def dashboard_query(self, dashboard: Optional[Dashboard]) -> dict:
         if not dashboard or not self.query:
             return self.query
         from posthog.hogql_queries.apply_dashboard_filters import apply_dashboard_filters
@@ -187,7 +187,7 @@ def generate_insight_cache_key(insight: Insight, dashboard: Optional[Dashboard])
             if q.get("source"):
                 q = q["source"]
 
-            return generate_cache_key("{}_{}".format(q, insight.team_id))
+            return generate_cache_key("{}_{}_{}".format(q, dashboard.filters, insight.team_id))
 
         dashboard_insight_filter = get_filter(data=insight.dashboard_filters(dashboard=dashboard), team=insight.team)
         candidate_filters_hash = generate_cache_key("{}_{}".format(dashboard_insight_filter.toJSON(), insight.team_id))

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -154,7 +154,7 @@ class Insight(models.Model):
         else:
             return self.filters
 
-    def dashboard_query(self, dashboard: Optional[Dashboard]) -> dict:
+    def dashboard_query(self, dashboard: Optional[Dashboard]) -> Optional[dict]:
         if not dashboard or not self.query:
             return self.query
         from posthog.hogql_queries.apply_dashboard_filters import apply_dashboard_filters

--- a/posthog/models/test/test_insight_model.py
+++ b/posthog/models/test/test_insight_model.py
@@ -210,3 +210,26 @@ class TestInsightModel(BaseTest):
             data = query_insight.dashboard_query(dashboard)
             actual = data["source"]["filters"]
             assert expected_filters == actual
+
+    def test_query_hash_varies_with_dashboard_filters(self) -> None:
+        query_insight = Insight.objects.create(
+            team=self.team,
+            query={
+                "kind": "DataTableNode",
+                "source": {
+                    "filters": {"dateRange": {"date_from": "-14d", "date_to": "-7d"}},
+                    "kind": "HogQLQuery",
+                    "modifiers": None,
+                    "query": "select * from events where {filters}",
+                    "response": None,
+                    "values": None,
+                },
+            },
+        )
+
+        dashboard = Dashboard.objects.create(team=self.team, filters={"date_from": "-4d", "date_to": "-3d"})
+
+        hash_sans_dashboard = generate_insight_cache_key(query_insight, None)
+        hash_with_dashboard = generate_insight_cache_key(query_insight, dashboard)
+
+        assert hash_sans_dashboard != hash_with_dashboard

--- a/posthog/models/test/test_insight_model.py
+++ b/posthog/models/test/test_insight_model.py
@@ -120,7 +120,22 @@ class TestInsightModel(BaseTest):
         assert filters_hash_one != filters_hash_two
 
     def test_dashboard_with_query_insight_and_filters(self) -> None:
+        browser_equals_firefox = {
+            "key": "$browser",
+            "label": None,
+            "operator": "exact",
+            "type": "event",
+            "value": ["Firefox"],
+        }
+        browser_equals_chrome = {
+            "key": "$browser",
+            "label": None,
+            "operator": "exact",
+            "type": "event",
+            "value": ["Chrome"],
+        }
 
+        # use test cases and a for loop because django TestCase doesn't have parametrization
         test_cases = [
             (
                 # test that query filters are equal when there are no dashboard filters
@@ -145,6 +160,33 @@ class TestInsightModel(BaseTest):
                 {"dateRange": {"date_from": "-14d", "date_to": "-7d"}},
                 {"date_from": "all"},
                 {"dateRange": {"date_from": "all", "date_to": None}, "properties": None},
+            ),
+            (
+                # test that if no filters are set then none are outputted
+                {},
+                {},
+                {"dateRange": {"date_from": None, "date_to": None}, "properties": None},
+            ),
+            (
+                # test that properties from the query are used when there are no dashboard properties
+                {"properties": [browser_equals_firefox]},
+                {},
+                {"dateRange": {"date_from": None, "date_to": None}, "properties": [browser_equals_firefox]},
+            ),
+            (
+                # test that properties from the dashboard are used when there are no query properties
+                {},
+                {"properties": [browser_equals_chrome]},
+                {"dateRange": {"date_from": None, "date_to": None}, "properties": [browser_equals_chrome]},
+            ),
+            (
+                # test that properties are merged when set in both query and dashboard
+                {"properties": [browser_equals_firefox]},
+                {"properties": [browser_equals_chrome]},
+                {
+                    "dateRange": {"date_from": None, "date_to": None},
+                    "properties": [browser_equals_firefox, browser_equals_chrome],
+                },
             ),
         ]
 

--- a/posthog/models/test/test_insight_model.py
+++ b/posthog/models/test/test_insight_model.py
@@ -208,26 +208,26 @@ class TestInsightModel(BaseTest):
             dashboard = Dashboard.objects.create(team=self.team, filters=dashboard_filters)
 
             data = query_insight.dashboard_query(dashboard)
+            assert data
             actual = data["source"]["filters"]
             assert expected_filters == actual
 
     def test_query_hash_varies_with_dashboard_filters(self) -> None:
-        query_insight = Insight.objects.create(
-            team=self.team,
-            query={
-                "kind": "DataTableNode",
-                "source": {
-                    "filters": {"dateRange": {"date_from": "-14d", "date_to": "-7d"}},
-                    "kind": "HogQLQuery",
-                    "modifiers": None,
-                    "query": "select * from events where {filters}",
-                    "response": None,
-                    "values": None,
-                },
+        query = {
+            "kind": "DataTableNode",
+            "source": {
+                "filters": {"dateRange": {"date_from": "-14d", "date_to": "-7d"}},
+                "kind": "HogQLQuery",
+                "modifiers": None,
+                "query": "select * from events where {filters}",
+                "response": None,
+                "values": None,
             },
-        )
+        }
+        dashboard_filters = {"date_from": "-4d", "date_to": "-3d"}
 
-        dashboard = Dashboard.objects.create(team=self.team, filters={"date_from": "-4d", "date_to": "-3d"})
+        query_insight = Insight.objects.create(team=self.team, query=query)
+        dashboard = Dashboard.objects.create(team=self.team, filters=dashboard_filters)
 
         hash_sans_dashboard = generate_insight_cache_key(query_insight, None)
         hash_with_dashboard = generate_insight_cache_key(query_insight, dashboard)

--- a/posthog/models/test/test_insight_model.py
+++ b/posthog/models/test/test_insight_model.py
@@ -118,3 +118,53 @@ class TestInsightModel(BaseTest):
         filters_hash_two = generate_insight_cache_key(insight_two, None)
 
         assert filters_hash_one != filters_hash_two
+
+    def test_dashboard_with_query_insight_and_filters(self) -> None:
+
+        test_cases = [
+            (
+                # test that query filters are equal when there are no dashboard filters
+                {"dateRange": {"date_from": "-14d", "date_to": "-7d"}},
+                {},
+                {"dateRange": {"date_from": "-14d", "date_to": "-7d"}, "properties": None},
+            ),
+            (
+                # test that dashboard filters are used when there are no query filters
+                {},
+                {"date_from": "-14d", "date_to": "-7d"},
+                {"dateRange": {"date_from": "-14d", "date_to": "-7d"}, "properties": None},
+            ),
+            (
+                # test that dashboard filters take priority
+                {"dateRange": {"date_from": "-2d", "date_to": "-1d"}},
+                {"date_from": "-4d", "date_to": "-3d"},
+                {"dateRange": {"date_from": "-4d", "date_to": "-3d"}, "properties": None},
+            ),
+            (
+                # test that dashboard filters take priority, even if only one value is set, the other is set to None
+                {"dateRange": {"date_from": "-14d", "date_to": "-7d"}},
+                {"date_from": "all"},
+                {"dateRange": {"date_from": "all", "date_to": None}, "properties": None},
+            ),
+        ]
+
+        for query_filters, dashboard_filters, expected_filters in test_cases:
+            query_insight = Insight.objects.create(
+                team=self.team,
+                query={
+                    "kind": "DataTableNode",
+                    "source": {
+                        "filters": query_filters,
+                        "kind": "HogQLQuery",
+                        "modifiers": None,
+                        "query": "select * from events where {filters}",
+                        "response": None,
+                        "values": None,
+                    },
+                },
+            )
+            dashboard = Dashboard.objects.create(team=self.team, filters=dashboard_filters)
+
+            data = query_insight.dashboard_query(dashboard)
+            actual = data["source"]["filters"]
+            assert expected_filters == actual

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -86,11 +86,6 @@ class CountPerActorMathType(str, Enum):
     p99_count_per_actor = "p99_count_per_actor"
 
 
-class DashboardFilter(BaseModel):
-    date_from: Optional[str] = None
-    date_to: Optional[str] = None
-
-
 class DatabaseSchemaQueryResponseField(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -950,6 +945,27 @@ class AnyResponseType(RootModel):
     root: Union[
         Dict[str, Any], HogQLQueryResponse, HogQLMetadataResponse, Union[AnyResponseTypeItem, Any], EventsQueryResponse
     ]
+
+
+class DashboardFilter(BaseModel):
+    date_from: Optional[str] = None
+    date_to: Optional[str] = None
+    properties: Optional[
+        List[
+            Union[
+                EventPropertyFilter,
+                PersonPropertyFilter,
+                ElementPropertyFilter,
+                SessionPropertyFilter,
+                CohortPropertyFilter,
+                RecordingDurationFilter,
+                GroupPropertyFilter,
+                FeaturePropertyFilter,
+                HogQLPropertyFilter,
+                EmptyPropertyFilter,
+            ]
+        ]
+    ] = None
 
 
 class DatabaseSchemaQuery(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -948,6 +948,9 @@ class AnyResponseType(RootModel):
 
 
 class DashboardFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
     date_from: Optional[str] = None
     date_to: Optional[str] = None
     properties: Optional[

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -86,6 +86,11 @@ class CountPerActorMathType(str, Enum):
     p99_count_per_actor = "p99_count_per_actor"
 
 
+class DashboardFilter(BaseModel):
+    date_from: Optional[str] = None
+    date_to: Optional[str] = None
+
+
 class DatabaseSchemaQueryResponseField(BaseModel):
     model_config = ConfigDict(
         extra="forbid",


### PR DESCRIPTION
Status: it works!

## Problem

https://github.com/PostHog/posthog/issues/18065

## Changes

* Add `apply_dashboard_filters` to the hogql query runner
* Add a top level `apply_dashboard_filters` function which can route query nodes into the correct runner
* Hook this into `to_representation` in `InsightSerializer`, and into `generate_insight_cache_key`

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
