### PR TITLE
fix(plugin-server): prevent multiple concurrent reloadPlugins and coa…

### DIFF
--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -11,6 +11,14 @@ import { teardownPlugins } from './plugins/teardown'
 
 type TaskRunner = (hub: Hub, args: any) => Promise<any> | any
 
+// If a reload is already scheduled, this will be a promise that resolves when the reload is done.
+let RELOAD_PLUGINS_PROMISE: Promise<void> | undefined
+
+// Whether the actual reload work has started. If `RELOAD_PLUGINS_PROMISE` is defined and this is
+// `false` it means the promise is still sleeping for jitter, and so concurrent requests can know
+// that a reload will start in the future.
+let RELOAD_PLUGINS_PROMISE_STARTED = false
+
 export const workerTasks: Record<string, TaskRunner> = {
     runPluginJob: (hub, { job }: { job: EnqueuedPluginJob }) => {
         return runPluginTask(hub, job.type, PluginTaskType.Job, job.pluginConfigId, job.payload)
@@ -31,11 +39,42 @@ export const workerTasks: Record<string, TaskRunner> = {
         return hub.pluginSchedule !== null
     },
     reloadPlugins: async (hub) => {
-        // Jitter the reload time to avoid all workers reloading at the same time.
-        const jitterMs = Math.random() * hub.RELOAD_PLUGIN_JITTER_MAX_MS
-        status.info('💤', `Sleeping for ${jitterMs}ms to jitter reloadPlugins`)
-        await sleep(jitterMs)
-        await retryIfRetriable(async () => await setupPlugins(hub))
+        if (RELOAD_PLUGINS_PROMISE && !RELOAD_PLUGINS_PROMISE_STARTED) {
+            // A reload is already scheduled and hasn't started yet. When it starts it will load the
+            // state of plugins after this reload request was issued, so we're done here.
+            return
+        }
+
+        if (RELOAD_PLUGINS_PROMISE && RELOAD_PLUGINS_PROMISE_STARTED) {
+            // A reload was in progress, we need to wait for it to finish and then we can schedule a
+            // new one (or a concurrent request will beat us to it after also waiting here, which is
+            // fine!).
+            await RELOAD_PLUGINS_PROMISE
+        }
+
+        if (!RELOAD_PLUGINS_PROMISE) {
+            // No reload is in progress, schedule one. If multiple concurrent requests got in line
+            // above, we only need one to schedule the reload here.
+
+            RELOAD_PLUGINS_PROMISE = (async () => {
+                // Jitter the reload time to avoid all workers reloading at the same time.
+                const jitterMs = Math.random() * hub.RELOAD_PLUGIN_JITTER_MAX_MS
+                status.info('💤', `Sleeping for ${jitterMs}ms to jitter reloadPlugins`)
+                await sleep(jitterMs)
+
+                RELOAD_PLUGINS_PROMISE_STARTED = true
+                try {
+                    const tries = 3
+                    const retrySleepMs = 5000
+                    await retryIfRetriable(async () => await setupPlugins(hub), tries, retrySleepMs)
+                } finally {
+                    RELOAD_PLUGINS_PROMISE = undefined
+                    RELOAD_PLUGINS_PROMISE_STARTED = false
+                }
+            })()
+
+            await RELOAD_PLUGINS_PROMISE
+        }
     },
     reloadSchedule: async (hub) => {
         await loadSchedule(hub)


### PR DESCRIPTION
…lesce them when possible

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Nothing prevented concurrent plugin reloads. This is racy and wastes resources.

## Changes

Coalesce reload requests when possible, serialize them when not.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
