### PR TITLE
fix(taxonomic-filter): mount required logics

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -71,6 +71,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
     key((props) => `${props.taxonomicFilterLogicKey}`),
     path(['lib', 'components', 'TaxonomicFilter', 'taxonomicFilterLogic']),
     connect({
+        logic: [actionsModel, cohortsModel],
         values: [
             teamLogic,
             ['currentTeamId'],

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -71,7 +71,6 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
     key((props) => `${props.taxonomicFilterLogicKey}`),
     path(['lib', 'components', 'TaxonomicFilter', 'taxonomicFilterLogic']),
     connect({
-        logic: [actionsModel, cohortsModel],
         values: [
             teamLogic,
             ['currentTeamId'],

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -21,10 +21,12 @@ import { Navigation as Navigation3000 } from '~/layout/navigation-3000/Navigatio
 import { useEffect } from 'react'
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { GlobalModals } from '~/layout/GlobalModals'
+import { actionsModel } from '~/models/actionsModel'
+import { cohortsModel } from '~/models/cohortsModel'
 
 export const appLogic = kea<appLogicType>([
     path(['scenes', 'App']),
-    connect([teamLogic, organizationLogic, frontendAppsLogic, inAppPromptLogic]),
+    connect([teamLogic, organizationLogic, frontendAppsLogic, inAppPromptLogic, actionsModel, cohortsModel]),
     actions({
         enableDelayedSpinner: true,
         ignoreFeatureFlags: true,


### PR DESCRIPTION
## Problem

Reload the app on https://app.posthog.com/replay/recent / http://localhost:8000/replay/recent, then click into the search input in the top bar. You will see an error that expected logics are not mounted.

See also https://posthoghelp.zendesk.com/agent/tickets/7202. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/10221)

## Changes

This PR mounts them.

## How did you test this code?

Verify the problem and fix locally