### PR TITLE
feat: Make sidebar notice compact

### DIFF
--- a/frontend/src/layout/navigation/SideBar/SidebarChangeNotice.tsx
+++ b/frontend/src/layout/navigation/SideBar/SidebarChangeNotice.tsx
@@ -35,13 +35,25 @@ const NOTICES: {
         identifier: Scene.DataManagement,
         description: (
             <>
-                <b>Annotations</b> have moved! You can now find them in the <b>Data Management</b> section.
+                <b>Annotations</b> have moved!
                 <br />
-                <br />
-                <b>Cohorts</b> have moved! You can now find them in the <b>People & Groups</b> section.
+                You can now find them in <b>Data Management</b>
             </>
         ),
+        placement: 'rightBottom',
         flagSuffix: 'annotations-2023-10-30',
+    },
+    {
+        identifier: Scene.PersonsManagement,
+        description: (
+            <>
+                <b>Cohorts</b> have moved!
+                <br />
+                You can now find them in <b>People & Groups</b>
+            </>
+        ),
+        placement: 'rightTop',
+        flagSuffix: 'cohorts-2023-10-30',
     },
 ]
 

--- a/frontend/src/layout/navigation/SideBar/SidebarChangeNotice.tsx
+++ b/frontend/src/layout/navigation/SideBar/SidebarChangeNotice.tsx
@@ -103,14 +103,11 @@ export function useSidebarChangeNotices({ identifier }: SidebarChangeNoticeProps
     return [!noticeAcknowledged ? notices : [], onAcknowledged]
 }
 
-export function SidebarChangeNoticeTooltip({
-    identifier,
-    children,
-}: SidebarChangeNoticeTooltipProps): JSX.Element | null {
+export function SidebarChangeNoticeTooltip({ identifier, children }: SidebarChangeNoticeTooltipProps): React.ReactNode {
     const [notices, onAcknowledged] = useSidebarChangeNotices({ identifier })
 
     if (!notices.length) {
-        return <>{children}</>
+        return children
     }
 
     return (
@@ -120,7 +117,14 @@ export function SidebarChangeNoticeTooltip({
             delayMs={0}
             title={<SidebarChangeNoticeContent notices={notices} onAcknowledged={onAcknowledged} />}
         >
-            {children}
+            {React.cloneElement(children as React.ReactElement, {
+                onClick: () => {
+                    onAcknowledged()
+                    if (React.isValidElement(children)) {
+                        children.props.onClick?.()
+                    }
+                },
+            })}
         </Tooltip>
     )
 }

--- a/frontend/src/layout/navigation/SideBar/SidebarChangeNotice.tsx
+++ b/frontend/src/layout/navigation/SideBar/SidebarChangeNotice.tsx
@@ -1,3 +1,4 @@
+import { IconCheck } from '@posthog/icons'
 import { LemonButton, LemonDivider, Tooltip, TooltipProps } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -27,6 +28,7 @@ export type SidebarChangeNoticeTooltipProps = SidebarChangeNoticeProps & {
 const NOTICES: {
     identifier: Scene
     description: React.ReactNode
+    placement: TooltipProps['placement']
     flagSuffix: string
 }[] = [
     {
@@ -51,19 +53,17 @@ export function SidebarChangeNoticeContent({
     onAcknowledged: () => void
 }): JSX.Element | null {
     return (
-        <div className="max-w-80">
-            {notices.map((notice, i) => (
-                <Fragment key={i}>
-                    {notice.description}
-                    <LemonDivider />
-                </Fragment>
-            ))}
-
-            <div className="flex justify-end">
-                <LemonButton type="primary" onClick={onAcknowledged}>
-                    Got it!
-                </LemonButton>
+        <div className="flex items-center gap-1">
+            <div className="flex-1">
+                {notices.map((notice, i) => (
+                    <Fragment key={i}>
+                        {notice.description}
+                        {i < notices.length - 1 && <LemonDivider />}
+                    </Fragment>
+                ))}
             </div>
+
+            <LemonButton size="small" onClick={onAcknowledged} icon={<IconCheck />} />
         </div>
     )
 }
@@ -103,8 +103,8 @@ export function SidebarChangeNoticeTooltip({
 
     return (
         <Tooltip
-            visible={true}
-            placement="right"
+            visible
+            placement={notices[0].placement}
             delayMs={0}
             title={<SidebarChangeNoticeContent notices={notices} onAcknowledged={onAcknowledged} />}
         >

--- a/frontend/src/layout/navigation/SideBar/SidebarChangeNotice.tsx
+++ b/frontend/src/layout/navigation/SideBar/SidebarChangeNotice.tsx
@@ -35,7 +35,7 @@ const NOTICES: {
         identifier: Scene.DataManagement,
         description: (
             <>
-                <b>Annotations</b> have moved!
+                <b>Annotations</b> have moved here!
                 <br />
                 You can now find them in <b>Data Management</b>
             </>
@@ -47,7 +47,7 @@ const NOTICES: {
         identifier: Scene.PersonsManagement,
         description: (
             <>
-                <b>Cohorts</b> have moved!
+                <b>Cohorts</b> have moved here!
                 <br />
                 You can now find them in <b>People & Groups</b>
             </>

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.scss
@@ -256,6 +256,19 @@
         }
     }
 
+    .ant-tooltip & {
+        // Buttons have an overriden style in tooltips, as they are always dark
+        &:hover {
+            background: rgba(255, 255, 255, 0.15) !important;
+        }
+        &:active {
+            background: rgba(255, 255, 255, 0.2) !important;
+        }
+        .LemonButton__icon {
+            color: #fff !important;
+        }
+    }
+
     .posthog-3000 & {
         font-size: 0.8125rem;
         border: none !important; // 3000 buttons never have borders


### PR DESCRIPTION
## Changes

This is a proposed tweak to #18200. Annotations and Cohorts are split into two notices, which are more compact than previously. Additionally, the notices now are automatically acknowledged when the sidebar item is clicked.
 
| Before | After |
|--------|--------|
| <img width="594" alt="Screenshot 2023-11-03 at 21 17 07" src="https://github.com/PostHog/posthog/assets/4550621/269cdcbb-d4cf-4527-ab90-f7f4d084461a"> | <img width="589" alt="Screenshot 2023-11-03 at 21 17 54" src="https://github.com/PostHog/posthog/assets/4550621/b1d7eab1-b610-4301-8f4d-8330b363e44c"> | 
