### PR TITLE
chore(plugin-server): migrate AWS SDK for JavaScript v2 APIs to v3

### DIFF
--- a/plugin-server/src/utils/db/s3-wrapper.ts
+++ b/plugin-server/src/utils/db/s3-wrapper.ts
@@ -8,26 +8,18 @@ export class S3Wrapper {
     }
 
     async upload(params: S3.Types.PutObjectRequest): Promise<S3.ManagedUpload.SendData> {
-        return await new Promise((resolve, reject) => {
-            this.s3.upload(params, (err, data) => (err ? reject(err) : resolve(data)))
-        })
+        return this.s3.upload(params).promise()
     }
 
     async getObject(params: S3.GetObjectRequest): Promise<S3.Types.GetObjectOutput> {
-        return await new Promise((resolve, reject) =>
-            this.s3.getObject(params, (err, data) => (err ? reject(err) : resolve(data)))
-        )
+        return this.s3.getObject(params).promise()
     }
 
     async deleteObject(params: S3.DeleteObjectRequest): Promise<S3.Types.DeleteObjectOutput> {
-        return await new Promise((resolve, reject) =>
-            this.s3.deleteObject(params, (err, data) => (err ? reject(err) : resolve(data)))
-        )
+        return this.s3.deleteObject(params).promise()
     }
 
     async listObjectsV2(params: S3.ListObjectsV2Request): Promise<S3.Types.ListObjectsV2Output> {
-        return await new Promise((resolve, reject) =>
-            this.s3.listObjectsV2(params, (err, data) => (err ? reject(err) : resolve(data)))
-        )
+        return this.s3.listObjectsV2(params).promise()
     }
 }

--- a/plugin-server/src/utils/db/s3-wrapper.ts
+++ b/plugin-server/src/utils/db/s3-wrapper.ts
@@ -9,25 +9,25 @@ export class S3Wrapper {
 
     async upload(params: S3.Types.PutObjectRequest): Promise<S3.ManagedUpload.SendData> {
         return await new Promise((resolve, reject) => {
-            this.s3?.upload(params, (err, data) => (err ? reject(err) : resolve(data)))
+            this.s3.upload(params, (err, data) => (err ? reject(err) : resolve(data)))
         })
     }
 
     async getObject(params: S3.GetObjectRequest): Promise<S3.Types.GetObjectOutput> {
         return await new Promise((resolve, reject) =>
-            this.s3?.getObject(params, (err, data) => (err ? reject(err) : resolve(data)))
+            this.s3.getObject(params, (err, data) => (err ? reject(err) : resolve(data)))
         )
     }
 
     async deleteObject(params: S3.DeleteObjectRequest): Promise<S3.Types.DeleteObjectOutput> {
         return await new Promise((resolve, reject) =>
-            this.s3?.deleteObject(params, (err, data) => (err ? reject(err) : resolve(data)))
+            this.s3.deleteObject(params, (err, data) => (err ? reject(err) : resolve(data)))
         )
     }
 
     async listObjectsV2(params: S3.ListObjectsV2Request): Promise<S3.Types.ListObjectsV2Output> {
         return await new Promise((resolve, reject) =>
-            this.s3?.listObjectsV2(params, (err, data) => (err ? reject(err) : resolve(data)))
+            this.s3.listObjectsV2(params, (err, data) => (err ? reject(err) : resolve(data)))
         )
     }
 }

