### PR TITLE
fix(surveys): mcq preview label color bug

### DIFF
--- a/frontend/src/scenes/surveys/SurveyAppearance.tsx
+++ b/frontend/src/scenes/surveys/SurveyAppearance.tsx
@@ -599,7 +599,7 @@ export function SurveyMultipleChoiceAppearance({
                                 name="choice"
                                 value={choice}
                             />
-                            <label>{choice}</label>
+                            <label style={{ color: textColor }}>{choice}</label>
                             <span className="choice-check">{check}</span>
                         </div>
                     ))}


### PR DESCRIPTION
## Problem

<img width="423" alt="Screen Shot 2023-10-23 at 4 22 35 PM" src="https://github.com/PostHog/posthog/assets/25164963/97077d53-fde3-4bae-8676-a29d9a3fe868">

Preview was not showing the right label colors

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
