### PR TITLE
fix(flags): Restrict deleting flags linked to an experiment

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -554,6 +554,8 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                                             ? "You have only 'View' access for this feature flag. To make changes, please contact the flag's creator."
                                                             : (featureFlag.features?.length || 0) > 0
                                                             ? 'This feature flag is in use with an early access feature. Delete the early access feature to delete this flag'
+                                                            : (featureFlag.experiment_set?.length || 0) > 0
+                                                            ? 'This feature flag is linked to an experiment. Delete the experiment to delete this flag'
                                                             : null
                                                     }
                                                 >

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -216,7 +216,15 @@ export function OverViewTab({
                                                 callback: loadFeatureFlags,
                                             })
                                         }}
-                                        disabled={!featureFlag.can_edit}
+                                        disabledReason={
+                                            !featureFlag.can_edit
+                                                ? "You have only 'View' access for this feature flag. To make changes, please contact the flag's creator."
+                                                : (featureFlag.features?.length || 0) > 0
+                                                ? 'This feature flag is in use with an early access feature. Delete the early access feature to delete this flag'
+                                                : (featureFlag.experiment_set?.length || 0) > 0
+                                                ? 'This feature flag is linked to an experiment. Delete the experiment to delete this flag'
+                                                : null
+                                        }
                                         fullWidth
                                     >
                                         Delete feature flag


### PR DESCRIPTION
## Problem

Don't allow deleting flags that shouldn't be deleted.

A more expansive fix which restricts this on the backend as well to follow, but just wanted to get this out quickly

<img width="866" alt="image" src="https://github.com/PostHog/posthog/assets/7115141/50a33578-1969-467f-8a1b-329023018578">

<img width="854" alt="image" src="https://github.com/PostHog/posthog/assets/7115141/e5d538f6-c41b-46db-b6ec-ec4276b6f7fc">


<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
