### PR TITLE
chore(data-warehouse): only show info button if flag is enabled

### DIFF
--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -238,25 +238,27 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
                             {'Save as View'}
                         </LemonButton>
                     ) : null}
-                    <LemonButtonWithDropdown
-                        className="ml-2"
-                        icon={<IconInfo />}
-                        type="secondary"
-                        size="small"
-                        dropdown={{
-                            overlay: (
-                                <div>
-                                    Save a query as a view that can be referenced in another query. This is useful for
-                                    modeling data and organizing large queries into readable chunks.{' '}
-                                    <Link to={'https://posthog.com/docs/data-warehouse'}>More Info</Link>{' '}
-                                </div>
-                            ),
-                            placement: 'right-start',
-                            fallbackPlacements: ['left-start'],
-                            actionable: true,
-                            closeParentPopoverOnClickInside: true,
-                        }}
-                    />
+                    {featureFlags[FEATURE_FLAGS.DATA_WAREHOUSE_VIEWS] && (
+                        <LemonButtonWithDropdown
+                            className="ml-2"
+                            icon={<IconInfo />}
+                            type="secondary"
+                            size="small"
+                            dropdown={{
+                                overlay: (
+                                    <div>
+                                        Save a query as a view that can be referenced in another query. This is useful
+                                        for modeling data and organizing large queries into readable chunks.{' '}
+                                        <Link to={'https://posthog.com/docs/data-warehouse'}>More Info</Link>{' '}
+                                    </div>
+                                ),
+                                placement: 'right-start',
+                                fallbackPlacements: ['left-start'],
+                                actionable: true,
+                                closeParentPopoverOnClickInside: true,
+                            }}
+                        />
+                    )}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Problem

- a views related button in the sql editor is showing up when it shouldn't

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- place behind feature flag

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
