### PR TITLE
feat: support modulepreload for reverse proxy

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/index.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/index.ts
@@ -30,7 +30,15 @@ export const CorsPlugin: ReplayPlugin & {
 
         if (node.nodeName === 'LINK') {
             const linkElement = node as HTMLLinkElement
-            linkElement.href = CorsPlugin._replaceFontUrl(linkElement.href)
+            const href = linkElement.href
+            if (!href) {
+                return
+            }
+            if (linkElement.getAttribute('rel') == 'modulepreload') {
+                linkElement.href = CorsPlugin._replaceJSUrl(href)
+            } else {
+                linkElement.href = CorsPlugin._replaceFontUrl(href)
+            }
         }
 
         if (node.nodeName === 'SCRIPT') {


### PR DESCRIPTION
#TIL link elements can load JS files using `rel="modulepreload"` 

Let's support that for the reverse proxy