### PR TITLE
feat: remember show advanced filters

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/SessionRecordingsFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/SessionRecordingsFilters.tsx
@@ -101,8 +101,9 @@ export function SessionRecordingsFilters({
                     size="small"
                     onClick={() => setShowAdvancedFilters(!showAdvancedFilters)}
                     disabledReason={
-                        hasAdvancedFilters &&
-                        'You are only allowed person filters and a single pageview event to switch back to simple filters'
+                        hasAdvancedFilters
+                            ? 'You are only allowed person filters and a single pageview event (filtered by current url) to switch back to simple filters'
+                            : undefined
                     }
                 >
                     Show {showAdvancedFilters ? 'simple filters' : 'advanced filters'}

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -348,6 +348,9 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
         showAdvancedFilters: [
             addedAdvancedFilters(props.filters, getDefaultFilters(props.personUUID)),
             {
+                persist: true,
+            },
+            {
                 setFilters: (showingAdvancedFilters, { filters }) =>
                     addedAdvancedFilters(filters, getDefaultFilters(props.personUUID)) ? true : showingAdvancedFilters,
                 setShowAdvancedFilters: (_, { showAdvancedFilters }) => showAdvancedFilters,

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -79,30 +79,64 @@ export const getDefaultFilters = (personUUID?: PersonUUID): RecordingFilters => 
     return personUUID ? DEFAULT_PERSON_RECORDING_FILTERS : DEFAULT_RECORDING_FILTERS
 }
 
+function isPageViewFilter(filter: Record<string, any>): boolean {
+    return filter.name === '$pageview'
+}
+function isCurrentURLPageViewFilter(eventsFilter: Record<string, any>): boolean {
+    const hasSingleProperty = Array.isArray(eventsFilter.properties) && eventsFilter.properties?.length === 1
+    const isCurrentURLProperty = hasSingleProperty && eventsFilter.properties[0].key === '$current_url'
+    return isPageViewFilter(eventsFilter) && isCurrentURLProperty
+}
+
+// checks are stored against filter keys so that the type system enforces adding a check when we add new filters
+const advancedFilterChecks: Record<
+    keyof RecordingFilters,
+    (filters: RecordingFilters, defaultFilters: RecordingFilters) => boolean
+> = {
+    actions: (filters) => (filters.actions ? filters.actions.length > 0 : false),
+    events: function (filters: RecordingFilters): boolean {
+        const eventsFilters = filters.events || []
+        // simple filters allow a single $pageview event filter with $current_url as the selected property
+        // anything else is advanced
+        return (
+            eventsFilters.length > 1 ||
+            (!!eventsFilters[0] &&
+                (!isPageViewFilter(eventsFilters[0]) || !isCurrentURLPageViewFilter(eventsFilters[0])))
+        )
+    },
+    properties: function (): boolean {
+        // TODO is this right? should we ever care about properties for choosing between advanced and simple?
+        return false
+    },
+    date_from: (filters, defaultFilters) => filters.date_from != defaultFilters.date_from,
+    date_to: (filters, defaultFilters) => filters.date_to != defaultFilters.date_to,
+    session_recording_duration: (filters, defaultFilters) =>
+        !equal(filters.session_recording_duration, defaultFilters.session_recording_duration),
+    duration_type_filter: (filters, defaultFilters) =>
+        filters.duration_type_filter !== defaultFilters.duration_type_filter,
+    console_search_query: (filters) =>
+        filters.console_search_query ? filters.console_search_query.trim().length > 0 : false,
+    console_logs: (filters) => (filters.console_logs ? filters.console_logs.length > 0 : false),
+    filter_test_accounts: (filters) => filters.filter_test_accounts ?? false,
+}
+
 export const addedAdvancedFilters = (
     filters: RecordingFilters | undefined,
     defaultFilters: RecordingFilters
 ): boolean => {
-    if (!filters) {
+    // if there are no filters or if some filters are not present then the page is still booting up
+    if (!filters || filters.session_recording_duration === undefined || filters.date_from === undefined) {
         return false
     }
 
-    const hasActions = filters.actions ? filters.actions.length > 0 : false
-    const hasChangedDateFrom = filters.date_from != defaultFilters.date_from
-    const hasChangedDateTo = filters.date_to != defaultFilters.date_to
-    const hasConsoleLogsFilters = filters.console_logs ? filters.console_logs.length > 0 : false
-    const hasChangedDuration = !equal(filters.session_recording_duration, defaultFilters.session_recording_duration)
-    const eventsFilters = filters.events || []
-    const hasAdvancedEvents = eventsFilters.length > 1 || (!!eventsFilters[0] && eventsFilters[0].name != '$pageview')
+    // keeps results with the keys for printing when debugging
+    const checkResults = Object.keys(advancedFilterChecks).map((key) => ({
+        key,
+        result: advancedFilterChecks[key](filters, defaultFilters),
+    }))
 
-    return (
-        hasActions ||
-        hasAdvancedEvents ||
-        hasChangedDuration ||
-        hasChangedDateFrom ||
-        hasChangedDateTo ||
-        hasConsoleLogsFilters
-    )
+    // if any check is true, then this is an advanced filter
+    return checkResults.some((checkResult) => checkResult.result)
 }
 
 export const defaultPageviewPropertyEntityFilter = (
@@ -351,8 +385,11 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                 persist: true,
             },
             {
-                setFilters: (showingAdvancedFilters, { filters }) =>
-                    addedAdvancedFilters(filters, getDefaultFilters(props.personUUID)) ? true : showingAdvancedFilters,
+                setFilters: (showingAdvancedFilters, { filters }) => {
+                    return addedAdvancedFilters(filters, getDefaultFilters(props.personUUID))
+                        ? true
+                        : showingAdvancedFilters
+                },
                 setShowAdvancedFilters: (_, { showAdvancedFilters }) => showAdvancedFilters,
             },
         ],

--- a/package.json
+++ b/package.json
@@ -223,7 +223,6 @@
         "@types/react-resizable": "^3.0.4",
         "@types/react-syntax-highlighter": "^15.5.7",
         "@types/react-textfit": "^1.1.0",
-        "@types/react-transition-group": "^4.4.4",
         "@types/react-virtualized": "^9.21.14",
         "@types/testing-library__jest-dom": "^5.14.5",
         "@types/zxcvbn": "^4.4.0",


### PR DESCRIPTION
Most people don't click "Show advanced filters"... a good signal that simple filters are useful (or the button is too hidden 🙈)

But the people that do click it almost all click it within 20 seconds. My guess is that means simple filters aren't ever useful for that group of people, let's remember that they chose to show advanced filters

See: https://app.posthog.com/insights/2fDcGdRA

* changing filters appropriately sets the advanced filter setting
* reloading the page re-uses the same last filter setting - so if you prefer advanced you're probably on it

![2023-10-25 10 41 34](https://github.com/PostHog/posthog/assets/984817/72f89c73-82d2-4618-ba4f-725241891bf5)
