### PR TITLE
fix(backfill-batch-exports): Do not run partial ranges

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
+++ b/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
@@ -129,6 +129,21 @@ async def temporal_worker(temporal_client):
             ],
         ),
         (
+            dt.datetime(2023, 1, 1, 10, 0, 0, tzinfo=dt.timezone.utc),
+            dt.datetime(2023, 1, 1, 12, 20, 0, tzinfo=dt.timezone.utc),
+            dt.timedelta(hours=1),
+            [
+                (
+                    dt.datetime(2023, 1, 1, 10, 0, 0, tzinfo=dt.timezone.utc),
+                    dt.datetime(2023, 1, 1, 11, 0, 0, tzinfo=dt.timezone.utc),
+                ),
+                (
+                    dt.datetime(2023, 1, 1, 11, 0, 0, tzinfo=dt.timezone.utc),
+                    dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc),
+                ),
+            ],
+        ),
+        (
             dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc),
             dt.datetime(2023, 1, 2, 0, 0, 0, tzinfo=dt.timezone.utc),
             dt.timedelta(hours=12),

--- a/posthog/temporal/workflows/backfill_batch_export.py
+++ b/posthog/temporal/workflows/backfill_batch_export.py
@@ -244,7 +244,9 @@ def backfill_range(
         current_end = current + step
 
         if current_end > end_at:
-            current_end = end_at
+            # Do not yield a range that is less than step.
+            # Same as built-in range.
+            break
 
         yield current, current_end
 


### PR DESCRIPTION
## Problem

Small (but fun) bug (good ol' off by one): Yielding partial date ranges (i.e. ranges that were less than `step`) would cause us to request a backfill for a period that doesn't have any runs in it (as it's less than a unit of frequency!).

I think I can explain the bug better with an example:

* Imagine we have an hourly batch export to backfill.
* We request a backfill for just one hour, but add a few extra minutes to the upper bound: ('20:00:00', '21:20:00').
* Runs are scheduled at the end of the period. In other words, the 19:00:00-20:00:00 batch starts at 20:00:00 (naturally, as we wait for all data in the batch to land).
* Our backfill request covers only one "start time": 21:00:00. This is because 22:00:00 is bigger than the upper bound, and 20:00:00 is equals to the lower bound (lower bounds are exclusive when making backfill requests to Temporal*). 
* So, with our ('20:00:00', '21:20:00') backfill request, we expect only one batch to be scheduled for backfill: 20:00:00-21:00:00

However, what ends up happening is that the current code yields one more range after `('20:00:00', '21:00:00')`: `('21:00:00', '21:20:00')`. This causes us to request a backfill for a period that has no runs. Since the schedule is hourly, the next run that could be backfilled is at 22:00:00, which is outside our range. This backfill request then never produces any runs, so there is nothing to wait for.

[*]: This is something that we could change potentially, but the bug happens regardless.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Break when we go beyond `end_at`. This is consistent with the behavior of the built-in `range`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a unit test for this case.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
