### PR TITLE
fix(plugin-server): jitter and retry reloadPlugins

### DIFF
--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -197,6 +197,7 @@ jobs:
             CLICKHOUSE_DATABASE: 'posthog_test'
             KAFKA_HOSTS: 'kafka:9092'
             DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
+            RELOAD_PLUGIN_JITTER_MAX_MS: 0
             POE_EMBRACE_JOIN_FOR_TEAMS: ${{matrix.POE_EMBRACE_JOIN_FOR_TEAMS}}
 
         steps:

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -133,6 +133,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         EXTERNAL_REQUEST_TIMEOUT_MS: 10 * 1000, // 10 seconds
         DROP_EVENTS_BY_TOKEN_DISTINCT_ID: '',
         POE_EMBRACE_JOIN_FOR_TEAMS: '',
+        RELOAD_PLUGIN_JITTER_MAX_MS: 60000,
 
         STARTUP_PROFILE_DURATION_SECONDS: 300, // 5 minutes
         STARTUP_PROFILE_CPU: false,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -204,6 +204,7 @@ export interface PluginsServerConfig {
     EXTERNAL_REQUEST_TIMEOUT_MS: number
     DROP_EVENTS_BY_TOKEN_DISTINCT_ID: string
     POE_EMBRACE_JOIN_FOR_TEAMS: string
+    RELOAD_PLUGIN_JITTER_MAX_MS: number
 
     // dump profiles to disk, covering the first N seconds of runtime
     STARTUP_PROFILE_DURATION_SECONDS: number


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

`reloadPlugins` causes a thundering heard of PG traffic *and* doesn't retry.

## Changes

jitter and retry

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
