### PR TITLE
feat: Add minmax index on inserted_at

### DIFF
--- a/posthog/clickhouse/migrations/0050_add_minmax_index_on_inserted_at.py
+++ b/posthog/clickhouse/migrations/0050_add_minmax_index_on_inserted_at.py
@@ -1,0 +1,20 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+ADD_INDEX_SQL = """
+ALTER TABLE sharded_events
+ON CLUSTER '{cluster}'
+ADD INDEX IF NOT EXISTS events_inserted_at_minmax_index COALESCE(inserted_at, _timestamp)
+TYPE minmax;
+"""
+
+MATERIALIZE_INDEX_SQL = """
+ALTER TABLE sharded_events
+ON CLUSTER '{cluster}'
+MATERIALIZE INDEX events_inserted_at_minmax_index;
+"""
+
+operations = [
+    run_sql_with_exceptions(ADD_INDEX_SQL.format(cluster=CLICKHOUSE_CLUSTER)),
+    run_sql_with_exceptions(MATERIALIZE_INDEX_SQL.format(cluster=CLICKHOUSE_CLUSTER)),
+]


### PR DESCRIPTION
## Problem

In order to support delayed events in batch exports, we need to drop the `timestamp` predicates from the batch exports query. However, doing so could have performance implications. We already tried using a projection (#17466), but ran into issues with deployment. As an alternative, we can use a `minmax` index as `inserted_at` is going to be loosely sorted based on `timestamp`, so it should be a good candidate for such an index:

* Most events arrive without delay, so their `inserted_at` will be close to timestamp in value, and thus be all clumped up together. So, `minmax` works great as we have most of the batch range in a single place: I imagine a set of dense granules with lots of hits, and a few values leaking to granules at the end and the start.
* For events that arrive with a big delay, CH can then use the `minmax` index to find granules where the `max(inserted_at)` is beyond the `max(timestamp)` of the granule, as that would indicate a delayed event. Since I assume these events will be split apart by a lot, this means a lot of data will skipped. My assumption is based on delayed events being relatively rare (which looking at user numbers, seems accurate for now).
* `minmax` indexes are also the most lightweight of the bunch, so I'm hopeful this will not impact other queries (i.e. inserts).


<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add a migration to create a `minmax` index.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

@fuziontech Happy to sync-up for testing if you agree on the potential of this index.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
