### PR TITLE
feat: p-s to support composeWebhook

### DIFF
--- a/plugin-server/functional_tests/plugins.test.ts
+++ b/plugin-server/functional_tests/plugins.test.ts
@@ -389,12 +389,14 @@ test.concurrent(
             properties: properties,
         }
 
-        await capture({ teamId, distinctId, uuid, event: event.event, properties: event.properties })
-
         await waitForExpect(async () => {
+            // We might have not completed the setup properly in time, so to avoid flaky tests, we'll
+            // try sending messages and checking the last log message until we get the expected result.
+            await capture({ teamId, distinctId, uuid, event: event.event, properties: event.properties })
             const logEntries = await fetchPluginConsoleLogEntries(pluginConfig.id)
             const onEvent = logEntries.filter(({ message: [method] }) => method === 'onEvent')
-            expect(onEvent).toEqual([
+            const lastLogEntry = onEvent.length > 0 ? onEvent[onEvent.length - 1] : null
+            expect(lastLogEntry).toEqual(
                 expect.objectContaining({
                     message: [
                         'onEvent',
@@ -410,8 +412,8 @@ test.concurrent(
                             ],
                         }),
                     ],
-                }),
-            ])
+                })
+            )
         })
     },
     20000

--- a/plugin-server/functional_tests/plugins.test.ts
+++ b/plugin-server/functional_tests/plugins.test.ts
@@ -394,16 +394,22 @@ test.concurrent(
         await waitForExpect(async () => {
             const logEntries = await fetchPluginConsoleLogEntries(pluginConfig.id)
             const onEvent = logEntries.filter(({ message: [method] }) => method === 'onEvent')
-            expect(onEvent.length).toBeGreaterThan(0)
-
-            const onEventEvent = onEvent[0].message[1]
-            expect(onEventEvent.elements).toEqual([
+            expect(onEvent).toEqual([
                 expect.objectContaining({
-                    attributes: {},
-                    nth_child: 1,
-                    nth_of_type: 2,
-                    tag_name: 'div',
-                    text: '💻',
+                    message: [
+                        'onEvent',
+                        expect.objectContaining({
+                            elements: [
+                                expect.objectContaining({
+                                    attributes: {},
+                                    nth_child: 1,
+                                    nth_of_type: 2,
+                                    tag_name: 'div',
+                                    text: '💻',
+                                }),
+                            ],
+                        }),
+                    ],
                 }),
             ])
         })

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
@@ -1,10 +1,13 @@
 import * as Sentry from '@sentry/node'
 import { EachBatchPayload, KafkaMessage } from 'kafkajs'
 
-import { RawClickHouseEvent } from '../../../types'
-import { convertToIngestionEvent } from '../../../utils/event'
+import { PluginConfig, PluginMethod, RawClickHouseEvent } from '../../../types'
+import { convertToIngestionEvent, convertToPostHogEvent } from '../../../utils/event'
 import { status } from '../../../utils/status'
-import { processOnEventStep } from '../../../worker/ingestion/event-pipeline/runAsyncHandlersStep'
+import {
+    processComposeWebhookStep,
+    processOnEventStep,
+} from '../../../worker/ingestion/event-pipeline/runAsyncHandlersStep'
 import { runInstrumentedFunction } from '../../utils'
 import { KafkaJSIngestionConsumer } from '../kafka-queue'
 import { eventDroppedCounter, latestOffsetTimestampGauge } from '../metrics'
@@ -13,28 +16,57 @@ import { eachBatchHandlerHelper } from './each-batch-webhooks'
 // Must require as `tsc` strips unused `import` statements and just requiring this seems to init some globals
 require('@sentry/tracing')
 
+export async function handleOnEventPlugins(
+    pluginConfigs: PluginConfig[],
+    clickHouseEvent: RawClickHouseEvent,
+    queue: KafkaJSIngestionConsumer
+): Promise<void> {
+    // Elements parsing can be extremely slow, so we skip it for some plugins
+    // # SKIP_ELEMENTS_PARSING_PLUGINS
+    const skipElementsChain = pluginConfigs.every((pluginConfig) =>
+        queue.pluginsServer.pluginConfigsToSkipElementsParsing?.(pluginConfig.plugin_id)
+    )
+
+    const event = convertToIngestionEvent(clickHouseEvent, skipElementsChain)
+    await runInstrumentedFunction({
+        func: () => processOnEventStep(queue.pluginsServer, event),
+        statsKey: `kafka_queue.process_async_handlers_on_event`,
+        timeoutMessage: 'After 30 seconds still running runAppsOnEventPipeline',
+        timeoutContext: () => ({
+            event: JSON.stringify(event),
+        }),
+        teamId: event.teamId,
+    })
+}
+
+export async function handleComposeWebhookPlugins(
+    clickHouseEvent: RawClickHouseEvent,
+    queue: KafkaJSIngestionConsumer
+): Promise<void> {
+    const event = convertToPostHogEvent(clickHouseEvent)
+    await runInstrumentedFunction({
+        func: () => processComposeWebhookStep(queue.pluginsServer, event),
+        statsKey: `kafka_queue.process_async_handlers_on_event`,
+        timeoutMessage: 'After 30 seconds still running runAppsOnEventPipeline',
+        timeoutContext: () => ({
+            event: JSON.stringify(event),
+        }),
+        teamId: event.team_id,
+    })
+}
+
 export async function eachMessageAppsOnEventHandlers(
     clickHouseEvent: RawClickHouseEvent,
     queue: KafkaJSIngestionConsumer
 ): Promise<void> {
     const pluginConfigs = queue.pluginsServer.pluginConfigsPerTeam.get(clickHouseEvent.team_id)
     if (pluginConfigs) {
-        // Elements parsing can be extremely slow, so we skip it for some plugins
-        // # SKIP_ELEMENTS_PARSING_PLUGINS
-        const skipElementsChain = pluginConfigs.every((pluginConfig) =>
-            queue.pluginsServer.pluginConfigsToSkipElementsParsing?.(pluginConfig.plugin_id)
-        )
-
-        const event = convertToIngestionEvent(clickHouseEvent, skipElementsChain)
-        await runInstrumentedFunction({
-            func: () => processOnEventStep(queue.pluginsServer, event),
-            statsKey: `kafka_queue.process_async_handlers_on_event`,
-            timeoutMessage: 'After 30 seconds still running runAppsOnEventPipeline',
-            timeoutContext: () => ({
-                event: JSON.stringify(event),
-            }),
-            teamId: event.teamId,
-        })
+        // Split between onEvent and composeWebhook plugins
+        const onEventPlugins = pluginConfigs.filter((pluginConfig) => pluginConfig.method === PluginMethod.onEvent)
+        await Promise.all([
+            handleOnEventPlugins(onEventPlugins, clickHouseEvent, queue),
+            handleComposeWebhookPlugins(clickHouseEvent, queue),
+        ])
     } else {
         eventDroppedCounter
             .labels({

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -7,8 +7,10 @@ import {
     PluginConfigSchema,
     PluginEvent,
     PluginSettings,
+    PostHogEvent,
     ProcessedPluginEvent,
     Properties,
+    Webhook,
 } from '@posthog/plugin-scaffold'
 import { Pool as GenericPool } from 'generic-pool'
 import { StatsD } from 'hot-shots'
@@ -381,6 +383,11 @@ export interface PluginCapabilities {
     methods?: string[]
 }
 
+export enum PluginMethod {
+    onEvent = 'onEvent',
+    composeWebhook = 'composeWebhook',
+}
+
 export interface PluginConfig {
     id: number
     team_id: TeamId
@@ -394,6 +401,10 @@ export interface PluginConfig {
     vm?: LazyPluginVM | null
     created_at: string
     updated_at?: string
+    // We're migrating to a new functions that take PostHogEvent instead of PluginEvent
+    // we'll need to know which method this plugin is using to call it the right way
+    // undefined for old plugins with multiple or deprecated methods
+    method?: PluginMethod
 }
 
 export interface PluginJsonConfig {
@@ -410,7 +421,7 @@ export interface PluginError {
     time: string
     name?: string
     stack?: string
-    event?: PluginEvent | ProcessedPluginEvent | null
+    event?: PluginEvent | ProcessedPluginEvent | PostHogEvent | null
 }
 
 export interface PluginAttachmentDB {
@@ -476,6 +487,7 @@ export type VMMethods = {
     getSettings?: () => PluginSettings
     onEvent?: (event: ProcessedPluginEvent) => Promise<void>
     exportEvents?: (events: PluginEvent[]) => Promise<void>
+    composeWebhook?: (event: PostHogEvent) => Webhook | null
     processEvent?: (event: PluginEvent) => Promise<PluginEvent>
 }
 

--- a/plugin-server/src/utils/db/error.ts
+++ b/plugin-server/src/utils/db/error.ts
@@ -1,4 +1,4 @@
-import { PluginEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
+import { PluginEvent, PostHogEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
 import { captureException } from '@sentry/node'
 
 import { Hub, PluginConfig, PluginError } from '../../types'
@@ -30,7 +30,7 @@ export async function processError(
     server: Hub,
     pluginConfig: PluginConfig | null,
     error: Error | string,
-    event?: PluginEvent | ProcessedPluginEvent | null
+    event?: PluginEvent | ProcessedPluginEvent | PostHogEvent | null
 ): Promise<void> {
     if (!pluginConfig) {
         captureException(new Error('Tried to process error for nonexistent plugin config!'), {

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -1,4 +1,4 @@
-import { PluginEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
+import { PluginEvent, PostHogEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 import { Message } from 'node-rdkafka'
 
@@ -59,6 +59,18 @@ export function parseRawClickHouseEvent(rawEvent: RawClickHouseEvent): ClickHous
         group4_created_at: rawEvent.group4_created_at
             ? clickHouseTimestampToDateTime(rawEvent.group4_created_at)
             : null,
+    }
+}
+export function convertToPostHogEvent(event: RawClickHouseEvent): PostHogEvent {
+    const properties = event.properties ? JSON.parse(event.properties) : {}
+    properties['$elements_chain'] = event.elements_chain // TODO: tests
+    return {
+        uuid: event.uuid,
+        event: event.event!,
+        team_id: event.team_id,
+        distinct_id: event.distinct_id,
+        properties,
+        timestamp: new Date(clickHouseTimestampToISO(event.timestamp)),
     }
 }
 

--- a/plugin-server/src/worker/ingestion/app-metrics.ts
+++ b/plugin-server/src/worker/ingestion/app-metrics.ts
@@ -15,7 +15,7 @@ export interface AppMetricIdentifier {
     pluginConfigId: number
     jobId?: string
     // Keep in sync with posthog/queries/app_metrics/serializers.py
-    category: 'processEvent' | 'onEvent' | 'exportEvents' | 'scheduledTask' | 'webhook'
+    category: 'processEvent' | 'onEvent' | 'exportEvents' | 'scheduledTask' | 'webhook' | 'composeWebhook'
 }
 
 export interface AppMetric extends AppMetricIdentifier {

--- a/plugin-server/src/worker/ingestion/event-pipeline/runAsyncHandlersStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runAsyncHandlersStep.ts
@@ -1,7 +1,9 @@
+import { PostHogEvent } from '@posthog/plugin-scaffold'
+
 import { runInstrumentedFunction } from '../../../main/utils'
 import { Hub, PostIngestionEvent } from '../../../types'
 import { convertToProcessedPluginEvent } from '../../../utils/event'
-import { runOnEvent } from '../../plugins/run'
+import { runComposeWebhook, runOnEvent } from '../../plugins/run'
 import { ActionMatcher } from '../action-matcher'
 import { HookCommander, instrumentWebhookStep } from '../hooks'
 
@@ -17,6 +19,20 @@ export async function processOnEventStep(hub: Hub, event: PostIngestionEvent) {
         statsKey: `kafka_queue.single_on_event`,
         timeoutMessage: `After 30 seconds still running onEvent`,
         teamId: event.teamId,
+    })
+    return null
+}
+
+export async function processComposeWebhookStep(hub: Hub, event: PostHogEvent) {
+    await runInstrumentedFunction({
+        timeoutContext: () => ({
+            team_id: event.team_id,
+            event_uuid: event.uuid,
+        }),
+        func: () => runComposeWebhook(hub, event),
+        statsKey: `kafka_queue.single_compose_webhook`,
+        timeoutMessage: `After 30 seconds still running composeWebhook`,
+        teamId: event.team_id,
     })
     return null
 }

--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -1,7 +1,8 @@
-import { PluginEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
+import { PluginEvent, PostHogEvent, ProcessedPluginEvent, Webhook } from '@posthog/plugin-scaffold'
 
 import { Hub, PluginConfig, PluginTaskType, VMMethods } from '../../types'
 import { processError } from '../../utils/db/error'
+import { trackedFetch } from '../../utils/fetch'
 import { instrument } from '../../utils/metrics'
 import { status } from '../../utils/status'
 import { IllegalOperationError } from '../../utils/utils'
@@ -70,6 +71,111 @@ export async function runOnEvent(hub: Hub, event: ProcessedPluginEvent): Promise
                         tag: pluginConfig.plugin?.name || '?',
                     },
                     () => runSingleTeamPluginOnEvent(hub, event, pluginConfig, onEvent)
+                )
+            )
+    )
+}
+
+async function runSingleTeamPluginComposeWebhook(
+    hub: Hub,
+    event: PostHogEvent,
+    pluginConfig: PluginConfig,
+    composeWebhook: any
+): Promise<void> {
+    const slowWarningTimeout = hub.EXTERNAL_REQUEST_TIMEOUT_MS * 0.7
+    const timeout = setTimeout(() => {
+        status.warn(
+            '⌛',
+            `Still running single composeWebhook plugin for team ${event.team_id} for plugin ${pluginConfig.id}`
+        )
+    }, slowWarningTimeout)
+    try {
+        // Runs composeWebhook for a single plugin without any retries
+        const metricName = 'plugin.compose_webhook'
+        const metricTags = {
+            plugin: pluginConfig.plugin?.name ?? '?',
+            teamId: event.team_id.toString(),
+        }
+        const timer = new Date()
+        try {
+            const webhook: Webhook | null = await composeWebhook!(event)
+            if (!webhook) {
+                // TODO: ideally we'd queryMetric it as skipped, but that's not an option atm
+                status.debug('Skipping composeWebhook returned null', {
+                    teamId: event.team_id,
+                    pluginConfigId: pluginConfig.id,
+                    eventUuid: event.uuid,
+                })
+                return
+            }
+            const request = await trackedFetch(webhook.url, {
+                method: webhook.method || 'POST',
+                body: JSON.stringify(webhook.body, undefined, 4),
+                headers: { 'Content-Type': 'application/json' },
+                timeout: hub.EXTERNAL_REQUEST_TIMEOUT_MS,
+            })
+            if (request.ok) {
+                await hub.appMetrics.queueMetric({
+                    teamId: event.team_id,
+                    pluginConfigId: pluginConfig.id,
+                    category: 'composeWebhook',
+                    successes: 1,
+                })
+            } else {
+                hub.statsd?.increment(`${metricName}.ERROR`, metricTags)
+                const error = `Fetch to ${webhook.url} failed with ${request.statusText}`
+                await processError(hub, pluginConfig, error, event)
+                await hub.appMetrics.queueError(
+                    {
+                        teamId: event.team_id,
+                        pluginConfigId: pluginConfig.id,
+                        category: 'composeWebhook',
+                        failures: 1,
+                    },
+                    {
+                        error,
+                        event,
+                    }
+                )
+            }
+        } catch (error) {
+            hub.statsd?.increment(`${metricName}.ERROR`, metricTags)
+            await processError(hub, pluginConfig, error, event)
+            await hub.appMetrics.queueError(
+                {
+                    teamId: event.team_id,
+                    pluginConfigId: pluginConfig.id,
+                    category: 'composeWebhook',
+                    failures: 1,
+                },
+                {
+                    error,
+                    event,
+                }
+            )
+        }
+        hub.statsd?.timing(metricName, timer, metricTags)
+    } finally {
+        clearTimeout(timeout)
+    }
+}
+
+export async function runComposeWebhook(hub: Hub, event: PostHogEvent): Promise<void> {
+    // Runs composeWebhook for all plugins for this team in parallel
+    const pluginMethodsToRun = await getPluginMethodsForTeam(hub, event.team_id, 'composeWebhook')
+
+    await Promise.all(
+        pluginMethodsToRun
+            .filter(([, method]) => !!method)
+            .map(([pluginConfig, composeWebhook]) =>
+                instrument(
+                    hub.statsd,
+                    {
+                        metricName: 'plugin.runComposeWebhook',
+                        key: 'plugin',
+                        tag: pluginConfig.plugin?.name || '?',
+                    },
+                    () => runSingleTeamPluginComposeWebhook(hub, event, pluginConfig, composeWebhook)
                 )
             )
     )

--- a/plugin-server/src/worker/vm/capabilities.ts
+++ b/plugin-server/src/worker/vm/capabilities.ts
@@ -47,7 +47,9 @@ function shouldSetupPlugin(serverCapability: keyof PluginServerCapabilities, plu
         return (pluginCapabilities.jobs || []).length > 0
     }
     if (serverCapability === 'processAsyncOnEventHandlers') {
-        return pluginCapabilities.methods?.some((method) => ['onEvent', 'exportEvents'].includes(method))
+        return pluginCapabilities.methods?.some((method) =>
+            ['onEvent', 'exportEvents', 'composeWebhook'].includes(method)
+        )
     }
 
     return false

--- a/plugin-server/src/worker/vm/vm.ts
+++ b/plugin-server/src/worker/vm/vm.ts
@@ -183,6 +183,7 @@ export function createPluginConfigVM(
                 exportEvents: __asyncFunctionGuard(__bindMeta('exportEvents'), 'exportEvents'),
                 onEvent: __asyncFunctionGuard(__bindMeta('onEvent'), 'onEvent'),
                 processEvent: __asyncFunctionGuard(__bindMeta('processEvent'), 'processEvent'),
+                composeWebhook: __bindMeta('composeWebhook'),
                 getSettings: __bindMeta('getSettings'),
             };
 

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -14,6 +14,7 @@ import {
     ClickHouseTimestamp,
     ClickHouseTimestampSecondPrecision,
     ISOTimestamp,
+    PluginMethod,
     PostIngestionEvent,
     RawClickHouseEvent,
 } from '../../../src/types'
@@ -173,8 +174,8 @@ describe('eachBatchX', () => {
         })
         it('parses elements when useful', async () => {
             queue.pluginsServer.pluginConfigsPerTeam.set(2, [
-                { ...pluginConfig39, plugin_id: 60 },
-                { ...pluginConfig39, plugin_id: 33 },
+                { ...pluginConfig39, plugin_id: 60, method: PluginMethod.onEvent },
+                { ...pluginConfig39, plugin_id: 33, method: PluginMethod.onEvent },
             ])
             queue.pluginsServer.pluginConfigsToSkipElementsParsing = buildIntegerMatcher('12,60,100', true)
             await eachBatchAppsOnEventHandlers(
@@ -193,8 +194,8 @@ describe('eachBatchX', () => {
         })
         it('skips elements parsing when not useful', async () => {
             queue.pluginsServer.pluginConfigsPerTeam.set(2, [
-                { ...pluginConfig39, plugin_id: 60 },
-                { ...pluginConfig39, plugin_id: 100 },
+                { ...pluginConfig39, plugin_id: 60, method: PluginMethod.onEvent },
+                { ...pluginConfig39, plugin_id: 100, method: PluginMethod.onEvent },
             ])
             queue.pluginsServer.pluginConfigsToSkipElementsParsing = buildIntegerMatcher('12,60,100', true)
             await eachBatchAppsOnEventHandlers(

--- a/plugin-server/tests/worker/plugins.test.ts
+++ b/plugin-server/tests/worker/plugins.test.ts
@@ -81,6 +81,7 @@ describe('plugins', () => {
         expect(pluginConfig.vm).toBeDefined()
         const vm = await pluginConfig.vm!.resolveInternalVm
         expect(Object.keys(vm!.methods).sort()).toEqual([
+            'composeWebhook',
             'exportEvents',
             'getSettings',
             'onEvent',

--- a/plugin-server/tests/worker/vm.test.ts
+++ b/plugin-server/tests/worker/vm.test.ts
@@ -58,6 +58,7 @@ describe('vm tests', () => {
 
         expect(Object.keys(vm).sort()).toEqual(['methods', 'tasks', 'vm', 'vmResponseVariable'])
         expect(Object.keys(vm.methods).sort()).toEqual([
+            'composeWebhook',
             'exportEvents',
             'getSettings',
             'onEvent',

--- a/posthog/queries/app_metrics/serializers.py
+++ b/posthog/queries/app_metrics/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 class AppMetricsRequestSerializer(serializers.Serializer):
     category = serializers.ChoiceField(
         # Keep in sync with plugin-server/src/worker/ingestion/app-metrics.ts
-        choices=["processEvent", "onEvent", "exportEvents", "scheduledTask", "webhook"],
+        choices=["processEvent", "onEvent", "exportEvents", "scheduledTask", "webhook", "composeWebhook"],
         help_text="What to gather metrics for",
         required=True,
     )
@@ -22,7 +22,7 @@ class AppMetricsRequestSerializer(serializers.Serializer):
 class AppMetricsErrorsRequestSerializer(serializers.Serializer):
     category = serializers.ChoiceField(
         # Keep in sync with plugin-server/src/worker/ingestion/app-metrics.ts
-        choices=["processEvent", "onEvent", "exportEvents", "scheduledTask", "webhook"],
+        choices=["processEvent", "onEvent", "exportEvents", "scheduledTask", "webhook", "composeWebhook"],
         help_text="What to gather errors for",
         required=True,
     )


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We're moving from `onEvent` to `composeWebhook` method for apps/plugins. This PR makes onEvent consumer also handle composeWebhook apps.

Currently when the composeWebhook returns null we don't count it anywhere.

We should convert all onEvent tests to be composeWebhook tests longer term

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Tested locally, created a composeWebhook app that sent errors for all and one that sent data to https://webhook.site/#!/e22ded9b-bf15-4f78-8263-170593d6bb99/e13a99fe-f392-437c-8f2c-e9506487bf5a/1 (via source app coding functionality)

