### PR TITLE
feat(web-analytics): Hide incomplete insights

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -2,14 +2,7 @@ import { actions, connect, kea, listeners, path, reducers, selectors, sharedList
 
 import type { webAnalyticsLogicType } from './webAnalyticsLogicType'
 import { NodeKind, QuerySchema, WebAnalyticsPropertyFilters, WebStatsBreakdown } from '~/queries/schema'
-import {
-    BaseMathType,
-    ChartDisplayType,
-    EventPropertyFilter,
-    HogQLPropertyFilter,
-    PropertyFilterType,
-    PropertyOperator,
-} from '~/types'
+import { EventPropertyFilter, HogQLPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
 import { isNotNil } from 'lib/utils'
 
 interface Layout {
@@ -363,63 +356,63 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                         ],
                     },
-                    {
-                        title: 'Unique users',
-                        layout: {
-                            colSpan: 6,
-                        },
-                        query: {
-                            kind: NodeKind.InsightVizNode,
-                            source: {
-                                kind: NodeKind.TrendsQuery,
-                                dateRange,
-                                interval: 'day',
-                                series: [
-                                    {
-                                        event: '$pageview',
-                                        kind: NodeKind.EventsNode,
-                                        math: BaseMathType.UniqueUsers,
-                                        name: '$pageview',
-                                    },
-                                ],
-                                trendsFilter: {
-                                    compare: true,
-                                    display: ChartDisplayType.ActionsLineGraph,
-                                },
-                                filterTestAccounts: true,
-                                properties: webAnalyticsFilters,
-                            },
-                        },
-                    },
-                    {
-                        title: 'World Map (Unique Users)',
-                        layout: {
-                            colSpan: 6,
-                        },
-                        query: {
-                            kind: NodeKind.InsightVizNode,
-                            source: {
-                                kind: NodeKind.TrendsQuery,
-                                breakdown: {
-                                    breakdown: '$geoip_country_code',
-                                    breakdown_type: 'person',
-                                },
-                                dateRange,
-                                series: [
-                                    {
-                                        event: '$pageview',
-                                        kind: NodeKind.EventsNode,
-                                        math: BaseMathType.UniqueUsers,
-                                    },
-                                ],
-                                trendsFilter: {
-                                    display: ChartDisplayType.WorldMap,
-                                },
-                                filterTestAccounts: true,
-                                properties: webAnalyticsFilters,
-                            },
-                        },
-                    },
+                    // {
+                    //     title: 'Unique visitors',
+                    //     layout: {
+                    //         colSpan: 6,
+                    //     },
+                    //     query: {
+                    //         kind: NodeKind.InsightVizNode,
+                    //         source: {
+                    //             kind: NodeKind.TrendsQuery,
+                    //             dateRange,
+                    //             interval: 'day',
+                    //             series: [
+                    //                 {
+                    //                     event: '$pageview',
+                    //                     kind: NodeKind.EventsNode,
+                    //                     math: BaseMathType.UniqueUsers,
+                    //                     name: '$pageview',
+                    //                 },
+                    //             ],
+                    //             trendsFilter: {
+                    //                 compare: true,
+                    //                 display: ChartDisplayType.ActionsLineGraph,
+                    //             },
+                    //             filterTestAccounts: true,
+                    //             properties: webAnalyticsFilters,
+                    //         },
+                    //     },
+                    // },
+                    // {
+                    //     title: 'World Map (Unique Users)',
+                    //     layout: {
+                    //         colSpan: 6,
+                    //     },
+                    //     query: {
+                    //         kind: NodeKind.InsightVizNode,
+                    //         source: {
+                    //             kind: NodeKind.TrendsQuery,
+                    //             breakdown: {
+                    //                 breakdown: '$geoip_country_code',
+                    //                 breakdown_type: 'person',
+                    //             },
+                    //             dateRange,
+                    //             series: [
+                    //                 {
+                    //                     event: '$pageview',
+                    //                     kind: NodeKind.EventsNode,
+                    //                     math: BaseMathType.UniqueUsers,
+                    //                 },
+                    //             ],
+                    //             trendsFilter: {
+                    //                 display: ChartDisplayType.WorldMap,
+                    //             },
+                    //             filterTestAccounts: true,
+                    //             properties: webAnalyticsFilters,
+                    //         },
+                    //     },
+                    // },
                 ]
             },
         ],


### PR DESCRIPTION
## Problem

Some insights don't fully work and are more confusing than they are worth if given to real users. Let's remove them now, with the itnention of adding them back when they are working as expected.

## Changes

Hide the world map and unique visitors trend

## How did you test this code?

ran it manually
