### PR TITLE
fix: Improve UI for select-box with no value options

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
+++ b/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
@@ -131,6 +131,22 @@ export function LemonMenuOverlay({ items, tooltipPlacement, itemsRef }: LemonMen
 
     const buttonSize = featureFlags[FEATURE_FLAGS.POSTHOG_3000] ? 'small' : 'medium'
 
+    if (sectionsOrItems.length === 0) {
+        return (
+            <LemonMenuItemButton
+                item={{
+                    active: false,
+                    onClick: () => {},
+                    label: '-',
+                    disabledReason: 'No options available for selection.',
+                }}
+                size={buttonSize}
+                tooltipPlacement={tooltipPlacement}
+                ref={itemsRef?.current?.[0]}
+            />
+        )
+    }
+
     return sectionsOrItems.length > 0 && isLemonMenuSection(sectionsOrItems[0]) ? (
         <LemonMenuSectionList
             sections={sectionsOrItems as LemonMenuSection[]}

--- a/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
@@ -125,7 +125,7 @@ export function LemonSelect<T extends string | number | boolean | null>({
 
     return (
         <LemonMenu
-            items={!isItemsEmpty ? items : [{ active: false, label: 'No Value', onClick: () => {} }]}
+            items={!isItemsEmpty ? items : [{ active: false, label: 'No Value', custom: true, onClick: () => {} }]}
             tooltipPlacement={optionTooltipPlacement}
             sameWidth={dropdownMatchSelectWidth}
             placement={dropdownPlacement}

--- a/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
@@ -121,11 +121,10 @@ export function LemonSelect<T extends string | number | boolean | null>({
 
     const activeLeaf = allLeafOptions.find((o) => o.value === value)
     const isClearButtonShown = allowClear && !!value
-    const isItemsEmpty = items.length === 0
 
     return (
         <LemonMenu
-            items={!isItemsEmpty ? items : [{ active: false, label: 'No Value', custom: true, onClick: () => {} }]}
+            items={items}
             tooltipPlacement={optionTooltipPlacement}
             sameWidth={dropdownMatchSelectWidth}
             placement={dropdownPlacement}
@@ -144,7 +143,6 @@ export function LemonSelect<T extends string | number | boolean | null>({
                 sideIcon={isClearButtonShown ? <div /> : undefined}
                 type="secondary"
                 status="stealth"
-                aria-disabled={isItemsEmpty}
                 {...buttonProps}
             >
                 <span>

--- a/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
@@ -121,10 +121,11 @@ export function LemonSelect<T extends string | number | boolean | null>({
 
     const activeLeaf = allLeafOptions.find((o) => o.value === value)
     const isClearButtonShown = allowClear && !!value
+    const isItemsEmpty = items.length === 0
 
     return (
         <LemonMenu
-            items={items}
+            items={!isItemsEmpty ? items : [{ active: false, label: 'No Value', onClick: () => {} }]}
             tooltipPlacement={optionTooltipPlacement}
             sameWidth={dropdownMatchSelectWidth}
             placement={dropdownPlacement}
@@ -143,6 +144,7 @@ export function LemonSelect<T extends string | number | boolean | null>({
                 sideIcon={isClearButtonShown ? <div /> : undefined}
                 type="secondary"
                 status="stealth"
+                aria-disabled={isItemsEmpty}
                 {...buttonProps}
             >
                 <span>


### PR DESCRIPTION
## Problem
I'm new to Posthog, and I found some room for UI improvement in the page below.
When we don't have any select option, it can be misleading if it's a bug or just because there's no options available.
![image](https://github.com/PostHog/posthog/assets/60994269/db9e811c-64ed-4ff1-abaa-9f53c7c515ac)

## Changes
I set `aria-disabled=true` for select-box with no options available, and put `No Value` for an option, which cannot be selected.
https://github.com/PostHog/posthog/assets/60994269/ee0d8a95-1881-4c08-9a75-55718feb2219

## How did you test this code?
・manually check if it works fine when I add an option.
・run the following test. `pnpm test:unit`