### PR TITLE
fix: fix unsubscribe survey typo

### DIFF
--- a/cypress/e2e/billingv2.cy.ts
+++ b/cypress/e2e/billingv2.cy.ts
@@ -9,13 +9,18 @@ describe('Billing', () => {
         cy.intercept('/api/billing-v2/deactivate?products=product_analytics', {
             fixture: 'api/billing-v2/billing-v2-unsubscribed-product-analytics.json',
         }).as('unsubscribeProductAnalytics')
+        cy.intercept('POST', '/e/?compression=gzip-js').as('eventAPICall')
+
         cy.get('[data-attr=more-button]').first().click()
         cy.contains('.LemonButton', 'Unsubscribe').click()
         cy.get('.LemonModal__content h3').should(
             'contain',
             'Why are you unsubscribing from Product analytics + data stack?'
         )
+        cy.get('[data-attr=unsubscribe-reason-survey-textarea]').type('Product analytics')
         cy.contains('.LemonModal .LemonButton', 'Unsubscribe').click()
+
+        cy.wait(['@eventAPICall']).its('response.statusCode').should('eq', '200')
 
         cy.get('.LemonModal').should('not.exist')
         cy.wait(['@unsubscribeProductAnalytics'])

--- a/cypress/e2e/billingv2.cy.ts
+++ b/cypress/e2e/billingv2.cy.ts
@@ -9,7 +9,6 @@ describe('Billing', () => {
         cy.intercept('/api/billing-v2/deactivate?products=product_analytics', {
             fixture: 'api/billing-v2/billing-v2-unsubscribed-product-analytics.json',
         }).as('unsubscribeProductAnalytics')
-        cy.intercept('POST', '/e/?compression=gzip-js').as('eventAPICall')
 
         cy.get('[data-attr=more-button]').first().click()
         cy.contains('.LemonButton', 'Unsubscribe').click()
@@ -19,8 +18,6 @@ describe('Billing', () => {
         )
         cy.get('[data-attr=unsubscribe-reason-survey-textarea]').type('Product analytics')
         cy.contains('.LemonModal .LemonButton', 'Unsubscribe').click()
-
-        cy.wait(['@eventAPICall']).its('response.statusCode').should('eq', '200')
 
         cy.get('.LemonModal').should('not.exist')
         cy.wait(['@unsubscribeProductAnalytics'])

--- a/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
+++ b/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
@@ -9,7 +9,7 @@ export const UnsubscribeSurveyModal = ({ product }: { product: BillingProductV2T
     const { setSurveyResponse, reportSurveySent, reportSurveyDismissed } = useActions(billingProductLogic({ product }))
     const { deactivateProduct } = useActions(billingLogic)
 
-    const textAreaNotEmpty = surveyResponse['$survey_repsonse']?.length > 0
+    const textAreaNotEmpty = surveyResponse['$survey_response']?.length > 0
     return (
         <LemonModal
             onClose={() => {


### PR DESCRIPTION
## Problem

There was a typo in the logic for checking whether the survey response was empty that was causing us to send 'survey dismissed' instead of 'survey sent' events. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
