### PR TITLE
feat: show exact playback time on hover

### DIFF
--- a/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
@@ -7,9 +7,11 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { useKeyHeld } from 'lib/hooks/useKeyHeld'
 import { IconSkipBackward } from 'lib/lemon-ui/icons'
 import clsx from 'clsx'
+import { dayjs } from 'lib/dayjs'
 
 export function Timestamp(): JSX.Element {
-    const { logicProps, currentPlayerTime, sessionPlayerData } = useValues(sessionRecordingPlayerLogic)
+    const { logicProps, currentPlayerTime, currentTimestamp, sessionPlayerData } =
+        useValues(sessionRecordingPlayerLogic)
     const { isScrubbing, scrubbingTime } = useValues(seekbarLogic(logicProps))
 
     const startTimeSeconds = ((isScrubbing ? scrubbingTime : currentPlayerTime) ?? 0) / 1000
@@ -19,8 +21,10 @@ export function Timestamp(): JSX.Element {
 
     return (
         <div className="whitespace-nowrap mr-4">
-            {colonDelimitedDuration(startTimeSeconds, fixedUnits)} /{' '}
-            {colonDelimitedDuration(endTimeSeconds, fixedUnits)}
+            <Tooltip overlay={dayjs(currentTimestamp).format('HH:mm:ss A')}>
+                {colonDelimitedDuration(startTimeSeconds, fixedUnits)}
+            </Tooltip>{' '}
+            / {colonDelimitedDuration(endTimeSeconds, fixedUnits)}
         </div>
     )
 }


### PR DESCRIPTION
## Problem

[A customer made a great point](https://posthoghelp.zendesk.com/agent/tickets/6769) that it is not possible to get the exact time of playback outside of events.

## Changes

Show the exact time when the current time is hovered

## How did you test this code?

Manually
<img width="479" alt="Screenshot 2023-11-01 at 11 18 49" src="https://github.com/PostHog/posthog/assets/6685876/ed2030dd-e07c-4414-b6b6-9ad40ec7cb3f">
