### PR TITLE
feat: drop console log events when disabled

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
@@ -30,9 +30,10 @@ function deduplicateConsoleLogEvents(consoleLogEntries: ConsoleLogEntry[]): Cons
     const deduped: ConsoleLogEntry[] = []
 
     for (const cle of consoleLogEntries) {
-        if (!seen.has(cle.message)) {
+        const fingerPrint = `${cle.log_level}-${cle.message}`
+        if (!seen.has(fingerPrint)) {
             deduped.push(cle)
-            seen.add(`${cle.log_level}-${cle.message}`)
+            seen.add(fingerPrint)
         }
     }
     return deduped

--- a/plugin-server/src/main/ingestion-queues/session-recording/types.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/types.ts
@@ -7,6 +7,7 @@ import { RRWebEvent } from '../../../types'
 export type IncomingRecordingMessage = {
     metadata: TopicPartitionOffset & {
         timestamp: number
+        consoleLogIngestionEnabled: boolean
     }
 
     team_id: number

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -336,7 +336,7 @@ function safeString(payload: (string | null)[]) {
         .join(' ')
 }
 
-enum RRWebEventType {
+export enum RRWebEventType {
     DomContentLoaded = 0,
     Load = 1,
     FullSnapshot = 2,

--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
@@ -43,10 +43,7 @@ describe('console log ingester', () => {
         )
 
         const mockedHighWaterMarker = { isBelowHighWaterMark: jest.fn() } as unknown as OffsetHighWaterMarker
-        consoleLogIngester = new ConsoleLogsIngester(
-            { ...defaultConfig, SESSION_RECORDING_CONSOLE_LOGS_INGESTION_ENABLED: true } as PluginsServerConfig,
-            mockedHighWaterMarker
-        )
+        consoleLogIngester = new ConsoleLogsIngester({ ...defaultConfig } as PluginsServerConfig, mockedHighWaterMarker)
         await consoleLogIngester.start()
     })
     describe('when enabled on team', () => {

--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
@@ -1,0 +1,212 @@
+import { HighLevelProducer } from 'node-rdkafka'
+
+import { defaultConfig } from '../../../../../src/config/config'
+import { createKafkaProducer, produce } from '../../../../../src/kafka/producer'
+import { ConsoleLogsIngester } from '../../../../../src/main/ingestion-queues/session-recording/services/console-logs-ingester'
+import { OffsetHighWaterMarker } from '../../../../../src/main/ingestion-queues/session-recording/services/offset-high-water-marker'
+import { IncomingRecordingMessage } from '../../../../../src/main/ingestion-queues/session-recording/types'
+import { PluginsServerConfig } from '../../../../../src/types'
+import { status } from '../../../../../src/utils/status'
+
+jest.mock('../../../../../src/utils/status')
+jest.mock('../../../../../src/kafka/producer')
+
+const makeIncomingMessage = (
+    data: Record<string, unknown>[],
+    consoleLogIngestionEnabled: boolean
+): IncomingRecordingMessage => {
+    return {
+        distinct_id: '',
+        events: data.map((d) => ({ type: 6, timestamp: 0, data: { ...d } })),
+        metadata: {
+            offset: 0,
+            partition: 0,
+            topic: 'topic',
+            timestamp: 0,
+            consoleLogIngestionEnabled,
+        },
+        session_id: '',
+        team_id: 0,
+    }
+}
+
+describe('console log ingester', () => {
+    let consoleLogIngester: ConsoleLogsIngester
+    const mockProducer: jest.Mock = jest.fn()
+
+    beforeEach(async () => {
+        mockProducer.mockClear()
+        mockProducer['connect'] = jest.fn()
+
+        jest.mocked(createKafkaProducer).mockImplementation(() =>
+            Promise.resolve(mockProducer as unknown as HighLevelProducer)
+        )
+
+        const mockedHighWaterMarker = { isBelowHighWaterMark: jest.fn() } as unknown as OffsetHighWaterMarker
+        consoleLogIngester = new ConsoleLogsIngester(
+            { ...defaultConfig, SESSION_RECORDING_CONSOLE_LOGS_INGESTION_ENABLED: true } as PluginsServerConfig,
+            mockedHighWaterMarker
+        )
+        await consoleLogIngester.start()
+    })
+    describe('when enabled on team', () => {
+        test('it truncates large console logs', async () => {
+            await consoleLogIngester.consume(
+                makeIncomingMessage(
+                    [
+                        {
+                            plugin: 'rrweb/console@1',
+                            payload: { level: 'log', payload: ['a'.repeat(3001)] },
+                        },
+                    ],
+                    true
+                )
+            )
+            expect(jest.mocked(status.warn).mock.calls).toEqual([])
+            expect(jest.mocked(produce).mock.calls).toEqual([
+                [
+                    {
+                        key: '',
+                        producer: mockProducer,
+                        topic: 'log_entries_test',
+                        value: Buffer.from(
+                            JSON.stringify({
+                                team_id: 0,
+                                message: 'a'.repeat(2999),
+                                log_level: 'log',
+                                log_source: 'session_replay',
+                                log_source_id: '',
+                                instance_id: null,
+                                timestamp: '1970-01-01 00:00:00.000',
+                            })
+                        ),
+                    },
+                ],
+            ])
+        })
+
+        test('it handles multiple console logs', async () => {
+            await consoleLogIngester.consume(
+                makeIncomingMessage(
+                    [
+                        {
+                            plugin: 'rrweb/console@1',
+                            payload: { level: 'log', payload: ['aaaaa'] },
+                        },
+                        {
+                            plugin: 'rrweb/something-else@1',
+                            payload: { level: 'log', payload: ['bbbbb'] },
+                        },
+                        {
+                            plugin: 'rrweb/console@1',
+                            payload: { level: 'log', payload: ['ccccc'] },
+                        },
+                    ],
+                    true
+                )
+            )
+            expect(jest.mocked(status.warn).mock.calls).toEqual([])
+            expect(jest.mocked(produce)).toHaveBeenCalledTimes(2)
+            expect(jest.mocked(produce).mock.calls).toEqual([
+                [
+                    {
+                        key: '',
+                        producer: mockProducer,
+                        topic: 'log_entries_test',
+                        value: Buffer.from(
+                            JSON.stringify({
+                                team_id: 0,
+                                message: 'aaaaa',
+                                log_level: 'log',
+                                log_source: 'session_replay',
+                                log_source_id: '',
+                                instance_id: null,
+                                timestamp: '1970-01-01 00:00:00.000',
+                            })
+                        ),
+                    },
+                ],
+                [
+                    {
+                        key: '',
+                        producer: mockProducer,
+                        topic: 'log_entries_test',
+                        value: Buffer.from(
+                            JSON.stringify({
+                                team_id: 0,
+                                message: 'ccccc',
+                                log_level: 'log',
+                                log_source: 'session_replay',
+                                log_source_id: '',
+                                instance_id: null,
+                                timestamp: '1970-01-01 00:00:00.000',
+                            })
+                        ),
+                    },
+                ],
+            ])
+        })
+
+        test('it de-duplicates console logs', async () => {
+            await consoleLogIngester.consume(
+                makeIncomingMessage(
+                    [
+                        {
+                            plugin: 'rrweb/console@1',
+                            payload: { level: 'log', payload: ['aaaaa'] },
+                        },
+                        {
+                            plugin: 'rrweb/console@1',
+                            payload: { level: 'log', payload: ['aaaaa'] },
+                        },
+                    ],
+                    true
+                )
+            )
+            expect(jest.mocked(status.warn).mock.calls).toEqual([])
+            expect(jest.mocked(produce).mock.calls).toEqual([
+                [
+                    {
+                        key: '',
+                        producer: mockProducer,
+                        topic: 'log_entries_test',
+                        value: Buffer.from(
+                            JSON.stringify({
+                                team_id: 0,
+                                message: 'aaaaa',
+                                log_level: 'log',
+                                log_source: 'session_replay',
+                                log_source_id: '',
+                                instance_id: null,
+                                timestamp: '1970-01-01 00:00:00.000',
+                            })
+                        ),
+                    },
+                ],
+            ])
+        })
+    })
+
+    describe('when disabled on team', () => {
+        test('it drops console logs', async () => {
+            await consoleLogIngester.consume(makeIncomingMessage([{ plugin: 'rrweb/console@1' }], false))
+            expect(jest.mocked(status.warn).mock.calls).toEqual([
+                [
+                    '⚠️',
+                    '[console-log-events-ingester] console_log_ingestion_disabled',
+                    {
+                        offset: 0,
+                        partition: 0,
+                        reason: 'console_log_ingestion_disabled',
+                    },
+                ],
+            ])
+            expect(jest.mocked(produce)).not.toHaveBeenCalled()
+        })
+        test('it does not drop events with no console logs', async () => {
+            await consoleLogIngester.consume(makeIncomingMessage([{ plugin: 'some-other-plugin' }], false))
+            expect(jest.mocked(status.warn).mock.calls).toEqual([])
+            expect(jest.mocked(produce)).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -224,7 +224,7 @@ describe('ingester', () => {
                     offset: 1,
                     partition: 1,
                 } satisfies Message,
-                () => Promise.resolve(1)
+                () => Promise.resolve({ teamId: 1, consoleLogIngestionEnabled: false })
             )
             expect(parsedMessage).toEqual({
                 distinct_id: '12345',
@@ -234,6 +234,7 @@ describe('ingester', () => {
                     partition: 1,
                     timestamp: 1,
                     topic: 'the_topic',
+                    consoleLogIngestionEnabled: false,
                 },
                 session_id: '018a47c2-2f4a-70a8-b480-5e51d8b8d070',
                 team_id: 1,
@@ -244,7 +245,7 @@ describe('ingester', () => {
         it('filters out invalid rrweb events', async () => {
             const numeric_id = 12345
 
-            const createMessage = ($snapshot_items) => {
+            const createMessage = ($snapshot_items: unknown[]) => {
                 return {
                     value: Buffer.from(
                         JSON.stringify({
@@ -281,7 +282,7 @@ describe('ingester', () => {
                         timestamp: null,
                     },
                 ]),
-                () => Promise.resolve(1)
+                () => Promise.resolve({ teamId: 1, consoleLogIngestionEnabled: true })
             )
             expect(parsedMessage).toEqual(undefined)
 
@@ -298,7 +299,7 @@ describe('ingester', () => {
                         timestamp: 123,
                     },
                 ]),
-                () => Promise.resolve(1)
+                () => Promise.resolve({ teamId: 1, consoleLogIngestionEnabled: true })
             )
             expect(parsedMessage2).toMatchObject({
                 events: [
@@ -310,7 +311,9 @@ describe('ingester', () => {
                 ],
             })
 
-            const parsedMessage3 = await ingester.parseKafkaMessage(createMessage([null]), () => Promise.resolve(1))
+            const parsedMessage3 = await ingester.parseKafkaMessage(createMessage([null]), () =>
+                Promise.resolve({ teamId: 1, consoleLogIngestionEnabled: false })
+            )
             expect(parsedMessage3).toEqual(undefined)
         })
     })


### PR DESCRIPTION
We had a team sending very large/numerous console logs in a very few session recordings. They also had long sessions.

The sessions were causing problems at ingestion and so we disabled the console log ingestion. But because their sessions were long-lived and this only affects new sessions it didn't relieve ingestion pressure.

So, we had to disable all recording for the team. So that when the teams refresher next updated we'd start dropping their recordings.

This PR amends the teams refresher to pick out (some) config for the teams so that we can still check if a team exist and is enabled for general replay ingestion - but also in the console log ingester check if a team is enabled and when there are console logs in an event drop them if the team is disabled