### PR TITLE
fix(surveys): make auto disappear optional

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -602,6 +602,17 @@ export default function SurveyEdit(): JSX.Element {
                                                                           textPlaceholder="ex: We really appreciate it."
                                                                       />
                                                                   </PureField>
+                                                                  <PureField label="Auto disappear">
+                                                                      <LemonCheckbox
+                                                                          checked={!!survey.appearance.autoDisappear}
+                                                                          onChange={(checked) =>
+                                                                              setSurveyValue('appearance', {
+                                                                                  ...survey.appearance,
+                                                                                  autoDisappear: checked,
+                                                                              })
+                                                                          }
+                                                                      />
+                                                                  </PureField>
                                                               </>
                                                           ),
                                                       },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2195,6 +2195,7 @@ export interface SurveyAppearance {
     displayThankYouMessage?: boolean
     thankYouMessageHeader?: string
     thankYouMessageDescription?: string
+    autoDisappear?: boolean
     position?: string
 }
 


### PR DESCRIPTION
## Problem

Confirmation messages would always auto disappear which is annoying if you want to display a longer thank you message

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
