### PR TITLE
fix: narrow event query person scope

### DIFF
--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -115,7 +115,9 @@ class EventsQueryRunner(QueryRunner):
                         where_exprs.append(action_to_expr(action))
                 if self.query.personId:
                     with self.timings.measure("person_id"):
-                        person: Optional[Person] = get_pk_or_uuid(Person.objects.all(), self.query.personId).first()
+                        person: Optional[Person] = get_pk_or_uuid(
+                            Person.objects.filter(team=self.team), self.query.personId
+                        ).first()
                         distinct_ids = person.distinct_ids if person is not None else []
                         ids_list = list(map(str, distinct_ids))
                         where_exprs.append(

--- a/posthog/hogql_queries/insights/test/test_events_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_events_query_runner.py
@@ -3,6 +3,8 @@ from typing import Tuple, Any
 from freezegun import freeze_time
 
 from posthog.hogql_queries.events_query_runner import EventsQueryRunner
+from posthog.models import Person, Team
+from posthog.models.organization import Organization
 from posthog.schema import (
     EventsQuery,
     EventPropertyFilter,
@@ -13,6 +15,7 @@ from posthog.test.base import (
     ClickhouseTestMixin,
     _create_event,
     _create_person,
+    flush_persons_and_events,
 )
 
 
@@ -108,3 +111,21 @@ class TestEventsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertEqual({"p_true", "p_false"}, set(row[0]["distinct_id"] for row in results))
+
+    def test_person_id_expands_to_distinct_ids(self):
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["id1", "id2"],
+        )
+        flush_persons_and_events()
+        person = Person.objects.first()
+        query = EventsQuery(kind="EventsQuery", select=["*"], personId=str(person.pk))
+
+        # matching team
+        query_ast = EventsQueryRunner(query=query, team=self.team).to_query()
+        self.assertEqual(query_ast.where.exprs[0].right.value, ["id1", "id2"])
+
+        # another team
+        another_team = Team.objects.create(organization=Organization.objects.create())
+        query_ast = EventsQueryRunner(query=query, team=another_team).to_query()
+        self.assertEqual(query_ast.where.exprs[0].right.value, [])

--- a/posthog/hogql_queries/insights/test/test_events_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_events_query_runner.py
@@ -119,7 +119,7 @@ class TestEventsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
         flush_persons_and_events()
         person = Person.objects.first()
-        query = EventsQuery(kind="EventsQuery", select=["*"], personId=str(person.pk))
+        query = EventsQuery(kind="EventsQuery", select=["*"], personId=str(person.pk))  # type: ignore
 
         # matching team
         query_ast = EventsQueryRunner(query=query, team=self.team).to_query()

--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -21,7 +21,7 @@ from posthog.utils import relative_date_parse
 
 
 def determine_event_conditions(
-    conditions: Dict[str, Union[None, str, List[str]]], tzinfo: ZoneInfo
+    conditions: Dict[str, Union[None, str, List[str]]], team: Team, tzinfo: ZoneInfo
 ) -> Tuple[str, Dict]:
     result = ""
     params: Dict[str, Union[str, List[str]]] = {}
@@ -44,7 +44,7 @@ def determine_event_conditions(
             params.update({"before": timestamp})
         elif k == "person_id":
             result += """AND distinct_id IN (%(distinct_ids)s) """
-            person = get_pk_or_uuid(Person.objects.all(), v).first()
+            person = get_pk_or_uuid(Person.objects.filter(team=team), v).first()
             distinct_ids = person.distinct_ids if person is not None else []
             params.update({"distinct_ids": list(map(str, distinct_ids))})
         elif k == "distinct_id":
@@ -84,6 +84,7 @@ def query_events_list(
             "before": (now() + timedelta(seconds=5)).isoformat(),
             **request_get_query_dict,
         },
+        team,
         tzinfo=team.timezone_info,
     )
     prop_filters, prop_filter_params = parse_prop_grouped_clauses(


### PR DESCRIPTION
## Problem

As discussed https://posthog.slack.com/archives/C064U1Q2256

## Changes

This PR narrows the scope.

## How did you test this code?

Added tests & verified locally