### PR TITLE
chore(p-s): add logs around setupPlugins

### DIFF
--- a/plugin-server/src/worker/plugins/setup.ts
+++ b/plugin-server/src/worker/plugins/setup.ts
@@ -1,4 +1,5 @@
 import { Hub, StatelessVmMap } from '../../types'
+import { status } from '../../utils/status'
 import { LazyPluginVM } from '../vm/lazy'
 import { loadPlugin } from './loadPlugin'
 import { loadPluginsFromDB } from './loadPluginsFromDB'
@@ -6,6 +7,7 @@ import { loadSchedule } from './loadSchedule'
 import { teardownPlugins } from './teardown'
 
 export async function setupPlugins(hub: Hub): Promise<void> {
+    status.info('🔁', `Loading plugin configs...`)
     const { plugins, pluginConfigs, pluginConfigsPerTeam } = await loadPluginsFromDB(hub)
     const pluginVMLoadPromises: Array<Promise<any>> = []
     const statelessVms = {} as StatelessVmMap
@@ -56,4 +58,6 @@ export async function setupPlugins(hub: Hub): Promise<void> {
     if (hub.capabilities.pluginScheduledTasks) {
         await loadSchedule(hub)
     }
+
+    status.info('✅', `Loaded ${pluginConfigs.size} configs for ${plugins.size} plugins`)
 }


### PR DESCRIPTION
## Problem

Let's stop blaming mmdb, this is the real reason for prod-us pods to be so slow to start.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
