### PR TITLE
fix: session recording timing reporting

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -541,7 +541,7 @@ def list_recordings(
 
     finish_serializing = time.perf_counter() * 1000
 
-    # timings are assumed to be in milliseconds
+    # timings are assumed to be in milliseconds when reported
     # but are gathered by time.perf_counter which is fractional seconds 🫠
     # so each value is multiplied by 1000 at collection
     timings = {

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -144,8 +144,10 @@ def list_recordings_response(
 ) -> Response:
     (recordings, timings) = list_recordings(filter, request, context=serializer_context)
     response = Response(recordings)
+    # timings are assumed to be in milliseconds
+    # but are gathered by time.perf_counter which is fractional seconds 🫠
     response.headers["Server-Timing"] = ", ".join(
-        f"{key};dur={round(duration, ndigits=2)}" for key, duration in timings.items()
+        f"{key};dur={round(duration * 1000, ndigits=2)}" for key, duration in timings.items()
     )
     return response
 

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -63,7 +63,7 @@ SNAPSHOT_SOURCE_REQUESTED = Counter(
 # context manager for gathering a sequence of server timings
 class ServerTimingsGathered:
     # Class level dictionary to store timings
-    timings_dict = {}
+    timings_dict: Dict[str, float] = {}
 
     def __call__(self, name):
         self.name = name


### PR DESCRIPTION
session recording timing looks too low when viewed in developer tools because `time.perf_counter` reports fractional seconds and server timing is assumed to be in milliseconds.

let's deduplicate a little and correct that

![Screenshot 2023-11-03 at 15 13 16](https://github.com/PostHog/posthog/assets/984817/4f0cfa75-47af-4b0a-89ca-d6c5e7dd55e8)
