### PR TITLE
chore(batch-exports): use Temporal interceptor for Sentry

### DIFF
--- a/posthog/temporal/sentry.py
+++ b/posthog/temporal/sentry.py
@@ -1,0 +1,83 @@
+from dataclasses import asdict, is_dataclass
+from typing import Any, Optional, Type, Union
+
+from temporalio import activity, workflow
+from temporalio.worker import (
+    ActivityInboundInterceptor,
+    ExecuteActivityInput,
+    ExecuteWorkflowInput,
+    Interceptor,
+    WorkflowInboundInterceptor,
+    WorkflowInterceptorClassInput,
+)
+
+with workflow.unsafe.imports_passed_through():
+    from sentry_sdk import Hub, capture_exception, set_context, set_tag
+
+
+def _set_common_workflow_tags(info: Union[workflow.Info, activity.Info]):
+    set_tag("temporal.workflow.type", info.workflow_type)
+    set_tag("temporal.workflow.id", info.workflow_id)
+
+
+class _SentryActivityInboundInterceptor(ActivityInboundInterceptor):
+    async def execute_activity(self, input: ExecuteActivityInput) -> Any:
+        # https://docs.sentry.io/platforms/python/troubleshooting/#addressing-concurrency-issues
+        with Hub(Hub.current):
+            set_tag("temporal.execution_type", "activity")
+            set_tag("module", input.fn.__module__ + "." + input.fn.__qualname__)
+
+            activity_info = activity.info()
+            _set_common_workflow_tags(activity_info)
+            set_tag("temporal.activity.id", activity_info.activity_id)
+            set_tag("temporal.activity.type", activity_info.activity_type)
+            set_tag("temporal.activity.task_queue", activity_info.task_queue)
+            set_tag("temporal.workflow.namespace", activity_info.workflow_namespace)
+            set_tag("temporal.workflow.run_id", activity_info.workflow_run_id)
+            try:
+                return await super().execute_activity(input)
+            except Exception as e:
+                if len(input.args) == 1 and is_dataclass(input.args[0]):
+                    set_context("temporal.activity.input", asdict(input.args[0]))
+                set_context("temporal.activity.info", activity.info().__dict__)
+                capture_exception()
+                raise e
+
+
+class _SentryWorkflowInterceptor(WorkflowInboundInterceptor):
+    async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
+        # https://docs.sentry.io/platforms/python/troubleshooting/#addressing-concurrency-issues
+        with Hub(Hub.current):
+            set_tag("temporal.execution_type", "workflow")
+            set_tag("module", input.run_fn.__module__ + "." + input.run_fn.__qualname__)
+            workflow_info = workflow.info()
+            _set_common_workflow_tags(workflow_info)
+            set_tag("temporal.workflow.task_queue", workflow_info.task_queue)
+            set_tag("temporal.workflow.namespace", workflow_info.namespace)
+            set_tag("temporal.workflow.run_id", workflow_info.run_id)
+            try:
+                return await super().execute_workflow(input)
+            except Exception as e:
+                if len(input.args) == 1 and is_dataclass(input.args[0]):
+                    set_context("temporal.workflow.input", asdict(input.args[0]))
+                set_context("temporal.workflow.info", workflow.info().__dict__)
+
+                if not workflow.unsafe.is_replaying():
+                    with workflow.unsafe.sandbox_unrestricted():
+                        capture_exception()
+                raise e
+
+
+class SentryInterceptor(Interceptor):
+    """Temporal Interceptor class which will report workflow & activity exceptions to Sentry"""
+
+    def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
+        """Implementation of
+        :py:meth:`temporalio.worker.Interceptor.intercept_activity`.
+        """
+        return _SentryActivityInboundInterceptor(super().intercept_activity(next))
+
+    def workflow_interceptor_class(
+        self, input: WorkflowInterceptorClassInput
+    ) -> Optional[Type[WorkflowInboundInterceptor]]:
+        return _SentryWorkflowInterceptor

--- a/posthog/temporal/worker.py
+++ b/posthog/temporal/worker.py
@@ -7,6 +7,7 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.temporal.client import connect
 from posthog.temporal.workflows import ACTIVITIES, WORKFLOWS
+from posthog.temporal.sentry import SentryInterceptor
 
 
 async def start_worker(
@@ -36,6 +37,7 @@ async def start_worker(
         activities=ACTIVITIES,
         workflow_runner=UnsandboxedWorkflowRunner(),
         graceful_shutdown_timeout=timedelta(minutes=5),
+        interceptors=[SentryInterceptor()],
     )
 
     # catch the TERM signal, and stop the worker gracefully


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We don't capture exceptions thrown inside Temporal activities/workflows anywhere.

## Changes

Bring in [the example Sentry Interceptor](https://github.com/temporalio/samples-python/blob/68ba233c5c8e1073d4f5a5c5db9e6e86c940a332/sentry/interceptor.py) but change it to not log all inputs (as they may contain sensitive data). We get the Workflow/Activity ID which should be enough to find the inputs if we need to. Note that Sentry does have some considerations for removing sensitive data, but since this is people's DB/Cloud auth keys I'd really rather have an allowlist than trust any automated sensitive-key-remover.

I also try to add `team_id` if it's on the inputs, because being able to use Sentry to aggregate/search by customer is very useful.

Replaces this PR: https://github.com/PostHog/posthog/pull/18618

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
