### PR TITLE
fix(surveys): add total NPS score and clean up old queries

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -13,6 +13,7 @@ import { surveysLogic } from './surveysLogic'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SurveyReleaseSummary } from './Survey'
 import {
+    ChartDisplayType,
     PropertyFilterType,
     PropertyOperator,
     RatingSurveyQuestion,
@@ -266,24 +267,31 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
         surveyMultipleChoiceResultsReady,
         surveyOpenTextResults,
         surveyOpenTextResultsReady,
+        surveyNPSScore,
     } = useValues(surveyLogic)
     const { setCurrentQuestionIndexAndType } = useActions(surveyLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-
+    console.log('results', surveyRatingResults)
     return (
         <>
-            {featureFlags[FEATURE_FLAGS.SURVEYS_RESULTS_VISUALIZATIONS] && (
                 <>
                     <Summary surveyUserStatsLoading={surveyUserStatsLoading} surveyUserStats={surveyUserStats} />
                     {survey.questions.map((question, i) => {
                         if (question.type === SurveyQuestionType.Rating) {
                             return (
-                                <RatingQuestionBarChart
-                                    key={`survey-q-${i}`}
-                                    surveyRatingResults={surveyRatingResults}
-                                    surveyRatingResultsReady={surveyRatingResultsReady}
-                                    questionIndex={i}
-                                />
+                                <>
+                                    {question.scale === 10 && <>
+                                        <div className="text-4xl font-bold">{surveyNPSScore}</div>
+                                        <div className="font-semibold text-muted-alt mb-2">Total NPS Score</div>
+                                        {featureFlags[FEATURE_FLAGS.SURVEYS_RESULTS_VISUALIZATIONS] && <SurveyNPSResults survey={survey as Survey} />}
+                                    </>}
+                                    <RatingQuestionBarChart
+                                        key={`survey-q-${i}`}
+                                        surveyRatingResults={surveyRatingResults}
+                                        surveyRatingResultsReady={surveyRatingResultsReady}
+                                        questionIndex={i}
+                                    />
+                                </>
                             )
                         } else if (question.type === SurveyQuestionType.SingleChoice) {
                             return (
@@ -315,55 +323,6 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
                         }
                     })}
                 </>
-            )}
-            {surveyMetricsQueries && !featureFlags[FEATURE_FLAGS.SURVEYS_RESULTS_VISUALIZATIONS] && (
-                <div className="flex flex-row gap-4 mb-4">
-                    <div className="flex-1">
-                        <Query query={surveyMetricsQueries.surveysShown} />
-                    </div>
-                    <div className="flex-1">
-                        <Query query={surveyMetricsQueries.surveysDismissed} />
-                    </div>
-                </div>
-            )}
-            {survey.questions.length > 1 && !featureFlags[FEATURE_FLAGS.SURVEYS_RESULTS_VISUALIZATIONS] && (
-                <div className="mb-4 max-w-80">
-                    <LemonSelect
-                        dropdownMatchSelectWidth
-                        fullWidth
-                        onChange={(idx) => {
-                            setCurrentQuestionIndexAndType(idx, survey.questions[idx].type)
-                        }}
-                        options={[
-                            ...survey.questions.map((q: SurveyQuestion, idx: number) => ({
-                                label: q.question,
-                                value: idx,
-                            })),
-                        ]}
-                        value={currentQuestionIndexAndType.idx}
-                    />
-                </div>
-            )}
-            {currentQuestionIndexAndType.type === SurveyQuestionType.Rating &&
-                !featureFlags[FEATURE_FLAGS.SURVEYS_RESULTS_VISUALIZATIONS] && (
-                    <div className="mb-4">
-                        <Query query={surveyRatingQuery} />
-                        {(survey.questions[currentQuestionIndexAndType.idx] as RatingSurveyQuestion).scale === 10 && (
-                            <>
-                                <LemonDivider className="my-4" />
-                                <h2>NPS Score</h2>
-                                <SurveyNPSResults survey={survey as Survey} />
-                            </>
-                        )}
-                    </div>
-                )}
-            {(currentQuestionIndexAndType.type === SurveyQuestionType.SingleChoice ||
-                currentQuestionIndexAndType.type === SurveyQuestionType.MultipleChoice) &&
-                !featureFlags[FEATURE_FLAGS.SURVEYS_RESULTS_VISUALIZATIONS] && (
-                    <div className="mb-4">
-                        <Query query={surveyMultipleChoiceQuery} />
-                    </div>
-                )}
             {!disableEventsTable && (surveyLoading ? <LemonSkeleton /> : <Query query={dataTableQuery} />)}
         </>
     )
@@ -371,71 +330,75 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
 
 function SurveyNPSResults({ survey }: { survey: Survey }): JSX.Element {
     return (
-        <Query
-            query={{
-                kind: NodeKind.InsightVizNode,
-                source: {
-                    kind: NodeKind.TrendsQuery,
-                    dateRange: {
-                        date_from: dayjs(survey.created_at).format('YYYY-MM-DD'),
-                        date_to: survey.end_date
-                            ? dayjs(survey.end_date).format('YYYY-MM-DD')
-                            : dayjs().add(1, 'day').format('YYYY-MM-DD'),
+        <>
+            <Query
+                query={{
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        dateRange: {
+                            date_from: dayjs(survey.created_at).format('YYYY-MM-DD'),
+                            date_to: survey.end_date
+                                ? dayjs(survey.end_date).format('YYYY-MM-DD')
+                                : dayjs().add(1, 'day').format('YYYY-MM-DD'),
+                        },
+                        series: [
+                            {
+                                event: SURVEY_EVENT_NAME,
+                                kind: NodeKind.EventsNode,
+                                custom_name: 'Promoters',
+                                properties: [
+                                    {
+                                        type: PropertyFilterType.Event,
+                                        key: '$survey_response',
+                                        operator: PropertyOperator.Exact,
+                                        value: [9, 10],
+                                    },
+                                ],
+                            },
+                            {
+                                event: SURVEY_EVENT_NAME,
+                                kind: NodeKind.EventsNode,
+                                custom_name: 'Passives',
+                                properties: [
+                                    {
+                                        type: PropertyFilterType.Event,
+                                        key: '$survey_response',
+                                        operator: PropertyOperator.Exact,
+                                        value: [7, 8],
+                                    },
+                                ],
+                            },
+                            {
+                                event: SURVEY_EVENT_NAME,
+                                kind: NodeKind.EventsNode,
+                                custom_name: 'Detractors',
+                                properties: [
+                                    {
+                                        type: PropertyFilterType.Event,
+                                        key: '$survey_response',
+                                        operator: PropertyOperator.Exact,
+                                        value: [0, 1, 2, 3, 4, 5, 6],
+                                    },
+                                ],
+                            },
+                        ],
+                        properties: [
+                            {
+                                type: PropertyFilterType.Event,
+                                key: '$survey_id',
+                                operator: PropertyOperator.Exact,
+                                value: survey.id,
+                            },
+                        ],
+                        trendsFilter: {
+                            formula: '(A / (A+B+C) * 100) - (C / (A+B+C)* 100)',
+                            display: ChartDisplayType.ActionsLineGraphCumulative,
+                        },
                     },
-                    series: [
-                        {
-                            event: SURVEY_EVENT_NAME,
-                            kind: NodeKind.EventsNode,
-                            custom_name: 'Promoters',
-                            properties: [
-                                {
-                                    type: PropertyFilterType.Event,
-                                    key: '$survey_response',
-                                    operator: PropertyOperator.Exact,
-                                    value: [9, 10],
-                                },
-                            ],
-                        },
-                        {
-                            event: SURVEY_EVENT_NAME,
-                            kind: NodeKind.EventsNode,
-                            custom_name: 'Passives',
-                            properties: [
-                                {
-                                    type: PropertyFilterType.Event,
-                                    key: '$survey_response',
-                                    operator: PropertyOperator.Exact,
-                                    value: [7, 8],
-                                },
-                            ],
-                        },
-                        {
-                            event: SURVEY_EVENT_NAME,
-                            kind: NodeKind.EventsNode,
-                            custom_name: 'Detractors',
-                            properties: [
-                                {
-                                    type: PropertyFilterType.Event,
-                                    key: '$survey_response',
-                                    operator: PropertyOperator.Exact,
-                                    value: [1, 2, 3, 4, 5, 6],
-                                },
-                            ],
-                        },
-                    ],
-                    properties: [
-                        {
-                            type: PropertyFilterType.Event,
-                            key: '$survey_id',
-                            operator: PropertyOperator.Exact,
-                            value: survey.id,
-                        },
-                    ],
-                    trendsFilter: {
-                        formula: '(A / (A+B+C) * 100) - (C / (A+B+C)* 100)',
-                    },
-                },
-            }}
-        />
+                }}
+            />
+        </>
+
     )
 }

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -1,5 +1,5 @@
 import { TZLabel } from '@posthog/apps-common'
-import { LemonButton, LemonDivider, LemonSelect, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, Link } from '@posthog/lemon-ui'
 import { useValues, useActions } from 'kea'
 import { EditableField } from 'lib/components/EditableField/EditableField'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -12,16 +12,7 @@ import { surveyLogic } from './surveyLogic'
 import { surveysLogic } from './surveysLogic'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SurveyReleaseSummary } from './Survey'
-import {
-    ChartDisplayType,
-    PropertyFilterType,
-    PropertyOperator,
-    RatingSurveyQuestion,
-    Survey,
-    SurveyQuestion,
-    SurveyQuestionType,
-    SurveyType,
-} from '~/types'
+import { ChartDisplayType, PropertyFilterType, PropertyOperator, Survey, SurveyQuestionType, SurveyType } from '~/types'
 import { SurveyAPIEditor } from './SurveyAPIEditor'
 import { NodeKind } from '~/queries/schema'
 import { dayjs } from 'lib/dayjs'
@@ -253,10 +244,6 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
         survey,
         dataTableQuery,
         surveyLoading,
-        surveyMetricsQueries,
-        surveyRatingQuery,
-        surveyMultipleChoiceQuery,
-        currentQuestionIndexAndType,
         surveyUserStats,
         surveyUserStatsLoading,
         surveyRatingResults,
@@ -269,60 +256,63 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
         surveyOpenTextResultsReady,
         surveyNPSScore,
     } = useValues(surveyLogic)
