### PR TITLE
chore: add a test for an entire batch of disabled teams

### DIFF
--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -648,4 +648,20 @@ describe('ingester', () => {
             ])
         })
     })
+
+    describe('when a team is disabled', () => {
+        it('can commit even if an entire batch is disabled', async () => {
+            // non-zero offset because the code can't commit offset 0
+            await ingester.handleEachBatch([
+                createKafkaMessage('invalid_token', { offset: 12 }),
+                createKafkaMessage('invalid_token', { offset: 13 }),
+            ])
+            expect(mockCommit).toHaveBeenCalledTimes(1)
+            expect(mockCommit).toHaveBeenCalledWith({
+                offset: 14,
+                partition: 1,
+                topic: 'session_recording_snapshot_item_events_test',
+            })
+        })
+    })
 })


### PR DESCRIPTION
We've got a stuck partition and we need to understand why

One theory is that if an entire batch was from a disabled team that we wouldn't commit. This didn't seem true and this test shows that at least in the simplest case it isn't true