### PR TITLE
feat(hogql-queries): modifiers in query runners

### DIFF
--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -1,6 +1,6 @@
 import json
 from datetime import timedelta
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional
 
 from dateutil.parser import isoparse
 from django.db.models import Prefetch
@@ -15,7 +15,7 @@ from posthog.hogql.property import action_to_expr, has_aggregation, property_to_
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.timings import HogQLTimings
 from posthog.hogql_queries.query_runner import QueryRunner
-from posthog.models import Action, Person, Team
+from posthog.models import Action, Person
 from posthog.models.element import chain_to_elements
 from posthog.models.person.person import get_distinct_ids_for_subquery
 from posthog.models.person.util import get_persons_by_distinct_ids
@@ -38,19 +38,6 @@ SELECT_STAR_FROM_EVENTS_FIELDS = [
 class EventsQueryRunner(QueryRunner):
     query: EventsQuery
     query_type = EventsQuery
-
-    def __init__(
-        self,
-        query: EventsQuery | Dict[str, Any],
-        team: Team,
-        timings: Optional[HogQLTimings] = None,
-        in_export_context: Optional[bool] = False,
-    ):
-        super().__init__(query, team, timings, in_export_context)
-        if isinstance(query, EventsQuery):
-            self.query = query
-        else:
-            self.query = EventsQuery.model_validate(query)
 
     def to_query(self) -> ast.SelectQuery:
         # Note: This code is inefficient and problematic, see https://github.com/PostHog/posthog/issues/13485 for details.
@@ -199,6 +186,7 @@ class EventsQueryRunner(QueryRunner):
             workload=Workload.ONLINE,
             query_type="EventsQuery",
             timings=self.timings,
+            modifiers=self.modifiers,
             in_export_context=self.in_export_context,
         )
 

--- a/posthog/hogql_queries/insights/insight_persons_query_runner.py
+++ b/posthog/hogql_queries/insights/insight_persons_query_runner.py
@@ -1,13 +1,11 @@
 from datetime import timedelta
-from typing import Dict, Optional, Any, cast
+from typing import cast
 
 from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
-from posthog.hogql.timings import HogQLTimings
 from posthog.hogql_queries.insights.lifecycle_query_runner import LifecycleQueryRunner
 from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQueryRunner
 from posthog.hogql_queries.query_runner import QueryRunner, get_query_runner
-from posthog.models import Team
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.schema import InsightPersonsQuery, HogQLQueryResponse
 
@@ -15,19 +13,6 @@ from posthog.schema import InsightPersonsQuery, HogQLQueryResponse
 class InsightPersonsQueryRunner(QueryRunner):
     query: InsightPersonsQuery
     query_type = InsightPersonsQuery
-
-    def __init__(
-        self,
-        query: InsightPersonsQuery | Dict[str, Any],
-        team: Team,
-        timings: Optional[HogQLTimings] = None,
-        in_export_context: Optional[bool] = False,
-    ):
-        super().__init__(query, team, timings, in_export_context)
-        if isinstance(query, InsightPersonsQuery):
-            self.query = query
-        else:
-            self.query = InsightPersonsQuery.model_validate(query)
 
     @cached_property
     def source_runner(self) -> QueryRunner:
@@ -54,6 +39,7 @@ class InsightPersonsQueryRunner(QueryRunner):
             query=self.to_query(),
             team=self.team,
             timings=self.timings,
+            modifiers=self.modifiers,
         )
 
     def _is_stale(self, cached_result_package):

