### PR TITLE
fix(flags): Do the expected for numeric comparisons

### DIFF
--- a/ee/clickhouse/models/test/test_filters.py
+++ b/ee/clickhouse/models/test/test_filters.py
@@ -610,6 +610,42 @@ class TestFiltering(ClickhouseTestMixin, property_to_Q_test_factory(_filter_pers
         events = _filter_events(filter, self.team)
         self.assertEqual(events[0]["id"], event1_uuid)
 
+    def test_numerical_person_properties(self):
+        _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"$a_number": 4})
+        _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"$a_number": 5})
+        _create_person(team_id=self.team.pk, distinct_ids=["p3"], properties={"$a_number": 6})
+
+        filter = Filter(
+            data={
+                "properties": [
+                    {
+                        "type": "person",
+                        "key": "$a_number",
+                        "value": 4,
+                        "operator": "gt",
+                    }
+                ]
+            }
+        )
+        self.assertEqual(len(_filter_persons(filter, self.team)), 2)
+
+        filter = Filter(data={"properties": [{"type": "person", "key": "$a_number", "value": 5}]})
+        self.assertEqual(len(_filter_persons(filter, self.team)), 1)
+
+        filter = Filter(
+            data={
+                "properties": [
+                    {
+                        "type": "person",
+                        "key": "$a_number",
+                        "value": 6,
+                        "operator": "lt",
+                    }
+                ]
+            }
+        )
+        self.assertEqual(len(_filter_persons(filter, self.team)), 2)
+
     def test_contains(self):
         _create_event(team=self.team, distinct_id="test", event="$pageview")
         event2_uuid = _create_event(

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -2,7 +2,7 @@ import datetime
 import json
 from typing import Any, Callable, Dict, List, Optional, cast
 
-from django.db.models import Q
+from django.db.models import Q, Func, F, CharField
 
 from posthog.constants import FILTER_TEST_ACCOUNTS
 from posthog.models import Cohort, Filter, Person, Team
@@ -218,42 +218,6 @@ def property_to_Q_test_factory(filter_persons: Callable, person_factory):
                 }
             )
             self.assertListEqual(filter.property_groups.values, [])
