### PR TITLE
fix: survey doesn't get dismissed when response textarea is empty

### DIFF
--- a/cypress/e2e/billingv2.cy.ts
+++ b/cypress/e2e/billingv2.cy.ts
@@ -5,7 +5,7 @@ describe('Billing', () => {
         cy.visit('/organization/billing')
     })
 
-    it('Show unsubscribe survey', () => {
+    it('Show and submit unsubscribe survey', () => {
         cy.intercept('/api/billing-v2/deactivate?products=product_analytics', {
             fixture: 'api/billing-v2/billing-v2-unsubscribed-product-analytics.json',
         })
@@ -17,7 +17,7 @@ describe('Billing', () => {
         )
         cy.contains('.LemonModal .LemonButton', 'Unsubscribe').click()
 
-        cy.get('[data-attr=upgrade-card-product_analytics]').should('be.visible')
+        cy.get('.LemonModal').should('not.exist')
     })
 
     it('Unsubscribe survey text area maintains unique state between product types', () => {

--- a/cypress/e2e/billingv2.cy.ts
+++ b/cypress/e2e/billingv2.cy.ts
@@ -8,7 +8,7 @@ describe('Billing', () => {
     it('Show and submit unsubscribe survey', () => {
         cy.intercept('/api/billing-v2/deactivate?products=product_analytics', {
             fixture: 'api/billing-v2/billing-v2-unsubscribed-product-analytics.json',
-        })
+        }).as('unsubscribeProductAnalytics')
         cy.get('[data-attr=more-button]').first().click()
         cy.contains('.LemonButton', 'Unsubscribe').click()
         cy.get('.LemonModal__content h3').should(
@@ -18,6 +18,7 @@ describe('Billing', () => {
         cy.contains('.LemonModal .LemonButton', 'Unsubscribe').click()
 
         cy.get('.LemonModal').should('not.exist')
+        cy.wait(['@unsubscribeProductAnalytics'])
     })
 
     it('Unsubscribe survey text area maintains unique state between product types', () => {

--- a/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
+++ b/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
@@ -83,6 +83,7 @@ export const UnsubscribeSurveyModal = ({ product }: { product: BillingProductV2T
                             status={textAreaNotEmpty ? 'primary' : 'muted'}
                             onClick={() => {
                                 textAreaNotEmpty && reportSurveySent(surveyID, surveyResponse)
+                                reportSurveyDismissed(surveyID)
                                 deactivateProduct(product.type)
                             }}
                         >

--- a/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
+++ b/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
@@ -6,9 +6,7 @@ import { billingLogic } from './billingLogic'
 
 export const UnsubscribeSurveyModal = ({ product }: { product: BillingProductV2Type }): JSX.Element | null => {
     const { surveyID, surveyResponse } = useValues(billingProductLogic({ product }))
-    const { setSurveyResponse, reportSurveySent, reportSurveyDismissed, setSurveyID } = useActions(
-        billingProductLogic({ product })
-    )
+    const { setSurveyResponse, reportSurveySent, reportSurveyDismissed } = useActions(billingProductLogic({ product }))
     const { deactivateProduct } = useActions(billingLogic)
 
     const textAreaNotEmpty = surveyResponse['$survey_repsonse']?.length > 0
@@ -84,8 +82,9 @@ export const UnsubscribeSurveyModal = ({ product }: { product: BillingProductV2T
                             type={textAreaNotEmpty ? 'primary' : 'tertiary'}
                             status={textAreaNotEmpty ? 'primary' : 'muted'}
                             onClick={() => {
-                                textAreaNotEmpty && reportSurveySent(surveyID, surveyResponse)
-                                setSurveyID('')
+                                textAreaNotEmpty
+                                    ? reportSurveySent(surveyID, surveyResponse)
+                                    : reportSurveyDismissed(surveyID)
                                 deactivateProduct(product.type)
                             }}
                         >

--- a/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
+++ b/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
@@ -6,7 +6,9 @@ import { billingLogic } from './billingLogic'
 
 export const UnsubscribeSurveyModal = ({ product }: { product: BillingProductV2Type }): JSX.Element | null => {
     const { surveyID, surveyResponse } = useValues(billingProductLogic({ product }))
-    const { setSurveyResponse, reportSurveySent, reportSurveyDismissed } = useActions(billingProductLogic({ product }))
+    const { setSurveyResponse, reportSurveySent, reportSurveyDismissed, setSurveyID } = useActions(
+        billingProductLogic({ product })
+    )
     const { deactivateProduct } = useActions(billingLogic)
 
     const textAreaNotEmpty = surveyResponse['$survey_repsonse']?.length > 0
@@ -83,7 +85,7 @@ export const UnsubscribeSurveyModal = ({ product }: { product: BillingProductV2T
                             status={textAreaNotEmpty ? 'primary' : 'muted'}
                             onClick={() => {
                                 textAreaNotEmpty && reportSurveySent(surveyID, surveyResponse)
-                                reportSurveyDismissed(surveyID)
+                                setSurveyID('')
                                 deactivateProduct(product.type)
                             }}
                         >

--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -207,6 +207,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
                 $survey_id: surveyID,
                 ...surveyResponse,
             })
+            actions.setSurveyID('')
         },
         reportSurveyDismissed: ({ surveyID }) => {
             posthog.capture('survey dismissed', {

--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -207,7 +207,6 @@ export const billingProductLogic = kea<billingProductLogicType>([
                 $survey_id: surveyID,
                 ...surveyResponse,
             })
-            actions.setSurveyID('')
         },
         reportSurveyDismissed: ({ surveyID }) => {
             posthog.capture('survey dismissed', {


### PR DESCRIPTION
## Problem

The survey modal wasn't getting dismissed upon unsubscribe when the response textarea was empty. This PR updates the logic and associated test. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
