### PR TITLE
fix: Account for group deletes when indexing groupType

### DIFF
--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -19,7 +19,7 @@ export const groupsModel = kea<groupsModelType>([
         values: [teamLogic, ['currentTeamId'], groupsAccessLogic, ['groupsEnabled', 'groupsAccessStatus']],
     }),
     loaders(({ values }) => ({
-        groupTypes: [
+        groupTypesRaw: [
             [] as Array<GroupType>,
             {
                 loadAllGroupTypes: async () => {
@@ -38,6 +38,20 @@ export const groupsModel = kea<groupsModelType>([
         ],
     })),
     selectors({
+        groupTypes: [
+            (s) => [s.groupTypesRaw],
+            (groupTypesRaw) => {
+                const groupTypes: GroupType[] = new Array(groupTypesRaw.length)
+
+                for (const groupType of groupTypesRaw) {
+                    groupTypes[groupType.group_type_index] = groupType
+                }
+
+                return groupTypes
+            },
+        ],
+        groupTypesLoading: [(s) => [s.groupTypesRawLoading], (groupTypesRawLoading) => groupTypesRawLoading],
+
         showGroupsOptions: [
             (s) => [s.groupsAccessStatus, s.groupsEnabled, s.groupTypes],
             (status, enabled, groupTypes) => status !== GroupsAccessStatus.Hidden || (enabled && groupTypes.length > 0),
@@ -64,9 +78,9 @@ export const groupsModel = kea<groupsModelType>([
             (s) => [s.groupTypes],
             (groupTypes) =>
                 (groupTypeIndex: number | null | undefined, deferToUserWording: boolean = false): Noun => {
-                    const groupType = groupTypes.find((groupType) => groupType.group_type_index === groupTypeIndex)
+                    if (groupTypeIndex != undefined && groupTypes.length > 0 && groupTypes[groupTypeIndex]) {
+                        const groupType = groupTypes[groupTypeIndex]
 
-                    if (groupTypeIndex != undefined && groupTypes.length > 0 && groupType) {
                         return {
                             singular: groupType.name_plural || groupType.group_type,
                             plural: groupType.name_plural || `${groupType.group_type}(s)`,

--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -64,8 +64,9 @@ export const groupsModel = kea<groupsModelType>([
             (s) => [s.groupTypes],
             (groupTypes) =>
                 (groupTypeIndex: number | null | undefined, deferToUserWording: boolean = false): Noun => {
-                    if (groupTypeIndex != undefined && groupTypes.length > 0 && groupTypes[groupTypeIndex]) {
-                        const groupType = groupTypes[groupTypeIndex]
+                    const groupType = groupTypes.find((groupType) => groupType.group_type_index === groupTypeIndex)
+
+                    if (groupTypeIndex != undefined && groupTypes.length > 0 && groupType) {
                         return {
                             singular: groupType.name_plural || groupType.group_type,
                             plural: groupType.name_plural || `${groupType.group_type}(s)`,


### PR DESCRIPTION
## Problem

When we delete a `GroupTypeMapping` object via the admin UI, the `group_type_index` of the remaining objects is not adjusted to account for the deletion of the `GroupTypeMapping`. This makes it so the actual index (now with one less item) doesn't match `group_type_index`.

In the frontend, we do not account for possible deletes, thus causing us to default to "Persons" as the label.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Check for the `group_type_index` value instead of assuming it matches the array.

I thought about doing the significantly more elegant `group_type_index % groupTypes.length()` but it doesn't quite work in all cases.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally, start with initial set of groups:

![image](https://github.com/PostHog/posthog/assets/18740659/4fdea895-6751-4fad-93f7-17a32ba01437)

Delete Organization(s) (index 1) via the admin UI:

![image](https://github.com/PostHog/posthog/assets/18740659/031ad9d9-58b5-4366-a142-227058303016)

The local development instance rapidly created Organization(s) again, but now it has index 3 instead of 1.

Notice two things:
1. Organization(s) is now named "Persons" (default)
2. Instance(s) is now named "Organization(s)" (because Organization(s) now has index 2 in the array!)

If we apply my changes, things look now as expected:

![image](https://github.com/PostHog/posthog/assets/18740659/08d47eea-6a23-487d-a9ac-0c8b145b1eaa)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