--- a/plugin-server/src/utils/db/s3-wrapper.ts
+++ b/plugin-server/src/utils/db/s3-wrapper.ts
@@ -1,25 +1,35 @@
-import { S3 } from 'aws-sdk'
+import {
+    DeleteObjectCommandInput,
+    DeleteObjectCommandOutput,
+    GetObjectCommandInput,
+    GetObjectCommandOutput,
+    ListObjectsV2CommandInput,
+    ListObjectsV2CommandOutput,
+    PutObjectCommandInput,
+    S3,
+    S3ClientConfig,
+} from '@aws-sdk/client-s3';
 
 export class S3Wrapper {
     s3: S3
 
-    constructor(options: S3.Types.ClientConfiguration) {
+    constructor(options: S3ClientConfig) {
         this.s3 = new S3(options)
     }
 
-    async upload(params: S3.Types.PutObjectRequest): Promise<S3.ManagedUpload.SendData> {
+    async upload(params: PutObjectCommandInput): Promise<S3.ManagedUpload.SendData> {
         return this.s3.upload(params).promise()
     }
 
-    async getObject(params: S3.GetObjectRequest): Promise<S3.Types.GetObjectOutput> {
+    async getObject(params: GetObjectCommandInput): Promise<GetObjectCommandOutput> {
         return this.s3.getObject(params).promise()
     }
 
-    async deleteObject(params: S3.DeleteObjectRequest): Promise<S3.Types.DeleteObjectOutput> {
+    async deleteObject(params: DeleteObjectCommandInput): Promise<DeleteObjectCommandOutput> {
         return this.s3.deleteObject(params).promise()
     }
 
-    async listObjectsV2(params: S3.ListObjectsV2Request): Promise<S3.Types.ListObjectsV2Output> {
+    async listObjectsV2(params: ListObjectsV2CommandInput): Promise<ListObjectsV2CommandOutput> {
         return this.s3.listObjectsV2(params).promise()
     }
 }

--- a/plugin-server/src/utils/db/s3-wrapper.ts
+++ b/plugin-server/src/utils/db/s3-wrapper.ts
@@ -1,4 +1,6 @@
 import {
+    AbortMultipartUploadCommandOutput,
+    CompleteMultipartUploadCommandOutput,
     DeleteObjectCommandInput,
     DeleteObjectCommandOutput,
     GetObjectCommandInput,
@@ -8,7 +10,8 @@ import {
     PutObjectCommandInput,
     S3,
     S3ClientConfig,
-} from '@aws-sdk/client-s3';
+} from '@aws-sdk/client-s3'
+import { Upload } from '@aws-sdk/lib-storage'
 
 export class S3Wrapper {
     s3: S3
@@ -17,19 +20,21 @@ export class S3Wrapper {
         this.s3 = new S3(options)
     }
 
-    async upload(params: PutObjectCommandInput): Promise<S3.ManagedUpload.SendData> {
-        return this.s3.upload(params).promise()
+    async upload(
+        params: PutObjectCommandInput
+    ): Promise<AbortMultipartUploadCommandOutput | CompleteMultipartUploadCommandOutput> {
+        return new Upload({ client: this.s3, params }).done()
     }
 
     async getObject(params: GetObjectCommandInput): Promise<GetObjectCommandOutput> {
-        return this.s3.getObject(params).promise()
+        return this.s3.getObject(params)
     }
 
     async deleteObject(params: DeleteObjectCommandInput): Promise<DeleteObjectCommandOutput> {
-        return this.s3.deleteObject(params).promise()
+        return this.s3.deleteObject(params)
     }
 
     async listObjectsV2(params: ListObjectsV2CommandInput): Promise<ListObjectsV2CommandOutput> {
-        return this.s3.listObjectsV2(params).promise()
+        return this.s3.listObjectsV2(params)
     }
 }


### PR DESCRIPTION
## Problem

From AWS SDK for JavaScript v2 [README](https://github.com/aws/aws-sdk-js):
> We are formalizing our plans to make the Maintenance Announcement (Phase 2) for AWS SDK for JavaScript v2 in 2023.

## Changes

Migrates AWS SDK for JavaScript v2 APIs to v3 using [aws-sdk-js-codemod](https://www.npmjs.com/package/aws-sdk-js-codemod).

```console
$ npx aws-sdk-js-codemod@0.26.1 -t v2-to-v3 packages/feedback/*.js
```


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
