### PR TITLE
Fix survey rating scale

### DIFF
--- a/cypress/e2e/surveys.cy.ts
+++ b/cypress/e2e/surveys.cy.ts
@@ -90,7 +90,7 @@ describe('Surveys', () => {
 
         cy.get('[id="scenes.surveys.surveyLogic.new.survey.questions.0.scale"]')
             .invoke('html')
-            .should('include', '1 - 10')
+            .should('include', '0 - 10')
 
         cy.get('[id="scenes.surveys.surveyLogic.new.survey.questions.0.upperBoundLabel"]').should(
             'have.value',
@@ -99,11 +99,11 @@ describe('Surveys', () => {
 
         // change the scale
         cy.get('[id="scenes.surveys.surveyLogic.new.survey.questions.0.scale"]').click()
-        cy.contains('1 - 5').click()
+        cy.contains('0 - 5').click()
 
         cy.get('[id="scenes.surveys.surveyLogic.new.survey.questions.0.scale"]')
             .invoke('html')
-            .should('include', '1 - 5')
+            .should('include', '0 - 5')
 
         // make sure the preview is updated
         cy.get('[data-attr="survey-preview"]')
@@ -111,7 +111,7 @@ describe('Surveys', () => {
             .should('contain', 'How likely are you to recommend us to a friend?')
             .should('contain', 'Unlikely')
             .should('contain', 'Very likely')
-        cy.get('[data-attr="survey-preview"]').find('form').find('.ratings-number').should('have.length', 5)
+        cy.get('[data-attr="survey-preview"]').find('form').find('.ratings-number').should('have.length', 6)
 
         // add targeting filters
         cy.get('.LemonCollapsePanel').contains('Targeting').click()

--- a/frontend/src/scenes/surveys/EditSurveyNew.tsx
+++ b/frontend/src/scenes/surveys/EditSurveyNew.tsx
@@ -452,14 +452,14 @@ export default function EditSurveyNew(): JSX.Element {
                                                                                             : []),
                                                                                         {
                                                                                             label: '0 - 5',
-                                                                                            value: 5,
+                                                                                            value: 6,
                                                                                         },
                                                                                         ...(question.display ===
                                                                                         'number'
                                                                                             ? [
                                                                                                   {
                                                                                                       label: '0 - 10',
-                                                                                                      value: 10,
+                                                                                                      value: 11,
                                                                                                   },
                                                                                               ]
                                                                                             : []),

--- a/frontend/src/scenes/surveys/EditSurveyNew.tsx
+++ b/frontend/src/scenes/surveys/EditSurveyNew.tsx
@@ -451,14 +451,14 @@ export default function EditSurveyNew(): JSX.Element {
                                                                                               ]
                                                                                             : []),
                                                                                         {
-                                                                                            label: '1 - 5',
+                                                                                            label: '0 - 5',
                                                                                             value: 5,
                                                                                         },
                                                                                         ...(question.display ===
                                                                                         'number'
                                                                                             ? [
                                                                                                   {
-                                                                                                      label: '1 - 10',
+                                                                                                      label: '0 - 10',
                                                                                                       value: 10,
                                                                                                   },
                                                                                               ]

--- a/frontend/src/scenes/surveys/EditSurveyOld.tsx
+++ b/frontend/src/scenes/surveys/EditSurveyOld.tsx
@@ -227,9 +227,9 @@ export default function EditSurveyOld(): JSX.Element {
                                                                         ...(question.display === 'emoji'
                                                                             ? [{ label: '1 - 3', value: 3 }]
                                                                             : []),
-                                                                        { label: '1 - 5', value: 5 },
+                                                                        { label: '0 - 5', value: 5 },
                                                                         ...(question.display === 'number'
-                                                                            ? [{ label: '1 - 10', value: 10 }]
+                                                                            ? [{ label: '0 - 10', value: 10 }]
                                                                             : []),
                                                                     ]}
                                                                 />

--- a/frontend/src/scenes/surveys/EditSurveyOld.tsx
+++ b/frontend/src/scenes/surveys/EditSurveyOld.tsx
@@ -227,9 +227,9 @@ export default function EditSurveyOld(): JSX.Element {
                                                                         ...(question.display === 'emoji'
                                                                             ? [{ label: '1 - 3', value: 3 }]
                                                                             : []),
-                                                                        { label: '0 - 5', value: 5 },
+                                                                        { label: '0 - 5', value: 6 },
                                                                         ...(question.display === 'number'
-                                                                            ? [{ label: '0 - 10', value: 10 }]
+                                                                            ? [{ label: '0 - 10', value: 11 }]
                                                                             : []),
                                                                     ]}
                                                                 />

--- a/frontend/src/scenes/surveys/SurveyAppearance.tsx
+++ b/frontend/src/scenes/surveys/SurveyAppearance.tsx
@@ -371,9 +371,9 @@ const NumberRating = ({
                 border: `1.5px solid ${appearance.borderColor || defaultSurveyAppearance.borderColor}`,
                 gridTemplateColumns: `repeat(${ratingSurveyQuestion.scale}, minmax(0, 1fr))`,
             }}
-            className={`rating-options-buttons ${ratingSurveyQuestion.scale === 5 ? '' : 'max-numbers'}`}
+            className={`rating-options-buttons ${ratingSurveyQuestion.scale === 6 ? '' : 'max-numbers'}`}
         >
-            {(ratingSurveyQuestion.scale === 5 ? [0, 1, 2, 3, 4, 5] : [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).map(
+            {(ratingSurveyQuestion.scale === 6 ? [0, 1, 2, 3, 4, 5] : [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).map(
                 (num, idx) => {
                     const active = activeNumber === num
                     return (

--- a/frontend/src/scenes/surveys/SurveyAppearance.tsx
+++ b/frontend/src/scenes/surveys/SurveyAppearance.tsx
@@ -373,19 +373,21 @@ const NumberRating = ({
             }}
             className={`rating-options-buttons ${ratingSurveyQuestion.scale === 5 ? '' : 'max-numbers'}`}
         >
-            {(ratingSurveyQuestion.scale === 5 ? [1, 2, 3, 4, 5] : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).map((num, idx) => {
-                const active = activeNumber === num
-                return (
-                    <RatingButton
-                        preview={preview}
-                        key={idx}
-                        active={active}
-                        appearance={appearance}
-                        num={num}
-                        setActiveNumber={setActiveNumber}
-                    />
-                )
-            })}
+            {(ratingSurveyQuestion.scale === 5 ? [0, 1, 2, 3, 4, 5] : [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).map(
+                (num, idx) => {
+                    const active = activeNumber === num
+                    return (
+                        <RatingButton
+                            preview={preview}
+                            key={idx}
+                            active={active}
+                            appearance={appearance}
+                            num={num}
+                            setActiveNumber={setActiveNumber}
+                        />
+                    )
+                }
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/surveys/constants.ts
+++ b/frontend/src/scenes/surveys/constants.ts
@@ -65,7 +65,7 @@ export const defaultSurveyFieldValues = {
                 question: 'How likely are you to recommend us to a friend?',
                 description: '',
                 display: 'number',
-                scale: 10,
+                scale: 11,
                 lowerBoundLabel: 'Unlikely',
                 upperBoundLabel: 'Very likely',
             },


### PR DESCRIPTION
## Problem

Aims to solve #17381 where survey rating scale should be inclusive of zero.

## Changes

https://github.com/PostHog/posthog/assets/107593248/5f84c57a-b392-42ad-a1a8-98ce36145f42


## How did you test this code?

-Manually selecting labels and ensuring the UI was correct.
-Ran E2E tests and fixed any failing tests that occurred.

----------------------------------------

_also had a small request, I've registered for Hacktoberfest and was hoping this could count toward it. Since it's opt in this year, the PR just needs to be marked with the_ `hacktoberfest-accepted` _label in order to be considered. I'd really appreciate any help with that!_
