### PR TITLE
feat(hogql): session.id and session.duration rename

### DIFF
--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -232,8 +232,8 @@
               "type": "lazy_table",
               "table": "events",
               "fields": [
-                  "$session_id",
-                  "session_duration"
+                  "id",
+                  "duration"
               ]
           }
       ],
@@ -1022,8 +1022,8 @@
               "type": "lazy_table",
               "table": "events",
               "fields": [
-                  "$session_id",
-                  "session_duration"
+                  "id",
+                  "duration"
               ]
           }
       ],


### PR DESCRIPTION
## Problem

Writing 
```sql
SELECT uuid, event, session.session_duration, session.$session_id FROM events LIMIT 100
```

is longer than

```sql
SELECT uuid, event, session.duration, session.id FROM events LIMIT 100
```

## Changes

Makes the second case work.

## How did you test this code?

Added a query test, as I noticed nothing broke when I changed the field names locally 🤔 
Something might still break in CI though...