### PR TITLE
feat(web-analytics): Add geographic query

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3176,7 +3176,10 @@
                 "InitialUTMCampaign",
                 "Browser",
                 "OS",
-                "DeviceType"
+                "DeviceType",
+                "Country",
+                "Region",
+                "City"
             ],
             "type": "string"
         },

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -619,6 +619,9 @@ export enum WebStatsBreakdown {
     Browser = 'Browser',
     OS = 'OS',
     DeviceType = 'DeviceType',
+    Country = 'Country',
+    Region = 'Region',
+    City = 'City',
 }
 export interface WebStatsTableQuery extends WebAnalyticsQueryBase {
     kind: NodeKind.WebStatsTableQuery

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -2,13 +2,13 @@ import { Query } from '~/queries/Query/Query'
 import { useActions, useValues } from 'kea'
 import { TabsTile, webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
-import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { isEventPropertyFilter } from 'lib/components/PropertyFilters/utils'
 import { NodeKind, QuerySchema } from '~/queries/schema'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { WebAnalyticsNotice } from 'scenes/web-analytics/WebAnalyticsNotice'
 import { webAnalyticsDataTableQueryContext, WebStatsTableTile } from 'scenes/web-analytics/WebAnalyticsDataTable'
 import { WebTabs } from 'scenes/web-analytics/WebTabs'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 const Filters = (): JSX.Element => {
     const { webAnalyticsFilters, dateTo, dateFrom } = useValues(webAnalyticsLogic)
@@ -22,6 +22,7 @@ const Filters = (): JSX.Element => {
                     onChange={(filters) => setWebAnalyticsFilters(filters.filter(isEventPropertyFilter))}
                     propertyFilters={webAnalyticsFilters}
                     pageKey={'web-analytics'}
+                    eventNames={['$pageview', '$pageleave', '$autocapture']}
                 />
             </div>
             <div className={'bg-border h-px w-full mt-2'} />

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -651,6 +651,9 @@ class WebStatsBreakdown(str, Enum):
     Browser = "Browser"
     OS = "OS"
     DeviceType = "DeviceType"
+    Country = "Country"
+    Region = "Region"
+    City = "City"
 
 
 class WebStatsTableQueryResponse(BaseModel):


### PR DESCRIPTION
## Problem

It'd be cool to show the main countries/regions/cities that users come from

## Changes

Add a new dashboard tile with multiple tabs. Re-add the world map but don't fix it yet, just don't make it the default tab.

Filtering for null on most breakdowns


<img width="557" alt="Screenshot 2023-10-30 at 17 39 01" src="https://github.com/PostHog/posthog/assets/2056078/51d96a45-339d-433e-9b5b-45e9a937b4cc">
<img width="573" alt="Screenshot 2023-10-30 at 17 38 57" src="https://github.com/PostHog/posthog/assets/2056078/5813b4b3-91a1-46fb-936c-90c73c4dec3a">
<img width="1128" alt="Screenshot 2023-10-30 at 17 38 42" src="https://github.com/PostHog/posthog/assets/2056078/ad454b33-99b3-4797-a2dc-8dd3daebb8d2">
<img width="1182" alt="Screenshot 2023-10-30 at 17 38 29" src="https://github.com/PostHog/posthog/assets/2056078/13a20511-24cd-4c42-8d8e-e35fce697c40">

## How did you test this code?
(Still behind FF) manual running