### PR TITLE
fix(backfill-batch-exports): Account for jitter

### DIFF
--- a/posthog/temporal/workflows/backfill_batch_export.py
+++ b/posthog/temporal/workflows/backfill_batch_export.py
@@ -139,11 +139,17 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
 
     handle = client.get_schedule_handle(inputs.schedule_id)
 
+    description = await handle.describe()
+    jitter = description.schedule.spec.jitter
+
     frequency = dt.timedelta(seconds=inputs.frequency_seconds)
     full_backfill_range = backfill_range(start_at, end_at, frequency * inputs.buffer_limit)
 
     for backfill_start_at, backfill_end_at in full_backfill_range:
         utcnow = dt.datetime.utcnow()
+
+        if jitter is not None:
+            backfill_end_at = backfill_end_at + jitter
 
         backfill = temporalio.client.ScheduleBackfill(
             start_at=backfill_start_at,


### PR DESCRIPTION
## Problem

When backfilling, we wait for the current batch of runs to be done. However, we do not account for potential jitter in the start time, that can cause the run to have a start time outside our range.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Account for jitter by adding it to the `backfill_end_at`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
