### PR TITLE
fix(ci): fix flaky 'plugins can use attachements' test

### DIFF
--- a/plugin-server/functional_tests/api.ts
+++ b/plugin-server/functional_tests/api.ts
@@ -151,14 +151,15 @@ export const createPlugin = async (plugin: Omit<Plugin, 'id'>) => {
 }
 
 export const createPluginConfig = async (
-    pluginConfig: Omit<PluginConfig, 'id' | 'created_at' | 'enabled' | 'order' | 'has_error'>
+    pluginConfig: Omit<PluginConfig, 'id' | 'created_at' | 'enabled' | 'order' | 'has_error'>,
+    enabled = true
 ) => {
     return await insertRow(postgres, 'posthog_pluginconfig', {
         ...pluginConfig,
         config: pluginConfig.config ?? {},
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
-        enabled: true,
+        enabled,
         order: 0,
     })
 }

--- a/plugin-server/functional_tests/plugins.test.ts
+++ b/plugin-server/functional_tests/plugins.test.ts
@@ -10,6 +10,7 @@ import {
     createPluginAttachment,
     createPluginConfig,
     createTeam,
+    enablePluginConfig,
     fetchEvents,
     fetchPluginConsoleLogEntries,
     fetchPostgresPersons,
@@ -573,7 +574,9 @@ test.concurrent('plugins can use attachements', async () => {
         source__index_ts: indexJs,
     })
 
-    const pluginConfig = await createPluginConfig({ team_id: teamId, plugin_id: plugin.id, config: {} })
+    // Create the pluginconfig disabled to avoid it being loaded by a concurrent test
+    // before the attachment is available.
+    const pluginConfig = await createPluginConfig({ team_id: teamId, plugin_id: plugin.id, config: {} }, false)
     await createPluginAttachment({
         teamId,
         pluginConfigId: pluginConfig.id,
@@ -583,6 +586,7 @@ test.concurrent('plugins can use attachements', async () => {
         key: 'testAttachment',
         contents: 'test',
     })
+    await enablePluginConfig(teamId, plugin.id)
 
     await reloadPlugins()
 


### PR DESCRIPTION
## Problem

Test is flaky, I think it comes from a race condition leading to the pluginconfig being loaded before we insert its attachment. We could insert both rows in a transaction, but it would require a hefty amount of plumbing changes.

Instead, let's create the config as disabled first, add the attachment, then enable the config. This mirrors the frontend flow better anyway.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
