### PR TITLE
chore: make log message filterable

### DIFF
--- a/plugin-server/src/main/utils.ts
+++ b/plugin-server/src/main/utils.ts
@@ -17,6 +17,8 @@ interface FunctionInstrumentation<T> {
 const logTime = (startTime: number, statsKey: string, error?: any) => {
     status.info('⏱️', `${statsKey} took ${Math.round(performance.now() - startTime)}ms`, {
         error,
+        statsKey,
+        type: 'instrumented_function_time_log',
     })
 }
 


### PR DESCRIPTION
makes a log message more easily filterable in grafana so I don't have to watch Ben filter things with text searches by hand like in the iron age