### PR TITLE
chore: make loki sad

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -308,8 +308,6 @@ export class SessionRecordingIngester {
             teamIdWithConfig = await getTeamFn(token)
         }
 
-        messagesParsedCounter.label(token).inc()
-
         // NB `==` so we're comparing undefined and null
         if (teamIdWithConfig == null || teamIdWithConfig.teamId == null) {
             eventDroppedCounter


### PR DESCRIPTION
We look at lagging partitions and want to know what proportion of their messages are from which teams, we then manually poke around in Loki and Kafka UI while swearing

There's a point in the parsing where we know we do or don't have a team id. Let's add the team to our message counter then