### PR TITLE
feat(insigts): remove aggregation_group_type_index for lifecycle and stickiness

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
@@ -86,7 +86,6 @@ export const queryNodeToFilter = (query: InsightQueryNode): Partial<FilterType> 
         date_from: query.dateRange?.date_from,
         entity_type: 'events',
         sampling_factor: query.samplingFactor,
-        aggregation_group_type_index: query.aggregation_group_type_index,
     })
 
     if (!isRetentionQuery(query) && !isPathsQuery(query)) {
@@ -105,6 +104,15 @@ export const queryNodeToFilter = (query: InsightQueryNode): Partial<FilterType> 
     // TODO stickiness should probably support breakdowns as well
     if ((isTrendsQuery(query) || isFunnelsQuery(query)) && query.breakdown) {
         Object.assign(filters, objectClean<Partial<Record<keyof BreakdownFilter, unknown>>>(query.breakdown))
+    }
+
+    if (!isLifecycleQuery(query) && !isStickinessQuery(query)) {
+        Object.assign(
+            filters,
+            objectClean({
+                aggregation_group_type_index: query.aggregation_group_type_index,
+            })
+        )
     }
 
     if (isTrendsQuery(query) || isStickinessQuery(query) || isLifecycleQuery(query) || isFunnelsQuery(query)) {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1801,10 +1801,6 @@
         "LifecycleQuery": {
             "additionalProperties": false,
             "properties": {
-                "aggregation_group_type_index": {
-                    "description": "Groups aggregation",
-                    "type": "number"
-                },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange",
                     "description": "Date range for the query"
@@ -2757,10 +2753,6 @@
         "StickinessQuery": {
             "additionalProperties": false,
             "properties": {
-                "aggregation_group_type_index": {
-                    "description": "Groups aggregation",
-                    "type": "number"
-                },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange",
                     "description": "Date range for the query"

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -501,7 +501,7 @@ export type StickinessFilter = Omit<
     StickinessFilterType & { hidden_legend_indexes?: number[] },
     keyof FilterType | 'hidden_legend_keys' | 'stickiness_days' | 'shown_as'
 >
-export interface StickinessQuery extends InsightsQueryBase {
+export interface StickinessQuery extends Omit<InsightsQueryBase, 'aggregation_group_type_index'> {
     kind: NodeKind.StickinessQuery
     /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
     interval?: IntervalType
@@ -530,7 +530,7 @@ export interface LifecycleQueryResponse extends QueryResponse {
     results: Record<string, any>[]
 }
 
-export interface LifecycleQuery extends InsightsQueryBase {
+export interface LifecycleQuery extends Omit<InsightsQueryBase, 'aggregation_group_type_index'> {
     kind: NodeKind.LifecycleQuery
     /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */
     interval?: IntervalType

--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -4,7 +4,7 @@ import { LemonSelect, LemonSelectSection } from '@posthog/lemon-ui'
 import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { GroupIntroductionFooter } from 'scenes/groups/GroupsIntroduction'
 import { InsightLogicProps } from '~/types'
-import { isFunnelsQuery, isInsightQueryNode } from '~/queries/utils'
+import { isFunnelsQuery, isInsightQueryNode, isLifecycleQuery, isStickinessQuery } from '~/queries/utils'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { FunnelsQuery } from '~/queries/schema'
 import { HogQLEditor } from 'lib/components/HogQLEditor/HogQLEditor'
@@ -51,7 +51,9 @@ export function AggregationSelect({
     }
 
     const value = getHogQLValue(
-        querySource.aggregation_group_type_index,
+        isLifecycleQuery(querySource) || isStickinessQuery(querySource)
+            ? undefined
+            : querySource.aggregation_group_type_index,
         isFunnelsQuery(querySource) ? querySource.funnelsFilter?.funnel_aggregate_by_hogql : undefined
     )
     const onChange = (value: string): void => {

--- a/frontend/src/scenes/retention/retentionLineGraphLogic.ts
+++ b/frontend/src/scenes/retention/retentionLineGraphLogic.ts
@@ -9,6 +9,7 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { retentionLogic } from './retentionLogic'
 
 import type { retentionLineGraphLogicType } from './retentionLineGraphLogicType'
+import { isLifecycleQuery, isStickinessQuery } from '~/queries/utils'
 
 const DEFAULT_RETENTION_LOGIC_KEY = 'default_retention_key'
 
@@ -117,7 +118,11 @@ export const retentionLineGraphLogic = kea<retentionLineGraphLogicType>([
         aggregationGroupTypeIndex: [
             (s) => [s.querySource],
             (querySource) => {
-                return querySource?.aggregation_group_type_index ?? 'people'
+                return (
+                    (isLifecycleQuery(querySource) || isStickinessQuery(querySource)
+                        ? null
+                        : querySource?.aggregation_group_type_index) ?? 'people'
+                )
             },
         ],
     }),

--- a/frontend/src/scenes/retention/retentionModalLogic.ts
+++ b/frontend/src/scenes/retention/retentionModalLogic.ts
@@ -7,6 +7,7 @@ import { retentionPeopleLogic } from './retentionPeopleLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 import type { retentionModalLogicType } from './retentionModalLogicType'
+import { isLifecycleQuery, isStickinessQuery } from '~/queries/utils'
 
 const DEFAULT_RETENTION_LOGIC_KEY = 'default_retention_key'
 
@@ -35,7 +36,10 @@ export const retentionModalLogic = kea<retentionModalLogicType>([
         aggregationTargetLabel: [
             (s) => [s.querySource, s.aggregationLabel],
             (querySource, aggregationLabel): Noun => {
-                const { aggregation_group_type_index } = querySource || {}
+                const aggregation_group_type_index =
+                    isLifecycleQuery(querySource) || isStickinessQuery(querySource)
+                        ? undefined
+                        : querySource?.aggregation_group_type_index
                 return aggregationLabel(aggregation_group_type_index)
             },
         ],

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -298,7 +298,7 @@ def _breakdown_filter(_filter: Dict):
 
 
 def _group_aggregation_filter(filter: Dict):
-    if _insight_type(filter) == "STICKINESS":
+    if _insight_type(filter) == "STICKINESS" or _insight_type(filter) == "LIFECYCLE":
         return {}
     return {"aggregation_group_type_index": filter.get("aggregation_group_type_index")}
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1439,7 +1439,6 @@ class StickinessQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    aggregation_group_type_index: Optional[float] = Field(default=None, description="Groups aggregation")
     dateRange: Optional[DateRange] = Field(default=None, description="Date range for the query")
     filterTestAccounts: Optional[bool] = Field(
         default=None, description="Exclude internal and test users by applying the respective filters"
@@ -1637,7 +1636,6 @@ class LifecycleQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    aggregation_group_type_index: Optional[float] = Field(default=None, description="Groups aggregation")
     dateRange: Optional[DateRange] = Field(default=None, description="Date range for the query")
     filterTestAccounts: Optional[bool] = Field(
         default=None, description="Exclude internal and test users by applying the respective filters"


### PR DESCRIPTION
## Problem

The `aggregation_group_type_index` field is not used for neither Lifecycle nor Stickiness insights, yet its presence in borked filters caused multiple wrong matches for Lifecycle queries.

## Changes

Officially remove this field from the schema, and make other corrections.

## How did you test this code?

Traced and fixed all TS errors. Running CI now.