### PR TITLE
feat: format property keys in simple events list

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/components/SimpleKeyValueList.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/SimpleKeyValueList.tsx
@@ -1,5 +1,7 @@
 // A React component that renders a list of key-value pairs in a simple way.
 
+import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
+
 export interface SimpleKeyValueListProps {
     item: Record<string, any>
 }
@@ -9,7 +11,9 @@ export function SimpleKeyValueList({ item }: SimpleKeyValueListProps): JSX.Eleme
         <div className="text-xs space-y-1 max-w-full">
             {Object.entries(item).map(([key, value]) => (
                 <div key={key} className="flex gap-4 items-start justify-between overflow-hidden">
-                    <span className="font-semibold">{key}</span>
+                    <span className="font-semibold">
+                        <PropertyKeyInfo value={key} />
+                    </span>
                     <pre className="text-primary-alt break-all mb-0">{JSON.stringify(value, null, 2)}</pre>
                 </div>
             ))}


### PR DESCRIPTION
I find the simple listing in replay difficult to scan for properties... 

| before | after |
| -- | -- |
|<img width="400" alt="Screenshot 2023-11-06 at 09 41 44" src="https://github.com/PostHog/posthog/assets/984817/22bea2bb-ba08-4421-83e6-d5fd50bea2e1">| <img width="400" alt="Screenshot 2023-11-06 at 09 27 52" src="https://github.com/PostHog/posthog/assets/984817/1526456d-dc8f-40f2-a472-d4789d9a9549">|

