### PR TITLE
feat(web-analytics): Add localised number formatting and right-aligned cells

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -309,7 +309,7 @@ export function LemonTable<T extends Record<string, any>>({
                                                     /* eslint-disable-next-line react/forbid-dom-props */
                                                     style={{ justifyContent: column.align }}
                                                 >
-                                                    <div className="flex items-center">
+                                                    <div className="w-full flex items-center">
                                                         {column.tooltip ? (
                                                             <Tooltip title={column.tooltip}>
                                                                 <div className="flex items-center">

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -309,7 +309,7 @@ export function LemonTable<T extends Record<string, any>>({
                                                     /* eslint-disable-next-line react/forbid-dom-props */
                                                     style={{ justifyContent: column.align }}
                                                 >
-                                                    <div className="w-full flex items-center">
+                                                    <div className="flex items-center">
                                                         {column.tooltip ? (
                                                             <Tooltip title={column.tooltip}>
                                                                 <div className="flex items-center">

--- a/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
@@ -11,12 +11,14 @@ import { getQueryFeatures, QueryFeature } from '~/queries/nodes/DataTable/queryF
 export interface ColumnMeta {
     title?: JSX.Element | string
     width?: number
+    align?: 'left' | 'right' | 'center'
 }
 
 export function renderColumnMeta(key: string, query: DataTableNode, context?: QueryContext): ColumnMeta {
     let width: number | undefined
     let title: JSX.Element | string | undefined
     const queryFeatures = getQueryFeatures(query.source)
+    let align: ColumnMeta['align']
 
     if (isHogQLQuery(query.source)) {
         title = key
@@ -43,6 +45,7 @@ export function renderColumnMeta(key: string, query: DataTableNode, context?: Qu
         ) : (
             queryContextColumn?.title ?? column.replace('_', ' ')
         )
+        align = queryContextColumn?.align
     } else if (key === 'person.$delete') {
         title = ''
         width = 0
@@ -71,5 +74,6 @@ export function renderColumnMeta(key: string, query: DataTableNode, context?: Qu
     return {
         title,
         ...(typeof width !== 'undefined' ? { width } : {}),
+        ...(align ? { align } : {}),
     }
 }

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -32,4 +32,5 @@ interface QueryContextColumn {
     title?: string
     renderTitle?: QueryContextColumnTitleComponent
     render?: QueryContextColumnComponent
+    align?: 'left' | 'right' | 'center' // default is left
 }

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -22,12 +22,21 @@ const PercentageCell: QueryContextColumnComponent = ({ value }) => {
     }
 }
 
+// format numbers according to the user's locale
+const numberFormatter = new Intl.NumberFormat()
+
 const NumericCell: QueryContextColumnComponent = ({ value }) => {
     return (
         <div className="w-full text-right">
-            <span className="flex-1 text-right">{String(value)}</span>
+            <span className="flex-1 text-right">
+                {typeof value === 'number' ? numberFormatter.format(value) : String(value)}
+            </span>
         </div>
     )
+}
+
+const RightAlignedTitle: QueryContextColumnTitleComponent = (props) => {
+    return <span className="flex-1 text-right">{props.columnName}</span>
 }
 
 const BreakdownValueTitle: QueryContextColumnTitleComponent = (props) => {
@@ -114,14 +123,17 @@ const queryContext: QueryContext = {
         },
         bounce_rate: {
             title: 'Bounce Rate',
+            renderTitle: RightAlignedTitle,
             render: PercentageCell,
         },
         views: {
             title: 'Views',
+            renderTitle: RightAlignedTitle,
             render: NumericCell,
         },
         visitors: {
             title: 'Visitors',
+            renderTitle: RightAlignedTitle,
             render: NumericCell,
         },
     },

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -12,11 +12,7 @@ import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 
 const PercentageCell: QueryContextColumnComponent = ({ value }) => {
     if (typeof value === 'number') {
-        return (
-            <div className="w-full text-right">
-                <span className="flex-1 text-right">{`${(value * 100).toFixed(1)}%`}</span>
-            </div>
-        )
+        return <span>{`${(value * 100).toFixed(1)}%`}</span>
     } else {
         return null
     }
@@ -26,17 +22,7 @@ const PercentageCell: QueryContextColumnComponent = ({ value }) => {
 const numberFormatter = new Intl.NumberFormat()
 
 const NumericCell: QueryContextColumnComponent = ({ value }) => {
-    return (
-        <div className="w-full text-right">
-            <span className="flex-1 text-right">
-                {typeof value === 'number' ? numberFormatter.format(value) : String(value)}
-            </span>
-        </div>
-    )
-}
-
-const RightAlignedTitle: QueryContextColumnTitleComponent = (props) => {
-    return <span className="flex-1 text-right">{props.columnName}</span>
+    return <span>{typeof value === 'number' ? numberFormatter.format(value * 1000) : String(value)}</span>
 }
 
 const BreakdownValueTitle: QueryContextColumnTitleComponent = (props) => {
@@ -123,18 +109,18 @@ const queryContext: QueryContext = {
         },
         bounce_rate: {
             title: 'Bounce Rate',
-            renderTitle: RightAlignedTitle,
             render: PercentageCell,
+            align: 'right',
         },
         views: {
             title: 'Views',
-            renderTitle: RightAlignedTitle,
             render: NumericCell,
+            align: 'right',
         },
         visitors: {
             title: 'Visitors',
-            renderTitle: RightAlignedTitle,
             render: NumericCell,
+            align: 'right',
         },
     },
 }

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -18,11 +18,8 @@ const PercentageCell: QueryContextColumnComponent = ({ value }) => {
     }
 }
 
-// format numbers according to the user's locale
-const numberFormatter = new Intl.NumberFormat()
-
 const NumericCell: QueryContextColumnComponent = ({ value }) => {
-    return <span>{typeof value === 'number' ? numberFormatter.format(value * 1000) : String(value)}</span>
+    return <span>{typeof value === 'number' ? value.toLocaleString() : String(value)}</span>
 }
 
 const BreakdownValueTitle: QueryContextColumnTitleComponent = (props) => {


### PR DESCRIPTION
## Problem

Large numbers are hard to read with commas, use the user-locale-based formatter to fix this.

## Changes

Web analytics
<img width="1270" alt="Screenshot 2023-10-20 at 10 55 17" src="https://github.com/PostHog/posthog/assets/2056078/5b8cc514-01d3-4daa-8f0a-3af860381cb2">


Existing data table (to prove I didn't break anything with my CSS change)
<img width="1280" alt="Screenshot 2023-10-20 at 10 54 29" src="https://github.com/PostHog/posthog/assets/2056078/028bc6d4-acae-4992-8bbc-3f90726a49e3">


## How did you test this code?
See the screenshots
