### PR TITLE
fix(version-checker): Use latest semantic version

### DIFF
--- a/frontend/src/lib/components/VersionChecker/versionCheckerLogic.test.ts
+++ b/frontend/src/lib/components/VersionChecker/versionCheckerLogic.test.ts
@@ -105,4 +105,42 @@ describe('versionCheckerLogic', () => {
         await expectLogic(logic).toFinishAllListeners()
         expectLogic(logic).toMatchValues({ versionWarning: options.expectation })
     })
+
+    it.each([
+        {
+            usedVersions: [
+                { version: '1.9.0', timestamp: '2023-01-01T12:00:00Z' },
+                { version: '1.83.1', timestamp: '2023-01-01T10:00:00Z' },
+            ],
+            expectation: {
+                currentVersion: '1.83.1',
+                latestVersion: '1.84.0',
+                diff: 1,
+                level: 'info',
+            },
+        },
+        {
+            usedVersions: [
+                { version: '1.80.0', timestamp: '2023-01-01T12:00:00Z' },
+                { version: '1.83.1', timestamp: '2023-01-01T10:00:00Z' },
+                { version: '1.84.0', timestamp: '2023-01-01T08:00:00Z' },
+            ],
+            expectation: null,
+        },
+        {
+            usedVersions: [
+                { version: '1.80.0', timestamp: '2023-01-01T12:00:00Z' },
+                { version: '1.83.1-beta', timestamp: '2023-01-01T10:00:00Z' },
+                { version: '1.84.0-delta', timestamp: '2023-01-01T08:00:00Z' },
+            ],
+            expectation: { currentVersion: '1.84.0-delta', diff: 1, latestVersion: '1.84.0', level: 'info' },
+        },
+    ])('when having multiple versions used, should match with the latest one', async (options) => {
+        useMockedVersions([{ version: '1.84.0' }], options.usedVersions)
+
+        logic.mount()
+
+        await expectLogic(logic).toFinishAllListeners()
+        expectLogic(logic).toMatchValues({ versionWarning: options.expectation })
+    })
 })

--- a/frontend/src/lib/components/VersionChecker/versionCheckerLogic.test.ts
+++ b/frontend/src/lib/components/VersionChecker/versionCheckerLogic.test.ts
@@ -123,6 +123,10 @@ describe('versionCheckerLogic', () => {
             usedVersions: [
                 { version: '1.80.0', timestamp: '2023-01-01T12:00:00Z' },
                 { version: '1.83.1', timestamp: '2023-01-01T10:00:00Z' },
+                { version: '1.20.1', timestamp: '2023-01-01T10:00:00Z' },
+                { version: '1.0.890', timestamp: '2023-01-01T10:00:00Z' },
+                { version: '0.89.5', timestamp: '2023-01-01T10:00:00Z' },
+                { version: '0.0.5', timestamp: '2023-01-01T10:00:00Z' },
                 { version: '1.84.0', timestamp: '2023-01-01T08:00:00Z' },
             ],
             expectation: null,

--- a/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
+++ b/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
@@ -88,18 +88,22 @@ export const versionCheckerLogic = kea<versionCheckerLogicType>([
             }
 
             const latestVersion = values.availableVersions[0].version
-            const currentVersion = values.usedVersions[0].version
 
-            if (latestVersion === currentVersion) {
+            // reverse sort, hence reversed arguments to localeCompare
+            const latestUsedVersion = [...values.usedVersions].sort((a, b) =>
+                b.version.localeCompare(a.version, undefined, { numeric: true })
+            )[0].version
+
+            if (latestVersion === latestUsedVersion) {
                 actions.setVersionWarning(null)
                 return
             }
 
-            let diff = values.availableVersions.findIndex((v) => v.version === currentVersion)
+            let diff = values.availableVersions.findIndex((v) => v.version === latestUsedVersion)
             diff = diff === -1 ? values.availableVersions.length : diff
 
             const warning: SDKVersionWarning = {
-                currentVersion,
+                currentVersion: latestUsedVersion,
                 latestVersion,
                 diff,
                 level: diff > 20 ? 'error' : diff > 10 ? 'warning' : 'info',

--- a/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
+++ b/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
@@ -89,7 +89,9 @@ export const versionCheckerLogic = kea<versionCheckerLogicType>([
 
             const latestVersion = values.availableVersions[0].version
 
-            // reverse sort, hence reversed arguments to localeCompare
+            // reverse sort, hence reversed arguments to localeCompare.
+            // We want the highest semantic version to be the latest used one, rather than
+            // the one with the latest timestamp, because secondary installations can spew old versions
             const latestUsedVersion = [...values.usedVersions].sort((a, b) =>
                 b.version.localeCompare(a.version, undefined, { numeric: true })
             )[0].version


### PR DESCRIPTION
## Problem


The version checker bugs out frequently, whenever, say a 2nd posthog instance running on localhost / old installation sends us events from an outdated library. This is much more common than we expected earlier.

Ex: see our instance

<img width="610" alt="image" src="https://github.com/PostHog/posthog/assets/7115141/3ef3a5e5-de2f-421f-ac5f-8dc0fd8495ee">


So, using the latest timestamp to get the latest used version doesn't work well.

Also, it's much worse to show this banner when they're on latest (further confusing them), than to not show this banner when they're not.

Now, instead, we use the highest semantic version. This means if they went to a higher version, then reverted, it will take upto 24 hours for us to reflect this change (when the higher version moves out of the last 24h date range). This has the advantage of _not_ incorrectly showing the banner when they have multiple versions of posthog-js sending stuff.

Q: Why isn't this in the clickhouse query?
A: Because semantic version comparison is hard

Q: Does the current semVer comparison work in all cases?
A: No, not all, pretty sure there are edge cases with 'alpha' versions and the like, but for all regular numbers should be fine

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
unit tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
