### PR TITLE
fix(flags): Ensure type coercion applies for isnot operator  as well

### DIFF
--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -130,13 +130,24 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -147,7 +158,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -158,7 +169,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -169,7 +180,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -198,7 +209,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -219,22 +230,6 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
-  '
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginconfig"."web_token",
-         "posthog_pluginsourcefile"."updated_at",
-         "posthog_plugin"."updated_at",
-         "posthog_pluginconfig"."updated_at"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_flag_with_behavioural_cohorts

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -130,24 +130,13 @@
 ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '
----
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
-  '
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -158,7 +147,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -169,7 +158,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -180,7 +169,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -209,7 +198,7 @@
   LIMIT 21
   '
 ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -230,6 +219,22 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
+  '
+---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
+  '
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
   '
 ---
 # name: TestDecide.test_flag_with_behavioural_cohorts

--- a/posthog/models/property/property.py
+++ b/posthog/models/property/property.py
@@ -71,8 +71,6 @@ OperatorType = Literal[
     "is_date_exact",
     "is_date_after",
     "is_date_before",
-    "is_relative_date_after",
-    "is_relative_date_before",
 ]
 
 OperatorInterval = Literal["day", "week", "month", "year"]

--- a/posthog/models/property/property.py
+++ b/posthog/models/property/property.py
@@ -71,6 +71,8 @@ OperatorType = Literal[
     "is_date_exact",
     "is_date_after",
     "is_date_before",
+    "is_relative_date_after",
+    "is_relative_date_before",
 ]
 
 OperatorInterval = Literal["day", "week", "month", "year"]
@@ -271,9 +273,9 @@ class Property:
     def _parse_value(value: ValueT, convert_to_number: bool = False) -> Any:
         if isinstance(value, list):
             return [Property._parse_value(v, convert_to_number) for v in value]
-        if value == "true":
+        if value == "true" or value == "True":
             return True
