### PR TITLE
chore: set RESTART_MODE to list for needrestart to prevent halt

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -3,6 +3,9 @@
 set -e
 
 export DEBIAN_FRONTEND=noninteractive
+# Automatically restart without asking.
+# this gets around needrestart command halting for user input
+export RESTART_MODE=l
 export POSTHOG_APP_TAG="${POSTHOG_APP_TAG:-latest}"
 export SENTRY_DSN="${SENTRY_DSN:-'https://public@sentry.example.com/1'}"
 


### PR DESCRIPTION
## Problem

`needrestart` command is still halting - tested and this does prevent the prompt for user input

## Changes

export RESTART_MODE=l

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
