### PR TITLE
fix: Change notice tooltips easier to close

### DIFF
--- a/frontend/src/layout/navigation/SideBar/SidebarChangeNotice.tsx
+++ b/frontend/src/layout/navigation/SideBar/SidebarChangeNotice.tsx
@@ -1,4 +1,3 @@
-import { IconCheck } from '@posthog/icons'
 import { LemonButton, LemonDivider, Tooltip, TooltipProps } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import { IconClose } from 'lib/lemon-ui/icons'

--- a/frontend/src/layout/navigation/SideBar/SidebarChangeNotice.tsx
+++ b/frontend/src/layout/navigation/SideBar/SidebarChangeNotice.tsx
@@ -1,6 +1,7 @@
 import { IconCheck } from '@posthog/icons'
 import { LemonButton, LemonDivider, Tooltip, TooltipProps } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
+import { IconClose } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import posthog from 'posthog-js'
 import React, { Fragment, useState } from 'react'
@@ -65,7 +66,7 @@ export function SidebarChangeNoticeContent({
     onAcknowledged: () => void
 }): JSX.Element | null {
     return (
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1" onClick={onAcknowledged}>
             <div className="flex-1">
                 {notices.map((notice, i) => (
                     <Fragment key={i}>
@@ -75,7 +76,7 @@ export function SidebarChangeNoticeContent({
                 ))}
             </div>
 
-            <LemonButton size="small" onClick={onAcknowledged} icon={<IconCheck />} />
+            <LemonButton size="small" onClick={onAcknowledged} icon={<IconClose />} />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

Apparently it wasn't super obvious - now clicking anywhere will dismiss it and it is an X icon

## Changes

<img width="491" alt="Screenshot 2023-11-08 at 17 17 21" src="https://github.com/PostHog/posthog/assets/2536520/8a3f3e01-1173-4eb4-8472-431f8f00b58f">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
