### PR TITLE
feat: Remove backfill warning

### DIFF
--- a/frontend/src/scenes/batch_exports/BatchExportBackfillModal.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportBackfillModal.tsx
@@ -7,7 +7,6 @@ import { Form } from 'kea-forms'
 import { Field } from 'lib/forms/Field'
 import { batchExportLogic } from './batchExportLogic'
 import { LemonCalendarSelectInput } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
-import { LemonBanner } from '@posthog/lemon-ui'
 
 export function BatchExportBackfillModal(): JSX.Element {
     const { batchExportConfig, isBackfillModalOpen, isBackfillFormSubmitting } = useValues(batchExportLogic)
@@ -54,11 +53,6 @@ export function BatchExportBackfillModal(): JSX.Element {
                 enableFormOnSubmit
                 className="space-y-2"
             >
-                <LemonBanner type="warning">
-                    Exporting historical data beyond 1 month is not recommended. We are actively working on increasing
-                    this limit.
-                </LemonBanner>
-
                 <Field name="start_at" label="Start Date" className="flex-1">
                     {({ value, onChange }) => (
                         <LemonCalendarSelectInput value={value} onChange={onChange} placeholder="Select start date" />


### PR DESCRIPTION
## Problem

Batch exports backfills have been refactored and no longer have this limitation. Some users can look at this warning and assume (incorrectly, but with good reason) that the limitation is still valid.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Remove warning from batch exports backfill modal.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
