### PR TITLE
fix: vscode launch file to debug celery tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,15 +21,15 @@
                 "redbeat.RedBeatScheduler",
                 "--without-heartbeat",
                 "--without-gossip",
-                "--without-mingle"
+                "--without-mingle",
+                "-Ofair",
+                "-n",
+                "node@%h"
             ],
             "env": {
-                "PYTHONUNBUFFERED": "1",
+                "SKIP_ASYNC_MIGRATIONS_SETUP": "0",
                 "DEBUG": "1",
-                "CLICKHOUSE_SECURE": "False",
-                "KAFKA_HOSTS": "localhost:9092",
-                "DATABASE_URL": "postgres://posthog:posthog@localhost:5432/posthog",
-                "WORKER_CONCURRENCY": "2",
+                "BILLING_SERVICE_URL": "https://billing.dev.posthog.dev",
                 "SKIP_SERVICE_VERSION_REQUIREMENTS": "1"
             }
         },


### PR DESCRIPTION
## Problem
- Using the existing vscode launch config for celery didn't allow me to debug tasks, and workers would spontaneously fail

## Changes
- Update the launch config with the same settings as what celery is loaded with in `./bin/start`

## How did you test this code?
- Run a task locally and debug it 🤓 
