### PR TITLE
chore(compose): add capture-rs profile with containerised capture for testing

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -89,6 +89,18 @@ services:
         command: ./bin/start-backend & ./bin/start-frontend
         restart: on-failure
 
+    capture:
+        image: ghcr.io/posthog/capture:main
+        restart: on-failure
+        environment:
+            ADDRESS: '0.0.0.0:3000'
+            KAFKA_TOPIC: 'events_plugin_ingestion'
+            KAFKA_HOSTS: 'kafka:9092'
+            REDIS_URL: 'redis://redis:6379/'
+        depends_on:
+            - redis
+            - kafka
+
     plugins:
         command: ./bin/plugin-server --no-restart-loop
         restart: on-failure

--- a/docker-compose.dev-full.yml
+++ b/docker-compose.dev-full.yml
@@ -89,6 +89,15 @@ services:
         environment:
             - DEBUG=1
 
+    capture:
+        extends:
+            file: docker-compose.base.yml
+            service: capture
+        ports:
+            - 3000:3000
+        environment:
+            - DEBUG=1
+
     plugins:
         extends:
             file: docker-compose.base.yml

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -72,6 +72,17 @@ services:
             - '1080:1080'
             - '1025:1025'
 
+    # Optional capture
+    capture:
+        profiles: ['capture-rs']
+        extends:
+            file: docker-compose.base.yml
+            service: capture
+        ports:
+            - 3000:3000
+        environment:
+            - DEBUG=1
+
     # Temporal containers
     elasticsearch:
         extends:


### PR DESCRIPTION
## Problem

We'll want to run capture-rs in the local devenv for manual integration testing. Instead of adding a rustc dependency right now, let's use the docker image.

It uses the new profiles feature, so it's not started by default. You can get it up with `docker compose -f docker-compose.dev.yml --profile capture-rs up -d`

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
