### PR TITLE
fix(retention): Properly apply Monday as the first day of the week

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -5,7 +5,7 @@
           NULL as breakdown_values_filter,
           NULL as selected_interval,
           returning_event_query as
-       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                e."$group_0" as target
         FROM events e
         WHERE team_id = 2
@@ -17,13 +17,13 @@
         GROUP BY target,
                  event_date),
           target_event_query as
-       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                         e."$group_0" as target,
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC')),
-                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
+                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC'), 0),
+                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0)
                           )
                       ] as breakdown_values
         FROM events e
@@ -70,7 +70,7 @@
           [0] as breakdown_values_filter,
           NULL as selected_interval,
           returning_event_query as
-       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                e."$group_0" as target
         FROM events e
         WHERE team_id = 2
@@ -82,13 +82,13 @@
         GROUP BY target,
                  event_date),
           target_event_query as
-       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                         e."$group_0" as target,
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC')),
-                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
+                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC'), 0),
+                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0)
                           )
                       ] as breakdown_values
         FROM events e
@@ -128,7 +128,7 @@
           NULL as breakdown_values_filter,
           NULL as selected_interval,
           returning_event_query as
-       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                e."$group_1" as target
         FROM events e
         WHERE team_id = 2
@@ -140,13 +140,13 @@
         GROUP BY target,
                  event_date),
           target_event_query as
-       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                         e."$group_1" as target,
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC')),
-                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
+                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC'), 0),
+                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0)
                           )
                       ] as breakdown_values
         FROM events e
@@ -190,7 +190,7 @@
           NULL as breakdown_values_filter,
           NULL as selected_interval,
           returning_event_query as
-       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                e."$group_0" as target
         FROM events e
         WHERE team_id = 2
@@ -202,13 +202,13 @@
         GROUP BY target,
                  event_date),
           target_event_query as
-       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                         e."$group_0" as target,
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC')),
-                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
+                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC'), 0),
+                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0)
                           )
                       ] as breakdown_values
         FROM events e
@@ -255,7 +255,7 @@
           [0] as breakdown_values_filter,
           NULL as selected_interval,
           returning_event_query as
-       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                e."$group_0" as target
         FROM events e
         WHERE team_id = 2
@@ -267,13 +267,13 @@
         GROUP BY target,
                  event_date),
           target_event_query as
-       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                         e."$group_0" as target,
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC')),
-                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
+                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC'), 0),
+                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0)
                           )
                       ] as breakdown_values
         FROM events e
@@ -313,7 +313,7 @@
           NULL as breakdown_values_filter,
           NULL as selected_interval,
           returning_event_query as
-       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                e."$group_1" as target
         FROM events e
         WHERE team_id = 2
@@ -325,13 +325,13 @@
         GROUP BY target,
                  event_date),
           target_event_query as
-       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                         e."$group_1" as target,
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC')),
-                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
+                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC'), 0),
+                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0)
                           )
                       ] as breakdown_values
         FROM events e
@@ -375,7 +375,7 @@
           NULL as breakdown_values_filter,
           NULL as selected_interval,
           returning_event_query as
-       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                e.person_id as target
         FROM events e
         LEFT JOIN
@@ -394,13 +394,13 @@
         GROUP BY target,
                  event_date),
           target_event_query as
-       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                         e.person_id as target,
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC')),
-                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
+                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC'), 0),
+                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0)
                           )
                       ] as breakdown_values
         FROM events e
@@ -451,7 +451,7 @@
           NULL as breakdown_values_filter,
           NULL as selected_interval,
           returning_event_query as
-       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                e.person_id as target
         FROM events e
         LEFT JOIN
@@ -470,13 +470,13 @@
         GROUP BY target,
                  event_date),
           target_event_query as
-       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                         e.person_id as target,
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC')),
-                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
+                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC'), 0),
+                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0)
                           )
                       ] as breakdown_values
         FROM events e
@@ -632,7 +632,7 @@
           [0] as breakdown_values_filter,
           NULL as selected_interval,
           returning_event_query as
-       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                e."$group_0" as target
         FROM events e
         WHERE team_id = 2
@@ -644,13 +644,13 @@
         GROUP BY target,
                  event_date),
           target_event_query as
-       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                         e."$group_0" as target,
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC')),
-                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
+                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC'), 0),
+                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0)
                           )
                       ] as breakdown_values
         FROM events e
@@ -693,7 +693,7 @@
           [0] as breakdown_values_filter,
           NULL as selected_interval,
           returning_event_query as
-       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                e."$group_0" as target
         FROM events e
         WHERE team_id = 2
@@ -705,13 +705,13 @@
         GROUP BY target,
                  event_date),
           target_event_query as
-       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
+       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
                         e."$group_0" as target,
                         [
                           dateDiff(
                               'Week',
-                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC')),
-                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))
+                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC'), 0),
+                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0)
                           )
                       ] as breakdown_values
         FROM events e

