### PR TITLE
fix: Use timezone aware now in backfill

### DIFF
--- a/posthog/temporal/workflows/backfill_batch_export.py
+++ b/posthog/temporal/workflows/backfill_batch_export.py
@@ -145,7 +145,7 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
     full_backfill_range = backfill_range(start_at, end_at, frequency * inputs.buffer_limit)
 
     for backfill_start_at, backfill_end_at in full_backfill_range:
-        utcnow = dt.datetime.utcnow()
+        utcnow = dt.datetime.now(dt.timezone.utc)
 
         if jitter is not None:
             backfill_end_at = backfill_end_at + jitter


### PR DESCRIPTION
## Problem

Seeing that Temporal cloud has stopped taking naive datetimes as inputs for search queries (which the backfill workflow uses). So, let's use timezone aware methods instead.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
