### PR TITLE
fix(batch-exports): Support delayed events when exporting low volume

### DIFF
--- a/posthog/management/commands/test/test_create_batch_export_from_app.py
+++ b/posthog/management/commands/test/test_create_batch_export_from_app.py
@@ -506,6 +506,7 @@ def test_create_batch_export_from_app_with_backfill(interval, plugin_config):
         batch_export_id = str(batch_export_data["id"])
         workflows = wait_for_workflow_executions(temporal, query=f'TemporalScheduledById="{batch_export_id}"')
 
-        assert len(workflows) == 1
+        # In the event the test takes too long, we may spawn more than one run
+        assert len(workflows) >= 1
         workflow_execution = workflows[0]
         assert workflow_execution.workflow_type == f"{export_type.lower()}-export"

--- a/posthog/temporal/workflows/bigquery_batch_export.py
+++ b/posthog/temporal/workflows/bigquery_batch_export.py
@@ -135,6 +135,8 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs):
             interval_end=inputs.data_interval_end,
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
+            # Heuristic: Should be fast to sort 10k events.
+            add_timestamp_predicate=True if count <= 10000 else False,
         )
         table_schema = [
             bigquery.SchemaField("uuid", "STRING"),


### PR DESCRIPTION
## Problem

Events ingested with a delay (as measured by the difference between `timestamp` and `inserted_at`) are omitted from a batch export if the delay is to big (1-2 days). This is because we do not have a sort key on `inserted_at`, thus are forced to include _some_ predicate that utilizes `timestamp` to ensure good performance.

However, we can assume that when exporting a low amount of events, sorting will be fast regardless, and we can get rid of the `timestamp` predicate. This will allow users with low volume to export events that were ingested with a delay.

The key now becomes how do we choose a threshold to define "low volume". I've gone with 10k, but I am open to hearing thoughts about this.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Omit `timestamp` predicate when exporting up to 10k events in a batch.

TODO:
* Add a unit test
 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
