### PR TITLE
chore(kea): upgrade logics to v3 format with codemod (closes #18230, #18229)

### DIFF
--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -1,4 +1,4 @@
-import { windowValues } from 'kea-windowvalues'
+import { windowValues } from 'kea-window-values'
 import { loaders } from 'kea-loaders'
 import { kea, path, connect, actions, reducers, selectors, listeners } from 'kea'
 import api from 'lib/api'

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -1,4 +1,6 @@
-import { kea } from 'kea'
+import { windowValues } from 'kea-windowvalues'
+import { loaders } from 'kea-loaders'
+import { kea, path, connect, actions, reducers, selectors, listeners } from 'kea'
 import api from 'lib/api'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
@@ -17,13 +19,13 @@ export type ProjectNoticeVariant =
     | 'unverified_email'
     | 'is_impersonated'
 
-export const navigationLogic = kea<navigationLogicType>({
-    path: ['layout', 'navigation', 'navigationLogic'],
-    connect: {
+export const navigationLogic = kea<navigationLogicType>([
+    path(['layout', 'navigation', 'navigationLogic']),
+    connect({
         values: [sceneLogic, ['sceneConfig', 'activeScene'], membersLogic, ['members', 'membersLoading']],
         actions: [eventUsageLogic, ['reportProjectNoticeDismissed']],
-    },
-    actions: {
+    }),
+    actions({
         toggleSideBarBase: (override?: boolean) => ({ override }), // Only use the override for testing
         toggleSideBarMobile: (override?: boolean) => ({ override }), // Only use the override for testing
         toggleActivationSideBar: true,
@@ -43,8 +45,25 @@ export const navigationLogic = kea<navigationLogicType>({
         closeAppSourceEditor: true,
         setOpenAppMenu: (id: number | null) => ({ id }),
         closeProjectNotice: (projectNoticeVariant: ProjectNoticeVariant) => ({ projectNoticeVariant }),
-    },
-    reducers: {
+    }),
+    loaders({
+        navigationStatus: [
+            { system_status_ok: true, async_migrations_ok: true } as {
+                system_status_ok: boolean
+                async_migrations_ok: boolean
+            },
+            {
+                loadNavigationStatus: async () => {
+                    return await api.get('api/instance_settings')
+                },
+            },
+        ],
+    }),
+    windowValues(() => ({
+        fullscreen: (window) => !!window.document.fullscreenElement,
+        mobileLayout: (window) => window.innerWidth < 992, // Sync width threshold with Sass variable $lg!
+    })),
+    reducers({
         // Non-mobile base
         isSideBarShownBase: [
             true,
@@ -112,12 +131,8 @@ export const navigationLogic = kea<navigationLogicType>({
                 closeProjectNotice: (state, { projectNoticeVariant }) => ({ ...state, [projectNoticeVariant]: true }),
             },
         ],
-    },
-    windowValues: () => ({
-        fullscreen: (window) => !!window.document.fullscreenElement,
-        mobileLayout: (window) => window.innerWidth < 992, // Sync width threshold with Sass variable $lg!
     }),
-    selectors: {
+    selectors({
         /** `noSidebar` whether the current scene should display a sidebar at all */
         noSidebar: [
             (s) => [s.fullscreen, s.sceneConfig],
@@ -201,21 +216,8 @@ export const navigationLogic = kea<navigationLogicType>({
                 return null
             },
         ],
-    },
-    loaders: {
-        navigationStatus: [
-            { system_status_ok: true, async_migrations_ok: true } as {
-                system_status_ok: boolean
-                async_migrations_ok: boolean
-            },
-            {
-                loadNavigationStatus: async () => {
-                    return await api.get('api/instance_settings')
-                },
-            },
-        ],
-    },
-    listeners: ({ actions, values }) => ({
+    }),
+    listeners(({ actions, values }) => ({
         closeProjectNotice: ({ projectNoticeVariant }) => {
             actions.reportProjectNoticeDismissed(projectNoticeVariant)
         },
@@ -226,5 +228,5 @@ export const navigationLogic = kea<navigationLogicType>({
                 actions.showActivationSideBar()
             }
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -60,8 +60,8 @@ export const navigationLogic = kea<navigationLogicType>([
         ],
     }),
     windowValues(() => ({
-        fullscreen: (window) => !!window.document.fullscreenElement,
-        mobileLayout: (window) => window.innerWidth < 992, // Sync width threshold with Sass variable $lg!
+        fullscreen: (window: Window) => !!window.document.fullscreenElement,
+        mobileLayout: (window: Window) => window.innerWidth < 992, // Sync width threshold with Sass variable $lg!
     })),
     reducers({
         // Non-mobile base

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
@@ -1,4 +1,5 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, props, key, path, actions, reducers, selectors, listeners, events } from 'kea'
 import api, { ACTIVITY_PAGE_SIZE, ActivityLogPaginatedResponse } from 'lib/api'
 import {
     ActivityLogItem,
@@ -11,7 +12,7 @@ import {
 import type { activityLogLogicType } from './activityLogLogicType'
 import { PaginationManual } from 'lib/lemon-ui/PaginationControl'
 import { urls } from 'scenes/urls'
-import { router } from 'kea-router'
+import { router, urlToAction } from 'kea-router'
 import { flagActivityDescriber } from 'scenes/feature-flags/activityDescriptions'
 import { pluginActivityDescriber } from 'scenes/plugins/pluginActivityDescriptions'
 import { insightActivityDescriber } from 'scenes/saved-insights/activityDescriptions'
@@ -51,30 +52,30 @@ export type ActivityLogLogicProps = {
     id?: number | string
 }
 
-export const activityLogLogic = kea<activityLogLogicType>({
-    path: (key) => ['lib', 'components', 'ActivityLog', 'activitylog', 'logic', key],
-    props: {} as ActivityLogLogicProps,
-    key: ({ scope, id }) => `activity/${scope}/${id || 'all'}`,
-    actions: {
+export const activityLogLogic = kea<activityLogLogicType>([
+    props({} as ActivityLogLogicProps),
+    key(({ scope, id }) => `activity/${scope}/${id || 'all'}`),
+    path((key) => ['lib', 'components', 'ActivityLog', 'activitylog', 'logic', key]),
+    actions({
         setPage: (page: number) => ({ page }),
-    },
-    loaders: ({ values, props }) => ({
+    }),
+    loaders(({ values, props }) => ({
         activity: [
             { results: [], total_count: 0 } as ActivityLogPaginatedResponse<ActivityLogItem>,
             {
                 fetchActivity: async () => await api.activity.list(props, values.page),
             },
         ],
-    }),
-    reducers: () => ({
+    })),
+    reducers(() => ({
         page: [
             1,
             {
                 setPage: (_, { page }) => page,
             },
         ],
-    }),
-    selectors: ({ actions }) => ({
+    })),
+    selectors(({ actions }) => ({
         pagination: [
             (s) => [s.page, s.totalCount],
             (page, totalCount): PaginationManual => {
@@ -100,14 +101,14 @@ export const activityLogLogic = kea<activityLogLogicType>({
                 return activity.total_count ?? null
             },
         ],
-    }),
-    listeners: ({ actions }) => ({
+    })),
+    listeners(({ actions }) => ({
         setPage: async (_, breakpoint) => {
             await breakpoint()
             actions.fetchActivity()
         },
-    }),
-    urlToAction: ({ values, actions, props }) => {
+    })),
+    urlToAction(({ values, actions, props }) => {
         const onPageChange = (
             searchParams: Record<string, any>,
             hashParams: Record<string, any>,
@@ -153,10 +154,10 @@ export const activityLogLogic = kea<activityLogLogicType>({
             [urls.appHistory(':pluginConfigId')]: (_, searchParams, hashParams) =>
                 onPageChange(searchParams, hashParams, ActivityScope.PLUGIN, true),
         }
-    },
-    events: ({ actions }) => ({
+    }),
+    events(({ actions }) => ({
         afterMount: () => {
             actions.fetchActivity()
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, props, key, path, connect, actions, reducers, selectors, listeners } from 'kea'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
@@ -17,19 +17,19 @@ export interface AddToDashboardModalLogicProps {
 }
 
 // Helping kea-typegen navigate the exported default class for Fuse
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
+
 export interface Fuse extends FuseClass<any> {}
 
-export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>({
-    path: ['lib', 'components', 'AddToDashboard', 'saveToDashboardModalLogic'],
-    props: {} as AddToDashboardModalLogicProps,
-    key: ({ insight }) => {
+export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>([
+    props({} as AddToDashboardModalLogicProps),
+    key(({ insight }) => {
         if (!insight.short_id) {
             throw Error('must provide an insight with a short id')
         }
         return insight.short_id
-    },
-    connect: (props: AddToDashboardModalLogicProps) => ({
+    }),
+    path(['lib', 'components', 'AddToDashboard', 'saveToDashboardModalLogic']),
+    connect((props: AddToDashboardModalLogicProps) => ({
         actions: [
             insightLogic({ dashboardItemId: props.insight.short_id, cachedInsight: props.insight }),
             ['updateInsight', 'updateInsightSuccess', 'updateInsightFailure'],
@@ -38,8 +38,8 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>({
             newDashboardLogic,
             ['showNewDashboardModal'],
         ],
-    }),
-    actions: {
+    })),
+    actions({
         addNewDashboard: true,
         setDashboardId: (id: number) => ({ id }),
         setSearchQuery: (query: string) => ({ query }),
@@ -47,9 +47,8 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>({
         setScrollIndex: (index: number) => ({ index }),
         addToDashboard: (insight: Partial<InsightModel>, dashboardId: number) => ({ insight, dashboardId }),
         removeFromDashboard: (insight: Partial<InsightModel>, dashboardId: number) => ({ insight, dashboardId }),
-    },
-
-    reducers: {
+    }),
+    reducers({
         _dashboardId: [null as null | number, { setDashboardId: (_, { id }) => id }],
         searchQuery: ['', { setSearchQuery: (_, { query }) => query }],
         scrollIndex: [-1 as number, { setScrollIndex: (_, { index }) => index }],
@@ -62,9 +61,8 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>({
                 updateInsightFailure: () => null,
             },
         ],
-    },
-
-    selectors: {
+    }),
+    selectors({
         dashboardId: [
             (s) => [
                 s._dashboardId,
@@ -108,9 +106,8 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>({
                 ...availableDashboards,
             ],
         ],
-    },
-
-    listeners: ({ actions, values, props }) => ({
+    }),
+    listeners(({ actions, values, props }) => ({
         setDashboardId: ({ id }) => {
             dashboardsModel.actions.setLastDashboardId(id)
         },
@@ -153,5 +150,5 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>({
                 }
             )
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
+++ b/frontend/src/lib/components/ChartFilter/chartFilterLogic.ts
@@ -1,27 +1,24 @@
-import { kea } from 'kea'
+import { kea, props, key, path, connect, actions, selectors, listeners } from 'kea'
 import type { chartFilterLogicType } from './chartFilterLogicType'
 import { ChartDisplayType, InsightLogicProps } from '~/types'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
-export const chartFilterLogic = kea<chartFilterLogicType>({
-    props: {} as InsightLogicProps,
-    key: keyForInsightLogicProps('new'),
-    path: (key) => ['lib', 'components', 'ChartFilter', 'chartFilterLogic', key],
-    connect: (props: InsightLogicProps) => ({
+export const chartFilterLogic = kea<chartFilterLogicType>([
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps('new')),
+    path((key) => ['lib', 'components', 'ChartFilter', 'chartFilterLogic', key]),
+    connect((props: InsightLogicProps) => ({
         actions: [insightVizDataLogic(props), ['updateInsightFilter', 'updateBreakdown']],
         values: [insightVizDataLogic(props), ['isTrends', 'isStickiness', 'display', 'series']],
-    }),
-
-    actions: () => ({
+    })),
+    actions(() => ({
         setChartFilter: (chartFilter: ChartDisplayType) => ({ chartFilter }),
-    }),
-
-    selectors: {
+    })),
+    selectors({
         chartFilter: [(s) => [s.display], (display): ChartDisplayType | null | undefined => display],
-    },
-
-    listeners: ({ actions, values }) => ({
+    }),
+    listeners(({ actions, values }) => ({
         setChartFilter: ({ chartFilter }) => {
             const { isTrends, isStickiness, display, series } = values
             const newDisplay = chartFilter as ChartDisplayType
@@ -42,5 +39,5 @@ export const chartFilterLogic = kea<chartFilterLogicType>({
                 }
             }
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, path, connect, actions, reducers, selectors, listeners, events } from 'kea'
 import { router } from 'kea-router'
 import type { commandPaletteLogicType } from './commandPaletteLogicType'
 import Fuse from 'fuse.js'
@@ -112,14 +112,14 @@ function resolveCommand(source: Command | CommandFlow, argument?: string, prefix
     return resultsWithCommand
 }
 
-export const commandPaletteLogic = kea<commandPaletteLogicType>({
-    path: ['lib', 'components', 'CommandPalette', 'commandPaletteLogic'],
-    connect: {
+export const commandPaletteLogic = kea<commandPaletteLogicType>([
+    path(['lib', 'components', 'CommandPalette', 'commandPaletteLogic']),
+    connect({
         actions: [personalAPIKeysLogic, ['createKey'], router, ['push']],
         values: [teamLogic, ['currentTeam'], userLogic, ['user']],
         logic: [preflightLogic],
-    },
-    actions: {
+    }),
+    actions({
         hidePalette: true,
         showPalette: true,
         togglePalette: true,
@@ -135,8 +135,8 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>({
         deregisterCommand: (commandKey: string) => ({ commandKey }),
         setCustomCommand: (commandKey: string) => ({ commandKey }),
         deregisterScope: (scope: string) => ({ scope }),
-    },
-    reducers: {
+    }),
+    reducers({
         isPaletteShown: [
             false,
             {
@@ -196,67 +196,8 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>({
                 },
             },
         ],
-    },
-
-    listeners: ({ actions, values }) => ({
-        showPalette: () => {
-            posthog.capture('palette shown', { isMobile: isMobile() })
-        },
-        togglePalette: () => {
-            if (values.isPaletteShown) {
-                posthog.capture('palette shown', { isMobile: isMobile() })
-            }
-        },
-        executeResult: ({ result }: { result: CommandResult }) => {
-            if (result.executor === true) {
-                actions.activateFlow(null)
-                actions.hidePalette()
-            } else {
-                const possibleFlow = result.executor?.() || null
-                actions.activateFlow(possibleFlow)
-                if (!possibleFlow) {
-                    actions.hidePalette()
-                }
-            }
-            // Capture command execution, without useless data
-            const { icon, index, ...cleanedResult }: Record<string, any> = result
-            const { resolver, ...cleanedCommand } = cleanedResult.source
-            cleanedResult.source = cleanedCommand
-            cleanedResult.isMobile = isMobile()
-            posthog.capture('palette command executed', cleanedResult)
-        },
-        deregisterScope: ({ scope }) => {
-            for (const command of Object.values(values.commandRegistrations)) {
-                if (command.scope === scope) {
-                    actions.deregisterCommand(command.key)
-                }
-            }
-        },
-        setInput: async ({ input }, breakpoint) => {
-            await breakpoint(300)
-            if (input.length > 8) {
-                const response = await api.persons.list({ search: input })
-                const person = response.results[0]
-                if (person) {
-                    actions.registerCommand({
-                        key: `person-${person.distinct_ids[0]}`,
-                        resolver: [
-                            {
-                                icon: IconPersonFilled,
-                                display: `View person ${input}`,
-                                executor: () => {
-                                    const { push } = router.actions
-                                    push(urls.personByDistinctId(person.distinct_ids[0]))
-                                },
-                            },
-                        ],
-                        scope: GLOBAL_COMMAND_SCOPE,
-                    })
-                }
-            }
-        },
     }),
-    selectors: {
+    selectors({
         isSqueak: [
             (selectors) => [selectors.input],
             (input: string) => {
@@ -390,9 +331,66 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>({
                 return resultsGroupedInOrder
             },
         ],
-    },
-
-    events: ({ actions, values }) => ({
+    }),
+    listeners(({ actions, values }) => ({
+        showPalette: () => {
+            posthog.capture('palette shown', { isMobile: isMobile() })
+        },
+        togglePalette: () => {
+            if (values.isPaletteShown) {
+                posthog.capture('palette shown', { isMobile: isMobile() })
+            }
+        },
+        executeResult: ({ result }: { result: CommandResult }) => {
+            if (result.executor === true) {
+                actions.activateFlow(null)
+                actions.hidePalette()
+            } else {
+                const possibleFlow = result.executor?.() || null
+                actions.activateFlow(possibleFlow)
+                if (!possibleFlow) {
+                    actions.hidePalette()
+                }
+            }
+            // Capture command execution, without useless data
+            const { icon, index, ...cleanedResult }: Record<string, any> = result
+            const { resolver, ...cleanedCommand } = cleanedResult.source
+            cleanedResult.source = cleanedCommand
+            cleanedResult.isMobile = isMobile()
+            posthog.capture('palette command executed', cleanedResult)
+        },
+        deregisterScope: ({ scope }) => {
+            for (const command of Object.values(values.commandRegistrations)) {
+                if (command.scope === scope) {
+                    actions.deregisterCommand(command.key)
+                }
+            }
+        },
+        setInput: async ({ input }, breakpoint) => {
+            await breakpoint(300)
+            if (input.length > 8) {
+                const response = await api.persons.list({ search: input })
+                const person = response.results[0]
+                if (person) {
+                    actions.registerCommand({
+                        key: `person-${person.distinct_ids[0]}`,
+                        resolver: [
+                            {
+                                icon: IconPersonFilled,
+                                display: `View person ${input}`,
+                                executor: () => {
+                                    const { push } = router.actions
+                                    push(urls.personByDistinctId(person.distinct_ids[0]))
+                                },
+                            },
+                        ],
+                        scope: GLOBAL_COMMAND_SCOPE,
+                    })
+                }
+            }
+        },
+    })),
+    events(({ actions, values }) => ({
         afterMount: () => {
             const { push } = actions
 
@@ -761,5 +759,5 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>({
             actions.deregisterCommand('share-feedback')
             actions.deregisterCommand('debug-copy-session-recording-url')
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/lib/components/CompareFilter/compareFilterLogic.ts
+++ b/frontend/src/lib/components/CompareFilter/compareFilterLogic.ts
@@ -1,15 +1,15 @@
-import { kea } from 'kea'
+import { kea, props, key, path, connect, actions, selectors, listeners } from 'kea'
 import { ChartDisplayType, InsightLogicProps } from '~/types'
 import type { compareFilterLogicType } from './compareFilterLogicType'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
-export const compareFilterLogic = kea<compareFilterLogicType>({
-    props: {} as InsightLogicProps,
-    key: keyForInsightLogicProps('new'),
-    path: (key) => ['lib', 'components', 'CompareFilter', 'compareFilterLogic', key],
-    connect: (props: InsightLogicProps) => ({
+export const compareFilterLogic = kea<compareFilterLogicType>([
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps('new')),
+    path((key) => ['lib', 'components', 'CompareFilter', 'compareFilterLogic', key]),
+    connect((props: InsightLogicProps) => ({
         values: [
             insightLogic(props),
             ['canEditInsight'],
@@ -17,14 +17,12 @@ export const compareFilterLogic = kea<compareFilterLogicType>({
             ['compare', 'display', 'insightFilter', 'isLifecycle', 'dateRange'],
         ],
         actions: [insightVizDataLogic(props), ['updateInsightFilter']],
-    }),
-
-    actions: () => ({
+    })),
+    actions(() => ({
         setCompare: (compare: boolean) => ({ compare }),
         toggleCompare: true,
-    }),
-
-    selectors: {
+    })),
+    selectors({
         disabled: [
             (s) => [s.canEditInsight, s.isLifecycle, s.display, s.dateRange],
             (canEditInsight, isLifecycle, display, dateRange) =>
@@ -33,14 +31,13 @@ export const compareFilterLogic = kea<compareFilterLogicType>({
                 display === ChartDisplayType.WorldMap ||
                 dateRange?.date_from === 'all',
         ],
-    },
-
-    listeners: ({ values, actions }) => ({
+    }),
+    listeners(({ values, actions }) => ({
         setCompare: ({ compare }) => {
             actions.updateInsightFilter({ compare })
         },
         toggleCompare: () => {
             actions.setCompare(!values.compare)
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/lib/components/DefinitionPopover/definitionPopoverLogic.ts
+++ b/frontend/src/lib/components/DefinitionPopover/definitionPopoverLogic.ts
@@ -1,4 +1,5 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, props, path, connect, actions, reducers, selectors, listeners, events } from 'kea'
 import type { definitionPopoverLogicType } from './definitionPopoverLogicType'
 import { TaxonomicDefinitionTypes, TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { capitalizeFirstLetter } from 'lib/utils'
@@ -33,35 +34,20 @@ export interface DefinitionPopoverLogicProps {
     openDetailInNewTab?: boolean
 }
 
-export const definitionPopoverLogic = kea<definitionPopoverLogicType>({
-    props: {} as DefinitionPopoverLogicProps,
-    connect: {
+export const definitionPopoverLogic = kea<definitionPopoverLogicType>([
+    props({} as DefinitionPopoverLogicProps),
+    path(['lib', 'components', 'DefinitionPanel', 'definitionPopoverLogic']),
+    connect({
         values: [userLogic, ['hasAvailableFeature']],
-    },
-    path: ['lib', 'components', 'DefinitionPanel', 'definitionPopoverLogic'],
-    actions: {
+    }),
+    actions({
         setDefinition: (item: Partial<TaxonomicDefinitionTypes>) => ({ item }),
         setLocalDefinition: (item: Partial<TaxonomicDefinitionTypes>) => ({ item }),
         setPopoverState: (state: DefinitionPopoverState) => ({ state }),
         handleCancel: true,
         recordHoverActivity: true,
-    },
-    reducers: {
-        state: [
-            DefinitionPopoverState.View as DefinitionPopoverState,
-            {
-                setPopoverState: (_, { state }) => state,
-            },
-        ],
-        localDefinition: [
-            {} as Partial<TaxonomicDefinitionTypes>,
-            {
-                setDefinition: (_, { item }) => item,
-                setLocalDefinition: (state, { item }) => ({ ...state, ...item } as Partial<TaxonomicDefinitionTypes>),
-            },
-        ],
-    },
-    loaders: ({ values, props, cache }) => ({
+    }),
+    loaders(({ values, props, cache }) => ({
         definition: [
             {} as Partial<TaxonomicDefinitionTypes>,
             {
@@ -121,8 +107,23 @@ export const definitionPopoverLogic = kea<definitionPopoverLogicType>({
                 },
             },
         ],
+    })),
+    reducers({
+        state: [
+            DefinitionPopoverState.View as DefinitionPopoverState,
+            {
+                setPopoverState: (_, { state }) => state,
+            },
+        ],
+        localDefinition: [
+            {} as Partial<TaxonomicDefinitionTypes>,
+            {
+                setDefinition: (_, { item }) => item,
+                setLocalDefinition: (state, { item }) => ({ ...state, ...item } as Partial<TaxonomicDefinitionTypes>),
+            },
+        ],
     }),
-    selectors: {
+    selectors({
         type: [() => [(_, props) => props.type], (type) => type],
         hideView: [() => [(_, props) => props.hideView], (hideView) => hideView ?? false],
         hideEdit: [() => [(_, props) => props.hideEdit], (hideEdit) => hideEdit ?? false],
@@ -198,8 +199,8 @@ export const definitionPopoverLogic = kea<definitionPopoverLogicType>({
                 return undefined
             },
         ],
-    },
-    listeners: ({ actions, selectors, values, props, cache }) => ({
+    }),
+    listeners(({ actions, selectors, values, props, cache }) => ({
         setDefinition: (_, __, ___, previousState) => {
             // Reset definition popover to view mode if context is switched
             if (
@@ -247,10 +248,10 @@ export const definitionPopoverLogic = kea<definitionPopoverLogicType>({
             await breakpoint(IS_TEST_MODE ? 1 : 1000) // Tests will wait for all breakpoints to finish
             eventUsageLogic.findMounted()?.actions?.reportDataManagementDefinitionHovered(values.type)
         },
-    }),
-    events: ({ actions }) => ({
+    })),
+    events(({ actions }) => ({
         afterMount: () => {
             actions.recordHoverActivity()
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/lib/components/HelpButton/HelpButton.tsx
+++ b/frontend/src/lib/components/HelpButton/HelpButton.tsx
@@ -1,5 +1,5 @@
 import './HelpButton.scss'
-import { kea, useActions, useValues } from 'kea'
+import { kea, useActions, useValues, props, key, path, connect, actions, reducers, listeners } from 'kea'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { HelpType } from '~/types'
 import type { helpButtonLogicType } from './HelpButtonType'
@@ -27,21 +27,23 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 const HELP_UTM_TAGS = '?utm_medium=in-product&utm_campaign=help-button-top'
 
-export const helpButtonLogic = kea<helpButtonLogicType>({
-    props: {} as {
-        key?: string
-    },
-    key: (props: { key?: string }) => props.key || 'global',
-    path: (key) => ['lib', 'components', 'HelpButton', key],
-    connect: {
+export const helpButtonLogic = kea<helpButtonLogicType>([
+    props(
+        {} as {
+            key?: string
+        }
+    ),
+    key((props: { key?: string }) => props.key || 'global'),
+    path((key) => ['lib', 'components', 'HelpButton', key]),
+    connect({
         actions: [eventUsageLogic, ['reportHelpButtonViewed']],
-    },
-    actions: {
+    }),
+    actions({
         toggleHelp: true,
         showHelp: true,
         hideHelp: true,
-    },
-    reducers: {
+    }),
+    reducers({
         isHelpVisible: [
             false,
             {
@@ -50,8 +52,8 @@ export const helpButtonLogic = kea<helpButtonLogicType>({
                 hideHelp: () => false,
             },
         ],
-    },
-    listeners: ({ actions, values }) => ({
+    }),
+    listeners(({ actions, values }) => ({
         showHelp: () => {
             actions.reportHelpButtonViewed()
         },
@@ -60,8 +62,8 @@ export const helpButtonLogic = kea<helpButtonLogicType>({
                 actions.reportHelpButtonViewed()
             }
         },
-    }),
-})
+    })),
+])
 
 export interface HelpButtonProps {
     placement?: Placement

--- a/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervalFilterLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, props, key, path, connect, actions, reducers, listeners } from 'kea'
 import { objectsEqual, dateMapping } from 'lib/utils'
 import type { intervalFilterLogicType } from './intervalFilterLogicType'
 import { IntervalKeyType, Intervals, intervals } from 'lib/components/IntervalFilter/intervals'
@@ -10,27 +10,27 @@ import { lemonToast } from 'lib/lemon-ui/lemonToast'
 import { BASE_MATH_DEFINITIONS } from 'scenes/trends/mathsLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
-export const intervalFilterLogic = kea<intervalFilterLogicType>({
-    props: {} as InsightLogicProps,
-    key: keyForInsightLogicProps('new'),
-    path: (key) => ['lib', 'components', 'IntervalFilter', 'intervalFilterLogic', key],
-    connect: (props: InsightLogicProps) => ({
+export const intervalFilterLogic = kea<intervalFilterLogicType>([
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps('new')),
+    path((key) => ['lib', 'components', 'IntervalFilter', 'intervalFilterLogic', key]),
+    connect((props: InsightLogicProps) => ({
         actions: [insightVizDataLogic(props), ['updateQuerySource']],
         values: [insightVizDataLogic(props), ['interval', 'querySource']],
-    }),
-    actions: () => ({
+    })),
+    actions(() => ({
         setInterval: (interval: IntervalKeyType) => ({ interval }),
         setEnabledIntervals: (enabledIntervals: Intervals) => ({ enabledIntervals }),
-    }),
-    reducers: () => ({
+    })),
+    reducers(() => ({
         enabledIntervals: [
             { ...intervals } as Intervals,
             {
                 setEnabledIntervals: (_, { enabledIntervals }) => enabledIntervals,
             },
         ],
-    }),
-    listeners: ({ values, actions, selectors }) => ({
+    })),
+    listeners(({ values, actions, selectors }) => ({
         setInterval: ({ interval }) => {
             if (values.interval !== interval) {
                 actions.updateQuerySource({ interval } as Partial<InsightQueryNode>)
@@ -140,5 +140,5 @@ export const intervalFilterLogic = kea<intervalFilterLogicType>({
             }
             actions.updateQuerySource({ interval } as Partial<InsightQueryNode>)
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/lib/components/PersonalAPIKeys/personalAPIKeysLogic.ts
+++ b/frontend/src/lib/components/PersonalAPIKeys/personalAPIKeysLogic.ts
@@ -1,13 +1,14 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, path, listeners, events } from 'kea'
 import api from 'lib/api'
 import { PersonalAPIKeyType } from '~/types'
 import type { personalAPIKeysLogicType } from './personalAPIKeysLogicType'
 import { copyToClipboard } from 'lib/utils'
 import { lemonToast } from 'lib/lemon-ui/lemonToast'
 
-export const personalAPIKeysLogic = kea<personalAPIKeysLogicType>({
-    path: ['lib', 'components', 'PersonalAPIKeys', 'personalAPIKeysLogic'],
-    loaders: ({ values }) => ({
+export const personalAPIKeysLogic = kea<personalAPIKeysLogicType>([
+    path(['lib', 'components', 'PersonalAPIKeys', 'personalAPIKeysLogic']),
+    loaders(({ values }) => ({
         keys: [
             [] as PersonalAPIKeyType[],
             {
@@ -27,17 +28,16 @@ export const personalAPIKeysLogic = kea<personalAPIKeysLogicType>({
                 },
             },
         ],
-    }),
-    listeners: () => ({
+    })),
+    listeners(() => ({
         createKeySuccess: async ({ keys }: { keys: PersonalAPIKeyType[] }) => {
             keys[0]?.value && (await copyToClipboard(keys[0].value, 'personal API key value'))
         },
         deleteKeySuccess: () => {
             lemonToast.success(`Personal API key deleted`)
         },
-    }),
-
-    events: ({ actions }) => ({
+    })),
+    events(({ actions }) => ({
         afterMount: [actions.loadKeys],
-    }),
-})
+    })),
+])

--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, props, key, path, connect, actions, reducers, selectors, listeners } from 'kea'
 import { TaxonomicPropertyFilterLogicProps } from 'lib/components/PropertyFilters/types'
 import {
     AnyPropertyFilter,
@@ -23,12 +23,11 @@ import {
 import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 
-export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType>({
-    path: (key) => ['lib', 'components', 'PropertyFilters', 'components', 'taxonomicPropertyFilterLogic', key],
-    props: {} as TaxonomicPropertyFilterLogicProps,
-    key: (props) => `${props.pageKey}-${props.filterIndex}`,
-
-    connect: (props: TaxonomicPropertyFilterLogicProps) => ({
+export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType>([
+    props({} as TaxonomicPropertyFilterLogicProps),
+    key((props) => `${props.pageKey}-${props.filterIndex}`),
+    path((key) => ['lib', 'components', 'PropertyFilters', 'components', 'taxonomicPropertyFilterLogic', key]),
+    connect((props: TaxonomicPropertyFilterLogicProps) => ({
         values: [
             props.propertyFilterLogic,
             ['filters'],
@@ -42,18 +41,16 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
             propertyDefinitionsModel,
             ['describeProperty'],
         ],
-    }),
-
-    actions: {
+    })),
+    actions({
         selectItem: (taxonomicGroup: TaxonomicFilterGroup, propertyKey?: TaxonomicFilterValue) => ({
             taxonomicGroup,
             propertyKey,
         }),
         openDropdown: true,
         closeDropdown: true,
-    },
-
-    reducers: {
+    }),
+    reducers({
         dropdownOpen: [
             false,
             {
@@ -61,9 +58,8 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
                 closeDropdown: () => false,
             },
         ],
-    },
-
-    selectors: {
+    }),
+    selectors({
         filter: [
             (s, p) => [s.filters, p.filterIndex],
             (filters, filterIndex): AnyPropertyFilter | null =>
@@ -82,9 +78,8 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
                 }
             },
         ],
-    },
-
-    listeners: ({ actions, values, props }) => ({
+    }),
+    listeners(({ actions, values, props }) => ({
         selectItem: ({ taxonomicGroup, propertyKey }) => {
             const propertyType = taxonomicFilterTypeToPropertyFilterType(taxonomicGroup.type)
             if (propertyKey && propertyType) {
@@ -134,5 +129,5 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
                 actions.closeDropdown()
             }
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1,4 +1,4 @@
-import { BuiltLogic, kea } from 'kea'
+import { BuiltLogic, kea, props, key, path, connect, actions, reducers, selectors, listeners } from 'kea'
 import type { taxonomicFilterLogicType } from './taxonomicFilterLogicType'
 import {
     ListStorage,
@@ -66,11 +66,11 @@ export const propertyTaxonomicGroupProps = (
     getIcon: getPropertyDefinitionIcon,
 })
 
-export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
-    path: ['lib', 'components', 'TaxonomicFilter', 'taxonomicFilterLogic'],
-    props: {} as TaxonomicFilterLogicProps,
-    key: (props) => `${props.taxonomicFilterLogicKey}`,
-    connect: {
+export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
+    props({} as TaxonomicFilterLogicProps),
+    key((props) => `${props.taxonomicFilterLogicKey}`),
+    path(['lib', 'components', 'TaxonomicFilter', 'taxonomicFilterLogic']),
+    connect({
         values: [
             teamLogic,
             ['currentTeamId'],
@@ -79,8 +79,8 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
             groupPropertiesModel,
             ['allGroupProperties'],
         ],
-    },
-    actions: () => ({
+    }),
+    actions(() => ({
         moveUp: true,
         moveDown: true,
         selectSelected: (onComplete?: () => void) => ({ onComplete }),
@@ -98,9 +98,8 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
             groupType,
             results,
         }),
-    }),
-
-    reducers: ({ selectors }) => ({
+    })),
+    reducers(({ selectors }) => ({
         searchQuery: [
             '',
             {
@@ -126,11 +125,8 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                 enableMouseInteractions: () => true,
             },
         ],
-    }),
-
-    // NB, don't change to the async "selectors: (logic) => {}", as this causes a white screen when infiniteListLogic-s
-    // connect to taxonomicFilterLogic to select their initial values. They won't be built yet and will be unknown.
-    selectors: {
+    })),
+    selectors({
         taxonomicFilterLogicKey: [
             (_, p) => [p.taxonomicFilterLogicKey],
             (taxonomicFilterLogicKey) => taxonomicFilterLogicKey,
@@ -546,8 +542,8 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                     .join('')
             },
         ],
-    },
-    listeners: ({ actions, values, props }) => ({
+    }),
+    listeners(({ actions, values, props }) => ({
         selectItem: ({ group, value, item }) => {
             if (item) {
                 props.onChange?.(group, value, item)
@@ -648,5 +644,5 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                 updatePropertyDefinitions(newPropertyDefinitions)
             }
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/lib/components/VisibilitySensor/visibilitySensorLogic.tsx
+++ b/frontend/src/lib/components/VisibilitySensor/visibilitySensorLogic.tsx
@@ -1,4 +1,4 @@
-import { windowValues } from 'kea-windowvalues'
+import { windowValues } from 'kea-window-values'
 import { kea, props, key, path, actions, reducers, selectors, listeners } from 'kea'
 
 import type { visibilitySensorLogicType } from './visibilitySensorLogicType'

--- a/frontend/src/lib/components/VisibilitySensor/visibilitySensorLogic.tsx
+++ b/frontend/src/lib/components/VisibilitySensor/visibilitySensorLogic.tsx
@@ -16,7 +16,7 @@ export const visibilitySensorLogic = kea<visibilitySensorLogicType>([
         scrolling: (element: HTMLElement) => ({ element }),
     })),
     windowValues({
-        innerHeight: (window) => window.innerHeight,
+        innerHeight: (window: Window) => window.innerHeight,
     }),
     reducers(() => ({
         visible: [

--- a/frontend/src/lib/components/VisibilitySensor/visibilitySensorLogic.tsx
+++ b/frontend/src/lib/components/VisibilitySensor/visibilitySensorLogic.tsx
@@ -1,46 +1,32 @@
-import { kea } from 'kea'
+import { windowValues } from 'kea-windowvalues'
+import { kea, props, key, path, actions, reducers, selectors, listeners } from 'kea'
 
 import type { visibilitySensorLogicType } from './visibilitySensorLogicType'
-export const visibilitySensorLogic = kea<visibilitySensorLogicType>({
-    path: (key) => ['lib', 'components', 'VisibilitySensor', 'visibilitySensorLogic', key],
-    props: {} as {
-        id: string
-        offset?: number
-    },
-
-    key: (props) => props.id || 'undefined',
-
-    actions: () => ({
+export const visibilitySensorLogic = kea<visibilitySensorLogicType>([
+    props(
+        {} as {
+            id: string
+            offset?: number
+        }
+    ),
+    key((props) => props.id || 'undefined'),
+    path((key) => ['lib', 'components', 'VisibilitySensor', 'visibilitySensorLogic', key]),
+    actions(() => ({
         setVisible: (visible: boolean) => ({ visible }),
         scrolling: (element: HTMLElement) => ({ element }),
+    })),
+    windowValues({
+        innerHeight: (window) => window.innerHeight,
     }),
-
-    reducers: () => ({
+    reducers(() => ({
         visible: [
             false,
             {
                 setVisible: (_, { visible }) => visible,
             },
         ],
-    }),
-
-    windowValues: {
-        innerHeight: (window) => window.innerHeight,
-    },
-
-    listeners: ({ actions, values }) => ({
-        scrolling: async ({ element }, breakpoint) => {
-            await breakpoint(500)
-
-            if (values.checkIsVisible(element) && !values.visible) {
-                actions.setVisible(true)
-            } else if (!values.checkIsVisible(element) && values.visible) {
-                actions.setVisible(false)
-            }
-        },
-    }),
-
-    selectors: () => ({
+    })),
+    selectors(() => ({
         checkIsVisible: [
             (selectors) => [selectors.innerHeight, (_, props) => props.offset || 0],
             (windowHeight, offset) => (element: HTMLElement) => {
@@ -55,5 +41,16 @@ export const visibilitySensorLogic = kea<visibilitySensorLogicType>({
                 return top + offset >= 0 && top + offset <= windowHeight
             },
         ],
-    }),
-})
+    })),
+    listeners(({ actions, values }) => ({
+        scrolling: async ({ element }, breakpoint) => {
+            await breakpoint(500)
+
+            if (values.checkIsVisible(element) && !values.visible) {
+                actions.setVisible(true)
+            } else if (!values.checkIsVisible(element) && values.visible) {
+                actions.setVisible(false)
+            }
+        },
+    })),
+])

--- a/frontend/src/lib/introductions/groupsAccessLogic.ts
+++ b/frontend/src/lib/introductions/groupsAccessLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, path, connect, selectors } from 'kea'
 import { AvailableFeature } from '~/types'
 import { teamLogic } from 'scenes/teamLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
@@ -13,12 +13,12 @@ export enum GroupsAccessStatus {
     Hidden,
 }
 
-export const groupsAccessLogic = kea<groupsAccessLogicType>({
-    path: ['lib', 'introductions', 'groupsAccessLogic'],
-    connect: {
+export const groupsAccessLogic = kea<groupsAccessLogicType>([
+    path(['lib', 'introductions', 'groupsAccessLogic']),
+    connect({
         values: [teamLogic, ['currentTeam'], preflightLogic, ['preflight'], userLogic, ['hasAvailableFeature']],
-    },
-    selectors: {
+    }),
+    selectors({
         groupsEnabled: [
             (s) => [s.hasAvailableFeature],
             (hasAvailableFeature) => hasAvailableFeature(AvailableFeature.GROUP_ANALYTICS),
@@ -50,5 +50,5 @@ export const groupsAccessLogic = kea<groupsAccessLogicType>({
             (s) => [s.groupsAccessStatus],
             (groupsAccessStatus) => groupsAccessStatus === GroupsAccessStatus.HasAccess,
         ],
-    },
-})
+    }),
+])

--- a/frontend/src/lib/logic/featureFlagLogic.ts
+++ b/frontend/src/lib/logic/featureFlagLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, path, actions, reducers, events } from 'kea'
 import type { featureFlagLogicType } from './featureFlagLogicType'
 import posthog from 'posthog-js'
 import { getAppContext } from 'lib/utils/getAppContext'
@@ -64,13 +64,12 @@ function spyOnFeatureFlags(featureFlags: FeatureFlagsSet): FeatureFlagsSet {
     }
 }
 
-export const featureFlagLogic = kea<featureFlagLogicType>({
-    path: ['lib', 'logic', 'featureFlagLogic'],
-    actions: {
+export const featureFlagLogic = kea<featureFlagLogicType>([
+    path(['lib', 'logic', 'featureFlagLogic']),
+    actions({
         setFeatureFlags: (flags: string[], variants: Record<string, string | boolean>) => ({ flags, variants }),
-    },
-
-    reducers: {
+    }),
+    reducers({
         featureFlags: [
             getPersistedFeatureFlags(),
             { persist: true },
@@ -84,11 +83,10 @@ export const featureFlagLogic = kea<featureFlagLogicType>({
                 setFeatureFlags: () => true,
             },
         ],
-    },
-
-    events: ({ actions }) => ({
+    }),
+    events(({ actions }) => ({
         afterMount: () => {
             posthog.onFeatureFlags(actions.setFeatureFlags)
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, path, connect, actions, listeners } from 'kea'
 import { isPostHogProp, keyMappingKeys } from 'lib/taxonomy'
 import posthog from 'posthog-js'
 import { userLogic } from 'scenes/userLogic'
@@ -208,12 +208,12 @@ function sanitizeFilterParams(filters: AnyPartialFilterType): Record<string, any
     }
 }
 
-export const eventUsageLogic = kea<eventUsageLogicType>({
-    path: ['lib', 'utils', 'eventUsageLogic'],
-    connect: () => ({
+export const eventUsageLogic = kea<eventUsageLogicType>([
+    path(['lib', 'utils', 'eventUsageLogic']),
+    connect(() => ({
         values: [preflightLogic, ['realm'], userLogic, ['user']],
-    }),
-    actions: {
+    })),
+    actions({
         // persons related
         reportPersonDetailViewed: (person: PersonType) => ({ person }),
         reportPersonsModalViewed: (params: any) => ({
@@ -505,8 +505,8 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportOnboardingProductSelected: (productKey: string) => ({ productKey }),
         reportOnboardingCompleted: (productKey: string) => ({ productKey }),
         reportSubscribedDuringOnboarding: (productKey: string) => ({ productKey }),
-    },
-    listeners: ({ values }) => ({
+    }),
+    listeners(({ values }) => ({
         reportAxisUnitsChanged: (properties) => {
             posthog.capture('axis units changed', properties)
         },
@@ -1264,5 +1264,5 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
                 product_key: productKey,
             })
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/models/actionsModel.ts
+++ b/frontend/src/models/actionsModel.ts
@@ -1,4 +1,5 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, props, path, connect, selectors, events } from 'kea'
 import api from 'lib/api'
 import { ActionType } from '~/types'
 import type { actionsModelType } from './actionsModelType'
@@ -12,13 +13,13 @@ export function findActionName(id: number): string | null {
     return actionsModel.findMounted()?.values.actions.find((a) => a.id === id)?.name || null
 }
 
-export const actionsModel = kea<actionsModelType>({
-    path: ['models', 'actionsModel'],
-    props: {} as ActionsModelProps,
-    connect: {
+export const actionsModel = kea<actionsModelType>([
+    props({} as ActionsModelProps),
+    path(['models', 'actionsModel']),
+    connect({
         values: [teamLogic, ['currentTeam']],
-    },
-    loaders: ({ props, values }) => ({
+    }),
+    loaders(({ props, values }) => ({
         actions: {
             __default: [] as ActionType[],
             loadActions: async () => {
@@ -27,8 +28,8 @@ export const actionsModel = kea<actionsModelType>({
             },
             updateAction: (action: ActionType) => (values.actions || []).map((a) => (action.id === a.id ? action : a)),
         },
-    }),
-    selectors: ({ selectors }) => ({
+    })),
+    selectors(({ selectors }) => ({
         actionsGrouped: [
             () => [selectors.actions],
             (actions: ActionType[]) => {
@@ -47,14 +48,13 @@ export const actionsModel = kea<actionsModelType>({
             (actions): Partial<Record<string | number, ActionType>> =>
                 Object.fromEntries(actions.map((action) => [action.id, action])),
         ],
-    }),
-
-    events: ({ values, actions }) => ({
+    })),
+    events(({ values, actions }) => ({
         afterMount: () => {
             if (isAuthenticatedTeam(values.currentTeam)) {
                 // Don't load on shared insights/dashboards
                 actions.loadActions()
             }
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/models/cohortsModel.ts
+++ b/frontend/src/models/cohortsModel.ts
@@ -1,4 +1,5 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, path, connect, actions, reducers, selectors, listeners, events } from 'kea'
 import api from 'lib/api'
 import type { cohortsModelType } from './cohortsModelType'
 import { CohortType, ExporterFormat } from '~/types'
@@ -9,20 +10,19 @@ import { isAuthenticatedTeam, teamLogic } from 'scenes/teamLogic'
 
 const POLL_TIMEOUT = 5000
 
-export const cohortsModel = kea<cohortsModelType>({
-    path: ['models', 'cohortsModel'],
-    connect: {
+export const cohortsModel = kea<cohortsModelType>([
+    path(['models', 'cohortsModel']),
+    connect({
         values: [teamLogic, ['currentTeam']],
-    },
-    actions: () => ({
+    }),
+    actions(() => ({
         setPollTimeout: (pollTimeout: number | null) => ({ pollTimeout }),
         updateCohort: (cohort: CohortType) => ({ cohort }),
         deleteCohort: (cohort: Partial<CohortType>) => ({ cohort }),
         cohortCreated: (cohort: CohortType) => ({ cohort }),
         exportCohortPersons: (id: CohortType['id'], columns?: string[]) => ({ id, columns }),
-    }),
-
-    loaders: () => ({
+    })),
+    loaders(() => ({
         cohorts: {
             __default: [] as CohortType[],
             loadCohorts: async () => {
@@ -32,9 +32,8 @@ export const cohortsModel = kea<cohortsModelType>({
                 return response?.results?.map((cohort) => processCohort(cohort)) || []
             },
         },
-    }),
-
-    reducers: {
+    })),
+    reducers({
         pollTimeout: [
             null as number | null,
             {
@@ -61,18 +60,16 @@ export const cohortsModel = kea<cohortsModelType>({
                 return [...state].filter((c) => c.id !== cohort.id)
             },
         },
-    },
-
-    selectors: {
+    }),
+    selectors({
         cohortsWithAllUsers: [(s) => [s.cohorts], (cohorts) => [{ id: 'all', name: 'All Users*' }, ...cohorts]],
         cohortsById: [
             (s) => [s.cohorts],
             (cohorts): Partial<Record<string | number, CohortType>> =>
                 Object.fromEntries(cohorts.map((cohort) => [cohort.id, cohort])),
         ],
-    },
-
-    listeners: ({ actions }) => ({
+    }),
+    listeners(({ actions }) => ({
         loadCohortsSuccess: async ({ cohorts }: { cohorts: CohortType[] }) => {
             const is_calculating = cohorts.filter((cohort) => cohort.is_calculating).length > 0
             if (!is_calculating) {
@@ -99,9 +96,8 @@ export const cohortsModel = kea<cohortsModelType>({
                 callback: actions.loadCohorts,
             })
         },
-    }),
-
-    events: ({ actions, values }) => ({
+    })),
+    events(({ actions, values }) => ({
         afterMount: () => {
             if (isAuthenticatedTeam(values.currentTeam)) {
                 // Don't load on shared insights/dashboards
@@ -111,5 +107,5 @@ export const cohortsModel = kea<cohortsModelType>({
         beforeUnmount: () => {
             clearTimeout(values.pollTimeout || undefined)
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/models/funnelsModel.ts
+++ b/frontend/src/models/funnelsModel.ts
@@ -1,4 +1,5 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, path, actions, reducers, listeners, events } from 'kea'
 import api from 'lib/api'
 import { toParams } from 'lib/utils'
 import { SavedFunnel, InsightType } from '~/types'
@@ -17,9 +18,14 @@ const parseSavedFunnel = (result: Record<string, any>): SavedFunnel => {
     }
 }
 
-export const funnelsModel = kea<funnelsModelType>({
-    path: ['models', 'funnelsModel'],
-    loaders: ({ values, actions }) => ({
+export const funnelsModel = kea<funnelsModelType>([
+    path(['models', 'funnelsModel']),
+    actions(() => ({
+        setNext: (next) => ({ next }),
+        loadNext: true,
+        appendFunnels: (funnels) => ({ funnels }),
+    })),
+    loaders(({ values, actions }) => ({
         funnels: {
             __default: [] as SavedFunnel[],
             loadFunnels: async () => {
@@ -40,8 +46,8 @@ export const funnelsModel = kea<funnelsModelType>({
                 return values.funnels.filter((funnel) => funnel.id !== funnelId)
             },
         },
-    }),
-    reducers: () => ({
+    })),
+    reducers(() => ({
         next: [
             null as null | string,
             {
@@ -58,13 +64,8 @@ export const funnelsModel = kea<funnelsModelType>({
                 setNext: () => false,
             },
         ],
-    }),
-    actions: () => ({
-        setNext: (next) => ({ next }),
-        loadNext: true,
-        appendFunnels: (funnels) => ({ funnels }),
-    }),
-    listeners: ({ values, actions }) => ({
+    })),
+    listeners(({ values, actions }) => ({
         loadNext: async () => {
             if (!values.next) {
                 throw new Error('URL of next page of funnels is not known.')
@@ -74,8 +75,8 @@ export const funnelsModel = kea<funnelsModelType>({
             actions.setNext(response.next)
             actions.appendFunnels(results)
         },
-    }),
-    events: ({ actions }) => ({
+    })),
+    events(({ actions }) => ({
         afterMount: actions.loadFunnels,
-    }),
-})
+    })),
+])

--- a/frontend/src/models/groupPropertiesModel.ts
+++ b/frontend/src/models/groupPropertiesModel.ts
@@ -1,16 +1,17 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, path, connect, selectors, events } from 'kea'
 import type { groupPropertiesModelType } from './groupPropertiesModelType'
 import api from 'lib/api'
 import { GroupTypeProperties, PersonProperty } from '~/types'
 import { teamLogic } from 'scenes/teamLogic'
 import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 
-export const groupPropertiesModel = kea<groupPropertiesModelType>({
-    path: ['models', 'groupPropertiesModel'],
-    connect: {
+export const groupPropertiesModel = kea<groupPropertiesModelType>([
+    path(['models', 'groupPropertiesModel']),
+    connect({
         values: [teamLogic, ['currentTeamId'], groupsAccessLogic, ['groupsEnabled']],
-    },
-    loaders: ({ values }) => ({
+    }),
+    loaders(({ values }) => ({
         allGroupProperties: [
             {} as GroupTypeProperties,
             {
@@ -22,8 +23,8 @@ export const groupPropertiesModel = kea<groupPropertiesModelType>({
                 },
             },
         ],
-    }),
-    selectors: {
+    })),
+    selectors({
         groupProperties: [
             (s) => [s.allGroupProperties],
             (groupProperties: GroupTypeProperties) =>
@@ -35,8 +36,8 @@ export const groupPropertiesModel = kea<groupPropertiesModelType>({
         groupProperties_2: [(s) => [s.allGroupProperties], (groupProperties) => groupProperties['2']],
         groupProperties_3: [(s) => [s.allGroupProperties], (groupProperties) => groupProperties['3']],
         groupProperties_4: [(s) => [s.allGroupProperties], (groupProperties) => groupProperties['4']],
-    },
-    events: ({ actions }) => ({
-        afterMount: actions.loadAllGroupProperties,
     }),
-})
+    events(({ actions }) => ({
+        afterMount: actions.loadAllGroupProperties,
+    })),
+])

--- a/frontend/src/models/index.ts
+++ b/frontend/src/models/index.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, path, connect } from 'kea'
 import { actionsModel } from './actionsModel'
 import { annotationsModel } from './annotationsModel'
 import { cohortsModel } from './cohortsModel'
@@ -7,7 +7,7 @@ import { propertyDefinitionsModel } from './propertyDefinitionsModel'
 import type { modelsType } from './indexType'
 
 /** "Models" are logics that are persistently mounted (start with app) */
-export const models = kea<modelsType>({
-    path: ['models', 'index'],
-    connect: [actionsModel, annotationsModel, cohortsModel, dashboardsModel, propertyDefinitionsModel],
-})
+export const models = kea<modelsType>([
+    path(['models', 'index']),
+    connect([actionsModel, annotationsModel, cohortsModel, dashboardsModel, propertyDefinitionsModel]),
+])

--- a/frontend/src/models/insightsModel.tsx
+++ b/frontend/src/models/insightsModel.tsx
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, path, connect, actions, listeners } from 'kea'
 import api from 'lib/api'
 import { promptLogic } from 'lib/logic/promptLogic'
 import { InsightModel } from '~/types'
@@ -6,10 +6,10 @@ import { teamLogic } from 'scenes/teamLogic'
 import type { insightsModelType } from './insightsModelType'
 import { lemonToast } from 'lib/lemon-ui/lemonToast'
 
-export const insightsModel = kea<insightsModelType>({
-    path: ['models', 'insightsModel'],
-    connect: [promptLogic({ key: 'rename-insight' }), teamLogic],
-    actions: () => ({
+export const insightsModel = kea<insightsModelType>([
+    path(['models', 'insightsModel']),
+    connect([promptLogic({ key: 'rename-insight' }), teamLogic]),
+    actions(() => ({
         renameInsight: (item: InsightModel) => ({ item }),
         renameInsightSuccess: (item: InsightModel) => ({ item }),
         //TODO this duplicates the insight but not the dashboard tile (e.g. if duplicated from dashboard you lose tile color
@@ -22,8 +22,8 @@ export const insightsModel = kea<insightsModelType>({
             dashboardId,
             insightIds,
         }),
-    }),
-    listeners: ({ actions }) => ({
+    })),
+    listeners(({ actions }) => ({
         renameInsight: async ({ item }) => {
             promptLogic({ key: 'rename-insight' }).actions.prompt({
                 title: 'Rename insight',
@@ -58,5 +58,5 @@ export const insightsModel = kea<insightsModelType>({
             actions.duplicateInsightSuccess(addedItem)
             lemonToast.success('Insight duplicated')
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -1,4 +1,4 @@
-import { kea, useMountedLogic, useValues, BindLogic } from 'kea'
+import { kea, useMountedLogic, useValues, BindLogic, path, connect, actions, reducers, selectors, events } from 'kea'
 import { ToastContainer, Slide } from 'react-toastify'
 import { preflightLogic } from './PreflightCheck/preflightLogic'
 import { userLogic } from 'scenes/userLogic'
@@ -28,18 +28,18 @@ import { useEffect } from 'react'
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { FeaturePreviewsModal } from '~/layout/FeaturePreviews'
 
-export const appLogic = kea<appLogicType>({
-    path: ['scenes', 'App'],
-    connect: [teamLogic, organizationLogic, frontendAppsLogic, inAppPromptLogic],
-    actions: {
+export const appLogic = kea<appLogicType>([
+    path(['scenes', 'App']),
+    connect([teamLogic, organizationLogic, frontendAppsLogic, inAppPromptLogic]),
+    actions({
         enableDelayedSpinner: true,
         ignoreFeatureFlags: true,
-    },
-    reducers: {
+    }),
+    reducers({
         showingDelayedSpinner: [false, { enableDelayedSpinner: () => true }],
         featureFlagsTimedOut: [false, { ignoreFeatureFlags: () => true }],
-    },
-    selectors: {
+    }),
+    selectors({
         showApp: [
             (s) => [
                 userLogic.selectors.userLoading,
@@ -57,8 +57,8 @@ export const appLogic = kea<appLogicType>({
                 )
             },
         ],
-    },
-    events: ({ actions, cache }) => ({
+    }),
+    events(({ actions, cache }) => ({
         afterMount: () => {
             cache.spinnerTimeout = window.setTimeout(() => actions.enableDelayedSpinner(), 1000)
             cache.featureFlagTimeout = window.setTimeout(() => actions.ignoreFeatureFlags(), 3000)
@@ -67,8 +67,8 @@ export const appLogic = kea<appLogicType>({
             window.clearTimeout(cache.spinnerTimeout)
             window.clearTimeout(cache.featureFlagTimeout)
         },
-    }),
-})
+    })),
+])
 
 export function App(): JSX.Element | null {
     const { showApp, showingDelayedSpinner } = useValues(appLogic)

--- a/frontend/src/scenes/dashboard/dashboardCollaboratorsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardCollaboratorsLogic.ts
@@ -1,4 +1,5 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, props, key, path, connect, actions, reducers, selectors, events } from 'kea'
 import api from 'lib/api'
 import { DashboardPrivilegeLevel, DashboardRestrictionLevel } from 'lib/constants'
 import { teamMembersLogic } from 'scenes/project/Settings/teamMembersLogic'
@@ -16,32 +17,24 @@ export interface DashboardCollaboratorsLogicProps {
     dashboardId: DashboardType['id']
 }
 
-export const dashboardCollaboratorsLogic = kea<dashboardCollaboratorsLogicType>({
-    path: (key) => ['scenes', 'dashboard', 'dashboardCollaboratorsLogic', key],
-    props: {} as DashboardCollaboratorsLogicProps,
-    key: (props) => props.dashboardId,
-    connect: (props: DashboardCollaboratorsLogicProps) => ({
+export const dashboardCollaboratorsLogic = kea<dashboardCollaboratorsLogicType>([
+    props({} as DashboardCollaboratorsLogicProps),
+    key((props) => props.dashboardId),
+    path((key) => ['scenes', 'dashboard', 'dashboardCollaboratorsLogic', key]),
+    connect((props: DashboardCollaboratorsLogicProps) => ({
         values: [
             teamMembersLogic,
             ['admins', 'plainMembers', 'allMembers', 'allMembersLoading'],
             dashboardLogic({ id: props.dashboardId }),
             ['dashboard'],
         ],
-    }),
-    actions: {
+    })),
+    actions({
         deleteExplicitCollaborator: (userUuid: UserType['uuid']) => ({ userUuid }),
         setExplicitCollaboratorsToBeAdded: (userUuids: string[]) => ({ userUuids }),
         addExplicitCollaborators: true,
-    },
-    reducers: {
-        explicitCollaboratorsToBeAdded: [
-            [] as string[],
-            {
-                setExplicitCollaboratorsToBeAdded: (_, { userUuids }) => userUuids,
-            },
-        ],
-    },
-    loaders: ({ values, props, actions }) => ({
+    }),
+    loaders(({ values, props, actions }) => ({
         explicitCollaborators: [
             [] as DashboardCollaboratorType[],
             {
@@ -74,8 +67,16 @@ export const dashboardCollaboratorsLogic = kea<dashboardCollaboratorsLogicType>(
                 },
             },
         ],
+    })),
+    reducers({
+        explicitCollaboratorsToBeAdded: [
+            [] as string[],
+            {
+                setExplicitCollaboratorsToBeAdded: (_, { userUuids }) => userUuids,
+            },
+        ],
     }),
-    selectors: {
+    selectors({
         allCollaborators: [
             (s) => [s.explicitCollaborators, s.admins, s.allMembers, s.dashboard],
             (explicitCollaborators, admins, allMembers, dashboard): FusedDashboardCollaboratorType[] => {
@@ -134,10 +135,10 @@ export const dashboardCollaboratorsLogic = kea<dashboardCollaboratorsLogicType>(
             (explicitCollaboratorsLoading, allMembersLoading): boolean =>
                 explicitCollaboratorsLoading || allMembersLoading,
         ],
-    },
-    events: ({ actions }) => ({
+    }),
+    events(({ actions }) => ({
         afterMount: () => {
             actions.loadExplicitCollaborators()
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
+++ b/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
@@ -1,4 +1,5 @@
-import { kea, useActions, useValues } from 'kea'
+import { actionToUrl, urlToAction } from 'kea-router'
+import { kea, useActions, useValues, path, connect, actions, reducers, selectors } from 'kea'
 import { urls } from 'scenes/urls'
 import type { eventsTabsLogicType } from './DataManagementPageTabsType'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
@@ -27,32 +28,32 @@ const tabUrls = {
     [DataManagementTab.Database]: urls.database(),
 }
 
-const eventsTabsLogic = kea<eventsTabsLogicType>({
-    path: ['scenes', 'events', 'eventsTabsLogic'],
-    connect: {
+const eventsTabsLogic = kea<eventsTabsLogicType>([
+    path(['scenes', 'events', 'eventsTabsLogic']),
+    connect({
         values: [featureFlagLogic, ['featureFlags']],
-    },
-    actions: {
+    }),
+    actions({
         setTab: (tab: DataManagementTab) => ({ tab }),
-    },
-    reducers: {
+    }),
+    reducers({
         tab: [
             DataManagementTab.EventDefinitions as DataManagementTab,
             {
                 setTab: (_, { tab }) => tab,
             },
         ],
-    },
-    selectors: {
+    }),
+    selectors({
         showWarningsTab: [
             (s) => [s.featureFlags],
             (featureFlags): boolean => !!featureFlags[FEATURE_FLAGS.INGESTION_WARNINGS_ENABLED],
         ],
-    },
-    actionToUrl: () => ({
-        setTab: ({ tab }) => tabUrls[tab as DataManagementTab] || urls.events(),
     }),
-    urlToAction: ({ actions, values }) => {
+    actionToUrl(() => ({
+        setTab: ({ tab }) => tabUrls[tab as DataManagementTab] || urls.events(),
+    })),
+    urlToAction(({ actions, values }) => {
         return Object.fromEntries(
             Object.entries(tabUrls).map(([key, url]) => [
                 url,
@@ -63,8 +64,8 @@ const eventsTabsLogic = kea<eventsTabsLogicType>({
                 },
             ])
         )
-    },
-})
+    }),
+])
 
 export function DataManagementPageTabs({ tab }: { tab: DataManagementTab }): JSX.Element {
     const { showWarningsTab } = useValues(eventsTabsLogic)

--- a/frontend/src/scenes/data-warehouse/DataWarehousePageTabs.tsx
+++ b/frontend/src/scenes/data-warehouse/DataWarehousePageTabs.tsx
@@ -1,4 +1,5 @@
-import { kea, useActions, useValues } from 'kea'
+import { actionToUrl, urlToAction } from 'kea-router'
+import { kea, useActions, useValues, path, actions, reducers } from 'kea'
 import { urls } from 'scenes/urls'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 
@@ -18,23 +19,23 @@ const tabUrls = {
     [DataWarehouseTab.Views]: urls.dataWarehouseSavedQueries(),
 }
 
-const dataWarehouseTabsLogic = kea<dataWarehouseTabsLogicType>({
-    path: ['scenes', 'warehouse', 'dataWarehouseTabsLogic'],
-    actions: {
+const dataWarehouseTabsLogic = kea<dataWarehouseTabsLogicType>([
+    path(['scenes', 'warehouse', 'dataWarehouseTabsLogic']),
+    actions({
         setTab: (tab: DataWarehouseTab) => ({ tab }),
-    },
-    reducers: {
+    }),
+    reducers({
         tab: [
             DataWarehouseTab.External as DataWarehouseTab,
             {
                 setTab: (_, { tab }) => tab,
             },
         ],
-    },
-    actionToUrl: () => ({
-        setTab: ({ tab }) => tabUrls[tab as DataWarehouseTab] || urls.dataWarehousePosthog(),
     }),
-    urlToAction: ({ actions, values }) => {
+    actionToUrl(() => ({
+        setTab: ({ tab }) => tabUrls[tab as DataWarehouseTab] || urls.dataWarehousePosthog(),
+    })),
+    urlToAction(({ actions, values }) => {
         return Object.fromEntries(
             Object.entries(tabUrls).map(([key, url]) => [
                 url,
@@ -45,8 +46,8 @@ const dataWarehouseTabsLogic = kea<dataWarehouseTabsLogicType>({
                 },
             ])
         )
-    },
-})
+    }),
+])
 
 export function DataWarehousePageTabs({ tab }: { tab: DataWarehouseTab }): JSX.Element {
     const { setTab } = useActions(dataWarehouseTabsLogic)

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -1,4 +1,5 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, props, key, path, connect, actions, reducers, selectors, listeners, events } from 'kea'
 import api from 'lib/api'
 import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { teamLogic } from 'scenes/teamLogic'
@@ -18,11 +19,11 @@ export interface GroupsListLogicProps {
     groupTypeIndex: number
 }
 
-export const groupsListLogic = kea<groupsListLogicType>({
-    props: {} as GroupsListLogicProps,
-    key: (props: GroupsListLogicProps) => props.groupTypeIndex,
-    path: ['groups', 'groupsListLogic'],
-    connect: {
+export const groupsListLogic = kea<groupsListLogicType>([
+    props({} as GroupsListLogicProps),
+    key((props: GroupsListLogicProps) => props.groupTypeIndex),
+    path(['groups', 'groupsListLogic']),
+    connect({
         values: [
             teamLogic,
             ['currentTeamId'],
@@ -31,12 +32,12 @@ export const groupsListLogic = kea<groupsListLogicType>({
             groupsAccessLogic,
             ['groupsEnabled'],
         ],
-    },
-    actions: () => ({
+    }),
+    actions(() => ({
         loadGroups: (url?: string | null) => ({ url }),
         setSearch: (search: string, debounce: boolean = true) => ({ search, debounce }),
-    }),
-    loaders: ({ props, values }) => ({
+    })),
+    loaders(({ props, values }) => ({
         groups: [
             { next: null, previous: null, results: [] } as GroupsPaginatedResponse,
             {
@@ -53,16 +54,16 @@ export const groupsListLogic = kea<groupsListLogicType>({
                 },
             },
         ],
-    }),
-    reducers: {
+    })),
+    reducers({
         search: [
             '',
             {
                 setSearch: (_, { search }) => search,
             },
         ],
-    },
-    selectors: {
+    }),
+    selectors({
         groupTypeName: [
             (s, p) => [p.groupTypeIndex, s.aggregationLabel],
             (groupTypeIndex, aggregationLabel): Noun =>
@@ -77,18 +78,18 @@ export const groupsListLogic = kea<groupsListLogicType>({
                 },
             ],
         ],
-    },
-    listeners: ({ actions }) => ({
+    }),
+    listeners(({ actions }) => ({
         setSearch: async ({ debounce }, breakpoint) => {
             if (debounce) {
                 await breakpoint(300)
             }
             actions.loadGroups()
         },
-    }),
-    events: ({ actions }) => ({
+    })),
+    events(({ actions }) => ({
         afterMount: () => {
             actions.loadGroups()
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/groups/relatedGroupsLogic.ts
+++ b/frontend/src/scenes/groups/relatedGroupsLogic.ts
@@ -1,24 +1,25 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, props, key, path, connect, actions, events } from 'kea'
 import api from 'lib/api'
 import { toParams } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { ActorType } from '~/types'
 import type { relatedGroupsLogicType } from './relatedGroupsLogicType'
 
-export const relatedGroupsLogic = kea<relatedGroupsLogicType>({
-    path: ['scenes', 'groups', 'relatedGroupsLogic'],
-    connect: { values: [teamLogic, ['currentTeamId']] },
-
-    props: {} as {
-        groupTypeIndex: number | null
-        id: string
-    },
-    key: (props) => `${props.groupTypeIndex ?? 'person'}-${props.id}`,
-
-    actions: () => ({
+export const relatedGroupsLogic = kea<relatedGroupsLogicType>([
+    props(
+        {} as {
+            groupTypeIndex: number | null
+            id: string
+        }
+    ),
+    key((props) => `${props.groupTypeIndex ?? 'person'}-${props.id}`),
+    path(['scenes', 'groups', 'relatedGroupsLogic']),
+    connect({ values: [teamLogic, ['currentTeamId']] }),
+    actions(() => ({
         loadRelatedActors: true,
-    }),
-    loaders: ({ values, props }) => ({
+    })),
+    loaders(({ values, props }) => ({
         relatedActors: [
             [] as ActorType[],
             {
@@ -32,8 +33,8 @@ export const relatedGroupsLogic = kea<relatedGroupsLogicType>({
                 setGroup: () => [],
             },
         ],
-    }),
-    events: ({ actions }) => ({
+    })),
+    events(({ actions }) => ({
         afterMount: actions.loadRelatedActors,
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/insights/views/Histogram/histogramLogic.ts
+++ b/frontend/src/scenes/insights/views/Histogram/histogramLogic.ts
@@ -1,19 +1,19 @@
-import { kea } from 'kea'
+import { kea, path, actions, reducers } from 'kea'
 import { getConfig, HistogramConfig } from 'scenes/insights/views/Histogram/histogramUtils'
 import type { histogramLogicType } from './histogramLogicType'
 import { FunnelLayout } from 'lib/constants'
 
-export const histogramLogic = kea<histogramLogicType>({
-    path: ['scenes', 'insights', 'Histogram', 'histogramLogic'],
-    actions: {
+export const histogramLogic = kea<histogramLogicType>([
+    path(['scenes', 'insights', 'Histogram', 'histogramLogic']),
+    actions({
         setConfig: (config: HistogramConfig) => ({ config }),
-    },
-    reducers: {
+    }),
+    reducers({
         config: [
             getConfig(FunnelLayout.vertical),
             {
                 setConfig: (state, { config }) => ({ ...state, ...config }),
             },
         ],
-    },
-})
+    }),
+])

--- a/frontend/src/scenes/insights/views/InsightsTable/insightsTableLogic.ts
+++ b/frontend/src/scenes/insights/views/InsightsTable/insightsTableLogic.ts
@@ -1,28 +1,30 @@
-import { kea } from 'kea'
+import { kea, props, path, actions, reducers, selectors } from 'kea'
 import { ChartDisplayType, FilterType } from '~/types'
 import type { insightsTableLogicType } from './insightsTableLogicType'
 import { isTrendsFilter } from 'scenes/insights/sharedUtils'
 
 export type CalcColumnState = 'total' | 'average' | 'median'
 
-export const insightsTableLogic = kea<insightsTableLogicType>({
-    path: ['scenes', 'insights', 'InsightsTable', 'insightsTableLogic'],
-    props: {} as {
-        hasMathUniqueFilter: boolean
-        filters: Partial<FilterType>
-    },
-    actions: {
+export const insightsTableLogic = kea<insightsTableLogicType>([
+    props(
+        {} as {
+            hasMathUniqueFilter: boolean
+            filters: Partial<FilterType>
+        }
+    ),
+    path(['scenes', 'insights', 'InsightsTable', 'insightsTableLogic']),
+    actions({
         setCalcColumnState: (state: CalcColumnState) => ({ state }),
-    },
-    reducers: ({ props }) => ({
+    }),
+    reducers(({ props }) => ({
         calcColumnState: [
             (props.hasMathUniqueFilter ? 'average' : 'total') as CalcColumnState,
             {
                 setCalcColumnState: (_, { state }) => state,
             },
         ],
-    }),
-    selectors: () => ({
+    })),
+    selectors(() => ({
         // Only allow table aggregation options when the math is total volume otherwise double counting will happen when the math is set to uniques
         // Except when view type is Table
         showTotalCount: [
@@ -39,5 +41,5 @@ export const insightsTableLogic = kea<insightsTableLogicType>({
                 )
             },
         ],
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/insights/views/LineGraph/lineGraphLogic.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/lineGraphLogic.ts
@@ -1,13 +1,13 @@
-import { kea } from 'kea'
+import { kea, path, selectors } from 'kea'
 import { TooltipItem } from 'chart.js'
 import { GraphDataset } from '~/types'
 import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 import type { lineGraphLogicType } from './lineGraphLogicType'
 
 // TODO: Eventually we should move all state from LineGraph into this logic
-export const lineGraphLogic = kea<lineGraphLogicType>({
-    path: ['scenes', 'insights', 'LineGraph', 'lineGraphLogic'],
-    selectors: {
+export const lineGraphLogic = kea<lineGraphLogicType>([
+    path(['scenes', 'insights', 'LineGraph', 'lineGraphLogic']),
+    selectors({
         createTooltipData: [
             () => [],
             () =>
@@ -51,5 +51,5 @@ export const lineGraphLogic = kea<lineGraphLogicType>({
                         }))
                 },
         ],
-    },
-})
+    }),
+])

--- a/frontend/src/scenes/instance/SystemStatus/staffUsersLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/staffUsersLogic.ts
@@ -1,4 +1,5 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, path, connect, actions, reducers, selectors, events } from 'kea'
 import { router } from 'kea-router'
 import api from 'lib/api'
 import { urls } from 'scenes/urls'
@@ -6,26 +7,18 @@ import { userLogic } from 'scenes/userLogic'
 import { UserType } from '~/types'
 import type { staffUsersLogicType } from './staffUsersLogicType'
 
-export const staffUsersLogic = kea<staffUsersLogicType>({
-    path: ['scenes', 'instance', 'SystemStatus', 'staffUsersLogic'],
-    connect: {
+export const staffUsersLogic = kea<staffUsersLogicType>([
+    path(['scenes', 'instance', 'SystemStatus', 'staffUsersLogic']),
+    connect({
         values: [userLogic, ['user']],
         actions: [userLogic, ['loadUser']],
-    },
-    actions: {
+    }),
+    actions({
         setStaffUsersToBeAdded: (userUuids: string[]) => ({ userUuids }),
         addStaffUsers: true,
         deleteStaffUser: (userUuid: string) => ({ userUuid }),
-    },
-    reducers: {
-        staffUsersToBeAdded: [
-            [] as string[],
-            {
-                setStaffUsersToBeAdded: (_, { userUuids }) => userUuids,
-            },
-        ],
-    },
-    loaders: ({ actions, values }) => ({
+    }),
+    loaders(({ actions, values }) => ({
         allUsers: [
             [] as UserType[],
             {
@@ -64,12 +57,20 @@ export const staffUsersLogic = kea<staffUsersLogicType>({
                 },
             },
         ],
+    })),
+    reducers({
+        staffUsersToBeAdded: [
+            [] as string[],
+            {
+                setStaffUsersToBeAdded: (_, { userUuids }) => userUuids,
+            },
+        ],
     }),
-    selectors: {
+    selectors({
         staffUsers: [(s) => [s.allUsers], (allUsers): UserType[] => allUsers.filter((user) => user.is_staff)],
         nonStaffUsers: [(s) => [s.allUsers], (allUsers): UserType[] => allUsers.filter((user) => !user.is_staff)],
-    },
-    events: ({ actions }) => ({
-        afterMount: [actions.loadAllUsers],
     }),
-})
+    events(({ actions }) => ({
+        afterMount: [actions.loadAllUsers],
+    })),
+])

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -1,10 +1,10 @@
-import { kea } from 'kea'
+import { kea, props, path, connect, actions, reducers, selectors, listeners } from 'kea'
 import { BillingProductV2Type, ProductKey } from '~/types'
 import { urls } from 'scenes/urls'
 
 import { billingLogic } from 'scenes/billing/billingLogic'
 import { teamLogic } from 'scenes/teamLogic'
-import { combineUrl, router } from 'kea-router'
+import { combineUrl, router, actionToUrl, urlToAction } from 'kea-router'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 import type { onboardingLogicType } from './onboardingLogicType'
@@ -40,14 +40,14 @@ export const getProductUri = (productKey: ProductKey): string => {
     }
 }
 
-export const onboardingLogic = kea<onboardingLogicType>({
-    props: {} as OnboardingLogicProps,
-    path: ['scenes', 'onboarding', 'onboardingLogic'],
-    connect: {
+export const onboardingLogic = kea<onboardingLogicType>([
+    props({} as OnboardingLogicProps),
+    path(['scenes', 'onboarding', 'onboardingLogic']),
+    connect({
         values: [billingLogic, ['billing'], teamLogic, ['currentTeam']],
         actions: [billingLogic, ['loadBillingSuccess'], teamLogic, ['updateCurrentTeamSuccess']],
-    },
-    actions: {
+    }),
+    actions({
         setProduct: (product: BillingProductV2Type | null) => ({ product }),
         setProductKey: (productKey: string | null) => ({ productKey }),
         completeOnboarding: (nextProductKey?: string) => ({ nextProductKey }),
@@ -57,8 +57,8 @@ export const onboardingLogic = kea<onboardingLogicType>({
         goToNextStep: true,
         goToPreviousStep: true,
         resetStepKey: true,
-    },
-    reducers: () => ({
+    }),
+    reducers(() => ({
         productKey: [
             null as string | null,
             {
@@ -97,8 +97,8 @@ export const onboardingLogic = kea<onboardingLogicType>({
                 setSubscribedDuringOnboarding: (_, { subscribedDuringOnboarding }) => subscribedDuringOnboarding,
             },
         ],
-    }),
-    selectors: {
+    })),
+    selectors({
         totalOnboardingSteps: [
             (s) => [s.allOnboardingSteps],
             (allOnboardingSteps: AllOnboardingSteps) => allOnboardingSteps.length,
@@ -150,8 +150,8 @@ export const onboardingLogic = kea<onboardingLogicType>({
                 (stepKey && allOnboardingSteps.length > 0 && !currentOnboardingStep) ||
                 (!stepKey && allOnboardingSteps.length > 0),
         ],
-    },
-    listeners: ({ actions, values }) => ({
+    }),
+    listeners(({ actions, values }) => ({
         loadBillingSuccess: () => {
             actions.setProduct(values.billing?.products.find((p) => p.type === values.productKey) || null)
         },
@@ -207,8 +207,8 @@ export const onboardingLogic = kea<onboardingLogicType>({
         resetStepKey: () => {
             actions.setStepKey(values.allOnboardingSteps[0].props.stepKey)
         },
-    }),
-    actionToUrl: ({ values }) => ({
+    })),
+    actionToUrl(({ values }) => ({
         setStepKey: ({ stepKey }) => {
             if (stepKey) {
                 return [`/onboarding/${values.productKey}`, { step: stepKey }]
@@ -243,8 +243,8 @@ export const onboardingLogic = kea<onboardingLogicType>({
                 return [values.onCompleteOnboardingRedirectUrl]
             }
         },
-    }),
-    urlToAction: ({ actions, values }) => ({
+    })),
+    urlToAction(({ actions, values }) => ({
         '/onboarding/:productKey': ({ productKey }, { success, upgraded, step }) => {
             if (!productKey) {
                 window.location.href = urls.default()
@@ -262,5 +262,5 @@ export const onboardingLogic = kea<onboardingLogicType>({
                 actions.resetStepKey()
             }
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/onboarding/sdks/sdksLogic.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdksLogic.tsx
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, path, connect, actions, reducers, selectors, listeners, events } from 'kea'
 
 import type { sdksLogicType } from './sdksLogicType'
 import { SDK, SDKInstructionsMap } from '~/types'
@@ -27,12 +27,12 @@ const getSourceOptions = (availableSDKInstructionsMap: SDKInstructionsMap): Lemo
     return selectOptions
 }
 
-export const sdksLogic = kea<sdksLogicType>({
-    path: ['scenes', 'onboarding', 'sdks', 'sdksLogic'],
-    connect: {
+export const sdksLogic = kea<sdksLogicType>([
+    path(['scenes', 'onboarding', 'sdks', 'sdksLogic']),
+    connect({
         values: [onboardingLogic, ['productKey']],
-    },
-    actions: {
+    }),
+    actions({
         setSourceFilter: (sourceFilter: string | null) => ({ sourceFilter }),
         filterSDKs: true,
         setSDKs: (sdks: SDK[]) => ({ sdks }),
@@ -40,9 +40,8 @@ export const sdksLogic = kea<sdksLogicType>({
         setSourceOptions: (sourceOptions: LemonSelectOptions<string>) => ({ sourceOptions }),
         resetSDKs: true,
         setAvailableSDKInstructionsMap: (sdkInstructionMap: SDKInstructionsMap) => ({ sdkInstructionMap }),
-    },
-
-    reducers: {
+    }),
+    reducers({
         sourceFilter: [
             null as string | null,
             {
@@ -73,8 +72,8 @@ export const sdksLogic = kea<sdksLogicType>({
                 setAvailableSDKInstructionsMap: (_, { sdkInstructionMap }) => sdkInstructionMap,
             },
         ],
-    },
-    selectors: {
+    }),
+    selectors({
         showSourceOptionsSelect: [
             (selectors) => [selectors.sourceOptions, selectors.availableSDKInstructionsMap],
             (sourceOptions: LemonSelectOptions<string>, availableSDKInstructionsMap: SDKInstructionsMap): boolean => {
@@ -83,8 +82,8 @@ export const sdksLogic = kea<sdksLogicType>({
                 return Object.keys(availableSDKInstructionsMap).length > 5 && sourceOptions.length > 2
             },
         ],
-    },
-    listeners: ({ actions, values }) => ({
+    }),
+    listeners(({ actions, values }) => ({
         filterSDKs: () => {
             const filteredSDks: SDK[] = allSDKs
                 .filter((sdk) => {
@@ -119,10 +118,10 @@ export const sdksLogic = kea<sdksLogicType>({
             actions.setSourceFilter(null)
             actions.setSourceOptions(getSourceOptions(values.availableSDKInstructionsMap))
         },
-    }),
-    events: ({ actions }) => ({
+    })),
+    events(({ actions }) => ({
         afterMount: () => {
             actions.filterSDKs()
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/organization/Settings/index.tsx
+++ b/frontend/src/scenes/organization/Settings/index.tsx
@@ -1,9 +1,10 @@
+import { actionToUrl, urlToAction } from 'kea-router'
 import { useState } from 'react'
 import { PageHeader } from 'lib/components/PageHeader'
 import { Invites } from './Invites'
 import { Members } from './Members'
 import { organizationLogic } from '../../organizationLogic'
-import { kea, useActions, useValues } from 'kea'
+import { kea, useActions, useValues, path, actions, reducers } from 'kea'
 import { DangerZone } from './DangerZone'
 import { RestrictedArea, RestrictedComponentProps } from 'lib/components/RestrictedArea'
 import { FEATURE_FLAGS, OrganizationMembershipLevel } from 'lib/constants'
@@ -82,30 +83,30 @@ function EmailPreferences({ isRestricted }: RestrictedComponentProps): JSX.Eleme
     )
 }
 
-const organizationSettingsTabsLogic = kea<organizationSettingsTabsLogicType>({
-    path: ['scenes', 'organization', 'Settings', 'index'],
-    actions: {
+const organizationSettingsTabsLogic = kea<organizationSettingsTabsLogicType>([
+    path(['scenes', 'organization', 'Settings', 'index']),
+    actions({
         setTab: (tab: OrganizationSettingsTabs) => ({ tab }),
-    },
-    reducers: {
+    }),
+    reducers({
         tab: [
             OrganizationSettingsTabs.GENERAL as OrganizationSettingsTabs,
             {
                 setTab: (_, { tab }) => tab,
             },
         ],
-    },
-    actionToUrl: () => ({
-        setTab: ({ tab }) => `${urls.organizationSettings()}?tab=${tab}`,
     }),
-    urlToAction: ({ values, actions }) => ({
+    actionToUrl(() => ({
+        setTab: ({ tab }) => `${urls.organizationSettings()}?tab=${tab}`,
+    })),
+    urlToAction(({ values, actions }) => ({
         [urls.organizationSettings()]: (_, searchParams) => {
             if (searchParams['tab'] && values.tab !== searchParams['tab']) {
                 actions.setTab(searchParams['tab'])
             }
         },
-    }),
-})
+    })),
+])
 
 export function OrganizationSettings(): JSX.Element {
     const { user } = useValues(userLogic)

--- a/frontend/src/scenes/organization/Settings/invitesLogic.tsx
+++ b/frontend/src/scenes/organization/Settings/invitesLogic.tsx
@@ -1,4 +1,5 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, path, listeners, events } from 'kea'
 import api from 'lib/api'
 import { OrganizationInviteType } from '~/types'
 import type { invitesLogicType } from './invitesLogicType'
@@ -6,9 +7,9 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { lemonToast } from 'lib/lemon-ui/lemonToast'
 
-export const invitesLogic = kea<invitesLogicType>({
-    path: ['scenes', 'organization', 'Settings', 'invitesLogic'],
-    loaders: ({ values }) => ({
+export const invitesLogic = kea<invitesLogicType>([
+    path(['scenes', 'organization', 'Settings', 'invitesLogic']),
+    loaders(({ values }) => ({
         invites: {
             __default: [] as OrganizationInviteType[],
             loadInvites: async () => {
@@ -41,8 +42,8 @@ export const invitesLogic = kea<invitesLogicType>({
                 return values.invites.filter((thisInvite) => thisInvite.id !== invite.id)
             },
         },
-    }),
-    listeners: {
+    })),
+    listeners({
         createInviteSuccess: async () => {
             const nameProvided = false // TODO: Change when adding support for names on invites
             eventUsageLogic.actions.reportInviteAttempted(
@@ -50,8 +51,8 @@ export const invitesLogic = kea<invitesLogicType>({
                 !!preflightLogic.values.preflight?.email_service_available
             )
         },
-    },
-    events: ({ actions }) => ({
-        afterMount: actions.loadInvites,
     }),
-})
+    events(({ actions }) => ({
+        afterMount: actions.loadInvites,
+    })),
+])

--- a/frontend/src/scenes/persons/mergeSplitPersonLogic.ts
+++ b/frontend/src/scenes/persons/mergeSplitPersonLogic.ts
@@ -1,4 +1,5 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, props, key, path, connect, actions, reducers, listeners, events } from 'kea'
 import { router } from 'kea-router'
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/lemonToast'
@@ -13,41 +14,22 @@ export interface SplitPersonLogicProps {
 
 export type PersonUuids = NonNullable<PersonType['uuid']>[]
 
-export const mergeSplitPersonLogic = kea<mergeSplitPersonLogicType>({
-    props: {} as SplitPersonLogicProps,
-    key: (props) => props.person.id ?? 'new',
-    path: (key) => ['scenes', 'persons', 'mergeSplitPersonLogic', key],
-    connect: () => ({
+export const mergeSplitPersonLogic = kea<mergeSplitPersonLogicType>([
+    props({} as SplitPersonLogicProps),
+    key((props) => props.person.id ?? 'new'),
+    path((key) => ['scenes', 'persons', 'mergeSplitPersonLogic', key]),
+    connect(() => ({
         actions: [
             personsLogic({ syncWithUrl: true }),
             ['setListFilters', 'loadPersons', 'setPerson', 'setSplitMergeModalShown'],
         ],
         values: [personsLogic({ syncWithUrl: true }), ['persons']],
-    }),
-    actions: {
+    })),
+    actions({
         setSelectedPersonToAssignSplit: (id: string) => ({ id }),
         cancel: true,
-    },
-    reducers: ({ props }) => ({
-        person: [props.person, {}],
-        selectedPersonsToAssignSplit: [
-            null as null | string,
-            {
-                setSelectedPersonToAssignSplit: (_, { id }) => id,
-            },
-        ],
     }),
-    listeners: ({ actions, values }) => ({
-        setListFilters: () => {
-            actions.loadPersons()
-        },
-        cancel: () => {
-            if (!values.executedLoading) {
-                actions.setSplitMergeModalShown(false)
-            }
-        },
-    }),
-    loaders: ({ values, actions }) => ({
+    loaders(({ values, actions }) => ({
         executed: [
             false,
             {
@@ -70,8 +52,27 @@ export const mergeSplitPersonLogic = kea<mergeSplitPersonLogicType>({
                 },
             },
         ],
-    }),
-    events: ({ actions }) => ({
+    })),
+    reducers(({ props }) => ({
+        person: [props.person, {}],
+        selectedPersonsToAssignSplit: [
+            null as null | string,
+            {
+                setSelectedPersonToAssignSplit: (_, { id }) => id,
+            },
+        ],
+    })),
+    listeners(({ actions, values }) => ({
+        setListFilters: () => {
+            actions.loadPersons()
+        },
+        cancel: () => {
+            if (!values.executedLoading) {
+                actions.setSplitMergeModalShown(false)
+            }
+        },
+    })),
+    events(({ actions }) => ({
         afterMount: [actions.loadPersons],
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -1,5 +1,6 @@
-import { kea } from 'kea'
-import { decodeParams, router } from 'kea-router'
+import { loaders } from 'kea-loaders'
+import { kea, props, key, path, connect, actions, reducers, selectors, listeners, events } from 'kea'
+import { decodeParams, router, actionToUrl, urlToAction } from 'kea-router'
 import api, { CountedPaginatedResponse } from 'lib/api'
 import type { personsLogicType } from './personsLogicType'
 import {
@@ -31,21 +32,21 @@ export interface PersonsLogicProps {
     fixedProperties?: PersonPropertyFilter[]
 }
 
-export const personsLogic = kea<personsLogicType>({
-    props: {} as PersonsLogicProps,
-    key: (props) => {
+export const personsLogic = kea<personsLogicType>([
+    props({} as PersonsLogicProps),
+    key((props) => {
         if (props.fixedProperties) {
             return JSON.stringify(props.fixedProperties)
         }
 
         return props.cohort ? `cohort_${props.cohort}` : 'scene'
-    },
-    path: (key) => ['scenes', 'persons', 'personsLogic', key],
-    connect: () => ({
+    }),
+    path((key) => ['scenes', 'persons', 'personsLogic', key]),
+    connect(() => ({
         actions: [eventUsageLogic, ['reportPersonDetailViewed']],
         values: [teamLogic, ['currentTeam'], featureFlagLogic, ['featureFlags']],
-    }),
-    actions: {
+    })),
+    actions({
         setPerson: (person: PersonType | null) => ({ person }),
         setPersons: (persons: PersonType[]) => ({ persons }),
         loadPerson: (id: string) => ({ id }),
@@ -60,193 +61,8 @@ export const personsLogic = kea<personsLogicType>({
         setActiveTab: (tab: PersonsTabType) => ({ tab }),
         setSplitMergeModalShown: (shown: boolean) => ({ shown }),
         setDistinctId: (distinctId: string) => ({ distinctId }),
-    },
-    reducers: () => ({
-        listFilters: [
-            {} as PersonListParams,
-            {
-                setListFilters: (state, { payload }) => {
-                    const newFilters = { ...state, ...payload }
-
-                    if (newFilters.properties?.length === 0) {
-                        delete newFilters['properties']
-                    }
-                    if (newFilters.properties) {
-                        newFilters.properties = convertPropertyGroupToProperties(
-                            newFilters.properties.filter(isValidPropertyFilter)
-                        )
-                    }
-                    return newFilters
-                },
-            },
-        ],
-        hiddenListProperties: [
-            [] as AnyPropertyFilter[],
-            {
-                setHiddenListProperties: (state, { payload }) => {
-                    let newProperties = [...state, ...payload]
-                    if (newProperties) {
-                        newProperties =
-                            convertPropertyGroupToProperties(newProperties.filter(isValidPropertyFilter)) || []
-                    }
-                    return newProperties
-                },
-            },
-        ],
-        activeTab: [
-            null as PersonsTabType | null,
-            {
-                navigateToTab: (_, { tab }) => tab,
-                setActiveTab: (_, { tab }) => tab,
-            },
-        ],
-        splitMergeModalShown: [
-            false,
-            {
-                setSplitMergeModalShown: (_, { shown }) => shown,
-            },
-        ],
-        persons: {
-            setPerson: (state, { person }) => ({
-                ...state,
-                results: state.results.map((p) => (person && p.id === person.id ? person : p)),
-            }),
-            setPersons: (state, { persons }) => ({
-                ...state,
-                results: [...persons, ...state.results],
-            }),
-        },
-        person: {
-            loadPerson: () => null,
-            setPerson: (_, { person }): PersonType | null => person,
-        },
-        distinctId: [
-            null as string | null,
-            {
-                setDistinctId: (_, { distinctId }) => distinctId,
-            },
-        ],
     }),
-    selectors: () => ({
-        apiDocsURL: [
-            () => [(_, props) => props.cohort],
-            (cohort: PersonsLogicProps['cohort']) =>
-                cohort
-                    ? 'https://posthog.com/docs/api/cohorts#get-api-projects-project_id-cohorts-id-persons'
-                    : 'https://posthog.com/docs/api/persons',
-        ],
-        cohortId: [() => [(_, props) => props.cohort], (cohort: PersonsLogicProps['cohort']) => cohort],
-        currentTab: [(s) => [s.activeTab, s.defaultTab], (activeTab, defaultTab) => activeTab || defaultTab],
-        defaultTab: [
-            (s) => [s.feedEnabled],
-            (feedEnabled) => (feedEnabled ? PersonsTabType.FEED : PersonsTabType.PROPERTIES),
-        ],
-        breadcrumbs: [
-            (s) => [s.person, router.selectors.location],
-            (person, location): Breadcrumb[] => {
-                const showPerson = person && location.pathname.match(/\/person\/.+/)
-                const breadcrumbs: Breadcrumb[] = [
-                    {
-                        name: 'Persons',
-                        path: urls.persons(),
-                    },
-                ]
-                if (showPerson) {
-                    breadcrumbs.push({
-                        name: asDisplay(person),
-                    })
-                }
-                return breadcrumbs
-            },
-        ],
-
-        exporterProps: [
-            (s) => [s.listFilters, (_, { cohort }) => cohort],
-            (listFilters, cohort: number | 'new' | undefined): TriggerExportProps[] => [
-                {
-                    export_format: ExporterFormat.CSV,
-                    export_context: {
-                        path: cohort
-                            ? api.cohorts.determineListUrl(cohort, listFilters)
-                            : api.persons.determineListUrl(listFilters),
-                    },
-                },
-            ],
-        ],
-        urlId: [() => [(_, props) => props.urlId], (urlId) => urlId],
-        showCustomerSuccessDashboards: [
-            (s) => [s.featureFlags],
-            (featureFlags) => featureFlags[FEATURE_FLAGS.CS_DASHBOARDS],
-        ],
-        feedEnabled: [(s) => [s.featureFlags], (featureFlags) => !!featureFlags[FEATURE_FLAGS.PERSON_FEED_CANVAS]],
-    }),
-    listeners: ({ actions, values }) => ({
-        editProperty: async ({ key, newValue }) => {
-            const person = values.person
-
-            if (person && person.id) {
-                let parsedValue = newValue
-
-                // Instrumentation stuff
-                let action: 'added' | 'updated'
-                const oldPropertyType = person.properties[key] === null ? 'null' : typeof person.properties[key]
-                let newPropertyType: string = typeof newValue
-
-                // If the property is a number, store it as a number
-                const attemptedParsedNumber = Number(newValue)
-                if (!Number.isNaN(attemptedParsedNumber) && typeof newValue !== 'boolean') {
-                    parsedValue = attemptedParsedNumber
-                    newPropertyType = 'number'
-                }
-
-                const lowercaseValue = typeof parsedValue === 'string' && parsedValue.toLowerCase()
-                if (lowercaseValue === 'true' || lowercaseValue === 'false' || lowercaseValue === 'null') {
-                    parsedValue = lowercaseValue === 'true' ? true : lowercaseValue === 'null' ? null : false
-                    newPropertyType = parsedValue !== null ? 'boolean' : 'null'
-                }
-
-                if (!Object.keys(person.properties).includes(key)) {
-                    person.properties = { [key]: parsedValue, ...person.properties } // To add property at the top (if new)
-                    action = 'added'
-                } else {
-                    person.properties[key] = parsedValue
-                    action = 'updated'
-                }
-
-                actions.setPerson({ ...person }) // To update the UI immediately while the request is being processed
-                // :KLUDGE: Person properties are updated asynchronously in the plugin server - the response won't reflect
-                //      the _updated_ properties yet.
-                await api.persons.updateProperty(person.id, key, parsedValue)
-                lemonToast.success(`Person property ${action}`)
-
-                eventUsageLogic.actions.reportPersonPropertyUpdated(
-                    action,
-                    Object.keys(person.properties).length,
-                    oldPropertyType,
-                    newPropertyType
-                )
-            }
-        },
-        deleteProperty: async ({ key }) => {
-            const person = values.person
-
-            if (person && person.id) {
-                const updatedProperties = { ...person.properties }
-                delete updatedProperties[key]
-
-                actions.setPerson({ ...person, properties: updatedProperties }) // To update the UI immediately
-                // await api.create(`api/person/${person.id}/delete_property`, { $unset: key })
-                await api.persons.deleteProperty(person.id, key)
-                lemonToast.success(`Person property deleted`)
-
-                eventUsageLogic.actions.reportPersonPropertyUpdated('removed', 1, undefined, undefined)
-            }
-        },
-        navigateToCohort: ({ cohort }) => {
-            router.actions.push(urls.cohort(cohort.id))
-        },
-    }),
-    loaders: ({ values, actions, props }) => ({
+    loaders(({ values, actions, props }) => ({
         persons: [
             { next: null, previous: null, count: 0, results: [], offset: 0 } as CountedPaginatedResponse<PersonType> & {
                 offset: number
@@ -343,8 +159,193 @@ export const personsLogic = kea<personsLogicType>({
                 },
             },
         ],
-    }),
-    actionToUrl: ({ values, props }) => ({
+    })),
+    reducers(() => ({
+        listFilters: [
+            {} as PersonListParams,
+            {
+                setListFilters: (state, { payload }) => {
+                    const newFilters = { ...state, ...payload }
+
+                    if (newFilters.properties?.length === 0) {
+                        delete newFilters['properties']
+                    }
+                    if (newFilters.properties) {
+                        newFilters.properties = convertPropertyGroupToProperties(
+                            newFilters.properties.filter(isValidPropertyFilter)
+                        )
+                    }
+                    return newFilters
+                },
+            },
+        ],
+        hiddenListProperties: [
+            [] as AnyPropertyFilter[],
+            {
+                setHiddenListProperties: (state, { payload }) => {
+                    let newProperties = [...state, ...payload]
+                    if (newProperties) {
+                        newProperties =
+                            convertPropertyGroupToProperties(newProperties.filter(isValidPropertyFilter)) || []
+                    }
+                    return newProperties
+                },
+            },
+        ],
+        activeTab: [
+            null as PersonsTabType | null,
+            {
+                navigateToTab: (_, { tab }) => tab,
+                setActiveTab: (_, { tab }) => tab,
+            },
+        ],
+        splitMergeModalShown: [
+            false,
+            {
+                setSplitMergeModalShown: (_, { shown }) => shown,
+            },
+        ],
+        persons: {
+            setPerson: (state, { person }) => ({
+                ...state,
+                results: state.results.map((p) => (person && p.id === person.id ? person : p)),
+            }),
+            setPersons: (state, { persons }) => ({
+                ...state,
+                results: [...persons, ...state.results],
+            }),
+        },
+        person: {
+            loadPerson: () => null,
+            setPerson: (_, { person }): PersonType | null => person,
+        },
+        distinctId: [
+            null as string | null,
+            {
+                setDistinctId: (_, { distinctId }) => distinctId,
+            },
+        ],
+    })),
+    selectors(() => ({
+        apiDocsURL: [
+            () => [(_, props) => props.cohort],
+            (cohort: PersonsLogicProps['cohort']) =>
+                cohort
+                    ? 'https://posthog.com/docs/api/cohorts#get-api-projects-project_id-cohorts-id-persons'
+                    : 'https://posthog.com/docs/api/persons',
+        ],
+        cohortId: [() => [(_, props) => props.cohort], (cohort: PersonsLogicProps['cohort']) => cohort],
+        currentTab: [(s) => [s.activeTab, s.defaultTab], (activeTab, defaultTab) => activeTab || defaultTab],
+        defaultTab: [
+            (s) => [s.feedEnabled],
+            (feedEnabled) => (feedEnabled ? PersonsTabType.FEED : PersonsTabType.PROPERTIES),
+        ],
+        breadcrumbs: [
+            (s) => [s.person, router.selectors.location],
+            (person, location): Breadcrumb[] => {
+                const showPerson = person && location.pathname.match(/\/person\/.+/)
+                const breadcrumbs: Breadcrumb[] = [
+                    {
+                        name: 'Persons',
+                        path: urls.persons(),
+                    },
+                ]
+                if (showPerson) {
+                    breadcrumbs.push({
+                        name: asDisplay(person),
+                    })
+                }
+                return breadcrumbs
+            },
+        ],
+
+        exporterProps: [
+            (s) => [s.listFilters, (_, { cohort }) => cohort],
+            (listFilters, cohort: number | 'new' | undefined): TriggerExportProps[] => [
+                {
+                    export_format: ExporterFormat.CSV,
+                    export_context: {
+                        path: cohort
+                            ? api.cohorts.determineListUrl(cohort, listFilters)
+                            : api.persons.determineListUrl(listFilters),
+                    },
+                },
+            ],
+        ],
+        urlId: [() => [(_, props) => props.urlId], (urlId) => urlId],
+        showCustomerSuccessDashboards: [
+            (s) => [s.featureFlags],
+            (featureFlags) => featureFlags[FEATURE_FLAGS.CS_DASHBOARDS],
+        ],
+        feedEnabled: [(s) => [s.featureFlags], (featureFlags) => !!featureFlags[FEATURE_FLAGS.PERSON_FEED_CANVAS]],
+    })),
+    listeners(({ actions, values }) => ({
+        editProperty: async ({ key, newValue }) => {
+            const person = values.person
+
+            if (person && person.id) {
+                let parsedValue = newValue
+
+                // Instrumentation stuff
+                let action: 'added' | 'updated'
+                const oldPropertyType = person.properties[key] === null ? 'null' : typeof person.properties[key]
+                let newPropertyType: string = typeof newValue
+
+                // If the property is a number, store it as a number
+                const attemptedParsedNumber = Number(newValue)
+                if (!Number.isNaN(attemptedParsedNumber) && typeof newValue !== 'boolean') {
+                    parsedValue = attemptedParsedNumber
+                    newPropertyType = 'number'
+                }
+
+                const lowercaseValue = typeof parsedValue === 'string' && parsedValue.toLowerCase()
+                if (lowercaseValue === 'true' || lowercaseValue === 'false' || lowercaseValue === 'null') {
+                    parsedValue = lowercaseValue === 'true' ? true : lowercaseValue === 'null' ? null : false
+                    newPropertyType = parsedValue !== null ? 'boolean' : 'null'
+                }
+
+                if (!Object.keys(person.properties).includes(key)) {
+                    person.properties = { [key]: parsedValue, ...person.properties } // To add property at the top (if new)
+                    action = 'added'
+                } else {
+                    person.properties[key] = parsedValue
+                    action = 'updated'
+                }
+
+                actions.setPerson({ ...person }) // To update the UI immediately while the request is being processed
+                // :KLUDGE: Person properties are updated asynchronously in the plugin server - the response won't reflect
+                //      the _updated_ properties yet.
+                await api.persons.updateProperty(person.id, key, parsedValue)
+                lemonToast.success(`Person property ${action}`)
+
+                eventUsageLogic.actions.reportPersonPropertyUpdated(
+                    action,
+                    Object.keys(person.properties).length,
+                    oldPropertyType,
+                    newPropertyType
+                )
+            }
+        },
+        deleteProperty: async ({ key }) => {
+            const person = values.person
+
+            if (person && person.id) {
+                const updatedProperties = { ...person.properties }
+                delete updatedProperties[key]
+
+                actions.setPerson({ ...person, properties: updatedProperties }) // To update the UI immediately
+                // await api.create(`api/person/${person.id}/delete_property`, { $unset: key })
+                await api.persons.deleteProperty(person.id, key)
+                lemonToast.success(`Person property deleted`)
+
+                eventUsageLogic.actions.reportPersonPropertyUpdated('removed', 1, undefined, undefined)
+            }
+        },
+        navigateToCohort: ({ cohort }) => {
+            router.actions.push(urls.cohort(cohort.id))
+        },
+    })),
+    actionToUrl(({ values, props }) => ({
         setListFilters: () => {
             if (props.syncWithUrl && router.values.location.pathname.indexOf('/persons') > -1) {
                 return ['/persons', values.listFilters, undefined, { replace: true }]
@@ -364,8 +365,8 @@ export const personsLogic = kea<personsLogicType>({
                 ]
             }
         },
-    }),
-    urlToAction: ({ actions, values, props }) => ({
+    })),
+    urlToAction(({ actions, values, props }) => ({
         '/person/*': ({ _: rawPersonDistinctId }, { sessionRecordingId }, { activeTab }) => {
             if (props.syncWithUrl) {
                 if (sessionRecordingId && values.activeTab !== PersonsTabType.SESSION_RECORDINGS) {
@@ -408,8 +409,8 @@ export const personsLogic = kea<personsLogicType>({
                 }
             }
         },
-    }),
-    events: ({ props, actions }) => ({
+    })),
+    events(({ props, actions }) => ({
         afterMount: () => {
             if (props.cohort && typeof props.cohort === 'number') {
                 actions.setListFilters({ cohort: props.cohort })
@@ -421,5 +422,5 @@ export const personsLogic = kea<personsLogicType>({
                 actions.loadPersons()
             }
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/products/productsLogic.tsx
+++ b/frontend/src/scenes/products/productsLogic.tsx
@@ -1,16 +1,16 @@
-import { kea } from 'kea'
+import { kea, path, actions, listeners } from 'kea'
 import { teamLogic } from 'scenes/teamLogic'
 import { ProductKey } from '~/types'
 
 import type { productsLogicType } from './productsLogicType'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
-export const productsLogic = kea<productsLogicType>({
-    path: () => ['scenes', 'products', 'productsLogic'],
-    actions: () => ({
+export const productsLogic = kea<productsLogicType>([
+    path(() => ['scenes', 'products', 'productsLogic']),
+    actions(() => ({
         onSelectProduct: (product: ProductKey) => ({ product }),
-    }),
-    listeners: () => ({
+    })),
+    listeners(() => ({
         onSelectProduct: ({ product }) => {
             eventUsageLogic.actions.reportOnboardingProductSelected(product)
 
@@ -30,5 +30,5 @@ export const productsLogic = kea<productsLogicType>({
                     return
             }
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/project/Settings/groupAnalyticsConfigLogic.ts
+++ b/frontend/src/scenes/project/Settings/groupAnalyticsConfigLogic.ts
@@ -1,20 +1,20 @@
-import { kea } from 'kea'
+import { kea, path, connect, actions, reducers, selectors, listeners } from 'kea'
 import { groupsModel } from '~/models/groupsModel'
 import type { groupAnalyticsConfigLogicType } from './groupAnalyticsConfigLogicType'
 
-export const groupAnalyticsConfigLogic = kea<groupAnalyticsConfigLogicType>({
-    path: ['scenes', 'project', 'Settings', 'groupAnalyticsConfigLogic'],
-    connect: {
+export const groupAnalyticsConfigLogic = kea<groupAnalyticsConfigLogicType>([
+    path(['scenes', 'project', 'Settings', 'groupAnalyticsConfigLogic']),
+    connect({
         values: [groupsModel, ['groupTypes', 'groupTypesLoading']],
         actions: [groupsModel, ['updateGroupTypesMetadata']],
-    },
-    actions: {
+    }),
+    actions({
         setSingular: (groupTypeIndex: number, value: string) => ({ groupTypeIndex, value }),
         setPlural: (groupTypeIndex: number, value: string) => ({ groupTypeIndex, value }),
         reset: true,
         save: true,
-    },
-    reducers: {
+    }),
+    reducers({
         singularChanges: [
             {} as Record<number, string | undefined>,
             {
@@ -31,15 +31,15 @@ export const groupAnalyticsConfigLogic = kea<groupAnalyticsConfigLogicType>({
                 updateGroupTypesMetadataSuccess: () => ({}),
             },
         ],
-    },
-    selectors: {
+    }),
+    selectors({
         hasChanges: [
             (s) => [s.singularChanges, s.pluralChanges],
             (singularChanges, pluralChanges) =>
                 Object.keys(singularChanges).length > 0 || Object.keys(pluralChanges).length > 0,
         ],
-    },
-    listeners: ({ values, actions }) => ({
+    }),
+    listeners(({ values, actions }) => ({
         save: async () => {
             const { groupTypes, singularChanges, pluralChanges } = values
             const payload = groupTypes.map((groupType) => {
@@ -55,5 +55,5 @@ export const groupAnalyticsConfigLogic = kea<groupAnalyticsConfigLogicType>({
 
             actions.updateGroupTypesMetadata(payload)
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/project/Settings/webhookIntegrationLogic.ts
+++ b/frontend/src/scenes/project/Settings/webhookIntegrationLogic.ts
@@ -1,4 +1,5 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, path, selectors, listeners } from 'kea'
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/lemonToast'
 import { capitalizeFirstLetter } from 'lib/utils'
@@ -10,9 +11,9 @@ function adjustDiscordWebhook(webhookUrl: string): string {
     return webhookUrl.replace(/\/*(?:posthog|slack)?\/?$/, '/slack')
 }
 
-export const webhookIntegrationLogic = kea<webhookIntegrationLogicType>({
-    path: ['scenes', 'project', 'Settings', 'webhookIntegrationLogic'],
-    loaders: ({ actions }) => ({
+export const webhookIntegrationLogic = kea<webhookIntegrationLogicType>([
+    path(['scenes', 'project', 'Settings', 'webhookIntegrationLogic']),
+    loaders(({ actions }) => ({
         testedWebhook: [
             null as string | null,
             {
@@ -46,8 +47,14 @@ export const webhookIntegrationLogic = kea<webhookIntegrationLogicType>({
                 },
             },
         ],
+    })),
+    selectors({
+        loading: [
+            (s) => [s.testedWebhookLoading, teamLogic.selectors.currentTeamLoading],
+            (testedWebhookLoading: boolean, currentTeamLoading: boolean) => testedWebhookLoading || currentTeamLoading,
+        ],
     }),
-    listeners: () => ({
+    listeners(() => ({
         testWebhookSuccess: async ({ testedWebhook }) => {
             if (testedWebhook) {
                 teamLogic.actions.updateCurrentTeam({ slack_incoming_webhook: testedWebhook })
@@ -56,11 +63,5 @@ export const webhookIntegrationLogic = kea<webhookIntegrationLogicType>({
         testWebhookFailure: ({ error }) => {
             lemonToast.error(capitalizeFirstLetter(error))
         },
-    }),
-    selectors: {
-        loading: [
-            (s) => [s.testedWebhookLoading, teamLogic.selectors.currentTeamLoading],
-            (testedWebhookLoading: boolean, currentTeamLoading: boolean) => testedWebhookLoading || currentTeamLoading,
-        ],
-    },
-})
+    })),
+])

--- a/frontend/src/scenes/retention/retentionLineGraphLogic.ts
+++ b/frontend/src/scenes/retention/retentionLineGraphLogic.ts
@@ -1,5 +1,5 @@
 import { dayjs, QUnitType } from 'lib/dayjs'
-import { kea } from 'kea'
+import { kea, props, key, path, connect, selectors } from 'kea'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { RetentionTrendPayload } from 'scenes/retention/types'
 import { InsightLogicProps, RetentionPeriod } from '~/types'
@@ -12,20 +12,19 @@ import type { retentionLineGraphLogicType } from './retentionLineGraphLogicType'
 
 const DEFAULT_RETENTION_LOGIC_KEY = 'default_retention_key'
 
-export const retentionLineGraphLogic = kea<retentionLineGraphLogicType>({
-    props: {} as InsightLogicProps,
-    key: keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY),
-    path: (key) => ['scenes', 'retention', 'retentionLineGraphLogic', key],
-    connect: (props: InsightLogicProps) => ({
+export const retentionLineGraphLogic = kea<retentionLineGraphLogicType>([
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY)),
+    path((key) => ['scenes', 'retention', 'retentionLineGraphLogic', key]),
+    connect((props: InsightLogicProps) => ({
         values: [
             insightVizDataLogic(props),
             ['querySource', 'dateRange', 'retentionFilter'],
             retentionLogic(props),
             ['results'],
         ],
-    }),
-
-    selectors: {
+    })),
+    selectors({
         trendSeries: [
             (s) => [s.results, s.retentionFilter],
             (results, retentionFilter): RetentionTrendPayload[] => {
@@ -121,5 +120,5 @@ export const retentionLineGraphLogic = kea<retentionLineGraphLogicType>({
                 return querySource?.aggregation_group_type_index ?? 'people'
             },
         ],
-    },
-})
+    }),
+])

--- a/frontend/src/scenes/retention/retentionLogic.ts
+++ b/frontend/src/scenes/retention/retentionLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, props, key, path, connect, selectors } from 'kea'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { RetentionTablePayload } from 'scenes/retention/types'
@@ -9,19 +9,19 @@ import type { retentionLogicType } from './retentionLogicType'
 
 const DEFAULT_RETENTION_LOGIC_KEY = 'default_retention_key'
 
-export const retentionLogic = kea<retentionLogicType>({
-    props: {} as InsightLogicProps,
-    key: keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY),
-    path: (key) => ['scenes', 'retention', 'retentionLogic', key],
-    connect: (props: InsightLogicProps) => ({
+export const retentionLogic = kea<retentionLogicType>([
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY)),
+    path((key) => ['scenes', 'retention', 'retentionLogic', key]),
+    connect((props: InsightLogicProps) => ({
         values: [insightVizDataLogic(props), ['insightQuery', 'insightData', 'querySource']],
-    }),
-    selectors: {
+    })),
+    selectors({
         results: [
             (s) => [s.insightQuery, s.insightData],
             (insightQuery, insightData): RetentionTablePayload[] => {
                 return isRetentionQuery(insightQuery) ? insightData?.result ?? [] : []
             },
         ],
-    },
-})
+    }),
+])

--- a/frontend/src/scenes/retention/retentionModalLogic.ts
+++ b/frontend/src/scenes/retention/retentionModalLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, props, key, path, connect, actions, reducers, selectors, listeners } from 'kea'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { Noun, groupsModel } from '~/models/groupsModel'
 import { InsightLogicProps } from '~/types'
@@ -10,19 +10,19 @@ import type { retentionModalLogicType } from './retentionModalLogicType'
 
 const DEFAULT_RETENTION_LOGIC_KEY = 'default_retention_key'
 
-export const retentionModalLogic = kea<retentionModalLogicType>({
-    props: {} as InsightLogicProps,
-    key: keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY),
-    path: (key) => ['scenes', 'retention', 'retentionModalLogic', key],
-    connect: (props: InsightLogicProps) => ({
+export const retentionModalLogic = kea<retentionModalLogicType>([
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY)),
+    path((key) => ['scenes', 'retention', 'retentionModalLogic', key]),
+    connect((props: InsightLogicProps) => ({
         values: [insightVizDataLogic(props), ['querySource'], groupsModel, ['aggregationLabel']],
         actions: [retentionPeopleLogic(props), ['loadPeople']],
-    }),
-    actions: () => ({
+    })),
+    actions(() => ({
         openModal: (rowIndex: number) => ({ rowIndex }),
         closeModal: true,
-    }),
-    reducers: {
+    })),
+    reducers({
         selectedRow: [
             null as number | null,
             {
@@ -30,8 +30,8 @@ export const retentionModalLogic = kea<retentionModalLogicType>({
                 closeModal: () => null,
             },
         ],
-    },
-    selectors: {
+    }),
+    selectors({
         aggregationTargetLabel: [
             (s) => [s.querySource, s.aggregationLabel],
             (querySource, aggregationLabel): Noun => {
@@ -39,10 +39,10 @@ export const retentionModalLogic = kea<retentionModalLogicType>({
                 return aggregationLabel(aggregation_group_type_index)
             },
         ],
-    },
-    listeners: ({ actions }) => ({
+    }),
+    listeners(({ actions }) => ({
         openModal: ({ rowIndex }) => {
             actions.loadPeople(rowIndex)
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/retention/retentionPeopleLogic.ts
+++ b/frontend/src/scenes/retention/retentionPeopleLogic.ts
@@ -1,4 +1,5 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, props, key, path, connect, actions, reducers, selectors, listeners } from 'kea'
 import api from 'lib/api'
 import { toParams } from 'lib/utils'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
@@ -12,23 +13,20 @@ import type { retentionPeopleLogicType } from './retentionPeopleLogicType'
 
 const DEFAULT_RETENTION_LOGIC_KEY = 'default_retention_key'
 
-export const retentionPeopleLogic = kea<retentionPeopleLogicType>({
-    props: {} as InsightLogicProps,
-    key: keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY),
-    path: (key) => ['scenes', 'retention', 'retentionPeopleLogic', key],
-    connect: (props: InsightLogicProps) => ({
+export const retentionPeopleLogic = kea<retentionPeopleLogicType>([
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY)),
+    path((key) => ['scenes', 'retention', 'retentionPeopleLogic', key]),
+    connect((props: InsightLogicProps) => ({
         values: [insightVizDataLogic(props), ['querySource']],
         actions: [insightVizDataLogic(props), ['loadDataSuccess']],
-    }),
-    actions: () => ({
+    })),
+    actions(() => ({
         clearPeople: true,
         loadMorePeople: true,
         loadMorePeopleSuccess: (payload: RetentionTablePeoplePayload) => ({ payload }),
-    }),
-    selectors: () => ({
-        apiFilters: [(s) => [s.querySource], (querySource) => (querySource ? queryNodeToFilter(querySource) : {})],
-    }),
-    loaders: ({ values }) => ({
+    })),
+    loaders(({ values }) => ({
         people: {
             __default: {} as RetentionTablePeoplePayload,
             loadPeople: async (rowIndex: number) => {
@@ -36,8 +34,8 @@ export const retentionPeopleLogic = kea<retentionPeopleLogicType>({
                 return (await api.get(`api/person/retention/?${urlParams}`)) as RetentionTablePeoplePayload
             },
         },
-    }),
-    reducers: {
+    })),
+    reducers({
         people: {
             clearPeople: () => ({}),
             loadPeople: () => ({}),
@@ -50,8 +48,11 @@ export const retentionPeopleLogic = kea<retentionPeopleLogicType>({
                 loadMorePeopleSuccess: () => false,
             },
         ],
-    },
-    listeners: ({ actions, values }) => ({
+    }),
+    selectors(() => ({
+        apiFilters: [(s) => [s.querySource], (querySource) => (querySource ? queryNodeToFilter(querySource) : {})],
+    })),
+    listeners(({ actions, values }) => ({
         loadDataSuccess: () => {
             // clear people when changing the insight filters
             actions.clearPeople()
@@ -67,5 +68,5 @@ export const retentionPeopleLogic = kea<retentionPeopleLogicType>({
                 actions.loadMorePeopleSuccess(newPayload)
             }
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -1,5 +1,5 @@
 import { dayjs } from 'lib/dayjs'
-import { kea } from 'kea'
+import { kea, props, key, path, connect, selectors } from 'kea'
 import { range } from 'lib/utils'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { InsightLogicProps } from '~/types'
@@ -29,19 +29,19 @@ const periodIsLatest = (date_to: string | null, period: string | null): boolean 
     }
 }
 
-export const retentionTableLogic = kea<retentionTableLogicType>({
-    props: {} as InsightLogicProps,
-    key: keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY),
-    path: (key) => ['scenes', 'retention', 'retentionTableLogic', key],
-    connect: (props: InsightLogicProps) => ({
+export const retentionTableLogic = kea<retentionTableLogicType>([
+    props({} as InsightLogicProps),
+    key(keyForInsightLogicProps(DEFAULT_RETENTION_LOGIC_KEY)),
+    path((key) => ['scenes', 'retention', 'retentionTableLogic', key]),
+    connect((props: InsightLogicProps) => ({
         values: [
             insightVizDataLogic(props),
             ['dateRange', 'retentionFilter', 'breakdown'],
             retentionLogic(props),
             ['results'],
         ],
-    }),
-    selectors: {
+    })),
+    selectors({
         isLatestPeriod: [
             (s) => [s.dateRange, s.retentionFilter],
             (dateRange, retentionFilter) => periodIsLatest(dateRange?.date_to || null, retentionFilter?.period || null),
@@ -91,5 +91,5 @@ export const retentionTableLogic = kea<retentionTableLogicType>({
                 ])
             },
         ],
-    },
-})
+    }),
+])

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -1,5 +1,6 @@
-import { kea } from 'kea'
-import { router } from 'kea-router'
+import { loaders } from 'kea-loaders'
+import { kea, path, connect, actions, reducers, selectors, listeners } from 'kea'
+import { router, actionToUrl, urlToAction } from 'kea-router'
 import api from 'lib/api'
 import { objectDiffShallow, objectsEqual, toParams } from 'lib/utils'
 import { InsightModel, LayoutView, SavedInsightsTabs } from '~/types'
@@ -58,13 +59,13 @@ function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsightFilters
     }
 }
 
-export const savedInsightsLogic = kea<savedInsightsLogicType>({
-    path: ['scenes', 'saved-insights', 'savedInsightsLogic'],
-    connect: {
+export const savedInsightsLogic = kea<savedInsightsLogicType>([
+    path(['scenes', 'saved-insights', 'savedInsightsLogic']),
+    connect({
         values: [teamLogic, ['currentTeamId'], featureFlagLogic, ['featureFlags']],
         logic: [eventUsageLogic],
-    },
-    actions: {
+    }),
+    actions({
         setSavedInsightsFilters: (
             filters: Partial<SavedInsightFilters>,
             merge: boolean = true,
@@ -79,8 +80,8 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>({
         loadInsights: (debounce: boolean = true) => ({ debounce }),
         setInsight: (insight: InsightModel) => ({ insight }),
         addInsight: (insight: InsightModel) => ({ insight }),
-    },
-    loaders: ({ values }) => ({
+    }),
+    loaders(({ values }) => ({
         insights: {
             __default: { results: [], count: 0, filters: null, offset: 0 } as InsightsResult,
             loadInsights: async ({ debounce }, breakpoint) => {
@@ -139,8 +140,8 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>({
                 return { ...values.insights, results: updatedInsights }
             },
         },
-    }),
-    reducers: {
+    })),
+    reducers({
         insights: {
             setInsight: (state, { insight }) => ({
                 ...state,
@@ -164,8 +165,8 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>({
                     }),
             },
         ],
-    },
-    selectors: ({ actions }) => ({
+    }),
+    selectors(({ actions }) => ({
         filters: [(s) => [s.rawFilters], (rawFilters): SavedInsightFilters => cleanFilters(rawFilters || {})],
         count: [(s) => [s.insights], (insights) => insights.count],
         usingFilters: [
@@ -236,8 +237,8 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>({
                 }
             },
         ],
-    }),
-    listeners: ({ actions, asyncActions, values, selectors }) => ({
+    })),
+    listeners(({ actions, asyncActions, values, selectors }) => ({
         setSavedInsightsFilters: async ({ merge, debounce }, breakpoint, __, previousState) => {
             const oldFilters = selectors.filters(previousState)
             const firstLoad = selectors.rawFilters(previousState) === null
@@ -307,8 +308,8 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>({
                 actions.loadInsights()
             }
         },
-    }),
-    actionToUrl: ({ values }) => {
+    })),
+    actionToUrl(({ values }) => {
         const changeUrl = ():
             | [
                   string,
@@ -336,8 +337,8 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>({
             loadInsights: changeUrl,
             setLayoutView: changeUrl,
         }
-    },
-    urlToAction: ({ actions, values }) => ({
+    }),
+    urlToAction(({ actions, values }) => ({
         [urls.savedInsights()]: async (_, searchParams, hashParams) => {
             if (hashParams.fromItem && String(hashParams.fromItem).match(/^[0-9]+$/)) {
                 // `fromItem` for legacy /insights url redirect support
@@ -367,5 +368,5 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>({
                 actions.setSavedInsightsFilters(nextFilters, false)
             }
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -1,5 +1,5 @@
-import { BuiltLogic, kea } from 'kea'
-import { router } from 'kea-router'
+import { BuiltLogic, kea, props, path, connect, actions, reducers, selectors, listeners } from 'kea'
+import { router, urlToAction } from 'kea-router'
 import posthog from 'posthog-js'
 import type { sceneLogicType } from './sceneLogicType'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -44,18 +44,20 @@ const sceneNavAlias: Partial<Record<Scene, Scene>> = {
     [Scene.ReplayPlaylist]: Scene.ReplayPlaylist,
 }
 
-export const sceneLogic = kea<sceneLogicType>({
-    props: {} as {
-        scenes?: Record<Scene, () => any>
-    },
-    connect: () => ({
+export const sceneLogic = kea<sceneLogicType>([
+    props(
+        {} as {
+            scenes?: Record<Scene, () => any>
+        }
+    ),
+    path(['scenes', 'sceneLogic']),
+    connect(() => ({
         logic: [router, userLogic, preflightLogic, appContextLogic],
         actions: [router, ['locationChanged']],
-    }),
-    path: ['scenes', 'sceneLogic'],
-    actions: {
+    })),
+    actions({
         /* 1. Prepares to open the scene, as the listener may override and do something
-            else (e.g. redirecting if unauthenticated), then calls (2) `loadScene`*/
+        else (e.g. redirecting if unauthenticated), then calls (2) `loadScene`*/
         openScene: (scene: Scene, params: SceneParams, method: string) => ({ scene, params, method }),
         // 2. Start loading the scene's Javascript and mount any logic, then calls (3) `setScene`
         loadScene: (scene: Scene, params: SceneParams, method: string) => ({ scene, params, method }),
@@ -83,8 +85,8 @@ export const sceneLogic = kea<sceneLogicType>({
         ) => ({ featureKey, featureName, featureCaption, featureAvailableCallback, guardOn, currentUsage }),
         hideUpgradeModal: true,
         reloadBrowserDueToImportError: true,
-    },
-    reducers: {
+    }),
+    reducers({
         scene: [
             null as Scene | null,
             {
@@ -128,8 +130,8 @@ export const sceneLogic = kea<sceneLogicType>({
                 reloadBrowserDueToImportError: () => new Date().valueOf(),
             },
         ],
-    },
-    selectors: {
+    }),
+    selectors({
         sceneConfig: [
             (s) => [s.scene],
             (scene: Scene): SceneConfig | null => {
@@ -167,38 +169,8 @@ export const sceneLogic = kea<sceneLogicType>({
         params: [(s) => [s.sceneParams], (sceneParams): Record<string, string> => sceneParams.params || {}],
         searchParams: [(s) => [s.sceneParams], (sceneParams): Record<string, any> => sceneParams.searchParams || {}],
         hashParams: [(s) => [s.sceneParams], (sceneParams): Record<string, any> => sceneParams.hashParams || {}],
-    },
-    urlToAction: ({ actions }) => {
-        const mapping: Record<
-            string,
-            (
-                params: Params,
-                searchParams: Params,
-                hashParams: Params,
-                payload: {
-                    method: string
-                }
-            ) => any
-        > = {}
-
-        for (const path of Object.keys(redirects)) {
-            mapping[path] = (params, searchParams, hashParams) => {
-                const redirect = redirects[path]
-                router.actions.replace(
-                    typeof redirect === 'function' ? redirect(params, searchParams, hashParams) : redirect
-                )
-            }
-        }
-        for (const [path, scene] of Object.entries(routes)) {
-            mapping[path] = (params, searchParams, hashParams, { method }) =>
-                actions.openScene(scene, { params, searchParams, hashParams }, method)
-        }
-
-        mapping['/*'] = (_, __, { method }) => actions.loadScene(Scene.Error404, emptySceneParams, method)
-
-        return mapping
-    },
-    listeners: ({ values, actions, props, selectors }) => ({
+    }),
+    listeners(({ values, actions, props, selectors }) => ({
         showUpgradeModal: ({ featureName }) => {
             eventUsageLogic.actions.reportUpgradeModalShown(featureName)
         },
@@ -410,5 +382,35 @@ export const sceneLogic = kea<sceneLogicType>({
                 router.actions.replace(pathname.replace(/(\/+)$/, ''), search, hash)
             }
         },
+    })),
+    urlToAction(({ actions }) => {
+        const mapping: Record<
+            string,
+            (
+                params: Params,
+                searchParams: Params,
+                hashParams: Params,
+                payload: {
+                    method: string
+                }
+            ) => any
+        > = {}
+
+        for (const path of Object.keys(redirects)) {
+            mapping[path] = (params, searchParams, hashParams) => {
+                const redirect = redirects[path]
+                router.actions.replace(
+                    typeof redirect === 'function' ? redirect(params, searchParams, hashParams) : redirect
+                )
+            }
+        }
+        for (const [path, scene] of Object.entries(routes)) {
+            mapping[path] = (params, searchParams, hashParams, { method }) =>
+                actions.openScene(scene, { params, searchParams, hashParams }, method)
+        }
+
+        mapping['/*'] = (_, __, { method }) => actions.loadScene(Scene.Error404, emptySceneParams, method)
+
+        return mapping
     }),
-})
+])

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -963,7 +963,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         },
     })),
     windowValues({
-        isSmallScreen: (window: any) => window.innerWidth < getBreakpoint('md'),
+        isSmallScreen: (window: Window) => window.innerWidth < getBreakpoint('md'),
     }),
 
     beforeUnmount(({ values, actions, cache, props }) => {

--- a/frontend/src/scenes/trends/mathsLogic.tsx
+++ b/frontend/src/scenes/trends/mathsLogic.tsx
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { kea, path, connect, selectors } from 'kea'
 import { groupsModel } from '~/models/groupsModel'
 import type { mathsLogicType } from './mathsLogicType'
 import { BaseMathType, CountPerActorMathType, HogQLMathType, PropertyMathType } from '~/types'
@@ -274,17 +274,17 @@ export function apiValueToMathType(math: string | undefined, groupTypeIndex: num
     return assembledMath
 }
 
-export const mathsLogic = kea<mathsLogicType>({
-    path: ['scenes', 'trends', 'mathsLogic'],
-    connect: {
+export const mathsLogic = kea<mathsLogicType>([
+    path(['scenes', 'trends', 'mathsLogic']),
+    connect({
         values: [
             groupsModel,
             ['groupTypes', 'aggregationLabel'],
             groupsAccessLogic,
             ['needsUpgradeForGroups', 'canStartUsingGroups'],
         ],
-    },
-    selectors: {
+    }),
+    selectors({
         mathDefinitions: [
             (s) => [s.groupsMathDefinitions],
             (groupsMathDefinitions): Record<string, MathDefinition> => {
@@ -347,5 +347,5 @@ export const mathsLogic = kea<mathsLogicType>({
                     ])
                 ),
         ],
-    },
-})
+    }),
+])

--- a/frontend/src/toolbar/actions/actionsLogic.ts
+++ b/frontend/src/toolbar/actions/actionsLogic.ts
@@ -1,24 +1,17 @@
-import { kea } from 'kea'
+import { loaders } from 'kea-loaders'
+import { kea, path, actions, reducers, selectors } from 'kea'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import type { actionsLogicType } from './actionsLogicType'
 import { ActionType } from '~/types'
 import Fuse from 'fuse.js'
 import { toolbarFetch } from '~/toolbar/utils'
 
-export const actionsLogic = kea<actionsLogicType>({
-    path: ['toolbar', 'actions', 'actionsLogic'],
-    actions: {
+export const actionsLogic = kea<actionsLogicType>([
+    path(['toolbar', 'actions', 'actionsLogic']),
+    actions({
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),
-    },
-    reducers: {
-        searchTerm: [
-            '',
-            {
-                setSearchTerm: (_, { searchTerm }) => searchTerm,
-            },
-        ],
-    },
-    loaders: ({ values }) => ({
+    }),
+    loaders(({ values }) => ({
         allActions: [
             [] as ActionType[],
             {
@@ -48,9 +41,16 @@ export const actionsLogic = kea<actionsLogicType>({
                 },
             },
         ],
+    })),
+    reducers({
+        searchTerm: [
+            '',
+            {
+                setSearchTerm: (_, { searchTerm }) => searchTerm,
+            },
+        ],
     }),
-
-    selectors: {
+    selectors({
         sortedActions: [
             (s) => [s.allActions, s.searchTerm],
             (allActions, searchTerm) => {
@@ -68,5 +68,5 @@ export const actionsLogic = kea<actionsLogicType>({
             },
         ],
         actionCount: [(s) => [s.allActions], (allActions) => allActions.length],
-    },
-})
+    }),
+])

--- a/frontend/src/toolbar/button/toolbarButtonLogic.ts
+++ b/frontend/src/toolbar/button/toolbarButtonLogic.ts
@@ -1,4 +1,5 @@
-import { kea } from 'kea'
+import { windowValues } from 'kea-windowvalues'
+import { kea, path, connect, actions, reducers, selectors, listeners } from 'kea'
 import { inBounds } from '~/toolbar/utils'
 import { heatmapLogic } from '~/toolbar/elements/heatmapLogic'
 import { elementsLogic } from '~/toolbar/elements/elementsLogic'
@@ -7,12 +8,12 @@ import type { toolbarButtonLogicType } from './toolbarButtonLogicType'
 import { posthog } from '~/toolbar/posthog'
 import { HedgehogActor } from 'lib/components/HedgehogBuddy/HedgehogBuddy'
 
-export const toolbarButtonLogic = kea<toolbarButtonLogicType>({
-    path: ['toolbar', 'button', 'toolbarButtonLogic'],
-    connect: () => ({
+export const toolbarButtonLogic = kea<toolbarButtonLogicType>([
+    path(['toolbar', 'button', 'toolbarButtonLogic']),
+    connect(() => ({
         actions: [actionsTabLogic, ['showButtonActions'], elementsLogic, ['enableInspect']],
-    }),
-    actions: () => ({
+    })),
+    actions(() => ({
         showHeatmapInfo: true,
         hideHeatmapInfo: true,
         showActionsInfo: true,
@@ -27,14 +28,12 @@ export const toolbarButtonLogic = kea<toolbarButtonLogicType>({
         saveActionsPosition: (x: number, y: number) => ({ x, y }),
         saveFlagsPosition: (x: number, y: number) => ({ x, y }),
         setHedgehogActor: (actor: HedgehogActor) => ({ actor }),
-    }),
-
-    windowValues: () => ({
+    })),
+    windowValues(() => ({
         windowHeight: (window) => window.innerHeight,
         windowWidth: (window) => Math.min(window.innerWidth, window.document.body.clientWidth),
-    }),
-
-    reducers: () => ({
+    })),
+    reducers(() => ({
         heatmapInfoVisible: [
             false,
             {
@@ -113,9 +112,8 @@ export const toolbarButtonLogic = kea<toolbarButtonLogicType>({
                 setHedgehogActor: (_, { actor }) => actor,
             },
         ],
-    }),
-
-    selectors: {
+    })),
+    selectors({
         dragPosition: [
             (s) => [s.lastDragPosition, s.windowWidth, s.windowHeight],
             (lastDragPosition, windowWidth, windowHeight) => {
@@ -195,9 +193,8 @@ export const toolbarButtonLogic = kea<toolbarButtonLogicType>({
             (flagsVisible, extensionPercentage) =>
                 flagsVisible ? Math.max(extensionPercentage, 0.53) : extensionPercentage,
         ],
-    },
-
-    listeners: ({ actions, values }) => ({
+    }),
+    listeners(({ actions, values }) => ({
         showFlags: () => {
             posthog.capture('toolbar mode triggered', { mode: 'flags', enabled: true })
             values.hedgehogActor?.setAnimation('flag')
@@ -224,5 +221,5 @@ export const toolbarButtonLogic = kea<toolbarButtonLogicType>({
                 y > windowHeight / 2 ? -(windowHeight - y) : y
             )
         },
-    }),
-})
+    })),
+])

--- a/frontend/src/toolbar/button/toolbarButtonLogic.ts
+++ b/frontend/src/toolbar/button/toolbarButtonLogic.ts
@@ -30,8 +30,8 @@ export const toolbarButtonLogic = kea<toolbarButtonLogicType>([
         setHedgehogActor: (actor: HedgehogActor) => ({ actor }),
     })),
     windowValues(() => ({
-        windowHeight: (window) => window.innerHeight,
-        windowWidth: (window) => Math.min(window.innerWidth, window.document.body.clientWidth),
+        windowHeight: (window: Window) => window.innerHeight,
+        windowWidth: (window: Window) => Math.min(window.innerWidth, window.document.body.clientWidth),
     })),
     reducers(() => ({
         heatmapInfoVisible: [

--- a/frontend/src/toolbar/button/toolbarButtonLogic.ts
+++ b/frontend/src/toolbar/button/toolbarButtonLogic.ts
@@ -1,4 +1,4 @@
-import { windowValues } from 'kea-windowvalues'
+import { windowValues } from 'kea-window-values'
 import { kea, path, connect, actions, reducers, selectors, listeners } from 'kea'
 import { inBounds } from '~/toolbar/utils'
 import { heatmapLogic } from '~/toolbar/elements/heatmapLogic'

--- a/frontend/src/toolbar/stats/currentPageLogic.ts
+++ b/frontend/src/toolbar/stats/currentPageLogic.ts
@@ -1,22 +1,20 @@
-import { kea } from 'kea'
+import { kea, path, actions, reducers, events } from 'kea'
 import type { currentPageLogicType } from './currentPageLogicType'
 
-export const currentPageLogic = kea<currentPageLogicType>({
-    path: ['toolbar', 'stats', 'currentPageLogic'],
-    actions: () => ({
+export const currentPageLogic = kea<currentPageLogicType>([
+    path(['toolbar', 'stats', 'currentPageLogic']),
+    actions(() => ({
         setHref: (href: string) => ({ href }),
         setWildcardHref: (href: string) => ({ href }),
-    }),
-
-    reducers: () => ({
+    })),
+    reducers(() => ({
         href: [window.location.href, { setHref: (_, { href }) => href }],
         wildcardHref: [
             window.location.href,
             { setHref: (_, { href }) => href, setWildcardHref: (_, { href }) => href },
         ],
-    }),
-
-    events: ({ actions, cache, values }) => ({
+    })),
+    events(({ actions, cache, values }) => ({
         afterMount: () => {
             cache.interval = window.setInterval(() => {
                 if (window.location.href !== values.href) {
@@ -34,5 +32,5 @@ export const currentPageLogic = kea<currentPageLogicType>({
             window.clearInterval(cache.interval)
             window.removeEventListener('popstate', cache.location)
         },
-    }),
-})
+    })),
+])


### PR DESCRIPTION
## Problem

We were still using the kea v2 format.

## Changes

This PR uses `npx kea-typegen write --convert-to-builders` to upgrade to the kea v3 format.

## How did you test this code?

CI run & clicked through app for a bit