### PR TITLE
feat(insights): add percentage support to pie charts (solves #18222)

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -25,6 +25,7 @@ export const PERCENT_STACK_VIEW_DISPLAY_TYPE = [
     ChartDisplayType.ActionsBar,
     ChartDisplayType.ActionsLineGraph,
     ChartDisplayType.ActionsAreaGraph,
+    ChartDisplayType.ActionsPie,
 ]
 
 export enum OrganizationMembershipLevel {

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -29,7 +29,7 @@ import { lineGraphLogic } from 'scenes/insights/views/LineGraph/lineGraphLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
-import ChartDataLabels from 'chartjs-plugin-datalabels'
+import ChartDataLabels, { Context } from 'chartjs-plugin-datalabels'
 
 let timer: NodeJS.Timeout | null = null
 
@@ -46,6 +46,11 @@ function setTooltipPosition(chart: Chart, tooltipEl: HTMLElement): void {
     }, 25)
 }
 
+function getPercentageForDataPoint(context: Context): number {
+    const total = context.dataset.data.reduce((a, b) => (a as number) + (b as number), 0) as number
+    return ((context.dataset.data[context.dataIndex] as number) / total) * 100
+}
+
 export function PieChart({
     datasets: _datasets,
     hiddenLegendKeys,
@@ -56,11 +61,14 @@ export function PieChart({
     trendsFilter,
     formula,
     showValueOnSeries,
+    supportsPercentStackView,
+    showPercentStackView,
     tooltip: tooltipConfig,
     showPersonsModal = true,
     labelGroupType,
 }: LineGraphProps): JSX.Element {
     const isPie = type === GraphType.Pie
+    const isPercentStackView = !!supportsPercentStackView && !!showPercentStackView
 
     if (!isPie) {
         throw new Error('PieChart must be a pie chart')
@@ -127,11 +135,7 @@ export function PieChart({
                             return context.dataset.backgroundColor?.[context.dataIndex] || 'black'
                         },
                         display: (context) => {
-                            const total = context.dataset.data.reduce(
-                                (a, b) => (a as number) + (b as number),
-                                0
-                            ) as number
-                            const percentage = ((context.dataset.data[context.dataIndex] as number) / total) * 100
+                            const percentage = getPercentageForDataPoint(context)
                             return showValueOnSeries !== false && // show if true or unset
                                 context.dataset.data.length > 1 &&
                                 percentage > 5
@@ -145,7 +149,14 @@ export function PieChart({
                             const paddingX = value < 10 ? 5 : 4
                             return { top: paddingY, bottom: paddingY, left: paddingX, right: paddingX }
                         },
-                        formatter: (value: number) => formatAggregationAxisValue(trendsFilter, value),
+                        formatter: (value: number, context) => {
+                            if (isPercentStackView) {
+                                const percentage = getPercentageForDataPoint(context)
+                                return `${percentage.toFixed(1)}%`
+                            }
+
+                            return formatAggregationAxisValue(trendsFilter, value)
+                        },
                         font: {
                             weight: 500,
                         },

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -24,9 +24,15 @@ export function ActionsPie({ inSharedMode, inCardView, showPersonsModal = true }
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
 
     const { insightProps, hiddenLegendKeys } = useValues(insightLogic)
-    const { indexedResults, labelGroupType, trendsFilter, formula, showValueOnSeries } = useValues(
-        trendsDataLogic(insightProps)
-    )
+    const {
+        indexedResults,
+        labelGroupType,
+        trendsFilter,
+        formula,
+        showValueOnSeries,
+        supportsPercentStackView,
+        showPercentStackView,
+    } = useValues(trendsDataLogic(insightProps))
 
     function updateData(): void {
         const _data = [...indexedResults].sort((a, b) => b.aggregated_value - a.aggregated_value)
@@ -87,6 +93,8 @@ export function ActionsPie({ inSharedMode, inCardView, showPersonsModal = true }
                             trendsFilter={trendsFilter}
                             formula={formula}
                             showValueOnSeries={showValueOnSeries}
+                            supportsPercentStackView={supportsPercentStackView}
+                            showPercentStackView={showPercentStackView}
                             onClick={
                                 !showPersonsModal || formula
                                     ? undefined


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/18222

## Changes

This PR implements "show as % of total" for pie charts. The `chartjs-plugin-stacked100` plugin does not work in this case, so I re-used a manual method for calculating the percentage.

## How did you test this code?

<img width="2245" alt="Screenshot 2023-10-30 at 17 07 38" src="https://github.com/PostHog/posthog/assets/1851359/af2c7e95-fa01-453a-a5b9-e0c8da531f65">
