### PR TITLE
fix: limit the number of distinct ids when listing replays

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -186,6 +186,13 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
         return representation
 
 
+# person distinct ids can grow to be a very large list
+# in the UI we don't need all of them, so we can limit the number of distinct ids we return
+class MinimalPersonSerializer(PersonSerializer):
+    def get_distinct_ids(self, person):
+        return person.distinct_ids[:10]
+
+
 def get_funnel_actor_class(filter: Filter) -> Callable:
     funnel_actor_class: Type[ActorBaseQuery]
 

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -16,7 +16,7 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from posthog.api.person import PersonSerializer
+from posthog.api.person import MinimalPersonSerializer
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.auth import SharingAccessTokenAuthentication
 from posthog.constants import SESSION_RECORDINGS_FILTER_IDS
@@ -62,7 +62,7 @@ SNAPSHOT_SOURCE_REQUESTED = Counter(
 class SessionRecordingSerializer(serializers.ModelSerializer):
     id = serializers.CharField(source="session_id", read_only=True)
     recording_duration = serializers.IntegerField(source="duration", read_only=True)
-    person = PersonSerializer(required=False)
+    person = MinimalPersonSerializer(required=False)
 
     class Meta:
         model = SessionRecording


### PR DESCRIPTION
In this question someone reports errors loading recordings https://posthog.com/questions/constantly-getting-error-message

Investigating their account their users have many distinct ids. Loading the recordings loads a 10MB response. At least 8MB of which is person distinct ids we don't use 🤦 

This adds a new serializer for persons which only returns the first ten distinct ids and uses it in the replay response