### PR TITLE
fix(support): sort the insight tooltip values by their row index when displaying th…

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -54,14 +54,12 @@ function renderDatumToTableCell(
     // Value can be undefined if the datum's series doesn't have ANY value for the breakdown value being rendered
     return (
         <div className="series-data-cell">
-            {
-                color && (
-                    // eslint-disable-next-line react/forbid-dom-props
-                    <span className="mr-2" style={{ color }}>
-                        ●
-                    </span>
-                ) /* eslint-disable-line react/forbid-dom-props */
-            }
+            {color && (
+                // eslint-disable-next-line react/forbid-dom-props
+                <span className="mr-2" style={{ color }}>
+                    ●
+                </span>
+            )}
             {datumValue !== undefined
                 ? formatAggregationValue(datumMathProperty, datumValue, renderCount, formatPropertyValueForDisplay)
                 : '–'}
@@ -156,7 +154,7 @@ export function InsightTooltip({
                             seriesColumnData?.count,
                             formatPropertyValueForDisplay,
                             renderCount,
-                            seriesColumnData.color
+                            seriesColumnData?.color
                         )
                     },
                 })

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -129,7 +129,7 @@ export function invertDataSource(seriesData: SeriesDatum[]): InvertedSeriesDatum
         if (datumKey in flattenedData) {
             flattenedData[datumKey].seriesData.push(s)
             flattenedData[datumKey].seriesData = flattenedData[datumKey].seriesData.sort(
-                (a, b) => b.dataIndex - a.dataIndex
+                (a, b) => (b.action?.order ?? b.dataIndex) - (a.action?.order ?? a.dataIndex)
             )
         } else {
             flattenedData[datumKey] = {

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -128,6 +128,9 @@ export function invertDataSource(seriesData: SeriesDatum[]): InvertedSeriesDatum
         const datumKey = `${s.breakdown_value}-${s.compare_label}`
         if (datumKey in flattenedData) {
             flattenedData[datumKey].seriesData.push(s)
+            flattenedData[datumKey].seriesData = flattenedData[datumKey].seriesData.sort(
+                (a, b) => b.dataIndex - a.dataIndex
+            )
         } else {
             flattenedData[datumKey] = {
                 id: datumKey,


### PR DESCRIPTION
## Problem
- Reported by researchgate, on insights with breakdowns where the values in the line graph tooltip dont align with the table view (the ordering of values being backward)
- See [Slack thread](https://posthog.slack.com/archives/C04F85S6BGQ/p1700044163352299) for screenshot + further details

## Changes
- It looks like the ordering of tooltip values were a `desc` sort on `count`. This meant that some tooltip values could be backwards if the larger of the breakdown values were in the second set of values (in the `B` set instead of the `A` set). 
- Ordering the values by their `action.order` (if exists) or their `dataIndex` (the order of the series groups) _should_ fix this

## How did you test this code?
- ~Off-topic, but recreating specific user bugs locally to test code is super hard (and the majority of my time on this was spent attempting to do so, rather unsuccessfully)~
- ~Instead, I ended up testing this on the prod site through the sources tab + console. So, not 100% confirmed to solve the actual issue, but I'm fairly sure it will~
- Confirmed this works in storybooks with the response from researchgate - [like this](https://posthog.slack.com/archives/C02E3BKC78F/p1700064970921859)