### PR TITLE
fix: Remove personID from events query

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -384,7 +384,6 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                                 ],
                                 orderBy: ['timestamp ASC'],
                                 limit: 1000000,
-                                personId: String(person.id),
                                 after: start.subtract(BUFFER_MS, 'ms').format(),
                                 before: end.add(BUFFER_MS, 'ms').format(),
                                 properties: [properties],


### PR DESCRIPTION
## Problem

After discussion of how to handle the lots-of-distinctids problem, we realised we could just omit the personID. 

Or maybe not...
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
