### PR TITLE
chore: Build unit docker image so we can build on arm

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -80,7 +80,7 @@ jobs:
                   push: true
                   file: production-unit.Dockerfile
                   tags: ${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:unit
-                  platforms: linux/amd64
+                  platforms: linux/arm64,linux/amd64
                   build-args: COMMIT_HASH=${{ github.sha }}
 
             - name: get deployer token

--- a/production-unit.Dockerfile
+++ b/production-unit.Dockerfile
@@ -136,7 +136,104 @@ RUN apt-get update && \
 #
 # ---------------------------------------------------------
 #
-FROM nginx/unit:1.28.0-python3.10
+# Build a version of the unit docker image for python3.10
+# We can remove this step once we are on python3.11
+FROM unit:python3.11 as unit
+FROM python:3.10-bullseye as unit-131-python-310
+
+# copied from https://github.com/nginx/unit/blob/master/pkg/docker/Dockerfile.python3.11
+LABEL org.opencontainers.image.title="Unit (python3.10)"
+LABEL org.opencontainers.image.description="Official build of Unit for Docker."
+LABEL org.opencontainers.image.url="https://unit.nginx.org"
+LABEL org.opencontainers.image.source="https://github.com/nginx/unit"
+LABEL org.opencontainers.image.documentation="https://unit.nginx.org/installation/#docker-images"
+LABEL org.opencontainers.image.vendor="NGINX Docker Maintainers <docker-maint@nginx.com>"
+LABEL org.opencontainers.image.version="1.31.1"
+
+RUN set -ex \
+    && savedAptMark="$(apt-mark showmanual)" \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates mercurial build-essential libssl-dev libpcre2-dev curl pkg-config \
+    && mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules \
+    && mkdir -p /usr/src/unit \
+    && cd /usr/src/unit \
+    && hg clone -u 1.31.1-1 https://hg.nginx.org/unit \
+    && cd unit \
+    && NCPU="$(getconf _NPROCESSORS_ONLN)" \
+    && DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" \
+    && CC_OPT="$(DEB_BUILD_MAINT_OPTIONS="hardening=+all,-pie" DEB_CFLAGS_MAINT_APPEND="-Wp,-D_FORTIFY_SOURCE=2 -fPIC" dpkg-buildflags --get CFLAGS)" \
+    && LD_OPT="$(DEB_BUILD_MAINT_OPTIONS="hardening=+all,-pie" DEB_LDFLAGS_MAINT_APPEND="-Wl,--as-needed -pie" dpkg-buildflags --get LDFLAGS)" \
+    && CONFIGURE_ARGS_MODULES="--prefix=/usr \
+                --statedir=/var/lib/unit \
+                --control=unix:/var/run/control.unit.sock \
+                --runstatedir=/var/run \
+                --pid=/var/run/unit.pid \
+                --logdir=/var/log \
+                --log=/var/log/unit.log \
+                --tmpdir=/var/tmp \
+                --user=unit \
+                --group=unit \
+                --openssl \
+                --libdir=/usr/lib/$DEB_HOST_MULTIARCH" \
+    && CONFIGURE_ARGS="$CONFIGURE_ARGS_MODULES \
+                --njs" \
+    && make -j $NCPU -C pkg/contrib .njs \
+    && export PKG_CONFIG_PATH=$(pwd)/pkg/contrib/njs/build \
+    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
+    && make -j $NCPU unitd \
+    && install -pm755 build/sbin/unitd /usr/sbin/unitd-debug \
+    && make clean \
+    && ./configure $CONFIGURE_ARGS --cc-opt="$CC_OPT" --ld-opt="$LD_OPT" --modulesdir=/usr/lib/unit/modules \
+    && make -j $NCPU unitd \
+    && install -pm755 build/sbin/unitd /usr/sbin/unitd \
+    && make clean \
+    && /bin/true \
+    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/debug-modules --debug \
+    && ./configure python --config=/usr/local/bin/python3-config \
+    && make -j $NCPU python3-install \
+    && make clean \
+    && ./configure $CONFIGURE_ARGS_MODULES --cc-opt="$CC_OPT" --modulesdir=/usr/lib/unit/modules \
+    && ./configure python --config=/usr/local/bin/python3-config \
+    && make -j $NCPU python3-install \
+    && cd \
+    && rm -rf /usr/src/unit \
+    && for f in /usr/sbin/unitd /usr/lib/unit/modules/*.unit.so; do \
+        ldd $f | awk '/=>/{print $(NF-1)}' | while read n; do dpkg-query -S $n; done | sed 's/^\([^:]\+\):.*$/\1/' | sort | uniq >> /requirements.apt; \
+       done \
+    && apt-mark showmanual | xargs apt-mark auto > /dev/null \
+    && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \
+    && /bin/true \
+    && mkdir -p /var/lib/unit/ \
+    && mkdir -p /docker-entrypoint.d/ \
+    && groupadd --gid 998 unit \
+    && useradd \
+         --uid 998 \
+         --gid unit \
+         --no-create-home \
+         --home /nonexistent \
+         --comment "unit user" \
+         --shell /bin/false \
+         unit \
+    && apt-get update \
+    && apt-get --no-install-recommends --no-install-suggests -y install curl $(cat /requirements.apt) \
+    && apt-get purge -y --auto-remove build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /requirements.apt \
+    && ln -sf /dev/stdout /var/log/unit.log
+
+COPY --from=unit /usr/local/bin/docker-entrypoint.sh /usr/local/bin/
+COPY --from=unit /usr/share/unit/welcome/welcome.* /usr/share/unit/welcome/
+
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+EXPOSE 80
+CMD ["unitd", "--no-daemon", "--control", "unix:/var/run/control.unit.sock"]
+
+#
+# ---------------------------------------------------------
+#
+FROM unit-131-python-310
 WORKDIR /code
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION


## Problem
We were using the unit 1.28-python3.10 image before. The unit python3.11 image is available on arm but 3.10 only on amd64. Build it ourself so that we can use arm and also latest unit on 3.10

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
