### PR TITLE
chore: stop capturing insight visuals

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -80,7 +80,7 @@ export function InsightViz({ uniqueKey, query, setQuery, context, readOnly }: In
                             <EditorFilters query={query.source} showing={showingFilters} embedded={embedded} />
                         )}
 
-                        <div className="insights-container" data-attr="insight-view">
+                        <div className="insights-container ph-no-capture" data-attr="insight-view">
                             <InsightContainer
                                 insightMode={insightMode}
                                 context={context}


### PR DESCRIPTION
## Problem

Insights that possibly contain customer data are being recorded

## Changes

No not record any `InsightViz` rendering

## How did you test this code?

Watching recordings back locally