### PR TITLE
chore: adding tests to the insight trends query runner

### DIFF
--- a/posthog/hogql_queries/insights/trends/aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/aggregation_operations.py
@@ -89,7 +89,7 @@ class AggregationOperations:
             else:
                 raise NotImplementedError()
 
-        return parse_expr("count(e.uuid)")
+        return parse_expr("count(e.uuid)")  # All "count per actor" get replaced during query orchestration
 
     def requires_query_orchestration(self) -> bool:
         math_to_return_true = [

--- a/posthog/hogql_queries/insights/trends/aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/aggregation_operations.py
@@ -13,7 +13,7 @@ class QueryAlternator:
     _group_bys: List[ast.Expr]
     _select_from: ast.JoinExpr | None
 
-    def __init__(self, query: ast.SelectQuery):
+    def __init__(self, query: ast.SelectQuery | ast.SelectUnionQuery):
         assert isinstance(query, ast.SelectQuery)
 
         self._query = query
@@ -21,7 +21,7 @@ class QueryAlternator:
         self._group_bys = []
         self._select_from = None
 
-    def build(self) -> ast.SelectQuery:
+    def build(self) -> ast.SelectQuery | ast.SelectUnionQuery:
         if len(self._selects) > 0:
             self._query.select.extend(self._selects)
 

--- a/posthog/hogql_queries/insights/trends/breakdown_values.py
+++ b/posthog/hogql_queries/insights/trends/breakdown_values.py
@@ -34,14 +34,14 @@ class BreakdownValues:
         self.histogram_bin_count = int(histogram_bin_count) if histogram_bin_count is not None else None
         self.group_type_index = int(group_type_index) if group_type_index is not None else None
 
-    def get_breakdown_values(self) -> List[str]:
+    def get_breakdown_values(self) -> List[str | int]:
         if self.breakdown_type == "cohort":
             return [int(self.breakdown_field)]
 
         if self.breakdown_type == "hogql":
             select_field = ast.Alias(
                 alias="value",
-                expr=parse_expr(self.breakdown_field),
+                expr=parse_expr(str(self.breakdown_field)),
             )
         else:
             select_field = ast.Alias(

--- a/posthog/hogql_queries/insights/trends/test/test_aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/test/test_aggregation_operations.py
@@ -1,7 +1,21 @@
-from typing import cast
+from datetime import datetime
+from typing import Literal, Union, cast
+
+import pytest
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
-from posthog.hogql_queries.insights.trends.aggregation_operations import QueryAlternator
+from posthog.hogql_queries.insights.trends.aggregation_operations import (
+    AggregationOperations,
+    QueryAlternator,
+)
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.models.team.team import Team
+from posthog.schema import (
+    BaseMathType,
+    CountPerActorMathType,
+    EventsNode,
+    PropertyMathType,
+)
 
 
 class TestQueryAlternator:
@@ -44,3 +58,91 @@ class TestQueryAlternator:
         query_modifier.build()
 
         assert query.select_from.table.chain == ["groups"]
+
+
+@pytest.mark.parametrize(
+    "math,math_property",
+    [
+        [BaseMathType.total, None],
+        [BaseMathType.dau, None],
+        [BaseMathType.weekly_active, None],
+        [BaseMathType.monthly_active, None],
+        [BaseMathType.unique_session, None],
+        [PropertyMathType.avg, "$browser"],
+        [PropertyMathType.sum, "$browser"],
+        [PropertyMathType.min, "$browser"],
+        [PropertyMathType.max, "$browser"],
+        [PropertyMathType.median, "$browser"],
+        [PropertyMathType.p90, "$browser"],
+        [PropertyMathType.p95, "$browser"],
+        [PropertyMathType.p99, "$browser"],
+        [CountPerActorMathType.avg_count_per_actor, None],
+        [CountPerActorMathType.min_count_per_actor, None],
+        [CountPerActorMathType.max_count_per_actor, None],
+        [CountPerActorMathType.median_count_per_actor, None],
+        [CountPerActorMathType.p90_count_per_actor, None],
+        [CountPerActorMathType.p95_count_per_actor, None],
+        [CountPerActorMathType.p99_count_per_actor, None],
+        ["hogql", None],
+    ],
+)
+def test_all_cases_return(
+    math: Union[
+        BaseMathType,
+        PropertyMathType,
+        CountPerActorMathType,
+        Literal["unique_group"],
+        Literal["hogql"],
+    ],
+    math_property: str,
+):
+    series = EventsNode(event="$pageview", math=math, math_property=math_property)
+    query_date_range = QueryDateRange(date_range=None, interval=None, now=datetime.now(), team=Team())
+
+    agg_ops = AggregationOperations(series, query_date_range)
+    res = agg_ops.select_aggregation()
+    assert isinstance(res, ast.Expr)
+
+
+@pytest.mark.parametrize(
+    "math,result",
+    [
+        [BaseMathType.total, False],
+        [BaseMathType.dau, False],
+        [BaseMathType.weekly_active, True],
+        [BaseMathType.monthly_active, True],
+        [BaseMathType.unique_session, False],
+        [PropertyMathType.avg, False],
+        [PropertyMathType.sum, False],
+        [PropertyMathType.min, False],
+        [PropertyMathType.max, False],
+        [PropertyMathType.median, False],
+        [PropertyMathType.p90, False],
+        [PropertyMathType.p95, False],
+        [PropertyMathType.p99, False],
+        [CountPerActorMathType.avg_count_per_actor, True],
+        [CountPerActorMathType.min_count_per_actor, True],
+        [CountPerActorMathType.max_count_per_actor, True],
+        [CountPerActorMathType.median_count_per_actor, True],
+        [CountPerActorMathType.p90_count_per_actor, True],
+        [CountPerActorMathType.p95_count_per_actor, True],
+        [CountPerActorMathType.p99_count_per_actor, True],
+        ["hogql", False],
+    ],
+)
+def test_requiring_query_orchestration(
+    math: Union[
+        BaseMathType,
+        PropertyMathType,
+        CountPerActorMathType,
+        Literal["unique_group"],
+        Literal["hogql"],
+    ],
+    result: bool,
+):
+    series = EventsNode(event="$pageview", math=math)
+    query_date_range = QueryDateRange(date_range=None, interval=None, now=datetime.now(), team=Team())
+
+    agg_ops = AggregationOperations(series, query_date_range)
+    res = agg_ops.requires_query_orchestration()
+    assert res == result

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -284,7 +284,12 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
     def test_trends_query_labels_hour(self):
         self._create_test_events()
 
-        response = self._run_trends_query(self.default_date_from, self.default_date_from, IntervalType.hour)
+        response = self._run_trends_query(
+            self.default_date_from,
+            self.default_date_from,
+            IntervalType.hour,
+            [EventsNode(event="$pageview")],
+        )
 
         self.assertEqual(
             [

--- a/posthog/hogql_queries/insights/trends/test/test_utils.py
+++ b/posthog/hogql_queries/insights/trends/test/test_utils.py
@@ -1,0 +1,38 @@
+import pytest
+from posthog.hogql_queries.insights.trends.utils import get_properties_chain
+
+
+def test_properties_chain_person():
+    p1 = get_properties_chain(breakdown_type="person", breakdown_field="field", group_type_index=None)
+    assert p1 == ["person", "properties", "field"]
+
+    p2 = get_properties_chain(breakdown_type="person", breakdown_field="field", group_type_index=1)
+    assert p2 == ["person", "properties", "field"]
+
+
+def test_properties_chain_session():
+    p1 = get_properties_chain(breakdown_type="session", breakdown_field="anything", group_type_index=None)
+    assert p1 == ["session", "session_duration"]
+
+    p2 = get_properties_chain(breakdown_type="session", breakdown_field="", group_type_index=None)
+    assert p2 == ["session", "session_duration"]
+
+    p3 = get_properties_chain(breakdown_type="session", breakdown_field="", group_type_index=1)
+    assert p3 == ["session", "session_duration"]
+
+
+def test_properties_chain_groups():
+    p1 = get_properties_chain(breakdown_type="group", breakdown_field="anything", group_type_index=1)
+    assert p1 == ["group_1", "properties", "anything"]
+
+    with pytest.raises(Exception) as e:
+        get_properties_chain(breakdown_type="group", breakdown_field="anything", group_type_index=None)
+        assert "group_type_index missing from params" in str(e.value)
+
+
+def test_properties_chain_events():
+    p1 = get_properties_chain(breakdown_type="event", breakdown_field="anything", group_type_index=None)
+    assert p1 == ["properties", "anything"]
+
+    p2 = get_properties_chain(breakdown_type="event", breakdown_field="anything_else", group_type_index=1)
+    assert p2 == ["properties", "anything_else"]

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -373,7 +373,7 @@ class TrendsQueryRunner(QueryRunner):
         )
         return field_type == "Boolean"
 
-    def _convert_boolean(self, value: any):
+    def _convert_boolean(self, value: Any):
         bool_map = {1: "true", 0: "false", "": ""}
         return bool_map.get(value) or value
 
@@ -390,7 +390,7 @@ class TrendsQueryRunner(QueryRunner):
             group_type_index=group_type_index if field_type == PropertyDefinition.Type.GROUP else None,
         ).property_type
 
-    def _query_to_filter(self) -> Dict[str, any]:
+    def _query_to_filter(self) -> Dict[str, Any]:
         filter_dict = {
             "insight": "TRENDS",
             "properties": self.query.properties,

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -189,13 +189,13 @@ class TrendsQueryRunner(QueryRunner):
                         item.strftime(
                             "%-d-%b-%Y{}".format(" %H:%M" if self.query_date_range.interval_name == "hour" else "")
                         )
-                        for item in val[0]
+                        for item in get_value("date", val)
                     ],
                     "days": [
                         item.strftime(
                             "%Y-%m-%d{}".format(" %H:%M:%S" if self.query_date_range.interval_name == "hour" else "")
                         )
-                        for item in val[0]
+                        for item in get_value("date", val)
                     ],
                     "count": float(sum(get_value("total", val))),
                     "label": "All events"

--- a/posthog/hogql_queries/insights/trends/utils.py
+++ b/posthog/hogql_queries/insights/trends/utils.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Literal, Optional, Union
 from posthog.schema import ActionsNode, EventsNode
 
 
@@ -9,7 +9,9 @@ def series_event_name(series: EventsNode | ActionsNode) -> str | None:
 
 
 def get_properties_chain(
-    breakdown_type: str, breakdown_field: str, group_type_index: Optional[float | int]
+    breakdown_type: Union[Literal["person"], Literal["session"], Literal["group"], Literal["event"]],
+    breakdown_field: str,
+    group_type_index: Optional[float | int],
 ) -> List[str]:
     if breakdown_type == "person":
         return ["person", "properties", breakdown_field]
@@ -20,5 +22,7 @@ def get_properties_chain(
     if breakdown_type == "group" and group_type_index is not None:
         group_type_index_int = int(group_type_index)
         return [f"group_{group_type_index_int}", "properties", breakdown_field]
+    elif breakdown_type == "group" and group_type_index is None:
+        raise Exception("group_type_index missing from params")
 
     return ["properties", breakdown_field]


### PR DESCRIPTION
## Problem
- Continuation of https://github.com/PostHog/meta/issues/130
- Adds a bunch of tests for the insights trend runner

## Changes
Trends test coverage
<img width="777" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/ac814675-f89e-4bca-91d3-829bf7b06fb8">


## How did you test this code?
With tests