--- a/posthog/hogql_queries/insights/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle_query_runner.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from math import ceil
-from typing import Optional, Any, Dict, List
+from typing import Optional, List
 
 from django.utils.timezone import datetime
 from posthog.caching.insights_api import (
@@ -14,9 +14,8 @@ from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import to_printed_hogql
 from posthog.hogql.property import property_to_expr, action_to_expr
 from posthog.hogql.query import execute_hogql_query
-from posthog.hogql.timings import HogQLTimings
 from posthog.hogql_queries.query_runner import QueryRunner
-from posthog.models import Team, Action
+from posthog.models import Action
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.schema import (
@@ -30,15 +29,6 @@ from posthog.schema import (
 class LifecycleQueryRunner(QueryRunner):
     query: LifecycleQuery
     query_type = LifecycleQuery
-
-    def __init__(
-        self,
-        query: LifecycleQuery | Dict[str, Any],
-        team: Team,
-        timings: Optional[HogQLTimings] = None,
-        in_export_context: Optional[bool] = False,
-    ):
-        super().__init__(query, team, timings, in_export_context)
 
     def to_query(self) -> ast.SelectQuery | ast.SelectUnionQuery:
         if self.query.samplingFactor == 0:
@@ -139,6 +129,7 @@ class LifecycleQueryRunner(QueryRunner):
             query=query,
             team=self.team,
             timings=self.timings,
+            modifiers=self.modifiers,
         )
 
         # TODO: can we move the data conversion part into the query as well? It would make it easier to swap

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -35,6 +35,7 @@ from posthog.schema import (
     HogQLQueryResponse,
     TrendsQuery,
     TrendsQueryResponse,
+    HogQLQueryModifiers,
 )
 
 
@@ -48,9 +49,10 @@ class TrendsQueryRunner(QueryRunner):
         query: TrendsQuery | Dict[str, Any],
         team: Team,
         timings: Optional[HogQLTimings] = None,
+        modifiers: Optional[HogQLQueryModifiers] = None,
         in_export_context: Optional[bool] = None,
     ):
-        super().__init__(query, team, timings, in_export_context)
+        super().__init__(query, team=team, timings=timings, modifiers=modifiers, in_export_context=in_export_context)
         self.series = self.setup_series()
 
     def _is_stale(self, cached_result_package):
@@ -129,6 +131,7 @@ class TrendsQueryRunner(QueryRunner):
                 query=query,
                 team=self.team,
                 timings=self.timings,
+                modifiers=self.modifiers,
             )
 
             timings.extend(response.timings)

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -87,6 +87,7 @@ def get_query_runner(
     team: Team,
     timings: Optional[HogQLTimings] = None,
     in_export_context: Optional[bool] = False,
+    modifiers: Optional[HogQLQueryModifiers] = None,
 ) -> "QueryRunner":
     kind = None
     if isinstance(query, dict):
@@ -104,6 +105,7 @@ def get_query_runner(
             team=team,
             timings=timings,
             in_export_context=in_export_context,
+            modifiers=modifiers,
         )
     if kind == "TrendsQuery":
         from .insights.trends.trends_query_runner import TrendsQueryRunner
@@ -113,6 +115,7 @@ def get_query_runner(
             team=team,
             timings=timings,
             in_export_context=in_export_context,
+            modifiers=modifiers,
         )
     if kind == "EventsQuery":
         from .events_query_runner import EventsQueryRunner
@@ -122,6 +125,7 @@ def get_query_runner(
             team=team,
             timings=timings,
             in_export_context=in_export_context,
+            modifiers=modifiers,
         )
     if kind == "PersonsQuery":
         from .persons_query_runner import PersonsQueryRunner
@@ -131,6 +135,7 @@ def get_query_runner(
             team=team,
             timings=timings,
             in_export_context=in_export_context,
+            modifiers=modifiers,
         )
     if kind == "InsightPersonsQuery":
         from .insights.insight_persons_query_runner import InsightPersonsQueryRunner
@@ -140,6 +145,7 @@ def get_query_runner(
             team=team,
             timings=timings,
             in_export_context=in_export_context,
+            modifiers=modifiers,
         )
     if kind == "HogQLQuery":
         from .hogql_query_runner import HogQLQueryRunner
@@ -149,6 +155,7 @@ def get_query_runner(
             team=team,
             timings=timings,
             in_export_context=in_export_context,
+            modifiers=modifiers,
         )
     if kind == "SessionsTimelineQuery":
         from .sessions_timeline_query_runner import SessionsTimelineQueryRunner
@@ -157,19 +164,20 @@ def get_query_runner(
             query=cast(SessionsTimelineQuery | Dict[str, Any], query),
             team=team,
             timings=timings,
+            modifiers=modifiers,
         )
     if kind == "WebOverviewQuery":
         from .web_analytics.web_overview import WebOverviewQueryRunner
 
-        return WebOverviewQueryRunner(query=query, team=team, timings=timings)
+        return WebOverviewQueryRunner(query=query, team=team, timings=timings, modifiers=modifiers)
     if kind == "WebTopClicksQuery":
         from .web_analytics.top_clicks import WebTopClicksQueryRunner
 
-        return WebTopClicksQueryRunner(query=query, team=team, timings=timings)
+        return WebTopClicksQueryRunner(query=query, team=team, timings=timings, modifiers=modifiers)
     if kind == "WebStatsTableQuery":
         from .web_analytics.stats_table import WebStatsTableQueryRunner
 
