### PR TITLE
fix(insights): fix insights display configs in notebooks

### DIFF
--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -84,19 +84,12 @@ export const insightDataLogic = kea<insightDataLogicType>([
 
     selectors({
         query: [
-            (s) => [s.propsQuery, s.filters, s.insight, s.internalQuery, s.filterTestAccountsDefault],
-            (propsQuery, filters, insight, internalQuery, filterTestAccountsDefault) =>
-                propsQuery ||
+            (s) => [s.filters, s.insight, s.internalQuery, s.filterTestAccountsDefault],
+            (filters, insight, internalQuery, filterTestAccountsDefault) =>
                 internalQuery ||
                 insight.query ||
                 (filters && filters.insight ? queryFromFilters(filters) : undefined) ||
                 queryFromKind(NodeKind.TrendsQuery, filterTestAccountsDefault),
-        ],
-
-        propsQuery: [
-            () => [(_, props) => props],
-            // overwrite query from props for standalone InsightVizNode queries
-            (props: InsightLogicProps) => (props.dashboardItemId?.startsWith('new-AdHoc.') ? props.query : null),
         ],
 
         isQueryBasedInsight: [

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -126,6 +126,7 @@ export const Settings = ({
 
         if (NodeKind.InsightVizNode === modifiedQuery.kind || NodeKind.SavedInsightNode === modifiedQuery.kind) {
             modifiedQuery.showFilters = true
+            modifiedQuery.showHeader = true
             modifiedQuery.showResults = false
             modifiedQuery.embedded = true
         }

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -70,7 +70,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeQueryAttributes
 
         if (NodeKind.InsightVizNode === modifiedQuery.kind || NodeKind.SavedInsightNode === modifiedQuery.kind) {
             modifiedQuery.showFilters = false
-            modifiedQuery.showHeader = true
+            modifiedQuery.showHeader = false
             modifiedQuery.showTable = false
             modifiedQuery.showCorrelationTable = false
             modifiedQuery.embedded = true

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -70,7 +70,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeQueryAttributes
 
         if (NodeKind.InsightVizNode === modifiedQuery.kind || NodeKind.SavedInsightNode === modifiedQuery.kind) {
             modifiedQuery.showFilters = false
-            modifiedQuery.showHeader = false
+            modifiedQuery.showHeader = true
             modifiedQuery.showTable = false
             modifiedQuery.showCorrelationTable = false
             modifiedQuery.embedded = true
@@ -87,7 +87,7 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeQueryAttributes
         <div
             className={clsx('flex flex-1 flex-col', NodeKind.DataTableNode === modifiedQuery.kind && 'overflow-hidden')}
         >
-            <Query query={modifiedQuery} uniqueKey={nodeId} readOnly={true} />
+            <Query query={modifiedQuery} uniqueKey={nodeId} />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

We decided to move forward with https://github.com/PostHog/posthog/pull/18266 and https://github.com/PostHog/posthog/pull/18257 to work around the issues with insight queries not updating in notebooks. (Note: both these PRs would not have been necessary with the `propsQuery` change mentioned further below).

The `readOnly` prop is preventing this to work and `showHeaders: false` is hiding the filters.

This still did not fix all the issues with notebooks, but removing the `propsQuery` did. I have no idea why, but could not find any problems in insights / dashboards / experiments. Thus suggesting we move forward with this and 🤞 everything works. If this causes any issues, we roll back the change.

## Changes

This PR removes the `readOnly` prop, un-hides the filters and removes the `propsQuery` from the query selector.

## How did you test this code?

Tested that editing the 