### PR TITLE
fix(notebooks): use varying keys for path and retention filters

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/PathsExclusions.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/PathsExclusions.tsx
@@ -4,6 +4,7 @@ import { pathsDataLogic } from 'scenes/paths/pathsDataLogic'
 
 import { EventPropertyFilter, PropertyFilterType, PropertyOperator, EditorFilterProps } from '~/types'
 import { PathItemFilters } from 'lib/components/PropertyFilters/PathItemFilters'
+import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 
 export function PathsExclusions({ insightProps }: EditorFilterProps): JSX.Element {
     const { pathsFilter, taxonomicGroupTypes } = useValues(pathsDataLogic(insightProps))
@@ -13,7 +14,7 @@ export function PathsExclusions({ insightProps }: EditorFilterProps): JSX.Elemen
     return (
         <PathItemFilters
             taxonomicGroupTypes={taxonomicGroupTypes}
-            pageKey="exclusion"
+            pageKey={`${keyForInsightLogicProps('new')(insightProps)}-exclude_events`}
             propertyFilters={
                 exclude_events &&
                 exclude_events.map(

--- a/frontend/src/scenes/insights/EditorFilters/RetentionSummary.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/RetentionSummary.tsx
@@ -53,7 +53,7 @@ export function RetentionSummary({ insightProps }: EditorFilterProps): JSX.Eleme
                                 updateInsightFilter({ target_entity: undefined })
                             }
                         }}
-                        typeKey={`${keyForInsightLogicProps('new')(insightProps)}-RetentionSummary`}
+                        typeKey={`${keyForInsightLogicProps('new')(insightProps)}-target_entity`}
                     />
                 </span>
                 <LemonSelect
@@ -113,7 +113,7 @@ export function RetentionSummary({ insightProps }: EditorFilterProps): JSX.Eleme
                                 updateInsightFilter({ returning_entity: undefined })
                             }
                         }}
-                        typeKey="retention-table-returning"
+                        typeKey={`${keyForInsightLogicProps('new')(insightProps)}-returning_entity`}
                     />
                 </span>
                 on any of the next {dateOptionPlurals[period ?? 'Day']}.


### PR DESCRIPTION
## Problem

Some path and retention filters aren't uniquely keyed. Therefore we couldn't have multiple filters on the same page.

## Changes

This PR keys them uniquely.

## How did you test this code?

Clicking around