### PR TITLE
fix(surveys): multiple choice label color fix

### DIFF
--- a/frontend/src/scenes/surveys/SurveyAppearance.scss
+++ b/frontend/src/scenes/surveys/SurveyAppearance.scss
@@ -158,6 +158,7 @@
 .multiple-choice-options {
     margin-top: 13px;
     font-size: 14px;
+    color: black;
 }
 .multiple-choice-options .choice-option {
     display: flex;

--- a/frontend/src/scenes/surveys/SurveyAppearance.tsx
+++ b/frontend/src/scenes/surveys/SurveyAppearance.tsx
@@ -604,7 +604,7 @@ export function SurveyMultipleChoiceAppearance({
                                 name="choice"
                                 value={choice}
                             />
-                            <label style={{ color: textColor }}>{choice}</label>
+                            <label>{choice}</label>
                             <span className="choice-check">{check}</span>
                         </div>
                     ))}


### PR DESCRIPTION
## Problem

Label color fix on appearance preview only. Survey works fine

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
<img width="444" alt="Screenshot 2023-11-08 at 6 03 38 PM" src="https://github.com/PostHog/posthog/assets/25164963/9f73966b-8a67-416e-8643-918b268e9049">

<img width="460" alt="Screenshot 2023-11-08 at 6 03 21 PM" src="https://github.com/PostHog/posthog/assets/25164963/e56e57f9-e2c8-420d-b07e-fd45cbeb24da">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
