### PR TITLE
fix(surveys): update subscribe link

### DIFF
--- a/frontend/src/lib/components/PayGateMini/PayGateMini.tsx
+++ b/frontend/src/lib/components/PayGateMini/PayGateMini.tsx
@@ -145,7 +145,7 @@ export function PayGateMini({
                 center
             >
                 {gateVariant === 'add-card'
-                    ? 'Upgrade now'
+                    ? 'Subscribe now'
                     : gateVariant === 'contact-sales'
                     ? 'Contact sales'
                     : 'Subscribe'}

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -12,6 +12,7 @@ import {
     LemonSelect,
     LemonTabs,
     LemonTextArea,
+    Link,
 } from '@posthog/lemon-ui'
 import { Field, PureField } from 'lib/forms/Field'
 import {
@@ -591,30 +592,37 @@ export default function SurveyEdit(): JSX.Element {
                                     />
                                     <div className="flex gap-2">
                                         {featureFlags[FEATURE_FLAGS.SURVEYS_MULTIPLE_QUESTIONS] && (
-                                            <LemonButton
-                                                type="secondary"
-                                                className="w-max mt-2"
-                                                icon={<IconPlus />}
-                                                sideIcon={
-                                                    surveysMultipleQuestionsAvailable ? null : (
-                                                        <IconLock className="ml-1 text-base text-muted" />
-                                                    )
-                                                }
-                                                disabledReason={
-                                                    surveysMultipleQuestionsAvailable
-                                                        ? null
-                                                        : 'Subscribe for multiple question surveys'
-                                                }
-                                                onClick={() => {
-                                                    setSurveyValue('questions', [
-                                                        ...survey.questions,
-                                                        { ...defaultSurveyFieldValues.open.questions[0] },
-                                                    ])
-                                                    setSelectedQuestion(survey.questions.length)
-                                                }}
-                                            >
-                                                Add question
-                                            </LemonButton>
+                                            <div className="flex items-center gap-2 mt-2">
+                                                <LemonButton
+                                                    type="secondary"
+                                                    className="w-max"
+                                                    icon={<IconPlus />}
+                                                    sideIcon={
+                                                        surveysMultipleQuestionsAvailable ? null : (
+                                                            <IconLock className="ml-1 text-base text-muted" />
+                                                        )
+                                                    }
+                                                    disabledReason={
+                                                        surveysMultipleQuestionsAvailable
+                                                            ? null
+                                                            : 'Subscribe to surveys for multiple questions'
+                                                    }
+                                                    onClick={() => {
+                                                        setSurveyValue('questions', [
+                                                            ...survey.questions,
+                                                            { ...defaultSurveyFieldValues.open.questions[0] },
+                                                        ])
+                                                        setSelectedQuestion(survey.questions.length)
+                                                    }}
+                                                >
+                                                    Add question
+                                                </LemonButton>
+                                                {!surveysMultipleQuestionsAvailable && (
+                                                    <Link to={'/organization/billing'} target="_blank" targetBlankIcon>
+                                                        Subscribe
+                                                    </Link>
+                                                )}
+                                            </div>
                                         )}
                                         {!survey.appearance.displayThankYouMessage && (
                                             <LemonButton


### PR DESCRIPTION
## Problem

Received feedback that there's no nice CTA for multiple questions. Add a link so users can go to the right page at least

## Changes

<img width="496" alt="Screen Shot 2023-10-24 at 6 55 58 PM" src="https://github.com/PostHog/posthog/assets/25164963/163f0330-ebbd-42d5-a11f-61eee1decaf5">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
