### PR TITLE
fix: Clear gauges when reporting

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
@@ -105,8 +105,8 @@ export class ConsoleLogsIngester {
             return
         }
 
-        const warn = (text: string, labels: Record<string, any> = {}) =>
-            status.warn('⚠️', `[console-log-events-ingester] ${text}`, {
+        const logDebug = (text: string, labels: Record<string, any> = {}) =>
+            status.debug('⚠️', `[console-log-events-ingester] ${text}`, {
                 offset: event.metadata.offset,
                 partition: event.metadata.partition,
                 ...labels,
@@ -120,7 +120,7 @@ export class ConsoleLogsIngester {
                 })
                 .inc()
 
-            warn(reason, {
+            logDebug(reason, {
                 reason,
                 ...labels,
             })

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
@@ -80,8 +80,8 @@ export class ReplayEventsIngester {
     }
 
     public async consume(event: IncomingRecordingMessage): Promise<Promise<number | null | undefined>[] | void> {
-        const warn = (text: string, labels: Record<string, any> = {}) =>
-            status.warn('⚠️', `[replay-events] ${text}`, {
+        const logDebug = (text: string, labels: Record<string, any> = {}) =>
+            status.debug('⚠️', `[replay-events] ${text}`, {
                 offset: event.metadata.offset,
                 partition: event.metadata.partition,
                 ...labels,
@@ -95,7 +95,7 @@ export class ReplayEventsIngester {
                 })
                 .inc()
 
-            warn(reason, {
+            logDebug(reason, {
                 reason,
                 ...labels,
             })

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -32,8 +32,6 @@ require('@sentry/tracing')
 const KAFKA_CONSUMER_GROUP_ID = 'session-recordings-blob'
 const KAFKA_CONSUMER_SESSION_TIMEOUT_MS = 30000
 
-// const flushIntervalTimeoutMs = 30000
-
 const gaugeSessionsHandled = new Gauge({
     name: 'recording_blob_ingestion_session_manager_count',
     help: 'A gauge of the number of sessions being handled by this blob ingestion consumer',
@@ -176,7 +174,7 @@ export class SessionRecordingIngester {
                 }
                 return acc
             }, {} as Record<number, number>)
-        }, 5000)
+        }, 10000)
     }
 
     private get connectedBatchConsumer(): KafkaConsumer | undefined {

--- a/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
@@ -31,22 +31,28 @@ export const bufferFileDir = (root: string) => path.join(root, 'session-buffer-f
 
 export const queryWatermarkOffsets = (
     kafkaConsumer: KafkaConsumer | undefined,
-    partition: number
+    partition: number,
+    timeout = 10000
 ): Promise<[number, number]> => {
     return new Promise<[number, number]>((resolve, reject) => {
         if (!kafkaConsumer) {
             return reject('Not connected')
         }
 
-        kafkaConsumer.queryWatermarkOffsets(KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS, partition, (err, offsets) => {
-            if (err) {
-                captureException(err)
-                status.error('🔥', 'Failed to query kafka watermark offsets', err)
-                return reject(err)
-            }
+        kafkaConsumer.queryWatermarkOffsets(
+            KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS,
+            timeout,
+            partition,
+            (err, offsets) => {
+                if (err) {
+                    captureException(err)
+                    status.error('🔥', 'Failed to query kafka watermark offsets', err)
+                    return reject(err)
+                }
 
-            resolve([partition, offsets.highOffset])
-        })
+                resolve([partition, offsets.highOffset])
+            }
+        )
     })
 }
 

--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
@@ -59,7 +59,7 @@ describe('console log ingester', () => {
                     true
                 )
             )
-            expect(jest.mocked(status.warn).mock.calls).toEqual([])
+            expect(jest.mocked(status.debug).mock.calls).toEqual([])
             expect(jest.mocked(produce).mock.calls).toEqual([
                 [
                     {
@@ -102,7 +102,7 @@ describe('console log ingester', () => {
                     true
                 )
             )
-            expect(jest.mocked(status.warn).mock.calls).toEqual([])
+            expect(jest.mocked(status.debug).mock.calls).toEqual([])
             expect(jest.mocked(produce)).toHaveBeenCalledTimes(2)
             expect(jest.mocked(produce).mock.calls).toEqual([
                 [
@@ -160,7 +160,7 @@ describe('console log ingester', () => {
                     true
                 )
             )
-            expect(jest.mocked(status.warn).mock.calls).toEqual([])
+            expect(jest.mocked(status.debug).mock.calls).toEqual([])
             expect(jest.mocked(produce).mock.calls).toEqual([
                 [
                     {
@@ -187,7 +187,7 @@ describe('console log ingester', () => {
     describe('when disabled on team', () => {
         test('it drops console logs', async () => {
             await consoleLogIngester.consume(makeIncomingMessage([{ plugin: 'rrweb/console@1' }], false))
-            expect(jest.mocked(status.warn).mock.calls).toEqual([
+            expect(jest.mocked(status.debug).mock.calls).toEqual([
                 [
                     '⚠️',
                     '[console-log-events-ingester] console_log_ingestion_disabled',
@@ -202,7 +202,7 @@ describe('console log ingester', () => {
         })
         test('it does not drop events with no console logs', async () => {
             await consoleLogIngester.consume(makeIncomingMessage([{ plugin: 'some-other-plugin' }], false))
-            expect(jest.mocked(status.warn).mock.calls).toEqual([])
+            expect(jest.mocked(status.debug).mock.calls).toEqual([])
             expect(jest.mocked(produce)).not.toHaveBeenCalled()
         })
     })

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -30,11 +30,16 @@ async function deleteKeysWithPrefix(hub: Hub) {
     await hub.redisPool.release(redisClient)
 }
 
-const mockQueryWatermarkOffsets = jest.fn()
-const mockCommittedOffsetsFn = jest.fn()
-const mockCommit = jest.fn()
-const mockAssignments = jest.fn()
-const mockIsConnected = jest.fn(() => true)
+const mockConsumer = {
+    on: jest.fn(),
+    commitSync: jest.fn(),
+    commit: jest.fn(),
+    queryWatermarkOffsets: jest.fn(),
+    committed: jest.fn(),
+    assignments: jest.fn(),
+    isConnected: jest.fn(() => true),
+    getMetadata: jest.fn(),
+}
 
 jest.mock('../../../../src/kafka/batch-consumer', () => {
     return {
@@ -44,15 +49,7 @@ jest.mock('../../../../src/kafka/batch-consumer', () => {
                     finally: jest.fn(),
                 }),
                 stop: jest.fn(),
-                consumer: {
-                    on: jest.fn(),
-                    commitSync: mockCommit,
-                    commit: mockCommit,
-                    queryWatermarkOffsets: mockQueryWatermarkOffsets,
-                    committed: mockCommittedOffsetsFn,
-                    assignments: mockAssignments,
-                    isConnected: mockIsConnected,
-                },
+                consumer: mockConsumer,
             })
         ),
     }
@@ -79,12 +76,20 @@ describe('ingester', () => {
         // The below mocks simulate committing to kafka and querying the offsets
         mockCommittedOffsets = {}
         mockOffsets = {}
-        mockCommit.mockImplementation((tpo: TopicPartitionOffset) => (mockCommittedOffsets[tpo.partition] = tpo.offset))
-        mockQueryWatermarkOffsets.mockImplementation((topic, partition, cb) => {
+        mockConsumer.commit.mockImplementation(
+            (tpo: TopicPartitionOffset) => (mockCommittedOffsets[tpo.partition] = tpo.offset)
+        )
+        mockConsumer.queryWatermarkOffsets.mockImplementation((topic, partition, cb) => {
             cb(null, { highOffset: mockOffsets[partition] ?? 1, lowOffset: 0 })
         })
 
-        mockCommittedOffsetsFn.mockImplementation((topicPartitions: TopicPartition[], timeout, cb) => {
+        mockConsumer.getMetadata.mockImplementation((options, cb) => {
+            cb(null, {
+                topics: [{ name: options.topic, partitions: [{ id: 0 }, { id: 1 }, { id: 2 }] }],
+            })
+        })
+
+        mockConsumer.committed.mockImplementation((topicPartitions: TopicPartition[], timeout, cb) => {
             const tpos: TopicPartitionOffset[] = topicPartitions.map((tp) => ({
                 topic: tp.topic,
                 partition: tp.partition,
@@ -101,7 +106,7 @@ describe('ingester', () => {
         ingester = new SessionRecordingIngester(config, hub.postgres, hub.objectStorage)
         await ingester.start()
 
-        mockAssignments.mockImplementation(() => [createTP(1), createTP(2)])
+        mockConsumer.assignments.mockImplementation(() => [createTP(1), createTP(2)])
     })
 
     afterEach(async () => {
@@ -347,12 +352,12 @@ describe('ingester', () => {
 
             await commitAllOffsets()
             // Doesn't flush if we have a blocking session
-            expect(mockCommit).toHaveBeenCalledTimes(0)
+            expect(mockConsumer.commit).toHaveBeenCalledTimes(0)
             await ingester.sessions[`${team.id}-sid1`].flush('buffer_age')
             await commitAllOffsets()
 
-            expect(mockCommit).toHaveBeenCalledTimes(1)
-            expect(mockCommit).toHaveBeenLastCalledWith(
+            expect(mockConsumer.commit).toHaveBeenCalledTimes(1)
+            expect(mockConsumer.commit).toHaveBeenLastCalledWith(
                 expect.objectContaining({
                     offset: 2 + 1,
                     partition: 1,
@@ -366,8 +371,8 @@ describe('ingester', () => {
             expect(ingester.partitionMetrics[1].lastMessageOffset).toBe(1)
             await commitAllOffsets()
 
-            expect(mockCommit).toHaveBeenCalledTimes(1)
-            expect(mockCommit).toHaveBeenLastCalledWith(
+            expect(mockConsumer.commit).toHaveBeenCalledTimes(1)
+            expect(mockConsumer.commit).toHaveBeenLastCalledWith(
                 expect.objectContaining({
                     partition: 1,
                     offset: 2,
@@ -376,14 +381,14 @@ describe('ingester', () => {
 
             // Repeat commit doesn't do anything
             await commitAllOffsets()
-            expect(mockCommit).toHaveBeenCalledTimes(1)
+            expect(mockConsumer.commit).toHaveBeenCalledTimes(1)
 
             await ingester.handleEachBatch([createMessage('sid1')])
             await ingester.sessions[`${team.id}-sid1`].flush('buffer_age')
             await commitAllOffsets()
 
-            expect(mockCommit).toHaveBeenCalledTimes(2)
-            expect(mockCommit).toHaveBeenLastCalledWith(
+            expect(mockConsumer.commit).toHaveBeenCalledTimes(2)
+            expect(mockConsumer.commit).toHaveBeenLastCalledWith(
                 expect.objectContaining({
                     partition: 1,
                     offset: 2 + 1,
@@ -406,12 +411,12 @@ describe('ingester', () => {
             })
 
             // No offsets are below the blocking one
-            expect(mockCommit).not.toHaveBeenCalled()
+            expect(mockConsumer.commit).not.toHaveBeenCalled()
             await ingester.sessions[`${team.id}-sid1`].flush('buffer_age')
 
             // Subsequent commit will commit the last known offset
             await commitAllOffsets()
-            expect(mockCommit).toHaveBeenLastCalledWith(
+            expect(mockConsumer.commit).toHaveBeenLastCalledWith(
                 expect.objectContaining({
                     partition: 1,
                     offset: 4 + 1,
@@ -431,7 +436,7 @@ describe('ingester', () => {
             await commitAllOffsets()
 
             // No offsets are below the blocking one
-            expect(mockCommit).not.toHaveBeenCalled()
+            expect(mockConsumer.commit).not.toHaveBeenCalled()
 
             // Add a new message and session and flush the old one
             await ingester.handleEachBatch([createMessage('sid2')])
@@ -439,7 +444,7 @@ describe('ingester', () => {
             await commitAllOffsets()
 
             // We should commit the offset of the blocking session
-            expect(mockCommit).toHaveBeenLastCalledWith(
+            expect(mockConsumer.commit).toHaveBeenLastCalledWith(
                 expect.objectContaining({
                     partition: 1,
                     offset: ingester.sessions[`${team.id}-sid2`].getLowestOffset(),
@@ -459,26 +464,26 @@ describe('ingester', () => {
 
             // We should now have a blocking session on partition 1 and 2 with partition 1 being committable
             await commitAllOffsets()
-            expect(mockCommit).toHaveBeenCalledTimes(1)
-            expect(mockCommit).toHaveBeenLastCalledWith(
+            expect(mockConsumer.commit).toHaveBeenCalledTimes(1)
+            expect(mockConsumer.commit).toHaveBeenLastCalledWith(
                 expect.objectContaining({
                     partition: 1,
                     offset: 2,
                 })
             )
 
-            mockCommit.mockReset()
+            mockConsumer.commit.mockReset()
             await ingester.sessions[`${team.id}-sid1`].flush('buffer_age')
             await ingester.sessions[`${team.id}-sid2`].flush('buffer_age')
             await commitAllOffsets()
-            expect(mockCommit).toHaveBeenCalledTimes(2)
-            expect(mockCommit).toHaveBeenCalledWith(
+            expect(mockConsumer.commit).toHaveBeenCalledTimes(2)
+            expect(mockConsumer.commit).toHaveBeenCalledWith(
                 expect.objectContaining({
                     partition: 1,
                     offset: 3,
                 })
             )
-            expect(mockCommit).toHaveBeenCalledWith(
+            expect(mockConsumer.commit).toHaveBeenCalledWith(
                 expect.objectContaining({
                     partition: 2,
                     offset: 3,
@@ -508,7 +513,7 @@ describe('ingester', () => {
             await ingester.handleEachBatch([createMessage('sid1'), createMessage('sid2'), createMessage('sid1')])
             await ingester.sessions[`${team.id}-sid1`].flush('buffer_age')
             await commitAllOffsets()
-            expect(mockCommit).toHaveBeenCalledTimes(1)
+            expect(mockConsumer.commit).toHaveBeenCalledTimes(1)
 
             // sid1 should be watermarked up until the 3rd message as it HAS been processed
             await expect(getSessionWaterMarks()).resolves.toEqual({ sid1: 3 })
@@ -528,7 +533,7 @@ describe('ingester', () => {
             await ingester.handleEachBatch([events[0], events[1]])
             await ingester.sessions[`${team.id}-sid2`].flush('buffer_age')
             await commitAllOffsets()
-            expect(mockCommit).not.toHaveBeenCalled()
+            expect(mockConsumer.commit).not.toHaveBeenCalled()
             await expect(getPersistentWaterMarks()).resolves.toEqual({
                 session_replay_console_logs_events_ingester: 2,
                 session_replay_events_ingester: 2,
@@ -564,7 +569,7 @@ describe('ingester', () => {
             const partitionMsgs1 = [createMessage('session_id_1', 1), createMessage('session_id_2', 1)]
             const partitionMsgs2 = [createMessage('session_id_3', 2), createMessage('session_id_4', 2)]
 
-            mockAssignments.mockImplementation(() => [createTP(1), createTP(2), createTP(3)])
+            mockConsumer.assignments.mockImplementation(() => [createTP(1), createTP(2), createTP(3)])
             await ingester.handleEachBatch([...partitionMsgs1, ...partitionMsgs2])
 
             expect(
@@ -580,7 +585,7 @@ describe('ingester', () => {
 
             // Call the second ingester to receive the messages. The revocation should still be in progress meaning they are "paused" for a bit
             // Once the revocation is complete the second ingester should receive the messages but drop most of them as they got flushes by the revoke
-            mockAssignments.mockImplementation(() => [createTP(2), createTP(3)])
+            mockConsumer.assignments.mockImplementation(() => [createTP(2), createTP(3)])
             await otherIngester.handleEachBatch([...partitionMsgs2, createMessage('session_id_4', 2)])
             await Promise.all(rebalancePromises)
 
@@ -619,8 +624,8 @@ describe('ingester', () => {
                 expect.stringContaining(`${team.id}.sid3.`), // json
             ])
 
-            expect(mockCommit).toHaveBeenCalledTimes(1)
-            expect(mockCommit).toHaveBeenLastCalledWith(
+            expect(mockConsumer.commit).toHaveBeenCalledTimes(1)
+            expect(mockConsumer.commit).toHaveBeenLastCalledWith(
                 expect.objectContaining({
                     offset: 2 + 1,
                     partition: 1,
@@ -671,8 +676,8 @@ describe('ingester', () => {
                 createKafkaMessage('invalid_token', { offset: 12 }),
                 createKafkaMessage('invalid_token', { offset: 13 }),
             ])
-            expect(mockCommit).toHaveBeenCalledTimes(1)
-            expect(mockCommit).toHaveBeenCalledWith({
+            expect(mockConsumer.commit).toHaveBeenCalledTimes(1)
+            expect(mockConsumer.commit).toHaveBeenCalledWith({
                 offset: 14,
                 partition: 1,
                 topic: 'session_recording_snapshot_item_events_test',


### PR DESCRIPTION
## Problem

The improved reporting logic doesn't rely on rebalance events to get things right _but_ it had one issue that it could hold on to gauge metrics after a partition was revoked because it only iterated the list it knew about.

## Changes

* Change this to iterate over the full list of partitions each time ensuring it is definitely clear.
* Swaps drop logs to debug as they are super noisy

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
