### PR TITLE
chore(hogql): Full error & NULL handling in C++ parser (1.0.0)

### DIFF
--- a/hogql_parser/.clang-format
+++ b/hogql_parser/.clang-format
@@ -1,3 +1,5 @@
 BasedOnStyle: Chromium
 ColumnLimit: 120
 AlignAfterOpenBracket: BlockIndent
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortFunctionsOnASingleLine: Empty

--- a/hogql_parser/.clang-format
+++ b/hogql_parser/.clang-format
@@ -2,4 +2,3 @@ BasedOnStyle: Chromium
 ColumnLimit: 120
 AlignAfterOpenBracket: BlockIndent
 AllowShortIfStatementsOnASingleLine: WithoutElse
-AllowShortFunctionsOnASingleLine: Empty

--- a/hogql_parser/error.cpp
+++ b/hogql_parser/error.cpp
@@ -10,6 +10,8 @@ using namespace std;
 
 EXCEPTION_CLASS_IMPLEMENTATION(HogQLException, runtime_error)
 
-EXCEPTION_CLASS_IMPLEMENTATION(HogQLSyntaxException, HogQLException)
-EXCEPTION_CLASS_IMPLEMENTATION(HogQLNotImplementedException, HogQLException)
-EXCEPTION_CLASS_IMPLEMENTATION(HogQLParsingException, HogQLException)
+EXCEPTION_CLASS_IMPLEMENTATION(SyntaxException, HogQLException)
+EXCEPTION_CLASS_IMPLEMENTATION(NotImplementedException, HogQLException)
+EXCEPTION_CLASS_IMPLEMENTATION(ParsingException, HogQLException)
+
+PyInternalException::PyInternalException() : exception() {}

--- a/hogql_parser/error.h
+++ b/hogql_parser/error.h
@@ -17,10 +17,16 @@
 EXCEPTION_CLASS_DEFINITION(HogQLException, std::runtime_error)
 
 // The input does not conform to HogQL syntax.
-EXCEPTION_CLASS_DEFINITION(HogQLSyntaxException, HogQLException)
+EXCEPTION_CLASS_DEFINITION(SyntaxException, HogQLException)
 
 // This feature isn't implemented in HogQL (yet).
-EXCEPTION_CLASS_DEFINITION(HogQLNotImplementedException, HogQLException)
+EXCEPTION_CLASS_DEFINITION(NotImplementedException, HogQLException)
 
 // An internal problem in the parser layer.
-EXCEPTION_CLASS_DEFINITION(HogQLParsingException, HogQLException)
+EXCEPTION_CLASS_DEFINITION(ParsingException, HogQLException)
+
+// Python runtime errored out somewhere - this means we must use the error it's already raised.
+class PyInternalException : public std::exception {
+ public:
+  PyInternalException();
+};

--- a/hogql_parser/parser.cpp
+++ b/hogql_parser/parser.cpp
@@ -12,43 +12,61 @@
 #include "string.h"
 
 #define VISIT(RULE) any visit##RULE(HogQLParser::RULE##Context* ctx) override
