### PR TITLE
fix: Checkout master before hogql-diff and use new GH syntax

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -62,20 +62,6 @@ runs:
           run: |
               sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
-        - name: Install antlr 4.13 (required by hoql_parser)
-          shell: bash
-          run: |
-              curl https://www.antlr.org/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip
-              anltr_known_md5sum="c875c148991aacd043f733827644a76f"
-              antlr_found_ms5sum="$(md5sum antlr4-source.zip | cut -d' ' -f1)"
-              if [[ "$anltr_known_md5sum" != "$antlr_found_ms5sum" ]]; then exit 64; fi
-              unzip antlr4-source.zip -d antlr4-source && cd antlr4-source
-              cmake .
-              DESTDIR=out make install
-              cp -r out/usr/local/include/antlr4-runtime /usr/include/
-              cp out/usr/local/lib64/libantlr4-runtime.so* /usr/lib64/
-              ldconfig
-
         - uses: syphar/restore-virtualenv@v1
           id: cache-backend-tests
           with:

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -49,6 +49,10 @@ runs:
               python-version: ${{ inputs.python-version }}
               token: ${{ inputs.token }}
 
+        - uses: actions/checkout@v3
+          with:
+              ref: master
+
         - name: Determine if hogql-parser has changed compared to master
           shell: bash
           id: hogql-parser-diff

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -60,6 +60,8 @@ runs:
               changed=$(git diff --quiet HEAD master -- hogql_parser/ && echo "false" || echo "true")
               echo "changed=$changed" >> $GITHUB_OUTPUT
 
+        - uses: actions/checkout@v3
+
         - name: Install SAML (python3-saml) dependencies
           shell: bash
           run: |

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -60,7 +60,21 @@ runs:
         - name: Install SAML (python3-saml) dependencies
           shell: bash
           run: |
-              sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl libantlr4-runtime-dev
+              sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
+        - name: Install antlr 4.13 (required by hoql_parser)
+          shell: bash
+          run: |
+              curl https://www.antlr.org/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip
+              anltr_known_md5sum="c875c148991aacd043f733827644a76f"
+              antlr_found_ms5sum="$(md5sum antlr4-source.zip | cut -d' ' -f1)"
+              if [[ "$anltr_known_md5sum" != "$antlr_found_ms5sum" ]]; then exit 64; fi
+              unzip antlr4-source.zip -d antlr4-source && cd antlr4-source
+              cmake .
+              DESTDIR=out make install
+              cp -r out/usr/local/include/antlr4-runtime /usr/include/
+              cp out/usr/local/lib64/libantlr4-runtime.so* /usr/lib64/
+              ldconfig
 
         - uses: syphar/restore-virtualenv@v1
           id: cache-backend-tests

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -53,6 +53,7 @@ runs:
           shell: bash
           id: hogql-parser-diff
           run: |
+              git fetch --no-tags --prune --depth=1 origin
               changed=$(git diff --quiet HEAD origin/master -- hogql_parser/ && echo "false" || echo "true")
               echo "changed=$changed" >> $GITHUB_OUTPUT
 

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -54,7 +54,7 @@ runs:
           id: hogql-parser-diff
           run: |
               changed=$(git diff --quiet HEAD master -- hogql_parser/ && echo "false" || echo "true")
-              echo "::set-output name=changed::$changed"
+              echo "changed=$changed" >> $GITHUB_OUTPUT
 
         - name: Install SAML (python3-saml) dependencies
           shell: bash

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -60,7 +60,7 @@ runs:
         - name: Install SAML (python3-saml) dependencies
           shell: bash
           run: |
-              sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+              sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl libantlr4-runtime-dev
 
         - uses: syphar/restore-virtualenv@v1
           id: cache-backend-tests

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -49,18 +49,12 @@ runs:
               python-version: ${{ inputs.python-version }}
               token: ${{ inputs.token }}
 
-        - uses: actions/checkout@v3
-          with:
-              ref: master
-
         - name: Determine if hogql-parser has changed compared to master
           shell: bash
           id: hogql-parser-diff
           run: |
-              changed=$(git diff --quiet HEAD master -- hogql_parser/ && echo "false" || echo "true")
+              changed=$(git diff --quiet HEAD origin/master -- hogql_parser/ && echo "false" || echo "true")
               echo "changed=$changed" >> $GITHUB_OUTPUT
-
-        - uses: actions/checkout@v3
 
         - name: Install SAML (python3-saml) dependencies
           shell: bash


### PR DESCRIPTION
## Problem

I'm seeing a `fatal: bad revision 'master'` line when checking if hogql-parser has changed compared to master. This is causing PRs to run for 5-7 minutes setting-up hogql/antlr, even if nothing changed.

The solution should be to fetch origin and diff with origin/master. I'm doing this manually which is probably not the cleanest, but given the amount of time lost to building antlr, this is nothing.

Moreover, we are using the set-output command which [was deprecated last year](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), but then [un-deprecated this year](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

It's not clear to me whether `::set-otuput` is still supported or not, but anyways, we should use the new recommended syntax. 


<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Swap `echo "::set-output name=changed::$changed"` for `echo "changed=$changed" >> $GITHUB_OUTPUT`
* Fetch origin and diff against `origin/master` for hogl changes.

<!-- If there are frontend changes, please include screenshots. `-->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

I rebased my PR on top of this, notice no time spent building antlr: https://github.com/PostHog/posthog/actions/runs/6789574178/job/18457089273?pr=18463. Compare that run against another earlier PR I merged which did built antlr: https://github.com/PostHog/posthog/actions/runs/6782379713/job/18435144400. None of them changed hogql_parser in anyway.

Logs of the old run:
```
Run changed=$(git diff --quiet HEAD master -- hogql_parser/ && echo "false" || echo "true")
fatal: bad revision 'master'
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
