### PR TITLE
fix(exports): breakdown limit

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -819,9 +819,16 @@ Using the correct cache and enriching the response with dashboard specific confi
         except HogQLException as e:
             raise ValidationError(str(e))
         filter = Filter(request=request, team=self.team)
+
+        params_breakdown_limit = request.GET.get("breakdown_limit")
+        if params_breakdown_limit is not None and params_breakdown_limit != "":
+            breakdown_values_limit = int(params_breakdown_limit)
+        else:
+            breakdown_values_limit = BREAKDOWN_VALUES_LIMIT
+
         next = (
-            format_paginated_url(request, filter.offset, BREAKDOWN_VALUES_LIMIT)
-            if len(result["result"]) >= BREAKDOWN_VALUES_LIMIT
+            format_paginated_url(request, filter.offset, breakdown_values_limit)
+            if len(result["result"]) >= breakdown_values_limit
             else None
         )
         if self.request.accepted_renderer.format == "csv":


### PR DESCRIPTION
## Problem
- When doing a CSV export with breakdown values, we send a `breakdown_limit` as the result limit from the insights api response. But this is then ignored when building the pagination url, and instead, the default limit of 25 is used. This means we duplicated results in the CSV files when there were more than 25 breakdown values
- [support ticket](https://posthoghelp.zendesk.com/agent/tickets/7251)

## Changes
- Uses the `breakdown_limit` param from the query string when it exists instead of the default `limit` for the pagination url of insights

## How did you test this code?
Recreating the issue and exporting locally with the correct results