### PR TITLE
feat(web-analytics): Add staleness check and update warning

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
@@ -25,11 +25,7 @@ export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
                 </p>
                 <p>
                     Please see{' '}
-                    <Link to={'https://posthog.com/docs/libraries/js'}>documentation for how to set up posthog-js</Link>{' '}
-                    and, if you are using a SPA (Single Page Apps) framework{' '}
-                    <Link to={'https://posthog.com/tutorials/single-page-app-pageviews'}>
-                        a tutorial for sending page views in a SPA
-                    </Link>
+                    <Link to={'https://posthog.com/docs/libraries/js'}>documentation for how to set up posthog-js</Link>
                     .
                 </p>
             </LemonBanner>
@@ -39,11 +35,12 @@ export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
             <LemonBanner type={'warning'} className={'mt-2'}>
                 <p>
                     No <code>$pageleave</code> events have been received, this means that Bounce rate and Session
-                    Duration might be inaccurate.
+                    duration might be inaccurate.
                 </p>
                 <p>
                     Please see{' '}
                     <Link to={'https://posthog.com/docs/libraries/js'}>documentation for how to set up posthog-js</Link>
+                    .
                 </p>
             </LemonBanner>
         )

--- a/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
@@ -21,9 +21,16 @@ export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
                             or <code>$pageleave</code>{' '}
                         </>
                     ) : null}
-                    events have been received, please read{' '}
-                    <Link to={'https://posthog.com/docs/product-analytics/capture-events'}>the documentation</Link> and
-                    fix this before using Web Analytics.
+                    events have been received. Web analytics won't work correctly (it'll be a little empty!)
+                </p>
+                <p>
+                    Please see{' '}
+                    <Link to={'https://posthog.com/docs/libraries/js'}>documentation for how to set up posthog-js</Link>{' '}
+                    and, if you are using a SPA (Single Page Apps) framework{' '}
+                    <Link to={'https://posthog.com/tutorials/single-page-app-pageviews'}>
+                        a tutorial for sending page views in a SPA
+                    </Link>
+                    .
                 </p>
             </LemonBanner>
         )
@@ -32,9 +39,11 @@ export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
             <LemonBanner type={'warning'} className={'mt-2'}>
                 <p>
                     No <code>$pageleave</code> events have been received, this means that Bounce rate and Session
-                    Duration might be inaccurate. Please read{' '}
-                    <Link to={'https://posthog.com/docs/product-analytics/capture-events'}>the documentation</Link> and
-                    fix this before using Web Analytics.
+                    Duration might be inaccurate.
+                </p>
+                <p>
+                    Please see{' '}
+                    <Link to={'https://posthog.com/docs/libraries/js'}>documentation for how to set up posthog-js</Link>
                 </p>
             </LemonBanner>
         )


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C03JJKLEC8L/p1700061413856629?thread_ts=1700056233.185239&cid=C03JJKLEC8L

## Changes

* Don't just check that the $pageleave/$pageview events have ever been sent, check that they have also been sent recently (I just used the staleness constant we already had, but might want to shorten this if it turns out to be too long).
* Change the error messages to include more relevant docs.

New error screenshots (ignore the fact that there obviously *are* pageviews)
<img width="1128" alt="Screenshot 2023-11-15 at 20 35 04" src="https://github.com/PostHog/posthog/assets/2056078/260adc9b-6e33-46ec-a1f1-f0a852caf26e">
<img width="1138" alt="Screenshot 2023-11-15 at 20 34 06" src="https://github.com/PostHog/posthog/assets/2056078/6651ed42-44ed-4871-877c-6dbbb1f6eb62">
<img width="1146" alt="Screenshot 2023-11-15 at 20 34 26" src="https://github.com/PostHog/posthog/assets/2056078/c77b61cc-5826-44bb-950d-7a66ef43ff35">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Ran it manually
