### PR TITLE
chore(3000): Unflag the Docs side panel

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -35,10 +35,7 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                     tabs.push(SidePanelTab.Support)
                 }
 
-                if (featureFlags[FEATURE_FLAGS.SIDE_PANEL_DOCS]) {
-                    tabs.push(SidePanelTab.Docs)
-                }
-
+                tabs.push(SidePanelTab.Docs)
                 tabs.push(SidePanelTab.Settings)
                 tabs.push(SidePanelTab.Activation)
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -172,7 +172,6 @@ export const FEATURE_FLAGS = {
     NOTEBOOK_CANVASES: 'notebook-canvases', // owner: #team-monitoring
     SESSION_RECORDING_SAMPLING: 'session-recording-sampling', // owner: #team-monitoring
     PERSON_FEED_CANVAS: 'person-feed-canvas', // owner: #project-canvas
-    SIDE_PANEL_DOCS: 'side-panel-docs', // owner: #noteforce-3000
     MULTI_PROJECT_FEATURE_FLAGS: 'multi-project-feature-flags', // owner: @jurajmajerik #team-feature-success
     NETWORK_PAYLOAD_CAPTURE: 'network-payload-capture', // owner: #team-monitoring
 } as const

--- a/frontend/src/lib/lemon-ui/Link/Link.tsx
+++ b/frontend/src/lib/lemon-ui/Link/Link.tsx
@@ -82,7 +82,6 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
             href: typeof to === 'string' ? to : undefined,
         })
 
-        const docsPanelEnabled = useFeatureFlag('SIDE_PANEL_DOCS')
         const is3000 = useFeatureFlag('POSTHOG_3000')
         const { openDocsPage } = useActions(sidePanelDocsLogic)
 
@@ -99,7 +98,7 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
                 return
             }
 
-            if (typeof to === 'string' && is3000 && docsPanelEnabled && isPostHogComDomain(to)) {
+            if (typeof to === 'string' && is3000 && isPostHogComDomain(to)) {
                 event.preventDefault()
                 openDocsPage(to)
                 return


### PR DESCRIPTION
## Changes

The Docs side panel feels like such an integral part of the 3000 experience, that I suggest unflagging it. Especially since we've just deployed a bunch of improvements to its mechanics.