### PR TITLE
feat: Only commit offsets if we are know the last commit

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -168,10 +168,6 @@ export class SessionRecordingIngester {
                 return acc
             }, {} as Record<number, number>)
         }, 5000)
-
-        this.committedOffsetsRefresher = new BackgroundRefresher(async () => {
-            return await queryCommittedOffsets(this.batchConsumer, this.assignedTopicPartitions)
-        }, 5000)
     }
 
     private get assignedTopicPartitions(): TopicPartition[] {

--- a/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon'
+import { TopicPartition } from 'node-rdkafka'
 import path from 'path'
 
 import { KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS } from '../../../config/kafka-topics'
@@ -48,5 +49,30 @@ export const queryWatermarkOffsets = (
                 resolve([partition, offsets.highOffset])
             }
         )
+    })
+}
+
+export const queryCommittedOffsets = (
+    batchConsumer: BatchConsumer | undefined,
+    topicPartitions: TopicPartition[]
+): Promise<Record<number, number>> => {
+    return new Promise<Record<number, number>>((resolve, reject) => {
+        if (!batchConsumer) {
+            return reject('Not connected')
+        }
+
+        batchConsumer.consumer.committed(topicPartitions, 5000, (err, offsets) => {
+            if (err) {
+                status.error('🔥', 'Failed to query kafka committed offsets', err)
+                return reject()
+            }
+
+            resolve(
+                offsets.reduce((acc, { partition, offset }) => {
+                    acc[partition] = offset
+                    return acc
+                }, {} as Record<number, number>)
+            )
+        })
     })
 }

--- a/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
@@ -43,7 +43,7 @@ export const queryWatermarkOffsets = (
             (err, offsets) => {
                 if (err) {
                     status.error('🔥', 'Failed to query kafka watermark offsets', err)
-                    return reject()
+                    return reject(err)
                 }
 
                 resolve([partition, offsets.highOffset])
@@ -61,10 +61,10 @@ export const queryCommittedOffsets = (
             return reject('Not connected')
         }
 
-        batchConsumer.consumer.committed(topicPartitions, 5000, (err, offsets) => {
+        batchConsumer.consumer.committed(topicPartitions, 10000, (err, offsets) => {
             if (err) {
                 status.error('🔥', 'Failed to query kafka committed offsets', err)
-                return reject()
+                return reject(err)
             }
 
             resolve(


### PR DESCRIPTION
## Problem

We should never commit older than the committed offset. This change makes sure of it by forcefully fetching the committed offsets and only committing if we had a response for that partition


## Changes

* As described

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
