### PR TITLE
feat(django): allow to enable new capture for specific teams

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -1,28 +1,27 @@
-from random import random
 import re
+from random import random
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
-from posthog.database_healthcheck import DATABASE_FOR_FLAG_MATCHING
-from posthog.metrics import LABEL_TEAM_ID
-from posthog.models.feature_flag.flag_analytics import increment_request_count
-from posthog.models.filters.mixins.utils import process_bool
 
 import structlog
+from django.conf import settings
 from django.http import HttpRequest, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
-from django.conf import settings
+from prometheus_client import Counter
 from rest_framework import status
 from sentry_sdk import capture_exception
 from statshog.defaults.django import statsd
-from prometheus_client import Counter
-
 
 from posthog.api.geoip import get_geoip_properties
 from posthog.api.utils import get_project_id, get_token
+from posthog.database_healthcheck import DATABASE_FOR_FLAG_MATCHING
 from posthog.exceptions import RequestParsingError, generate_exception_response
 from posthog.logging.timing import timed
+from posthog.metrics import LABEL_TEAM_ID
 from posthog.models import Team, User
 from posthog.models.feature_flag import get_all_feature_flags
+from posthog.models.feature_flag.flag_analytics import increment_request_count
+from posthog.models.filters.mixins.utils import process_bool
 from posthog.models.utils import execute_with_timeout
 from posthog.plugins.site import get_decide_site_apps
 from posthog.utils import get_ip_address, label_for_team_id_to_track, load_data_from_request
@@ -214,6 +213,9 @@ def get_decide(request: HttpRequest):
                 if team.autocapture_exceptions_opt_in
                 else False
             )
