### PR TITLE
chore(linting): Add no-constant-binary-expression

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -204,6 +204,7 @@ module.exports = {
                 ],
             },
         ],
+        'no-constant-binary-expression': 'error',
         'no-constant-condition': 'off',
         'no-prototype-builtins': 'off',
         'no-irregular-whitespace': 'off',

--- a/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRangeInline.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRangeInline.tsx
@@ -33,8 +33,7 @@ export function LemonCalendarRangeInline({
     // How many months fit on the screen, capped between 1..2
     function getMonthCount(): number {
         const width =
-            // eslint-disable-next-line valid-typeof
-            typeof window === undefined ? WIDTH_OF_ONE_CALENDAR_MONTH * CALENDARS_IF_NO_WINDOW : window.innerWidth
+            typeof window === 'undefined' ? WIDTH_OF_ONE_CALENDAR_MONTH * CALENDARS_IF_NO_WINDOW : window.innerWidth
         return Math.min(Math.max(1, Math.floor(width / WIDTH_OF_ONE_CALENDAR_MONTH)), 2)
     }
     const [autoMonthCount, setAutoMonthCount] = useState(getMonthCount())

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -632,6 +632,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 properties.stickiness_days = filters.stickiness_days
             }
             properties.mode = insightMode // View or edit
+            // eslint-disable-next-line no-constant-binary-expression
             properties.viewer_is_creator = insightModel.created_by?.uuid === values.user?.uuid ?? null // `null` means we couldn't determine this
             properties.is_saved = insightModel.saved
             properties.description_length = insightModel.description?.length ?? 0

--- a/frontend/src/scenes/cohorts/cohortUtils.tsx
+++ b/frontend/src/scenes/cohorts/cohortUtils.tsx
@@ -240,8 +240,8 @@ export function validateGroup(
                     BehavioralLifecycleType.StopPerformEvent,
                     BehavioralEventType.PerformSequenceEvents,
                 ].includes(c.value as BehavioralLifecycleType | BehavioralEventType)
-                    ? calculateDays(Number(c.seq_time_value) ?? 0, c.seq_time_interval ?? TimeUnitType.Day) >
-                      calculateDays(Number(c.time_value) ?? 0, c.time_interval ?? TimeUnitType.Day)
+                    ? calculateDays(Number(c.seq_time_value ?? 0), c.seq_time_interval ?? TimeUnitType.Day) >
+                      calculateDays(Number(c.time_value ?? 0), c.time_interval ?? TimeUnitType.Day)
                         ? {
                               id: CohortClientErrors.SequentialTimeMismatch,
                               seq_time_value: CohortClientErrors.SequentialTimeMismatch,

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
@@ -17,7 +17,7 @@ export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Ele
     return (
         <DateFilter
             dateTo={dateRange?.date_to ?? undefined}
-            dateFrom={dateRange?.date_from ?? '-7d' ?? undefined}
+            dateFrom={dateRange?.date_from ?? '-7d'}
             disabled={disabled}
             onChange={(date_from, date_to) => {
                 updateDateRange({ date_from, date_to })

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/Session.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePersonFeed/Session.tsx
@@ -26,7 +26,7 @@ export const Session = ({ session }: SessionProps): JSX.Element => {
     const [isFolded, setIsFolded] = useState(false)
 
     const onOpenReplay = (): void => {
-        const newChildren = [...children] || []
+        const newChildren = [...(children || [])]
 
         const existingChild = newChildren.find((child) => child.attrs?.nodeId === `${nodeId}-active-replay`)
 

--- a/frontend/src/scenes/session-recordings/player/playerMetaLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerMetaLogic.ts
@@ -84,6 +84,7 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
         currentWindowIndex: [
             (s) => [s.windowIds, s.currentSegment],
             (windowIds, currentSegment) => {
+                // eslint-disable-next-line no-constant-binary-expression
                 const index = windowIds.findIndex((windowId) => windowId === currentSegment?.windowId ?? -1)
 
                 return index === -1 ? 0 : index


### PR DESCRIPTION
## Problem

Inspired by this article seen on HN: https://eslint.org/blog/2022/07/interesting-bugs-caught-by-no-constant-binary-expression/

I enabled it and saw some (minor) bugs

## Changes

Enabled the linting rule. Where the fix was obvious, I made the fix, where not obvious I adding an eslint-ignore.

## How did you test this code?

Relied on our testing suite (and linting)
Tagged people who had touched this or adjacent lines recently:  @pauldambra @thmsobrmlr @benjackwhite @daibhin 
