### PR TITLE
fix: Use sasl_params instead of ssl context for batch exports logger

### DIFF
--- a/posthog/temporal/workflows/logger.py
+++ b/posthog/temporal/workflows/logger.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from structlog.processors import EventRenamer
 from structlog.typing import FilteringBoundLogger
 
-from posthog.kafka_client.helper import get_kafka_ssl_context
+from posthog.kafka_client.client import _sasl_params
 from posthog.kafka_client.topics import KAFKA_LOG_ENTRIES
 
 BACKGROUND_LOGGER_TASKS = set()
@@ -255,7 +255,7 @@ class KafkaLogProducerFromQueue:
                 security_protocol=settings.KAFKA_SECURITY_PROTOCOL or "PLAINTEXT",
                 acks="all",
                 api_version="2.5.0",
-                ssl_context=get_kafka_ssl_context(),
+                **_sasl_params(),
             )
         )
         self.logger = structlog.get_logger()


### PR DESCRIPTION
## Problem

SSL Context setup is not working for the batch exports logger. So, let's try the other option: sasl_params.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
