### PR TITLE
fix: Only send unsubscribe survey if response is non-empty

### DIFF
--- a/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
+++ b/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
@@ -82,7 +82,7 @@ export const UnsubscribeSurveyModal = ({ product }: { product: BillingProductV2T
                             type={textAreaNotEmpty ? 'primary' : 'tertiary'}
                             status={textAreaNotEmpty ? 'primary' : 'muted'}
                             onClick={() => {
-                                reportSurveySent(surveyID, surveyResponse)
+                                textAreaNotEmpty && reportSurveySent(surveyID, surveyResponse)
                                 deactivateProduct(product.type)
                             }}
                         >


### PR DESCRIPTION
## Problem

Reduce the number of empty survey responses in app.posthog.com

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
