### PR TITLE
Revert "feat: Use actual kafka offset for threshold check (#18288)"

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -92,6 +92,7 @@ const counterKafkaMessageReceived = new Counter({
 type PartitionMetrics = {
     lastMessageTimestamp?: number
     lastMessageOffset?: number
+    lastKnownCommit?: number
 }
 
 export interface TeamIDWithConfig {
@@ -377,14 +378,6 @@ export class SessionRecordingIngester {
                 }
 
                 await runInstrumentedFunction({
-                    statsKey: `recordingingester.handleEachBatch.refreshOffsets`,
-                    func: async () => {
-                        // Refresh what the actual committed offsets are - we can drop all messages that are below this as well as only committing higher
-                        await this.offsetsRefresher.refresh()
-                    },
-                })
-
-                await runInstrumentedFunction({
                     statsKey: `recordingingester.handleEachBatch.parseKafkaMessages`,
                     func: async () => {
                         for (const message of messages) {
@@ -397,6 +390,7 @@ export class SessionRecordingIngester {
                                 metrics.lastMessageTimestamp = timestamp
 
                                 // If we don't have a last known commit then set it to the offset before as that must be the last commit
+                                metrics.lastKnownCommit = metrics.lastKnownCommit ?? offset - 1
                                 metrics.lastMessageOffset = offset
 
                                 counterKafkaMessageReceived.inc({ partition })
@@ -729,8 +723,6 @@ export class SessionRecordingIngester {
         partitions: Record<number, PartitionMetrics>,
         blockingSessions: SessionManager[]
     ): Promise<void> {
-        const offsetsByPartition = await this.offsetsRefresher.get()
-
         await Promise.all(
             Object.entries(partitions).map(async ([p, metrics]) => {
                 /**
@@ -739,8 +731,6 @@ export class SessionRecordingIngester {
                  * OR the latest offset we have consumed for that partition
                  */
                 const partition = parseInt(p)
-                const committedHighOffset = offsetsByPartition[partition]
-
                 const tp = {
                     topic: this.topic,
                     partition,
@@ -766,6 +756,7 @@ export class SessionRecordingIngester {
                 const highestOffsetToCommit = potentiallyBlockingOffset
                     ? potentiallyBlockingOffset - 1 // TRICKY: We want to commit the offset before the lowest blocking offset
                     : metrics.lastMessageOffset // Or the last message we have seen as it is no longer blocked
+                const lastKnownCommit = metrics.lastKnownCommit ?? -1
 
                 if (!highestOffsetToCommit) {
                     if (partition === 101) {
@@ -773,7 +764,7 @@ export class SessionRecordingIngester {
                             blockingSession: potentiallyBlockingSession?.sessionId,
                             blockingSessionTeamId: potentiallyBlockingSession?.teamId,
                             partition: partition,
-                            committedHighOffset,
+                            lastKnownCommit,
                             lastMessageOffset: metrics.lastMessageOffset,
                             highestOffsetToCommit,
                         })
@@ -781,8 +772,8 @@ export class SessionRecordingIngester {
                     return
                 }
 
-                // If the last known commit is ahead of the highest offset we want to commit then we don't need to do anything
-                if (committedHighOffset > highestOffsetToCommit) {
+                // If the last known commit is more than or equal to the highest offset we want to commit then we don't need to do anything
+                if (lastKnownCommit >= highestOffsetToCommit) {
                     if (partition === 101) {
                         status.warn(
                             '🤔',
@@ -791,7 +782,7 @@ export class SessionRecordingIngester {
                                 blockingSession: potentiallyBlockingSession?.sessionId,
                                 blockingSessionTeamId: potentiallyBlockingSession?.teamId,
                                 partition: partition,
-                                committedHighOffset,
+                                lastKnownCommit,
                                 lastMessageOffset: metrics.lastMessageOffset,
                                 highestOffsetToCommit,
                             }
@@ -806,6 +797,8 @@ export class SessionRecordingIngester {
                     // for some reason you commit the next offset you expect to read and not the one you actually have
                     offset: highestOffsetToCommit + 1,
                 })
+
+                metrics.lastKnownCommit = highestOffsetToCommit
 
                 // Store the committed offset to the persistent store to avoid rebalance issues
                 await this.persistentHighWaterMarker.add(tp, KAFKA_CONSUMER_GROUP_ID, highestOffsetToCommit)


### PR DESCRIPTION
This reverts commit 977c8e9391cd306a9ff571c19c84a12550306ebc.

## Problem

We made a mistake so lets revert.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
