### PR TITLE
fix(search): various search improvements

### DIFF
--- a/posthog/api/search.py
+++ b/posthog/api/search.py
@@ -68,7 +68,11 @@ def class_queryset(klass: type[Model], team: Team, query: str | None):
         qs = qs.annotate(result_id=Cast("pk", CharField()))
 
     if query:
-        qs = qs.annotate(rank=SearchRank(SearchVector("name"), SearchQuery(query, config="simple", search_type="raw")))
+        qs = qs.annotate(
+            rank=SearchRank(
+                SearchVector("name", config="simple"), SearchQuery(query, config="simple", search_type="raw")
+            )
+        )
         qs = qs.filter(rank__gt=0.05)
         values.append("rank")
 

--- a/posthog/api/search.py
+++ b/posthog/api/search.py
@@ -13,6 +13,8 @@ from posthog.api.routing import StructuredViewSetMixin
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.models import Action, Cohort, Insight, Dashboard, FeatureFlag, Experiment, Team
 
+LIMIT = 25
+
 
 class SearchViewSet(StructuredViewSetMixin, viewsets.ViewSet):
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
@@ -29,7 +31,10 @@ class SearchViewSet(StructuredViewSetMixin, viewsets.ViewSet):
             qs = qs.union(klass_qs)
             counts[type] = klass_qs.count()
 
-        return Response({"results": qs, "counts": counts})
+        if query:
+            qs = qs.order_by("-rank")
+
+        return Response({"results": qs[:LIMIT], "counts": counts})
 
 
 UNSAFE_CHARACTERS = r"[\'&|!<>():]"
@@ -63,9 +68,8 @@ def class_queryset(klass: type[Model], team: Team, query: str | None):
         qs = qs.annotate(result_id=Cast("pk", CharField()))
 
     if query:
-        qs = qs.annotate(rank=SearchRank(SearchVector("name"), SearchQuery(query, search_type="raw")))
+        qs = qs.annotate(rank=SearchRank(SearchVector("name"), SearchQuery(query, config="simple", search_type="raw")))
         qs = qs.filter(rank__gt=0.05)
-        qs = qs.order_by("-rank")
         values.append("rank")
 
     qs = qs.values(*values)


### PR DESCRIPTION
## Problem

The search has various problems:
- There is no limit on the search results, making it incredibly slow for our team with many entities.
- The ranking is done on an entity level, instead of ranking the whole unioned queryset.
- The search query removes stop words, so that a query for "we" would return empty. Turns out a lot of things in our domain start with "we" - "web", "weekly", ...

## Changes

This PR addresses the above. The current implementation of limit is a bit modest, as it doesn't support pagination (couldn't get this done in drf - thankful for any pointers) and clicking on a category might return less results than expected. I'm going to address the later issue if we continue with the full-text search instead of switching to a fuzzy search.

## How did you test this code?

Locally