### PR TITLE
fix: Fail backfill on schedule deletion

### DIFF
--- a/posthog/temporal/tests/utils/models.py
+++ b/posthog/temporal/tests/utils/models.py
@@ -30,7 +30,12 @@ async def acreate_batch_export(team_id: int, interval: str, name: str, destinati
 async def adelete_batch_export(batch_export: BatchExport, temporal_client: temporalio.client.Client) -> None:
     """Async delete a BatchExport and its underlying Schedule."""
     handle = temporal_client.get_schedule_handle(str(batch_export.id))
-    await handle.delete()
+
+    try:
+        await handle.delete()
+    except temporalio.service.RPCError:
+        # This means the schedule was already deleted, so we can continue
+        pass
 
     await sync_to_async(batch_export.delete)()  # type: ignore
 

--- a/posthog/temporal/workflows/backfill_batch_export.py
+++ b/posthog/temporal/workflows/backfill_batch_export.py
@@ -371,7 +371,7 @@ class BackfillBatchExportWorkflow(PostHogWorkflow):
                 retry_policy=temporalio.common.RetryPolicy(
                     initial_interval=dt.timedelta(seconds=10),
                     maximum_interval=dt.timedelta(seconds=60),
-                    non_retryable_error_types=["TemporalScheduleDeletedError"],
+                    non_retryable_error_types=["TemporalScheduleNotFoundError"],
                 ),
                 # Temporal requires that we set a timeout.
                 # Allocate 5 minutes per expected number of runs to backfill as a timeout.

--- a/posthog/temporal/workflows/backfill_batch_export.py
+++ b/posthog/temporal/workflows/backfill_batch_export.py
@@ -90,8 +90,11 @@ async def get_schedule_frequency(schedule_id: str) -> float:
 
     try:
         desc = await handle.describe()
-    except temporalio.service.RPCError:
-        raise TemporalScheduleNotFoundError(schedule_id)
+    except temporalio.service.RPCError as e:
+        if e.status == temporalio.service.RPCStatusCode.NOT_FOUND:
+            raise TemporalScheduleNotFoundError(schedule_id)
+        else:
+            raise
 
     interval = desc.schedule.spec.intervals[0]
     return interval.every.total_seconds()
@@ -274,8 +277,11 @@ async def check_temporal_schedule_exists(client: temporalio.client.Client, sched
 
     try:
         await handle.describe()
-    except temporalio.service.RPCError:
-        return False
+    except temporalio.service.RPCError as e:
+        if e.status == temporalio.service.RPCStatusCode.NOT_FOUND:
+            return False
+        else:
+            raise
     return True
 
 

--- a/posthog/temporal/workflows/backfill_batch_export.py
+++ b/posthog/temporal/workflows/backfill_batch_export.py
@@ -245,6 +245,9 @@ async def wait_for_schedule_backfill_in_range(
     while not done:
         await asyncio.sleep(wait_delay)
 
+        if await check_temporal_schedule_exists(client, schedule_id) is False:
+            raise TemporalScheduleNotFoundError(schedule_id)
+
         workflows = [workflow async for workflow in client.list_workflows(query=query)]
 
         if not workflows:
@@ -253,9 +256,6 @@ async def wait_for_schedule_backfill_in_range(
 
         if check_workflow_executions_not_running(workflows) is False:
             continue
-
-        if await check_temporal_schedule_exists(client, schedule_id) is False:
-            raise TemporalScheduleNotFoundError(schedule_id)
 
         done = True
 


### PR DESCRIPTION
## Problem

Backfills are not cleaned up properly when deleting an export. If a backfill is still running, it should stop if it's underlying schedule (batch export) is deleted.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Raise a non-retryable `TemporalScheduleNotFoundError` if we cannot get the schedule while waiting on the backfill runs.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added unit tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
