### PR TITLE
fix: update person recordings default date range

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -72,7 +72,7 @@ export const DEFAULT_RECORDING_FILTERS: RecordingFilters = {
 
 const DEFAULT_PERSON_RECORDING_FILTERS: RecordingFilters = {
     ...DEFAULT_RECORDING_FILTERS,
-    date_from: '-21d',
+    date_from: '-30d',
 }
 
 export const getDefaultFilters = (personUUID?: PersonUUID): RecordingFilters => {


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/6645 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/9520)

persons recordings was defaulting to -21d and confused someone since retention is now defaulted to -30d

So, now the default is -30d.

The recent replay page remains at -7d since the loading speed is about 50% faster at -7d than at -30d