### PR TITLE
feat: Use actual kafka offset for threshold check

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -759,31 +759,35 @@ export class SessionRecordingIngester {
                 const lastKnownCommit = metrics.lastKnownCommit ?? -1
 
                 if (!highestOffsetToCommit) {
-                    status.warn('🤔', 'blob_ingester_consumer - no highestOffsetToCommit for partition', {
-                        blockingSession: potentiallyBlockingSession?.sessionId,
-                        blockingSessionTeamId: potentiallyBlockingSession?.teamId,
-                        partition: partition,
-                        lastKnownCommit,
-                        lastMessageOffset: metrics.lastMessageOffset,
-                        highestOffsetToCommit,
-                    })
-                    return
-                }
-
-                // If the last known commit is more than or equal to the highest offset we want to commit then we don't need to do anything
-                if (lastKnownCommit >= highestOffsetToCommit) {
-                    status.warn(
-                        '🤔',
-                        'blob_ingester_consumer - last known commit was higher than the highestOffsetToCommit',
-                        {
+                    if (partition === 101) {
+                        status.warn('🤔', 'blob_ingester_consumer - no highestOffsetToCommit for partition', {
                             blockingSession: potentiallyBlockingSession?.sessionId,
                             blockingSessionTeamId: potentiallyBlockingSession?.teamId,
                             partition: partition,
                             lastKnownCommit,
                             lastMessageOffset: metrics.lastMessageOffset,
                             highestOffsetToCommit,
-                        }
-                    )
+                        })
+                    }
+                    return
+                }
+
+                // If the last known commit is more than or equal to the highest offset we want to commit then we don't need to do anything
+                if (lastKnownCommit >= highestOffsetToCommit) {
+                    if (partition === 101) {
+                        status.warn(
+                            '🤔',
+                            'blob_ingester_consumer - last known commit was higher than the highestOffsetToCommit',
+                            {
+                                blockingSession: potentiallyBlockingSession?.sessionId,
+                                blockingSessionTeamId: potentiallyBlockingSession?.teamId,
+                                partition: partition,
+                                lastKnownCommit,
+                                lastMessageOffset: metrics.lastMessageOffset,
+                                highestOffsetToCommit,
+                            }
+                        )
+                    }
                     return
                 }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -92,7 +92,6 @@ const counterKafkaMessageReceived = new Counter({
 type PartitionMetrics = {
     lastMessageTimestamp?: number
     lastMessageOffset?: number
-    lastKnownCommit?: number
 }
 
 export interface TeamIDWithConfig {
@@ -390,7 +389,6 @@ export class SessionRecordingIngester {
                                 metrics.lastMessageTimestamp = timestamp
 
                                 // If we don't have a last known commit then set it to the offset before as that must be the last commit
-                                metrics.lastKnownCommit = metrics.lastKnownCommit ?? offset - 1
                                 metrics.lastMessageOffset = offset
 
                                 counterKafkaMessageReceived.inc({ partition })
@@ -723,6 +721,8 @@ export class SessionRecordingIngester {
         partitions: Record<number, PartitionMetrics>,
         blockingSessions: SessionManager[]
     ): Promise<void> {
+        const offsetsByPartition = await this.offsetsRefresher.get()
+
         await Promise.all(
             Object.entries(partitions).map(async ([p, metrics]) => {
                 /**
@@ -731,6 +731,8 @@ export class SessionRecordingIngester {
                  * OR the latest offset we have consumed for that partition
                  */
                 const partition = parseInt(p)
+                const committedHighOffset = offsetsByPartition[partition]
+
                 const tp = {
                     topic: this.topic,
                     partition,
@@ -756,7 +758,6 @@ export class SessionRecordingIngester {
                 const highestOffsetToCommit = potentiallyBlockingOffset
                     ? potentiallyBlockingOffset - 1 // TRICKY: We want to commit the offset before the lowest blocking offset
                     : metrics.lastMessageOffset // Or the last message we have seen as it is no longer blocked
-                const lastKnownCommit = metrics.lastKnownCommit ?? -1
 
                 if (!highestOffsetToCommit) {
                     if (partition === 101) {
@@ -764,7 +765,7 @@ export class SessionRecordingIngester {
                             blockingSession: potentiallyBlockingSession?.sessionId,
                             blockingSessionTeamId: potentiallyBlockingSession?.teamId,
                             partition: partition,
-                            lastKnownCommit,
+                            committedHighOffset,
                             lastMessageOffset: metrics.lastMessageOffset,
                             highestOffsetToCommit,
                         })
@@ -773,7 +774,7 @@ export class SessionRecordingIngester {
                 }
 
                 // If the last known commit is more than or equal to the highest offset we want to commit then we don't need to do anything
-                if (lastKnownCommit >= highestOffsetToCommit) {
+                if (committedHighOffset >= highestOffsetToCommit) {
                     if (partition === 101) {
                         status.warn(
                             '🤔',
@@ -782,7 +783,7 @@ export class SessionRecordingIngester {
                                 blockingSession: potentiallyBlockingSession?.sessionId,
                                 blockingSessionTeamId: potentiallyBlockingSession?.teamId,
                                 partition: partition,
-                                lastKnownCommit,
+                                committedHighOffset,
                                 lastMessageOffset: metrics.lastMessageOffset,
                                 highestOffsetToCommit,
                             }
@@ -797,8 +798,6 @@ export class SessionRecordingIngester {
                     // for some reason you commit the next offset you expect to read and not the one you actually have
                     offset: highestOffsetToCommit + 1,
                 })
-
-                metrics.lastKnownCommit = highestOffsetToCommit
 
                 // Store the committed offset to the persistent store to avoid rebalance issues
                 await this.persistentHighWaterMarker.add(tp, KAFKA_CONSUMER_GROUP_ID, highestOffsetToCommit)

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -759,11 +759,31 @@ export class SessionRecordingIngester {
                 const lastKnownCommit = metrics.lastKnownCommit ?? -1
 
                 if (!highestOffsetToCommit) {
+                    status.warn('🤔', 'blob_ingester_consumer - no highestOffsetToCommit for partition', {
+                        blockingSession: potentiallyBlockingSession?.sessionId,
+                        blockingSessionTeamId: potentiallyBlockingSession?.teamId,
+                        partition: partition,
+                        lastKnownCommit,
+                        lastMessageOffset: metrics.lastMessageOffset,
+                        highestOffsetToCommit,
+                    })
                     return
                 }
 
                 // If the last known commit is more than or equal to the highest offset we want to commit then we don't need to do anything
                 if (lastKnownCommit >= highestOffsetToCommit) {
+                    status.warn(
+                        '🤔',
+                        'blob_ingester_consumer - last known commit was higher than the highestOffsetToCommit',
+                        {
+                            blockingSession: potentiallyBlockingSession?.sessionId,
+                            blockingSessionTeamId: potentiallyBlockingSession?.teamId,
+                            partition: partition,
+                            lastKnownCommit,
+                            lastMessageOffset: metrics.lastMessageOffset,
+                            highestOffsetToCommit,
+                        }
+                    )
                     return
                 }
 

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -657,4 +657,20 @@ describe('ingester', () => {
             ])
         })
     })
+
+    describe('when a team is disabled', () => {
+        it('can commit even if an entire batch is disabled', async () => {
+            // non-zero offset because the code can't commit offset 0
+            await ingester.handleEachBatch([
+                createKafkaMessage('invalid_token', { offset: 12 }),
+                createKafkaMessage('invalid_token', { offset: 13 }),
+            ])
+            expect(mockCommit).toHaveBeenCalledTimes(1)
+            expect(mockCommit).toHaveBeenCalledWith({
+                offset: 14,
+                partition: 1,
+                topic: 'session_recording_snapshot_item_events_test',
+            })
+        })
+    })
 })

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -439,7 +439,6 @@ describe('ingester', () => {
         })
 
         it('should not be affected by other partitions ', async () => {
-            console.log('test start')
             await ingester.handleEachBatch([
                 createMessage('sid1', 1),
                 createMessage('sid2', 2),


### PR DESCRIPTION
## Problem

We were using the "lastKnownCommit" tracker to try and not commit older offsets to kafka which was a bit of a hack.
Now we have the offsetRefresher that checks what state we are in (added for scaling metrics) which we can use instead.

It is refreshed every 5 seconds, so it won't be perfect but in reality it was more of a safety net to stop us going really back in time, like by an hour so this safety net will still work but might also avoid some buggy behaviour

## Changes

* Removes the lastKnownCommit metric
* Refreshes the offsets before each batch
* Updates all tests to actually use logic very close to real kafka 

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