-    const { setCurrentQuestionIndexAndType } = useActions(surveyLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    console.log('results', surveyRatingResults)
+
     return (
         <>
-                <>
-                    <Summary surveyUserStatsLoading={surveyUserStatsLoading} surveyUserStats={surveyUserStats} />
-                    {survey.questions.map((question, i) => {
-                        if (question.type === SurveyQuestionType.Rating) {
-                            return (
-                                <>
-                                    {question.scale === 10 && <>
+            <>
+                <Summary surveyUserStatsLoading={surveyUserStatsLoading} surveyUserStats={surveyUserStats} />
+                {survey.questions.map((question, i) => {
+                    if (question.type === SurveyQuestionType.Rating) {
+                        return (
+                            <>
+                                {question.scale === 10 && (
+                                    <>
                                         <div className="text-4xl font-bold">{surveyNPSScore}</div>
                                         <div className="font-semibold text-muted-alt mb-2">Total NPS Score</div>
-                                        {featureFlags[FEATURE_FLAGS.SURVEYS_RESULTS_VISUALIZATIONS] && <SurveyNPSResults survey={survey as Survey} />}
-                                    </>}
-                                    <RatingQuestionBarChart
-                                        key={`survey-q-${i}`}
-                                        surveyRatingResults={surveyRatingResults}
-                                        surveyRatingResultsReady={surveyRatingResultsReady}
-                                        questionIndex={i}
-                                    />
-                                </>
-                            )
-                        } else if (question.type === SurveyQuestionType.SingleChoice) {
-                            return (
-                                <SingleChoiceQuestionPieChart
+                                        {featureFlags[FEATURE_FLAGS.SURVEYS_RESULTS_VISUALIZATIONS] && (
+                                            <SurveyNPSResults survey={survey as Survey} />
+                                        )}
+                                    </>
+                                )}
+                                <RatingQuestionBarChart
                                     key={`survey-q-${i}`}
-                                    surveySingleChoiceResults={surveySingleChoiceResults}
-                                    surveySingleChoiceResultsReady={surveySingleChoiceResultsReady}
+                                    surveyRatingResults={surveyRatingResults}
+                                    surveyRatingResultsReady={surveyRatingResultsReady}
                                     questionIndex={i}
                                 />
-                            )
-                        } else if (question.type === SurveyQuestionType.MultipleChoice) {
-                            return (
-                                <MultipleChoiceQuestionBarChart
-                                    key={`survey-q-${i}`}
-                                    surveyMultipleChoiceResults={surveyMultipleChoiceResults}
-                                    surveyMultipleChoiceResultsReady={surveyMultipleChoiceResultsReady}
-                                    questionIndex={i}
-                                />
-                            )
-                        } else if (question.type === SurveyQuestionType.Open) {
-                            return (
-                                <OpenTextViz
-                                    key={`survey-q-${i}`}
-                                    surveyOpenTextResults={surveyOpenTextResults}
-                                    surveyOpenTextResultsReady={surveyOpenTextResultsReady}
-                                    questionIndex={i}
-                                />
-                            )
-                        }
-                    })}
-                </>
+                            </>
+                        )
+                    } else if (question.type === SurveyQuestionType.SingleChoice) {
+                        return (
+                            <SingleChoiceQuestionPieChart
+                                key={`survey-q-${i}`}
+                                surveySingleChoiceResults={surveySingleChoiceResults}
+                                surveySingleChoiceResultsReady={surveySingleChoiceResultsReady}
+                                questionIndex={i}
+                            />
+                        )
+                    } else if (question.type === SurveyQuestionType.MultipleChoice) {
+                        return (
+                            <MultipleChoiceQuestionBarChart
+                                key={`survey-q-${i}`}
+                                surveyMultipleChoiceResults={surveyMultipleChoiceResults}
+                                surveyMultipleChoiceResultsReady={surveyMultipleChoiceResultsReady}
+                                questionIndex={i}
+                            />
+                        )
+                    } else if (question.type === SurveyQuestionType.Open) {
+                        return (
+                            <OpenTextViz
+                                key={`survey-q-${i}`}
+                                surveyOpenTextResults={surveyOpenTextResults}
+                                surveyOpenTextResultsReady={surveyOpenTextResultsReady}
+                                questionIndex={i}
+                            />
+                        )
+                    }
+                })}
+            </>
             {!disableEventsTable && (surveyLoading ? <LemonSkeleton /> : <Query query={dataTableQuery} />)}
         </>
     )
@@ -399,6 +389,5 @@ function SurveyNPSResults({ survey }: { survey: Survey }): JSX.Element {
                 }}
             />
         </>
