### PR TITLE
chore(plugin-server): log timing per rdkafka batch loop rather than b…

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -256,13 +256,9 @@ async function ingestEvent(
     const result = await runEventPipeline(server, event)
 
     server.statsd?.timing('kafka_queue.each_event', eachEventStartTimer)
-    countAndLogEvents()
 
     return result
 }
-
-let messageCounter = 0
-let messageLogDate = 0
 
 function computeKey(pluginEvent: PipelineEvent): string {
     return `${pluginEvent.team_id ?? pluginEvent.token}:${pluginEvent.distinct_id}`
@@ -336,19 +332,4 @@ export function splitIngestionBatch(
     }
     output.toProcess = Array.from(batches.values())
     return output
-}
-
-function countAndLogEvents(): void {
-    const now = new Date().valueOf()
-    messageCounter++
-    if (now - messageLogDate > 10000) {
-        status.info(
-            '🕒',
-            `Processed ${messageCounter} events${
-                messageLogDate === 0 ? '' : ` in ${Math.round((now - messageLogDate) / 10) / 100}s`
-            }`
-        )
-        messageCounter = 0
-        messageLogDate = now
-    }
 }


### PR DESCRIPTION
…ased on a schedule

## Problem

We have two different logs on timed schedules, but it's more useful to know how long each batch took (and how large it was) because that's also how often it's checking in the with the Kafka consumer group.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Log per batch rather than on a set timer.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
