### PR TITLE
chore(batch-exports): Do not retry on RefreshError and NotFound

### DIFF
--- a/posthog/temporal/workflows/bigquery_batch_export.py
+++ b/posthog/temporal/workflows/bigquery_batch_export.py
@@ -263,6 +263,8 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
                     non_retryable_error_types=[
                         # Raised on missing permissions
                         "Forbidden",
+                        # Invalid token
+                        "RefreshError",
                     ],
                 ),
             )

--- a/posthog/temporal/workflows/bigquery_batch_export.py
+++ b/posthog/temporal/workflows/bigquery_batch_export.py
@@ -261,10 +261,12 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
                     maximum_interval=dt.timedelta(seconds=120),
                     maximum_attempts=10,
                     non_retryable_error_types=[
-                        # Raised on missing permissions
+                        # Raised on missing permissions.
                         "Forbidden",
-                        # Invalid token
+                        # Invalid token.
                         "RefreshError",
+                        # Usually means the dataset or project doesn't exist.
+                        "NotFound",
                     ],
                 ),
             )


### PR DESCRIPTION
## Problem

Another couple of errors I've seen pop-up. Apparently:
1. RefreshError: Some error with the Google cloud token, not much we can do on our front.
2. NotFound: The dataset or the project given by the ID provided doesn't exist.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Do not retry on `"RefreshError"` nor on `"NotFound"`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
