### PR TITLE
chore(hogql): Use the C++ parser in local dev

### DIFF
--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -39,8 +39,11 @@ def parse_expr(
     start: Optional[int] = 0,
     timings: Optional[HogQLTimings] = None,
     *,
-    backend: Literal["python", "cpp"] = "python",
+    backend: Optional[Literal["python", "cpp"]] = None,
 ) -> ast.Expr:
+    if not backend:
+        # TODO: Switch over to C++ in production once we are confident there are no issues
+        backend = "cpp" if settings.DEBUG else "python"
     if timings is None:
         timings = HogQLTimings()
     with timings.measure(f"parse_expr_{backend}"):
@@ -56,8 +59,11 @@ def parse_order_expr(
     placeholders: Optional[Dict[str, ast.Expr]] = None,
     timings: Optional[HogQLTimings] = None,
     *,
-    backend: Literal["python", "cpp"] = "python",
+    backend: Optional[Literal["python", "cpp"]] = None,
 ) -> ast.Expr:
+    if not backend:
+        # TODO: Switch over to C++ in production once we are confident there are no issues
+        backend = "cpp" if settings.DEBUG else "python"
     if timings is None:
         timings = HogQLTimings()
     with timings.measure(f"parse_order_expr_{backend}"):
@@ -73,7 +79,7 @@ def parse_select(
     placeholders: Optional[Dict[str, ast.Expr]] = None,
     timings: Optional[HogQLTimings] = None,
     *,
-    backend: Optional[Literal["python", "cpp"]],
+    backend: Optional[Literal["python", "cpp"]] = None,
 ) -> ast.SelectQuery | ast.SelectUnionQuery:
     if not backend:
         # TODO: Switch over to C++ in production once we are confident there are no issues

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Literal, Optional, cast
 
 from antlr4 import CommonTokenStream, InputStream, ParseTreeVisitor, ParserRuleContext
 from antlr4.error.ErrorListener import ErrorListener
+from django.conf import settings
 
 from posthog.hogql import ast
 from posthog.hogql.base import AST
@@ -72,8 +73,11 @@ def parse_select(
     placeholders: Optional[Dict[str, ast.Expr]] = None,
     timings: Optional[HogQLTimings] = None,
     *,
-    backend: Literal["python", "cpp"] = "python",
+    backend: Optional[Literal["python", "cpp"]],
 ) -> ast.SelectQuery | ast.SelectUnionQuery:
+    if not backend:
+        # TODO: Switch over to C++ in production once we are confident there are no issues
+        backend = "cpp" if settings.DEBUG else "python"
     if timings is None:
         timings = HogQLTimings()
     with timings.measure(f"parse_select_{backend}"):


### PR DESCRIPTION
## Problem

It's time to actually start using the C++ parser.

## Changes

Before we do that in production, I would prefer to add more NULL guards to `parser.cpp` (we _don't_ want to run into the [billion-dollar mistake](https://www.infoq.com/presentations/Null-References-The-Billion-Dollar-Mistake-Tony-Hoare/)), just so we're sure the production processes can't segfault (this should never happen in normal operation, but e.g. if a pod runs out of memory, there is currently a risk that the parser can't allocate a Python object, and currently the whole Python process crashes with no recourse, which would be very annoying).

But we were just hacking with @thmsobrmlr when suddenly we had to wait TWENTY seconds for Python to parse a statement (the actual query took 0.2s). Let's start using the new parser in local dev and we might also uncover some issue (or find that it's perfect).