### PR TITLE
chore: ensure DEBIAN_FRONTEND=noninteractive for hobby deploy

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -2,6 +2,7 @@
 
 set -e
 
+export DEBIAN_FRONTEND=noninteractive
 export POSTHOG_APP_TAG="${POSTHOG_APP_TAG:-latest}"
 export SENTRY_DSN="${SENTRY_DSN:-'https://public@sentry.example.com/1'}"
 


### PR DESCRIPTION
## Problem

CI for hobby is currently failing because of needed user input. This _should_ let the system know that no user input should be called for.


## Changes

`export DEBIAN_FRONTEND=noninteractive` in the script 

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
