### PR TITLE
refactor: Postgres (+ Redshift) batch exports now async

### DIFF
--- a/posthog/temporal/tests/batch_exports/conftest.py
+++ b/posthog/temporal/tests/batch_exports/conftest.py
@@ -1,5 +1,7 @@
+import psycopg
 import pytest
 import pytest_asyncio
+from psycopg import sql
 
 
 @pytest.fixture
@@ -40,3 +42,71 @@ async def truncate_events(clickhouse_client):
     """
     yield
     await clickhouse_client.execute_query("TRUNCATE TABLE IF EXISTS `sharded_events`")
+
+
+@pytest_asyncio.fixture
+async def setup_postgres_test_db(postgres_config):
+    """Fixture to manage a database for Redshift export testing.
+
+    Managing a test database involves the following steps:
+    1. Creating a test database.
+    2. Initializing a connection to that database.
+    3. Creating a test schema.
+    4. Yielding the connection to be used in tests.
+    5. After tests, drop the test schema and any tables in it.
+    6. Drop the test database.
+    """
+    connection = await psycopg.AsyncConnection.connect(
+        user=postgres_config["user"],
+        password=postgres_config["password"],
+        host=postgres_config["host"],
+        port=postgres_config["port"],
+    )
+    await connection.set_autocommit(True)
+
+    async with connection.cursor() as cursor:
+        await cursor.execute(
+            sql.SQL("SELECT 1 FROM pg_database WHERE datname = %s"),
+            (postgres_config["database"],),
+        )
+
+        if await cursor.fetchone() is None:
+            await cursor.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(postgres_config["database"])))
+
+    await connection.close()
+
+    # We need a new connection to connect to the database we just created.
+    connection = await psycopg.AsyncConnection.connect(
+        user=postgres_config["user"],
+        password=postgres_config["password"],
+        host=postgres_config["host"],
+        port=postgres_config["port"],
+        dbname=postgres_config["database"],
+    )
+    await connection.set_autocommit(True)
+
+    async with connection.cursor() as cursor:
+        await cursor.execute(
+            sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(postgres_config["schema"]))
+        )
+
+    yield
+
+    async with connection.cursor() as cursor:
+        await cursor.execute(sql.SQL("DROP SCHEMA {} CASCADE").format(sql.Identifier(postgres_config["schema"])))
+
+    await connection.close()
+
+    # We need a new connection to drop the database, as we cannot drop the current database.
+    connection = await psycopg.AsyncConnection.connect(
+        user=postgres_config["user"],
+        password=postgres_config["password"],
+        host=postgres_config["host"],
+        port=postgres_config["port"],
+    )
+    await connection.set_autocommit(True)
+
+    async with connection.cursor() as cursor:
+        await cursor.execute(sql.SQL("DROP DATABASE {}").format(sql.Identifier(postgres_config["database"])))
+
+    await connection.close()

--- a/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
@@ -5,11 +5,11 @@ from random import randint
 from uuid import uuid4
 
 import psycopg
-import psycopg.sql
 import pytest
 import pytest_asyncio
 from django.conf import settings
 from django.test import override_settings
+from psycopg import sql
 from temporalio import activity
 from temporalio.client import WorkflowFailureError
 from temporalio.common import RetryPolicy
@@ -41,9 +41,7 @@ async def assert_events_in_postgres(connection, schema, table_name, events, excl
 
     async with connection.cursor() as cursor:
         await cursor.execute(
-            psycopg.sql.SQL("SELECT * FROM {} ORDER BY event, timestamp").format(
-                psycopg.sql.Identifier(schema, table_name)
-            )
+            sql.SQL("SELECT * FROM {} ORDER BY event, timestamp").format(sql.Identifier(schema, table_name))
         )
         columns = [column.name for column in cursor.description]
 
@@ -110,14 +108,12 @@ async def setup_test_db(postgres_config):
 
     async with connection.cursor() as cursor:
         await cursor.execute(
-            psycopg.sql.SQL("SELECT 1 FROM pg_database WHERE datname = %s"),
+            sql.SQL("SELECT 1 FROM pg_database WHERE datname = %s"),
             (postgres_config["database"],),
         )
 
         if await cursor.fetchone() is None:
-            await cursor.execute(
-                psycopg.sql.SQL("CREATE DATABASE {}").format(psycopg.sql.Identifier(postgres_config["database"]))
-            )
+            await cursor.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(postgres_config["database"])))
 
     await connection.close()
 
@@ -133,15 +129,13 @@ async def setup_test_db(postgres_config):
 
     async with connection.cursor() as cursor:
         await cursor.execute(
-            psycopg.sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(psycopg.sql.Identifier(postgres_config["schema"]))
+            sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(postgres_config["schema"]))
         )
 
     yield
 
     async with connection.cursor() as cursor:
-        await cursor.execute(
-            psycopg.sql.SQL("DROP SCHEMA {} CASCADE").format(psycopg.sql.Identifier(postgres_config["schema"]))
-        )
+        await cursor.execute(sql.SQL("DROP SCHEMA {} CASCADE").format(sql.Identifier(postgres_config["schema"])))
 
     await connection.close()
 
@@ -155,9 +149,7 @@ async def setup_test_db(postgres_config):
     await connection.set_autocommit(True)
 
     async with connection.cursor() as cursor:
-        await cursor.execute(
-            psycopg.sql.SQL("DROP DATABASE {}").format(psycopg.sql.Identifier(postgres_config["database"]))
-        )
+        await cursor.execute(sql.SQL("DROP DATABASE {}").format(sql.Identifier(postgres_config["database"])))
 
     await connection.close()
 

--- a/posthog/temporal/workflows/postgres_batch_export.py
+++ b/posthog/temporal/workflows/postgres_batch_export.py
@@ -122,7 +122,7 @@ async def create_table_in_postgres(
                     # This is safe as we are hardcoding the type values anyways.
                     sql.SQL("{field} {type}").format(
                         field=sql.Identifier(field),
-                        type=sql.SQL(field_type),  # type: ignore
+                        type=sql.SQL(field_type),
                     )
                     for field, field_type in fields
                 ),

--- a/posthog/temporal/workflows/redshift_batch_export.py
+++ b/posthog/temporal/workflows/redshift_batch_export.py
@@ -4,10 +4,7 @@ import json
 import typing
 from dataclasses import dataclass
 
-import psycopg2
-import psycopg2.extensions
-import psycopg2.extras
-from psycopg2 import sql
+import psycopg
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
@@ -32,9 +29,9 @@ from posthog.temporal.workflows.postgres_batch_export import (
 )
 
 
-def insert_records_to_redshift(
+async def insert_records_to_redshift(
     records: collections.abc.Iterator[dict[str, typing.Any]],
-    redshift_connection: psycopg2.extensions.connection,
+    redshift_connection: psycopg.AsyncConnection,
     schema: str,
     table: str,
     batch_size: int = 100,
@@ -62,18 +59,18 @@ def insert_records_to_redshift(
 
     columns = batch[0].keys()
 
-    with redshift_connection.cursor() as cursor:
-        query = sql.SQL("INSERT INTO {table} ({fields}) VALUES {placeholder}").format(
-            table=sql.Identifier(schema, table),
-            fields=sql.SQL(", ").join(map(sql.Identifier, columns)),
-            placeholder=sql.Placeholder(),
+    async with redshift_connection.cursor() as cursor:
+        query = psycopg.sql.SQL("INSERT INTO {table} ({fields}) VALUES {placeholder}").format(
+            table=psycopg.sql.Identifier(schema, table),
+            fields=psycopg.sql.SQL(", ").join(map(psycopg.sql.Identifier, columns)),
+            placeholder=psycopg.sql.Placeholder(),
         )
-        template = sql.SQL("({})").format(sql.SQL(", ").join(map(sql.Placeholder, columns)))
+        template = psycopg.sql.SQL("({})").format(psycopg.sql.SQL(", ").join(map(psycopg.sql.Placeholder, columns)))
 
         rows_exported = get_rows_exported_metric()
 
-        def flush_to_redshift():
-            psycopg2.extras.execute_values(cursor, query, batch, template)
+        async def flush_to_redshift():
+            await cursor.execute_many(cursor, query, batch, template)
             rows_exported.add(len(batch))
             # It would be nice to record BYTES_EXPORTED for Redshift, but it's not worth estimating
             # the byte size of each batch the way things are currently written. We can revisit this
@@ -85,11 +82,11 @@ def insert_records_to_redshift(
             if len(batch) < batch_size:
                 continue
 
-            flush_to_redshift()
+            await flush_to_redshift()
             batch = []
 
         if len(batch) > 0:
-            flush_to_redshift()
+            await flush_to_redshift()
 
 
 @dataclass
@@ -160,7 +157,7 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs):
         )
         properties_type = "VARCHAR(65535)" if inputs.properties_data_type == "varchar" else "SUPER"
 
-        with postgres_connection(inputs) as connection:
+        async with postgres_connection(inputs) as connection:
             create_table_in_postgres(
                 connection,
                 schema=inputs.schema,
@@ -202,8 +199,8 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs):
                 for key in schema_columns
             }
 
-        with postgres_connection(inputs) as connection:
-            insert_records_to_redshift(
+        async with postgres_connection(inputs) as connection:
+            await insert_records_to_redshift(
                 (map_to_record(result) for result in results_iterator), connection, inputs.schema, inputs.table_name
             )
 

--- a/requirements.in
+++ b/requirements.in
@@ -59,6 +59,7 @@ Pillow==9.2.0
 posthoganalytics==3.0.1
 prance==0.22.2.22.0
 psycopg2-binary==2.9.7
+psycopg==3.1
 pyarrow==12.0.1
 pydantic==2.3.0
 pyjwt==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -362,6 +362,8 @@ protobuf==4.22.1
     #   grpcio-status
     #   proto-plus
     #   temporalio
+psycopg==3.1
+    # via -r requirements.in
 psycopg2-binary==2.9.7
     # via -r requirements.in
 ptyprocess==0.6.0
@@ -529,6 +531,7 @@ types-s3transfer==0.6.1
     # via boto3-stubs
 typing-extensions==4.7.1
     # via
+    #   psycopg
     #   pydantic
     #   pydantic-core
     #   qrcode


### PR DESCRIPTION
## Problem

Making PG batch exports async means less blocking the main thread, more concurrent tasks, more performance! Let's do all destinations async and bring down the number of required workers!

Turns out is quite easy to make Postgres batch exports async. What's more, the new COPY API doesn't require a file, so we may try a different buffered approach in the future. I'm very excited for the future of batch exports!

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Add psycopg dependency
* Replace psycopg2 for psycopg everywhere.
* Sprinkle in `async` and `await`.
* The only user-facing change is that ip and site url are now `""` instead of `None`, but I don't think that's very significant: at least semantically we are not losing or gaining anything as these fields are meant to be deprecated, and in terms of schema both are compatible.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Same tests as before, just now async too.
Also added redshift tests that target local postgres db instance. Since postgres is fairly compatible with Redshift, having automated tests is better than nothing (of course, tests can still be run against a real Redshift instance).

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
