### PR TITLE
refactor(batch-exports): upgrade temporalio dep and use their built i…

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -8,8 +8,6 @@ with workflow.unsafe.imports_passed_through():
     from django.conf import settings
     from django.core.management.base import BaseCommand
 
-from prometheus_client import start_http_server
-
 from posthog.temporal.worker import start_worker
 
 
@@ -74,12 +72,12 @@ class Command(BaseCommand):
         structlog.reset_defaults()
 
         metrics_port = int(options["metrics_port"])
-        start_http_server(port=metrics_port)
 
         asyncio.run(
             start_worker(
                 temporal_host,
                 temporal_port,
+                metrics_port=metrics_port,
                 namespace=namespace,
                 task_queue=task_queue,
                 server_root_ca_cert=server_root_ca_cert,

--- a/posthog/temporal/worker.py
+++ b/posthog/temporal/worker.py
@@ -12,13 +12,14 @@ from posthog.temporal.workflows import ACTIVITIES, WORKFLOWS
 async def start_worker(
     host,
     port,
+    metrics_port,
     namespace,
     task_queue,
     server_root_ca_cert=None,
     client_cert=None,
     client_key=None,
 ):
-    runtime = Runtime(telemetry=TelemetryConfig(metrics=PrometheusConfig(bind_address="0.0.0.0:8596")))
+    runtime = Runtime(telemetry=TelemetryConfig(metrics=PrometheusConfig(bind_address="0.0.0.0:%d" % metrics_port)))
     client = await connect(
         host,
         port,

--- a/posthog/temporal/workflows/bigquery_batch_export.py
+++ b/posthog/temporal/workflows/bigquery_batch_export.py
@@ -12,8 +12,6 @@ from temporalio.common import RetryPolicy
 from posthog.batch_exports.service import BigQueryBatchExportInputs
 from posthog.temporal.workflows.base import PostHogWorkflow
 from posthog.temporal.workflows.batch_exports import (
-    BYTES_EXPORTED,
-    ROWS_EXPORTED,
     BatchExportTemporaryFile,
     CreateBatchExportRunInputs,
     UpdateBatchExportRunStatusInputs,
@@ -25,6 +23,7 @@ from posthog.temporal.workflows.batch_exports import (
 )
 from posthog.temporal.workflows.clickhouse import get_client
 from posthog.temporal.workflows.logger import bind_batch_exports_logger
+from posthog.temporal.workflows.metrics import get_bytes_exported_metric, get_rows_exported_metric
 
 
 def load_jsonl_file_to_bigquery_table(jsonl_file, table, table_schema, bigquery_client):
@@ -164,6 +163,8 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs):
             )
 
             with BatchExportTemporaryFile() as jsonl_file:
+                rows_exported = get_rows_exported_metric()
+                bytes_exported = get_bytes_exported_metric()
 
                 def flush_to_bigquery():
                     logger.debug(
@@ -172,8 +173,9 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs):
                         jsonl_file.bytes_since_last_reset,
                     )
                     load_jsonl_file_to_bigquery_table(jsonl_file, bigquery_table, table_schema, bq_client)
-                    ROWS_EXPORTED.labels(destination="bigquery").inc(jsonl_file.records_since_last_reset)
-                    BYTES_EXPORTED.labels(destination="bigquery").inc(jsonl_file.bytes_since_last_reset)
+
+                    rows_exported.add(jsonl_file.records_since_last_reset)
+                    bytes_exported.add(jsonl_file.bytes_since_last_reset)
 
                 for result in results_iterator:
                     row = {

--- a/posthog/temporal/workflows/metrics.py
+++ b/posthog/temporal/workflows/metrics.py
@@ -1,0 +1,24 @@
+from temporalio import activity
+from temporalio.common import MetricCounter
+
+
+def get_rows_exported_metric() -> MetricCounter:
+    return activity.metric_meter().create_counter("batch_export_rows_exported", "Number of rows exported.")
+
+
+def get_bytes_exported_metric() -> MetricCounter:
+    return activity.metric_meter().create_counter("batch_export_bytes_exported", "Number of bytes exported.")
+
+
+def get_export_started_metric() -> MetricCounter:
+    return activity.metric_meter().create_counter("batch_export_started", "Number of batch exports started.")
+
+
+def get_export_finished_metric(status: str) -> MetricCounter:
+    return (
+        activity.metric_meter()
+        .with_additional_attributes({"status": status})
+        .create_counter(
+            "batch_export_finished", "Number of batch exports finished, for any reason (including failure)."
+        )
+    )

--- a/posthog/temporal/workflows/redshift_batch_export.py
+++ b/posthog/temporal/workflows/redshift_batch_export.py
@@ -14,7 +14,6 @@ from temporalio.common import RetryPolicy
 from posthog.batch_exports.service import RedshiftBatchExportInputs
 from posthog.temporal.workflows.base import PostHogWorkflow
 from posthog.temporal.workflows.batch_exports import (
-    ROWS_EXPORTED,
     CreateBatchExportRunInputs,
     UpdateBatchExportRunStatusInputs,
     create_export_run,

--- a/posthog/temporal/workflows/s3_batch_export.py
+++ b/posthog/temporal/workflows/s3_batch_export.py
@@ -15,8 +15,6 @@ from temporalio.common import RetryPolicy
 from posthog.batch_exports.service import S3BatchExportInputs
 from posthog.temporal.workflows.base import PostHogWorkflow
 from posthog.temporal.workflows.batch_exports import (
-    BYTES_EXPORTED,
-    ROWS_EXPORTED,
     BatchExportTemporaryFile,
     CreateBatchExportRunInputs,
     UpdateBatchExportRunStatusInputs,
@@ -28,6 +26,7 @@ from posthog.temporal.workflows.batch_exports import (
 )
 from posthog.temporal.workflows.clickhouse import get_client
 from posthog.temporal.workflows.logger import bind_batch_exports_logger
+from posthog.temporal.workflows.metrics import get_bytes_exported_metric, get_rows_exported_metric
 
 
 def get_allowed_template_variables(inputs) -> dict[str, str]:
@@ -431,6 +430,8 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
 
         async with s3_upload as s3_upload:
             with BatchExportTemporaryFile(compression=inputs.compression) as local_results_file:
+                rows_exported = get_rows_exported_metric()
+                bytes_exported = get_bytes_exported_metric()
 
                 async def flush_to_s3(last_uploaded_part_timestamp: str, last=False):
                     logger.debug(
@@ -442,8 +443,8 @@ async def insert_into_s3_activity(inputs: S3InsertInputs):
                     )
 
                     await s3_upload.upload_part(local_results_file)
-                    ROWS_EXPORTED.labels(destination="s3").inc(local_results_file.records_since_last_reset)
-                    BYTES_EXPORTED.labels(destination="s3").inc(local_results_file.bytes_since_last_reset)
+                    rows_exported.add(local_results_file.records_since_last_reset)
+                    bytes_exported.add(local_results_file.bytes_since_last_reset)
 
                     activity.heartbeat(last_uploaded_part_timestamp, s3_upload.to_state())
 

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -24,6 +24,7 @@ from posthog.temporal.workflows.batch_exports import (
 )
 from posthog.temporal.workflows.clickhouse import get_client
 from posthog.temporal.workflows.logger import bind_batch_exports_logger
+from posthog.temporal.workflows.metrics import get_bytes_exported_metric, get_rows_exported_metric
 
 
 class SnowflakeFileNotUploadedError(Exception):
@@ -178,11 +179,14 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs):
             local_results_file = tempfile.NamedTemporaryFile(suffix=".jsonl")
             rows_in_file = 0
 
+            rows_exported = get_rows_exported_metric()
+            bytes_exported = get_bytes_exported_metric()
+
             def flush_to_snowflake(lrf: tempfile._TemporaryFileWrapper, rows_in_file: int):
                 lrf.flush()
                 put_file_to_snowflake_table(cursor, lrf.name, inputs.table_name)
-                ROWS_EXPORTED.labels(destination="snowflake").inc(rows_in_file)
-                BYTES_EXPORTED.labels(destination="snowflake").inc(lrf.tell())
+                rows_exported.add(rows_in_file)
+                bytes_exported.add(lrf.tell())
 
             try:
                 while True:

--- a/posthog/temporal/workflows/snowflake_batch_export.py
+++ b/posthog/temporal/workflows/snowflake_batch_export.py
@@ -12,8 +12,6 @@ from temporalio.common import RetryPolicy
 from posthog.batch_exports.service import SnowflakeBatchExportInputs
 from posthog.temporal.workflows.base import PostHogWorkflow
 from posthog.temporal.workflows.batch_exports import (
-    BYTES_EXPORTED,
-    ROWS_EXPORTED,
     CreateBatchExportRunInputs,
     UpdateBatchExportRunStatusInputs,
     create_export_run,

--- a/requirements.in
+++ b/requirements.in
@@ -79,7 +79,7 @@ social-auth-core==4.3.0
 statshog==1.0.6
 structlog==23.2.0
 sqlparse==0.4.4
-temporalio==1.1.0
+temporalio==1.4.0
 token-bucket==0.3.0
 toronado==0.1.0
 webdriver_manager==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -503,7 +503,7 @@ structlog==23.2.0
     # via
     #   -r requirements.in
     #   django-structlog
-temporalio==1.1.0
+temporalio==1.4.0
     # via -r requirements.in
 tenacity==6.1.0
     # via celery-redbeat


### PR DESCRIPTION
…n metrics support

## Problem

The temporalio SDK already exposes its own Prometheus server and metrics (and not via a Python dependency, but via their Core SDK built in Rust). The [latest temporalio SDK exposes access to this metrics server](https://github.com/temporalio/sdk-python/releases) so you can add custom metrics.

Using this helps a few things:

1. We don't have to run and scrape 2 Prometheus servers (one for our Python stuff and one for temporal metrics)
2. Their metrics stuff respects retries inside of workflows (i.e. doesn't double increment), for when we want to add more metrics there
3. We get things like the activity name (which includes destination) for free
4. We don't re-export and scrape a ton of unrelated Django metrics just because they happen to be defined at module level

Once this is merged I can scrape the temporal metrics server and we'll both temporal metrics and our custom ones from the same place.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Upgrade temporalio dep, use it for metrics.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
