### PR TITLE
chore: Make plugin-server ignore deleted plugin configs

### DIFF
--- a/plugin-server/src/utils/db/sql.ts
+++ b/plugin-server/src/utils/db/sql.ts
@@ -21,7 +21,9 @@ function pluginConfigsInForceQuery(specificField?: keyof PluginConfig): string {
        LEFT JOIN posthog_organization ON posthog_organization.id = posthog_team.organization_id
        LEFT JOIN posthog_plugin ON posthog_plugin.id = posthog_pluginconfig.plugin_id
        WHERE (
-           posthog_pluginconfig.enabled='t' AND posthog_organization.plugins_access_level > 0
+           posthog_pluginconfig.enabled='t'
+           AND (posthog_pluginconfig.deleted is NULL OR posthog_pluginconfig.deleted!='t')
+           AND posthog_organization.plugins_access_level > 0
        )`
 }
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
https://github.com/PostHog/posthog/pull/18384#pullrequestreview-1717557302
> still adding the `and not deleted` to the plugin-server query in case there's a regression in the orm layer


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
