### PR TITLE
feat: Added blobby batch size counter

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
@@ -22,7 +22,7 @@ import { OffsetHighWaterMarker } from './offset-high-water-marker'
 import { RealtimeManager } from './realtime-manager'
 
 const BUCKETS_LINES_WRITTEN = [0, 10, 50, 100, 500, 1000, 2000, 5000, 10000, Infinity]
-const BUCKETS_KB_WRITTEN = [0, 128, 512, 1024, 5120, 10240, 20480, 51200, 102400, 204800, Infinity]
+export const BUCKETS_KB_WRITTEN = [0, 128, 512, 1024, 5120, 10240, 20480, 51200, 102400, 204800, Infinity]
 const S3_UPLOAD_WARN_TIME_SECONDS = 2 * 60 * 1000
 
 const counterS3FilesWritten = new Counter({

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -23,7 +23,7 @@ import { OffsetHighWaterMarker } from './services/offset-high-water-marker'
 import { PartitionLocker } from './services/partition-locker'
 import { RealtimeManager } from './services/realtime-manager'
 import { ReplayEventsIngester } from './services/replay-events-ingester'
-import { SessionManager } from './services/session-manager'
+import { BUCKETS_KB_WRITTEN, SessionManager } from './services/session-manager'
 import { IncomingRecordingMessage } from './types'
 import { bufferFileDir, now, queryWatermarkOffsets } from './utils'
 
@@ -81,6 +81,12 @@ const histogramKafkaBatchSize = new Histogram({
     name: 'recording_blob_ingestion_kafka_batch_size',
     help: 'The size of the batches we are receiving from Kafka',
     buckets: [0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 600, Infinity],
+})
+
+const histogramKafkaBatchSizeKb = new Histogram({
+    name: 'recording_blob_ingestion_kafka_batch_size_kb',
+    help: 'The size in kb of the batches we are receiving from Kafka',
+    buckets: BUCKETS_KB_WRITTEN,
 })
 
 const counterKafkaMessageReceived = new Counter({
@@ -374,6 +380,7 @@ export class SessionRecordingIngester {
             logExecutionTime: true,
             func: async () => {
                 histogramKafkaBatchSize.observe(messages.length)
+                histogramKafkaBatchSizeKb.observe(messages.reduce((acc, m) => (m.value?.length ?? 0) + acc, 0))
 
                 const recordingMessages: IncomingRecordingMessage[] = []
 
@@ -387,31 +394,32 @@ export class SessionRecordingIngester {
                         for (const message of messages) {
                             const { partition, offset, timestamp } = message
 
-                            if (timestamp && this.partitionAssignments[partition]) {
-                                const metrics = this.partitionAssignments[partition]
+                            this.partitionAssignments[partition] = this.partitionAssignments[partition] || {}
+                            const metrics = this.partitionAssignments[partition]
 
+                            // If we don't have a last known commit then set it to the offset before as that must be the last commit
+                            metrics.lastMessageOffset = offset
+
+                            counterKafkaMessageReceived.inc({ partition })
+
+                            if (timestamp) {
                                 // For some reason timestamp can be null. If it isn't, update our ingestion metrics
                                 metrics.lastMessageTimestamp = timestamp
-
-                                // If we don't have a last known commit then set it to the offset before as that must be the last commit
-                                metrics.lastMessageOffset = offset
-
-                                counterKafkaMessageReceived.inc({ partition })
 
                                 gaugeLagMilliseconds
                                     .labels({
                                         partition: partition.toString(),
                                     })
                                     .set(now() - timestamp)
+                            }
 
-                                const offsetsByPartition = await this.latestOffsetsRefresher.get()
-                                const highOffset = offsetsByPartition[partition]
+                            const offsetsByPartition = await this.latestOffsetsRefresher.get()
+                            const highOffset = offsetsByPartition[partition]
 
-                                if (highOffset) {
-                                    metrics.offsetLag = highOffset - metrics.lastMessageOffset
-                                    // NOTE: This is an important metric used by the autoscaler
-                                    gaugeLag.set({ partition }, Math.max(0, metrics.offsetLag))
-                                }
+                            if (highOffset) {
+                                metrics.offsetLag = highOffset - metrics.lastMessageOffset
+                                // NOTE: This is an important metric used by the autoscaler
+                                gaugeLag.set({ partition }, Math.max(0, metrics.offsetLag))
                             }
 
                             const recordingMessage = await this.parseKafkaMessage(message, (token) =>

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -380,7 +380,7 @@ export class SessionRecordingIngester {
             logExecutionTime: true,
             func: async () => {
                 histogramKafkaBatchSize.observe(messages.length)
-                histogramKafkaBatchSizeKb.observe(messages.reduce((acc, m) => (m.value?.length ?? 0) + acc, 0))
+                histogramKafkaBatchSizeKb.observe(messages.reduce((acc, m) => (m.value?.length ?? 0) + acc, 0) / 1024)
 
                 const recordingMessages: IncomingRecordingMessage[] = []
 


### PR DESCRIPTION
## Problem

It would be useful to know how big the incoming message batch is so we can better estimate the effect it would have on memory usage.

## Changes

* Counts the kb of the batch roughly
* Ensures we always create the partitionmetrics, regardless of assignment

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