-        if value == "false":
+        if value == "false" or value == "False":
             return False
         if isinstance(value, int):
             return value

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -1,3 +1,94 @@
+# name: TestFeatureFlagMatcher.test_coercion_of_booleans_with_is_not_operator
+  '
+  SELECT NOT ((("posthog_person"."properties" -> 'disabled') = 'false'
+               OR ("posthog_person"."properties" -> 'disabled') = '"false"')
+              AND "posthog_person"."properties" ? 'disabled'
+              AND NOT (("posthog_person"."properties" -> 'disabled') = 'null')) AS "flag_X_condition_0",
+             NOT ((("posthog_person"."properties" -> 'disabled') = 'false'
+                   OR ("posthog_person"."properties" -> 'disabled') = '"false"')
+                  AND "posthog_person"."properties" ? 'disabled'
+                  AND NOT (("posthog_person"."properties" -> 'disabled') = 'null')) AS "flag_X_condition_1",
+                 NOT ((("posthog_person"."properties" -> 'disabled') = 'false'
+                       OR ("posthog_person"."properties" -> 'disabled') = '"false"')
+                      AND "posthog_person"."properties" ? 'disabled'
+                      AND NOT (("posthog_person"."properties" -> 'disabled') = 'null')) AS "flag_X_condition_2",
+                     NOT ((("posthog_person"."properties" -> 'disabled') = 'false'
+                           OR ("posthog_person"."properties" -> 'disabled') = '"false"')
+                          AND "posthog_person"."properties" ? 'disabled'
+                          AND NOT (("posthog_person"."properties" -> 'disabled') = 'null')) AS "flag_X_condition_3",
+                         NOT ((("posthog_person"."properties" -> 'disabled') = 'false'
+                               OR ("posthog_person"."properties" -> 'disabled') = '"false"')
+                              AND "posthog_person"."properties" ? 'disabled'
+                              AND NOT (("posthog_person"."properties" -> 'disabled') = 'null')) AS "flag_X_condition_4",
+                             NOT ((("posthog_person"."properties" -> 'string_disabled') = 'false'
+                                   OR ("posthog_person"."properties" -> 'string_disabled') = '"false"')
+                                  AND "posthog_person"."properties" ? 'string_disabled'
+                                  AND NOT (("posthog_person"."properties" -> 'string_disabled') = 'null')) AS "flag_X_condition_5",
+                                 NOT ((("posthog_person"."properties" -> 'string_disabled') = 'false'
+                                       OR ("posthog_person"."properties" -> 'string_disabled') = '"false"')
+                                      AND "posthog_person"."properties" ? 'string_disabled'
+                                      AND NOT (("posthog_person"."properties" -> 'string_disabled') = 'null')) AS "flag_X_condition_6",
+                                     NOT ((("posthog_person"."properties" -> 'string_disabled') = 'false'
+                                           OR ("posthog_person"."properties" -> 'string_disabled') = '"false"')
+                                          AND "posthog_person"."properties" ? 'string_disabled'
+                                          AND NOT (("posthog_person"."properties" -> 'string_disabled') = 'null')) AS "flag_X_condition_7",
+                                         NOT ((("posthog_person"."properties" -> 'string_disabled') = 'false'
+                                               OR ("posthog_person"."properties" -> 'string_disabled') = '"false"')
+                                              AND "posthog_person"."properties" ? 'string_disabled'
+                                              AND NOT (("posthog_person"."properties" -> 'string_disabled') = 'null')) AS "flag_X_condition_8"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = '307'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
+# name: TestFeatureFlagMatcher.test_coercion_of_strings_and_numbers_with_is_not_operator
+  '
+  SELECT (NOT ((("posthog_person"."properties" -> 'Organizer Id') IN ('"307"')
+                OR ("posthog_person"."properties" -> 'Organizer Id') IN ('307'))
+               AND "posthog_person"."properties" ? 'Organizer Id'
+               AND NOT (("posthog_person"."properties" -> 'Organizer Id') = 'null'))
+          AND NOT (("posthog_person"."properties" -> 'Organizer Id') IN ('307')
+                   AND "posthog_person"."properties" ? 'Organizer Id'
+                   AND NOT (("posthog_person"."properties" -> 'Organizer Id') = 'null'))
+          AND NOT ((("posthog_person"."properties" -> 'Organizer Id') = '"307"'
+                    OR ("posthog_person"."properties" -> 'Organizer Id') = '307')
+                   AND "posthog_person"."properties" ? 'Organizer Id'
+                   AND NOT (("posthog_person"."properties" -> 'Organizer Id') = 'null'))
+          AND NOT (("posthog_person"."properties" -> 'Organizer Id') = '307'
+                   AND "posthog_person"."properties" ? 'Organizer Id'
+                   AND NOT (("posthog_person"."properties" -> 'Organizer Id') = 'null'))) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = '307'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
+# name: TestFeatureFlagMatcher.test_coercion_of_strings_and_numbers_with_is_not_operator.1
+  '
+  SELECT NOT ((("posthog_person"."properties" -> 'Distinct Id') IN ('"307"')
+               OR ("posthog_person"."properties" -> 'Distinct Id') IN ('307'))
+              AND "posthog_person"."properties" ? 'Distinct Id'
+              AND NOT (("posthog_person"."properties" -> 'Distinct Id') = 'null')) AS "flag_X_condition_0",
+             NOT (("posthog_person"."properties" -> 'Distinct Id') IN ('307')
+                  AND "posthog_person"."properties" ? 'Distinct Id'
+                  AND NOT (("posthog_person"."properties" -> 'Distinct Id') = 'null')) AS "flag_X_condition_1",
+                 NOT ((("posthog_person"."properties" -> 'Distinct Id') = '"307"'
+                       OR ("posthog_person"."properties" -> 'Distinct Id') = '307')
+                      AND "posthog_person"."properties" ? 'Distinct Id'
+                      AND NOT (("posthog_person"."properties" -> 'Distinct Id') = 'null')) AS "flag_X_condition_2",
+                     NOT (("posthog_person"."properties" -> 'Distinct Id') = '307'
+                          AND "posthog_person"."properties" ? 'Distinct Id'
+                          AND NOT (("posthog_person"."properties" -> 'Distinct Id') = 'null')) AS "flag_X_condition_3"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = '307'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
 # name: TestFeatureFlagMatcher.test_db_matches_independent_of_string_or_number_type
   '
   SELECT "posthog_team"."id",


### PR DESCRIPTION
## Problem

Flags had this nasty bug where type coercion didn't apply correctly for `is_not` operator. As a result, `is_not` was also not an inverse of `exact` operator.

This was very bad & annoying. I've now combined the code, such that `exact` and `is_not` take the same codepaths, which ensures any future changes will keep them as inverses of each other.

This also fixes any issues around flag conditions with `value != 100`  or `value != '100'` not matching when they should.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
