### PR TITLE
fix: Simplify plugin server tests

### DIFF
--- a/plugin-server/tests/server.test.ts
+++ b/plugin-server/tests/server.test.ts
@@ -10,7 +10,7 @@ import { resetTestDatabase } from './helpers/sql'
 jest.mock('../src/utils/kill')
 jest.mock('../src/main/graphile-worker/schedule')
 jest.mock('../src/main/graphile-worker/worker-setup')
-jest.setTimeout(60000) // 60 sec timeout
+jest.setTimeout(20000) // 20 sec timeout - longer indicates an issue
 
 function numberOfScheduledJobs() {
     return Object.keys(nodeSchedule.scheduledJobs).length
@@ -36,15 +36,11 @@ describe('server', () => {
 
     beforeEach(() => {
         jest.spyOn(Sentry, 'captureMessage')
-
-        jest.useFakeTimers({ advanceTimers: true })
     })
 
     afterEach(async () => {
         await pluginsServer?.stop?.()
         pluginsServer = null
-        jest.runOnlyPendingTimers()
-        jest.useRealTimers()
     })
 
     test('startPluginsServer does not error', async () => {


### PR DESCRIPTION
## Problem

Noticed when debugging another issue that the timeout is misleading - the test only takes a few seconds - timeout indicates something is broke.

## Changes

* Reduce timeout
* Remove fake timers as they weren't needed

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
