### PR TITLE
fix: Add committed refresher to use instead of high offsets

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon'
+import { TopicPartition } from 'node-rdkafka'
 import path from 'path'
 
 import { KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS } from '../../../config/kafka-topics'
@@ -48,5 +49,30 @@ export const queryWatermarkOffsets = (
                 resolve([partition, offsets.highOffset])
             }
         )
+    })
+}
+
+export const queryCommittedOffsets = (
+    batchConsumer: BatchConsumer | undefined,
+    topicPartitions: TopicPartition[]
+): Promise<Record<number, number>> => {
+    return new Promise<Record<number, number>>((resolve, reject) => {
+        if (!batchConsumer) {
+            return reject('Not connected')
+        }
+
+        batchConsumer.consumer.committed(topicPartitions, 5000, (err, offsets) => {
+            if (err) {
+                status.error('🔥', 'Failed to query kafka committed offsets', err)
+                return reject()
+            }
+
+            resolve(
+                offsets.reduce((acc, { partition, offset }) => {
+                    acc[partition] = offset
+                    return acc
+                }, {} as Record<number, number>)
+            )
+        })
     })
 }


### PR DESCRIPTION
## Problem

We were using the high offset refresher to determine if something had already been committed which is incorrect. Now we have a refresher, specifically for checking the actual committed values.

## Changes

* What it says on the tin

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