--- a/posthog/models/filters/mixins/retention.py
+++ b/posthog/models/filters/mixins/retention.py
@@ -76,10 +76,16 @@ class RetentionDateDerivedMixin(PeriodMixin, TotalIntervalsMixin, DateMixin, Sel
         if self.period == "Hour":
             return self.date_to - tdelta
         elif self.period == "Week":
-            date_from = self.date_to - tdelta
-            return date_from - timedelta(days=date_from.isoweekday() % 7)
+            date_from: datetime = self.date_to - tdelta
+            week_start_alignment_days = date_from.isoweekday() % 7
+            if team := getattr(self, "team", None):
+                from posthog.models.team.team import WeekStartDay
+
+                if team.week_start_day == WeekStartDay.MONDAY:
+                    week_start_alignment_days = date_from.weekday()
+            return date_from - timedelta(days=week_start_alignment_days)
         else:
-            date_to = self.date_to.replace(hour=0, minute=0, second=0, microsecond=0)
+            date_to: datetime = self.date_to.replace(hour=0, minute=0, second=0, microsecond=0)
             return date_to - tdelta
 
     @cached_property

--- a/posthog/queries/test/__snapshots__/test_retention.ambr
+++ b/posthog/queries/test/__snapshots__/test_retention.ambr
@@ -459,3 +459,147 @@
            intervals_from_base
   '
 ---
+# name: TestFOSSRetention.test_week_interval
+  '
+  WITH actor_query AS
+    (WITH 'Week' as period,
+          NULL as breakdown_values_filter,
+          NULL as selected_interval,
+          returning_event_query as
+       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
+               pdi.person_id as target
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND e.event = '$pageview'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
+        GROUP BY target,
+                 event_date),
+          target_event_query as
+       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
+                        pdi.person_id as target,
+                        [
+                          dateDiff(
+                              'Week',
+                              toStartOfWeek(toDateTime('2020-06-07 00:00:00', 'UTC'), 0),
+                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0)
+                          )
+                      ] as breakdown_values
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND e.event = '$pageview'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC') ) SELECT DISTINCT breakdown_values,
+                                                                                                    intervals_from_base,
+                                                                                                    actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM target_event_query AS target_event
+        JOIN returning_event_query AS returning_event ON returning_event.target = target_event.target
+        WHERE returning_event.event_date > target_event.event_date
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM target_event_query AS target_event)
+     WHERE (breakdown_values_filter is NULL
+            OR breakdown_values = breakdown_values_filter)
+       AND (selected_interval is NULL
+            OR intervals_from_base = selected_interval) )
+  SELECT actor_activity.breakdown_values AS breakdown_values,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         COUNT(DISTINCT actor_activity.actor_id) AS count
+  FROM actor_query AS actor_activity
+  GROUP BY breakdown_values,
+           intervals_from_base
+  ORDER BY breakdown_values,
+           intervals_from_base
+  '
+---
+# name: TestFOSSRetention.test_week_interval.1
+  '
+  WITH actor_query AS
+    (WITH 'Week' as period,
+          NULL as breakdown_values_filter,
+          NULL as selected_interval,
+          returning_event_query as
+       (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 3) AS event_date,
+               pdi.person_id as target
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND e.event = '$pageview'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-08 00:00:00', 'UTC')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
+        GROUP BY target,
+                 event_date),
+          target_event_query as
+       (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 3) AS event_date,
+                        pdi.person_id as target,
+                        [
+                          dateDiff(
+                              'Week',
+                              toStartOfWeek(toDateTime('2020-06-08 00:00:00', 'UTC'), 3),
+                              toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 3)
+                          )
+                      ] as breakdown_values
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND e.event = '$pageview'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-08 00:00:00', 'UTC')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC') ) SELECT DISTINCT breakdown_values,
+                                                                                                    intervals_from_base,
+                                                                                                    actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM target_event_query AS target_event
+        JOIN returning_event_query AS returning_event ON returning_event.target = target_event.target
+        WHERE returning_event.event_date > target_event.event_date
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM target_event_query AS target_event)
+     WHERE (breakdown_values_filter is NULL
+            OR breakdown_values = breakdown_values_filter)
+       AND (selected_interval is NULL
+            OR intervals_from_base = selected_interval) )
+  SELECT actor_activity.breakdown_values AS breakdown_values,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         COUNT(DISTINCT actor_activity.actor_id) AS count
+  FROM actor_query AS actor_activity
+  GROUP BY breakdown_values,
+           intervals_from_base
+  ORDER BY breakdown_values,
+           intervals_from_base
+  '
+---

--- a/posthog/queries/util.py
+++ b/posthog/queries/util.py
@@ -107,7 +107,7 @@ def get_start_of_interval_sql(
     elif "%(timezone)s" not in source:
         source = f"toTimeZone(toDateTime({source}, 'UTC'), %(timezone)s)"
     trunc_func_args = [source]
-    if interval == "week":
+    if trunc_func == "toStartOfWeek":
         trunc_func_args.append((WeekStartDay(team.week_start_day or 0)).clickhouse_mode)
     interval_sql = f"{trunc_func}({', '.join(trunc_func_args)})"
     # For larger intervals dates are returned instead of datetimes, and we always want datetimes for comparisons


### PR DESCRIPTION
## Problem

Resolves ZEN-6295 – the first day of the week setting did not apply in Retention, because Retention's `period` value starts with a capital letter, while other insights' `interval` is all-lowercase. 🙈 `date_from` was also incorrect for week-based Retention insights when Monday is the first day of the week.

## Changes

We now properly handle uppercase `interval` (i.e. `period`) by delegating this to `get_trunc_func_ch()`.
We also are aware of the first day of the week in `RetentionDateDerivedMixin`'s `date_from` – which is a really bad design TBH, because this should all live in SQL – but that's how Retention is architected currently.

## How did you test this code?

Added a query test.