-
     )
 }

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -762,6 +762,22 @@ export const surveyLogic = kea<surveyLogicType>([
                 return null
             },
         ],
+        surveyNPSScore: [
+            (s) => [s.surveyRatingResults],
+            (surveyRatingResults) => {
+                if (surveyRatingResults) {
+                    const questionIdx = Object.keys(surveyRatingResults)[0]
+                    const questionResults = surveyRatingResults[questionIdx].data
+                    if (questionResults.length === 11) {
+                        const promoters = questionResults.slice(9, 11).reduce((a, b) => a + b, 0)
+                        const passives = questionResults.slice(7, 9).reduce((a, b) => a + b, 0)
+                        const detractors = questionResults.slice(0, 7).reduce((a, b) => a + b, 0)
+                        const npsScore = ((promoters - detractors) / (promoters + passives + detractors)) * 100
+                        return npsScore
+                    }
+                }
+            }
+        ]
     }),
     forms(({ actions, props, values }) => ({
         survey: {

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -7,7 +7,6 @@ import api from 'lib/api'
 import { urls } from 'scenes/urls'
 import {
     Breadcrumb,
-    ChartDisplayType,
     PropertyFilterType,
     PropertyOperator,
     Survey,
@@ -16,20 +15,14 @@ import {
     SurveyUrlMatchType,
 } from '~/types'
 import type { surveyLogicType } from './surveyLogicType'
-import { DataTableNode, InsightVizNode, HogQLQuery, NodeKind } from '~/queries/schema'
+import { DataTableNode, HogQLQuery, NodeKind } from '~/queries/schema'
 import { hogql } from '~/queries/utils'
 import { surveysLogic } from './surveysLogic'
 import { dayjs } from 'lib/dayjs'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
 import { featureFlagLogic as enabledFlagLogic } from 'lib/logic/featureFlagLogic'
-import {
-    defaultSurveyFieldValues,
-    SURVEY_EVENT_NAME,
-    SURVEY_RESPONSE_PROPERTY,
-    NEW_SURVEY,
-    NewSurvey,
-} from './constants'
+import { defaultSurveyFieldValues, NEW_SURVEY, NewSurvey } from './constants'
 import { sanitize } from 'dompurify'
 
 export enum SurveyEditSection {
@@ -126,7 +119,6 @@ export const surveyLogic = kea<surveyLogicType>([
             isEditingThankYouMessage,
         }),
         archiveSurvey: true,
-        setCurrentQuestionIndexAndType: (idx: number, type: SurveyQuestionType) => ({ idx, type }),
         setWritingHTMLDescription: (writingHTML: boolean) => ({ writingHTML }),
         setSurveyTemplateValues: (template: any) => ({ template }),
         setSelectedQuestion: (idx: number | null) => ({ idx }),
@@ -426,8 +418,7 @@ export const surveyLogic = kea<surveyLogicType>([
         archiveSurvey: async () => {
             actions.updateSurvey({ archived: true })
         },
-        loadSurveySuccess: ({ survey }) => {
-            actions.setCurrentQuestionIndexAndType(0, survey.questions[0].type)
+        loadSurveySuccess: () => {
             actions.loadSurveyUserStats()
         },
         resetTargeting: () => {
@@ -501,13 +492,6 @@ export const surveyLogic = kea<surveyLogicType>([
             SurveyEditSection.Steps as SurveyEditSection | null,
             {
                 setSelectedSection: (_, { section }) => section,
-            },
-        ],
-        // TODO: remove this currentQuestionIndexAndType once surveys visualisation flag is rolled out
-        currentQuestionIndexAndType: [
-            { idx: 0, type: SurveyQuestionType.Open } as { idx: number; type: SurveyQuestionType },
-            {
-                setCurrentQuestionIndexAndType: (_, { idx, type }) => ({ idx, type }),
             },
         ],
         surveyRatingResultsReady: [
@@ -590,16 +574,8 @@ export const surveyLogic = kea<surveyLogicType>([
                 ...(survey?.name ? [{ name: survey.name }] : []),
             ],
         ],
-        surveyResponseProperty: [
-            (s) => [s.currentQuestionIndexAndType],
-            (currentQuestionIndexAndType): string => {
-                return currentQuestionIndexAndType.idx === 0
-                    ? SURVEY_RESPONSE_PROPERTY
-                    : `${SURVEY_RESPONSE_PROPERTY}_${currentQuestionIndexAndType.idx}`
-            },
-        ],
         dataTableQuery: [
-            (s) => [s.survey, s.surveyResponseProperty],
+            (s) => [s.survey],
             (survey): DataTableNode | null => {
                 if (survey.id === 'new') {
                     return null
@@ -647,102 +623,6 @@ export const surveyLogic = kea<surveyLogicType>([
                 }
             },
         ],
-        surveyMetricsQueries: [
-            (s) => [s.survey],
-            (survey): SurveyMetricsQueries | null => {
-                const surveyId = survey.id
-                if (surveyId === 'new') {
-                    return null
-                }
-                const startDate = dayjs((survey as Survey).created_at).format('YYYY-MM-DD')
-                const endDate = survey.end_date
-                    ? dayjs(survey.end_date).add(1, 'day').format('YYYY-MM-DD')
-                    : dayjs().add(1, 'day').format('YYYY-MM-DD')
-
-                const surveysShownHogqlQuery = `select count(distinct person.id) as 'survey shown' from events where event == 'survey shown' and properties.$survey_id == '${surveyId}' and timestamp >= '${startDate}' and timestamp <= '${endDate}' `
-                const surveysDismissedHogqlQuery = `select count(distinct person.id) as 'survey dismissed' from events where event == 'survey dismissed' and properties.$survey_id == '${surveyId}' and timestamp >= '${startDate}' and timestamp <= '${endDate}'`
-                return {
-                    surveysShown: {
-                        kind: NodeKind.DataTableNode,
-                        source: {
-                            kind: NodeKind.HogQLQuery,
-                            query: surveysShownHogqlQuery,
-                        },
-                        showTimings: false,
-                    },
-                    surveysDismissed: {
-                        kind: NodeKind.DataTableNode,
-                        source: {
-                            kind: NodeKind.HogQLQuery,
-                            query: surveysDismissedHogqlQuery,
-                        },
-                        showTimings: false,
-                    },
-                }
-            },
-        ],
-        surveyRatingQuery: [
-            (s) => [s.survey, s.surveyResponseProperty],
-            (survey, surveyResponseProperty): InsightVizNode | null => {
-                if (survey.id === 'new') {
-                    return null
-                }
-                const startDate = dayjs((survey as Survey).created_at).format('YYYY-MM-DD')
-                const endDate = survey.end_date
-                    ? dayjs(survey.end_date).add(1, 'day').format('YYYY-MM-DD')
-                    : dayjs().add(1, 'day').format('YYYY-MM-DD')
-
-                return {
-                    kind: NodeKind.InsightVizNode,
-                    source: {
-                        kind: NodeKind.TrendsQuery,
-                        dateRange: {
-                            date_from: startDate,
-                            date_to: endDate,
-                        },
-                        properties: [
-                            {
-                                type: PropertyFilterType.Event,
-                                key: '$survey_id',
-                                operator: PropertyOperator.Exact,
-                                value: survey.id,
-                            },
-                        ],
-                        series: [{ event: SURVEY_EVENT_NAME, kind: NodeKind.EventsNode }],
-                        trendsFilter: { display: ChartDisplayType.ActionsBarValue },
-                        breakdown: { breakdown: surveyResponseProperty, breakdown_type: 'event' },
-                    },
-                    showTable: true,
-                }
-            },
-        ],
-        surveyMultipleChoiceQuery: [
-            (s) => [s.survey, s.surveyResponseProperty, s.currentQuestionIndexAndType],
-            (survey, surveyResponseProperty, currentQuestionIndexAndType): DataTableNode | null => {
-                if (survey.id === 'new') {
-                    return null
-                }
-
-                const startDate = dayjs((survey as Survey).created_at).format('YYYY-MM-DD')
-                const endDate = survey.end_date
-                    ? dayjs(survey.end_date).add(1, 'day').format('YYYY-MM-DD')
-                    : dayjs().add(1, 'day').format('YYYY-MM-DD')
-
-                const singleChoiceQuery = `select count(), properties.${surveyResponseProperty} as choice from events where event == 'survey sent' and properties.$survey_id == '${survey.id}' and timestamp >= '${startDate}' and timestamp <= '${endDate}' group by choice order by count() desc`
-                const multipleChoiceQuery = `select count(), arrayJoin(JSONExtractArrayRaw(properties, '${surveyResponseProperty}')) as choice from events where event == 'survey sent' and properties.$survey_id == '${survey.id}' and timestamp >= '${startDate}' and timestamp <= '${endDate}'  group by choice order by count() desc`
-                return {
-                    kind: NodeKind.DataTableNode,
-                    source: {
-                        kind: NodeKind.HogQLQuery,
-                        query:
-                            currentQuestionIndexAndType.type === SurveyQuestionType.SingleChoice
-                                ? singleChoiceQuery
-                                : multipleChoiceQuery,
-                    },
-                    showTimings: false,
-                }
-            },
-        ],
         hasTargetingFlag: [
             (s) => [s.survey],
             (survey): boolean => {
@@ -767,7 +647,7 @@ export const surveyLogic = kea<surveyLogicType>([
             (surveyRatingResults) => {
                 if (surveyRatingResults) {
                     const questionIdx = Object.keys(surveyRatingResults)[0]
-                    const questionResults = surveyRatingResults[questionIdx].data
+                    const questionResults: number[] = surveyRatingResults[questionIdx].data
                     if (questionResults.length === 11) {
                         const promoters = questionResults.slice(9, 11).reduce((a, b) => a + b, 0)
                         const passives = questionResults.slice(7, 9).reduce((a, b) => a + b, 0)
@@ -776,8 +656,8 @@ export const surveyLogic = kea<surveyLogicType>([
                         return npsScore
                     }
                 }
-            }
-        ]
+            },
+        ],
     }),
     forms(({ actions, props, values }) => ({
         survey: {


### PR DESCRIPTION
## Problem

We should show total nps score 

## Changes

<img width="586" alt="Screenshot 2023-10-26 at 5 05 53 PM" src="https://github.com/PostHog/posthog/assets/25164963/ab42ec64-c7e6-4843-87c9-8bdbe5011355">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
