### PR TITLE
chore(linting): Add react-hooks eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
         'eslint:recommended',
         'plugin:@typescript-eslint/recommended',
         'plugin:react/recommended',
+        'plugin:react-hooks/recommended',
         'plugin:eslint-comments/recommended',
         'plugin:storybook/recommended',
         'prettier',
@@ -59,6 +60,8 @@ module.exports = {
                 html: true,
             },
         ],
+        'react-hooks/rules-of-hooks': 'error',
+        'react-hooks/exhaustive-deps': 'error',
         'no-unused-vars': 'off',
         '@typescript-eslint/no-unused-vars': [
             'error',
@@ -250,6 +253,12 @@ module.exports = {
             },
             env: {
                 node: true,
+            },
+        },
+        {
+            files: ['*Type.ts'],
+            rules: {
+                'no-restricted-imports': 'off',
             },
         },
     ],

--- a/frontend/src/layout/FeaturePreviews/FeaturePreviewsModal.tsx
+++ b/frontend/src/layout/FeaturePreviews/FeaturePreviewsModal.tsx
@@ -15,6 +15,8 @@ export function FeaturePreviewsModal({
         useValues(featurePreviewsLogic)
     const { hideFeaturePreviewsModal, loadEarlyAccessFeatures } = useActions(featurePreviewsLogic)
 
+    // FIXME
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     useLayoutEffect(() => loadEarlyAccessFeatures(), [])
 
     return (

--- a/frontend/src/layout/navigation-3000/components/Sidebar.stories.tsx
+++ b/frontend/src/layout/navigation-3000/components/Sidebar.stories.tsx
@@ -42,6 +42,8 @@ export function Dashboards(): JSX.Element {
     const { activeNavbarItem } = useValues(navigation3000Logic)
     useEffect(() => {
         showSidebar(Scene.Dashboards) // Active this sidebar
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     return (
@@ -62,6 +64,8 @@ export function FeatureFlags(): JSX.Element {
     const { activeNavbarItem } = useValues(navigation3000Logic)
     useEffect(() => {
         showSidebar(Scene.FeatureFlags) // Activate this sidebar
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     return (

--- a/frontend/src/layout/navigation/Navigation.stories.tsx
+++ b/frontend/src/layout/navigation/Navigation.stories.tsx
@@ -73,6 +73,8 @@ export function AppPageWithSideBarHidden(): JSX.Element {
     useEffect(() => {
         toggleSideBarBase(false)
         toggleSideBarMobile(false)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     return <BaseAppPage />
@@ -84,6 +86,8 @@ export function AppPageWithSideBarShown(): JSX.Element {
     useEffect(() => {
         toggleSideBarBase(true)
         toggleSideBarMobile(true)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     return <BaseAppPage />

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.test.setup.ts
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.test.setup.ts
@@ -45,6 +45,8 @@ async function testSetup(
     scope: ActivityScope,
     url: string
 ): Promise<ReturnType<typeof activityLogLogic.build>> {
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     useMocks({
         get: {
             [url]: {

--- a/frontend/src/lib/components/AnnotationsOverlay/useAnnotationsPositioning.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/useAnnotationsPositioning.ts
@@ -36,5 +36,7 @@ export function useAnnotationsPositioning(
                 firstTickLeftPx: 0,
             }
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [chart, chartWidth, chartHeight])
 }

--- a/frontend/src/lib/components/BillingAlertsV2.tsx
+++ b/frontend/src/lib/components/BillingAlertsV2.tsx
@@ -15,6 +15,8 @@ export function BillingAlertsV2(): JSX.Element | null {
         if (billingAlert) {
             reportBillingAlertShown(billingAlert)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [billingAlert])
 
     if (!billingAlert || alertHidden) {

--- a/frontend/src/lib/components/Cards/CardMeta.tsx
+++ b/frontend/src/lib/components/Cards/CardMeta.tsx
@@ -49,6 +49,8 @@ export function CardMeta({
 
     useEffect(() => {
         setPrimaryHeight?.(primaryHeight)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [primaryHeight])
 
     const foldedHeight = `calc(${primaryHeight}px ${

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -207,6 +207,8 @@ export function FilterBasedCardContent({
         ) {
             window.dispatchEvent(new Event('resize'))
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [style?.height])
 
     return (

--- a/frontend/src/lib/components/DefinitionPopover/DefinitionPopoverContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopover/DefinitionPopoverContents.tsx
@@ -391,15 +391,23 @@ export function ControlledDefinitionPopover({
         return null
     }
 
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { state, singularType, isElement, definition } = useValues(definitionPopoverLogic)
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { setDefinition } = useActions(definitionPopoverLogic)
 
     const icon = group.getIcon?.(definition || item)
 
     // Must use `useEffect` here to hydrate popover card with the newest item, since lifecycle of `ItemPopover` is controlled
     // independently by `infiniteListLogic`
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
         setDefinition(item)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [item])
 
     return (

--- a/frontend/src/lib/components/EditableField/EditableField.tsx
+++ b/frontend/src/lib/components/EditableField/EditableField.tsx
@@ -264,12 +264,16 @@ const AutosizeInput = ({
 
     const inputStyles = useMemo(() => {
         return inputRef.current ? window.getComputedStyle(inputRef.current) : null
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [inputRef.current])
 
     useLayoutEffect(() => {
         if (inputStyles && placeHolderSizerRef.current) {
             copyStyles(inputStyles, placeHolderSizerRef.current)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [placeHolderSizerRef, placeHolderSizerRef])
 
     useLayoutEffect(() => {
@@ -291,6 +295,8 @@ const AutosizeInput = ({
         if (newInputWidth !== inputWidth) {
             setInputWidth(newInputWidth)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [sizerRef.current, placeHolderSizerRef.current, placeholder, value])
 
     return (

--- a/frontend/src/lib/components/ExportButton/exporter.tsx
+++ b/frontend/src/lib/components/ExportButton/exporter.tsx
@@ -131,6 +131,8 @@ function DelayedContent({ atStart, afterDelay }: DelayedContentProps): JSX.Eleme
         setTimeout(() => {
             setContent(afterDelay)
         }, 30000)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
     return <>{content}</>
 }

--- a/frontend/src/lib/components/FullScreen.tsx
+++ b/frontend/src/lib/components/FullScreen.tsx
@@ -52,6 +52,8 @@ export function FullScreen({ onExit }: { onExit?: () => any }): null {
                 // will break on IE11
             }
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     return null

--- a/frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.tsx
+++ b/frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.tsx
@@ -414,6 +414,8 @@ export function HedgehogBuddy({
 
     useEffect(() => {
         return actor.setupKeyboardListeners()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -422,10 +424,14 @@ export function HedgehogBuddy({
 
     useEffect(() => {
         actor.accessories = accessories
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [accessories])
 
     useEffect(() => {
         actor.darkMode = isDarkModeOn
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isDarkModeOn])
 
     useEffect(() => {
@@ -441,6 +447,8 @@ export function HedgehogBuddy({
         return () => {
             clearTimeout(timer)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     useEffect(() => {
@@ -455,6 +463,8 @@ export function HedgehogBuddy({
 
     useEffect(() => {
         onPositionChange?.(actor)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [actor.x, actor.y])
 
     const onClick = (): void => {

--- a/frontend/src/lib/components/Map/Map.tsx
+++ b/frontend/src/lib/components/Map/Map.tsx
@@ -49,6 +49,8 @@ export function MapComponent({ center, markers, className, mapLibreStyleUrl }: M
                 marker.addTo(map.current)
             }
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     useResizeObserver({

--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
@@ -197,6 +197,8 @@ export function PropertiesTable({
         )
     }
 
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const objectProperties = useMemo(() => {
         if (!properties || !(properties instanceof Object)) {
             return []
@@ -243,6 +245,8 @@ export function PropertiesTable({
             })
         }
         return entries
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [properties, sortProperties, searchTerm, filtered])
 
     if (properties instanceof Object) {

--- a/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
@@ -34,6 +34,8 @@ export function PathItemFilters({
         if (propertyFilters && !objectsEqual(propertyFilters, filtersWithNew)) {
             setFilters([...propertyFilters, {} as EmptyPropertyFilter])
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [propertyFilters])
 
     return (

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -57,6 +57,8 @@ export function PropertyFilters({
     // Update the logic's internal filters when the props change
     useEffect(() => {
         setFilters(propertyFilters ?? [])
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [propertyFilters])
 
     return (

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -89,6 +89,8 @@ export function OperatorValueSelect({
         } else if (limitedElementProperty && !operators.includes(currentOperator)) {
             setCurrentOperator(PropertyOperator.Exact)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [propertyDefinition, propkey, operator])
 
     return (

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -73,6 +73,8 @@ export function PropertyValue({
                 setInput(toString(value))
             }
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [value])
 
     const load = (newInput: string | undefined): void => {
@@ -94,6 +96,8 @@ export function PropertyValue({
 
     useEffect(() => {
         load('')
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [propertyKey])
 
     useEffect(() => {

--- a/frontend/src/lib/components/ResizableTable/index.tsx
+++ b/frontend/src/lib/components/ResizableTable/index.tsx
@@ -206,6 +206,8 @@ export function ResizableTable<RecordType extends Record<any, any> = any>({
             updateScrollGradient()
             setHeaderShouldRender(true)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     return (

--- a/frontend/src/lib/components/RestrictedArea.tsx
+++ b/frontend/src/lib/components/RestrictedArea.tsx
@@ -57,6 +57,8 @@ export function RestrictedArea({
             )}s and up. Your level is ${membershipLevelToName.get(scopeAccessLevel)}.`
         }
         return null
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentOrganization])
 
     return restrictionReason ? (

--- a/frontend/src/lib/components/StickyView/StickyView.tsx
+++ b/frontend/src/lib/components/StickyView/StickyView.tsx
@@ -24,6 +24,8 @@ export function StickyView({ children, top = '0px', marginTop = 0 }: StickyViewP
         window.addEventListener('scroll', onScroll)
 
         return () => window.removeEventListener('scroll', onScroll)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fixed])
 
     return (

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -82,6 +82,8 @@ export function EditSubscription({
         if (subscription?.target_type === 'slack' && slackIntegration) {
             loadSlackChannels()
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [subscription?.target_type, slackIntegration])
 
     // If slackChannels aren't loaded, make sure we display only the channel name and not the actual underlying value

--- a/frontend/src/lib/components/Support/SupportModal.tsx
+++ b/frontend/src/lib/components/Support/SupportModal.tsx
@@ -55,8 +55,12 @@ export function SupportModal({ loggedIn = true }: { loggedIn?: boolean }): JSX.E
         }
         return null
     }
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const dropRef = useRef<HTMLDivElement>(null)
 
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { setFilesToUpload, filesToUpload, uploading } = useUploadFiles({
         onUpload: (url, fileName) => {
             setSendSupportRequestValue('message', sendSupportRequest.message + `\n\nAttachment "${fileName}": ${url}`)

--- a/frontend/src/lib/components/TZLabel/index.tsx
+++ b/frontend/src/lib/components/TZLabel/index.tsx
@@ -33,6 +33,8 @@ const TZLabelPopoverContent = React.memo(function TZLabelPopoverContent({
 
     useEffect(() => {
         reportTimezoneComponentViewed('label', currentTeam?.timezone, shortTimeZone())
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     return (
@@ -106,6 +108,8 @@ function TZLabelRaw({
             }
         }, 1000)
         return () => clearInterval(interval)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [parsedTime, format])
 
     const innerContent = (

--- a/frontend/src/lib/components/Table/Table.tsx
+++ b/frontend/src/lib/components/Table/Table.tsx
@@ -25,6 +25,8 @@ export function createdAtColumn<T extends Record<string, any> = Record<string, a
 }
 
 export function createdByColumn<T extends Record<string, any> = Record<string, any>>(items: T[]): ColumnType<T> {
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { user } = useValues(userLogic)
     return {
         title: normalizeColumnTitle('Created by'),

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.stories.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.stories.tsx
@@ -32,6 +32,8 @@ export const EventsFree: StoryFn<typeof TaxonomicFilter> = (args) => {
         // Highlight the second item, as the first one is "All events", which doesn't have a definition to show
         // - we do want to show the definition popover here too
         setIndex(1)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
     return (
         <div className="w-fit border rounded p-2 bg-bg-light">
@@ -66,6 +68,8 @@ export const Actions: StoryFn<typeof TaxonomicFilter> = (args) => {
         // Highlight the second item, as the first one is "All events", which doesn't have a definition to show
         // - we do want to show the definition popover here too
         setIndex(0)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
     return (
         <div className="w-fit border rounded p-2 bg-white">

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -62,6 +62,8 @@ export function TaxonomicFilter({
         if (groupType !== TaxonomicFilterGroupType.HogQLExpression) {
             window.setTimeout(() => focusInput(), 1)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     const style = {

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -72,6 +72,8 @@ export function TaxonomicPopover<ValueType extends TaxonomicFilterValue = Taxono
         if (!buttonPropsFinal.loading) {
             setLocalValue(value || ('' as ValueType))
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [value])
 
     return (

--- a/frontend/src/lib/components/UnitPicker/CustomUnitModal.tsx
+++ b/frontend/src/lib/components/UnitPicker/CustomUnitModal.tsx
@@ -44,6 +44,8 @@ export function CustomUnitModal({
     )
     useEffect(() => {
         setLocalFormativeElementValue(chooseFormativeElementValue(formativeElement, trendsFilter))
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [formativeElement])
 
     if (formativeElement === null) {

--- a/frontend/src/lib/components/VisibilitySensor/VisibilitySensor.tsx
+++ b/frontend/src/lib/components/VisibilitySensor/VisibilitySensor.tsx
@@ -17,6 +17,8 @@ export function VisibilitySensor({ id, offset, children }: VisibilityProps): JSX
         const element = ref.current
         document.addEventListener('scroll', () => element && scrolling(element))
         return () => document.removeEventListener('scroll', () => element && scrolling(element))
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [ref.current])
 
     return <div ref={ref}>{children}</div>

--- a/frontend/src/lib/hooks/useD3.ts
+++ b/frontend/src/lib/hooks/useD3.ts
@@ -17,7 +17,8 @@ export const useD3 = (
             }
             return () => {}
         },
-
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         dependencies
     )
     return ref

--- a/frontend/src/lib/hooks/useEventListener.ts
+++ b/frontend/src/lib/hooks/useEventListener.ts
@@ -51,6 +51,8 @@ export function useEventListener(
             }
         },
 
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [eventName, element, ...(deps || [])] // Re-run if eventName or element changes
     )
 }

--- a/frontend/src/lib/hooks/useKeyHeld.tsx
+++ b/frontend/src/lib/hooks/useKeyHeld.tsx
@@ -11,6 +11,8 @@ export function useKeyHeld(key: string, deps?: DependencyList): boolean {
 
     useEffect(() => {
         checkKeysHeld()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [key, ...(deps || [])])
 
     useEventListener(

--- a/frontend/src/lib/hooks/useLongPress.js
+++ b/frontend/src/lib/hooks/useLongPress.js
@@ -42,6 +42,8 @@ export function useLongPress(
         return () => {
             clearTimeout(timerId)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [callback, ms, startLongPress])
 
     function start(e) {

--- a/frontend/src/lib/hooks/useOutsideClickHandler.ts
+++ b/frontend/src/lib/hooks/useOutsideClickHandler.ts
@@ -45,5 +45,7 @@ export function useOutsideClickHandler(
                 document.removeEventListener('touchend', handleClick)
             }
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [...allRefs, ...extraDeps])
 }

--- a/frontend/src/lib/hooks/usePageVisibility.ts
+++ b/frontend/src/lib/hooks/usePageVisibility.ts
@@ -37,5 +37,7 @@ export function usePageVisibility(callback: (pageIsVisible: boolean) => void): v
         return function cleanUp() {
             document.removeEventListener(visibilityChange, onVisibilityChange)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 }

--- a/frontend/src/lib/hooks/useScrollable.ts
+++ b/frontend/src/lib/hooks/useScrollable.ts
@@ -32,6 +32,8 @@ export function useScrollable(): [React.RefObject<HTMLDivElement>, [boolean, boo
                 clearInterval(timeout)
             }
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [scrollRef.current])
 
     useLayoutEffect(() => {

--- a/frontend/src/lib/hooks/useSecondRender.js
+++ b/frontend/src/lib/hooks/useSecondRender.js
@@ -8,6 +8,8 @@ export function useSecondRender(callback) {
             setSecondRender(true)
             callback()
         })
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     return secondRender

--- a/frontend/src/lib/hooks/useUploadFiles.ts
+++ b/frontend/src/lib/hooks/useUploadFiles.ts
@@ -67,6 +67,8 @@ export function useUploadFiles({
             }
         }
         uploadFiles().catch(console.error)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [filesToUpload])
 
     return { setFilesToUpload, filesToUpload, uploading }

--- a/frontend/src/lib/hooks/useWhyDidIRender.ts
+++ b/frontend/src/lib/hooks/useWhyDidIRender.ts
@@ -20,5 +20,6 @@ export function useWhyDidIRender(name: string, props: Record<string, any>): void
             }
         }
         oldProps.current = props
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [Object.values(props)])
 }

--- a/frontend/src/lib/hooks/useWindowSize.js
+++ b/frontend/src/lib/hooks/useWindowSize.js
@@ -25,7 +25,8 @@ export function useWindowSize() {
             window.addEventListener('resize', handleResize)
             return () => window.removeEventListener('resize', handleResize)
         },
-
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [] // Empty array ensures that effect is only run on mount and unmount
     )
 

--- a/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendar.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendar.tsx
@@ -43,6 +43,8 @@ export function LemonCalendar(props: LemonCalendarProps): JSX.Element {
         if (props.leftmostMonth && props.leftmostMonth.isSame(leftmostMonth, 'd')) {
             setLeftmostMonth(props.leftmostMonth)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.leftmostMonth])
 
     return (

--- a/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRangeInline.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRangeInline.tsx
@@ -67,6 +67,8 @@ export function LemonCalendarRangeInline({
         ) {
             setLeftmostMonth(leftmostMonthForRange)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [rangeStart, rangeEnd])
 
     return (

--- a/frontend/src/lib/lemon-ui/LemonCollapse/LemonCollapse.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCollapse/LemonCollapse.tsx
@@ -43,6 +43,8 @@ export function LemonCollapse<K extends React.Key>({
     let isPanelExpanded: (key: K) => boolean
     let onPanelChange: (key: K, isExpanded: boolean) => void
     if (props.multiple) {
+        // FIXME
+        // eslint-disable-next-line react-hooks/rules-of-hooks
         const [localActiveKeys, setLocalActiveKeys] = useState<Set<K>>(new Set(props.defaultActiveKeys ?? []))
         const effectiveActiveKeys = props.activeKeys ? new Set(props.activeKeys) : localActiveKeys
         isPanelExpanded = (key: K) => effectiveActiveKeys.has(key)
@@ -57,6 +59,8 @@ export function LemonCollapse<K extends React.Key>({
             setLocalActiveKeys(newActiveKeys)
         }
     } else {
+        // FIXME
+        // eslint-disable-next-line react-hooks/rules-of-hooks
         const [localActiveKey, setLocalActiveKey] = useState<K | null>(props.defaultActiveKey ?? null)
         const effectiveActiveKey = props.activeKey ?? localActiveKey
         isPanelExpanded = (key: K) => key === effectiveActiveKey

--- a/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
@@ -61,6 +61,8 @@ export function LemonDialog({
             setIsOpen(false)
         }
         lastLocation.current = currentLocation.pathname
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentLocation])
 
     return (

--- a/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
@@ -40,6 +40,8 @@ export const LemonFileInput = ({
         if (value && value !== files) {
             setFiles(value)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [value])
 
     const onInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
@@ -104,6 +106,8 @@ export const LemonFileInput = ({
             div?.removeEventListener('dragover', handleDrag)
             div?.removeEventListener('drop', handleDrop)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [value])
 
     useEffect(() => {

--- a/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
+++ b/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
@@ -105,6 +105,8 @@ export function LemonMenu({
                 setTimeout(() => itemsRef?.current?.[activeItemIndex]?.current?.scrollIntoView({ block: 'center' }), 0)
             }
         },
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [onVisibilityChange, activeItemIndex]
     )
 

--- a/frontend/src/lib/lemon-ui/LemonMenu/useKeyboardNavigation.ts
+++ b/frontend/src/lib/lemon-ui/LemonMenu/useKeyboardNavigation.ts
@@ -45,7 +45,11 @@ export function useKeyboardNavigation<R extends HTMLElement = HTMLElement, I ext
             item.current?.addEventListener('keydown', handleKeyDown)
         }
         return () => {
+            // FIXME
+            // eslint-disable-next-line react-hooks/exhaustive-deps
             referenceRef.current?.removeEventListener('keydown', handleKeyDown)
+            // FIXME
+            // eslint-disable-next-line react-hooks/exhaustive-deps
             for (const item of itemsRef.current) {
                 item.current?.removeEventListener('keydown', handleKeyDown)
             }

--- a/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
@@ -116,6 +116,8 @@ export function LemonSelect<T extends string | number | boolean | null>({
                 }
                 onSelect?.(newValue)
             }),
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [options, value]
     )
 

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -147,6 +147,8 @@ export function LemonTable<T extends Record<string, any>>({
                 )
             }
         },
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [location, searchParams, hashParams, push]
     )
 
@@ -190,6 +192,8 @@ export function LemonTable<T extends Record<string, any>>({
             }
         }
         return dataSource
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [dataSource, currentSorting])
 
     const paginationState = usePagination(sortedDataSource, pagination, id)
@@ -203,6 +207,8 @@ export function LemonTable<T extends Record<string, any>>({
                 window.scrollTo(window.scrollX, window.scrollY + realTableOffsetTop)
             }
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [paginationState.currentPage, scrollRef.current])
 
     if (firstColumnSticky && expandable) {

--- a/frontend/src/lib/lemon-ui/PaginationControl/usePagination.ts
+++ b/frontend/src/lib/lemon-ui/PaginationControl/usePagination.ts
@@ -16,6 +16,8 @@ export function usePagination<T>(
 
     const setCurrentPage = useCallback(
         (newPage: number) => push(location.pathname, { ...searchParams, [currentPageParam]: newPage }, hashParams),
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [location, searchParams, hashParams, push]
     )
 
@@ -39,6 +41,8 @@ export function usePagination<T>(
             currentStartIndex: calculatedStartIndex,
             currentEndIndex: calculatedEndIndex,
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentPage, pageCount, pagination, dataSource])
 
     return {

--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -150,6 +150,8 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
         if (referenceElement) {
             reference(referenceElement)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [referenceElement])
 
     useEventListener(
@@ -180,6 +182,8 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
         if (visible && referenceRef?.current && floatingRef?.current) {
             return autoUpdate(referenceRef.current, floatingRef.current, update)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [visible, referenceRef?.current, floatingRef?.current, ...additionalRefs])
 
     const _onClickInside: MouseEventHandler<HTMLDivElement> = (e): void => {

--- a/frontend/src/lib/lemon-ui/ProfilePicture/ProfilePicture.tsx
+++ b/frontend/src/lib/lemon-ui/ProfilePicture/ProfilePicture.tsx
@@ -55,6 +55,8 @@ export function ProfilePicture({
                 }
             })
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [email])
 
     if (gravatarUrl) {

--- a/frontend/src/lib/lemon-ui/hooks.ts
+++ b/frontend/src/lib/lemon-ui/hooks.ts
@@ -35,6 +35,8 @@ export function useSliderPositioning<C extends HTMLElement, S extends HTMLElemen
                 hasRenderedInitiallyRef.current = true
             }
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentValue, containerWidth])
 
     return {

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -45,6 +45,8 @@ export function Query(props: QueryProps): JSX.Element | null {
         if (propsQuery !== localQuery) {
             localSetQuery(propsQuery)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [propsQuery])
 
     const query = readOnly ? propsQuery : localQuery

--- a/frontend/src/queries/nodes/DataNode/AutoLoad.tsx
+++ b/frontend/src/queries/nodes/DataNode/AutoLoad.tsx
@@ -13,6 +13,8 @@ export function AutoLoad(): JSX.Element {
     useEffect(() => {
         startAutoLoad()
         return () => stopAutoLoad()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     return (

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -370,6 +370,8 @@ export function DataTable({ uniqueKey, query, setQuery, context, cachedResults }
     const setQuerySource = useCallback(
         (source: EventsNode | EventsQuery | PersonsNode | PersonsQuery | HogQLQuery) =>
             setQuery?.({ ...query, source }),
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [setQuery]
     )
 

--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -39,6 +39,8 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
     const monacoDisposables = useRef([] as IDisposable[])
     useEffect(() => {
         return () => {
+            // FIXME
+            // eslint-disable-next-line react-hooks/exhaustive-deps
             monacoDisposables.current.forEach((d) => d?.dispose())
         }
     }, [])

--- a/frontend/src/queries/nodes/TimeToSeeData/Trace/Trace.tsx
+++ b/frontend/src/queries/nodes/TimeToSeeData/Trace/Trace.tsx
@@ -41,6 +41,8 @@ function SpanBar({
         if (nextStartMargin !== startMargin) {
             setStartMargin(nextStartMargin)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [spanData, maxSpan])
 
     return (

--- a/frontend/src/scenes/apps/AppMetricsGraph.tsx
+++ b/frontend/src/scenes/apps/AppMetricsGraph.tsx
@@ -83,6 +83,8 @@ export function AppMetricsGraph({ tab, metrics, metricsLoading }: AppMetricsGrap
                 chart?.destroy()
             }
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [metrics])
 
     if (metricsLoading || !metrics) {

--- a/frontend/src/scenes/apps/HistoricalExportsTab.tsx
+++ b/frontend/src/scenes/apps/HistoricalExportsTab.tsx
@@ -32,6 +32,8 @@ export function HistoricalExportsTab(): JSX.Element {
 
         updateTimer()
         return () => timer && clearTimeout(timer)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [hasRunningExports])
 
     return (

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -68,6 +68,8 @@ export function Login(): JSX.Element {
         } catch (e) {
             captureException(e)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     useEffect(() => {

--- a/frontend/src/scenes/batch_exports/BatchExportScene.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportScene.tsx
@@ -312,7 +312,11 @@ export function LogsTab({ batchExportId }: BatchExportLogsProps): JSX.Element {
         batchExportLogsBackground,
         isThereMoreToLoad,
         batchExportLogsTypes,
+        // FIXME
+        // eslint-disable-next-line react-hooks/rules-of-hooks
     } = useValues(logic)
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { revealBackground, loadBatchExportLogsMore, setBatchExportLogsTypes, setSearchTerm } = useActions(logic)
 
     return (
@@ -377,6 +381,8 @@ export function BatchExportScene(): JSX.Element {
     useEffect(() => {
         loadBatchExportConfig()
         loadBatchExportRuns()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     if (!batchExportConfig && !batchExportConfigLoading) {

--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -47,6 +47,8 @@ export function Billing(): JSX.Element {
         if (billing) {
             reportBillingV2Shown()
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [!!billing])
 
     const { ref, size } = useResizeBreakpoints({

--- a/frontend/src/scenes/billing/PlanComparison.tsx
+++ b/frontend/src/scenes/billing/PlanComparison.tsx
@@ -94,7 +94,11 @@ export const PlanComparison = ({
         return null
     }
     const fullyFeaturedPlan = plans[plans.length - 1]
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { reportBillingUpgradeClicked } = useActions(eventUsageLogic)
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { redirectPath, billing } = useValues(billingLogic)
 
     const upgradeButtons = plans?.map((plan) => {

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -67,6 +67,8 @@ function DashboardScene(): JSX.Element {
             // request cancellation of any running queries when this component is no longer in the dom
             abortAnyRunningQuery()
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     useKeyboardHotkeys(

--- a/frontend/src/scenes/data-management/events/EventDefinitionProperties.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionProperties.tsx
@@ -17,6 +17,8 @@ export function EventDefinitionProperties({ definition }: { definition: EventDef
 
     useEffect(() => {
         loadPropertiesForEvent(definition)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     const columns: LemonTableColumns<PropertyDefinition> = [

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -106,6 +106,8 @@ export function Experiment(): JSX.Element {
 
     useEffect(() => {
         setExposureAndSampleSize(exposure, sampleSize)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [exposure, sampleSize])
 
     // Parameters for experiment results

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -601,6 +601,8 @@ function UsageTab({ featureFlag }: { id: string; featureFlag: FeatureFlagType })
         ) {
             enrichUsageDashboard()
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [dashboard])
 
     const propertyFilter: AnyPropertyFilter[] = [

--- a/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
@@ -132,6 +132,8 @@ export function CodeInstructions({
         if (featureFlag?.ensure_experience_continuity) {
             setShowLocalEvalCode(false)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedLanguage, featureFlag])
 
     const groups = featureFlag?.filters?.groups || []

--- a/frontend/src/scenes/feature-flags/FeatureFlags.stories.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.stories.tsx
@@ -62,6 +62,8 @@ export function EditFeatureFlag(): JSX.Element {
 
 export function EditMultiVariateFeatureFlag(): JSX.Element {
     useEffect(() => {
+        // FIXME
+        // eslint-disable-next-line react-hooks/rules-of-hooks
         useAvailableFeatures([AvailableFeature.MULTIVARIATE_FLAGS])
         router.actions.push(urls.featureFlag(1502))
     }, [])

--- a/frontend/src/scenes/funnels/FunnelBarChart/FunnelBarChart.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarChart/FunnelBarChart.tsx
@@ -107,6 +107,8 @@ export function FunnelBarChart({
                 </tbody>
             </table>
         )
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [visibleStepsWithConversionMetrics, height])
 
     // negative margin-top so that the scrollable shadow is visible on the canvas label as well

--- a/frontend/src/scenes/funnels/FunnelBarGraph/Bar.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph/Bar.tsx
@@ -76,6 +76,8 @@ export function Bar({
 
     useEffect(() => {
         decideLabelPosition()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [wrapperWidth])
 
     return (

--- a/frontend/src/scenes/funnels/useFunnelTooltip.tsx
+++ b/frontend/src/scenes/funnels/useFunnelTooltip.tsx
@@ -148,6 +148,8 @@ export function useFunnelTooltip(showPersonsModal: boolean): React.RefObject<HTM
             tooltipEl.style.left = 'revert'
             tooltipEl.style.top = 'revert'
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isTooltipShown, tooltipOrigin, currentTooltip])
 
     return vizRef

--- a/frontend/src/scenes/groups/GroupDashboard.tsx
+++ b/frontend/src/scenes/groups/GroupDashboard.tsx
@@ -40,6 +40,8 @@ export function GroupDashboard({ groupData }: { groupData: Group }): JSX.Element
                 setProperties([...current, desired])
             }
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [dashboard, groupData])
 
     return (

--- a/frontend/src/scenes/ingestion/IngestionWizard.tsx
+++ b/frontend/src/scenes/ingestion/IngestionWizard.tsx
@@ -37,6 +37,8 @@ export function IngestionWizard(): JSX.Element {
         if (!platform) {
             reportIngestionLandingSeen()
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [platform])
 
     if (featureFlags[FEATURE_FLAGS.PRODUCT_SPECIFIC_ONBOARDING] === 'test') {

--- a/frontend/src/scenes/insights/EditorFilters/FunnelsQuerySteps.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/FunnelsQuerySteps.tsx
@@ -30,6 +30,8 @@ export function FunnelsQuerySteps({ insightProps }: EditorFilterProps): JSX.Elem
         updateQuerySource({ series: actionsAndEventsToSeries(payload as any) } as FunnelsQuery)
     }
 
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { groupsTaxonomicTypes, showGroupsOptions } = useValues(groupsModel)
 
     const filterSteps = series || []

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -37,6 +37,8 @@ export function Insight({ insightId }: InsightSceneProps): JSX.Element {
 
     useEffect(() => {
         reportInsightViewedForRecentInsights()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [insightId])
 
     // Show the skeleton if loading an insight for which we only know the id

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
@@ -115,6 +115,8 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
     // to be shown on the /funnels page, even if we try to use a selector with props to hydrate it
     useEffect(() => {
         setLocalFilters(filters)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [filters])
 
     function onSortEnd({ oldIndex, newIndex }: { oldIndex: number; newIndex: number }): void {

--- a/frontend/src/scenes/insights/filters/ActionFilter/RenameModal.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/RenameModal.tsx
@@ -78,6 +78,8 @@ function useSelectAllText(
             return () => clearTimeout(autoFocusTimeout)
         },
 
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         dependencies
     )
 }

--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -65,7 +65,11 @@ export function AggregationSelect({
             updateQuerySource({ aggregation_group_type_index: groupIndex } as FunnelsQuery)
         }
     }
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { groupTypes, aggregationLabel } = useValues(groupsModel)
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { needsUpgradeForGroups, canStartUsingGroups } = useValues(groupsAccessLogic)
 
     const baseValues = [UNIQUE_USERS]

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -83,6 +83,8 @@ const cleanBreakdownParams = (cleanedParams: Partial<FilterType>, filters: Parti
         // For the map, make sure we are breaking down by country
         // Support automatic switching to country code breakdown both from no breakdown and from country name breakdown
         cleanedParams['breakdown'] = '$geoip_country_code'
+        // FIXME
+        // eslint-disable-next-line react-hooks/rules-of-hooks
         useMostRelevantBreakdownType(cleanedParams, filters)
         return
     }

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -76,6 +76,8 @@ function useBoldNumberTooltip({
                 }
             }
         )
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isTooltipShown])
 
     return divRef

--- a/frontend/src/scenes/insights/views/BoldNumber/Textfit.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/Textfit.tsx
@@ -65,9 +65,16 @@ const Textfit = ({ min, max, children }: { min: number; max: number; children: R
     useEffect(() => {
         window.addEventListener('resize', handleWindowResize)
         return () => window.removeEventListener('resize', handleWindowResize)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
-    useEffect(() => handleWindowResize(), [parentRef, childRef])
+    useEffect(
+        () => handleWindowResize(),
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [parentRef, childRef]
+    )
 
     return (
         // eslint-disable-next-line react/forbid-dom-props

--- a/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTable.tsx
@@ -52,6 +52,8 @@ export function FunnelCorrelationTable(): JSX.Element | null {
         if (loadedEventCorrelationsTableOnce) {
             loadEventCorrelations({})
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [querySource])
 
     const { openCorrelationPersonsModal } = useActions(funnelPersonsModalLogic(insightProps))

--- a/frontend/src/scenes/insights/views/Funnels/FunnelPropertyCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelPropertyCorrelationTable.tsx
@@ -43,6 +43,8 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
         if (loadedPropertyCorrelationsTableOnce) {
             loadPropertyCorrelations({})
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [querySource])
 
     const { openCorrelationPersonsModal } = useActions(funnelPersonsModalLogic(insightProps))

--- a/frontend/src/scenes/insights/views/Histogram/Histogram.tsx
+++ b/frontend/src/scenes/insights/views/Histogram/Histogram.tsx
@@ -87,6 +87,8 @@ export function Histogram({
                 config.margin.right
         )
         setConfig(getConfig(layout, isDashboardItem ? width : minWidth, height))
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [data.length, layout, width, height])
 
     const ref = useD3(

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -368,6 +368,8 @@ export function LineGraph_({
             }
         }
 
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         datasets = datasets.map((dataset) => processDataset(dataset))
 
         const seriesMax = Math.max(...datasets.flatMap((d) => d.data).filter((n) => !!n))

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -86,6 +86,8 @@ export function PieChart({
         // Hide intentionally hidden keys
         if (!areObjectValuesEmpty(hiddenLegendKeys)) {
             // If series are nested (for ActionsHorizontalBar and Pie), filter out the series by index
+            // FIXME
+            // eslint-disable-next-line react-hooks/exhaustive-deps
             datasets = filterNestedDataset(hiddenLegendKeys, datasets)
         }
 

--- a/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
@@ -94,6 +94,8 @@ function useWorldMapTooltip(showPersonsModal: boolean): React.RefObject<SVGSVGEl
             tooltipEl.style.left = 'revert'
             tooltipEl.style.top = 'revert'
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isTooltipShown, tooltipCoordinates, currentTooltip])
 
     return svgRef

--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
@@ -61,6 +61,8 @@ export function AsyncMigrations(): JSX.Element {
             const interval = setInterval(() => loadAsyncMigrations(), STATUS_RELOAD_INTERVAL_MS)
             return () => clearInterval(interval)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isAnyMigrationRunning])
 
     const nameColumn: AsyncMigrationColumnType = {

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
@@ -21,6 +21,8 @@ export function InstanceConfigTab(): JSX.Element {
 
     useEffect(() => {
         loadInstanceSettings()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     useKeyboardHotkeys({

--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -94,6 +94,8 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
     useEffect(() => {
         // TRICKY: child nodes mount the parent logic so we need to control the mounting / unmounting directly in this component
         return () => unregisterNodeLogic(nodeId)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     useWhyDidIRender('NodeWrapper.logicProps', {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeCohort.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeCohort.tsx
@@ -118,6 +118,8 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeCohortAttribute
                   ]
                 : []
         )
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [cohort, cohortMissing])
 
     if (cohortMissing) {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeEarlyAccessFeature.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeEarlyAccessFeature.tsx
@@ -38,12 +38,16 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeEarlyAccessAttr
                   ]
                 : []
         )
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [earlyAccessFeature])
 
     useEffect(() => {
         setTitlePlaceholder(
             earlyAccessFeature.name ? `Early Access Management: ${earlyAccessFeature.name}` : 'Early Access Management'
         )
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [earlyAccessFeature?.name])
 
     if (earlyAccessFeatureMissing) {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeExperiment.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeExperiment.tsx
@@ -41,6 +41,8 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeExperimentAttri
 
     useEffect(() => {
         loadExperiment()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [id])
 
     if (experimentMissing) {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeFlag.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeFlag.tsx
@@ -93,6 +93,8 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeFlagAttributes>
                   }
                 : undefined,
         ])
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [featureFlag])
 
     if (featureFlagMissing) {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeFlagCodeExample.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeFlagCodeExample.tsx
@@ -19,6 +19,8 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeFlagCodeExample
         setTitlePlaceholder(
             featureFlag.key ? `Feature flag code example: ${featureFlag.key}` : 'Feature flag code example'
         )
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [featureFlag?.key])
 
     if (!featureFlagMissing) {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroup.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeGroup.tsx
@@ -56,6 +56,8 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeGroupAttributes
                 },
             },
         ])
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [groupData])
 
     if (!groupData && !groupDataLoading) {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeImage.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeImage.tsx
@@ -36,6 +36,8 @@ const Component = ({ attributes, updateAttributes }: NotebookNodeProps<NotebookN
                     setUploading(false)
                 })
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [file])
 
     const imageSource = useMemo(

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePerson.tsx
@@ -58,6 +58,8 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodePersonAttribute
                 },
             },
         ])
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [person])
 
     const iconPropertyKeys = ['$geoip_country_code', '$browser', '$device_type', '$os']

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePlaylist.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePlaylist.tsx
@@ -46,6 +46,8 @@ const Component = ({
                 })
             },
         }),
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [playerKey, filters, pinned]
     )
 
@@ -93,6 +95,8 @@ const Component = ({
                   ]
                 : []
         )
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeSessionRecording])
 
     useEffect(() => {
@@ -108,6 +112,8 @@ const Component = ({
                 }, 100)
             },
         })
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     return <SessionRecordingsPlaylist {...recordingPlaylistLogicProps} />

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -56,6 +56,8 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeQueryAttributes
         }
 
         setTitlePlaceholder(title)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [query])
 
     const modifiedQuery = useMemo(() => {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
@@ -56,6 +56,8 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeRecordingAttrib
 
     useEffect(() => {
         loadRecordingMeta()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
     // TODO Only load data when in view...
 
@@ -86,6 +88,8 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeRecordingAttrib
                   }
                 : undefined,
         ])
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [sessionPlayerMetaData?.person?.id])
 
     useEffect(() => {
@@ -100,6 +104,8 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeRecordingAttrib
                 scrollIntoView()
             },
         })
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     if (!sessionPlayerMetaData && !sessionPlayerMetaDataLoading) {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeReplayTimestamp.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeReplayTimestamp.tsx
@@ -25,6 +25,8 @@ const Component = (props: NodeViewProps): JSX.Element => {
         const logicById = sourceNodeId ? findNodeLogicById(sourceNodeId) : null
 
         return logicById ?? findNodeLogic(NotebookNodeType.Recording, { id: sessionRecordingId })
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [findNodeLogic])
 
     const handlePlayInNotebook = (): void => {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeSurvey.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeSurvey.tsx
@@ -36,10 +36,14 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeSurveyAttribute
                   }
                 : undefined,
         ])
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [survey])
 
     useEffect(() => {
         setTitlePlaceholder(survey.name ? `Survey: ${survey.name}` : 'Survey')
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [survey.name])
 
     if (surveyMissing) {

--- a/frontend/src/scenes/notebooks/Nodes/components/NotebookNodeTitle.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/NotebookNodeTitle.tsx
@@ -14,6 +14,8 @@ export function NotebookNodeTitle(): JSX.Element {
 
     useEffect(() => {
         setNewValue(nodeAttributes.title ?? '')
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [editing])
 
     const commitEdit = (): void => {

--- a/frontend/src/scenes/notebooks/Nodes/utils.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/utils.tsx
@@ -141,6 +141,8 @@ export function useSyncedAttributes<T extends CustomNotebookNodeAttributes>(
             // NOTE: queueMicrotask protects us from TipTap's flushSync calls, ensuring we never modify the state whilst the flush is happening
             queueMicrotask(() => props.updateAttributes(stringifiedAttrs))
         },
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [props.updateAttributes]
     )
 

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -56,6 +56,8 @@ export function Editor(): JSX.Element {
 
     const { resetSuggestions, setPreviousNode } = useActions(insertionSuggestionsLogic)
 
+    // FIXME
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const headingPlaceholder = useMemo(() => sampleOne(PLACEHOLDER_TITLES), [shortId])
 
     const updatePreviousNode = useCallback(() => {
@@ -63,6 +65,8 @@ export function Editor(): JSX.Element {
         if (editor) {
             setPreviousNode(getNodeBeforeActiveNode(editor))
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [editorRef.current])
 
     const _editor = useEditor({

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
@@ -42,6 +42,8 @@ export function Notebook({
         if (initialContent && mode === 'canvas') {
             setLocalContent(initialContent)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [notebook])
 
     useWhyDidIRender('Notebook', {
@@ -58,10 +60,14 @@ export function Notebook({
         if (!notebook && !notebookLoading) {
             loadNotebook()
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     useEffect(() => {
         setEditable(editable)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [editable])
 
     useEffect(() => {
@@ -72,6 +78,8 @@ export function Notebook({
         if (editor) {
             editor.focus(initialAutofocus)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [editor])
 
     // TODO - Render a special state if the notebook is empty

--- a/frontend/src/scenes/notebooks/Notebook/NotebookMeta.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookMeta.tsx
@@ -65,6 +65,8 @@ export const NotebookSyncInfo = (props: NotebookLogicProps): JSX.Element | null 
             clearTimeout(t)
             clearDebounceTimeout()
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [syncStatus])
 
     if (!debouncedSyncStatus) {

--- a/frontend/src/scenes/notebooks/Notebook/NotebookPopover.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookPopover.tsx
@@ -136,6 +136,8 @@ export function NotebookPopover(): JSX.Element {
         if (ref.current) {
             setElementRef(ref)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [ref.current])
 
     return (

--- a/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
@@ -309,6 +309,8 @@ export const SlashCommands = forwardRef<SlashCommandsRef, SlashCommandsProps>(fu
     const [selectedIndex, setSelectedIndex] = useState(0)
     const [selectedHorizontalIndex, setSelectedHorizontalIndex] = useState(0)
 
+    // FIXME
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const allCommmands = [...TEXT_CONTROLS, ...SLASH_COMMANDS]
 
     const fuse = useMemo(() => {
@@ -323,6 +325,8 @@ export const SlashCommands = forwardRef<SlashCommandsRef, SlashCommandsProps>(fu
             return allCommmands
         }
         return fuse.search(query).map((result) => result.item)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [query, fuse])
 
     const filteredSlashCommands = useMemo(
@@ -377,6 +381,8 @@ export const SlashCommands = forwardRef<SlashCommandsRef, SlashCommandsProps>(fu
 
             return false
         },
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [selectedIndex, selectedHorizontalIndex, filteredCommands]
     )
 

--- a/frontend/src/scenes/notebooks/NotebookSelectButton/NotebookSelectButton.tsx
+++ b/frontend/src/scenes/notebooks/NotebookSelectButton/NotebookSelectButton.tsx
@@ -115,6 +115,8 @@ export function NotebookSelectList(props: NotebookSelectProps): JSX.Element {
             loadNotebooksContainingResource()
         }
         loadAllNotebooks()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     return (
@@ -215,6 +217,8 @@ export function NotebookSelectButton({ children, ...props }: NotebookSelectButto
         if (!nodeLogic) {
             loadNotebooksContainingResource()
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [nodeLogic])
 
     const button = (

--- a/frontend/src/scenes/notebooks/NotebooksTable/NotebooksTable.tsx
+++ b/frontend/src/scenes/notebooks/NotebooksTable/NotebooksTable.tsx
@@ -23,6 +23,8 @@ export function NotebooksTable(): JSX.Element {
 
     useEffect(() => {
         loadNotebooks()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     const columns: LemonTableColumns<NotebookListItemType> = [

--- a/frontend/src/scenes/notebooks/Suggestions/FloatingSuggestions.tsx
+++ b/frontend/src/scenes/notebooks/Suggestions/FloatingSuggestions.tsx
@@ -17,6 +17,8 @@ export function FloatingSuggestions({ editor }: { editor: TTEditor }): JSX.Eleme
 
     useEffect(() => {
         setEditor(notebookEditor)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [notebookEditor])
 
     return (

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -31,6 +31,8 @@ const OnboardingWrapper = ({ children }: { children: React.ReactNode }): JSX.Ele
 
     useEffect(() => {
         createAllSteps()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [children])
 
     useEffect(() => {
@@ -38,6 +40,8 @@ const OnboardingWrapper = ({ children }: { children: React.ReactNode }): JSX.Ele
             return
         }
         setAllOnboardingSteps(allSteps)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [allSteps])
 
     if (!product || !children) {
@@ -127,6 +131,8 @@ export function Onboarding(): JSX.Element | null {
         if (featureFlags[FEATURE_FLAGS.PRODUCT_SPECIFIC_ONBOARDING] !== 'test') {
             location.href = urls.ingestion()
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     if (!product) {

--- a/frontend/src/scenes/onboarding/sdks/SDKs.tsx
+++ b/frontend/src/scenes/onboarding/sdks/SDKs.tsx
@@ -26,6 +26,8 @@ export function SDKs({
 
     useEffect(() => {
         setAvailableSDKInstructionsMap(sdkInstructionMap)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     return (

--- a/frontend/src/scenes/paths/Paths.tsx
+++ b/frontend/src/scenes/paths/Paths.tsx
@@ -37,6 +37,8 @@ export function Paths(): JSX.Element {
         elements?.forEach((node) => node?.parentNode?.removeChild(node))
 
         renderPaths(canvasRef, canvasWidth, canvasHeight, paths, pathsFilter || {}, setNodeCards)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [paths, !insightDataLoading, canvasWidth, canvasHeight])
 
     if (insightDataError) {

--- a/frontend/src/scenes/persons/PersonCohorts.tsx
+++ b/frontend/src/scenes/persons/PersonCohorts.tsx
@@ -12,6 +12,8 @@ export function PersonCohorts(): JSX.Element {
 
     useEffect(() => {
         loadCohorts()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [person])
 
     const columns: LemonTableColumns<CohortType> = [

--- a/frontend/src/scenes/persons/PersonDashboard.tsx
+++ b/frontend/src/scenes/persons/PersonDashboard.tsx
@@ -40,6 +40,8 @@ export function PersonDashboard({ person }: { person: PersonType }): JSX.Element
                 ])
             }
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [dashboard, person])
 
     return (

--- a/frontend/src/scenes/persons/PersonPreview.tsx
+++ b/frontend/src/scenes/persons/PersonPreview.tsx
@@ -20,6 +20,8 @@ export function PersonPreview(props: PersonPreviewProps): JSX.Element | null {
         return null
     }
 
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { person, personLoading } = useValues(personLogic({ id: props.distinctId }))
 
     if (personLoading) {

--- a/frontend/src/scenes/persons/PersonsSearch.tsx
+++ b/frontend/src/scenes/persons/PersonsSearch.tsx
@@ -15,11 +15,15 @@ export const PersonsSearch = (): JSX.Element => {
 
     useEffect(() => {
         setSearchTerm(listFilters.search || '')
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     useEffect(() => {
         setListFilters({ search: searchTerm || undefined })
         loadPersonsDebounced()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [searchTerm])
 
     return (

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -70,6 +70,8 @@ export function PluginDrawer(): JSX.Element {
             form.resetFields()
         }
         updateInvisibleAndRequiredFields()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [editingPlugin?.id, editingPlugin?.config_schema])
 
     const updateInvisibleAndRequiredFields = (): void => {

--- a/frontend/src/scenes/plugins/plugin/PluginImage.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginImage.tsx
@@ -30,6 +30,8 @@ export function PluginImage({
                 image: `https://raw.githubusercontent.com/${user}/${repo}/${path || 'main'}/logo.png`,
             })
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [url])
 
     return pluginType === 'source' ? (

--- a/frontend/src/scenes/plugins/tabs/apps/AppManagementView.tsx
+++ b/frontend/src/scenes/plugins/tabs/apps/AppManagementView.tsx
@@ -23,7 +23,11 @@ export function AppManagementView({
         return <></>
     }
     const { installingPluginUrl, pluginsNeedingUpdates, pluginsUpdating, loading, unusedPlugins } =
+        // FIXME
+        // eslint-disable-next-line react-hooks/rules-of-hooks
         useValues(pluginsLogic)
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { installPlugin, editPlugin, updatePlugin, uninstallPlugin, patchPlugin } = useActions(pluginsLogic)
 
     return (

--- a/frontend/src/scenes/plugins/tabs/apps/AppsManagementTab.tsx
+++ b/frontend/src/scenes/plugins/tabs/apps/AppsManagementTab.tsx
@@ -19,6 +19,8 @@ export function AppsManagementTab(): JSX.Element {
         return <></>
     }
 
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { checkForUpdates, openAdvancedInstallModal } = useActions(pluginsLogic)
 
     const {
@@ -32,12 +34,18 @@ export function AppsManagementTab(): JSX.Element {
         hasUpdatablePlugins,
         checkingForUpdates,
         updateStatus,
+        // FIXME
+        // eslint-disable-next-line react-hooks/rules-of-hooks
     } = useValues(pluginsLogic)
 
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const officialPlugins = useMemo(
         () => filteredUninstalledPlugins.filter((plugin) => plugin.maintainer === 'official'),
         [filteredUninstalledPlugins]
     )
+    // FIXME
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const communityPlugins = useMemo(
         () => filteredUninstalledPlugins.filter((plugin) => plugin.maintainer === 'community'),
         [filteredUninstalledPlugins]

--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -112,6 +112,8 @@ export function Products(): JSX.Element {
         if (featureFlags[FEATURE_FLAGS.PRODUCT_SPECIFIC_ONBOARDING] !== 'test') {
             location.href = urls.ingestion()
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     return (

--- a/frontend/src/scenes/project-homepage/RecentInsights.tsx
+++ b/frontend/src/scenes/project-homepage/RecentInsights.tsx
@@ -38,6 +38,8 @@ export function RecentInsights(): JSX.Element {
 
     useEffect(() => {
         loadRecentInsights()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
     return (
         <>

--- a/frontend/src/scenes/session-recordings/filters/SessionRecordingsFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/SessionRecordingsFilters.tsx
@@ -57,6 +57,8 @@ export function SessionRecordingsFilters({
                 events: localFilters.events,
             })
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [localFilters])
 
     useEffect(() => {
@@ -65,6 +67,8 @@ export function SessionRecordingsFilters({
         if (!equal(filters.actions, localFilters.actions) || !equal(filters.events, localFilters.events)) {
             setLocalFilters(filtersToLocalFilters(filters))
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [filters])
 
     return (

--- a/frontend/src/scenes/session-recordings/player/PlayerFrame.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrame.tsx
@@ -16,6 +16,8 @@ export const PlayerFrame = (): JSX.Element => {
         if (frameRef.current) {
             setRootFrame(frameRef.current)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [frameRef, sessionRecordingId])
 
     const containerRef = useRef<HTMLDivElement | null>(null)
@@ -31,11 +33,15 @@ export const PlayerFrame = (): JSX.Element => {
         window.addEventListener('resize', windowResize)
 
         return () => window.removeEventListener('resize', windowResize)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [player?.replayer])
 
     // Recalculate the player size when the player changes dimensions
     useEffect(() => {
         windowResize()
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [containerDimensions])
 
     const windowResize = (): void => {

--- a/frontend/src/scenes/session-recordings/player/PlayerUpNext.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerUpNext.tsx
@@ -43,6 +43,8 @@ export function PlayerUpNext({ interrupted, clearInterrupted, playlistLogic }: P
         }
 
         return () => clearTimeout(timeoutRef.current)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [endReached, !!nextSessionRecording])
 
     useEffect(() => {

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerSeekbarPreview.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerSeekbarPreview.tsx
@@ -48,6 +48,8 @@ const PlayerSeekbarPreviewFrame = ({
         if (isVisible) {
             debouncedSeekToTime(minMs + (maxMs - minMs) * percentage)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [percentage, minMs, maxMs, isVisible])
 
     return (
@@ -90,6 +92,8 @@ export function PlayerSeekbarPreview({ minMs, maxMs, seekBarRef }: PlayerSeekbar
         // fixes react-hooks/exhaustive-deps warning about stale ref elements
         const { current } = ref
         return () => current?.removeEventListener('mousemove', handleMouseMove)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [seekBarRef])
 
     return (

--- a/frontend/src/scenes/session-recordings/player/controller/Seekbar.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/Seekbar.tsx
@@ -31,6 +31,8 @@ export function Seekbar(): JSX.Element {
             setSlider(sliderRef)
             setThumb(thumbRef)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [sliderRef.current, thumbRef.current, sessionRecordingId])
 
     return (
@@ -63,7 +65,7 @@ export function Seekbar(): JSX.Element {
                             ))}
                         </div>
 
-                        {/* eslint-disable-next-line react/forbid-dom-props */}
+                        {}
                         <div
                             className="PlayerSeekbar__currentbar"
                             style={{ width: `${Math.max(thumbLeftPos, 0)}px` }}

--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspector.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspector.tsx
@@ -51,6 +51,8 @@ export function PlayerInspector({ onFocusChange }: { onFocusChange: (focus: bool
         window.addEventListener('click', onClickHandler)
 
         return () => window.removeEventListener('click', onClickHandler)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [inspectorFocus])
 
     return (

--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorList.tsx
@@ -114,6 +114,8 @@ export function PlayerInspectorList(): JSX.Element {
             positionMarkerEl.id = 'PlayerInspectorListMarker'
             listElement?.appendChild(positionMarkerEl)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [listRef.current])
 
     useEffect(() => {
@@ -131,6 +133,8 @@ export function PlayerInspectorList(): JSX.Element {
                 listRef.current.scrollToRow(playbackIndicatorIndex)
             }
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [playbackIndicatorIndex, syncScroll])
 
     const renderRow: ListRowRenderer = ({ index, key, parent, style }) => {

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
@@ -82,12 +82,16 @@ export function PlayerInspectorListItem({
             return
         }
         onLayoutDebounced({ width, height: totalHeight })
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [width])
     useEffect(() => {
         if (!width || !totalHeight) {
             return
         }
         onLayout({ width, height: totalHeight })
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [totalHeight])
 
     const windowNumber =

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -180,6 +180,8 @@ export function RatingQuestionBarChart({
 
     useEffect(() => {
         loadSurveyRatingResults({ questionIndex })
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [questionIndex])
 
     return (
@@ -279,6 +281,8 @@ export function SingleChoiceQuestionPieChart({
 
     useEffect(() => {
         loadSurveySingleChoiceResults({ questionIndex })
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [questionIndex])
 
     return (
@@ -379,6 +383,8 @@ export function MultipleChoiceQuestionBarChart({
 
     useEffect(() => {
         loadSurveyMultipleChoiceResults({ questionIndex })
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [questionIndex])
 
     return (
@@ -450,6 +456,8 @@ export function OpenTextViz({
 
     useEffect(() => {
         loadSurveyOpenTextResults({ questionIndex })
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [questionIndex])
 
     return (

--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -63,6 +63,8 @@ export function ActionsHorizontalBar({ inCardView, showPersonsModal = true }: Ch
         if (indexedResults) {
             updateData()
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [indexedResults])
 
     return data && total > 0 ? (

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -62,6 +62,8 @@ export function ActionsPie({ inSharedMode, inCardView, showPersonsModal = true }
         if (indexedResults) {
             updateData()
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [indexedResults, hiddenLegendKeys])
 
     return data ? (

--- a/frontend/src/toolbar/button/HedgehogButton.tsx
+++ b/frontend/src/toolbar/button/HedgehogButton.tsx
@@ -27,6 +27,8 @@ export function HedgehogButton(): JSX.Element {
         if (actorRef.current) {
             setHedgehogActor(actorRef.current)
         }
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [actorRef.current])
 
     return (

--- a/frontend/src/toolbar/button/ToolbarButton.tsx
+++ b/frontend/src/toolbar/button/ToolbarButton.tsx
@@ -85,6 +85,8 @@ export function ToolbarButton(): JSX.Element {
         }
         window.addEventListener('mousemove', globalMouseMove.current)
         return () => window.removeEventListener('mousemove', globalMouseMove.current)
+        // FIXME
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isAuthenticated])
 
     // using useLongPress for short presses (clicks) since it detects if the element was dragged (no click) or not (click)

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
         "eslint-plugin-posthog": "link:./eslint-rules",
         "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-react": "^7.33.2",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-storybook": "^0.6.15",
         "file-loader": "^6.1.0",
         "givens": "^1.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -555,6 +555,9 @@ devDependencies:
   eslint-plugin-react:
     specifier: ^7.33.2
     version: 7.33.2(eslint@8.52.0)
+  eslint-plugin-react-hooks:
+    specifier: ^4.6.0
+    version: 4.6.0(eslint@8.52.0)
   eslint-plugin-storybook:
     specifier: ^0.6.15
     version: 0.6.15(eslint@8.52.0)(typescript@4.9.5)
@@ -10081,6 +10084,15 @@ packages:
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.5
+    dev: true
+
+  /eslint-plugin-react-hooks@4.6.0(eslint@8.52.0):
+    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    dependencies:
+      eslint: 8.52.0
     dev: true
 
   /eslint-plugin-react@7.33.2(eslint@8.52.0):


### PR DESCRIPTION
## Problem

We don't have this lint rule enabled, which makes it very easy to introduce subtle bugs

## Changes
Add the https://www.npmjs.com/package/eslint-plugin-react-hooks eslint plugin. It's made by the core react team to catch react hooks bugs.

It would be impossible to make code changes across the codebase, verify the correctness of each one, and get a reviewer for each one. Instead, I added a comment disabling the rule, and a FIXME comment so that someone who owns these files can take a closer look. This feels not-urgent, as presumably the code is already working in production. This approach means that we will get the warnings for new code without needing to spent excessive effort on old code.

## How did you test this code?
Linting and tests pass
