### PR TITLE
chore(batch-exports): Do not retry on forbidden

### DIFF
--- a/posthog/temporal/workflows/bigquery_batch_export.py
+++ b/posthog/temporal/workflows/bigquery_batch_export.py
@@ -260,7 +260,10 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
                     initial_interval=dt.timedelta(seconds=10),
                     maximum_interval=dt.timedelta(seconds=120),
                     maximum_attempts=10,
-                    non_retryable_error_types=[],
+                    non_retryable_error_types=[
+                        # Raised on missing permissions
+                        "Forbidden",
+                    ],
                 ),
             )
 


### PR DESCRIPTION
## Problem

These exceptions are common on permission errors, in which there is no reason to retry:

```
  "applicationFailureInfo": {
    "type": "Forbidden",
    "nonRetryable": false,
    "details": null
  }
```

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Make "Forbidden" errors non-retryable.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
