### PR TITLE
fix: Disable heartbeat timeouts for destinations that do not support it 

### DIFF
--- a/posthog/temporal/workflows/batch_exports.py
+++ b/posthog/temporal/workflows/batch_exports.py
@@ -712,7 +712,7 @@ async def execute_batch_export_insert_activity(
     non_retryable_error_types: list[str],
     update_inputs: UpdateBatchExportRunStatusInputs,
     start_to_close_timeout_seconds: int = 3600,
-    heartbeat_timeout_seconds: int = 120,
+    heartbeat_timeout_seconds: int | None = 120,
     maximum_attempts: int = 10,
     initial_retry_interval_seconds: int = 10,
     maximum_retry_interval_seconds: int = 120,
@@ -747,7 +747,7 @@ async def execute_batch_export_insert_activity(
             activity,
             inputs,
             start_to_close_timeout=dt.timedelta(seconds=start_to_close_timeout_seconds),
-            heartbeat_timeout=dt.timedelta(seconds=heartbeat_timeout_seconds),
+            heartbeat_timeout=dt.timedelta(seconds=heartbeat_timeout_seconds) if heartbeat_timeout_seconds else None,
             retry_policy=retry_policy,
         )
     except exceptions.ActivityError as e:

--- a/posthog/temporal/workflows/bigquery_batch_export.py
+++ b/posthog/temporal/workflows/bigquery_batch_export.py
@@ -271,4 +271,6 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
                 "NotFound",
             ],
             update_inputs=update_inputs,
+            # Disable heartbeat timeout until we add heartbeat support.
+            heartbeat_timeout_seconds=None,
         )

--- a/posthog/temporal/workflows/postgres_batch_export.py
+++ b/posthog/temporal/workflows/postgres_batch_export.py
@@ -331,4 +331,6 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
                 "InsufficientPrivilege"
             ],
             update_inputs=update_inputs,
+            # Disable heartbeat timeout until we add heartbeat support.
+            heartbeat_timeout_seconds=None,
         )

--- a/posthog/temporal/workflows/redshift_batch_export.py
+++ b/posthog/temporal/workflows/redshift_batch_export.py
@@ -259,5 +259,10 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
         )
 
         await execute_batch_export_insert_activity(
-            insert_into_redshift_activity, insert_inputs, non_retryable_error_types=[], update_inputs=update_inputs
+            insert_into_redshift_activity,
+            insert_inputs,
+            non_retryable_error_types=[],
+            update_inputs=update_inputs,
+            # Disable heartbeat timeout until we add heartbeat support.
+            heartbeat_timeout_seconds=None,
         )

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -353,4 +353,6 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
                 "ForbiddenError",
             ],
             update_inputs=update_inputs,
+            # Disable heartbeat timeout until we add heartbeat support.
+            heartbeat_timeout_seconds=None,
         )


### PR DESCRIPTION
## Problem

We enabled a heartbeat timeout for all batch exports, but not all destinations support it yet. This means that long running exports are timing out, and since they don't heartbeat, temporal cannot communicate back to the worker, so they are unilaterally retried from the server POV.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Disable heartbeat_timeout for all but S3.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
