### PR TITLE
feat(web-analytics): design tweaks

### DIFF
--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -30,7 +30,7 @@ export function WebOverview(props: { query: WebOverviewQuery; cachedResults?: An
     const results = (response as WebOverviewQueryResponse | undefined)?.results
 
     return (
-        <EvenlyDistributedRows className="w-full gap-2" minWidthRems={8}>
+        <EvenlyDistributedRows className="w-full gap-x-2 gap-y-8" minWidthRems={8}>
             {results?.map((item) => <WebOverviewItemCell key={item.key} item={item} />) || []}
         </EvenlyDistributedRows>
     )

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -13,12 +13,29 @@ import {
 } from 'scenes/web-analytics/WebAnalyticsTile'
 import { WebTabs } from 'scenes/web-analytics/WebTabs'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+import clsx from 'clsx'
 
 const Filters = (): JSX.Element => {
     const { webAnalyticsFilters, dateTo, dateFrom } = useValues(webAnalyticsLogic)
     const { setWebAnalyticsFilters, setDates } = useActions(webAnalyticsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const hasPosthog3000 = featureFlags[FEATURE_FLAGS.POSTHOG_3000]
+
     return (
-        <div className="sticky top-0 z-20 pt-2">
+        <div
+            className={clsx('sticky z-20 pt-2', !hasPosthog3000 && 'top-0 bg-white')}
+            // eslint-disable-next-line react/forbid-dom-props
+            style={
+                hasPosthog3000
+                    ? {
+                          backgroundColor: 'var(--bg-3000)',
+                          top: 'var(--breadcrumbs-height)',
+                      }
+                    : undefined
+            }
+        >
             <div className="flex flex-row flex-wrap gap-2">
                 <DateFilter dateFrom={dateFrom} dateTo={dateTo} onChange={setDates} />
                 <PropertyFilters
@@ -72,7 +89,7 @@ const Tiles = (): JSX.Element => {
     const { tiles } = useValues(webAnalyticsLogic)
 
     return (
-        <div className="mt-2 grid grid-cols-1 md:grid-cols-12 gap-4">
+        <div className="mt-8 grid grid-cols-1 md:grid-cols-12 gap-x-4 gap-y-10">
             {tiles.map((tile, i) => {
                 if ('query' in tile) {
                     const { query, title, layout } = tile
@@ -83,7 +100,7 @@ const Tiles = (): JSX.Element => {
                                 layout.rowSpan ?? 1
                             }  flex flex-col`}
                         >
-                            {title && <h2 className="m-0  mb-1">{title}</h2>}
+                            {title && <h2 className="m-0 mb-3">{title}</h2>}
                             <WebQuery query={query} />
                         </div>
                     )

--- a/frontend/src/scenes/web-analytics/WebTabs.tsx
+++ b/frontend/src/scenes/web-analytics/WebTabs.tsx
@@ -22,8 +22,8 @@ export const WebTabs = ({
 
     return (
         <div className={clsx(className, 'flex flex-col')}>
-            <div className="flex flex-row items-center self-stretch">
-                {<h2 className="flex-1 m-0 mb-1">{activeTab?.title}</h2>}
+            <div className="flex flex-row items-center self-stretch mb-3">
+                {<h2 className="flex-1 m-0">{activeTab?.title}</h2>}
                 <div className="flex flex-col items-stretch">
                     {tabs.length > 1 && (
                         // TODO switch to a select if more than 3

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -238,7 +238,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         tabs: [
                             {
                                 id: GraphsTab.UNIQUE_USERS,
-                                title: 'Unique Visitors',
+                                title: 'Unique visitors',
                                 linkText: 'Visitors',
                                 query: {
                                     kind: NodeKind.InsightVizNode,
@@ -266,7 +266,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: GraphsTab.PAGE_VIEWS,
-                                title: 'Page Views',
+                                title: 'Page views',
                                 linkText: 'Views',
                                 query: {
                                     kind: NodeKind.InsightVizNode,
@@ -332,7 +332,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         tabs: [
                             {
                                 id: PathTab.PATH,
-                                title: 'Top Paths',
+                                title: 'Top paths',
                                 linkText: 'Path',
                                 query: {
                                     full: true,
@@ -347,7 +347,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: PathTab.INITIAL_PATH,
-                                title: 'Top Entry Paths',
+                                title: 'Top entry paths',
                                 linkText: 'Entry Path',
                                 query: {
                                     full: true,
@@ -371,7 +371,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         tabs: [
                             {
                                 id: SourceTab.REFERRING_DOMAIN,
-                                title: 'Top Referrers',
+                                title: 'Top referrers',
                                 linkText: 'Referrer',
                                 query: {
                                     full: true,
@@ -386,8 +386,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: SourceTab.UTM_SOURCE,
-                                title: 'Top Sources',
-                                linkText: 'UTM Source',
+                                title: 'Top sources',
+                                linkText: 'UTM source',
                                 query: {
                                     full: true,
                                     kind: NodeKind.DataTableNode,
@@ -401,8 +401,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: SourceTab.UTM_CAMPAIGN,
-                                title: 'Top Campaigns',
-                                linkText: 'UTM Campaign',
+                                title: 'Top campaigns',
+                                linkText: 'UTM campaign',
                                 query: {
                                     full: true,
                                     kind: NodeKind.DataTableNode,
@@ -425,7 +425,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         tabs: [
                             {
                                 id: DeviceTab.BROWSER,
-                                title: 'Top Browsers',
+                                title: 'Top browsers',
                                 linkText: 'Browser',
                                 query: {
                                     full: true,
@@ -455,8 +455,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: DeviceTab.DEVICE_TYPE,
-                                title: 'Top Device Types',
-                                linkText: 'Device Type',
+                                title: 'Top device types',
+                                linkText: 'Device type',
                                 query: {
                                     full: true,
                                     kind: NodeKind.DataTableNode,
@@ -479,7 +479,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         tabs: [
                             {
                                 id: GeographyTab.MAP,
-                                title: 'World Map',
+                                title: 'World map',
                                 linkText: 'Map',
                                 query: {
                                     kind: NodeKind.InsightVizNode,
@@ -508,7 +508,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: GeographyTab.COUNTRIES,
-                                title: 'Top Countries',
+                                title: 'Top countries',
                                 linkText: 'Countries',
                                 query: {
                                     full: true,
@@ -523,7 +523,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: GeographyTab.REGIONS,
-                                title: 'Top Regions',
+                                title: 'Top regions',
                                 linkText: 'Regions',
                                 query: {
                                     full: true,
@@ -538,7 +538,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: GeographyTab.CITIES,
-                                title: 'Top Cities',
+                                title: 'Top cities',
                                 linkText: 'Cities',
                                 query: {
                                     full: true,


### PR DESCRIPTION
## Problem

Web analytics design issues:
* Some UI was a bit cramped
* The sticky filters bar doesn't have a background
* Web analytics wasn't originally designed with posthog3000 in mind


## Changes

* Change headings to sentence case to match guidelines
* Add a background for ther sticky filter bar
* Support posthog 3000
* Add space between various elements

Sticky filter bar with posthog 3000
<img width="1591" alt="Screenshot 2023-11-13 at 10 19 28" src="https://github.com/PostHog/posthog/assets/2056078/40d3ae44-e9f6-41e5-a06b-0955072e875c">
<img width="1651" alt="Screenshot 2023-11-13 at 10 19 16" src="https://github.com/PostHog/posthog/assets/2056078/2a154ba8-7350-4770-b37d-aea0d326707b">

Sticky filter bar with old UI
<img width="1342" alt="Screenshot 2023-11-13 at 10 27 37" src="https://github.com/PostHog/posthog/assets/2056078/439dbcfe-007c-4b30-bb2b-abf23fb42c34">

Space between overview stats
<img width="1197" alt="Screenshot 2023-11-13 at 10 28 13" src="https://github.com/PostHog/posthog/assets/2056078/b7acddb5-199c-40f8-b3e3-3c816a571c33">

Mobile - old UI
<img width="418" alt="Screenshot 2023-11-13 at 10 29 17" src="https://github.com/PostHog/posthog/assets/2056078/bb895312-6654-42d3-8b49-bad2482b1bfc">


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
