### PR TITLE
fix(batch-exports): Only read person properties for S3

### DIFF
--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -127,24 +127,13 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
-  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -155,7 +144,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -166,7 +155,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -177,7 +166,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -206,7 +195,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -227,6 +216,22 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
+  '
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_flag_with_behavioural_cohorts

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -127,13 +127,24 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -144,7 +155,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -155,7 +166,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -166,7 +177,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -195,7 +206,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -216,22 +227,6 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
-  '
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginconfig"."web_token",
-         "posthog_pluginsourcefile"."updated_at",
-         "posthog_plugin"."updated_at",
-         "posthog_pluginconfig"."updated_at"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_flag_with_behavioural_cohorts

--- a/posthog/temporal/tests/batch_exports/test_batch_exports.py
+++ b/posthog/temporal/tests/batch_exports/test_batch_exports.py
@@ -309,7 +309,8 @@ async def test_get_rows_count_can_include_events(client):
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_get_results_iterator(client):
+@pytest.mark.parametrize("include_person_properties", (False, True))
+async def test_get_results_iterator(client, include_person_properties):
     """Test the rows returned by get_results_iterator."""
     team_id = randint(1, 1000000)
 
@@ -345,7 +346,13 @@ async def test_get_results_iterator(client):
         events=events,
     )
 
-    iter_ = get_results_iterator(client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", use_s3_fields=True)
+    iter_ = get_results_iterator(
+        client,
+        team_id,
+        "2023-04-20 14:30:00",
+        "2023-04-20 14:31:00",
+        include_person_properties=include_person_properties,
+    )
     rows = [row for row in iter_]
 
     all_expected = sorted(events, key=operator.itemgetter("event"))
@@ -355,6 +362,9 @@ async def test_get_results_iterator(client):
 
     for expected, result in zip(all_expected, all_result):
         for key, value in result.items():
+            if key == "person_properties" and not include_person_properties:
+                continue
+
             if key in ("timestamp", "inserted_at", "created_at"):
                 expected_value = to_isoformat(expected[key])
             else:
@@ -366,7 +376,8 @@ async def test_get_results_iterator(client):
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_get_results_iterator_handles_duplicates(client):
+@pytest.mark.parametrize("include_person_properties", (False, True))
+async def test_get_results_iterator_handles_duplicates(client, include_person_properties):
     """Test the rows returned by get_results_iterator are de-duplicated."""
     team_id = randint(1, 1000000)
 
@@ -404,7 +415,13 @@ async def test_get_results_iterator_handles_duplicates(client):
         events=duplicate_events,
     )
 
-    iter_ = get_results_iterator(client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", use_s3_fields=True)
+    iter_ = get_results_iterator(
+        client,
+        team_id,
+        "2023-04-20 14:30:00",
+        "2023-04-20 14:31:00",
+        include_person_properties=include_person_properties,
+    )
     rows = [row for row in iter_]
 
     all_expected = sorted(events, key=operator.itemgetter("event"))
@@ -415,6 +432,9 @@ async def test_get_results_iterator_handles_duplicates(client):
 
     for expected, result in zip(all_expected, all_result):
         for key, value in result.items():
+            if key == "person_properties" and not include_person_properties:
+                continue
+
             if key in ("timestamp", "inserted_at", "created_at"):
                 expected_value = to_isoformat(expected[key])
             else:
@@ -426,7 +446,8 @@ async def test_get_results_iterator_handles_duplicates(client):
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_get_results_iterator_can_exclude_events(client):
+@pytest.mark.parametrize("include_person_properties", (False, True))
+async def test_get_results_iterator_can_exclude_events(client, include_person_properties):
     """Test the rows returned by get_results_iterator can exclude events."""
     team_id = randint(1, 1000000)
 
@@ -467,7 +488,12 @@ async def test_get_results_iterator_can_exclude_events(client):
     # Exclude the latter half of events.
     exclude_events = (f"test-{i}" for i in range(5000, 10000))
     iter_ = get_results_iterator(
-        client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", exclude_events=exclude_events, use_s3_fields=True
+        client,
+        team_id,
+        "2023-04-20 14:30:00",
+        "2023-04-20 14:31:00",
+        exclude_events=exclude_events,
+        include_person_properties=include_person_properties,
     )
     rows = [row for row in iter_]
 
@@ -479,6 +505,9 @@ async def test_get_results_iterator_can_exclude_events(client):
 
     for expected, result in zip(all_expected, all_result):
         for key, value in result.items():
+            if key == "person_properties" and not include_person_properties:
+                continue
+
             if key in ("timestamp", "inserted_at", "created_at"):
                 expected_value = to_isoformat(expected[key])
             else:
@@ -490,7 +519,8 @@ async def test_get_results_iterator_can_exclude_events(client):
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_get_results_iterator_can_include_events(client):
+@pytest.mark.parametrize("include_person_properties", (False, True))
+async def test_get_results_iterator_can_include_events(client, include_person_properties):
     """Test the rows returned by get_results_iterator can include events."""
     team_id = randint(1, 1000000)
 
@@ -531,7 +561,12 @@ async def test_get_results_iterator_can_include_events(client):
     # Include the latter half of events.
     include_events = (f"test-{i}" for i in range(5000, 10000))
     iter_ = get_results_iterator(
-        client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", include_events=include_events, use_s3_fields=True
+        client,
+        team_id,
+        "2023-04-20 14:30:00",
+        "2023-04-20 14:31:00",
+        include_events=include_events,
+        include_person_properties=include_person_properties,
     )
     rows = [row for row in iter_]
 
@@ -543,6 +578,9 @@ async def test_get_results_iterator_can_include_events(client):
 
     for expected, result in zip(all_expected, all_result):
         for key, value in result.items():
+            if key == "person_properties" and not include_person_properties:
+                continue
+
             if key in ("timestamp", "inserted_at", "created_at"):
                 expected_value = to_isoformat(expected[key])
             else:

--- a/posthog/temporal/tests/batch_exports/test_batch_exports.py
+++ b/posthog/temporal/tests/batch_exports/test_batch_exports.py
@@ -345,7 +345,7 @@ async def test_get_results_iterator(client):
         events=events,
     )
 
