### PR TITLE
fix: Reset structlog on temporal worker

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -341,7 +341,7 @@ def create_batch_export_run(
     data_interval_start: str,
     data_interval_end: str,
     status: str = BatchExportRun.Status.STARTING,
-):
+) -> BatchExportRun:
     """Create a BatchExportRun after a Temporal Workflow execution.
 
     In a first approach, this method is intended to be called only by Temporal Workflows,
@@ -364,15 +364,19 @@ def create_batch_export_run(
     return run
 
 
-def update_batch_export_run_status(run_id: UUID, status: str, latest_error: str | None):
+def update_batch_export_run_status(run_id: UUID, status: str, latest_error: str | None) -> BatchExportRun:
     """Update the status of an BatchExportRun with given id.
 
     Arguments:
         id: The id of the BatchExportRun to update.
     """
-    updated = BatchExportRun.objects.filter(id=run_id).update(status=status, latest_error=latest_error)
+    model = BatchExportRun.objects.filter(id=run_id)
+    updated = model.update(status=status, latest_error=latest_error)
+
     if not updated:
         raise ValueError(f"BatchExportRun with id {run_id} not found.")
+
+    return model.get()
 
 
 def sync_batch_export(batch_export: BatchExport, created: bool):
@@ -447,7 +451,7 @@ def create_batch_export_backfill(
     start_at: str,
     end_at: str,
     status: str = BatchExportRun.Status.RUNNING,
-):
+) -> BatchExportBackfill:
     """Create a BatchExportBackfill.
 
 
@@ -470,13 +474,17 @@ def create_batch_export_backfill(
     return backfill
 
 
-def update_batch_export_backfill_status(backfill_id: UUID, status: str):
+def update_batch_export_backfill_status(backfill_id: UUID, status: str) -> BatchExportBackfill:
     """Update the status of an BatchExportBackfill with given id.
 
     Arguments:
         id: The id of the BatchExportBackfill to update.
         status: The new status to assign to the BatchExportBackfill.
     """
-    updated = BatchExportBackfill.objects.filter(id=backfill_id).update(status=status)
+    model = BatchExportBackfill.objects.filter(id=backfill_id)
+    updated = model.update(status=status)
+
     if not updated:
         raise ValueError(f"BatchExportBackfill with id {backfill_id} not found.")
+
+    return model.get()

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -1,11 +1,12 @@
 import asyncio
 import logging
 
+import structlog
 from temporalio import workflow
 
 with workflow.unsafe.imports_passed_through():
-    from django.core.management.base import BaseCommand
     from django.conf import settings
+    from django.core.management.base import BaseCommand
 
 from prometheus_client import start_http_server
 
@@ -69,6 +70,8 @@ class Command(BaseCommand):
         if options["client_key"]:
             options["client_key"] = "--SECRET--"
         logging.info(f"Starting Temporal Worker with options: {options}")
+
+        structlog.reset_defaults()
 
         metrics_port = int(options["metrics_port"])
         start_http_server(port=metrics_port)

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -626,7 +626,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_0')
+                                                      'user_one_2')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -626,7 +626,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_2')
+                                                      'user_one_0')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---

