### PR TITLE
chore: Add Redshift to create_batch_export_from_app command

### DIFF
--- a/posthog/management/commands/create_batch_export_from_app.py
+++ b/posthog/management/commands/create_batch_export_from_app.py
@@ -228,9 +228,27 @@ def map_plugin_config_to_destination(plugin_config: PluginConfig) -> tuple[str, 
             "exclude_events": plugin_config.config.get("eventsToIgnore", "").split(",") or None,
         }
         export_type = "Postgres"
+
+    elif plugin.name == "Redshift Export Plugin":
+        config = {
+            "database": plugin_config.config["dbName"],
+            "user": plugin_config.config["dbUsername"],
+            "password": plugin_config.config["dbPassword"],
+            "schema": "",
+            "host": plugin_config.config["clusterHost"],
+            "port": int(
+                plugin_config.config.get("clusterPort", "5439"),
+            ),
+            "table_name": plugin_config.config.get("tableName", "posthog_event"),
+            "exclude_events": plugin_config.config.get("eventsToIgnore", "").split(",") or None,
+            "properties_data_type": plugin_config.config.get("propertiesDataType", "varchar"),
+        }
+        export_type = "Redshift"
+
     else:
         raise CommandError(
-            f"Unsupported Plugin: '{plugin.name}'.  Supported Plugins are: 'Snowflake Export' and 'S3 Export Plugin'"
+            f"Unsupported Plugin: '{plugin.name}'."
+            "Supported Plugins are: 'BigQuery Export', 'PostgreSQL Export Plugin', 'Redshift Export Plugin', 'Snowflake Export', and 'S3 Export Plugin'"
         )
 
     return (export_type, config)


### PR DESCRIPTION
## Problem

Need to migrate Redshift export app to batch exports.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add Redshift Export Plugin to plugins supported by `create_batch_export_from_app` command.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added Redshift to command's tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