-
-        def test_numerical_person_properties(self):
-            person_factory(team_id=self.team.pk, distinct_ids=["p1"], properties={"$a_number": 4})
-            person_factory(team_id=self.team.pk, distinct_ids=["p2"], properties={"$a_number": 5})
-            person_factory(team_id=self.team.pk, distinct_ids=["p3"], properties={"$a_number": 6})
-
-            filter = Filter(
-                data={
-                    "properties": [
-                        {
-                            "type": "person",
-                            "key": "$a_number",
-                            "value": 4,
-                            "operator": "gt",
-                        }
-                    ]
-                }
-            )
-            self.assertEqual(len(filter_persons(filter, self.team)), 2)
-
-            filter = Filter(data={"properties": [{"type": "person", "key": "$a_number", "value": 5}]})
-            self.assertEqual(len(filter_persons(filter, self.team)), 1)
-
-            filter = Filter(
-                data={
-                    "properties": [
-                        {
-                            "type": "person",
-                            "key": "$a_number",
-                            "value": 6,
-                            "operator": "lt",
-                        }
-                    ]
-                }
-            )
-            self.assertEqual(len(filter_persons(filter, self.team)), 2)
 
         def test_contains_persons(self):
             person_factory(
@@ -818,6 +782,56 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
             data["date_to"] = date_to
 
         return Filter(data=data)
+
+    def test_numerical_person_properties(self):
+        _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"$a_number": 4})
+        _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"$a_number": 5})
+        _create_person(team_id=self.team.pk, distinct_ids=["p3"], properties={"$a_number": 6})
+        _create_person(team_id=self.team.pk, distinct_ids=["p4"], properties={"$a_number": 14})
+
+        flush_persons_and_events()
+
+        def filter_persons_with_annotation(filter: Filter, team: Team):
+            persons = Person.objects.annotate(
+                **{
+                    "properties_$a_number_type": Func(
+                        F("properties__$a_number"), function="JSONB_TYPEOF", output_field=CharField()
+                    )
+                }
+            ).filter(properties_to_Q(filter.property_groups.flat))
+            persons = persons.filter(team_id=team.pk)
+            return [str(uuid) for uuid in persons.values_list("uuid", flat=True)]
+
+        filter = Filter(
+            data={
+                "properties": [
+                    {
+                        "type": "person",
+                        "key": "$a_number",
+                        "value": "4",
+                        "operator": "gt",
+                    }
+                ]
+            }
+        )
+        self.assertEqual(len(filter_persons_with_annotation(filter, self.team)), 3)
+
+        filter = Filter(data={"properties": [{"type": "person", "key": "$a_number", "value": 5}]})
+        self.assertEqual(len(filter_persons_with_annotation(filter, self.team)), 1)
+
+        filter = Filter(
+            data={
+                "properties": [
+                    {
+                        "type": "person",
+                        "key": "$a_number",
+                        "value": 6,
+                        "operator": "lt",
+                    }
+                ]
+            }
+        )
+        self.assertEqual(len(filter_persons_with_annotation(filter, self.team)), 2)
 
 
 def filter_persons_with_property_group(

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -142,6 +142,7 @@ def match_property(property: Property, override_property_values: Dict[str, Any])
         except re.error:
             return False
 
+    # TODO: Use the input property to determine what to compare against!!
     if operator == "gt":
         return type(override_value) == type(value) and override_value > value
 

--- a/posthog/queries/test/test_base.py
+++ b/posthog/queries/test/test_base.py
@@ -154,7 +154,8 @@ class TestMatchProperties(TestCase):
 
         self.assertFalse(match_property(property_a, {"key": 0}))
         self.assertFalse(match_property(property_a, {"key": -1}))
-        self.assertFalse(match_property(property_a, {"key": "23"}))
+        # now we handle type mismatches so this should be true
+        self.assertTrue(match_property(property_a, {"key": "23"}))
 
         property_b = Property(key="key", value=1, operator="lt")
         self.assertTrue(match_property(property_b, {"key": 0}))
@@ -171,15 +172,31 @@ class TestMatchProperties(TestCase):
 
         self.assertFalse(match_property(property_c, {"key": 0}))
         self.assertFalse(match_property(property_c, {"key": -1}))
-        self.assertFalse(match_property(property_c, {"key": "3"}))
+        # now we handle type mismatches so this should be true
+        self.assertTrue(match_property(property_c, {"key": "3"}))
 
         property_d = Property(key="key", value="43", operator="lt")
         self.assertTrue(match_property(property_d, {"key": "41"}))
         self.assertTrue(match_property(property_d, {"key": "42"}))
+        self.assertTrue(match_property(property_d, {"key": 42}))
 
         self.assertFalse(match_property(property_d, {"key": "43"}))
         self.assertFalse(match_property(property_d, {"key": "44"}))
         self.assertFalse(match_property(property_d, {"key": 44}))
+
+        property_e = Property(key="key", value="30", operator="lt")
+        self.assertTrue(match_property(property_e, {"key": "29"}))
+
+        # depending on the type of override, we adjust type comparison
+        self.assertTrue(match_property(property_e, {"key": "100"}))
+        self.assertFalse(match_property(property_e, {"key": 100}))
+
+        property_f = Property(key="key", value="123aloha", operator="gt")
+        self.assertFalse(match_property(property_f, {"key": "123"}))
+        self.assertFalse(match_property(property_f, {"key": 122}))
+
+        # this turns into a string comparison
+        self.assertTrue(match_property(property_f, {"key": 129}))
 
     def test_match_property_date_operators(self):
         property_a = Property(key="key", value="2022-05-01", operator="is_date_before")

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -344,6 +344,58 @@
          AND "posthog_group"."group_type_index" = 2)
   '
 ---
