### PR TITLE
fix(feature flags): fix filters dropdown width

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -261,6 +261,7 @@ export function OverViewTab({
                                             <b>Type</b>
                                         </span>
                                         <LemonSelect
+                                            dropdownMatchSelectWidth={false}
                                             onChange={(type) => {
                                                 if (type) {
                                                     if (type === 'all') {
@@ -287,6 +288,7 @@ export function OverViewTab({
                                     <b>Status</b>
                                 </span>
                                 <LemonSelect
+                                    dropdownMatchSelectWidth={false}
                                     onChange={(status) => {
                                         if (status) {
                                             if (status === 'all') {
@@ -310,6 +312,7 @@ export function OverViewTab({
                                     <b>Created by</b>
                                 </span>
                                 <LemonSelect
+                                    dropdownMatchSelectWidth={false}
                                     onChange={(user) => {
                                         if (user) {
                                             if (user === 'any') {


### PR DESCRIPTION
## Problem
Filter options are being truncated because the dropdown matches the Select width.

<img width="129" alt="Screenshot 2023-10-31 at 15 31 18" src="https://github.com/PostHog/posthog/assets/22996112/1d86f390-9647-4168-9e54-75f209642ebf">

## Changes
Set `dropdownMatchSelectWidth` to `false`

<img width="152" alt="Screenshot 2023-10-31 at 15 31 37" src="https://github.com/PostHog/posthog/assets/22996112/f4f0f564-14a5-4cda-9b1f-cdaaaf3d1a8f">

## How did you test this code?
👀 