### PR TITLE
feat(hogql): better debug errors

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1541,38 +1541,51 @@
             "additionalProperties": false,
             "properties": {
                 "clickhouse": {
+                    "description": "Executed ClickHouse query",
                     "type": "string"
                 },
                 "columns": {
+                    "description": "Returned columns",
                     "items": {},
                     "type": "array"
                 },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' is true. Throws an error otherwise.",
+                    "type": "string"
+                },
                 "explain": {
+                    "description": "Query explanation output",
                     "items": {
                         "type": "string"
                     },
                     "type": "array"
                 },
                 "hogql": {
+                    "description": "Generated HogQL query",
                     "type": "string"
                 },
                 "modifiers": {
-                    "$ref": "#/definitions/HogQLQueryModifiers"
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
                 },
                 "query": {
+                    "description": "Input query string",
                     "type": "string"
                 },
                 "results": {
+                    "description": "Query results",
                     "items": {},
                     "type": "array"
                 },
                 "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
                     "items": {
                         "$ref": "#/definitions/QueryTiming"
                     },
                     "type": "array"
                 },
                 "types": {
+                    "description": "Types of returned columns",
                     "items": {},
                     "type": "array"
                 }

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -139,14 +139,25 @@ export interface HogQLQueryModifiers {
 }
 
 export interface HogQLQueryResponse {
+    /** Input query string */
     query?: string
+    /** Generated HogQL query */
     hogql?: string
+    /** Executed ClickHouse query */
     clickhouse?: string
+    /** Query results */
     results?: any[]
-    types?: any[]
+    /** Query error. Returned only if 'explain' is true. Throws an error otherwise. */
+    error?: string
+    /** Returned columns */
     columns?: any[]
+    /** Types of returned columns */
+    types?: any[]
+    /** Measured timings for different parts of the query generation process */
     timings?: QueryTiming[]
+    /** Query explanation output */
     explain?: string[]
+    /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiers
 }
 

--- a/frontend/src/scenes/debug/HogQLDebug.tsx
+++ b/frontend/src/scenes/debug/HogQLDebug.tsx
@@ -91,6 +91,14 @@ export function HogQLDebug({ query, setQuery, queryKey }: HogQLDebugProps): JSX.
                     </>
                 ) : (
                     <>
+                        {response?.error ? (
+                            <>
+                                <h2 className="text-danger">Error Running Query!</h2>
+                                <CodeSnippet language={Language.Text} wrap>
+                                    {response.error}
+                                </CodeSnippet>
+                            </>
+                        ) : null}
                         {response?.hogql ? (
                             <>
                                 <h2>Executed HogQL</h2>

--- a/posthog/hogql_queries/hogql_query_runner.py
+++ b/posthog/hogql_queries/hogql_query_runner.py
@@ -65,6 +65,7 @@ class HogQLQueryRunner(QueryRunner):
             workload=Workload.ONLINE,
             timings=self.timings,
             in_export_context=self.in_export_context,
+            explain=bool(self.query.explain),
         )
 
     def _is_stale(self, cached_result_package):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -828,15 +828,22 @@ class HogQLQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    clickhouse: Optional[str] = None
-    columns: Optional[List] = None
-    explain: Optional[List[str]] = None
-    hogql: Optional[str] = None
-    modifiers: Optional[HogQLQueryModifiers] = None
-    query: Optional[str] = None
-    results: Optional[List] = None
-    timings: Optional[List[QueryTiming]] = None
-    types: Optional[List] = None
+    clickhouse: Optional[str] = Field(default=None, description="Executed ClickHouse query")
+    columns: Optional[List] = Field(default=None, description="Returned columns")
+    error: Optional[str] = Field(
+        default=None, description="Query error. Returned only if 'explain' is true. Throws an error otherwise."
+    )
+    explain: Optional[List[str]] = Field(default=None, description="Query explanation output")
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query")
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    query: Optional[str] = Field(default=None, description="Input query string")
+    results: Optional[List] = Field(default=None, description="Query results")
+    timings: Optional[List[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: Optional[List] = Field(default=None, description="Types of returned columns")
 
 
 class LifecycleFilter(BaseModel):


### PR DESCRIPTION
## Problem

If a `HogQLQuery` errors when running the ClickHouse query, we eat up the error, and the query that was run. This makes it hard to debug if there's an error in the generated ClickHouse query.

## Changes

When running under the `/debug` URL, a HogQL error or a verified ClickHouse error will now be returned _together with_ the ClickHouse SQL that was run. This makes debugging much easier.

Before:

<img width="1451" alt="image" src="https://github.com/PostHog/posthog/assets/53387/65fa367f-e083-42c5-9d21-dac73ac7a546">

After:

<img width="1491" alt="image" src="https://github.com/PostHog/posthog/assets/53387/114e2b22-afc1-4e44-a7cd-09b7a7762331">


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