--- a/posthog/temporal/tests/batch_exports/test_run_updates.py
+++ b/posthog/temporal/tests/batch_exports/test_run_updates.py
@@ -122,6 +122,7 @@ async def test_update_export_run_status(activity_environment, team, batch_export
     update_inputs = UpdateBatchExportRunStatusInputs(
         id=str(run_id),
         status="Completed",
+        team_id=inputs.team_id,
     )
     await activity_environment.run(update_export_run_status, update_inputs)
 

--- a/posthog/temporal/workflows/backfill_batch_export.py
+++ b/posthog/temporal/workflows/backfill_batch_export.py
@@ -22,7 +22,6 @@ from posthog.temporal.workflows.batch_exports import (
     create_batch_export_backfill_model,
     update_batch_export_backfill_model_status,
 )
-from posthog.temporal.workflows.logger import bind_batch_exports_logger
 
 
 class HeartbeatDetails(typing.NamedTuple):
@@ -284,13 +283,6 @@ class BackfillBatchExportWorkflow(PostHogWorkflow):
     @temporalio.workflow.run
     async def run(self, inputs: BackfillBatchExportInputs) -> None:
         """Workflow implementation to backfill a BatchExport."""
-        logger = await bind_batch_exports_logger(team_id=inputs.team_id)
-        logger.info(
-            "Starting Backfill for BatchExport: %s - %s",
-            inputs.start_at,
-            inputs.end_at,
-        )
-
         create_batch_export_backfill_inputs = CreateBatchExportBackfillInputs(
             team_id=inputs.team_id,
             batch_export_id=inputs.batch_export_id,
@@ -347,16 +339,13 @@ class BackfillBatchExportWorkflow(PostHogWorkflow):
 
         except temporalio.exceptions.ActivityError as e:
             if isinstance(e.cause, temporalio.exceptions.CancelledError):
-                logger.error("Backfill was cancelled.")
                 update_inputs.status = "Cancelled"
             else:
-                logger.exception("Backfill failed.", exc_info=e.cause)
                 update_inputs.status = "Failed"
 
             raise
 
-        except Exception as e:
-            logger.exception("Backfill failed with an unexpected error.", exc_info=e)
+        except Exception:
             update_inputs.status = "Failed"
             raise
 

--- a/posthog/temporal/workflows/bigquery_batch_export.py
+++ b/posthog/temporal/workflows/bigquery_batch_export.py
@@ -212,14 +212,6 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
     @workflow.run
     async def run(self, inputs: BigQueryBatchExportInputs):
         """Workflow implementation to export data to BigQuery."""
-        logger = await bind_batch_exports_logger(team_id=inputs.team_id, destination="BigQuery")
-        data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
-        logger.info(
-            "Starting batch export %s - %s",
-            data_interval_start,
-            data_interval_end,
-        )
-
         data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
 
         create_export_run_inputs = CreateBatchExportRunInputs(
@@ -240,7 +232,7 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
             ),
         )
 
-        update_inputs = UpdateBatchExportRunStatusInputs(id=run_id, status="Completed")
+        update_inputs = UpdateBatchExportRunStatusInputs(id=run_id, status="Completed", team_id=inputs.team_id)
 
         insert_inputs = BigQueryInsertInputs(
             team_id=inputs.team_id,

--- a/posthog/temporal/workflows/logger.py
+++ b/posthog/temporal/workflows/logger.py
@@ -165,14 +165,12 @@ def get_temporal_context() -> dict[str, str | int]:
     * workflow_run_id: The ID of the Temporal Workflow Execution running the batch export.
     * workflow_type: The name of the Temporal Workflow.
 
-    We attempt to fetch the context from the activity information, and then from the workflow
-    information. If both are undefined, an empty dict is returned. When running this in
-    an activity or a workflow, at least one context will be defined.
+    We attempt to fetch the context from the activity information. If undefined, an empty dict
+    is returned. When running this in an activity the context will be defined.
     """
     activity_info = attempt_to_fetch_activity_info()
-    workflow_info = attempt_to_fetch_workflow_info()
 
-    info = activity_info or workflow_info
+    info = activity_info
 
     if info is None:
         return {}
@@ -218,25 +216,6 @@ def attempt_to_fetch_activity_info() -> Info | None:
         workflow_type = activity_info.workflow_type
         workflow_run_id = activity_info.workflow_run_id
         attempt = activity_info.attempt
-
-    return (workflow_id, workflow_type, workflow_run_id, attempt)
-
-
-def attempt_to_fetch_workflow_info() -> Info | None:
-    """Fetch Workflow information from Temporal.
-
-    Returns:
-        None if calling outside a Workflow, else the relevant Info.
-    """
-    try:
-        workflow_info = temporalio.workflow.info()
-    except RuntimeError:
-        return None
-    else:
-        workflow_id = workflow_info.workflow_id
-        workflow_type = workflow_info.workflow_type
-        workflow_run_id = workflow_info.run_id
-        attempt = workflow_info.attempt
 
     return (workflow_id, workflow_type, workflow_run_id, attempt)
 

--- a/posthog/temporal/workflows/postgres_batch_export.py
+++ b/posthog/temporal/workflows/postgres_batch_export.py
@@ -273,13 +273,7 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
     @workflow.run
     async def run(self, inputs: PostgresBatchExportInputs):
         """Workflow implementation to export data to Postgres."""
-        logger = await bind_batch_exports_logger(team_id=inputs.team_id, destination="PostgreSQL")
         data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
-        logger.info(
-            "Starting Postgres export batch %s - %s",
-            data_interval_start,
-            data_interval_end,
-        )
 
         create_export_run_inputs = CreateBatchExportRunInputs(
             team_id=inputs.team_id,
@@ -299,7 +293,11 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
             ),
         )
 
-        update_inputs = UpdateBatchExportRunStatusInputs(id=run_id, status="Completed")
+        update_inputs = UpdateBatchExportRunStatusInputs(
+            id=run_id,
+            status="Completed",
+            team_id=inputs.team_id,
+        )
 
         insert_inputs = PostgresInsertInputs(
             team_id=inputs.team_id,

--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -493,9 +493,7 @@ class S3BatchExportWorkflow(PostHogWorkflow):
     @workflow.run
     async def run(self, inputs: S3BatchExportInputs):
         """Workflow implementation to export data to S3 bucket."""
-        logger = await bind_batch_exports_logger(team_id=inputs.team_id, destination="S3")
         data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
-        logger.info("Starting batch export %s - %s", data_interval_start, data_interval_end)
 
         create_export_run_inputs = CreateBatchExportRunInputs(
             team_id=inputs.team_id,
@@ -515,7 +513,11 @@ class S3BatchExportWorkflow(PostHogWorkflow):
             ),
         )
 
-        update_inputs = UpdateBatchExportRunStatusInputs(id=run_id, status="Completed")
+        update_inputs = UpdateBatchExportRunStatusInputs(
+            id=run_id,
+            status="Completed",
+            team_id=inputs.team_id,
+        )
 
         insert_inputs = S3InsertInputs(
             bucket_name=inputs.bucket_name,


### PR DESCRIPTION
## Problem

We are not logging because structlog appears to already be configured (so, `if not structlog.is_configured()` returns `False`). I believe this is because of `django_structlog` configuring it even though we are not running django - just the temporal worker. A good reason to eventually split up batch exports into their own package.

Moreover, even when configuring structlog, we are still not logging. This is because the kafka producer fails to connect due to the Temporal event loop not implementing `is_running`. The recommended approach seems is to move logging into activities, so that's what I have done. This has resulted in some loss of precision with logging, but this is something that we can get better with time.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Reset structlog on starting the temporal worker.
* Move all logging to activities

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
