### PR TITLE
fix: Request batch export logs with level filter

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1258,7 +1258,7 @@ const api = {
             const params = toParams(
                 {
                     limit: LOGS_PORTION_LIMIT,
-                    type_filter: typeFilters,
+                    level_filter: typeFilters,
                     search: searchTerm || undefined,
                     before: trailingEntry?.timestamp,
                     after: leadingEntry?.timestamp,

--- a/posthog/api/test/batch_exports/operations.py
+++ b/posthog/api/test/batch_exports/operations.py
@@ -113,9 +113,9 @@ def patch_batch_export(client, team_id, batch_export_id, new_batch_export_data):
     )
 
 
-def get_batch_export_log_entries(client: TestClient, team_id: int, batch_export_id: str):
-    return client.get(f"/api/projects/{team_id}/batch_exports/{batch_export_id}/logs")
+def get_batch_export_log_entries(client: TestClient, team_id: int, batch_export_id: str, **extra):
+    return client.get(f"/api/projects/{team_id}/batch_exports/{batch_export_id}/logs", extra)
 
 
-def get_batch_export_run_log_entries(client: TestClient, team_id: int, batch_export_id: str, run_id):
-    return client.get(f"/api/projects/{team_id}/batch_exports/{batch_export_id}/runs/{run_id}/logs")
+def get_batch_export_run_log_entries(client: TestClient, team_id: int, batch_export_id: str, run_id, **extra):
+    return client.get(f"/api/projects/{team_id}/batch_exports/{batch_export_id}/runs/{run_id}/logs", extra)

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -365,7 +365,7 @@ class BatchExportLogViewSet(StructuredViewSetMixin, mixins.ListModelMixin, views
         if before_raw is not None:
             before = dt.datetime.fromisoformat(before_raw.replace("Z", "+00:00"))
 
-        level_filter = [BatchExportLogEntryLevel[t] for t in (self.request.GET.getlist("level_filter", []))]
+        level_filter = [BatchExportLogEntryLevel[t.upper()] for t in (self.request.GET.getlist("level_filter", []))]
         return fetch_batch_export_log_entries(
             team_id=self.parents_query_dict["team_id"],
             batch_export_id=self.parents_query_dict["batch_export_id"],


### PR DESCRIPTION
## Problem

The logs endpoint for batch exports takes a level_filter parameter, not type_filter.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Change type_filter for level_filter
Also accept lowercase level_filter

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
