### PR TITLE
fix(batch-exports): move start/finish metric to workflow level

### DIFF
--- a/posthog/temporal/workflows/metrics.py
+++ b/posthog/temporal/workflows/metrics.py
@@ -1,4 +1,4 @@
-from temporalio import activity
+from temporalio import activity, workflow
 from temporalio.common import MetricCounter
 
 
@@ -11,12 +11,12 @@ def get_bytes_exported_metric() -> MetricCounter:
 
 
 def get_export_started_metric() -> MetricCounter:
-    return activity.metric_meter().create_counter("batch_export_started", "Number of batch exports started.")
+    return workflow.metric_meter().create_counter("batch_export_started", "Number of batch exports started.")
 
 
 def get_export_finished_metric(status: str) -> MetricCounter:
     return (
-        activity.metric_meter()
+        workflow.metric_meter()
         .with_additional_attributes({"status": status})
         .create_counter(
             "batch_export_finished", "Number of batch exports finished, for any reason (including failure)."


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Where these were (at the activity level) we only knew that the activity was a `create_export_run` and a `update_export_run_status`. But we want to know the destination, so putting these at the Workflow level makes more sense.

## Changes

Move start/finish metrics from activity to workflow.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
