### PR TITLE
fix: unhandledRejection types are looser than assumed

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -184,7 +184,7 @@ export async function startPluginsServer(
     ])
 
     process.on('unhandledRejection', (error: Error | any, promise: Promise<any>) => {
-        status.error('🤮', `Unhandled Promise Rejection: ${error?.stack || error} for promise: ${promise}`)
+        status.error('🤮', `Unhandled Promise Rejection: ${error} for promise: ${promise}`)
 
         if (error instanceof KafkaJSProtocolError) {
             kafkaProtocolErrors.inc({

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -184,7 +184,7 @@ export async function startPluginsServer(
     ])
 
     process.on('unhandledRejection', (error: Error | any, promise: Promise<any>) => {
-        status.error('🤮', `Unhandled Promise Rejection: ${error} for promise: ${promise}`)
+        status.error('🤮', `Unhandled Promise Rejection`, { error, promise })
 
         if (error instanceof KafkaJSProtocolError) {
             kafkaProtocolErrors.inc({

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -183,8 +183,8 @@ export async function startPluginsServer(
         27, // REBALANCE_IN_PROGRESS
     ])
 
-    process.on('unhandledRejection', (error: Error) => {
-        status.error('🤮', `Unhandled Promise Rejection: ${error.stack}`)
+    process.on('unhandledRejection', (error: Error | any, promise: Promise<any>) => {
+        status.error('🤮', `Unhandled Promise Rejection: ${error?.stack || error} for promise: ${promise}`)
 
         if (error instanceof KafkaJSProtocolError) {
             kafkaProtocolErrors.inc({


### PR DESCRIPTION
We had a period of c 90 minutes where blob ingestion was failing to start

See https://posthog.slack.com/archives/C0185UNBSJZ/p1698707508193559?thread_ts=1698684867.238139&cid=C0185UNBSJZ

The errors that were (maybe) causing this were hidden because a top level handler for `unhandledRejection` assumed that it always received an `Error` from which it could read `stack` 

Slightly ridiculously the error being received was `undefined` https://posthog.sentry.io/issues/4410219272/?query=is%3Aunresolved+PLUGIN_SERVER_MODE%3Arecordings-blob-ingestion&referrer=issue-stream&statsPeriod=1h&stream_index=2

Looking at https://nodejs.org/docs/latest-v18.x/api/process.html#event-unhandledrejection the signature for the handler is 

```
Event: 'unhandledRejection'
reason <Error> | <any> The object with which the promise was rejected (typically an Error object).
promise <Promise> The rejected promise.
```

This changes the handler to log the error without trying to read its properties, bringing the log message to almost match the example from the docs