### PR TITLE
fix(surveys): Improve taxonomy for surveys

### DIFF
--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -192,17 +192,21 @@ export const KEY_MAPPING: KeyMappingInterface = {
         },
         $survey_response: {
             label: 'Survey Response',
-            description: 'What the user responded with to the survey',
+            description: 'The response value for the first question in the survey.',
             examples: ['I love it!', 5, "['choice 1', 'choice 3']"],
         },
         $survey_name: {
             label: 'Survey Name',
-            description: 'The name of the survey',
+            description: 'The name of the survey.',
             examples: ['Product Feedback for New Product', 'Home page NPS'],
+        },
+        $survey_questions: {
+            label: 'Survey Questions',
+            description: 'The questions asked in the survey.',
         },
         $survey_id: {
             label: 'Survey ID',
-            description: 'The unique identifier for the survey',
+            description: 'The unique identifier for the survey.',
         },
         $device: {
             label: 'Device',
@@ -793,6 +797,35 @@ export function getKeyMapping(
             data.description = `${data.description} Data from the first time this user was seen.`
         }
         return data
+    } else if (value.startsWith('$survey_response/')) {
+        const surveyId = value.replace(/^\$survey_response\//, '')
+        if (surveyId) {
+            return {
+                label: `Survey Responded: ${surveyId}`,
+                description: `Whether the user responded to survey with ID: "${surveyId}".`,
+            }
+        }
+    } else if (value.startsWith('$survey_dismiss/')) {
+        const surveyId = value.replace(/^\$survey_dismiss\//, '')
+        if (surveyId) {
+            return {
+                label: `Survey Dismissed: ${surveyId}`,
+                description: `Whether the user dismissed survey with ID: "${surveyId}".`,
+            }
+        }
+    } else if (value.startsWith('$survey_response_')) {
+        const surveyIndex = value.replace(/^\$survey_response_/, '')
+        if (surveyIndex) {
+            const index = Number(surveyIndex) + 1
+            // yes this will return 21th, but I'm applying the domain logic of
+            // it being very unlikely that someone will have more than 20 questions,
+            // rather than hyper optimising the suffix.
+            const suffix = index === 1 ? 'st' : index === 2 ? 'nd' : index === 3 ? 'rd' : 'th'
+            return {
+                label: `Survey Response Question ID: ${surveyIndex}`,
+                description: `The response value for the ${index}${suffix} question in the survey.`,
+            }
+        }
     } else if (value.startsWith('$feature/')) {
         const featureFlagKey = value.replace(/^\$feature\//, '')
         if (featureFlagKey) {


### PR DESCRIPTION
## Problem

Improve taxonomy for surveys. Replaces raw text like `$survey_questions` with the nicer posthog prop value

<img width="1208" alt="image" src="https://github.com/PostHog/posthog/assets/7115141/af4757b2-0a16-4b20-9e7d-cea08efb5bdf">


<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
