### PR TITLE
fix(postgres-batch-exports): The correct sslmode is disable

### DIFF
--- a/posthog/temporal/workflows/postgres_batch_export.py
+++ b/posthog/temporal/workflows/postgres_batch_export.py
@@ -36,9 +36,9 @@ def postgres_connection(inputs):
         port=inputs.port,
         # The 'hasSelfSignedCert' parameter in the postgres-plugin was provided mainly
         # for users of Heroku and RDS. It was used to set 'rejectUnauthorized' to false if a self-signed cert was used.
-        # Mapping this to sslmode is not straight-forward, but going by Heroku's recommendation (see below) we should use 'no-verify'.
+        # Mapping this to sslmode is not straight-forward, but going by Heroku's recommendation (see below) we should use 'disable'.
         # Reference: https://devcenter.heroku.com/articles/connecting-heroku-postgres#connecting-in-node-js
-        sslmode="no-verify" if inputs.has_self_signed_cert is True else "prefer",
+        sslmode="disable" if inputs.has_self_signed_cert is True else "prefer",
     )
 
     try:


### PR DESCRIPTION
## Problem

`"no-verify"` is not actually a supported SSLMode. I got this confused when investigating how to map `hasSelfSignedCert` to `sslmode` (as the [Heroku docs](https://devcenter.heroku.com/articles/connecting-heroku-postgres#connecting-in-node-js) for node state `"no-verify"`). But looking at the [libpq docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE) reveals the value should be `"disable"`.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Use `"disable"` instead of `"no-verify"`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
