### PR TITLE
docs: Show the project membership endpoint

### DIFF
--- a/ee/api/explicit_team_member.py
+++ b/ee/api/explicit_team_member.py
@@ -110,7 +110,7 @@ class ExplicitTeamMemberViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     lookup_field = "parent_membership__user__uuid"
     ordering = ["level", "-joined_at"]
     serializer_class = ExplicitTeamMemberSerializer
-    include_in_docs = False
+    include_in_docs = True
 
     def get_permissions(self):
         if (

--- a/ee/models/explicit_team_membership.py
+++ b/ee/models/explicit_team_membership.py
@@ -1,11 +1,7 @@
-from typing import TYPE_CHECKING
-
 from django.db import models
 
 from posthog.models.utils import UUIDModel, sane_repr
-
-if TYPE_CHECKING:
-    from posthog.models.organization import OrganizationMembership
+from posthog.models.organization import OrganizationMembership
 
 
 # We call models that grant a user access to some grouping of users a "membership"


### PR DESCRIPTION
## Problem

A customer wants to add members to their private projects in bulk, and that endpoint is currently hidden ([internal Slack thread](https://posthog.slack.com/archives/C02E3BKC78F/p1698750139178839)).

## Changes

I think it's okay to expose basic documentation of the project explicit members endpoint. We can't provide guarantees for it, but it's going to be niche anyway.