### PR TITLE
fix: Prevent Users from Setting Billing Limit when They Have 100% Discount

### DIFF
--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -355,6 +355,12 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                                     <LemonButton
                                                         fullWidth
                                                         status="stealth"
+                                                        disabledReason={
+                                                            billing?.discount_percent === 100
+                                                                ? "You can't set a billing limit with a 100% discount"
+                                                                : null
+                                                        }
+                                                        tooltipPlacement="bottom"
                                                         onClick={() => setIsEditingBillingLimit(true)}
                                                     >
                                                         Set billing limit


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/6659 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/9246)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
