### PR TITLE
feat(insights): hogql insight load on load

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -131,7 +131,13 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                     }
 
                     if (props.cachedResults && !refresh) {
-                        return props.cachedResults
+                        if (
+                            props.cachedResults['result'] ||
+                            props.cachedResults['results'] ||
+                            !isInsightQueryNode(props.query)
+                        ) {
+                            return props.cachedResults
+                        }
                     }
 
                     if (!values.currentTeamId) {


### PR DESCRIPTION
## Problem

HogQL insights wouldn't load when opened from the insights list:

![2023-11-14 15 57 31](https://github.com/PostHog/posthog/assets/53387/8970df13-e9c1-49fe-8c46-d27172b8a6e9)


## Changes

Reloads data if no "results" in cached results. The insights lists had cached the rest of the metadata for an insight.

![2023-11-14 15 58 29](https://github.com/PostHog/posthog/assets/53387/54858424-742e-4873-9c09-b761483873b8)

I don't have data locally, but it did start loading and return an empty result from the API. There was no request before.

## How did you test this code?

In the browser.