### PR TITLE
fix: 404 on missing site app

### DIFF
--- a/posthog/api/site_app.py
+++ b/posthog/api/site_app.py
@@ -34,5 +34,5 @@ def get_site_app(request: HttpRequest, id: int, token: str, hash: str) -> HttpRe
             "Unable to serve site app source code.",
             code="missing_site_app_source",
             type="server_error",
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            status_code=status.HTTP_404_NOT_FOUND,
         )


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Missing site app code returns a 503 Service Unavailable. This is a confusing error to send to users, and also leads to us [paging on server errors](https://posthog.slack.com/archives/C0113360FFV/p1699372524405599) that don't represent an actual server issue*.

*As far as I can tell, anyway.

## Changes

Change to a 404.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
