### PR TITLE
feat: Dark mode/display on load

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelDocs.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelDocs.tsx
@@ -3,14 +3,41 @@ import { POSTHOG_WEBSITE_ORIGIN, sidePanelDocsLogic } from './sidePanelDocsLogic
 import { useEffect, useRef, useState } from 'react'
 import clsx from 'clsx'
 import { SidePanelPaneHeader } from '../components/SidePanelPane'
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
 import { IconExternal } from '@posthog/icons'
+import { themeLogic } from '../../themeLogic'
+
+function SidePanelDocsSkeleton(): JSX.Element {
+    return (
+        <div className="absolute inset-0 p-4 space-y-2">
+            <LemonSkeleton className="w-full h-10 mb-12" />
+            <LemonSkeleton className="w-1/3 h-8" />
+            <LemonSkeleton className="w-1/2 h-4 mb-10" />
+            <LemonSkeleton className="w-full h-4" />
+            <LemonSkeleton className="w-full h-4 opacity-80" />
+            <LemonSkeleton className="w-full h-4 opacity-60" />
+            <LemonSkeleton className="w-full h-4 opacity-40" />
+            <LemonSkeleton className="w-1/2 h-4 opacity-20" />
+        </div>
+    )
+}
 
 export const SidePanelDocs = (): JSX.Element => {
     const { iframeSrc, currentUrl } = useValues(sidePanelDocsLogic)
     const { updatePath, unmountIframe, closeSidePanel } = useActions(sidePanelDocsLogic)
     const ref = useRef<HTMLIFrameElement>(null)
     const [ready, setReady] = useState(false)
+    const { isDarkModeOn } = useValues(themeLogic)
+
+    useEffect(() => {
+        ref.current?.contentWindow?.postMessage(
+            {
+                type: 'theme-toggle',
+                isDarkModeOn,
+            },
+            '*'
+        )
+    }, [isDarkModeOn, ref.current])
 
     useEffect(() => {
         const onMessage = (event: MessageEvent): void => {
@@ -46,12 +73,11 @@ export const SidePanelDocs = (): JSX.Element => {
                     Open on posthog.com
                 </LemonButton>
             </SidePanelPaneHeader>
-            <iframe
-                src={iframeSrc}
-                title="Docs"
-                className={clsx('flex-1 w-full h-full', !ready && 'hidden')}
-                ref={ref}
-            />
+            <div className="relative flex-1">
+                <iframe src={iframeSrc} title="Docs" className={clsx('w-full h-full', !ready && 'hidden')} ref={ref} />
+
+                {!ready && <SidePanelDocsSkeleton />}
+            </div>
         </>
     )
 }

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelDocsLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelDocsLogic.ts
@@ -59,9 +59,7 @@ export const sidePanelDocsLogic = kea<sidePanelDocsLogicType>([
             let path = urlOrPath
             try {
                 const url = new URL(urlOrPath)
-                if (url.origin === POSTHOG_WEBSITE_ORIGIN) {
-                    path = url.pathname + url.search
-                }
+                path = url.pathname + url.search
             } catch (e) {
                 // not a valid URL, continue
             }

--- a/frontend/src/layout/navigation-3000/themeLogic.ts
+++ b/frontend/src/layout/navigation-3000/themeLogic.ts
@@ -61,6 +61,16 @@ export const themeLogic = kea<themeLogicType>([
     subscriptions({
         isDarkModeOn: (isDarkModeOn) => {
             document.body.setAttribute('theme', isDarkModeOn ? 'dark' : 'light')
+            const docsIframe: HTMLIFrameElement | null = document.querySelector('iframe[title="Docs"]')
+            if (docsIframe) {
+                docsIframe.contentWindow?.postMessage(
+                    {
+                        type: 'theme-toggle',
+                        isDarkModeOn,
+                    },
+                    '*'
+                )
+            }
         },
     }),
     events(({ cache, actions }) => ({

--- a/frontend/src/layout/navigation-3000/themeLogic.ts
+++ b/frontend/src/layout/navigation-3000/themeLogic.ts
@@ -61,16 +61,6 @@ export const themeLogic = kea<themeLogicType>([
     subscriptions({
         isDarkModeOn: (isDarkModeOn) => {
             document.body.setAttribute('theme', isDarkModeOn ? 'dark' : 'light')
-            const docsIframe: HTMLIFrameElement | null = document.querySelector('iframe[title="Docs"]')
-            if (docsIframe) {
-                docsIframe.contentWindow?.postMessage(
-                    {
-                        type: 'theme-toggle',
-                        isDarkModeOn,
-                    },
-                    '*'
-                )
-            }
         },
     }),
     events(({ cache, actions }) => ({


### PR DESCRIPTION
## Changes

- Posts a message to the posthog.com iframe when the theme is toggled (the theme is then toggled within the iframe as well)
- Hides iframe until a ready message is received (this should fix the nav flicker issue)
- Updates the message `type` logic to support the new format in [this PR](https://github.com/PostHog/posthog.com/pull/7144)

