### PR TITLE
feat(web-analytics): add health check warnings

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
@@ -13,7 +13,7 @@ export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
 
     if (statusCheck.shouldWarnAboutNoPageviews) {
         return (
-            <LemonBanner type={'warning'}>
+            <LemonBanner type={'warning'} className={'mt-2'}>
                 <p>
                     No <code>$pageview</code>{' '}
                     {statusCheck.shouldWarnAboutNoPageleaves ? (
@@ -29,7 +29,7 @@ export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
         )
     } else if (statusCheck.shouldWarnAboutNoPageleaves) {
         return (
-            <LemonBanner type={'warning'}>
+            <LemonBanner type={'warning'} className={'mt-2'}>
                 <p>
                     No <code>$pageleave</code> events have been received, this means that Bounce rate and Session
                     Duration might be inaccurate. Please read{' '}

--- a/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
@@ -1,10 +1,10 @@
 import { useValues } from 'kea'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { Link } from 'lib/lemon-ui/Link'
-import { webAnalyticsLogic, WebAnalyticsStatusCheck } from 'scenes/web-analytics/webAnalyticsLogic'
+import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 
 export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
-    const statusCheck: WebAnalyticsStatusCheck | null = useValues(webAnalyticsLogic).statusCheck
+    const { statusCheck } = useValues(webAnalyticsLogic)
 
     // No need to show loading or error states for this warning
     if (!statusCheck) {

--- a/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
@@ -1,0 +1,43 @@
+import { useValues } from 'kea'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { Link } from 'lib/lemon-ui/Link'
+import { webAnalyticsLogic, WebAnalyticsStatusCheck } from 'scenes/web-analytics/webAnalyticsLogic'
+
+export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
+    const statusCheck: WebAnalyticsStatusCheck | null = useValues(webAnalyticsLogic).statusCheck
+
+    // No need to show loading or error states for this warning
+    if (!statusCheck) {
+        return null
+    }
+
+    if (statusCheck.shouldWarnAboutNoPageviews) {
+        return (
+            <LemonBanner type={'warning'}>
+                <p>
+                    No <code>$pageview</code>{' '}
+                    {statusCheck.shouldWarnAboutNoPageleaves ? (
+                        <>
+                            or <code>$pageleave</code>{' '}
+                        </>
+                    ) : null}
+                    events have been received, please read{' '}
+                    <Link to={'https://posthog.com/docs/product-analytics/capture-events'}>the documentation</Link> and
+                    fix this before using Web Analytics.
+                </p>
+            </LemonBanner>
+        )
+    } else if (statusCheck.shouldWarnAboutNoPageleaves) {
+        return (
+            <LemonBanner type={'warning'}>
+                <p>
+                    No <code>$pageleave</code> events have been received, this means that Bounce rate and Session
+                    Duration might be inaccurate. Please read{' '}
+                    <Link to={'https://posthog.com/docs/product-analytics/capture-events'}>the documentation</Link> and
+                    fix this before using Web Analytics.
+                </p>
+            </LemonBanner>
+        )
+    }
+    return null
+}

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -16,6 +16,7 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import clsx from 'clsx'
+import { WebAnalyticsHealthCheck } from 'scenes/web-analytics/WebAnalyticsHealthCheck'
 
 const Filters = (): JSX.Element => {
     const { webAnalyticsFilters, dateTo, dateFrom } = useValues(webAnalyticsLogic)
@@ -148,6 +149,7 @@ export const WebAnalyticsDashboard = (): JSX.Element => {
         <div className="w-full flex flex-col pt-2">
             <WebAnalyticsNotice />
             <Filters />
+            <WebAnalyticsHealthCheck />
             <Tiles />
         </div>
     )

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -569,6 +569,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         // load the status check query here and pass the response into the component, so the response
         // is accessible in this logic
         statusCheck: {
+            __default: null as WebAnalyticsStatusCheck | null,
             loadStatusCheck: async (): Promise<WebAnalyticsStatusCheck> => {
                 const [pageviewResult, pageleaveResult] = await Promise.allSettled([
                     api.eventDefinitions.list({

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -20,11 +20,7 @@ from posthog.schema import (
     PersonPropertyFilter,
 )
 
-WebQueryNode = Union[
-    WebOverviewQuery,
-    WebTopClicksQuery,
-    WebStatsTableQuery,
-]
+WebQueryNode = Union[WebOverviewQuery, WebTopClicksQuery, WebStatsTableQuery]
 
 
 class WebAnalyticsQueryRunner(QueryRunner, ABC):


### PR DESCRIPTION
## Problem

If posthog-js is misconfigured and not sending pageview or pageleave events, it'd be good to warn the user as their numbers might be inaccurate

## Changes

Check the event definitions endpoint to see if $pageview and $pageleave are being sent, and if not, show a warning

See screenshot (there is vertical padding in this space in my other PR, and the missing space after $pageleave is fixed) 
<img width="1146" alt="Screenshot 2023-11-13 at 15 54 13" src="https://github.com/PostHog/posthog/assets/2056078/6eb80e81-cfdd-484e-8a6c-22b35f51c1c2">

## How did you test this code
* Deleted my dockerised DB, created a new project, saw the warning was there.
* Deleted my dockerised DB, created a new project with generate_demo_data. This does not create events $pageview directly but will create them if you click around in the UI and have the plugin server running. After doing this, checked that the warning was not present.
