### PR TITLE
fix: No dark mode for unauthenticated pages

### DIFF
--- a/frontend/src/layout/navigation-3000/themeLogic.ts
+++ b/frontend/src/layout/navigation-3000/themeLogic.ts
@@ -41,7 +41,11 @@ export const themeLogic = kea<themeLogicType>([
             ],
             (darkModeSavedPreference, darkModeSystemPreference, featureFlags, sceneConfig) => {
                 // NOTE: Unauthenticated users always get the light mode until we have full support across onboarding flows
-                if (sceneConfig?.layout === 'plain' || sceneConfig?.allowUnauthenticated) {
+                if (
+                    sceneConfig?.layout === 'plain' ||
+                    sceneConfig?.allowUnauthenticated ||
+                    sceneConfig?.onlyUnauthenticated
+                ) {
                     return false
                 }
                 // Dark mode is a PostHog 3000 feature


### PR DESCRIPTION
## Problem

I missed a check for dark mode.

## Changes

* Don't have dark mode on any unauthenticated scene
* This is only temporary so I didn't worry too much about making this a "scene" property

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
