### PR TITLE
fix: do not sync session reset feature flag

### DIFF
--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -38,11 +38,12 @@ class Command(BaseCommand):
             deleted_flags = FeatureFlag.objects.filter(team=team, deleted=True).values_list("key", flat=True)
             for flag in flags.keys():
                 flag_type = flags[flag]
+                is_enabled = flag not in INACTIVE_FLAGS
 
                 if flag in deleted_flags:
                     ff = FeatureFlag.objects.filter(team=team, key=flag)[0]
                     ff.deleted = False
-                    ff.active = flag not in INACTIVE_FLAGS
+                    ff.active = is_enabled
                     ff.save()
                     print(f"Undeleted feature flag '{flag} for team {team.id} {' - ' + team.name if team.name else ''}")
                 elif flag not in existing_flags:
@@ -53,7 +54,7 @@ class Command(BaseCommand):
                             name=flag,
                             key=flag,
                             created_by=first_user,
-                            active=flag not in INACTIVE_FLAGS,
+                            active=is_enabled,
                             filters={
                                 "groups": [{"properties": [], "rollout_percentage": None}],
                                 "multivariate": {
@@ -79,6 +80,6 @@ class Command(BaseCommand):
                             name=flag,
                             key=flag,
                             created_by=first_user,
-                            active=flag not in INACTIVE_FLAGS,
+                            active=is_enabled,
                         )
                     print(f"Created feature flag '{flag} for team {team.id} {' - ' + team.name if team.name else ''}")

--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -36,8 +36,8 @@ class Command(BaseCommand):
             deleted_flags = FeatureFlag.objects.filter(team=team, deleted=True).values_list("key", flat=True)
             for flag in flags.keys():
                 flag_type = flags[flag]
-                # do not sync the cloud announcement flag for in-app banners
-                if flag == "cloud-announcement":
+                # do not sync the cloud announcement or session reset flags
+                if flag == "cloud-announcement" or flag == "session-reset-on-load":
                     continue
                 elif flag in deleted_flags:
                     ff = FeatureFlag.objects.filter(team=team, key=flag)[0]


### PR DESCRIPTION
There's a helpful flag that can be useful in testing which resets the session id when you load the page.

Except it isn't helpful when you forget it exists and you're testing whether session id persists correctly.

Adds "inactive flags" to the sync_feature_flag command. 

Now, instead of skipping flags we don't want active by default, we sync them but ensure they are not enabled. That way the flag exists for discovery by future developers without being turned on and confusing people (or at least me)