### PR TITLE
fix: clarity on popover timezone

### DIFF
--- a/frontend/src/lib/components/TZLabel/index.tsx
+++ b/frontend/src/lib/components/TZLabel/index.tsx
@@ -23,9 +23,10 @@ export type TZLabelProps = Omit<LemonDropdownProps, 'overlay' | 'trigger' | 'chi
     showPopover?: boolean
     noStyles?: boolean
     className?: string
+    children?: JSX.Element
 }
 
-const TZLabelPopoverContent = React.memo(function TZLabelPopoverContent({
+export const TZLabelPopoverContent = React.memo(function TZLabelPopoverContent({
     showSeconds,
     time,
 }: Pick<TZLabelProps, 'showSeconds'> & { time: dayjs.Dayjs }): JSX.Element {
@@ -88,6 +89,7 @@ function TZLabelRaw({
     showPopover = true,
     noStyles = false,
     className,
+    children,
     ...dropdownProps
 }: TZLabelProps): JSX.Element {
     const parsedTime = useMemo(() => (dayjs.isDayjs(time) ? time : dayjs(time)), [time])
@@ -110,7 +112,7 @@ function TZLabelRaw({
         return () => clearInterval(interval)
     }, [parsedTime, format])
 
-    const innerContent = (
+    const innerContent = children ?? (
         <span
             className={
                 !noStyles ? clsx('whitespace-nowrap', showPopover && 'border-dotted border-b', className) : className

--- a/frontend/src/lib/components/TZLabel/index.tsx
+++ b/frontend/src/lib/components/TZLabel/index.tsx
@@ -26,7 +26,7 @@ export type TZLabelProps = Omit<LemonDropdownProps, 'overlay' | 'trigger' | 'chi
     children?: JSX.Element
 }
 
-export const TZLabelPopoverContent = React.memo(function TZLabelPopoverContent({
+const TZLabelPopoverContent = React.memo(function TZLabelPopoverContent({
     showSeconds,
     time,
 }: Pick<TZLabelProps, 'showSeconds'> & { time: dayjs.Dayjs }): JSX.Element {

--- a/frontend/src/lib/lemon-ui/Popover/Popover.scss
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.scss
@@ -114,7 +114,7 @@
     width: 0.5rem;
     height: 0.5rem;
     transform: rotate(45deg);
-    background: var(--bg-light);
+    background: var(--bg-3000);
 
     [data-placement^='bottom'] & {
         top: -0.25rem;

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
@@ -8,6 +8,7 @@ import { useKeyHeld } from 'lib/hooks/useKeyHeld'
 import { IconSkipBackward } from 'lib/lemon-ui/icons'
 import clsx from 'clsx'
 import { dayjs } from 'lib/dayjs'
+import { TZLabel } from '@posthog/apps-common'
 
 export function Timestamp(): JSX.Element {
     const { logicProps, currentPlayerTime, currentTimestamp, sessionPlayerData } =
@@ -21,9 +22,9 @@ export function Timestamp(): JSX.Element {
 
     return (
         <div className="whitespace-nowrap mr-4">
-            <Tooltip overlay={dayjs(currentTimestamp).format('HH:mm:ss A')}>
-                {colonDelimitedDuration(startTimeSeconds, fixedUnits)}
-            </Tooltip>{' '}
+            <TZLabel time={dayjs(currentTimestamp)} showSeconds>
+                <span>{colonDelimitedDuration(startTimeSeconds, fixedUnits)}</span>
+            </TZLabel>{' '}
             / {colonDelimitedDuration(endTimeSeconds, fixedUnits)}
         </div>
     )


### PR DESCRIPTION
## Problem

I made a change in https://github.com/PostHog/posthog/pull/18320 to add a time but it wasn't clear what the timezone was

## Changes

- Migrate to the `TZLabel` component
- Allow for children so that the `innerContent` can be custom
- Fix caret color on popovers

## How did you test this code?

Visually
<img width="432" alt="Screenshot 2023-11-09 at 11 04 09" src="https://github.com/PostHog/posthog/assets/6685876/cecf3b18-c569-4516-a179-3df3ce2e68ec">