### PR TITLE
fix(batch-exports-backfill): Instantiate tuple when resuming from heartbeat

### DIFF
--- a/posthog/temporal/workflows/backfill_batch_export.py
+++ b/posthog/temporal/workflows/backfill_batch_export.py
@@ -123,7 +123,7 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
     if details:
         # If we receive details from a previous run, it means we were restarted for some reason.
         # Let's not double-backfill and instead wait for any outstanding runs.
-        last_activity_details = details[0]
+        last_activity_details = HeartbeatDetails(*details[0])
 
         details = HeartbeatDetails(
             schedule_id=inputs.schedule_id,


### PR DESCRIPTION
## Problem

When resuming a backfill from heartbeat, temporal serializes details as a tuple, which means they do not allow dot access.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Instantiate a proper namedtuple to allow dot access.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