+# name: TestFeatureFlagMatcher.test_numeric_operator_with_groups_and_person_flags
+  '
+  SELECT "posthog_grouptypemapping"."id",
+         "posthog_grouptypemapping"."team_id",
+         "posthog_grouptypemapping"."group_type",
+         "posthog_grouptypemapping"."group_type_index",
+         "posthog_grouptypemapping"."name_singular",
+         "posthog_grouptypemapping"."name_plural"
+  FROM "posthog_grouptypemapping"
+  WHERE "posthog_grouptypemapping"."team_id" = 2
+  '
+---
+# name: TestFeatureFlagMatcher.test_numeric_operator_with_groups_and_person_flags.1
+  '
+  SELECT (((("posthog_person"."properties" -> 'number') >= '"20"'
+            AND JSONB_TYPEOF(("posthog_person"."properties" -> 'number')) = 'string')
+           OR (("posthog_person"."properties" -> 'number') >= '20.0'
+               AND JSONB_TYPEOF(("posthog_person"."properties" -> 'number')) = 'number'))
+          AND "posthog_person"."properties" ? 'number'
+          AND NOT (("posthog_person"."properties" -> 'number') = 'null')) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = '307'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
+# name: TestFeatureFlagMatcher.test_numeric_operator_with_groups_and_person_flags.2
+  '
+  SELECT (((("posthog_group"."group_properties" -> 'number') > '"100"'
+            AND JSONB_TYPEOF(("posthog_group"."group_properties" -> 'number')) = 'string')
+           OR (("posthog_group"."group_properties" -> 'number') > '100.0'
+               AND JSONB_TYPEOF(("posthog_group"."group_properties" -> 'number')) = 'number'))
+          AND "posthog_group"."group_properties" ? 'number'
+          AND NOT (("posthog_group"."group_properties" -> 'number') = 'null')) AS "flag_X_condition_0"
+  FROM "posthog_group"
+  WHERE ("posthog_group"."team_id" = 2
+         AND "posthog_group"."group_key" = 'foo'
+         AND "posthog_group"."group_type_index" = 0)
+  '
+---
+# name: TestFeatureFlagMatcher.test_numeric_operator_with_groups_and_person_flags.3
+  '
+  SELECT (("posthog_group"."group_properties" -> 'number') > '"100b2c"'
+          AND "posthog_group"."group_properties" ? 'number'
+          AND NOT (("posthog_group"."group_properties" -> 'number') = 'null')) AS "flag_X_condition_0"
+  FROM "posthog_group"
+  WHERE ("posthog_group"."team_id" = 2
+         AND "posthog_group"."group_key" = 'foo-project'
+         AND "posthog_group"."group_type_index" = 1)
+  '
+---
 # name: TestFeatureFlagMatcher.test_super_condition_matches_string
   '
   SELECT ((("posthog_person"."properties" -> 'is_enabled') = 'true'

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -460,12 +460,13 @@ class QueryMatchingTest:
         if replace_all_numbers:
             query = re.sub(r"(\"?) = \d+", r"\1 = 2", query)
             query = re.sub(r"(\"?) IN \(\d+(, \d+)*\)", r"\1 IN (1, 2, 3, 4, 5 /* ... */)", query)
-            # feature flag conditions use primary keys as columns in queries, so replace those too
-            query = re.sub(r"flag_\d+_condition", r"flag_X_condition", query)
-            query = re.sub(r"flag_\d+_super_condition", r"flag_X_super_condition", query)
         else:
             query = re.sub(r"(team|cohort)_id(\"?) = \d+", r"\1_id\2 = 2", query)
             query = re.sub(r"\d+ as (team|cohort)_id(\"?)", r"2 as \1_id\2", query)
+
+        # feature flag conditions use primary keys as columns in queries, so replace those always
+        query = re.sub(r"flag_\d+_condition", r"flag_X_condition", query)
+        query = re.sub(r"flag_\d+_super_condition", r"flag_X_super_condition", query)
 
         # hog ql checks team ids differently
         query = re.sub(


### PR DESCRIPTION
## Problem

We have `>, <, >=, <=` operators that can apply on both strings and numbers.

This leads to A LOT of confusion when things don't work as expected. For example, '30' < '100' is false for strings, true for numbers.

Fixes: https://github.com/PostHog/posthog/issues/14497

I cycled through a lot of options, like a new numeric operator, converting the flag condition input to numeric when required, always default to one.

All of them have their disadvantages, and mostly make for a terrible user experience.

I think I've found a reasonable middle ground: Now, no matter what property we want to compare against, we use the type of the property, and the type of the flag condition to determine what to do, with the type of property in db taking priority.

So:

The db (or property override) has type string, the flag condition has type string, then -> always do a string comparison

The db (or property override) has type numeric, the flag condition has type string, then -> if flag condition can be parsed as number, do a numeric comparison. If flag condition can't be parsed as number, then do a string comparison.

---

The case we _don't_ handle well is when someone sets string properties, when they meant to set them as numeric, as in this case we'll default to string comparison instead. We kinda need to do this to prevent breaking flags when they send invalid numbers as strings, and want us to coerce them into numbers. We _could_ try and be more defensive here, but this feels overkill and prone to other issues, like when we incorrectly assume '1.23' as a number when it's a version string. Will revisit this if new issues arise here. But right now I think it's reasonable to have users send the right type.

---

Q: How does this work, there are no numeric coercion types here?
A:  Like so:

```
select '30' > '100', '{"a": "whatevs", "b": 30}'::jsonb->'b' > '100'
>>> true, false
```

The first is a string comparison, but the second is a json comparison, which explicitly treats '100' as the _number_ 100. If you wanted this to be a string, you'll have '"100"' instead (because json).

So we can leverage this to get what we want by not explicitly converting all types to numeric (which is _a lot_ more fragile, because it can break the SQL, which breaks all flags for the person)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Our previous coverage wasn't great here, so adding more tests for existing functionality as well.

lot more tests to come
bazinga!
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
