### PR TITLE
fix: fixed 'yesterday' insights not filtering on the correct end date

### DIFF
--- a/cypress/e2e/trends.cy.ts
+++ b/cypress/e2e/trends.cy.ts
@@ -140,7 +140,7 @@ describe('Trends', () => {
     it('Apply date filter', () => {
         cy.get('[data-attr=date-filter]').click()
         cy.get('div').contains('Yesterday').should('exist').click()
-        cy.get('.trends-insights-container .insight-empty-state').should('exist')
+        cy.get('[data-attr=trend-line-graph]').should('exist')
     })
 
     it('Apply property breakdown', () => {

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -47,7 +47,7 @@ class QueryDateRange:
         delta_mapping = None
 
         if self._date_range and self._date_range.date_to:
-            date_to, delta_mapping = relative_date_parse_with_delta_mapping(
+            date_to, delta_mapping, _position = relative_date_parse_with_delta_mapping(
                 self._date_range.date_to,
                 self._team.timezone_info,
                 always_truncate=True,

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -351,7 +351,7 @@ class DateMixin(BaseParamMixin):
             if self._date_from == "all":
                 return None
             elif isinstance(self._date_from, str):
-                date, delta_mapping = relative_date_parse_with_delta_mapping(
+                date, delta_mapping, _position = relative_date_parse_with_delta_mapping(
                     self._date_from,
                     self.team.timezone_info,  # type: ignore
                     always_truncate=True,
@@ -385,7 +385,11 @@ class DateMixin(BaseParamMixin):
                             tzinfo=ZoneInfo("UTC")
                         )
                     except ValueError:
-                        date, delta_mapping = relative_date_parse_with_delta_mapping(
+                        (
+                            date,
+                            delta_mapping,
+                            _position,
+                        ) = relative_date_parse_with_delta_mapping(
                             self._date_to,
                             self.team.timezone_info,  # type: ignore
                             always_truncate=True,

--- a/posthog/queries/query_date_range.py
+++ b/posthog/queries/query_date_range.py
@@ -53,9 +53,10 @@ class QueryDateRange:
     def date_to_param(self) -> datetime:
         date_to = self._now
         delta_mapping = None
+        position: str | None = None
         if isinstance(self._filter._date_to, str):
-            date_to, delta_mapping = relative_date_parse_with_delta_mapping(
-                self._filter._date_to, self._team.timezone_info, always_truncate=True
+            date_to, delta_mapping, position = relative_date_parse_with_delta_mapping(
+                self._filter._date_to, self._team.timezone_info
             )
         elif isinstance(self._filter._date_to, datetime):
             date_to = self._localize_to_team(self._filter._date_to)
@@ -64,7 +65,7 @@ class QueryDateRange:
         if not self._filter.use_explicit_dates:
             if not self.is_hourly(self._filter._date_to):
                 date_to = date_to.replace(hour=23, minute=59, second=59, microsecond=999999)
-            elif is_relative:
+            elif is_relative and not position:
                 date_to = date_to.replace(minute=59, second=59, microsecond=999999)
 
         return date_to

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -173,7 +173,7 @@ def relative_date_parse_with_delta_mapping(
     *,
     always_truncate: bool = False,
     now: Optional[datetime.datetime] = None,
-) -> Tuple[datetime.datetime, Optional[Dict[str, int]]]:
+) -> Tuple[datetime.datetime, Optional[Dict[str, int]], str | None]:
     """Returns the parsed datetime, along with the period mapping - if the input was a relative datetime string."""
     try:
         try:
@@ -191,14 +191,14 @@ def relative_date_parse_with_delta_mapping(
             parsed_dt = parsed_dt.replace(tzinfo=timezone_info)
         else:
             parsed_dt = parsed_dt.astimezone(timezone_info)
-        return parsed_dt, None
+        return parsed_dt, None, None
 
     regex = r"\-?(?P<number>[0-9]+)?(?P<type>[a-z])(?P<position>Start|End)?"
     match = re.search(regex, input)
     parsed_dt = (now or dt.datetime.now()).astimezone(timezone_info)
     delta_mapping: Dict[str, int] = {}
     if not match:
-        return parsed_dt, delta_mapping
+        return parsed_dt, delta_mapping, None
     if match.group("type") == "h":
         delta_mapping["hours"] = int(match.group("number"))
     elif match.group("type") == "d":
@@ -244,7 +244,7 @@ def relative_date_parse_with_delta_mapping(
             parsed_dt = parsed_dt.replace(minute=0, second=0, microsecond=0)
         else:
             parsed_dt = parsed_dt.replace(hour=0, minute=0, second=0, microsecond=0)
-    return parsed_dt, delta_mapping
+    return parsed_dt, delta_mapping, match.group("position") or None
 
 
 def relative_date_parse(


### PR DESCRIPTION
## Problem
Filtering on `yesterday` would filter between the hours of midnight and 1am instead of the whole day. Fixes support issue raised here https://github.com/PostHog/posthog/issues/18382

## Changes
- Dont edit the time when a time position is used (`Start` or `End`)
- Remove the usage of `always_truncate` when dealing with the insights query date range class. Confirmed to be okay from here https://github.com/PostHog/posthog/pull/16965#discussion_r1300400571

## How did you test this code?
Clicked in the browser and checked clickhouse query ran