### PR TITLE
fix(notebooks): use varying keys for sampling filter

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/samplingFilterLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/samplingFilterLogic.ts
@@ -1,4 +1,4 @@
-import { kea, path, connect, actions, reducers, props, selectors, listeners } from 'kea'
+import { kea, path, connect, actions, reducers, props, selectors, listeners, key } from 'kea'
 import { subscriptions } from 'kea-subscriptions'
 
 import { insightVizDataLogic } from '../insightVizDataLogic'
@@ -6,12 +6,14 @@ import { insightVizDataLogic } from '../insightVizDataLogic'
 import { InsightLogicProps } from '~/types'
 
 import type { samplingFilterLogicType } from './samplingFilterLogicType'
+import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 
 export const AVAILABLE_SAMPLING_PERCENTAGES = [0.1, 1, 10, 25]
 
 export const samplingFilterLogic = kea<samplingFilterLogicType>([
-    path(['scenes', 'insights', 'EditorFilters', 'samplingFilterLogic']),
     props({} as InsightLogicProps),
+    key(keyForInsightLogicProps('new')),
+    path((key) => ['scenes', 'insights', 'EditorFilters', 'samplingFilterLogic', key]),
     connect((props: InsightLogicProps) => ({
         values: [insightVizDataLogic(props), ['querySource']],
         actions: [insightVizDataLogic(props), ['updateQuerySource']],


### PR DESCRIPTION
## Problem

The sampling filter isn't uniquely keyed. Therefore we couldn't have multiple sampling filters on the same page.

See how updating one samping filter updates the other filter as well:

![2023-11-14 13 59 57](https://github.com/PostHog/posthog/assets/1851359/3e145209-463b-4f08-89e5-fe7ee5d2f1ef)

## Changes

This PR uniquely keys the relevant logics.

## How did you test this code?

Locally, with 👀