### PR TITLE
feat(web-analytics): Add alpha notice

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -57,6 +57,7 @@ export const TARGET_AREA_TO_NAME = {
     session_replay: 'Session Replay (Recordings)',
     toolbar: 'Toolbar & heatmaps',
     surveys: 'Surveys',
+    web_analytics: 'Web Analytics',
 }
 
 export const SUPPORT_KIND_TO_SUBJECT = {
@@ -85,6 +86,7 @@ export const URL_PATH_TO_TARGET_AREA: Record<string, SupportTicketTargetArea> = 
     toolbar: 'session_replay',
     warehouse: 'data_warehouse',
     surveys: 'surveys',
+    web: 'web_analytics',
 }
 
 export function getURLPathToTargetArea(pathname: string): SupportTicketTargetArea | null {

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -9,6 +9,9 @@ import { QueryContext, QueryContextColumnComponent, QueryContextColumnTitleCompo
 import { useCallback } from 'react'
 import { UnexpectedNeverError } from 'lib/utils'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { supportLogic } from 'lib/components/Support/supportLogic'
+import { IconBugReport, IconFeedback } from 'lib/lemon-ui/icons'
 
 const PercentageCell: QueryContextColumnComponent = ({ value }) => {
     if (typeof value === 'number') {
@@ -209,9 +212,29 @@ const Tiles = (): JSX.Element => {
     )
 }
 
+export const Notice = (): JSX.Element => {
+    const { openSupportForm } = useActions(supportLogic)
+
+    return (
+        <LemonBanner type={'info'}>
+            <p>PostHog Web Analytics is in closed Alpha. Thanks for taking part! We'd love to hear what you think.</p>
+            <p>
+                <a onClick={() => openSupportForm('bug')}>
+                    <IconBugReport /> Report a bug
+                </a>{' '}
+                -{' '}
+                <a onClick={() => openSupportForm('feedback')}>
+                    <IconFeedback /> Give feedback
+                </a>
+            </p>
+        </LemonBanner>
+    )
+}
+
 export const WebAnalyticsDashboard = (): JSX.Element => {
     return (
-        <div className="w-full flex flex-col">
+        <div className="w-full flex flex-col pt-2">
+            <Notice />
             <Filters />
             <Tiles />
         </div>

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -11,7 +11,7 @@ import { UnexpectedNeverError } from 'lib/utils'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { supportLogic } from 'lib/components/Support/supportLogic'
-import { IconBugReport, IconFeedback } from 'lib/lemon-ui/icons'
+import { IconBugReport, IconFeedback, IconGithub } from 'lib/lemon-ui/icons'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 const PercentageCell: QueryContextColumnComponent = ({ value }) => {
@@ -230,6 +230,10 @@ export const Notice = (): JSX.Element => {
                     -{' '}
                     <a onClick={() => openSupportForm('feedback')}>
                         <IconFeedback /> Give feedback
+                    </a>{' '}
+                    -{' '}
+                    <a href={'https://github.com/PostHog/posthog/issues/18177'}>
+                        <IconGithub /> View GitHub issue
                     </a>
                 </p>
             ) : null}

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -12,6 +12,7 @@ import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { supportLogic } from 'lib/components/Support/supportLogic'
 import { IconBugReport, IconFeedback } from 'lib/lemon-ui/icons'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 const PercentageCell: QueryContextColumnComponent = ({ value }) => {
     if (typeof value === 'number') {
@@ -214,19 +215,24 @@ const Tiles = (): JSX.Element => {
 
 export const Notice = (): JSX.Element => {
     const { openSupportForm } = useActions(supportLogic)
+    const { preflight } = useValues(preflightLogic)
+
+    const showSupportOptions = preflight?.cloud
 
     return (
         <LemonBanner type={'info'}>
             <p>PostHog Web Analytics is in closed Alpha. Thanks for taking part! We'd love to hear what you think.</p>
-            <p>
-                <a onClick={() => openSupportForm('bug')}>
-                    <IconBugReport /> Report a bug
-                </a>{' '}
-                -{' '}
-                <a onClick={() => openSupportForm('feedback')}>
-                    <IconFeedback /> Give feedback
-                </a>
-            </p>
+            {showSupportOptions ? (
+                <p>
+                    <a onClick={() => openSupportForm('bug')}>
+                        <IconBugReport /> Report a bug
+                    </a>{' '}
+                    -{' '}
+                    <a onClick={() => openSupportForm('feedback')}>
+                        <IconFeedback /> Give feedback
+                    </a>
+                </p>
+            ) : null}
         </LemonBanner>
     )
 }


### PR DESCRIPTION
## Problem
I'd like to know how people are getting on with web analytics

## Changes
Add web-analytics as a support area
Add a notice
<img width="1145" alt="Screenshot 2023-10-25 at 10 50 07" src="https://github.com/PostHog/posthog/assets/2056078/45012316-e631-4c38-b725-125b7dda99d0">

## How did you test this code?
(behind FF) ran it manually
