### PR TITLE
feat(onboarding): remove the skip ("None of these") button

### DIFF
--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -104,7 +104,6 @@ export function Products(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const { billing } = useValues(billingLogic)
     const { currentTeam } = useValues(teamLogic)
-    const { updateCurrentTeam } = useActions(teamLogic)
     const isFirstProduct = Object.keys(currentTeam?.has_completed_onboarding_for || {}).length === 0
     const products = billing?.products || []
 
@@ -131,23 +130,6 @@ export function Products(): JSX.Element {
                             .map((product) => (
                                 <ProductCard product={product} key={product.type} />
                             ))}
-                    </div>
-                    <div className="mt-20">
-                        <LemonButton
-                            status="muted"
-                            onClick={() => {
-                                updateCurrentTeam({
-                                    has_completed_onboarding_for: {
-                                        ...currentTeam?.has_completed_onboarding_for,
-                                        skipped_onboarding: true,
-                                    },
-                                })
-                                router.actions.replace(urls.default())
-                            }}
-                            size="small"
-                        >
-                            None of these
-                        </LemonButton>
                     </div>
                 </>
             ) : (


### PR DESCRIPTION
## Problem

People who simply skip onboarding are way less likely to use the product (eg. the Product Interactions action). 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Don't let them skip. This means that if we have a product on the website without an onboarding flow , then people could have a bit of a confusing experience when they sign up and don't see that product in the options. Solution for this is to add pricing as soon as possible, or later add support for non-billing products having onboarding flows.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
