### PR TITLE
fix: workaround snapshots not found check

### DIFF
--- a/posthog/session_recordings/queries/session_replay_events.py
+++ b/posthog/session_recordings/queries/session_replay_events.py
@@ -23,7 +23,11 @@ class SessionReplayEvents:
             FROM session_replay_events
             WHERE team_id = %(team_id)s
             AND session_id = %(session_id)s
-            AND min_first_timestamp >= now() - INTERVAL %(recording_ttl_days)s DAY
+            -- we should check for the `ttl_days(team)` TTL here,
+            -- but for a shared/pinned recording
+            -- the TTL effectively becomes 1 year
+            -- and we don't know which we're dealing with
+            AND min_first_timestamp >= now() - INTERVAL 370 DAY
             """,
             {
                 "team_id": team.pk,


### PR DESCRIPTION
If a recording is shared or pinned its TTL is 1 year. When loading snapshots we check existence by checking if the recording exists in `session_replay_events` within the team's TTL.

But once that TTL period has passed then the shared/pinned recording should still be available even though others from the same day won't be

As a quick fix, let's allow a year and a bit to get this working again