### PR TITLE
fix: subdomain cleaning

### DIFF
--- a/frontend/src/scenes/authentication/redirectToLoggedInInstance.test.ts
+++ b/frontend/src/scenes/authentication/redirectToLoggedInInstance.test.ts
@@ -1,0 +1,14 @@
+import { cleanedCookieSubdomain } from 'scenes/authentication/redirectToLoggedInInstance'
+
+describe('redirectToLoggedInInstance', () => {
+    test.each([
+        ['handles null', null, null],
+        ['handles EU', 'https://eu.posthog.com', 'eu'],
+        ['handles US', 'https://app.posthog.com', 'app'],
+        ['handles leading quotes', '"https://eu.posthog.com', 'eu'],
+        ['handles trailing quotes', 'https://eu.posthog.com"', 'eu'],
+        ['handles wrapping quotes', '"https://eu.posthog.com"', 'eu'],
+    ])('%s', (_name, cookie, expected) => {
+        expect(cleanedCookieSubdomain(cookie)).toEqual(expected)
+    })
+})

--- a/frontend/src/scenes/authentication/redirectToLoggedInInstance.ts
+++ b/frontend/src/scenes/authentication/redirectToLoggedInInstance.ts
@@ -23,6 +23,7 @@
 
 import { lemonToast } from '@posthog/lemon-ui'
 import { getCookie } from 'lib/api'
+import { captureException } from '@sentry/react'
 
 // cookie values
 const PH_CURRENT_INSTANCE = 'ph_current_instance'
@@ -35,15 +36,21 @@ const SUBDOMAIN_TO_NAME = {
 } as const
 
 export function cleanedCookieSubdomain(loggedInInstance: string | null): string | null {
-    // replace '"' as for some reason the cookie value is wrapped in quotes e.g. "https://eu.posthog.com"
-    const url = loggedInInstance?.replace(/"/g, '')
-    if (!url) {
+    try {
+        // replace '"' as for some reason the cookie value is wrapped in quotes e.g. "https://eu.posthog.com"
+        const url = loggedInInstance?.replace(/"/g, '')
+        if (!url) {
+            return null
+        }
+
+        const parsedURL = new URL(url)
+        const host = parsedURL.host
+        return url ? host.split('.')[0] : null
+    } catch (e) {
+        // let's not allow errors in this code break the log-in page 🤞
+        captureException(e, { extra: { loggedInInstance } })
         return null
     }
-
-    const parsedURL = new URL(url)
-    const host = parsedURL.host
-    return url ? host.split('.')[0] : null
 }
 
 export function redirectIfLoggedInOtherInstance(): (() => void) | undefined {

--- a/frontend/src/scenes/authentication/redirectToLoggedInInstance.ts
+++ b/frontend/src/scenes/authentication/redirectToLoggedInInstance.ts
@@ -34,12 +34,23 @@ const SUBDOMAIN_TO_NAME = {
     app: 'US',
 } as const
 
+export function cleanedCookieSubdomain(loggedInInstance: string | null): string | null {
+    // replace '"' as for some reason the cookie value is wrapped in quotes e.g. "https://eu.posthog.com"
+    const url = loggedInInstance?.replace(/"/g, '')
+    if (!url) {
+        return null
+    }
+
+    const parsedURL = new URL(url)
+    const host = parsedURL.host
+    return url ? host.split('.')[0] : null
+}
+
 export function redirectIfLoggedInOtherInstance(): (() => void) | undefined {
     const currentSubdomain = window.location.hostname.split('.')[0]
 
     const loggedInInstance = getCookie(PH_CURRENT_INSTANCE)
-    // replace '"' as for some reason the cookie value is wrapped in quotes e.g. "https://eu.posthog.com"
-    const loggedInSubdomain = loggedInInstance ? new URL(loggedInInstance.replace('"', '')).host.split('.')[0] : null
+    const loggedInSubdomain = cleanedCookieSubdomain(loggedInInstance)
 
     if (!loggedInSubdomain) {
         return // not logged into another subdomain


### PR DESCRIPTION
string replace in JS only replaces the first match when the match pattern is a string.

we were using it to strip wrapping quotes from the cookie instance when redirecting between app and EU

this switches to a global regex and adds tests (thankfully there was a comment on the code at least)