### PR TITLE
feat: Support for migrating bigquery and postgres

### DIFF
--- a/posthog/management/commands/create_batch_export_from_app.py
+++ b/posthog/management/commands/create_batch_export_from_app.py
@@ -1,12 +1,12 @@
 import datetime as dt
 import json
-from psycopg2.extensions import parse_dsn
 
 from django.core.management.base import BaseCommand, CommandError
+from psycopg2.extensions import parse_dsn
 
 from posthog.batch_exports.models import BatchExport, BatchExportDestination
 from posthog.batch_exports.service import backfill_export, sync_batch_export
-from posthog.models.plugin import PluginConfig
+from posthog.models.plugin import PluginAttachment, PluginConfig
 from posthog.temporal.client import sync_connect
 
 
@@ -170,6 +170,7 @@ def map_plugin_config_to_destination(plugin_config: PluginConfig) -> tuple[str, 
             "exclude_events": plugin_config.config["eventsToIgnore"].split(","),
         }
         export_type = "S3"
+
     elif plugin.name == "Snowflake Export":
         config = {
             "account": plugin_config.config["account"],
@@ -182,42 +183,49 @@ def map_plugin_config_to_destination(plugin_config: PluginConfig) -> tuple[str, 
             "role": plugin_config.config.get("role", None),
         }
         export_type = "Snowflake"
+
     elif plugin.name == "BigQuery Export":
-        config_file = json.load(plugin_config.config["googleCloudKeyJson"])
+        config_file_contents = PluginAttachment.objects.get(
+            team=plugin_config.team, plugin_config=plugin_config, key="googleCloudKeyJson"
+        ).contents
+        config_json = json.loads(bytes(config_file_contents))
 
         config = {
-            "project_id": config_file["project_id"],
-            "private_key": config_file["private_key"],
-            "private_key_id": config_file["private_key_id"],
-            "token_uri": config_file["token_uri"],
-            "client_email": config_file["client_email"],
+            "project_id": config_json["project_id"],
+            "private_key": config_json["private_key"],
+            "private_key_id": config_json["private_key_id"],
+            "token_uri": config_json["token_uri"],
+            "client_email": config_json["client_email"],
             "dataset_id": plugin_config.config["datasetId"],
             "table_id": plugin_config.config["tableId"],
-            "exclude_events": [plugin_config.config.get("exportEventsToIgnore", "").split(",")] or None,
+            "exclude_events": plugin_config.config.get("exportEventsToIgnore", "").split(",") or None,
         }
         export_type = "BigQuery"
+
     elif plugin.name == "PostgreSQL Export Plugin":
         if database_url := plugin_config.config.get("databaseUrl", None):
             raw_config = parse_dsn(database_url)
         else:
             raw_config = {
                 "host": plugin_config.config["host"],
-                "port": int(plugin_config.config.get("port", 5432)),
+                "port": plugin_config.config.get("port", "5432"),
                 "dbname": plugin_config.config["dbName"],
                 "user": plugin_config.config["dbUsername"],
                 "password": plugin_config.config["dbPassword"],
             }
 
+        has_self_signed_cert = plugin_config.config.get("hasSelfSignedCert", "No") == "Yes"
+
         config = {
-            "database": raw_config["database"],
+            "database": raw_config["dbname"],
             "user": raw_config["user"],
             "password": raw_config["password"],
             "schema": "",
             "host": raw_config["host"],
-            "port": raw_config["port"],
+            "port": int(raw_config["port"]),
             "table_name": plugin_config.config.get("tableName", "posthog_event"),
-            "has_self_signed_cert": plugin_config.config.get("hasSelfSignedCert", None),
-            "exclude_events": [plugin_config.config.get("eventsToIgnore", "").split(",")] or None,
+            "has_self_signed_cert": has_self_signed_cert,
+            "exclude_events": plugin_config.config.get("eventsToIgnore", "").split(",") or None,
         }
         export_type = "Postgres"
     else:

--- a/posthog/management/commands/test/test_create_batch_export_from_app.py
+++ b/posthog/management/commands/test/test_create_batch_export_from_app.py
@@ -1,5 +1,5 @@
+import collections
 import datetime as dt
-import itertools
 import json
 import typing
 
@@ -15,7 +15,7 @@ from posthog.api.test.test_team import create_team
 from posthog.management.commands.create_batch_export_from_app import (
     map_plugin_config_to_destination,
 )
-from posthog.models import Plugin, PluginConfig
+from posthog.models import Plugin, PluginAttachment, PluginConfig
 from posthog.temporal.client import sync_connect
 from posthog.temporal.codec import EncryptionCodec
 
@@ -58,6 +58,30 @@ def s3_plugin(organization) -> typing.Generator[Plugin, None, None]:
     plugin.delete()
 
 
+@pytest.fixture
+def bigquery_plugin(organization) -> typing.Generator[Plugin, None, None]:
+    plugin = Plugin.objects.create(
+        name="BigQuery Export",
+        url="https://github.com/PostHog/bigquery-plugin",
+        plugin_type="custom",
+        organization=organization,
+    )
+    yield plugin
+    plugin.delete()
+
+
+@pytest.fixture
+def postgres_plugin(organization) -> typing.Generator[Plugin, None, None]:
+    plugin = Plugin.objects.create(
+        name="PostgreSQL Export Plugin",
+        url="https://github.com/PostHog/postgres-plugin",
+        plugin_type="custom",
+        organization=organization,
+    )
+    yield plugin
+    plugin.delete()
+
+
 test_snowflake_config = {
     "account": "snowflake-account",
     "username": "test-user",
@@ -77,68 +101,162 @@ test_s3_config = {
     "compression": "gzip",
     "eventsToIgnore": "$feature_flag_called",
 }
+test_bigquery_config = {
+    "tableId": "my_table_id",
+    "datasetId": "my_dataset_id",
+    "googleCloudKeyJson": {
+        "type": "service_accout",
+        "project_id": "my_project_id",
+        "private_key_id": "my_private_key_id",
+        "private_key": "-----BEGIN PRIVATE KEY-----Wow much private, such key-----END PRIVATE KEY-----",
+        "client_email": "email@google.com",
+        "client_id": "client_id",
+        "auth_uri": "https://accouts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata",
+    },
+    "exportEventsToIgnore": "$feature_flag_called,$pageleave,$pageview,$rageclick,$identify",
+}
+test_postgres_config = {
+    "host": "localhost",
+    "port": "5432",
+    "dbName": "dev",
+    "tableName": "posthog_event",
+    "dbPassword": "password",
+    "dbUsername": "username",
+    "databaseUrl": "",
+    "eventsToIgnore": "$feature_flag_called",
+    "hasSelfSignedCert": "Yes",
+}
+test_postgres_config_with_database_url = {
+    "port": "54322",
+    "dbName": "prod",
+    "host": "localhost",
+    "tableName": "posthog_event",
+    "dbPassword": "password_in_url",
+    "dbUsername": "username_in_url",
+    "databaseUrl": "postgres://username_in_url:password_in_url@localhost:54322/prod",
+    "eventsToIgnore": "$feature_flag_called,$pageleave,$pageview,$rageclick,$identify",
+    "hasSelfSignedCert": "Yes",
+}
+
+PluginConfigParams = collections.namedtuple(
+    "PluginConfigParams", ("plugin_type", "disabled", "database_url"), defaults=(False, False)
+)
 
 
 @pytest.fixture
-def config(request):
-    if request.param == "S3":
-        return test_s3_config
-    elif request.param == "Snowflake":
-        return test_snowflake_config
+def config(request) -> dict[str, str]:
+    """Dispatch into one of the configurations for testing according to export/plugin type."""
+    if isinstance(request.param, tuple):
+        params = PluginConfigParams(*request.param)
     else:
-        raise ValueError(f"Unsupported plugin: {request.param}")
+        params = PluginConfigParams(request.param)
+
+    match params.plugin_type:
+        case "S3":
+            return test_s3_config
+        case "Snowflake":
+            return test_snowflake_config
+        case "BigQuery":
+            return test_bigquery_config
+        case "Postgres":
+            if params.database_url is True:
+                return test_postgres_config_with_database_url
+            else:
+                return test_postgres_config
+        case _:
+            raise ValueError(f"Unsupported plugin: {request.param}")
 
 
 @pytest.fixture
-def snowflake_plugin_config(snowflake_plugin, team) -> typing.Generator[PluginConfig, None, None]:
+def plugin_config(
+    request, bigquery_plugin, postgres_plugin, s3_plugin, snowflake_plugin, team
+) -> typing.Generator[PluginConfig, None, None]:
+    """Manage a PluginConfig for testing.
+
+    We dispatch to each supported plugin/export type according to
+    request.param.
+    """
+    if isinstance(request.param, tuple):
+        params = PluginConfigParams(*request.param)
+    else:
+        params = PluginConfigParams(request.param)
+
+    attachment_contents = None
+    attachment_key = None
+
+    match params.plugin_type:
+        case "S3":
+            plugin = s3_plugin
+            config = test_s3_config
+        case "Snowflake":
+            plugin = snowflake_plugin
+            config = test_snowflake_config
+        case "BigQuery":
+            plugin = bigquery_plugin
+            config = test_bigquery_config
+
+            json_attachment = config["googleCloudKeyJson"]
+            attachment_contents = json.dumps(json_attachment).encode("utf-8")
+            attachment_key = "googleCloudKeyJson"
+
+            # Merge these back so that we can assert their prescense later.
+            config = {**config, **json_attachment}
+
+        case "Postgres":
+            plugin = postgres_plugin
+
+            if params.database_url is True:
+                config = test_postgres_config_with_database_url
+            else:
+                config = test_postgres_config
+
+        case _:
+            raise ValueError(f"Unsupported plugin: {params.plugin_type}")
+
     plugin_config = PluginConfig.objects.create(
-        plugin=snowflake_plugin,
+        plugin=plugin,
         order=1,
         team=team,
         enabled=True,
-        config=test_snowflake_config,
+        config=config,
     )
+
+    attachment = None
+    if attachment_contents and attachment_key:
+        attachment = PluginAttachment.objects.create(
+            key=attachment_key,
+            plugin_config=plugin_config,
+            team=team,
+            contents=attachment_contents,
+            file_size=len(attachment_contents),
+            file_name=attachment_key,
+        )
+
+    if params.disabled is True:
+        plugin_config.enabled = False
+        plugin_config.save()
+
     yield plugin_config
+
     plugin_config.delete()
 
-
-@pytest.fixture
-def s3_plugin_config(s3_plugin, team) -> typing.Generator[PluginConfig, None, None]:
-    plugin_config = PluginConfig.objects.create(
-        plugin=s3_plugin, order=1, team=team, enabled=True, config=test_s3_config
-    )
-    yield plugin_config
-    plugin_config.delete()
-
-
-@pytest.fixture
-def plugin_config(request, s3_plugin_config, snowflake_plugin_config) -> PluginConfig:
-    if request.param == "S3":
-        return s3_plugin_config
-    elif request.param == "Snowflake":
-        return snowflake_plugin_config
-    else:
-        raise ValueError(f"Unsupported plugin: {request.param}")
-
-
-@pytest.fixture
-def disabled_plugin_config(request, s3_plugin_config, snowflake_plugin_config) -> PluginConfig:
-    if request.param == "S3":
-        s3_plugin_config.enabled = False
-        s3_plugin_config.save()
-        return s3_plugin_config
-    elif request.param == "Snowflake":
-        snowflake_plugin_config.enabled = False
-        snowflake_plugin_config.save()
-        return snowflake_plugin_config
-    else:
-        raise ValueError(f"Unsupported plugin: {request.param}")
+    if attachment:
+        attachment.delete()
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "plugin_config,config,expected_type",
-    [("S3", "S3", "S3"), ("Snowflake", "Snowflake", "Snowflake")],
+    [
+        ("S3", "S3", "S3"),
+        ("Snowflake", "Snowflake", "Snowflake"),
+        ("BigQuery", "BigQuery", "BigQuery"),
+        ("Postgres", "Postgres", "Postgres"),
+        (("Postgres", False, True), ("Postgres", False, True), "Postgres"),
+    ],
     indirect=["plugin_config", "config"],
 )
 def test_map_plugin_config_to_destination(plugin_config, config, expected_type):
@@ -149,15 +267,33 @@ def test_map_plugin_config_to_destination(plugin_config, config, expected_type):
 
     result_values = list(export_config.values())
     for key, value in config.items():
-        if key == "eventsToIgnore":
-            assert value in export_config["exclude_events"]
+        if key == "eventsToIgnore" or key == "exportEventsToIgnore":
+            assert value.split(",") == export_config["exclude_events"]
+            continue
+
+        if key == "hasSelfSignedCert":
+            assert (value == "Yes") == export_config["has_self_signed_cert"]
+            continue
+
+        if key == "port":
+            value = int(value)
+
+        if key in (
+            "databaseUrl",
+            "googleCloudKeyJson",
+        ):
+            # We don't use these in exports, or we parse them and store them with a different key.
             continue
 
         assert value in result_values
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("plugin_config", ["S3", "Snowflake"], indirect=True)
+@pytest.mark.parametrize(
+    "plugin_config",
+    ("S3", "Snowflake", "BigQuery", "Postgres", ("Postgres", False, True)),
+    indirect=True,
+)
 def test_create_batch_export_from_app_fails_with_mismatched_team_id(plugin_config):
     """Test the create_batch_export_from_app command fails if team_id does not match PluginConfig.team_id."""
 
@@ -171,7 +307,11 @@ def test_create_batch_export_from_app_fails_with_mismatched_team_id(plugin_confi
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("plugin_config", ["S3", "Snowflake"], indirect=True)
+@pytest.mark.parametrize(
+    "plugin_config",
+    ("S3", "Snowflake", "BigQuery", "Postgres", ("Postgres", False, True)),
+    indirect=True,
+)
 def test_create_batch_export_from_app_dry_run(plugin_config):
     """Test a dry_run of the create_batch_export_from_app command."""
     output = call_command(
@@ -195,11 +335,13 @@ def test_create_batch_export_from_app_dry_run(plugin_config):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("interval", ("hour", "day"))
 @pytest.mark.parametrize(
-    "interval,plugin_config,disable_plugin_config",
-    itertools.product(["hour", "day"], ["S3", "Snowflake"], [True, False]),
-    indirect=["plugin_config"],
+    "plugin_config",
+    (("S3", False), ("Snowflake", False), ("BigQuery", False), ("Postgres", False), ("Postgres", False, True)),
+    indirect=True,
 )
+@pytest.mark.parametrize("disable_plugin_config", (True, False))
 def test_create_batch_export_from_app(
     interval,
     plugin_config,
@@ -252,20 +394,22 @@ def test_create_batch_export_from_app(
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("interval", ("hour", "day"))
 @pytest.mark.parametrize(
-    "interval,disabled_plugin_config,migrate_disabled_plugin_config",
-    itertools.product(["hour", "day"], ["S3", "Snowflake"], [True, False]),
-    indirect=["disabled_plugin_config"],
+    "plugin_config",
+    (("S3", True), ("Snowflake", True), ("BigQuery", True), ("Postgres", True), ("Postgres", True, True)),
+    indirect=True,
 )
+@pytest.mark.parametrize("migrate_disabled_plugin_config", (True, False))
 def test_create_batch_export_from_app_with_disabled_plugin(
     interval,
-    disabled_plugin_config,
+    plugin_config,
     migrate_disabled_plugin_config,
 ):
     """Test a live run of the create_batch_export_from_app command."""
     args = [
-        f"--plugin-config-id={disabled_plugin_config.id}",
-        f"--team-id={disabled_plugin_config.team.id}",
+        f"--plugin-config-id={plugin_config.id}",
+        f"--team-id={plugin_config.team.id}",
         f"--interval={interval}",
     ]
     if migrate_disabled_plugin_config:
@@ -273,14 +417,14 @@ def test_create_batch_export_from_app_with_disabled_plugin(
 
     output = call_command("create_batch_export_from_app", *args)
 
-    disabled_plugin_config.refresh_from_db()
-    assert disabled_plugin_config.enabled is False
+    plugin_config.refresh_from_db()
+    assert plugin_config.enabled is False
 
-    export_type, config = map_plugin_config_to_destination(disabled_plugin_config)
+    export_type, config = map_plugin_config_to_destination(plugin_config)
 
     batch_export_data = json.loads(output)
 
-    assert batch_export_data["team_id"] == disabled_plugin_config.team.id
+    assert batch_export_data["team_id"] == plugin_config.team.id
     assert batch_export_data["interval"] == interval
     assert batch_export_data["name"] == f"{export_type} Export"
     assert batch_export_data["destination_data"] == {
@@ -305,7 +449,7 @@ def test_create_batch_export_from_app_with_disabled_plugin(
     args = json.loads(decoded_payload[0].data)
 
     # Common inputs
-    assert args["team_id"] == disabled_plugin_config.team.pk
+    assert args["team_id"] == plugin_config.team.pk
     assert args["batch_export_id"] == str(batch_export_data["id"])
     assert args["interval"] == interval
 
@@ -326,15 +470,11 @@ async def list_workflows(temporal, schedule_id: str):
 
 
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize("interval", ("hour", "day"))
 @pytest.mark.parametrize(
-    "interval,plugin_config",
-    [
-        ("hour", "S3"),
-        ("day", "S3"),
-        ("hour", "Snowflake"),
-        ("day", "Snowflake"),
-    ],
-    indirect=["plugin_config"],
+    "plugin_config",
+    (("S3", False), ("Snowflake", False), ("BigQuery", False), ("Postgres", False), ("Postgres", False, True)),
+    indirect=True,
 )
 def test_create_batch_export_from_app_with_backfill(interval, plugin_config):
     """Test a live run of the create_batch_export_from_app command with the backfill flag set."""

--- a/posthog/management/commands/test/test_create_batch_export_from_app.py
+++ b/posthog/management/commands/test/test_create_batch_export_from_app.py
@@ -492,9 +492,9 @@ def test_create_batch_export_from_app_with_backfill(interval, plugin_config):
         output = call_command("create_batch_export_from_app", *args)
 
         batch_export_data = json.loads(output)
-        # time.sleep(10)
         workflows = list_workflows(temporal, str(batch_export_data["id"]))
 
-        assert len(workflows) == 1
+        # Backfills are triggered by a Workflow now, so there should be two running.
+        assert len(workflows) == 2
         workflow_execution = workflows[0]
         assert workflow_execution.workflow_type == f"{export_type.lower()}-export"


### PR DESCRIPTION
## Problem

To migrate users over to batch exports, we need to extend the `create_batch_export_from_app` management command to Support BigQuery and Postgres.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Added support for migrating BigQuery and Postgres apps to batch exports.
Removed some duplication in tests.
Updated tests to test migration of BigQuery and Postgres apps.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Extended unit tests to cover BigQuery and Postgres.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