-#define VISIT_UNSUPPORTED(RULE)                                     \
-  VISIT(RULE) {                                                     \
-    throw HogQLNotImplementedException("Unsupported rule: " #RULE); \
+#define VISIT_UNSUPPORTED(RULE)                                \
+  VISIT(RULE) {                                                \
+    throw NotImplementedException("Unsupported rule: " #RULE); \
   }
-#define HANDLE_HOGQL_EXCEPTION(TYPE)                                                                             \
-  (const HogQL##TYPE& e) {                                                                                       \
-    PyObject* error_type = PyObject_GetAttrString(state->errors_module, #TYPE);                                  \
-    if (!error_type) {                                                                                           \
-      return NULL;                                                                                               \
-    }                                                                                                            \
-    string err_what = e.what();                                                                                  \
-    PyObject* py_err = PyObject_CallObject(error_type, Py_BuildValue("(s#)", err_what.data(), err_what.size())); \
-    if (!py_err) {                                                                                               \
-      Py_DECREF(error_type);                                                                                     \
-      return NULL;                                                                                               \
-    }                                                                                                            \
-    PyObject* py_start = PyLong_FromSize_t(e.start);                                                             \
-    PyObject* py_end = PyLong_FromSize_t(e.end);                                                                 \
-    PyObject_SetAttrString(py_err, "start", py_start);                                                           \
-    PyObject_SetAttrString(py_err, "end", py_end);                                                               \
-    Py_DECREF(py_start);                                                                                         \
-    Py_DECREF(py_end);                                                                                           \
-    PyErr_SetObject(error_type, py_err);                                                                         \
-    Py_DECREF(error_type);                                                                                       \
-    Py_DECREF(py_err);                                                                                           \
-    return NULL;                                                                                                 \
+
+#define HANDLE_HOGQL_EXCEPTION(TYPE)                                                                    \
+  (const TYPE& e) {                                                                                     \
+    string err_what = e.what();                                                                         \
+    PyObject *error_type = NULL, *py_err_args = NULL, *py_err = NULL, *py_start = NULL, *py_end = NULL; \
+    int err_indicator = 0;                                                                              \
+    error_type = PyObject_GetAttrString(state->errors_module, #TYPE);                                   \
+    if (!error_type) goto exit##TYPE;                                                                   \
+    py_err_args = Py_BuildValue("(s#)", err_what.data(), err_what.size());                              \
+    if (!py_err_args) goto exit##TYPE;                                                                  \
+    py_err = PyObject_CallObject(error_type, py_err_args);                                              \
+    if (!py_err) goto exit##TYPE;                                                                       \
+    py_start = PyLong_FromSize_t(e.start);                                                              \
+    if (!py_start) goto exit##TYPE;                                                                     \
+    py_end = PyLong_FromSize_t(e.end);                                                                  \
+    if (!py_end) goto exit##TYPE;                                                                       \
+    err_indicator = PyObject_SetAttrString(py_err, "start", py_start);                                  \
+    if (err_indicator == -1) goto exit##TYPE;                                                           \
+    err_indicator = PyObject_SetAttrString(py_err, "end", py_end);                                      \
+    if (err_indicator == -1) goto exit##TYPE;                                                           \
+    PyErr_SetObject(error_type, py_err);                                                                \
+    exit##TYPE:;                                                                                        \
+    Py_XDECREF(py_end);                                                                                 \
+    Py_XDECREF(py_start);                                                                               \
+    Py_XDECREF(py_err);                                                                                 \
+    Py_XDECREF(error_type);                                                                             \
+    return NULL;                                                                                        \
   }
+
+#define RETURN_NEW_AST_NODE(TYPE_NAME, KWARGS_FORMAT, ...)                                                    \
+  PyObject* ret = build_ast_node(TYPE_NAME, KWARGS_FORMAT, __VA_ARGS__);                                      \
+  /* Fortunately we don't need to care about decrementing Py_BuildValue/Py_VaBuildValue args, */              \
+  /* so just throw is enough: https://github.com/python/cpython/blob/a254120f/Python/modsupport.c#L147-L148*/ \
+  if (!ret) throw PyInternalException();                                                                      \
+  return ret
 
 using namespace std;
 
 // PYTHON UTILS (`X_` stands for "extension")
 
-// Extend `list` with `extension`. In-place.
-void X_PyList_Extend(PyObject* list, PyObject* extension) {
+// Extend `list` with `extension` in-place. Return 0 on success, -1 on error.
+int X_PyList_Extend(PyObject* list, PyObject* extension) {
   Py_ssize_t list_size = PyList_Size(list);
+  if (list_size == -1) {
+    return -1;
+  }
   Py_ssize_t extension_size = PyList_Size(extension);
-  PyList_SetSlice(list, list_size, list_size + extension_size, extension);
+  if (extension_size == -1) {
+    return -1;
+  }
+  return PyList_SetSlice(list, list_size, list_size + extension_size, extension);
 }
 
 // Decref all elements of a vector.
@@ -58,7 +76,7 @@ void X_Py_DECREF_ALL(vector<PyObject*> objects) {
   }
 }
 
-// Construct a Python list from a vector of strings. Return value: New reference.
+// Construct a Python list from a vector of strings. Return value: New reference (or NULL on error).
 PyObject* X_PyList_FromStrings(const vector<string>& items) {
   PyObject* list = PyList_New(items.size());
   if (!list) {
@@ -84,50 +102,57 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   const vector<string> RESERVED_KEYWORDS = {"true", "false", "null", "team_id"};
 
   // Build an AST node of the specified type. Return value: New reference.
-  template <typename... Args>
-  PyObject* build_ast_node(const char* type_name, const char* kwargs_format, Args... kwargs_items) {
-    PyObject* node_type = PyObject_GetAttrString(state->ast_module, type_name);
-    if (!node_type) {
-      throw HogQLParsingException("AST node type \"" + string(type_name) + "\" does not exist");
-    }
-    PyObject* args = PyTuple_New(0);
-    PyObject* kwargs = Py_BuildValue(kwargs_format, kwargs_items...);
-    PyObject* result = PyObject_Call(node_type, args, kwargs);
-    Py_DECREF(kwargs);
-    Py_DECREF(args);
-    Py_DECREF(node_type);
-    return result;
+  PyObject* build_ast_node(const char* type_name, const char* kwargs_format, ...) {
+    va_list valist;
+    va_start(valist, kwargs_format);
+    PyObject *node_type = NULL, *args = NULL, *kwargs = NULL, *ast_node = NULL;
+    node_type = PyObject_GetAttrString(state->ast_module, type_name);
+    if (!node_type) goto exit;
+    args = PyTuple_New(0);
+    if (!args) goto exit;
+    kwargs = Py_VaBuildValue(kwargs_format, valist);
+    if (!kwargs) goto exit;
+    ast_node = PyObject_Call(node_type, args, kwargs);
+  exit:
+    va_end(valist);
+    Py_XDECREF(kwargs);
+    Py_XDECREF(args);
+    Py_XDECREF(node_type);
+    return ast_node;
   }
 
   // Return the specified member of the specified enum. Return value: New reference.
-  PyObject* get_ast_enum_member(const char* enum_name, const char* enum_member) {
+  PyObject* get_ast_enum_member(const char* enum_name, const char* enum_member_name) {
     PyObject* enum_type = PyObject_GetAttrString(state->ast_module, enum_name);
-    PyObject* result = PyObject_GetAttrString(enum_type, enum_member);
+    if (!enum_type) {
+      return NULL;
+    }
+    PyObject* enum_member = PyObject_GetAttrString(enum_type, enum_member_name);
     Py_DECREF(enum_type);
-    return result;
+    if (!enum_member) {
+      return NULL;
+    }
+    return enum_member;
   }
 
-  // Return whether the passed object is an instance of the specified AST node type.
-  bool is_ast_node_instance(PyObject* obj, const char* type_name) {
-    PyObject* node_type = PyObject_GetAttrString(state->ast_module, type_name);
-    if (!node_type) {
-      throw HogQLParsingException("AST node type \"" + string(type_name) + "\" does not exist");
-    }
-    bool result = PyObject_IsInstance(obj, node_type);
-    Py_DECREF(node_type);
-    return result;
+#define IS_AST_NODE_INSTANCE_IMPL(HOGQL_MODULE, TYPE_NAME)                               \
+  PyObject* node_type = PyObject_GetAttrString(state->HOGQL_MODULE##_module, TYPE_NAME); \
+  if (!node_type) return -1;                                                             \
+  int ret = PyObject_IsInstance(obj, node_type);                                         \
+  Py_DECREF(node_type);                                                                  \
+  return ret;
+
+  // Return 1 if the passed object is an instance of the specified AST node type, 0 if not, -1 if an error occurred.
+  int is_ast_node_instance(PyObject* obj, const char* type_name) {
+    IS_AST_NODE_INSTANCE_IMPL(ast, type_name)
   }
 
-  // Return whether the passed object is an instance of _any_ AST node type.
-  bool is_ast_node_instance(PyObject* obj) {
-    PyObject* node_type = PyObject_GetAttrString(state->base_module, "AST");
-    if (!node_type) {
-      throw HogQLParsingException("AST base type \"AST\" does not exist");
-    }
-    bool result = PyObject_IsInstance(obj, node_type);
-    Py_DECREF(node_type);
-    return result;
+  // Return 1 if the passed object is an instance of _any_ AST node type, 0 if not, -1 if an error occurred.
+  int is_ast_node_instance(PyObject* obj) {
+    IS_AST_NODE_INSTANCE_IMPL(base, "AST")
   }
+
+#undef IS_AST_NODE_INSTANCE_IMPL
 
  public:
   HogQLParseTreeConverter(parser_state* state) : state(state) {}
@@ -143,7 +168,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     } else {
       auto ctx = dynamic_cast<antlr4::ParserRuleContext*>(tree);
       if (!ctx) {
-        throw HogQLParsingException("Parse tree node is neither a Token nor a ParserRuleContext");
+        throw ParsingException("Parse tree node is neither a Token nor a ParserRuleContext");
       }
       start = ctx->getStart()->getStartIndex();
       stop = ctx->getStop()->getStopIndex();
@@ -152,47 +177,76 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     any node;
     try {
       node = tree->accept(this);
-    } catch (const HogQLSyntaxException& e) {
+    } catch (const SyntaxException& e) {
       if (e.start == 0 && e.end == 0) {  // If start and end are unset, rethrow with the current start and stop
-        throw HogQLSyntaxException(e.what(), start, stop + 1);
+        throw SyntaxException(e.what(), start, stop + 1);
       }
       throw;
     }
     if (node.has_value() && node.type() == typeid(PyObject*)) {
       PyObject* py_node = any_cast<PyObject*>(node);
-      if (py_node && is_ast_node_instance(py_node)) {
-        PyObject* py_start = PyLong_FromSize_t(start);
-        PyObject* py_end = PyLong_FromSize_t(stop + 1);
-        PyObject_SetAttrString(py_node, "start", py_start);
-        PyObject_SetAttrString(py_node, "end", py_end);
-        Py_DECREF(py_start);
-        Py_DECREF(py_end);
+      if (py_node) {
+        int is_ast = is_ast_node_instance(py_node);
+        if (is_ast == -1) {
+          Py_DECREF(py_node);
+          throw PyInternalException();
+        }
+        if (is_ast) {
+          PyObject *py_start = NULL, *py_end = NULL;
+          int err_indicator = 0;
+          py_start = PyLong_FromSize_t(start);
+          if (!py_start) goto error;
+          py_end = PyLong_FromSize_t(stop + 1);
+          if (!py_end) goto error;
+          err_indicator = PyObject_SetAttrString(py_node, "start", py_start);
+          if (err_indicator == -1) goto error;
+          err_indicator = PyObject_SetAttrString(py_node, "end", py_end);
+          if (err_indicator == -1) goto error;
+          goto success;
+        error:
+          Py_XDECREF(py_start);
+          Py_XDECREF(py_end);
+          Py_DECREF(py_node);
+          throw PyInternalException();
+        success:
+          Py_XDECREF(py_start);
+          Py_XDECREF(py_end);
+        }
       }
     }
     return node;
   }
 
-  // This is the only method that should be called from outside the class.
+  // This is the only method that should actually be called from outside the class.
   // Convert the parse tree to an AST node result. If an error has occurred in conversion, handle it gracefully.
   PyObject* visitAsPyObjectFinal(antlr4::tree::ParseTree* tree) {
     try {
       return visitAsPyObject(tree);
     } catch HANDLE_HOGQL_EXCEPTION(SyntaxException) catch HANDLE_HOGQL_EXCEPTION(NotImplementedException
-    ) catch HANDLE_HOGQL_EXCEPTION(ParsingException) catch (const bad_any_cast& e) {
+    ) catch HANDLE_HOGQL_EXCEPTION(ParsingException) catch (const PyInternalException& e) {
+      return NULL;
+    } catch (const bad_any_cast& e) {
       PyObject* error_type = PyObject_GetAttrString(state->errors_module, "ParsingException");
-      PyErr_SetString(error_type, "Parsing failed due to bad type casting");
+      if (error_type) {
+        PyErr_SetString(error_type, "Parsing failed due to bad type casting");
+      }
       return NULL;
     }
   }
 
   PyObject* visitAsPyObject(antlr4::tree::ParseTree* tree) {
-    PyObject* cast_result = any_cast<PyObject*>(visit(tree));
-    if (!cast_result) {
-      throw HogQLParsingException(
-          "Rule resulted in a null PyObject pointer. A Python exception must be set at this point."
+    if (PyErr_Occurred()) {
+      // Exit if an error has occurred in a previous visit - can happen in build_ast_node() calls. We return NULL
+      // instead of throwing an exception, because in this case we want Py_BuildValue/Py_VaBuildValue to complete
+      return NULL;
+    }
+    PyObject* ret = any_cast<PyObject*>(visit(tree));
+    if (!ret) {
+      throw ParsingException(
+          "Rule resulted in a null PyObject pointer. A PyInternalException should have been raised instead."
       );
     }
-    return cast_result;
+    return ret;
   }
 
   PyObject* visitAsPyObjectOrNone(antlr4::tree::ParseTree* tree) {
@@ -204,7 +258,9 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   PyObject* visitAsPyObjectOrEmptyList(antlr4::tree::ParseTree* tree) {
     if (tree == NULL) {
-      return PyList_New(0);
+      PyObject* list = PyList_New(0);
+      if (!list) throw PyInternalException();
+      return list;
     }
     return visitAsPyObject(tree);
   }
@@ -213,23 +269,28 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   // to its parent within vectors
   template <typename T>
   PyObject* visitPyListOfObjects(vector<T> tree) {
-    PyObject* result = PyList_New(tree.size());
-    for (size_t i = 0; i < tree.size(); i++) {
-      PyList_SET_ITEM(result, i, visitAsPyObject(tree[i]));
+    PyObject* ret = PyList_New(tree.size());
+    if (!ret) {
+      throw PyInternalException();
     }
-    return result;
+    for (size_t i = 0; i < tree.size(); i++) {
+      PyList_SET_ITEM(ret, i, visitAsPyObject(tree[i]));
+    }
+    return ret;
   }
 
-  string visitAsString(antlr4::tree::ParseTree* tree) { return any_cast<string>(visit(tree)); }
+  string visitAsString(antlr4::tree::ParseTree* tree) {
+    return any_cast<string>(visit(tree));
+  }
 
   template <typename T>
   vector<string> visitAsVectorOfStrings(vector<T> tree) {
-    vector<string> result;
-    result.reserve(tree.size());
+    vector<string> ret;
+    ret.reserve(tree.size());
     for (auto child : tree) {
-      result.push_back(visitAsString(child));
+      ret.push_back(visitAsString(child));
     }
-    return result;
+    return ret;
   }
 
   VISIT(Select) {
@@ -260,6 +321,8 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   }
 
   VISIT(SelectUnionStmt) {
+    PyObject* flattened_queries = PyList_New(0);
+    if (!flattened_queries) throw PyInternalException();
     // Using a vector of PyObjects atypically here, because this is a precursor of flattened_queries
     vector<PyObject*> select_queries;
     auto select_stmt_with_parens_ctxs = ctx->selectStmtWithParens();
@@ -267,40 +330,61 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     for (auto select_stmt_with_parens_ctx : select_stmt_with_parens_ctxs) {
       select_queries.push_back(visitAsPyObject(select_stmt_with_parens_ctx));
     }
-    PyObject* flattened_queries = PyList_New(0);
     for (auto query : select_queries) {
+      int is_select_query = is_ast_node_instance(query, "SelectQuery");
+      if (is_select_query == -1) goto select_queries_loop_py_error;
       if (is_ast_node_instance(query, "SelectQuery")) {
-        PyList_Append(flattened_queries, query);
+        int append_code = PyList_Append(flattened_queries, query);
+        if (append_code == -1) goto select_queries_loop_py_error;
       } else if (is_ast_node_instance(query, "SelectUnionQuery")) {
         // Extend flattened_queries with sub_select_queries
         PyObject* sub_select_queries = PyObject_GetAttrString(query, "select_queries");
-        X_PyList_Extend(flattened_queries, sub_select_queries);
+        if (!sub_select_queries) goto select_queries_loop_py_error;
+        int extend_code = X_PyList_Extend(flattened_queries, sub_select_queries);
+        if (extend_code == -1) goto select_queries_loop_py_error;
         Py_DECREF(sub_select_queries);
       } else {
         Py_DECREF(flattened_queries);
         X_Py_DECREF_ALL(select_queries);
-        throw HogQLParsingException("Unexpected query node type: " + string(Py_TYPE(query)->tp_name));
+        throw ParsingException("Unexpected query node type: " + string(Py_TYPE(query)->tp_name));
       }
     }
+    goto select_queries_loop_success;
+  select_queries_loop_py_error:
     X_Py_DECREF_ALL(select_queries);
-    if (PyList_Size(flattened_queries) == 1) {
+    Py_DECREF(flattened_queries);
+    throw PyInternalException();
+  select_queries_loop_success:
+    X_Py_DECREF_ALL(select_queries);
+    Py_ssize_t flattened_queries_size = PyList_Size(flattened_queries);
+    if (flattened_queries_size == -1) {
+      Py_DECREF(flattened_queries);
+      throw PyInternalException();
+    }
+    if (flattened_queries_size == 1) {
       PyObject* query = PyList_GET_ITEM(flattened_queries, 0);
       Py_INCREF(query);
       Py_DECREF(flattened_queries);
       return query;
     }
-    return build_ast_node("SelectUnionQuery", "{s:N}", "select_queries", flattened_queries);
+    RETURN_NEW_AST_NODE("SelectUnionQuery", "{s:N}", "select_queries", flattened_queries);
   }
 
   VISIT(SelectStmt) {
+    PyObject* select_from = visitAsPyObjectOrNone(ctx->fromClause());  // This is immediately stolen by select_query
     PyObject* select_query = build_ast_node(
         "SelectQuery", "{s:N,s:N,s:N,s:N,s:N,s:N,s:N,s:N,s:N}", "ctes", visitAsPyObjectOrNone(ctx->withClause()),
         "select", visitAsPyObjectOrEmptyList(ctx->columnExprList()), "distinct",
-        Py_NewRef(ctx->DISTINCT() ? Py_True : Py_None), "select_from", visitAsPyObjectOrNone(ctx->fromClause()),
-        "where", visitAsPyObjectOrNone(ctx->whereClause()), "prewhere", visitAsPyObjectOrNone(ctx->prewhereClause()),
-        "having", visitAsPyObjectOrNone(ctx->havingClause()), "group_by", visitAsPyObjectOrNone(ctx->groupByClause()),
-        "order_by", visitAsPyObjectOrNone(ctx->orderByClause())
+        Py_NewRef(ctx->DISTINCT() ? Py_True : Py_None), "select_from", select_from, "where",
+        visitAsPyObjectOrNone(ctx->whereClause()), "prewhere", visitAsPyObjectOrNone(ctx->prewhereClause()), "having",
+        visitAsPyObjectOrNone(ctx->havingClause()), "group_by", visitAsPyObjectOrNone(ctx->groupByClause()), "order_by",
+        visitAsPyObjectOrNone(ctx->orderByClause())
     );
+    if (!select_query) {
+      throw PyInternalException();
+    }
+
+    int err_indicator = 0;
 
     auto window_clause_ctx = ctx->windowClause();
     if (window_clause_ctx) {
@@ -308,111 +392,181 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       auto identifier_ctxs = window_clause_ctx->identifier();
       if (window_expr_ctxs.size() != identifier_ctxs.size()) {
         Py_DECREF(select_query);
-        throw HogQLParsingException("WindowClause must have a matching number of window exprs and identifiers");
+        throw ParsingException("WindowClause must have a matching number of window exprs and identifiers");
       }
       PyObject* window_exprs = PyDict_New();
+      if (!window_exprs) {
+        Py_DECREF(select_query);
+        throw PyInternalException();
+      }
       for (size_t i = 0; i < window_expr_ctxs.size(); i++) {
         PyObject* window_expr = visitAsPyObject(window_expr_ctxs[i]);
-        PyDict_SetItemString(window_exprs, visitAsString(identifier_ctxs[i]).c_str(), window_expr);
+        err_indicator = PyDict_SetItemString(window_exprs, visitAsString(identifier_ctxs[i]).c_str(), window_expr);
         Py_DECREF(window_expr);
+        if (err_indicator == -1) {
+          Py_DECREF(select_query);
+          Py_DECREF(window_exprs);
+          throw PyInternalException();
+        }
       }
-      PyObject_SetAttrString(select_query, "window_exprs", window_exprs);
+      err_indicator = PyObject_SetAttrString(select_query, "window_exprs", window_exprs);
       Py_DECREF(window_exprs);
+      if (err_indicator == -1) {
+        Py_DECREF(select_query);
+        throw PyInternalException();
+      }
     }
 
     auto limit_and_offset_clause_ctx = ctx->limitAndOffsetClause();
     if (limit_and_offset_clause_ctx) {
       PyObject* limit = visitAsPyObject(limit_and_offset_clause_ctx->columnExpr(0));
-      PyObject_SetAttrString(select_query, "limit", limit);
+      err_indicator = PyObject_SetAttrString(select_query, "limit", limit);
       Py_DECREF(limit);
+      if (err_indicator == -1) {
+        Py_DECREF(select_query);
+        throw PyInternalException();
+      }
       auto offset_ctx = limit_and_offset_clause_ctx->columnExpr(1);
       if (offset_ctx) {
         PyObject* offset = visitAsPyObject(offset_ctx);
-        PyObject_SetAttrString(select_query, "offset", offset);
+        err_indicator = PyObject_SetAttrString(select_query, "offset", offset);
         Py_DECREF(offset);
+        if (err_indicator == -1) {
+          Py_DECREF(select_query);
+          throw PyInternalException();
+        }
       }
       auto limit_by_exprs_ctx = limit_and_offset_clause_ctx->columnExprList();
       if (limit_by_exprs_ctx) {
         PyObject* limit_by_exprs = visitAsPyObject(limit_by_exprs_ctx);
-        PyObject_SetAttrString(select_query, "limit_by", limit_by_exprs);
+        err_indicator = PyObject_SetAttrString(select_query, "limit_by", limit_by_exprs);
         Py_DECREF(limit_by_exprs);
+        if (err_indicator == -1) {
+          Py_DECREF(select_query);
+          throw PyInternalException();
+        }
       }
       if (limit_and_offset_clause_ctx->WITH() && limit_and_offset_clause_ctx->TIES()) {
-        PyObject_SetAttrString(select_query, "limit_with_ties", Py_True);
+        err_indicator = PyObject_SetAttrString(select_query, "limit_with_ties", Py_True);
+        if (err_indicator == -1) {
+          Py_DECREF(select_query);
+          throw PyInternalException();
+        }
       }
     } else {
       auto offset_only_clause_ctx = ctx->offsetOnlyClause();
       if (offset_only_clause_ctx) {
         PyObject* offset_only_clause = visitAsPyObject(offset_only_clause_ctx->columnExpr());
-        PyObject_SetAttrString(select_query, "offset", offset_only_clause);
+        err_indicator = PyObject_SetAttrString(select_query, "offset", offset_only_clause);
         Py_DECREF(offset_only_clause);
+        if (err_indicator == -1) {
+          Py_DECREF(select_query);
+          throw PyInternalException();
+        }
       }
     }
 
     auto array_join_clause_ctx = ctx->arrayJoinClause();
     if (array_join_clause_ctx) {
-      if (Py_IsNone(PyObject_GetAttrString(select_query, "select_from"))) {
+      if (Py_IsNone(select_from)) {
         Py_DECREF(select_query);
-        throw HogQLSyntaxException("Using ARRAY JOIN without a FROM clause is not permitted");
+        throw SyntaxException("Using ARRAY JOIN without a FROM clause is not permitted");
       }
       PyObject* join_op = PyUnicode_FromString(
           array_join_clause_ctx->LEFT()    ? "LEFT ARRAY JOIN"
           : array_join_clause_ctx->INNER() ? "INNER ARRAY JOIN"
                                            : "ARRAY JOIN"
       );
-      PyObject_SetAttrString(select_query, "array_join_op", join_op);
+      if (!join_op) {
+        Py_DECREF(select_query);
+        throw PyInternalException();
+      }
+      err_indicator = PyObject_SetAttrString(select_query, "array_join_op", join_op);
       Py_DECREF(join_op);
+      if (err_indicator == -1) {
+        Py_DECREF(select_query);
+        throw PyInternalException();
+      }
 
       auto array_join_arrays_ctx = array_join_clause_ctx->columnExprList();
       PyObject* array_join_list = visitAsPyObject(array_join_arrays_ctx);
-      for (Py_ssize_t i = 0; i < PyList_Size(array_join_list); i++) {
+      Py_ssize_t array_join_list_size = PyList_Size(array_join_list);
+      if (array_join_list_size == -1) {
+        Py_DECREF(select_query);
+        Py_DECREF(array_join_list);
+        throw PyInternalException();
+      }
+      for (Py_ssize_t i = 0; i < array_join_list_size; i++) {
         PyObject* expr = PyList_GET_ITEM(array_join_list, i);
-        bool is_alias = is_ast_node_instance(expr, "Alias");
+        int is_alias = is_ast_node_instance(expr, "Alias");
+        if (is_alias == -1) {
+          Py_DECREF(array_join_list);
+          Py_DECREF(select_query);
+          throw PyInternalException();
+        }
         if (!is_alias) {
           Py_DECREF(array_join_list);
           Py_DECREF(select_query);
           auto relevant_column_expr_ctx = array_join_arrays_ctx->columnExpr(i);
-          throw HogQLSyntaxException(
+          throw SyntaxException(
               "ARRAY JOIN arrays must have an alias", relevant_column_expr_ctx->getStart()->getStartIndex(),
               relevant_column_expr_ctx->getStop()->getStopIndex() + 1
           );
         }
       }
-      PyObject_SetAttrString(select_query, "array_join_list", array_join_list);
+      err_indicator = PyObject_SetAttrString(select_query, "array_join_list", array_join_list);
       Py_DECREF(array_join_list);
+      if (err_indicator == -1) {
+        Py_DECREF(select_query);
+        throw PyInternalException();
+      }
     }
 
     if (ctx->topClause()) {
       Py_DECREF(select_query);
-      throw HogQLNotImplementedException("Unsupported: SelectStmt.topClause()");
+      throw NotImplementedException("Unsupported: SelectStmt.topClause()");
     }
     if (ctx->settingsClause()) {
       Py_DECREF(select_query);
-      throw HogQLNotImplementedException("Unsupported: SelectStmt.settingsClause()");
+      throw NotImplementedException("Unsupported: SelectStmt.settingsClause()");
     }
 
     return select_query;
   }
 
-  VISIT(WithClause) { return visit(ctx->withExprList()); }
+  VISIT(WithClause) {
+    return visit(ctx->withExprList());
+  }
 
   VISIT_UNSUPPORTED(TopClause)
 
-  VISIT(FromClause) { return visit(ctx->joinExpr()); }
+  VISIT(FromClause) {
+    return visit(ctx->joinExpr());
+  }
 
   VISIT_UNSUPPORTED(ArrayJoinClause)
 
   VISIT_UNSUPPORTED(WindowClause)
 
-  VISIT(PrewhereClause) { return visit(ctx->columnExpr()); }
+  VISIT(PrewhereClause) {
+    return visit(ctx->columnExpr());
+  }
 
-  VISIT(WhereClause) { return visit(ctx->columnExpr()); }
+  VISIT(WhereClause) {
+    return visit(ctx->columnExpr());
+  }
 
-  VISIT(GroupByClause) { return visit(ctx->columnExprList()); }
+  VISIT(GroupByClause) {
+    return visit(ctx->columnExprList());
+  }
 
-  VISIT(HavingClause) { return visit(ctx->columnExpr()); }
+  VISIT(HavingClause) {
+    return visit(ctx->columnExpr());
+  }
 
-  VISIT(OrderByClause) { return visit(ctx->orderExprList()); }
+  VISIT(OrderByClause) {
+    return visit(ctx->orderExprList());
+  }
 
   VISIT_UNSUPPORTED(ProjectionOrderByClause)
 
@@ -420,10 +574,42 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   VISIT_UNSUPPORTED(SettingsClause)
 
-  VISIT(JoinExprOp) {
-    PyObject* join1 = visitAsPyObject(ctx->joinExpr(0));
-    PyObject* join2 = visitAsPyObject(ctx->joinExpr(1));
+#define CONCAT_JOIN_EXPRS()                                                                                      \
+  PyObject* last_join = join1;                                                                                   \
+  PyObject* next_join =                                                                                          \
+      PyObject_GetAttrString(last_join, "next_join"); /* 1500 is Python's recursion limit (C_RECURSION_LIMIT) */ \
+  for (size_t i = 0; i < 1500; i++) { /* We can safely decref, because a reference is anyway held by join1 */    \
+    Py_XDECREF(next_join);                                                                                       \
+    if (!next_join) {                                                                                            \
+      Py_DECREF(join1);                                                                                          \
+      Py_DECREF(join2);                                                                                          \
+      throw PyInternalException();                                                                               \
+    }                                                                                                            \
+    int reached_end_of_chain = Py_IsNone(next_join);                                                             \
+    if (reached_end_of_chain == -1) {                                                                            \
+      Py_DECREF(join1);                                                                                          \
+      Py_DECREF(join2);                                                                                          \
+      throw PyInternalException();                                                                               \
+    }                                                                                                            \
+    if (reached_end_of_chain) {                                                                                  \
+      int err_indicator = PyObject_SetAttrString(last_join, "next_join", join2);                                 \
+      if (err_indicator == -1) {                                                                                 \
+        Py_DECREF(join1);                                                                                        \
+        Py_DECREF(join2);                                                                                        \
+        throw PyInternalException();                                                                             \
+      }                                                                                                          \
+      Py_DECREF(join2);                                                                                          \
+      return join1;                                                                                              \
+    }                                                                                                            \
+    last_join = next_join;                                                                                       \
+    next_join = PyObject_GetAttrString(last_join, "next_join");                                                  \
+  }                                                                                                              \
+  Py_DECREF(join1);                                                                                              \
+  Py_DECREF(join2);                                                                                              \
+  PyErr_SetString(PyExc_RecursionError, "maximum recursion depth exceeded during JOIN parsing");                 \
+  throw PyInternalException(); /* This should never be reached, but `while (true)`s are scary, so better to be safe */
 
+  VISIT(JoinExprOp) {
     auto join_op_ctx = ctx->joinOp();
     PyObject* py_join_op;
     if (join_op_ctx) {
@@ -432,61 +618,89 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     } else {
       py_join_op = PyUnicode_FromString("JOIN");
     }
-    PyObject_SetAttrString(join2, "join_type", py_join_op);
+    if (!py_join_op) throw PyInternalException();
+
+    int err_indicator = 0;
+
+    PyObject* join2 = visitAsPyObject(ctx->joinExpr(1));
+    err_indicator = PyObject_SetAttrString(join2, "join_type", py_join_op);
     Py_DECREF(py_join_op);
-    PyObject* constraint = visitAsPyObject(ctx->joinConstraintClause());
-    PyObject_SetAttrString(join2, "constraint", constraint);
-    Py_DECREF(constraint);
-
-    PyObject* last_join = join1;
-    PyObject* next_join = PyObject_GetAttrString(last_join, "next_join");
-    while (!Py_IsNone(next_join)) {
-      last_join = next_join;
-      Py_DECREF(next_join);
-      next_join = PyObject_GetAttrString(last_join, "next_join");
+    if (err_indicator == -1) {
+      Py_DECREF(join2);
+      throw PyInternalException();
     }
-    Py_DECREF(next_join);
-    PyObject_SetAttrString(last_join, "next_join", join2);
-    Py_DECREF(join2);
+    PyObject* constraint = visitAsPyObject(ctx->joinConstraintClause());
+    err_indicator = PyObject_SetAttrString(join2, "constraint", constraint);
+    Py_DECREF(constraint);
+    if (err_indicator == -1) {
+      Py_DECREF(join2);
+      throw PyInternalException();
+    }
 
-    return join1;
+    PyObject* join1 = visitAsPyObject(ctx->joinExpr(0));
+
+    CONCAT_JOIN_EXPRS()
   }
 
   VISIT(JoinExprTable) {
-    PyObject* sample = visitAsPyObjectOrNone(ctx->sampleClause());
     PyObject* table = visitAsPyObject(ctx->tableExpr());
-    PyObject* table_final = ctx->FINAL() ? Py_True : Py_None;
-    if (is_ast_node_instance(table, "JoinExpr")) {
-      PyObject_SetAttrString(table, "table_final", table_final);
-      PyObject_SetAttrString(table, "sample", sample);
-      Py_DECREF(sample);
-      return table;
+    int is_table_join_expr = is_ast_node_instance(table, "JoinExpr");
+    if (is_table_join_expr == -1) {
+      Py_DECREF(table);
+      throw PyInternalException();
     }
-    return build_ast_node("JoinExpr", "{s:N,s:O,s:N}", "table", table, "table_final", table_final, "sample", sample);
+    PyObject* table_final = ctx->FINAL() ? Py_True : Py_None;
+    PyObject* sample = visitAsPyObjectOrNone(ctx->sampleClause());
+    if (is_table_join_expr) {
+      int err_indicator = 0;
+      err_indicator = PyObject_SetAttrString(table, "sample", sample);
+      Py_DECREF(sample);
+      if (err_indicator == -1) {
+        Py_DECREF(table);
+        throw PyInternalException();
+      }
+      err_indicator = PyObject_SetAttrString(table, "table_final", table_final);
+      if (err_indicator == -1) {
+        Py_DECREF(table);
+        throw PyInternalException();
+      }
+      return table;
+    } else {
+      PyObject* ret =
+          build_ast_node("JoinExpr", "{s:N,s:O,s:N}", "table", table, "table_final", table_final, "sample", sample);
+      if (!ret) {
+        Py_DECREF(table);
+        Py_DECREF(sample);
+        throw PyInternalException();
+      }
+      return ret;
+    }
   }
 
-  VISIT(JoinExprParens) { return visit(ctx->joinExpr()); }
+  VISIT(JoinExprParens) {
+    return visit(ctx->joinExpr());
+  }
 
   VISIT(JoinExprCrossOp) {
-    PyObject* join1 = visitAsPyObject(ctx->joinExpr(0));
-    PyObject* join2 = visitAsPyObject(ctx->joinExpr(1));
     PyObject* join_type = PyUnicode_FromString("CROSS JOIN");
-    PyObject_SetAttrString(join2, "join_type", join_type);
+    if (!join_type) {
+      throw PyInternalException();
+    }
+
+    PyObject* join2 = visitAsPyObject(ctx->joinExpr(1));
+    int err_indicator = PyObject_SetAttrString(join2, "join_type", join_type);
+    if (err_indicator == -1) {
+      Py_DECREF(join2);
+      throw PyInternalException();
+    }
     Py_DECREF(join_type);
 
-    PyObject* last_join = join1;
-    PyObject* next_join = PyObject_GetAttrString(last_join, "next_join");
-    while (!Py_IsNone(next_join)) {
-      last_join = next_join;
-      Py_DECREF(next_join);
-      next_join = PyObject_GetAttrString(last_join, "next_join");
-    }
-    Py_DECREF(next_join);
-    PyObject_SetAttrString(last_join, "next_join", join2);
-    Py_DECREF(join2);
+    PyObject* join1 = visitAsPyObject(ctx->joinExpr(0));
 
-    return join1;
+    CONCAT_JOIN_EXPRS()
   }
+
+#undef CONCAT_JOIN_EXPRS
 
   VISIT(JoinOpInner) {
     vector<string> tokens;
@@ -553,31 +767,38 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   VISIT(JoinConstraintClause) {
     if (ctx->USING()) {
-      throw HogQLNotImplementedException("Unsupported: JOIN ... USING");
+      throw NotImplementedException("Unsupported: JOIN ... USING");
     }
     PyObject* column_expr_list = visitAsPyObject(ctx->columnExprList());
-    if (PyList_Size(column_expr_list) != 1) {
+    Py_ssize_t column_expr_list_size = PyList_Size(column_expr_list);
+    if (column_expr_list_size == -1) {
       Py_DECREF(column_expr_list);
-      throw HogQLNotImplementedException("Unsupported: JOIN ... ON with multiple expressions");
+      throw PyInternalException();
+    }
+    if (column_expr_list_size > 1) {
+      Py_DECREF(column_expr_list);
+      throw NotImplementedException("Unsupported: JOIN ... ON with multiple expressions");
     }
     PyObject* expr = Py_NewRef(PyList_GET_ITEM(column_expr_list, 0));
     Py_DECREF(column_expr_list);
-    return build_ast_node("JoinConstraint", "{s:N}", "expr", expr);
+    RETURN_NEW_AST_NODE("JoinConstraint", "{s:N}", "expr", expr);
   }
 
   VISIT(SampleClause) {
     PyObject* sample_ratio_expr = visitAsPyObject(ctx->ratioExpr(0));
     PyObject* offset_ratio_expr = ctx->OFFSET() ? visitAsPyObjectOrNone(ctx->ratioExpr(1)) : Py_NewRef(Py_None);
-    return build_ast_node(
+    RETURN_NEW_AST_NODE(
         "SampleExpr", "{s:N,s:N}", "sample_value", sample_ratio_expr, "offset_value", offset_ratio_expr
     );
   }
 
-  VISIT(OrderExprList) { return visitPyListOfObjects(ctx->orderExpr()); }
+  VISIT(OrderExprList) {
+    return visitPyListOfObjects(ctx->orderExpr());
+  }
 
   VISIT(OrderExpr) {
     const char* order = ctx->DESC() || ctx->DESCENDING() ? "DESC" : "ASC";
-    return build_ast_node("OrderExpr", "{s:N,s:s}", "expr", visitAsPyObject(ctx->columnExpr()), "order", order);
+    RETURN_NEW_AST_NODE("OrderExpr", "{s:N,s:s}", "expr", visitAsPyObject(ctx->columnExpr()), "order", order);
   }
 
   VISIT(RatioExpr) {
@@ -589,15 +810,15 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     auto number_literal_ctxs = ctx->numberLiteral();
 
     if (number_literal_ctxs.size() > 2) {
-      throw HogQLParsingException("RatioExpr must have at most two number literals");
+      throw ParsingException("RatioExpr must have at most two number literals");
     } else if (number_literal_ctxs.size() == 0) {
-      throw HogQLParsingException("RatioExpr must have at least one number literal");
+      throw ParsingException("RatioExpr must have at least one number literal");
     }
 
     auto left_ctx = number_literal_ctxs[0];
     auto right_ctx = ctx->SLASH() && number_literal_ctxs.size() > 1 ? number_literal_ctxs[1] : NULL;
 
-    return build_ast_node(
+    RETURN_NEW_AST_NODE(
         "RatioExpr", "{s:N,s:N}", "left", visitAsPyObject(left_ctx), "right", visitAsPyObjectOrNone(right_ctx)
     );
   }
@@ -609,27 +830,56 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   VISIT(WindowExpr) {
     auto frame_ctx = ctx->winFrameClause();
     PyObject* frame = visitAsPyObjectOrNone(frame_ctx);
-    PyObject* frame_start = Py_NewRef(PyTuple_Check(frame) ? PyTuple_GetItem(frame, 0) : frame);
-    PyObject* frame_end = Py_NewRef(PyTuple_Check(frame) ? PyTuple_GetItem(frame, 1) : Py_None);
+    int is_frame_a_tuple = PyTuple_Check(frame);
+    if (is_frame_a_tuple == -1) {
+      Py_DECREF(frame);
+      throw PyInternalException();
+    }
+    if (is_frame_a_tuple) {
+      Py_ssize_t frame_tuple_size = PyTuple_Size(frame);
+      if (frame_tuple_size == -1) {
+        Py_DECREF(frame);
+        throw PyInternalException();
+      }
+      if (frame_tuple_size != 2) {
+        Py_DECREF(frame);
+        throw ParsingException("WindowExpr frame must be a tuple of size 2");
+      }
+    }
+    PyObject* frame_start = Py_NewRef(is_frame_a_tuple ? PyTuple_GET_ITEM(frame, 0) : frame);
+    PyObject* frame_end = Py_NewRef(is_frame_a_tuple ? PyTuple_GET_ITEM(frame, 1) : Py_None);
     Py_DECREF(frame);
-    PyObject* partition_by = visitAsPyObjectOrNone(ctx->winPartitionByClause());
-    PyObject* order_by = visitAsPyObjectOrNone(ctx->winOrderByClause());
     PyObject* frame_method = frame_ctx && frame_ctx->RANGE()  ? PyUnicode_FromString("RANGE")
                              : frame_ctx && frame_ctx->ROWS() ? PyUnicode_FromString("ROWS")
                                                               : Py_NewRef(Py_None);
-    return build_ast_node(
+    if (!frame_method) {
+      Py_DECREF(frame_start);
+      Py_DECREF(frame_end);
+      throw PyInternalException();
+    }
+    PyObject* partition_by = visitAsPyObjectOrNone(ctx->winPartitionByClause());
+    PyObject* order_by = visitAsPyObjectOrNone(ctx->winOrderByClause());
+    RETURN_NEW_AST_NODE(
         "WindowExpr", "{s:N,s:N,s:N,s:N,s:N}", "partition_by", partition_by, "order_by", order_by, "frame_method",
         frame_method, "frame_start", frame_start, "frame_end", frame_end
     );
   }
 
-  VISIT(WinPartitionByClause) { return visit(ctx->columnExprList()); }
+  VISIT(WinPartitionByClause) {
+    return visit(ctx->columnExprList());
+  }
 
-  VISIT(WinOrderByClause) { return visit(ctx->orderExprList()); }
+  VISIT(WinOrderByClause) {
+    return visit(ctx->orderExprList());
+  }
 
-  VISIT(WinFrameClause) { return visit(ctx->winFrameExtend()); }
+  VISIT(WinFrameClause) {
+    return visit(ctx->winFrameExtend());
+  }
 
-  VISIT(FrameStart) { return visit(ctx->winFrameBound()); }
+  VISIT(FrameStart) {
+    return visit(ctx->winFrameBound());
+  }
 
   VISIT(FrameBetween) {
     return Py_BuildValue("NN", visitAsPyObject(ctx->winFrameBound(0)), visitAsPyObject(ctx->winFrameBound(1)));
@@ -642,19 +892,22 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
         PyObject* constant = visitAsPyObject(ctx->numberLiteral());
         number = PyObject_GetAttrString(constant, "value");
         Py_DECREF(constant);
+        if (!number) throw PyInternalException();
       } else {
         number = Py_NewRef(Py_None);
       }
-      return build_ast_node(
+      RETURN_NEW_AST_NODE(
           "WindowFrameExpr", "{s:s,s:N}", "frame_type", ctx->PRECEDING() ? "PRECEDING" : "FOLLOWING", "frame_value",
           number
       );
     } else {
-      return build_ast_node("WindowFrameExpr", "{s:s}", "frame_type", "CURRENT ROW");
+      RETURN_NEW_AST_NODE("WindowFrameExpr", "{s:s}", "frame_type", "CURRENT ROW");
     }
   }
 
-  VISIT(Expr) { return visit(ctx->columnExpr()); }
+  VISIT(Expr) {
+    return visit(ctx->columnExpr());
+  }
 
   VISIT_UNSUPPORTED(ColumnTypeExprSimple)
 
@@ -666,10 +919,12 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   VISIT_UNSUPPORTED(ColumnTypeExprParam)
 
-  VISIT(ColumnExprList) { return visitPyListOfObjects(ctx->columnExpr()); }
+  VISIT(ColumnExprList) {
+    return visitPyListOfObjects(ctx->columnExpr());
+  }
 
   VISIT(ColumnExprTernaryOp) {
-    return build_ast_node(
+    RETURN_NEW_AST_NODE(
         "Call", "{s:s, s:[NNN]}", "name", "if", "args", visitAsPyObject(ctx->columnExpr(0)),
         visitAsPyObject(ctx->columnExpr(1)), visitAsPyObject(ctx->columnExpr(2))
     );
@@ -684,34 +939,40 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     } else if (ctx->STRING_LITERAL()) {
       alias = unquote_string_terminal(ctx->STRING_LITERAL());
     } else {
-      throw HogQLParsingException("A ColumnExprAlias must have the alias in some form");
+      throw ParsingException("A ColumnExprAlias must have the alias in some form");
     }
     PyObject* expr = visitAsPyObject(ctx->columnExpr());
 
     if (find(RESERVED_KEYWORDS.begin(), RESERVED_KEYWORDS.end(), boost::algorithm::to_lower_copy(alias)) !=
         RESERVED_KEYWORDS.end()) {
       Py_DECREF(expr);
-      throw HogQLSyntaxException("\"" + alias + "\" cannot be an alias or identifier, as it's a reserved keyword");
+      throw SyntaxException("\"" + alias + "\" cannot be an alias or identifier, as it's a reserved keyword");
     }
 
-    return build_ast_node("Alias", "{s:N,s:s#}", "expr", expr, "alias", alias.data(), alias.size());
+    RETURN_NEW_AST_NODE("Alias", "{s:N,s:s#}", "expr", expr, "alias", alias.data(), alias.size());
   }
 
   VISIT_UNSUPPORTED(ColumnExprExtract)
 
   VISIT(ColumnExprNegate) {
-    return build_ast_node(
-        "ArithmeticOperation", "{s:N,s:N,s:N}", "left", build_ast_node("Constant", "{s:i}", "value", 0), "right",
-        visitAsPyObject(ctx->columnExpr()), "op", get_ast_enum_member("ArithmeticOperationOp", "Sub")
+    PyObject* left = build_ast_node("Constant", "{s:i}", "value", 0);
+    if (!left) throw PyInternalException();
+    PyObject* op = get_ast_enum_member("ArithmeticOperationOp", "Sub");
+    if (!op) {
+      Py_DECREF(left);
+      throw PyInternalException();
+    }
+    RETURN_NEW_AST_NODE(
+        "ArithmeticOperation", "{s:N,s:N,s:N}", "left", left, "right", visitAsPyObject(ctx->columnExpr()), "op", op
     );
   }
 
-  VISIT(ColumnExprSubquery) { return visit(ctx->selectUnionStmt()); }
+  VISIT(ColumnExprSubquery) {
+    return visit(ctx->selectUnionStmt());
+  }
 
   VISIT(ColumnExprArray) {
-    auto column_expr_list_ctx = ctx->columnExprList();
-    PyObject* exprs = visitAsPyObjectOrEmptyList(column_expr_list_ctx);
-    return build_ast_node("Array", "{s:N}", "exprs", exprs);
+    RETURN_NEW_AST_NODE("Array", "{s:N}", "exprs", visitAsPyObjectOrEmptyList(ctx->columnExprList()));
   }
 
   VISIT_UNSUPPORTED(ColumnExprSubstring)
@@ -727,11 +988,12 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     } else if (ctx->PERCENT()) {
       op = get_ast_enum_member("ArithmeticOperationOp", "Mod");
     } else {
-      throw HogQLParsingException("Unsupported value of rule ColumnExprPrecedence1");
+      throw ParsingException("Unsupported value of rule ColumnExprPrecedence1");
     }
+    if (!op) throw PyInternalException();
     PyObject* left = visitAsPyObject(ctx->left);
     PyObject* right = visitAsPyObject(ctx->right);
-    return build_ast_node("ArithmeticOperation", "{s:N,s:N,s:N}", "left", left, "right", right, "op", op);
+    RETURN_NEW_AST_NODE("ArithmeticOperation", "{s:N,s:N,s:N}", "left", left, "right", right, "op", op);
   }
 
   VISIT(ColumnExprPrecedence2) {
@@ -739,39 +1001,106 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     PyObject* right = visitAsPyObject(ctx->right);
 
     if (ctx->PLUS()) {
-      return build_ast_node(
-          "ArithmeticOperation", "{s:N,s:N,s:N}", "left", left, "right", right, "op",
-          get_ast_enum_member("ArithmeticOperationOp", "Add")
-      );
-    } else if (ctx->DASH()) {
-      return build_ast_node(
-          "ArithmeticOperation", "{s:N,s:N,s:N}", "left", left, "right", right, "op",
-          get_ast_enum_member("ArithmeticOperationOp", "Sub")
-      );
-    } else if (ctx->CONCAT()) {
-      PyObject* args;
-      if (is_ast_node_instance(left, "Call") &&
-          PyObject_RichCompareBool(PyObject_GetAttrString(left, "name"), PyUnicode_FromString("concat"), Py_EQ)) {
-        args = PyObject_GetAttrString(left, "args");
-      } else {
-        args = Py_BuildValue("[O]", left);
+      PyObject* op = get_ast_enum_member("ArithmeticOperationOp", "Add");
+      if (!op) {
+        Py_DECREF(left);
+        Py_DECREF(right);
+        throw PyInternalException();
       }
+      RETURN_NEW_AST_NODE("ArithmeticOperation", "{s:N,s:N,s:N}", "left", left, "right", right, "op", op);
+    } else if (ctx->DASH()) {
+      PyObject* op = get_ast_enum_member("ArithmeticOperationOp", "Sub");
+      if (!op) {
+        Py_DECREF(left);
+        Py_DECREF(right);
+        throw PyInternalException();
+      }
+      RETURN_NEW_AST_NODE("ArithmeticOperation", "{s:N,s:N,s:N}", "left", left, "right", right, "op", op);
+    } else if (ctx->CONCAT()) {
+#define IS_NODE_A_CONCAT_CALL(VAR)                                                               \
+  int is_##VAR##_a_concat_call = false;                                                          \
+  int is_##VAR##_a_call = is_ast_node_instance(VAR, "Call");                                     \
+  if (is_##VAR##_a_call == -1) {                                                                 \
+    Py_DECREF(left);                                                                             \
+    Py_DECREF(right);                                                                            \
+    throw PyInternalException();                                                                 \
+  }                                                                                              \
+  if (is_##VAR##_a_call) {                                                                       \
+    PyObject* VAR##_name = PyObject_GetAttrString(VAR, "name");                                  \
+    if (!VAR##_name) {                                                                           \
+      Py_DECREF(left);                                                                           \
+      Py_DECREF(right);                                                                          \
+      Py_DECREF(concat_as_str);                                                                  \
+      throw PyInternalException();                                                               \
+    }                                                                                            \
+    PyObject* VAR##_name_lower = PyObject_CallMethod(VAR##_name, "lower", NULL);                 \
+    Py_DECREF(VAR##_name);                                                                       \
+    if (!VAR##_name_lower) {                                                                     \
+      Py_DECREF(left);                                                                           \
+      Py_DECREF(right);                                                                          \
+      Py_DECREF(concat_as_str);                                                                  \
+      throw PyInternalException();                                                               \
+    }                                                                                            \
+    is_##VAR##_a_concat_call = PyObject_RichCompareBool(VAR##_name_lower, concat_as_str, Py_EQ); \
+    Py_DECREF(VAR##_name_lower);                                                                 \
+    if (is_##VAR##_a_concat_call == -1) {                                                        \
+      Py_DECREF(left);                                                                           \
+      Py_DECREF(right);                                                                          \
+      Py_DECREF(concat_as_str);                                                                  \
+      throw PyInternalException();                                                               \
+    }                                                                                            \
+  }
 
-      if (is_ast_node_instance(right, "Call") &&
-          PyObject_RichCompareBool(PyObject_GetAttrString(right, "name"), PyUnicode_FromString("concat"), Py_EQ)) {
+      PyObject* concat_as_str = PyUnicode_FromString("concat");
+      if (!concat_as_str) {
+        Py_DECREF(left);
+        Py_DECREF(right);
+        throw PyInternalException();
+      }
+      IS_NODE_A_CONCAT_CALL(left);
+      IS_NODE_A_CONCAT_CALL(right);
+      Py_DECREF(concat_as_str);
+
+#undef IS_NODE_A_CONCAT_CALL
+
+      PyObject* args = is_left_a_concat_call ? PyObject_GetAttrString(left, "args") : Py_BuildValue("[O]", left);
+      if (!args) {
+        Py_DECREF(left);
+        Py_DECREF(right);
+        throw PyInternalException();
+      }
+      if (is_right_a_concat_call) {
         PyObject* right_args = PyObject_GetAttrString(right, "args");
-        X_PyList_Extend(args, right_args);
+        if (!right_args) {
+          Py_DECREF(args);
+          Py_DECREF(left);
+          Py_DECREF(right);
+          throw PyInternalException();
+        }
+        int err_indicator = X_PyList_Extend(args, right_args);
         Py_DECREF(right_args);
+        if (err_indicator == -1) {
+          Py_DECREF(args);
+          Py_DECREF(left);
+          Py_DECREF(right);
+          throw PyInternalException();
+        }
       } else {
-        PyList_Append(args, right);
+        int err_indicator = PyList_Append(args, right);
+        if (err_indicator == -1) {
+          Py_DECREF(args);
+          Py_DECREF(left);
+          Py_DECREF(right);
+          throw PyInternalException();
+        }
       }
       Py_DECREF(right);
       Py_DECREF(left);
-      return build_ast_node("Call", "{s:s,s:N}", "name", "concat", "args", args);
+      RETURN_NEW_AST_NODE("Call", "{s:s,s:N}", "name", "concat", "args", args);
     } else {
       Py_DECREF(right);
       Py_DECREF(left);
-      throw HogQLParsingException("Unsupported value of rule ColumnExprPrecedence2");
+      throw ParsingException("Unsupported value of rule ColumnExprPrecedence2");
     }
   }
 
@@ -824,13 +1153,14 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
         }
       }
     } else {
-      throw HogQLParsingException("Unsupported value of rule ColumnExprPrecedence3");
+      throw ParsingException("Unsupported value of rule ColumnExprPrecedence3");
     }
+    if (!op) throw PyInternalException();
 
     PyObject* left = visitAsPyObject(ctx->left);
     PyObject* right = visitAsPyObject(ctx->right);
 
-    return build_ast_node("CompareOperation", "{s:N,s:N,s:N}", "left", left, "right", right, "op", op);
+    RETURN_NEW_AST_NODE("CompareOperation", "{s:N,s:N,s:N}", "left", left, "right", right, "op", op);
   }
 
   VISIT(ColumnExprInterval) {
@@ -853,107 +1183,183 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     } else if (interval_ctx->YEAR()) {
       name = "toIntervalYear";
     } else {
-      throw HogQLParsingException("Unsupported value of rule ColumnExprInterval");
+      throw ParsingException("Unsupported value of rule ColumnExprInterval");
     }
 
     PyObject* arg = visitAsPyObject(ctx->columnExpr());
-    return build_ast_node("Call", "{s:s,s:[N]}", "name", name, "args", arg);
+    RETURN_NEW_AST_NODE("Call", "{s:s,s:[N]}", "name", name, "args", arg);
   }
 
   VISIT(ColumnExprIsNull) {
-    return build_ast_node(
-        "CompareOperation", "{s:N,s:N,s:N}", "left", visitAsPyObject(ctx->columnExpr()), "right",
-        build_ast_node("Constant", "{s:O}", "value", Py_None), "op",
-        get_ast_enum_member("CompareOperationOp", ctx->NOT() ? "NotEq" : "Eq")
-
+    PyObject* null_constant = build_ast_node("Constant", "{s:O}", "value", Py_None);
+    if (!null_constant) throw PyInternalException();
+    PyObject* op = get_ast_enum_member("CompareOperationOp", ctx->NOT() ? "NotEq" : "Eq");
+    if (!op) {
+      Py_DECREF(null_constant);
+      throw PyInternalException();
+    }
+    RETURN_NEW_AST_NODE(
+        "CompareOperation", "{s:N,s:N,s:N}", "left", visitAsPyObject(ctx->columnExpr()), "right", null_constant, "op",
+        op
     );
   }
 
   VISIT_UNSUPPORTED(ColumnExprTrim)
 
   VISIT(ColumnExprTuple) {
-    auto column_expr_list_ctx = ctx->columnExprList();
-    return build_ast_node("Tuple", "{s:N}", "exprs", visitAsPyObjectOrEmptyList(column_expr_list_ctx));
+    RETURN_NEW_AST_NODE("Tuple", "{s:N}", "exprs", visitAsPyObjectOrEmptyList(ctx->columnExprList()));
   }
 
   VISIT(ColumnExprArrayAccess) {
-    PyObject* object = visitAsPyObject(ctx->columnExpr(0));
     PyObject* property = visitAsPyObject(ctx->columnExpr(1));
-    if (is_ast_node_instance(property, "Constant") &&
-        PyObject_RichCompareBool(PyObject_GetAttrString(property, "value"), PyLong_FromLong(0), Py_EQ)) {
+    int is_property_a_constant = is_ast_node_instance(property, "Constant");
+    if (is_property_a_constant == -1) {
       Py_DECREF(property);
-      Py_DECREF(object);
-      throw HogQLSyntaxException("SQL indexes start from one, not from zero. E.g: array[1]");
+      throw PyInternalException();
     }
-    return build_ast_node("ArrayAccess", "{s:N,s:N}", "array", object, "property", property);
+    if (is_property_a_constant) {
+      PyObject* property_value = PyObject_GetAttrString(property, "value");
+      if (!property_value) {
+        Py_DECREF(property);
+        throw PyInternalException();
+      }
+      PyObject* zero = PyLong_FromLong(0);
+      if (!zero) {
+        Py_DECREF(property_value);
+        Py_DECREF(property);
+        throw PyInternalException();
+      }
+      int is_property_zero = PyObject_RichCompareBool(property_value, zero, Py_EQ);
+      if (is_property_zero == -1) {
+        Py_DECREF(zero);
+        Py_DECREF(property_value);
+        Py_DECREF(property);
+        throw PyInternalException();
+      }
+      if (is_property_zero) {
+        Py_DECREF(zero);
+        Py_DECREF(property_value);
+        Py_DECREF(property);
+        throw SyntaxException("SQL indexes start from one, not from zero. E.g: array[1]");
+      }
+    }
+    PyObject* object = visitAsPyObject(ctx->columnExpr(0));
+    RETURN_NEW_AST_NODE("ArrayAccess", "{s:N,s:N}", "array", object, "property", property);
   }
 
   VISIT(ColumnExprPropertyAccess) {
-    PyObject* object = visitAsPyObject(ctx->columnExpr());
     string identifier = visitAsString(ctx->identifier());
     PyObject* property = build_ast_node("Constant", "{s:s#}", "value", identifier.data(), identifier.size());
-    return build_ast_node("ArrayAccess", "{s:N,s:N}", "array", object, "property", property);
+    if (!property) {
+      throw PyInternalException();
+    }
+    PyObject* object = visitAsPyObject(ctx->columnExpr());
+    RETURN_NEW_AST_NODE("ArrayAccess", "{s:N,s:N}", "array", object, "property", property);
   }
 
   VISIT_UNSUPPORTED(ColumnExprBetween)
 
-  VISIT(ColumnExprParens) { return visit(ctx->columnExpr()); }
+  VISIT(ColumnExprParens) {
+    return visit(ctx->columnExpr());
+  }
 
   VISIT_UNSUPPORTED(ColumnExprTimestamp)
 
   VISIT(ColumnExprAnd) {
     PyObject* left = visitAsPyObject(ctx->columnExpr(0));
     PyObject* right = visitAsPyObject(ctx->columnExpr(1));
-    PyObject* exprs;
-    if (is_ast_node_instance(left, "And")) {
-      exprs = PyObject_GetAttrString(left, "exprs");
-    } else {
-      exprs = Py_BuildValue("[O]", left);
+
+    int is_left_an_and = is_ast_node_instance(left, "And");
+    if (is_left_an_and == -1) {
+      Py_DECREF(left);
+      Py_DECREF(right);
+      throw PyInternalException();
     }
-    if (is_ast_node_instance(right, "And")) {
+    PyObject* exprs = is_left_an_and ? PyObject_GetAttrString(left, "exprs") : Py_BuildValue("[O]", left);
+
+    int is_right_an_and = is_ast_node_instance(right, "And");
+    if (is_right_an_and == -1) goto right_check_error;
+    if (is_right_an_and) {
       PyObject* right_exprs = PyObject_GetAttrString(right, "exprs");
-      X_PyList_Extend(exprs, right_exprs);
+      if (!right_exprs) goto right_check_error;
+      int err_indicator = X_PyList_Extend(exprs, right_exprs);
       Py_DECREF(right_exprs);
+      if (err_indicator == -1) goto right_check_error;
     } else {
-      PyList_Append(exprs, right);
+      int err_indicator = PyList_Append(exprs, right);
+      if (err_indicator == -1) goto right_check_error;
     }
+    goto right_check_success;
+  right_check_error:
+    Py_DECREF(exprs);
+    Py_DECREF(left);
+    Py_DECREF(right);
+    throw PyInternalException();
+  right_check_success:
     Py_DECREF(right);
     Py_DECREF(left);
 
-    return build_ast_node("And", "{s:N}", "exprs", exprs);
+    RETURN_NEW_AST_NODE("And", "{s:N}", "exprs", exprs);
   }
 
   VISIT(ColumnExprOr) {
     PyObject* left = visitAsPyObject(ctx->columnExpr(0));
     PyObject* right = visitAsPyObject(ctx->columnExpr(1));
-    PyObject* exprs;
-    if (is_ast_node_instance(left, "Or")) {
-      exprs = PyObject_GetAttrString(left, "exprs");
-    } else {
-      exprs = Py_BuildValue("[O]", left);
+
+    int is_left_an_or = is_ast_node_instance(left, "Or");
+    if (is_left_an_or == -1) {
+      Py_DECREF(left);
+      Py_DECREF(right);
+      throw PyInternalException();
     }
-    if (is_ast_node_instance(right, "Or")) {
+    PyObject* exprs = is_left_an_or ? PyObject_GetAttrString(left, "exprs") : Py_BuildValue("[O]", left);
+
+    int is_right_an_or = is_ast_node_instance(right, "Or");
+    if (is_right_an_or == -1) goto right_check_error;
+    if (is_right_an_or) {
       PyObject* right_exprs = PyObject_GetAttrString(right, "exprs");
-      X_PyList_Extend(exprs, right_exprs);
+      if (!right_exprs) goto right_check_error;
+      int err_indicator = X_PyList_Extend(exprs, right_exprs);
+      if (err_indicator == -1) goto right_check_error;
       Py_DECREF(right_exprs);
     } else {
-      PyList_Append(exprs, right);
+      int err_indicator = PyList_Append(exprs, right);
+      if (err_indicator == -1) goto right_check_error;
     }
+    goto right_check_success;
+  right_check_error:
+    Py_DECREF(exprs);
+    Py_DECREF(left);
+    Py_DECREF(right);
+    throw PyInternalException();
+  right_check_success:
     Py_DECREF(right);
     Py_DECREF(left);
 
-    return build_ast_node("Or", "{s:N}", "exprs", exprs);
+    RETURN_NEW_AST_NODE("Or", "{s:N}", "exprs", exprs);
   }
 
   VISIT(ColumnExprTupleAccess) {
-    PyObject* tuple = visitAsPyObject(ctx->columnExpr());
     PyObject* index = PyLong_FromString(ctx->DECIMAL_LITERAL()->getText().c_str(), NULL, 10);
-    if (PyObject_RichCompareBool(index, PyLong_FromLong(0), Py_EQ)) {
+    if (!index) throw PyInternalException();
+    PyObject* zero = PyLong_FromLong(0);
+    if (!zero) {
       Py_DECREF(index);
-      Py_DECREF(tuple);
-      throw HogQLSyntaxException("SQL indexes start from one, not from zero. E.g: array[1]");
+      throw PyInternalException();
     }
-    return build_ast_node("TupleAccess", "{s:N,s:N}", "tuple", tuple, "index", index);
+    int is_index_zero = PyObject_RichCompareBool(index, zero, Py_EQ);
+    if (is_index_zero == -1) {
+      Py_DECREF(zero);
+      Py_DECREF(index);
+      throw PyInternalException();
+    }
+    if (is_index_zero) {
+      Py_DECREF(zero);
+      Py_DECREF(index);
+      throw SyntaxException("SQL indexes start from one, not from zero. E.g: array[1]");
+    }
+    PyObject* tuple = visitAsPyObject(ctx->columnExpr());
+    RETURN_NEW_AST_NODE("TupleAccess", "{s:N,s:N}", "tuple", tuple, "index", index);
   }
 
   VISIT(ColumnExprCase) {
@@ -961,37 +1367,59 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     size_t columns_size = column_expr_ctx.size();
     PyObject* columns = visitPyListOfObjects(column_expr_ctx);
     if (ctx->caseExpr) {
-      PyObject* arg_0 = PyList_GetItem(columns, 0);
-      PyObject* arg_1 = build_ast_node("Array", "{s:[]}", "exprs");
-      PyObject* arg_2 = build_ast_node("Array", "{s:[]}", "exprs");
-      PyObject* arg_3 = PyList_GetItem(columns, columns_size - 1);
-      PyObject* args = Py_BuildValue("[ONNO]", arg_0, arg_1, arg_2, arg_3);
-      PyObject* temp_expr_lists[2] = {PyObject_GetAttrString(arg_1, "exprs"), PyObject_GetAttrString(arg_2, "exprs")};
+      PyObject *arg_0 = NULL, *arg_1 = NULL, *arg_2 = NULL, *arg_3 = NULL, *args = NULL;
+      PyObject* temp_expr_lists[2] = {NULL, NULL};
+      arg_0 = PyList_GET_ITEM(columns, 0);
+      arg_1 = build_ast_node("Array", "{s:[]}", "exprs");
+      if (!arg_1) goto error;
+      arg_2 = build_ast_node("Array", "{s:[]}", "exprs");
+      if (!arg_2) goto error;
+      arg_3 = PyList_GET_ITEM(columns, columns_size - 1);
+      args = Py_BuildValue("[ONNO]", arg_0, arg_1, arg_2, arg_3);
+      if (!args) goto error;
+      temp_expr_lists[0] = PyObject_GetAttrString(arg_1, "exprs");
+      if (!temp_expr_lists[0]) goto error;
+      temp_expr_lists[1] = PyObject_GetAttrString(arg_2, "exprs");
+      if (!temp_expr_lists[1]) goto error;
       for (size_t index = 1; index < columns_size - 1; index++) {
-        PyList_Append(temp_expr_lists[(index - 1) % 2], PyList_GetItem(columns, index));
+        PyObject* item = PyList_GetItem(columns, index);
+        if (!item) goto error;
+        int err_indicator = PyList_Append(temp_expr_lists[(index - 1) % 2], item);
+        if (err_indicator == -1) goto error;
       }
-      Py_DECREF(temp_expr_lists[0]);
       Py_DECREF(temp_expr_lists[1]);
+      Py_DECREF(temp_expr_lists[0]);
       Py_DECREF(columns);
-      return build_ast_node("Call", "{s:s,s:N}", "name", "transform", "args", args);
+      goto success;
+    error:
+      Py_XDECREF(temp_expr_lists[1]);
+      Py_XDECREF(temp_expr_lists[0]);
+      Py_XDECREF(args);
+      Py_XDECREF(arg_2);
+      Py_XDECREF(arg_1);
+      Py_XDECREF(columns);
+      throw PyInternalException();
+    success:
+      RETURN_NEW_AST_NODE("Call", "{s:s,s:N}", "name", "transform", "args", args);
     } else {
-      return build_ast_node("Call", "{s:s,s:N}", "name", columns_size == 3 ? "if" : "multiIf", "args", columns);
+      RETURN_NEW_AST_NODE("Call", "{s:s,s:N}", "name", columns_size == 3 ? "if" : "multiIf", "args", columns);
     }
   }
 
   VISIT_UNSUPPORTED(ColumnExprDate)
 
-  VISIT(ColumnExprNot) { return build_ast_node("Not", "{s:N}", "expr", visitAsPyObject(ctx->columnExpr())); }
+  VISIT(ColumnExprNot) {
+    RETURN_NEW_AST_NODE("Not", "{s:N}", "expr", visitAsPyObject(ctx->columnExpr()));
+  }
 
   VISIT(ColumnExprWinFunctionTarget) {
     auto column_expr_list_ctx = ctx->columnExprList();
     string name = visitAsString(ctx->identifier(0));
     string over_identifier = visitAsString(ctx->identifier(1));
     PyObject* args = visitAsPyObjectOrEmptyList(column_expr_list_ctx);
-    return build_ast_node(
+    RETURN_NEW_AST_NODE(
         "WindowFunction", "{s:s#,s:N,s:s#}", "name", name.data(), name.size(), "args", args, "over_identifier",
         over_identifier.data(), over_identifier.size()
-
     );
   }
 
@@ -1000,17 +1428,19 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     auto column_expr_list_ctx = ctx->columnExprList();
     PyObject* args = visitAsPyObjectOrEmptyList(column_expr_list_ctx);
     PyObject* over_expr = visitAsPyObjectOrNone(ctx->windowExpr());
-    return build_ast_node(
+    RETURN_NEW_AST_NODE(
         "WindowFunction", "{s:s#,s:N,s:N}", "name", identifier.data(), identifier.size(), "args", args, "over_expr",
         over_expr
     );
   }
 
-  VISIT(ColumnExprIdentifier) { return visit(ctx->columnIdentifier()); }
+  VISIT(ColumnExprIdentifier) {
+    return visit(ctx->columnIdentifier());
+  }
 
   VISIT(ColumnExprFunction) {
     string name = visitAsString(ctx->identifier());
-    return build_ast_node(
+    RETURN_NEW_AST_NODE(
         "Call", "{s:s#,s:N,s:N,s:O}", "name", name.data(), name.size(), "params",
         visitAsPyObjectOrNone(ctx->columnExprList()), "args", visitAsPyObjectOrEmptyList(ctx->columnArgList()),
         "distinct", ctx->DISTINCT() ? Py_True : Py_False
@@ -1022,9 +1452,9 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     if (table_identifier_ctx) {
       vector<string> table = any_cast<vector<string>>(visit(table_identifier_ctx));
       table.push_back("*");
-      return build_ast_node("Field", "{s:N}", "chain", X_PyList_FromStrings(table));
+      RETURN_NEW_AST_NODE("Field", "{s:N}", "chain", X_PyList_FromStrings(table));
     }
-    return build_ast_node("Field", "{s:[s]}", "chain", "*");
+    RETURN_NEW_AST_NODE("Field", "{s:[s]}", "chain", "*");
   }
 
   VISIT(ColumnExprTagElement) { return visit(ctx->hogqlxTagElement()); }
@@ -1032,18 +1462,30 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   VISIT(ColumnArgList) { return visitPyListOfObjects(ctx->columnArgExpr()); }
 
   VISIT(ColumnLambdaExpr) {
-    vector<string> args = visitAsVectorOfStrings(ctx->identifier());
-    return build_ast_node(
-        "Lambda", "{s:N,s:N}", "args", X_PyList_FromStrings(args), "expr", visitAsPyObject(ctx->columnExpr())
+    RETURN_NEW_AST_NODE(
+        "Lambda", "{s:N,s:N}", "args", X_PyList_FromStrings(visitAsVectorOfStrings(ctx->identifier())), "expr",
+        visitAsPyObject(ctx->columnExpr())
     );
   }
 
   VISIT(WithExprList) {
     PyObject* ctes = PyDict_New();
+    if (!ctes) throw PyInternalException();
     for (auto with_expr_ctx : ctx->withExpr()) {
       PyObject* cte = visitAsPyObject(with_expr_ctx);
       PyObject* name = PyObject_GetAttrString(cte, "name");
-      PyDict_SetItem(ctes, name, cte);
+      if (!name) {
+        Py_DECREF(cte);
+        Py_DECREF(ctes);
+        throw PyInternalException();
+      }
+      int err_indicator = PyDict_SetItem(ctes, name, cte);
+      if (err_indicator == -1) {
+        Py_DECREF(name);
+        Py_DECREF(cte);
+        Py_DECREF(ctes);
+        throw PyInternalException();
+      }
       Py_DECREF(name);
       Py_DECREF(cte);
     }
@@ -1052,7 +1494,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   VISIT(WithExprSubquery) {
     string name = visitAsString(ctx->identifier());
-    return build_ast_node(
+    RETURN_NEW_AST_NODE(
         "CTE", "{s:s#,s:N,s:s}", "name", name.data(), name.size(), "expr", visitAsPyObject(ctx->selectUnionStmt()),
         "cte_type", "subquery"
     );
@@ -1061,9 +1503,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   VISIT(WithExprColumn) {
     PyObject* expr = visitAsPyObject(ctx->columnExpr());
     string name = visitAsString(ctx->identifier());
-    return build_ast_node(
-        "CTE", "{s:s#,s:N,s:s}", "name", name.data(), name.size(), "expr", expr, "cte_type", "column"
-    );
+    RETURN_NEW_AST_NODE("CTE", "{s:s#,s:N,s:s}", "name", name.data(), name.size(), "expr", expr, "cte_type", "column");
   }
 
   VISIT(ColumnIdentifier) {
@@ -1082,26 +1522,30 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       string text = ctx->getText();
       boost::algorithm::to_lower(text);
       if (!text.compare("true")) {
-        return build_ast_node("Constant", "{s:O}", "value", Py_True);
+        RETURN_NEW_AST_NODE("Constant", "{s:O}", "value", Py_True);
       }
       if (!text.compare("false")) {
-        return build_ast_node("Constant", "{s:O}", "value", Py_False);
+        RETURN_NEW_AST_NODE("Constant", "{s:O}", "value", Py_False);
       }
-      return build_ast_node("Field", "{s:N}", "chain", X_PyList_FromStrings(nested));
+      RETURN_NEW_AST_NODE("Field", "{s:N}", "chain", X_PyList_FromStrings(nested));
     }
     vector<string> table_plus_nested = table;
     table_plus_nested.insert(table_plus_nested.end(), nested.begin(), nested.end());
-    return build_ast_node("Field", "{s:N}", "chain", X_PyList_FromStrings(table_plus_nested));
+    RETURN_NEW_AST_NODE("Field", "{s:N}", "chain", X_PyList_FromStrings(table_plus_nested));
   }
 
-  VISIT(NestedIdentifier) { return visitAsVectorOfStrings(ctx->identifier()); }
+  VISIT(NestedIdentifier) {
+    return visitAsVectorOfStrings(ctx->identifier());
+  }
 
   VISIT(TableExprIdentifier) {
     vector<string> chain = any_cast<vector<string>>(visit(ctx->tableIdentifier()));
-    return build_ast_node("Field", "{s:N}", "chain", X_PyList_FromStrings(chain));
+    RETURN_NEW_AST_NODE("Field", "{s:N}", "chain", X_PyList_FromStrings(chain));
   }
 
-  VISIT(TableExprSubquery) { return visit(ctx->selectUnionStmt()); }
+  VISIT(TableExprSubquery) {
+    return visit(ctx->selectUnionStmt());
+  }
 
   VISIT(TableExprPlaceholder) {
     return visitAsPyObject(ctx->placeholder());
@@ -1112,33 +1556,45 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     string alias = any_cast<string>(alias_ctx ? visit(alias_ctx) : visit(ctx->identifier()));
     if (find(RESERVED_KEYWORDS.begin(), RESERVED_KEYWORDS.end(), boost::algorithm::to_lower_copy(alias)) !=
         RESERVED_KEYWORDS.end()) {
-      throw HogQLSyntaxException("ALIAS is a reserved keyword");
+      throw SyntaxException("ALIAS is a reserved keyword");
     }
-    PyObject* table = visitAsPyObject(ctx->tableExpr());
     PyObject* py_alias = PyUnicode_FromStringAndSize(alias.data(), alias.size());
-    if (is_ast_node_instance(table, "JoinExpr")) {
-      PyObject_SetAttrString(table, "alias", py_alias);
+    if (!py_alias)  throw PyInternalException();
+    PyObject* table = visitAsPyObject(ctx->tableExpr());
+    int is_table_a_join_expr = is_ast_node_instance(table, "JoinExpr");
+    if (is_table_a_join_expr == -1) {
       Py_DECREF(py_alias);
+      throw PyInternalException();
+    }
+    if (is_table_a_join_expr) {
+      int err_indicator = PyObject_SetAttrString(table, "alias", py_alias);
+      Py_DECREF(py_alias);
+      if (err_indicator == -1) {
+        Py_DECREF(table);
+        throw PyInternalException();
+      }
       return table;
     }
-    return build_ast_node("JoinExpr", "{s:N,s:N}", "table", table, "alias", py_alias);
+    RETURN_NEW_AST_NODE("JoinExpr", "{s:N,s:N}", "table", table, "alias", py_alias);
   }
 
-  VISIT(TableExprFunction) { return visit(ctx->tableFunctionExpr()); }
+  VISIT(TableExprFunction) {
+    return visit(ctx->tableFunctionExpr());
+  }
 
   VISIT(TableExprTag) { return visit(ctx->hogqlxTagElement()); }
 
   VISIT(TableFunctionExpr) {
-    string name = visitAsString(ctx->identifier());
-    PyObject* table_args;
     auto table_args_ctx = ctx->tableArgList();
-    if (table_args_ctx) {
-      table_args = visitAsPyObject(table_args_ctx);
-    } else {
-      table_args = Py_NewRef(Py_None);
+    PyObject* table_args = table_args_ctx ? visitAsPyObject(table_args_ctx) : Py_NewRef(Py_None);
+    string table_name = visitAsString(ctx->identifier());
+    PyObject* table = build_ast_node("Field", "{s:[s#]}", "chain", table_name.data(), table_name.size());
+    if (!table) {
+      Py_DECREF(table_args);
+      throw PyInternalException();
     }
-    return build_ast_node(
-        "JoinExpr", "{s:N,s:N}", "table", build_ast_node("Field", "{s:[s#]}", "chain", name.data(), name.size()),
+    RETURN_NEW_AST_NODE(
+        "JoinExpr", "{s:N,s:N}", "table", table,
         "table_args", table_args
     );
   }
@@ -1152,39 +1608,42 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     return vector<string>{text};
   }
 
-  VISIT(TableArgList) { return visitPyListOfObjects(ctx->columnExpr()); }
+  VISIT(TableArgList) {
+    return visitPyListOfObjects(ctx->columnExpr());
+  }
 
-  VISIT(DatabaseIdentifier) { return visit(ctx->identifier()); }
+  VISIT(DatabaseIdentifier) {
+    return visit(ctx->identifier());
+  }
 
   VISIT_UNSUPPORTED(FloatingLiteral)
 
   VISIT(NumberLiteral) {
     string text = ctx->getText();
     boost::algorithm::to_lower(text);
-    PyObject* value;
-    PyObject* result;
     if (text.find(".") != string::npos || text.find("e") != string::npos || !text.compare("-inf") ||
         !text.compare("inf") || !text.compare("nan")) {
-      PyObject* pyText = PyUnicode_FromStringAndSize(text.data(), text.size());
-      value = PyFloat_FromString(pyText);
-      result = build_ast_node("Constant", "{s:N}", "value", value);
-      Py_DECREF(pyText);
+      PyObject* py_text = PyUnicode_FromStringAndSize(text.data(), text.size());
+      if (!py_text) throw PyInternalException();
+      PyObject* value = PyFloat_FromString(py_text);
+      Py_DECREF(py_text);
+      if (!value) throw PyInternalException();
+      RETURN_NEW_AST_NODE("Constant", "{s:N}", "value", value);
     } else {
-      value = PyLong_FromString(text.c_str(), NULL, 10);
-      result = build_ast_node("Constant", "{s:N}", "value", value);
+      PyObject* value = PyLong_FromString(text.c_str(), NULL, 10);
+      if (!value) throw PyInternalException();
+      RETURN_NEW_AST_NODE("Constant", "{s:N}", "value", value);
     }
-
-    return result;
   }
 
   VISIT(Literal) {
     if (ctx->NULL_SQL()) {
-      return build_ast_node("Constant", "{s:O}", "value", Py_None);
+      RETURN_NEW_AST_NODE("Constant", "{s:O}", "value", Py_None);
     }
     auto string_literal_terminal = ctx->STRING_LITERAL();
     if (string_literal_terminal) {
       string text = unquote_string_terminal(string_literal_terminal);
-      return build_ast_node("Constant", "{s:s#}", "value", text.data(), text.size());
+      RETURN_NEW_AST_NODE("Constant", "{s:s#}", "value", text.data(), text.size());
     }
     return visitChildren(ctx);
   }
@@ -1302,7 +1761,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   VISIT_UNSUPPORTED(EnumValue)
 
   VISIT(ColumnExprNullish) {
-    return build_ast_node(
+    RETURN_NEW_AST_NODE(
         "Call", "{s:s, s:[NN]}", "name", "ifNull", "args", visitAsPyObject(ctx->columnExpr(0)),
         visitAsPyObject(ctx->columnExpr(1))
     );
@@ -1327,7 +1786,7 @@ class HogQLErrorListener : public antlr4::BaseErrorListener {
     if (start == string::npos) {
       start = 0;
     }
-    throw HogQLSyntaxException(msg, start, input.size());
+    throw SyntaxException(msg, start, input.size());
   }
 
  private:
@@ -1352,8 +1811,8 @@ parser_state* get_module_state(PyObject* module) {
 
 // MODULE METHODS
 
-#define METHOD_PARSE_NODE(PascalCase, camelCase, snake_case)                    \
-  static PyObject* method_parse_##snake_case(PyObject* self, PyObject* args) {  \
+#define METHOD_PARSE_NODE(PASCAL_CASE, CAMEL_CASE, SNAKE_CASE)                  \
+  static PyObject* method_parse_##SNAKE_CASE(PyObject* self, PyObject* args) {  \
     parser_state* state = get_module_state(self);                               \
     const char* str;                                                            \
     if (!PyArg_ParseTuple(args, "s", &str)) {                                   \
@@ -1366,18 +1825,18 @@ parser_state* get_module_state(PyObject* module) {
     parser->removeErrorListeners();                                             \
     auto error_listener = new HogQLErrorListener(str);                          \
     parser->addErrorListener(error_listener);                                   \
-    HogQLParser::PascalCase##Context* parse_tree;                               \
+    HogQLParser::PASCAL_CASE##Context* parse_tree;                              \
     try {                                                                       \
-      parse_tree = parser->camelCase();                                         \
+      parse_tree = parser->CAMEL_CASE();                                        \
     } catch HANDLE_HOGQL_EXCEPTION(SyntaxException);                            \
     HogQLParseTreeConverter converter = HogQLParseTreeConverter(state);         \
-    PyObject* result = converter.visitAsPyObjectFinal(parse_tree);              \
+    PyObject* result_node = converter.visitAsPyObjectFinal(parse_tree);         \
     delete error_listener;                                                      \
     delete parser;                                                              \
     delete stream;                                                              \
     delete lexer;                                                               \
     delete input_stream;                                                        \
-    return result;                                                              \
+    return result_node;                                                         \
   }
 
 METHOD_PARSE_NODE(Expr, expr, expr)

--- a/hogql_parser/parser.cpp
+++ b/hogql_parser/parser.cpp
@@ -143,14 +143,10 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   return ret;
 
   // Return 1 if the passed object is an instance of the specified AST node type, 0 if not, -1 if an error occurred.
-  int is_ast_node_instance(PyObject* obj, const char* type_name) {
-    IS_AST_NODE_INSTANCE_IMPL(ast, type_name)
-  }
+  int is_ast_node_instance(PyObject* obj, const char* type_name) { IS_AST_NODE_INSTANCE_IMPL(ast, type_name) }
 
   // Return 1 if the passed object is an instance of _any_ AST node type, 0 if not, -1 if an error occurred.
-  int is_ast_node_instance(PyObject* obj) {
-    IS_AST_NODE_INSTANCE_IMPL(base, "AST")
-  }
+  int is_ast_node_instance(PyObject* obj) { IS_AST_NODE_INSTANCE_IMPL(base, "AST") }
 
 #undef IS_AST_NODE_INSTANCE_IMPL
 
@@ -279,9 +275,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     return ret;
   }
 
-  string visitAsString(antlr4::tree::ParseTree* tree) {
-    return any_cast<string>(visit(tree));
-  }
+  string visitAsString(antlr4::tree::ParseTree* tree) { return any_cast<string>(visit(tree)); }
 
   template <typename T>
   vector<string> visitAsVectorOfStrings(vector<T> tree) {
@@ -309,7 +303,9 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       return visit(tag_element_ctx);
     }
 
-    throw HogQLParsingException("Unexpected Select node. Must have either selectUnionStmt, selectStmt, or hogqlxTagElement set.");
+    throw HogQLParsingException(
+        "Unexpected Select node. Must have either selectUnionStmt, selectStmt, or hogqlxTagElement set."
+    );
   }
 
   VISIT(SelectStmtWithParens) {
@@ -602,39 +598,25 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     return select_query;
   }
 
-  VISIT(WithClause) {
-    return visit(ctx->withExprList());
-  }
+  VISIT(WithClause) { return visit(ctx->withExprList()); }
 
   VISIT_UNSUPPORTED(TopClause)
 
-  VISIT(FromClause) {
-    return visit(ctx->joinExpr());
-  }
+  VISIT(FromClause) { return visit(ctx->joinExpr()); }
 
   VISIT_UNSUPPORTED(ArrayJoinClause)
 
   VISIT_UNSUPPORTED(WindowClause)
 
-  VISIT(PrewhereClause) {
-    return visit(ctx->columnExpr());
-  }
+  VISIT(PrewhereClause) { return visit(ctx->columnExpr()); }
 
-  VISIT(WhereClause) {
-    return visit(ctx->columnExpr());
-  }
+  VISIT(WhereClause) { return visit(ctx->columnExpr()); }
 
-  VISIT(GroupByClause) {
-    return visit(ctx->columnExprList());
-  }
+  VISIT(GroupByClause) { return visit(ctx->columnExprList()); }
 
-  VISIT(HavingClause) {
-    return visit(ctx->columnExpr());
-  }
+  VISIT(HavingClause) { return visit(ctx->columnExpr()); }
 
-  VISIT(OrderByClause) {
-    return visit(ctx->orderExprList());
-  }
+  VISIT(OrderByClause) { return visit(ctx->orderExprList()); }
 
   VISIT_UNSUPPORTED(ProjectionOrderByClause)
 
@@ -770,9 +752,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     }
   }
 
-  VISIT(JoinExprParens) {
-    return visit(ctx->joinExpr());
-  }
+  VISIT(JoinExprParens) { return visit(ctx->joinExpr()); }
 
   VISIT(JoinExprCrossOp) {
     PyObject* join_type = PyUnicode_FromString("CROSS JOIN");
@@ -903,9 +883,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     );
   }
 
-  VISIT(OrderExprList) {
-    return visitPyListOfObjects(ctx->orderExpr());
-  }
+  VISIT(OrderExprList) { return visitPyListOfObjects(ctx->orderExpr()); }
 
   VISIT(OrderExpr) {
     const char* order = ctx->DESC() || ctx->DESCENDING() ? "DESC" : "ASC";
@@ -1002,21 +980,13 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     );
   }
 
-  VISIT(WinPartitionByClause) {
-    return visit(ctx->columnExprList());
-  }
+  VISIT(WinPartitionByClause) { return visit(ctx->columnExprList()); }
 
-  VISIT(WinOrderByClause) {
-    return visit(ctx->orderExprList());
-  }
+  VISIT(WinOrderByClause) { return visit(ctx->orderExprList()); }
 
-  VISIT(WinFrameClause) {
-    return visit(ctx->winFrameExtend());
-  }
+  VISIT(WinFrameClause) { return visit(ctx->winFrameExtend()); }
 
-  VISIT(FrameStart) {
-    return visit(ctx->winFrameBound());
-  }
+  VISIT(FrameStart) { return visit(ctx->winFrameBound()); }
 
   VISIT(FrameBetween) {
     PyObject* min = visitAsPyObject(ctx->winFrameBound(0));
@@ -1050,9 +1020,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     }
   }
 
-  VISIT(Expr) {
-    return visit(ctx->columnExpr());
-  }
+  VISIT(Expr) { return visit(ctx->columnExpr()); }
 
   VISIT_UNSUPPORTED(ColumnTypeExprSimple)
 
@@ -1064,9 +1032,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   VISIT_UNSUPPORTED(ColumnTypeExprParam)
 
-  VISIT(ColumnExprList) {
-    return visitPyListOfObjects(ctx->columnExpr());
-  }
+  VISIT(ColumnExprList) { return visitPyListOfObjects(ctx->columnExpr()); }
 
   VISIT(ColumnExprTernaryOp) {
     PyObject* arg_1 = visitAsPyObject(ctx->columnExpr(0));
@@ -1132,9 +1098,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     RETURN_NEW_AST_NODE("ArithmeticOperation", "{s:N,s:N,s:N}", "left", left, "right", right, "op", op);
   }
 
-  VISIT(ColumnExprSubquery) {
-    return visit(ctx->selectUnionStmt());
-  }
+  VISIT(ColumnExprSubquery) { return visit(ctx->selectUnionStmt()); }
 
   VISIT(ColumnExprArray) {
     RETURN_NEW_AST_NODE("Array", "{s:N}", "exprs", visitAsPyObjectOrEmptyList(ctx->columnExprList()));
@@ -1383,7 +1347,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       throw ParsingException("Unsupported value of rule ColumnExprInterval");
     }
 
-    RETURN_NEW_AST_NODE("Call", "{s:s,s:[N]}", "name", name, "args",  visitAsPyObject(ctx->columnExpr()));
+    RETURN_NEW_AST_NODE("Call", "{s:s,s:[N]}", "name", name, "args", visitAsPyObject(ctx->columnExpr()));
   }
 
   VISIT(ColumnExprIsNull) {
@@ -1470,9 +1434,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   VISIT_UNSUPPORTED(ColumnExprBetween)
 
-  VISIT(ColumnExprParens) {
-    return visit(ctx->columnExpr());
-  }
+  VISIT(ColumnExprParens) { return visit(ctx->columnExpr()); }
 
   VISIT_UNSUPPORTED(ColumnExprTimestamp)
 
@@ -1571,7 +1533,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       throw PyInternalException();
     }
     int is_index_zero = PyObject_RichCompareBool(index, zero, Py_EQ);
-      Py_DECREF(zero);
+    Py_DECREF(zero);
     if (is_index_zero == -1) {
       Py_DECREF(index);
       throw PyInternalException();
@@ -1636,9 +1598,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   VISIT_UNSUPPORTED(ColumnExprDate)
 
-  VISIT(ColumnExprNot) {
-    RETURN_NEW_AST_NODE("Not", "{s:N}", "expr", visitAsPyObject(ctx->columnExpr()));
-  }
+  VISIT(ColumnExprNot) { RETURN_NEW_AST_NODE("Not", "{s:N}", "expr", visitAsPyObject(ctx->columnExpr())); }
 
   VISIT(ColumnExprWinFunctionTarget) {
     auto column_expr_list_ctx = ctx->columnExprList();
@@ -1668,24 +1628,21 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     );
   }
 
-  VISIT(ColumnExprIdentifier) {
-    return visit(ctx->columnIdentifier());
-  }
+  VISIT(ColumnExprIdentifier) { return visit(ctx->columnIdentifier()); }
 
   VISIT(ColumnExprFunction) {
     string name = visitAsString(ctx->identifier());
     PyObject* params = visitAsPyObjectOrNone(ctx->columnExprList());
-PyObject* args;
-try {
-  args =  visitAsPyObjectOrEmptyList(ctx->columnArgList());
-} catch (...) {
-  Py_DECREF(params);
-  throw;
-}
+    PyObject* args;
+    try {
+      args = visitAsPyObjectOrEmptyList(ctx->columnArgList());
+    } catch (...) {
+      Py_DECREF(params);
+      throw;
+    }
     RETURN_NEW_AST_NODE(
-        "Call", "{s:s#,s:N,s:N,s:O}", "name", name.data(), name.size(), "params",
-        params, "args",args,
-        "distinct", ctx->DISTINCT() ? Py_True : Py_False
+        "Call", "{s:s#,s:N,s:N,s:O}", "name", name.data(), name.size(), "params", params, "args", args, "distinct",
+        ctx->DISTINCT() ? Py_True : Py_False
     );
   }
 
@@ -1712,10 +1669,7 @@ try {
       Py_DECREF(expr);
       throw;
     }
-    RETURN_NEW_AST_NODE(
-        "Lambda", "{s:N,s:N}", "args",args, "expr",
-        expr
-    );
+    RETURN_NEW_AST_NODE("Lambda", "{s:N,s:N}", "args", args, "expr", expr);
   }
 
   VISIT(WithExprList) {
@@ -1790,22 +1744,16 @@ try {
     RETURN_NEW_AST_NODE("Field", "{s:N}", "chain", X_PyList_FromStrings(table_plus_nested));
   }
 
-  VISIT(NestedIdentifier) {
-    return visitAsVectorOfStrings(ctx->identifier());
-  }
+  VISIT(NestedIdentifier) { return visitAsVectorOfStrings(ctx->identifier()); }
 
   VISIT(TableExprIdentifier) {
     vector<string> chain = any_cast<vector<string>>(visit(ctx->tableIdentifier()));
     RETURN_NEW_AST_NODE("Field", "{s:N}", "chain", X_PyList_FromStrings(chain));
   }
 
-  VISIT(TableExprSubquery) {
-    return visit(ctx->selectUnionStmt());
-  }
+  VISIT(TableExprSubquery) { return visit(ctx->selectUnionStmt()); }
 
-  VISIT(TableExprPlaceholder) {
-    return visitAsPyObject(ctx->placeholder());
-  }
+  VISIT(TableExprPlaceholder) { return visitAsPyObject(ctx->placeholder()); }
 
   VISIT(TableExprAlias) {
     auto alias_ctx = ctx->alias();
@@ -1823,7 +1771,7 @@ try {
       Py_DECREF(py_alias);
       throw;
     }
-    
+
     int is_table_a_join_expr = is_ast_node_instance(table, "JoinExpr");
     if (is_table_a_join_expr == -1) {
       Py_DECREF(py_alias);
@@ -1841,9 +1789,7 @@ try {
     RETURN_NEW_AST_NODE("JoinExpr", "{s:N,s:N}", "table", table, "alias", py_alias);
   }
 
-  VISIT(TableExprFunction) {
-    return visit(ctx->tableFunctionExpr());
-  }
+  VISIT(TableExprFunction) { return visit(ctx->tableFunctionExpr()); }
 
   VISIT(TableExprTag) { return visit(ctx->hogqlxTagElement()); }
 
@@ -1868,13 +1814,9 @@ try {
     return vector<string>{text};
   }
 
-  VISIT(TableArgList) {
-    return visitPyListOfObjects(ctx->columnExpr());
-  }
+  VISIT(TableArgList) { return visitPyListOfObjects(ctx->columnExpr()); }
 
-  VISIT(DatabaseIdentifier) {
-    return visit(ctx->identifier());
-  }
+  VISIT(DatabaseIdentifier) { return visit(ctx->identifier()); }
 
   VISIT_UNSUPPORTED(FloatingLiteral)
 
@@ -1952,23 +1894,18 @@ try {
     if (string_literal_ctx) {
       string text = unquote_string_terminal(string_literal_ctx);
       PyObject* value = build_ast_node("Constant", "{s:s#}", "value", text.data(), text.size());
-      return build_ast_node(
-          "HogQLXAttribute", "{s:s#,s:N}", "name", name.data(), name.size(), "value", value
-      );
+      return build_ast_node("HogQLXAttribute", "{s:s#,s:N}", "name", name.data(), name.size(), "value", value);
     }
 
     PyObject* value = build_ast_node("Constant", "{s:O}", "value", Py_True);
-    return build_ast_node(
-        "HogQLXAttribute", "{s:s#,s:N}", "name", name.data(), name.size(), "value", value
-    );
+    return build_ast_node("HogQLXAttribute", "{s:s#,s:N}", "name", name.data(), name.size(), "value", value);
   }
 
   VISIT(HogqlxTagElementClosed) {
     string kind = visitAsString(ctx->identifier());
     PyObject* tag_element = build_ast_node(
-        "HogQLXTag", "{s:s#,s:N}",
-        "kind", kind.data(), kind.size(),
-        "attributes", visitPyListOfObjects(ctx->hogqlxTagAttribute())
+        "HogQLXTag", "{s:s#,s:N}", "kind", kind.data(), kind.size(), "attributes",
+        visitPyListOfObjects(ctx->hogqlxTagAttribute())
     );
     return tag_element;
   }
@@ -1996,20 +1933,20 @@ try {
     }
 
     if (tag_element_ctx) {
-        if (found_source) {
-            Py_DECREF(attributes);
-            throw HogQLSyntaxException("Nested HogQLX tags cannot have a source attribute");
-        }
-        PyList_SET_ITEM(attributes, tag_attribute_ctx.size(), build_ast_node(
-            "HogQLXAttribute", "{s:s#,s:N}", "name", "source", 6, "value", visitAsPyObject(ctx->hogqlxTagElement())
-        ));
+      if (found_source) {
+        Py_DECREF(attributes);
+        throw HogQLSyntaxException("Nested HogQLX tags cannot have a source attribute");
+      }
+      PyList_SET_ITEM(
+          attributes, tag_attribute_ctx.size(),
+          build_ast_node(
+              "HogQLXAttribute", "{s:s#,s:N}", "name", "source", 6, "value", visitAsPyObject(ctx->hogqlxTagElement())
+          )
+      );
     }
 
-    PyObject* tag_element = build_ast_node(
-        "HogQLXTag", "{s:s#,s:N}",
-        "kind", opening.data(), opening.size(),
-        "attributes", attributes
-    );
+    PyObject* tag_element =
+        build_ast_node("HogQLXTag", "{s:s#,s:N}", "kind", opening.data(), opening.size(), "attributes", attributes);
     return tag_element;
   }
 
@@ -2029,10 +1966,7 @@ try {
       Py_DECREF(value);
       throw;
     }
-    RETURN_NEW_AST_NODE(
-        "Call", "{s:s, s:[NN]}", "name", "ifNull", "args", value,
-        fallback
-    );
+    RETURN_NEW_AST_NODE("Call", "{s:s, s:[NN]}", "name", "ifNull", "args", value, fallback);
   }
 };
 

--- a/hogql_parser/setup.py
+++ b/hogql_parser/setup.py
@@ -32,7 +32,7 @@ module = Extension(
 
 setup(
     name="hogql_parser",
-    version="0.1.12",
+    version="1.0.0",
     url="https://github.com/PostHog/posthog/tree/master/hogql_parser",
     author="PostHog Inc.",
     author_email="hey@posthog.com",

--- a/hogql_parser/string.cpp
+++ b/hogql_parser/string.cpp
@@ -8,7 +8,7 @@ using namespace std;
 string unquote_string(string text) {
   size_t original_text_size = text.size();
   if (original_text_size == 0) {
-    throw HogQLParsingException("Encountered an unexpected empty string input");
+    throw ParsingException("Encountered an unexpected empty string input");
   }
   const char first_char = text.front();
   const char last_char = text.back();
@@ -29,7 +29,7 @@ string unquote_string(string text) {
     boost::replace_all(text, "{{", "{");
     boost::replace_all(text, "\\{", "{");
   } else {
-    throw HogQLSyntaxException("Invalid string literal, must start and end with the same quote type: " + text);
+    throw SyntaxException("Invalid string literal, must start and end with the same quote type: " + text);
   }
 
   // Copied from clickhouse_driver/util/escape.py
@@ -50,7 +50,9 @@ string unquote_string_terminal(antlr4::tree::TerminalNode* node) {
   string text = node->getText();
   try {
     return unquote_string(text);
-  } catch (HogQLException& e) {
-    throw HogQLSyntaxException(e.what(), node->getSymbol()->getStartIndex(), node->getSymbol()->getStopIndex() + 1);
+  } catch (SyntaxException& e) {
+    throw SyntaxException(e.what(), node->getSymbol()->getStartIndex(), node->getSymbol()->getStopIndex() + 1);
+  } catch (ParsingException& e) {
+    throw ParsingException(e.what(), node->getSymbol()->getStartIndex(), node->getSymbol()->getStopIndex() + 1);
   }
 }

--- a/package.json
+++ b/package.json
@@ -305,7 +305,8 @@
         "!(posthog/hogql/grammar/*)*.{py,pyi}": [
             "black",
             "ruff"
-        ]
+        ],
+        "!(HogQL*)*.{c,cpp,h,hpp}": "clang-format -i"
     },
     "browserslist": {
         "development": [

--- a/requirements.in
+++ b/requirements.in
@@ -88,4 +88,4 @@ django-two-factor-auth==1.14.0
 phonenumberslite==8.13.6
 openai==0.27.8
 nh3==0.2.14
-hogql-parser==0.1.12
+hogql-parser==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -251,7 +251,7 @@ gunicorn==20.1.0
     # via -r requirements.in
 h11==0.13.0
     # via wsproto
-hogql-parser==0.1.12
+hogql-parser==1.0.0
     # via -r requirements.in
 idna==2.8
     # via


### PR DESCRIPTION
## Changes

This is the final stage of making the C++ parser production-ready: to prevent any and all segfaults, we must check for `NULL` pointers in all Python/C API call returning `PyObject*`, and for -1 in all calls returning an integer (e.g. `PyList_Size()`, but also `PyObject_SetAttrString()`).

I had to do a bunch more reading of CPython docs and code to get all of this right, which is why this is not the way I initially wrote the converter… even though that would have made for much more readable PRs than this one.

The way I went about making sure nothing is missed is basically just checking every match for this regex:

`(Py(Object_|Unicode_|Dict_|List_|Long_|Float_|Tuple_|Import_|_(Va)?Build))|build_ast_node\(|is_ast_node_instance\(|get_ast_enum_member\(`

I had to rewrite nearly each of the 200+ call sites to handle every situation where a NULL might pop up. This means throwing an error after decrementing refcounts for all `PyObject*`s in scope.

Additionally, I made sure we similarly clean up refcounts if any `visit()` call throws (which can be due to a Python exception, but also a syntax exception).

There's some new info on all of the above in `hogql_parser/CONTRIBUTING.md`.

## How did you test this code?

All parser tests succeed.