+
+            if settings.NEW_ANALYTICS_CAPTURE_TEAM_IDS and str(team.id) in settings.NEW_ANALYTICS_CAPTURE_TEAM_IDS:
+                response["analytics"] = {"endpoint": settings.NEW_ANALYTICS_CAPTURE_ENDPOINT}
 
             if team.session_recording_opt_in and (
                 on_permitted_recording_domain(team, request) or not team.recording_domains

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -45,6 +45,7 @@ ALWAYS_ALLOWED_ENDPOINTS = [
 ]
 
 if DEBUG:
+    # /i/ is the new root path for capture endpoints
     ALWAYS_ALLOWED_ENDPOINTS.append("i")
 
 default_cookie_options = {

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -1,7 +1,8 @@
 import os
+
 import structlog
 
-from posthog.settings.utils import get_from_env, get_list
+from posthog.settings.utils import get_from_env, get_list, get_set
 from posthog.utils import str_to_bool
 
 logger = structlog.get_logger(__name__)
@@ -32,3 +33,6 @@ PARTITION_KEY_BUCKET_REPLENTISH_RATE = get_from_env(
 
 REPLAY_RETENTION_DAYS_MIN = get_from_env("REPLAY_RETENTION_DAYS_MIN", type_cast=int, default=30)
 REPLAY_RETENTION_DAYS_MAX = get_from_env("REPLAY_RETENTION_DAYS_MAX", type_cast=int, default=90)
+
+NEW_ANALYTICS_CAPTURE_ENDPOINT = os.getenv("NEW_CAPTURE_ENDPOINT", "/i/v0/e/")
+NEW_ANALYTICS_CAPTURE_TEAM_IDS = get_set(os.getenv("NEW_ANALYTICS_CAPTURE_TEAM_IDS", ""))

--- a/posthog/settings/utils.py
+++ b/posthog/settings/utils.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, List, Optional, Set
 
 from django.core.exceptions import ImproperlyConfigured
 
@@ -26,3 +26,9 @@ def get_list(text: str) -> List[str]:
     if not text:
         return []
     return [item.strip() for item in text.split(",")]
+
+
+def get_set(text: str) -> Set[str]:
+    if not text:
+        return set()
+    return {item.strip() for item in text.split(",")}

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -112,6 +112,13 @@ if STATSD_HOST is not None:
     MIDDLEWARE.insert(0, "django_statsd.middleware.StatsdMiddleware")
     MIDDLEWARE.append("django_statsd.middleware.StatsdMiddlewareTimer")
 
+if DEBUG:
+    # Used on local devenv to forward `/i/` to capture-rs on port 3000,
+    # we short-circuit the whole middleware chain to avoid CSRF and auth errors,
+    # like CaptureMiddleware does.
+    MIDDLEWARE.insert(0, "posthog.middleware.CaptureRsProxyMiddleware")
+    INSTALLED_APPS.append("revproxy")
+
 # Append Enterprise Edition as an app if available
 try:
     from ee.apps import EnterpriseConfig  # noqa: F401

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -113,10 +113,7 @@ if STATSD_HOST is not None:
     MIDDLEWARE.append("django_statsd.middleware.StatsdMiddlewareTimer")
 
 if DEBUG:
-    # Used on local devenv to forward `/i/` to capture-rs on port 3000,
-    # we short-circuit the whole middleware chain to avoid CSRF and auth errors,
-    # like CaptureMiddleware does.
-    MIDDLEWARE.insert(0, "posthog.middleware.CaptureRsProxyMiddleware")
+    # Used on local devenv to reverse-proxy all of /i/* to capture-rs on port 3000
     INSTALLED_APPS.append("revproxy")
 
 # Append Enterprise Edition as an app if available

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -177,7 +177,7 @@ if settings.DEBUG:
     # what we do.
     urlpatterns.append(path("_metrics", ExportToDjangoView))
 
-    # Reverse-proxy all of /i/* to capture-rs on port 3000
+    # Reverse-proxy all of /i/* to capture-rs on port 3000 when running the local devenv
     urlpatterns.append(re_path(r"(?P<path>^i/.*)", ProxyView.as_view(upstream="http://localhost:3000")))
 
 

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -8,6 +8,7 @@ from django.urls import URLPattern, include, path, re_path
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie, requires_csrf_token
 from django_prometheus.exports import ExportToDjangoView
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
+from revproxy.views import ProxyView
 from sentry_sdk import last_event_id
 from two_factor.urls import urlpatterns as tf_urls
 
@@ -175,6 +176,10 @@ if settings.DEBUG:
     # external clients cannot see them. See the gunicorn setup for details on
     # what we do.
     urlpatterns.append(path("_metrics", ExportToDjangoView))
+
+    # Reverse-proxy all of /i/* to capture-rs on port 3000
+    urlpatterns.append(re_path(r"(?P<path>^i/.*)", ProxyView.as_view(upstream="http://localhost:3000")))
+
 
 if settings.TEST:
 

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -34,7 +34,6 @@ from posthog.api.prompt import prompt_webhook
 from posthog.api.survey import surveys
 from posthog.demo.legacy import demo_route
 from posthog.models import User
-
 from .utils import render_template
 from .views import health, login_required, preflight_check, robots_txt, security_txt, stats
 from .year_in_posthog import year_in_posthog

--- a/requirements.in
+++ b/requirements.in
@@ -30,6 +30,7 @@ django-prometheus==2.2.0
 django-redis==5.2.0
 django-statsd==2.5.2
 django-structlog==2.1.3
+django-revproxy==0.12.0
 djangorestframework==3.14.0
 djangorestframework-csv==2.1.1
 djangorestframework-dataclasses==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -144,6 +144,7 @@ django==3.2.19
     #   django-phonenumber-field
     #   django-picklefield
     #   django-redis
+    #   django-revproxy
     #   django-structlog
     #   django-two-factor-auth
     #   djangorestframework
@@ -178,6 +179,8 @@ django-picklefield==3.0.1
 django-prometheus==2.2.0
     # via -r requirements.in
 django-redis==5.2.0
+    # via -r requirements.in
+django-revproxy==0.12.0
     # via -r requirements.in
 django-statsd==2.5.2
     # via -r requirements.in
@@ -534,6 +537,7 @@ uritemplate==4.1.1
 urllib3[secure,socks]==1.26.13
     # via
     #   botocore
+    #   django-revproxy
     #   geoip2
     #   google-auth
     #   requests


### PR DESCRIPTION
## Problem

https://github.com/PostHog/capture/ is deployed and ready to accept some test traffic, but we need to progressively send some traffic there.

## Changes

- Add NEW_ANALYTICS_CAPTURE_TEAM_IDS and NEW_ANALYTICS_CAPTURE_ENDPOINT settings, that are the backend companion to https://github.com/PostHog/posthog-js/pull/831
- In `DEBUG=1`, add a reverse-proxy on the `/i/` path from django's port 8000 to capture-rs' port 3000, to forward requests when running the local devenv. On prod and hobby, we'll use ingress routing instead

## How did you test this code?

Run `NEW_ANALYTICS_CAPTURE_TEAM_IDS=1 DEBUG=1 ./bin/start`. Needs https://github.com/PostHog/posthog/pull/18140 for the capture container to run.