### PR TITLE
fix: Fix issue with getting lag metric

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -169,7 +169,7 @@ export class SessionRecordingIngester {
             )
 
             return results.reduce((acc, [partition, highOffset]) => {
-                if (partition && highOffset !== undefined) {
+                if (typeof partition === 'number' && typeof highOffset === 'number') {
                     acc[partition] = highOffset
                 }
                 return acc

--- a/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
@@ -41,8 +41,8 @@ export const queryWatermarkOffsets = (
 
         kafkaConsumer.queryWatermarkOffsets(
             KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS,
-            timeout,
             partition,
+            timeout,
             (err, offsets) => {
                 if (err) {
                     captureException(err)


### PR DESCRIPTION
## Problem

Arguments were the wrong way round... As we are trying not too let it crash the process we didn't notice much as it errors.

## Changes

* Fixes the fetching of the offsets stuff, tests will follow.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
