### PR TITLE
refactor(plugin-server): combine 2 person merge queries into a single…

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -965,36 +965,43 @@ export class DB {
         return insertResult.rows[0]
     }
 
-    // Feature Flag Hash Key overrides
-    public async addFeatureFlagHashKeysForMergedPerson(
+    public async updateCohortsAndFeatureFlagsForMerge(
         teamID: Team['id'],
         sourcePersonID: Person['id'],
         targetPersonID: Person['id'],
         tx?: TransactionClient
     ): Promise<void> {
-        // Delete and insert in a single query to ensure
-        // this function is safe wherever it is run.
-        // The CTE helps make this happen.
-        //
-        // Every override is unique for a team-personID-featureFlag combo.
-        // In case we run into a conflict we would ideally use the override from most recent
-        // personId used, so the user experience is consistent, however that's tricky to figure out
-        // this also happens rarely, so we're just going to do the performance optimal thing
-        // i.e. do nothing on conflicts, so we keep using the value that the person merged into had
+        // When personIDs change, update places depending on a person_id foreign key
+
         await this.postgres.query(
             tx ?? PostgresUse.COMMON_WRITE,
-            `
-            WITH deletions AS (
-                DELETE FROM posthog_featureflaghashkeyoverride WHERE team_id = $1 AND person_id = $2
+            // Do two high level things in a single round-trip to the DB.
+            //
+            // 1. Update cohorts.
+            // 2. Update (delete+insert) feature flags.
+            //
+            // NOTE: Every override is unique for a team-personID-featureFlag combo. In case we run
+            // into a conflict we would ideally use the override from most recent personId used, so
+            // the user experience is consistent, however that's tricky to figure out this also
+            // happens rarely, so we're just going to do the performance optimal thing i.e. do
+            // nothing on conflicts, so we keep using the value that the person merged into had
+            `WITH cohort_update AS (
+                UPDATE posthog_cohortpeople
+                SET person_id = $1
+                WHERE person_id = $2
+                RETURNING person_id
+            ),
+            deletions AS (
+                DELETE FROM posthog_featureflaghashkeyoverride
+                WHERE team_id = $3 AND person_id = $2
                 RETURNING team_id, person_id, feature_flag_key, hash_key
             )
             INSERT INTO posthog_featureflaghashkeyoverride (team_id, person_id, feature_flag_key, hash_key)
-                SELECT team_id, $3, feature_flag_key, hash_key
+                SELECT team_id, $1, feature_flag_key, hash_key
                 FROM deletions
-                ON CONFLICT DO NOTHING
-            `,
-            [teamID, sourcePersonID, targetPersonID],
-            'addFeatureFlagHashKeysForMergedPerson'
+                ON CONFLICT DO NOTHING`,
+            [targetPersonID, sourcePersonID, teamID],
+            'updateCohortAndFeatureFlagsPeople'
         )
     }
 

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -845,7 +845,7 @@ describe('DB', () => {
         })
     })
 
-    describe('addFeatureFlagHashKeysForMergedPerson()', () => {
+    describe('updateCohortsAndFeatureFlagsForMerge()', () => {
         let team: Team
         let sourcePersonID: Person['id']
         let targetPersonID: Person['id']
@@ -889,7 +889,7 @@ describe('DB', () => {
         })
 
         it("doesn't fail on empty data", async () => {
-            await db.addFeatureFlagHashKeysForMergedPerson(team.id, sourcePersonID, targetPersonID)
+            await db.updateCohortsAndFeatureFlagsForMerge(team.id, sourcePersonID, targetPersonID)
         })
 
         it('updates all valid keys when target person had no overrides', async () => {
@@ -906,7 +906,7 @@ describe('DB', () => {
                 hash_key: 'override_value_for_beta_feature',
             })
 
-            await db.addFeatureFlagHashKeysForMergedPerson(team.id, sourcePersonID, targetPersonID)
+            await db.updateCohortsAndFeatureFlagsForMerge(team.id, sourcePersonID, targetPersonID)
 
             const result = await getAllHashKeyOverrides()
 
@@ -947,7 +947,7 @@ describe('DB', () => {
                 hash_key: 'existing_override_value_for_beta_feature',
             })
 
-            await db.addFeatureFlagHashKeysForMergedPerson(team.id, sourcePersonID, targetPersonID)
+            await db.updateCohortsAndFeatureFlagsForMerge(team.id, sourcePersonID, targetPersonID)
 
             const result = await getAllHashKeyOverrides()
 
@@ -982,7 +982,7 @@ describe('DB', () => {
                 hash_key: 'override_value_for_beta_feature',
             })
 
-            await db.addFeatureFlagHashKeysForMergedPerson(team.id, sourcePersonID, targetPersonID)
+            await db.updateCohortsAndFeatureFlagsForMerge(team.id, sourcePersonID, targetPersonID)
 
             const result = await getAllHashKeyOverrides()
 

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -959,7 +959,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         new_person_id = person.id
         old_person_id = person2.id
         # this happens in the plugin server
-        # https://github.com/PostHog/posthog/blob/master/plugin-server/src/worker/ingestion/person-state.ts#L696 (addFeatureFlagHashKeysForMergedPerson)
+        # https://github.com/PostHog/posthog/blob/master/plugin-server/src/utils/db/db.ts (updateCohortsAndFeatureFlagsForMerge)
         # at which point we run the query
         query = f"""
             WITH deletions AS (

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -679,7 +679,7 @@ def get_all_feature_flags(
                     # In all cases, we simply try to find all personIDs associated with the distinct_id
                     # and the hash_key_override, and add overrides for all these personIDs.
                     # On merge, if a person is deleted, it is fine because the below line in plugin-server will take care of it.
-                    # https://github.com/PostHog/posthog/blob/master/plugin-server/src/worker/ingestion/person-state.ts#L696 (addFeatureFlagHashKeysForMergedPerson)
+                    # https://github.com/PostHog/posthog/blob/master/plugin-server/src/utils/db/db.ts (updateCohortsAndFeatureFlagsForMerge)
 
                     writing_hash_key_override = set_feature_flag_hash_key_overrides(
                         team_id, [distinct_id, hash_key_override], hash_key_override


### PR DESCRIPTION
… round trip to PG

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We do a lot of round trips to the DB during a Person merge. 

## Changes

This removes a round trip by combining some very easy to combine queries that were already right next to each other in the code.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Existing, well-tested code. This is a drop in replacement other than making the function name more clear.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
