### PR TITLE
fix: User select in 3000

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.scss
+++ b/frontend/src/layout/navigation-3000/Navigation.scss
@@ -37,6 +37,7 @@
     border-right: 1px solid transparent; // This is just for sizing, the visible border is on the content
     box-sizing: content-box;
     z-index: var(--z-main-nav);
+    user-select: none;
 
     .LemonButton {
         min-height: 2.25rem !important; // Reduce minimum height

--- a/frontend/src/layout/navigation-3000/components/Breadcrumbs.scss
+++ b/frontend/src/layout/navigation-3000/components/Breadcrumbs.scss
@@ -13,6 +13,7 @@
     overflow-x: auto;
     font-size: 0.8125rem;
     font-weight: 600;
+    user-select: none;
 }
 
 .Breadcrumbs3000__breadcrumb {

--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.scss
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.scss
@@ -45,6 +45,7 @@
         width: 3rem;
         border-left-width: 1px;
         overflow-y: auto;
+        user-select: none;
     }
 
     .SidePanel3000__content {

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -625,7 +625,6 @@ body {
         --mid: var(--bg-3000);
         --side: var(--bg-3000);
         background: var(--bg-3000);
-        user-select: none; // Make the app feel less page-like and more app-like - apps scarcely allow text selection
 
         * > {
             ::-webkit-scrollbar {


### PR DESCRIPTION
## Problem

This seemed to have been added a little prematurely. I can see a global no-select makes a lot of sense when we get there, but it needs proper consideration as at the moment it makes many parts of the app less useful / unusable.

## Changes

* Removes the global select none and replaces with specific overrides for the top level 3000 elements.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
