### PR TITLE
feat(hogql): fix leaky locations in metadata

### DIFF
--- a/posthog/hogql/filters.py
+++ b/posthog/hogql/filters.py
@@ -63,6 +63,7 @@ class ReplaceFilters(CloningVisitor):
                     parse_expr(
                         "timestamp < {timestamp}",
                         {"timestamp": ast.Constant(value=parsed_date)},
+                        start=None,  # do not add location information for "timestamp" to the metadata
                     )
                 )
 
@@ -77,6 +78,7 @@ class ReplaceFilters(CloningVisitor):
                     parse_expr(
                         "timestamp >= {timestamp}",
                         {"timestamp": ast.Constant(value=parsed_date)},
+                        start=None,  # do not add location information for "timestamp" to the metadata
                     )
                 )
 


### PR DESCRIPTION
## Problem

Various lazy selects/joins, and other parsed expressions added noise into the HogQL metadata:

![2023-11-09 18 07 47](https://github.com/PostHog/posthog/assets/53387/c3f3b02a-2f66-4055-b814-b51f8cdc02ea)

![2023-11-09 17 48 26](https://github.com/PostHog/posthog/assets/53387/e70cd3ef-8a37-4063-9383-e97ec08fe559)


## Changes

<img width="774" alt="image" src="https://github.com/PostHog/posthog/assets/53387/18ae274e-a9d5-4c19-987a-2fb00bb36952">

## How did you test this code?

In the UI