### PR TITLE
feat: Added support for extended search in replays

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorControls.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorControls.tsx
@@ -1,5 +1,4 @@
-import { LemonButton, LemonInput, LemonSelect, LemonCheckbox } from '@posthog/lemon-ui'
-import { Tooltip } from 'antd'
+import { LemonButton, LemonInput, LemonSelect, LemonCheckbox, Tooltip } from '@posthog/lemon-ui'
 import { useValues, useActions } from 'kea'
 import {
     IconInfo,
@@ -17,6 +16,7 @@ import { IconWindow } from 'scenes/session-recordings/player/icons'
 import { playerSettingsLogic } from '../playerSettingsLogic'
 import { SessionRecordingPlayerMode, sessionRecordingPlayerLogic } from '../sessionRecordingPlayerLogic'
 import { playerInspectorLogic } from './playerInspectorLogic'
+import { InspectorSearchInfo } from './components/InspectorSearchInfo'
 
 const TabToIcon = {
     [SessionRecordingPlayerTab.ALL]: undefined,
@@ -88,6 +88,11 @@ export function PlayerInspectorControls(): JSX.Element {
                         type="search"
                         value={searchQuery}
                         fullWidth
+                        suffix={
+                            <Tooltip title={<InspectorSearchInfo />}>
+                                <IconInfo />
+                            </Tooltip>
+                        }
                     />
                 </div>
                 {windowIds.length > 1 ? (

--- a/frontend/src/scenes/session-recordings/player/inspector/components/InspectorSearchInfo.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/InspectorSearchInfo.tsx
@@ -1,0 +1,92 @@
+export function InspectorSearchInfo(): JSX.Element {
+    return (
+        <>
+            Searching is "fuzzy" by default meaning that it will try and match many properties that are <i>close</i> to
+            the search query.
+            <br />
+            <table>
+                <thead>
+                    <tr>
+                        <th>Token</th>
+                        <th>Match type</th>
+                        <th>Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>
+                            <code>jscript</code>
+                        </td>
+                        <td>fuzzy-match</td>
+                        <td>
+                            Items that fuzzy match <code>jscript</code>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code>=scheme</code>
+                        </td>
+                        <td>exact-match</td>
+                        <td>
+                            Items that are <code>scheme</code>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code>'python</code>
+                        </td>
+                        <td>include-match</td>
+                        <td>
+                            Items that include <code>python</code>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code>!ruby</code>
+                        </td>
+                        <td>inverse-exact-match</td>
+                        <td>
+                            Items that do not include <code>ruby</code>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code>^java</code>
+                        </td>
+                        <td>prefix-exact-match</td>
+                        <td>
+                            Items that start with <code>java</code>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code>!^earlang</code>
+                        </td>
+                        <td>inverse-prefix-exact-match</td>
+                        <td>
+                            Items that do not start with <code>earlang</code>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code>.js$</code>
+                        </td>
+                        <td>suffix-exact-match</td>
+                        <td>
+                            Items that end with <code>.js</code>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code>!.go$</code>
+                        </td>
+                        <td>inverse-suffix-exact-match</td>
+                        <td>
+                            Items that do not end with <code>.go</code>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </>
+    )
+}

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -713,6 +713,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                     findAllMatches: true,
                     ignoreLocation: true,
                     shouldSort: false,
+                    useExtendedSearch: true,
                 }),
         ],
 


### PR DESCRIPTION
## Problem

Fuse has some nice options for controlling how the search works if we would just enable them.



## Changes

* Adds support for it and a tooltip with the same table as in  https://www.fusejs.io/examples.html#extended-search

<img width="662" alt="Screenshot 2023-10-27 at 15 45 27" src="https://github.com/PostHog/posthog/assets/2536520/9c6d7afb-d72c-4ba8-b0ca-d087a332bd49">

<img width="648" alt="Screenshot 2023-10-27 at 15 45 17" src="https://github.com/PostHog/posthog/assets/2536520/57d39161-c496-4415-bed3-069b42de2e4e">

<img width="656" alt="Screenshot 2023-10-27 at 15 45 10" src="https://github.com/PostHog/posthog/assets/2536520/59d9c8c6-97be-40bf-8f0b-be999dc0c021">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
