### PR TITLE
fix: Fixed up button heights in sidepanel

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.scss
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.scss
@@ -7,10 +7,6 @@
     display: flex;
     background: var(--accent-3000);
 
-    .LemonButton {
-        min-height: 2.25rem !important; // Reduce minimum height
-    }
-
     &--open {
         position: relative;
         max-width: 60%;
@@ -46,6 +42,10 @@
         border-left-width: 1px;
         overflow-y: auto;
         user-select: none;
+
+        .LemonButton {
+            min-height: 2.25rem !important; // Reduce minimum height
+        }
     }
 
     .SidePanel3000__content {


### PR DESCRIPTION
## Problem

The selector was too broad so it affected buttons it shouldn't have

## Changes

* Fixes it to only apply to the bar.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