-    iter_ = get_results_iterator(client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00")
+    iter_ = get_results_iterator(client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", use_s3_fields=True)
     rows = [row for row in iter_]
 
     all_expected = sorted(events, key=operator.itemgetter("event"))
@@ -404,7 +404,7 @@ async def test_get_results_iterator_handles_duplicates(client):
         events=duplicate_events,
     )
 
-    iter_ = get_results_iterator(client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00")
+    iter_ = get_results_iterator(client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", use_s3_fields=True)
     rows = [row for row in iter_]
 
     all_expected = sorted(events, key=operator.itemgetter("event"))
@@ -467,7 +467,7 @@ async def test_get_results_iterator_can_exclude_events(client):
     # Exclude the latter half of events.
     exclude_events = (f"test-{i}" for i in range(5000, 10000))
     iter_ = get_results_iterator(
-        client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", exclude_events=exclude_events
+        client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", exclude_events=exclude_events, use_s3_fields=True
     )
     rows = [row for row in iter_]
 
@@ -531,7 +531,7 @@ async def test_get_results_iterator_can_include_events(client):
     # Include the latter half of events.
     include_events = (f"test-{i}" for i in range(5000, 10000))
     iter_ = get_results_iterator(
-        client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", include_events=include_events
+        client, team_id, "2023-04-20 14:30:00", "2023-04-20 14:31:00", include_events=include_events, use_s3_fields=True
     )
     rows = [row for row in iter_]
 

--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -138,7 +138,7 @@ def get_results_iterator(
     interval_end: str,
     exclude_events: collections.abc.Iterable[str] | None = None,
     include_events: collections.abc.Iterable[str] | None = None,
-    use_s3_fields: bool = False,
+    include_person_properties: bool = False,
 ) -> typing.Generator[dict[str, typing.Any], None, None]:
     data_interval_start_ch = dt.datetime.fromisoformat(interval_start).strftime("%Y-%m-%d %H:%M:%S")
     data_interval_end_ch = dt.datetime.fromisoformat(interval_end).strftime("%Y-%m-%d %H:%M:%S")
@@ -158,7 +158,7 @@ def get_results_iterator(
         events_to_include_tuple = ()
 
     query = SELECT_QUERY_TEMPLATE.substitute(
-        fields=S3_FIELDS if use_s3_fields else FIELDS,
+        fields=S3_FIELDS if include_person_properties else FIELDS,
         order_by="ORDER BY inserted_at",
         format="FORMAT ArrowStream",
         exclude_events=exclude_events_statement,

--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -109,6 +109,22 @@ properties,
 -- Point in time identity fields
 toString(distinct_id) as distinct_id,
 toString(person_id) as person_id,
+-- Autocapture fields
+elements_chain
+"""
+
+S3_FIELDS = """
+DISTINCT ON (event, cityHash64(distinct_id), cityHash64(uuid))
+toString(uuid) as uuid,
+team_id,
+timestamp,
+inserted_at,
+created_at,
+event,
+properties,
+-- Point in time identity fields
+toString(distinct_id) as distinct_id,
+toString(person_id) as person_id,
 person_properties,
 -- Autocapture fields
 elements_chain
@@ -122,6 +138,7 @@ def get_results_iterator(
     interval_end: str,
     exclude_events: collections.abc.Iterable[str] | None = None,
     include_events: collections.abc.Iterable[str] | None = None,
+    use_s3_fields: bool = False,
 ) -> typing.Generator[dict[str, typing.Any], None, None]:
     data_interval_start_ch = dt.datetime.fromisoformat(interval_start).strftime("%Y-%m-%d %H:%M:%S")
     data_interval_end_ch = dt.datetime.fromisoformat(interval_end).strftime("%Y-%m-%d %H:%M:%S")
@@ -141,7 +158,7 @@ def get_results_iterator(
         events_to_include_tuple = ()
 
     query = SELECT_QUERY_TEMPLATE.substitute(
-        fields=FIELDS,
+        fields=S3_FIELDS if use_s3_fields else FIELDS,
         order_by="ORDER BY inserted_at",
         format="FORMAT ArrowStream",
         exclude_events=exclude_events_statement,

--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -379,6 +379,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
             interval_end=inputs.data_interval_end,
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
+            use_s3_fields=True,
         )
 
         result = None

--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -379,7 +379,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
             interval_end=inputs.data_interval_end,
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
-            use_s3_fields=True,
+            include_person_properties=True,
         )
 
         result = None


### PR DESCRIPTION
## Problem

Only S3 exports deal with `person_properties`; all other destinations do not include this field in their schemas. It can be quite the heavy field, so let's not read it to avoid heavy queries. It may even be droppable from S3, but starting with the safe ones that do not require it.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Only read `person_properties` if `use_s3_fields` is set to `True`, which is only done in `s3_batch_export.py`. It's a bit rough solution, ideally we would have all fields be configurable and then each destination sets it's own. But this is just to fix an issue, and we can develop it further later.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Nothing should change for any destination.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
