### PR TITLE
ci: Don't build HogQL parser if version hasn't changed

### DIFF
--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -22,14 +22,14 @@ jobs:
         if: github.repository == 'PostHog/posthog'
         runs-on: ubuntu-22.04
         outputs:
-            parser_any_changed: ${{ steps.changed-files-yaml.outputs.parser_any_changed }}
+            parser-release-needed: ${{ steps.version.outputs.parser-release-needed }}
         steps:
             - uses: actions/checkout@v4
               with:
                   fetch-depth: 0 # Fetching all for comparison since last push (not just last commit)
 
             - name: Check if hogql_parser/ has changed
-              id: changed-files-yaml
+              id: changed-files
               uses: tj-actions/changed-files@v39
               with:
                   since_last_remote_commit: true
@@ -37,24 +37,29 @@ jobs:
                       parser:
                       - hogql_parser/**
 
-            - name: Notify about release needed
-              if: steps.changed-files-yaml.outputs.parser_any_changed == 'true'
+            - name: Check if version was bumped
               shell: bash
+              id: version
               run: |
-                  published=$(curl -fSsl https://pypi.org/pypi/hogql-parser/json | jq -r '.info.version')
-                  local=$(python hogql_parser/setup.py --version)
-                  # TODO: Only comment if no comment alraedy exists for $local
-                  if [[ "$published" == "$local" ]]; then
-                    message_body="It looks like the code of \`hogql-parser\` has changed since last push, but its version stayed the same at $local. 👀\nMake sure to resolve this in \`hogql_parser/setup.py\` before merging!"
-                    curl -s -u posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }} -X POST -d "{ \"body\": \"$message_body\" }" "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
+                  parser_release_needed='false'
+                  if [[ ${{ steps.changed-files.outputs.parser_any_changed }} == 'true' ]]; then
+                    published=$(curl -fSsl https://pypi.org/pypi/hogql-parser/json | jq -r '.info.version')
+                    local=$(python hogql_parser/setup.py --version)
+                    if [[ "$published" != "$local" ]]; then
+                      parser_release_needed='true'
+                    else
+                      message_body="It looks like the code of \`hogql-parser\` has changed since last push, but its version stayed the same at $local. 👀\nMake sure to resolve this in \`hogql_parser/setup.py\` before merging!"
+                      curl -s -u posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }} -X POST -d "{ \"body\": \"$message_body\" }" "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
+                    fi
                   fi
+                  echo "::set-output name=parser-release-needed::$parser_release_needed"
 
     build-wheels:
         name: Build wheels on ${{ matrix.os }}
         needs: check-version
         runs-on: ${{ matrix.os }}
         timeout-minutes: 30
-        if: ${{ needs.check-version.outputs.parser_any_changed == 'true' }}
+        if: ${{ needs.check-version.outputs.parser-release-needed == 'true' }}
         strategy:
             matrix:
                 # As of October 2023, GitHub doesn't have ARM Actions runners… and ARM emulation is insanely slow


### PR DESCRIPTION
## Problem

Currently we build `hogql_parser` on every push where its files have changed, even if we know the release isn't publishable because the version hasn't changed.

## Changes

Now we'll only build if we can actually push a new release.
