### PR TITLE
fix: Support panel react to params

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
@@ -9,7 +9,6 @@ import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerL
 import { IconNotebook, IconQuestion, IconInfo } from '@posthog/icons'
 import { SidePanelDocs } from './panels/SidePanelDocs'
 import { SidePanelSupport } from './panels/SidePanelSupport'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { NotebookPanel } from 'scenes/notebooks/NotebookPanel/NotebookPanel'
 
 export const SidePanelTabs: Record<SidePanelTab, { label: string; Icon: any; Content: any }> = {
@@ -30,15 +29,9 @@ export const SidePanelTabs: Record<SidePanelTab, { label: string; Icon: any; Con
     },
 }
 
-export function SidePanel(): JSX.Element {
-    const { selectedTab, sidePanelOpen } = useValues(sidePanelLogic)
+export function SidePanel(): JSX.Element | null {
+    const { selectedTab, sidePanelOpen, enabledTabs } = useValues(sidePanelLogic)
     const { openSidePanel, closeSidePanel } = useActions(sidePanelLogic)
-
-    const docsEnabled = useFeatureFlag('SIDE_PANEL_DOCS')
-
-    const enabledTabs = docsEnabled
-        ? Object.keys(SidePanelTabs)
-        : Object.keys(SidePanelTabs).filter((tab) => tab !== SidePanelTab.Docs)
 
     const activeTab = sidePanelOpen && selectedTab
 
@@ -58,6 +51,10 @@ export function SidePanel(): JSX.Element {
 
     const { desiredWidth, isResizeInProgress } = useValues(resizerLogic(resizerLogicProps))
 
+    if (!enabledTabs.length) {
+        return null
+    }
+
     return (
         <div
             className={clsx(
@@ -75,7 +72,7 @@ export function SidePanel(): JSX.Element {
             <div className="SidePanel3000__bar">
                 <div className="rotate-90 flex items-center gap-1 px-2">
                     {Object.entries(SidePanelTabs)
-                        .filter(([tab]) => enabledTabs.includes(tab))
+                        .filter(([tab]) => enabledTabs.includes(tab as SidePanelTab))
                         .map(([tab, { label, Icon }]) => (
                             <LemonButton
                                 key={tab}

--- a/frontend/src/lib/components/HelpButton/HelpButton.tsx
+++ b/frontend/src/lib/components/HelpButton/HelpButton.tsx
@@ -91,9 +91,9 @@ export function HelpButton({
     const { hedgehogModeEnabled } = useValues(hedgehogbuddyLogic)
     const { setHedgehogModeEnabled } = useActions(hedgehogbuddyLogic)
     const { openSupportForm } = useActions(supportLogic)
-    const { preflight } = useValues(preflightLogic)
+    const { isCloudOrDev } = useValues(preflightLogic)
 
-    const showSupportOptions: boolean = preflight?.cloud || false
+    const showSupportOptions: boolean = isCloudOrDev || false
 
     if (contactOnly && !showSupportOptions) {
         return null // We don't offer support for self-hosted instances

--- a/frontend/src/lib/components/Support/SupportModal.tsx
+++ b/frontend/src/lib/components/Support/SupportModal.tsx
@@ -3,13 +3,16 @@ import { supportLogic } from './supportLogic'
 import { LemonModal } from 'lib/lemon-ui/LemonModal/LemonModal'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SupportForm, SupportFormButtons } from './SupportForm'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 
 export function SupportModal({ loggedIn = true }: { loggedIn?: boolean }): JSX.Element | null {
     const { sendSupportRequest, isSupportFormOpen, sendSupportLoggedOutRequest, title } = useValues(supportLogic)
     const { closeSupportForm } = useActions(supportLogic)
+    const { isCloudOrDev } = useValues(preflightLogic)
+    const is3000 = useFeatureFlag('POSTHOG_3000')
     // the support model can be shown when logged out, file upload is not offered to anonymous users
 
-    if (!preflightLogic.values.preflight?.cloud) {
+    if (!isCloudOrDev || is3000) {
         return null
     }
 

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -12,6 +12,7 @@ import { captureException } from '@sentry/react'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import * as Sentry from '@sentry/react'
+import { SidePanelTab, sidePanelLogic } from '~/layout/navigation-3000/sidepanel/sidePanelLogic'
 
 function getSessionReplayLink(): string {
     const link = posthog
@@ -110,6 +111,7 @@ export const supportLogic = kea<supportLogicType>([
     path(['lib', 'components', 'support', 'supportLogic']),
     connect(() => ({
         values: [userLogic, ['user'], preflightLogic, ['preflight']],
+        actions: [sidePanelLogic, ['openSidePanel', 'closeSidePanel']],
     })),
     actions(() => ({
         closeSupportForm: () => true,
@@ -212,6 +214,8 @@ export const supportLogic = kea<supportLogicType>([
                 target_area: target_area ?? getURLPathToTargetArea(window.location.pathname),
                 message: '',
             })
+
+            actions.openSidePanel(SidePanelTab.Feedback)
         },
         openSupportLoggedOutForm: async ({ name, email, kind, target_area }) => {
             actions.resetSendSupportLoggedOutRequest({


### PR DESCRIPTION
## Problem

The side panel was added but had a remaining issue that the feedback wouldn't open correctly in reaction to the hash params

## Changes

![2023-11-02 10 31 20](https://github.com/PostHog/posthog/assets/2536520/0c2715ee-f150-4f31-8891-3fd2fff42d5b)


* Fixes to open the side panel in reaction to opening the support form
* Shows support controls for devving 
* Fixes flagged sidebar items.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
