### PR TITLE
fix(plugin-server): filter NaN out of buildIntegerMatcher

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -226,14 +226,19 @@ export function overrideWithEnv(
 }
 
 export function buildIntegerMatcher(config: string | undefined, allowStar: boolean): ValueMatcher<number> {
-    // Builds a ValueMatcher on a coma-separated list of values.
+    // Builds a ValueMatcher on a comma-separated list of values.
     // Optionally, supports a '*' value to match everything
-    if (!config) {
+    if (!config || config.trim().length == 0) {
         return () => false
     } else if (allowStar && config === '*') {
         return () => true
     } else {
-        const values = new Set(config.split(',').map((n) => parseInt(n)))
+        const values = new Set(
+            config
+                .split(',')
+                .map((n) => parseInt(n))
+                .filter((num) => !isNaN(num))
+        )
         return (v: number) => {
             return values.has(v)
         }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Noticed when doing this: https://github.com/PostHog/charts/pull/457

An empty string still results in an empty string on split, so `"".split(",").map((n) => parseInt(n))` results in `[NaN]`.

This probably isn't a problem in practice today, but it's a scary footgun if we ever accidentally pass `NaN` into a `ValueMatcher<number>`

## Changes

Drop `NaN` so we don't accidentally match on it.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
