### PR TITLE
fix: Load more button text for batch exports

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.stories.tsx
@@ -223,7 +223,7 @@ WithFooter.args = {
         <>
             <div className="flex items-center m-2">
                 <LemonButton center fullWidth>
-                    Load more button in the footer!
+                    Load more rows
                 </LemonButton>
             </div>
         </>

--- a/frontend/src/scenes/batch_exports/BatchExportScene.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportScene.tsx
@@ -101,7 +101,7 @@ export function RunsTab(): JSX.Element {
                                             onClick={loadNextBatchExportRuns}
                                             loading={batchExportRunsResponseLoading}
                                         >
-                                            Load more button in the footer!
+                                            Load more rows
                                         </LemonButton>
                                     </div>
                                 )


### PR DESCRIPTION
## Problem

Button text typo -- feel free to edit if you want it to say something else, but current text was `Load more button in the footer!` which seemed wrong.

## Changes

<img width="768" alt="image" src="https://github.com/PostHog/posthog/assets/1840235/cdd2f864-7fd6-41a9-90c8-f1ad4787804b">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

n/a
