### PR TITLE
fix: allow flagging of settings as well as sections of settings

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -156,6 +156,7 @@ export const SettingsMap: SettingSection[] = [
                 id: 'replay-ingestion',
                 title: 'Ingestion controls',
                 component: <ReplayCostControl />,
+                flag: 'SESSION_RECORDING_SAMPLING',
             },
         ],
     },

--- a/frontend/src/scenes/settings/settingsLogic.ts
+++ b/frontend/src/scenes/settings/settingsLogic.ts
@@ -76,8 +76,8 @@ export const settingsLogic = kea<settingsLogicType>([
             },
         ],
         settings: [
-            (s) => [s.selectedLevel, s.selectedSectionId, s.sections],
-            (selectedLevel, selectedSectionId, sections): Setting[] => {
+            (s) => [s.selectedLevel, s.selectedSectionId, s.sections, s.featureFlags],
+            (selectedLevel, selectedSectionId, sections, featureFlags): Setting[] => {
                 let settings: Setting[] = []
 
                 if (!selectedSectionId) {
@@ -88,7 +88,7 @@ export const settingsLogic = kea<settingsLogicType>([
                     settings = sections.find((x) => x.id === selectedSectionId)?.settings || []
                 }
 
-                return settings
+                return settings.filter((x) => (x.flag ? featureFlags[FEATURE_FLAGS[x.flag]] : true))
             },
         ],
     }),

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -67,6 +67,7 @@ export type Setting = {
     title: string
     description?: JSX.Element | string
     component: JSX.Element
+    flag?: keyof typeof FEATURE_FLAGS
 }
 
 export type SettingSection = {


### PR DESCRIPTION
follow-up to https://github.com/PostHog/posthog/pull/18419

The ingestion controls settings are feature flagged so we didn't show any controls, but the settings data mapping didn't know this so would render the title for everyone.

Extends the type so that individual settings can be flagged as well as entire sections.

## here with flag off the title is still shown

<img width="722" alt="Screenshot 2023-11-09 at 19 07 22" src="https://github.com/PostHog/posthog/assets/984817/2dc4def5-3497-4cd8-bc2c-a4ec9225db39">
