### PR TITLE
chore(ruff): Add --fix to ruff check pre commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,7 +302,7 @@
         ],
         "!(posthog/hogql/grammar/*)*.{py,pyi}": [
             "ruff format",
-            "ruff check"
+            "ruff check --fix"
         ]
     },
     "browserslist": {


### PR DESCRIPTION
## Problem

I want to commit and ruff has a problem that it can fix itself.

## Changes

- run with `--fix` – is there a downside to this?

## How did you test this code?

- did something that wouldn't pass lint
- got autofixed while commiting 🧹 
