### PR TITLE
feat(web-analytics): Hide breakdown prompt from the world map display

### DIFF
--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -72,21 +72,23 @@ export function TrendInsight({ view }: Props): JSX.Element {
                     {renderViz()}
                 </div>
             )}
-            {breakdown && loadMoreBreakdownUrl && (
-                <div className="my-4 flex flex-col items-center">
-                    <div className="text-muted mb-2">
-                        For readability, <b>not all breakdown values are displayed</b>. Click below to load them.
+            {display !== ChartDisplayType.WorldMap && // the world map doesn't need this cta
+                breakdown &&
+                loadMoreBreakdownUrl && (
+                    <div className="my-4 flex flex-col items-center">
+                        <div className="text-muted mb-2">
+                            For readability, <b>not all breakdown values are displayed</b>. Click below to load them.
+                        </div>
+                        <LemonButton
+                            onClick={loadMoreBreakdownValues}
+                            loading={breakdownValuesLoading}
+                            size="small"
+                            type="secondary"
+                        >
+                            Load more breakdown values
+                        </LemonButton>
                     </div>
-                    <LemonButton
-                        onClick={loadMoreBreakdownValues}
-                        loading={breakdownValuesLoading}
-                        size="small"
-                        type="secondary"
-                    >
-                        Load more breakdown values
-                    </LemonButton>
-                </div>
-            )}
+                )}
         </>
     )
 }


### PR DESCRIPTION
## Problem

This UI element isn't necessary, and in fact actively does the wrong thing.

Here's a bug:
* Create a new trend https://app.posthog.com/insights/new, set it to world map
* Wait for it to load
* Press the button to load more breakdown values
* Press the button a few more times
* Search for a particularly country name using the browser's search feature (e.g. greece)
* Observe that it appears multiple times
* Expected: countries appear at most once

## Changes

Remove this UI element for world maps

## How did you test this code?

Here's a screenshot of a world map trend insight without this button
<img width="1098" alt="Screenshot 2023-11-02 at 20 22 40" src="https://github.com/PostHog/posthog/assets/2056078/2c8b4e9b-ab27-4b29-8462-1f8c06646306">


