### PR TITLE
feat(ingestion): use kafka message ts when rate-limiting to overflow

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -313,7 +313,10 @@ export function splitIngestionBatch(
         }
         const pluginEvent = formPipelineEvent(message)
         const eventKey = computeKey(pluginEvent)
-        if (overflowMode === IngestionOverflowMode.Reroute && !ConfiguredLimiter.consume(eventKey, 1)) {
+        if (
+            overflowMode === IngestionOverflowMode.Reroute &&
+            !ConfiguredLimiter.consume(eventKey, 1, message.timestamp)
+        ) {
             // Local overflow detection triggering, reroute to overflow topic too
             message.key = null
             ingestionPartitionKeyOverflowed.labels(`${pluginEvent.team_id ?? pluginEvent.token}`).inc()

--- a/plugin-server/src/utils/token-bucket.ts
+++ b/plugin-server/src/utils/token-bucket.ts
@@ -21,22 +21,20 @@ export class Storage {
     }
 
     replenish(key: string, now?: number): void {
-        if (typeof now === 'undefined') {
-            now = Date.now()
-        }
-
-        if (this.buckets.has(key) === false) {
-            this.buckets.set(key, [this.bucketCapacity, now])
+        const replenish_timestamp: number = now ?? Date.now()
+        const bucket = this.buckets.get(key)
+        if (bucket === undefined) {
+            this.buckets.set(key, [this.bucketCapacity, replenish_timestamp])
             return
         }
 
-        // We have checked the key exists already, so this cannot be undefined
-        const bucket: Bucket = this.buckets.get(key)!
-
-        // replenishRate is per second, but timestamps are in milliseconds
-        const replenishedTokens = this.replenishRate * ((now - bucket[1]) / 1000) + bucket[0]
-        bucket[0] = Math.min(replenishedTokens, this.bucketCapacity)
-        bucket[1] = now
+        // Replenish the bucket if replenish_timestamp is higher than lastReplenishedTimestamp
+        const secondsToReplenish = (replenish_timestamp - bucket[1]) / 1000
+        if (secondsToReplenish > 0) {
+            bucket[0] += this.replenishRate * secondsToReplenish
+            bucket[0] = Math.min(bucket[0], this.bucketCapacity)
+            bucket[1] = replenish_timestamp
+        }
     }
 
     consume(key: string, tokens: number): boolean {

--- a/plugin-server/tests/utils/token-bucket.test.ts
+++ b/plugin-server/tests/utils/token-bucket.test.ts
@@ -59,12 +59,37 @@ describe('Storage', () => {
             expect(storage.buckets.get(key)![0]).toEqual(10)
             expect(storage.buckets.get(key)![1]).toEqual(now.valueOf())
 
+            // get two tokens to be replenished
+            storage.consume(key, 2)
+            expect(storage.buckets.get(key)![0]).toEqual(8)
+
             // 20 seconds would exceed capacity of 10 tokens at 1 token/sec.
             storage.replenish(key, now.valueOf() + 20000)
 
             expect(storage.buckets.has(key)).toEqual(true)
             expect(storage.buckets.get(key)![0]).toEqual(10)
             expect(storage.buckets.get(key)![1]).toEqual(now.valueOf() + 20000)
+        })
+
+        it('does not add if now is in the past', () => {
+            const key = 'test'
+            const storage = new Storage(10, 1)
+            const now = new Date('2023-02-08T08:00:00')
+
+            storage.replenish(key, now.valueOf())
+            expect(storage.buckets.get(key)![0]).toEqual(10)
+            expect(storage.buckets.get(key)![1]).toEqual(now.valueOf())
+
+            // get two tokens to be replenished
+            storage.consume(key, 2)
+            expect(storage.buckets.get(key)![0]).toEqual(8)
+
+            // Will be a no-op
+            storage.replenish(key, now.valueOf() - 20000)
+
+            expect(storage.buckets.has(key)).toEqual(true)
+            expect(storage.buckets.get(key)![0]).toEqual(8)
+            expect(storage.buckets.get(key)![1]).toEqual(now.valueOf())
         })
     })
 

--- a/plugin-server/tests/utils/token-bucket.test.ts
+++ b/plugin-server/tests/utils/token-bucket.test.ts
@@ -84,7 +84,7 @@ describe('Storage', () => {
             storage.consume(key, 2)
             expect(storage.buckets.get(key)![0]).toEqual(8)
 
-            // Will be a no-op
+            // Will be a no-op due to a lower now value
             storage.replenish(key, now.valueOf() - 20000)
 
             expect(storage.buckets.has(key)).toEqual(true)


### PR DESCRIPTION
## Problem

When recovering from lag, `plugins-analytics` triggers overflow more intensely, due to false-positives

## Changes

- Call `Limiter.consume` with the timestamp from the kafka message. From local testing, it is in milliseconds, as expected by the limiter.
- Make sure that `Limiter.replenish` can handle timestamps given out of order (consuming several partitions). We don't replenish if given a lower timestamp than before.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
