### PR TITLE
feat(web-analytics): Make this week's dates line up with last week's

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -186,7 +186,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             },
         ],
         dateTo: [
-            '-0d' as string | null,
+            null as string | null,
             {
                 setDates: (_, { dateTo }) => dateTo,
             },


### PR DESCRIPTION
## Problem

The date range is set up so that the weeks don't line up - I want to fix this and ensure that they do

Previously
<img width="584" alt="Screenshot 2023-11-09 at 15 01 38" src="https://github.com/PostHog/posthog/assets/2056078/b550825f-706d-4c9c-a886-69d2cd5dec5a">

## Changes

Just change the default to one that you get when you choose "last 7 days" on the date filter

## How did you test this code?

(behind FF) manually