-        return WebStatsTableQueryRunner(query=query, team=team, timings=timings)
+        return WebStatsTableQueryRunner(query=query, team=team, timings=timings, modifiers=modifiers)
 
     raise ValueError(f"Can't get a runner for an unknown query kind: {kind}")
 

--- a/posthog/hogql_queries/sessions_timeline_query_runner.py
+++ b/posthog/hogql_queries/sessions_timeline_query_runner.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 import json
-from typing import Dict, Optional, Any, cast
+from typing import Dict, cast
 from posthog.api.element import ElementSerializer
 
 
@@ -10,7 +10,6 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.timings import HogQLTimings
 from posthog.hogql_queries.query_runner import QueryRunner
-from posthog.models import Team
 from posthog.models.element.element import chain_to_elements
 from posthog.schema import EventType, SessionsTimelineQuery, SessionsTimelineQueryResponse, TimelineEntry
 from posthog.utils import relative_date_parse
@@ -36,18 +35,6 @@ class SessionsTimelineQueryRunner(QueryRunner):
 
     query: SessionsTimelineQuery
     query_type = SessionsTimelineQuery
-
-    def __init__(
-        self,
-        query: SessionsTimelineQuery | Dict[str, Any],
-        team: Team,
-        timings: Optional[HogQLTimings] = None,
-    ):
-        super().__init__(query, team, timings)
-        if isinstance(query, SessionsTimelineQuery):
-            self.query = query
-        else:
-            self.query = SessionsTimelineQuery.model_validate(query)
 
     def _get_events_subquery(self) -> ast.SelectQuery:
         after = relative_date_parse(self.query.after or "-24h", self.team.timezone_info)
@@ -147,6 +134,7 @@ class SessionsTimelineQueryRunner(QueryRunner):
             workload=Workload.ONLINE,
             query_type="SessionsTimelineQuery",
             timings=self.timings,
+            modifiers=self.modifiers,
         )
         assert query_result.results is not None
         timeline_entries_map: Dict[str, TimelineEntry] = {}

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -92,7 +92,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)  # type: ignore
 
         cache_key = runner._cache_key()
-        self.assertEqual(cache_key, "cache_33c9ea3098895d5a363a75feefafef06")
+        self.assertEqual(cache_key, "cache_b8a6b70478ec6139c8f7f379c808d5b9")
 
     def test_cache_key_runner_subclass(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -106,7 +106,7 @@ class TestQueryRunner(BaseTest):
         runner = TestSubclassQueryRunner(query={"some_attr": "bla"}, team=team)  # type: ignore
 
         cache_key = runner._cache_key()
-        self.assertEqual(cache_key, "cache_d626615de8ad0df73c1d8610ca586597")
+        self.assertEqual(cache_key, "cache_cfab9e42d088def74792922de5b513ac")
 
     def test_cache_key_different_timezone(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -117,7 +117,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)  # type: ignore
 
         cache_key = runner._cache_key()
-        self.assertEqual(cache_key, "cache_aeb23ec9e8de56dd8499f99f2e976d5a")
+        self.assertEqual(cache_key, "cache_9f12fefe07c0ab79e93935aed6b0bfa6")
 
     def test_cache_response(self):
         TestQueryRunner = self.setup_test_query_runner_class()

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -77,6 +77,7 @@ LIMIT 10
             query=self.to_query(),
             team=self.team,
             timings=self.timings,
+            modifiers=self.modifiers,
         )
 
         return WebStatsTableQueryResponse(

--- a/posthog/hogql_queries/web_analytics/top_clicks.py
+++ b/posthog/hogql_queries/web_analytics/top_clicks.py
@@ -50,6 +50,7 @@ LIMIT 10
             query=self.to_query(),
             team=self.team,
             timings=self.timings,
+            modifiers=self.modifiers,
         )
 
         return WebTopClicksQueryResponse(

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -104,6 +104,7 @@ CROSS JOIN sessions_query
             query=self.to_query(),
             team=self.team,
             timings=self.timings,
+            modifiers=self.modifiers,
         )
 
         row = response.results[0]


### PR DESCRIPTION
## Problem

You couldn't pass HogQL query modifiers into query runners. 

## Changes

Now you can.
Also removes redundant initializers for several query runners.

## How did you test this code?

All HogQL query tests still pass.
Added test for at least the HogQLQueryRunner 