### PR TITLE
feat: track unplayable replay

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -21,7 +21,7 @@ import {
     SessionRecordingUsageType,
 } from '~/types'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { eventWithTime } from '@rrweb/types'
+import { EventType, eventWithTime } from '@rrweb/types'
 import { Dayjs, dayjs } from 'lib/dayjs'
 import type { sessionRecordingDataLogicType } from './sessionRecordingDataLogicType'
 import { chainToElements } from 'lib/utils/elements-chain'
@@ -597,6 +597,42 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
             (s) => [s.sessionPlayerSnapshotData],
             (sessionPlayerSnapshotData): Record<string, eventWithTime[]> => {
                 return mapSnapshotsToWindowId(sessionPlayerSnapshotData?.snapshots || [])
+            },
+        ],
+
+        snapshotsInvalid: [
+            (s, p) => [s.snapshotsByWindowId, s.fullyLoaded, p.sessionRecordingId],
+            (snapshotsByWindowId, fullyLoaded, sessionRecordingId): boolean => {
+                if (!fullyLoaded) {
+                    return false
+                }
+
+                const windowsHaveFullSnapshot = Object.entries(snapshotsByWindowId).reduce(
+                    (acc, [windowId, events]) => {
+                        acc[`window-id-${windowId}-has-full-snapshot`] = events.some(
+                            (event) => event.type === EventType.FullSnapshot
+                        )
+                        return acc
+                    },
+                    {}
+                )
+                const anyWindowMissingFullSnapshot = !Object.values(windowsHaveFullSnapshot).some((x) => x)
+                const everyWindowMissingFullSnapshot = !Object.values(windowsHaveFullSnapshot).every((x) => x)
+
+                if (everyWindowMissingFullSnapshot) {
+                    // video is definitely unplayable
+                    posthog.capture('recording_has_no_full_snapshot', {
+                        ...windowsHaveFullSnapshot,
+                        sessionId: sessionRecordingId,
+                    })
+                } else if (anyWindowMissingFullSnapshot) {
+                    posthog.capture('recording_window_missing_full_snapshot', {
+                        ...windowsHaveFullSnapshot,
+                        sessionId: sessionRecordingId,
+                    })
+                }
+
+                return everyWindowMissingFullSnapshot || anyWindowMissingFullSnapshot
             },
         ],
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -104,6 +104,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 'sessionPlayerData',
                 'sessionPlayerSnapshotDataLoading',
                 'sessionPlayerMetaDataLoading',
+                'snapshotsInvalid',
             ],
             playerSettingsLogic,
             ['speed', 'skipInactivitySetting'],
@@ -345,6 +346,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 s.isSkippingInactivity,
                 s.snapshotsLoaded,
                 s.sessionPlayerSnapshotDataLoading,
+                s.snapshotsInvalid,
             ],
             (
                 playingState,
@@ -353,8 +355,13 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 isScrubbing,
                 isSkippingInactivity,
                 snapshotsLoaded,
-                snapshotsLoading
+                snapshotsLoading,
+                snapshotsInvalid
             ) => {
+                if (snapshotsInvalid) {
+                    return SessionPlayerState.ERROR
+                }
+
                 if (isScrubbing) {
                     // If scrubbing, playingState takes precedence
                     return playingState


### PR DESCRIPTION
## Problem
https://github.com/PostHog/posthog-js/pull/839 introduced a bug fixed in https://github.com/PostHog/posthog-js/pull/878 which increased the number of unplayable videos. But I don't think it increased it from _zero_.

We need a better way of knowing without customers taking time to tell us

## Changes

Checks for windows with no full snapshot in the snapshot data
Marks videos as unplayable for user when any window has no full snapshot
Sends events to PostHog so we can track it

## How did you test this code?

👀 locally