### PR TITLE
fix: revert login link to standard anchor

### DIFF
--- a/frontend/src/lib/components/SocialLoginButton/SocialLoginButton.tsx
+++ b/frontend/src/lib/components/SocialLoginButton/SocialLoginButton.tsx
@@ -7,7 +7,6 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { router, combineUrl } from 'kea-router'
-import { Link } from '@posthog/lemon-ui'
 
 interface SocialLoginLinkProps {
     provider: SSOProvider
@@ -29,9 +28,10 @@ function SocialLoginLink({ provider, extraQueryParams, children }: SocialLoginLi
     const loginUrl = combineUrl(`/login/${provider}/`, loginParams).url
 
     return (
-        <Link className="block" to={loginUrl}>
+        // eslint-disable-next-line react/forbid-elements
+        <a className="block" href={loginUrl}>
             {children}
-        </Link>
+        </a>
     )
 }
 


### PR DESCRIPTION
## Problem

Currently cannot login
 
## Changes

Revert to a standard link, as was the case before https://github.com/PostHog/posthog/commit/3819d767f651ce9e8b2ae586a30eab4962f922bc#diff-2d96ec20737df6751fb07069a6ea9ca23707ff49d99644fe3adb1c4261ca8f97

## How did you test this code?

Reverting changed behaviour