### PR TITLE
feat(web-analytics): Hide geography tile if not using geoip

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsTile.tsx
@@ -1,8 +1,8 @@
 import { QueryContext, QueryContextColumnComponent, QueryContextColumnTitleComponent } from '~/queries/types'
 import { DataTableNode, InsightVizNode, NodeKind, WebStatsBreakdown } from '~/queries/schema'
 import { UnexpectedNeverError } from 'lib/utils'
-import { useActions } from 'kea'
-import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
+import { useActions, useValues } from 'kea'
+import { GeographyTab, webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 import { useCallback, useMemo } from 'react'
 import { Query } from '~/queries/Query/Query'
 import { countryCodeToFlag, countryCodeToName } from 'scenes/insights/views/WorldMap'
@@ -173,11 +173,16 @@ export const webAnalyticsDataTableQueryContext: QueryContext = {
 }
 
 export const WebStatsTrendTile = ({ query }: { query: InsightVizNode }): JSX.Element => {
-    const { togglePropertyFilter } = useActions(webAnalyticsLogic)
+    const { togglePropertyFilter, setGeographyTab } = useActions(webAnalyticsLogic)
+    const { hasCountryFilter } = useValues(webAnalyticsLogic)
     const { key: worldMapPropertyName } = webStatsBreakdownToPropertyName(WebStatsBreakdown.Country)
     const onWorldMapClick = useCallback(
         (breakdownValue: string) => {
             togglePropertyFilter(PropertyFilterType.Event, worldMapPropertyName, breakdownValue)
+            if (!hasCountryFilter) {
+                // if we just added a country filter, switch to the region tab, as the world map will not be useful
+                setGeographyTab(GeographyTab.REGIONS)
+            }
         },
         [togglePropertyFilter, worldMapPropertyName]
     )

--- a/frontend/src/scenes/web-analytics/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsTile.tsx
@@ -187,9 +187,14 @@ export const WebStatsTrendTile = ({ query }: { query: InsightVizNode }): JSX.Ele
             ...webAnalyticsDataTableQueryContext,
             chartRenderingMetadata: {
                 [ChartDisplayType.WorldMap]: {
-                    countryProps: (countryCode, values) => ({
-                        onClick: values && values.count > 0 ? () => onWorldMapClick(countryCode) : undefined,
-                    }),
+                    countryProps: (countryCode, values) => {
+                        return {
+                            onClick:
+                                values && (values.count > 0 || values.aggregated_value > 0)
+                                    ? () => onWorldMapClick(countryCode)
+                                    : undefined,
+                        }
+                    },
                 },
             },
         }

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -15,6 +15,7 @@ import {
     EventDefinition,
     EventDefinitionType,
     InsightType,
+    PropertyDefinition,
     PropertyFilterType,
     PropertyOperator,
     RetentionPeriod,
@@ -225,6 +226,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 s.dateFrom,
                 s.dateTo,
                 () => values.isGreaterThanMd,
+                () => values.shouldShowGeographyTile,
             ],
             (
                 webAnalyticsFilters,
@@ -235,13 +237,14 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 geographyTab,
                 dateFrom,
                 dateTo,
-                isGreaterThanMd: boolean
+                isGreaterThanMd: boolean,
+                shouldShowGeographyTile
             ): WebDashboardTile[] => {
                 const dateRange = {
                     date_from: dateFrom,
                     date_to: dateTo,
                 }
-                return [
+                const tiles: (WebDashboardTile | null)[] = [
                     {
                         layout: {
                             colSpan: 12,
@@ -494,89 +497,6 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         ],
                     },
                     {
-                        layout: {
-                            colSpan: 6,
-                        },
-                        activeTabId: geographyTab,
-                        setTabId: actions.setGeographyTab,
-                        tabs: [
-                            {
-                                id: GeographyTab.MAP,
-                                title: 'World map',
-                                linkText: 'Map',
-                                query: {
-                                    kind: NodeKind.InsightVizNode,
-                                    source: {
-                                        kind: NodeKind.TrendsQuery,
-                                        breakdown: {
-                                            breakdown: '$geoip_country_code',
-                                            breakdown_type: 'person',
-                                        },
-                                        dateRange,
-                                        series: [
-                                            {
-                                                event: '$pageview',
-                                                kind: NodeKind.EventsNode,
-                                                math: BaseMathType.UniqueUsers,
-                                            },
-                                        ],
-                                        trendsFilter: {
-                                            display: ChartDisplayType.WorldMap,
-                                        },
-                                        filterTestAccounts: true,
-                                        properties: webAnalyticsFilters,
-                                    },
-                                    hidePersonsModal: true,
-                                },
-                            },
-                            {
-                                id: GeographyTab.COUNTRIES,
-                                title: 'Top countries',
-                                linkText: 'Countries',
-                                query: {
-                                    full: true,
-                                    kind: NodeKind.DataTableNode,
-                                    source: {
-                                        kind: NodeKind.WebStatsTableQuery,
-                                        properties: webAnalyticsFilters,
-                                        breakdownBy: WebStatsBreakdown.Country,
-                                        dateRange,
-                                    },
-                                },
-                            },
-                            {
-                                id: GeographyTab.REGIONS,
-                                title: 'Top regions',
-                                linkText: 'Regions',
-                                query: {
-                                    full: true,
-                                    kind: NodeKind.DataTableNode,
-                                    source: {
-                                        kind: NodeKind.WebStatsTableQuery,
-                                        properties: webAnalyticsFilters,
-                                        breakdownBy: WebStatsBreakdown.Region,
-                                        dateRange,
-                                    },
-                                },
-                            },
-                            {
-                                id: GeographyTab.CITIES,
-                                title: 'Top cities',
-                                linkText: 'Cities',
-                                query: {
-                                    full: true,
-                                    kind: NodeKind.DataTableNode,
-                                    source: {
-                                        kind: NodeKind.WebStatsTableQuery,
-                                        properties: webAnalyticsFilters,
-                                        breakdownBy: WebStatsBreakdown.City,
-                                        dateRange,
-                                    },
-                                },
-                            },
-                        ],
-                    },
-                    {
                         title: 'Retention',
                         layout: {
                             colSpan: 12,
@@ -604,7 +524,93 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                         },
                     },
+                    shouldShowGeographyTile
+                        ? {
+                              layout: {
+                                  colSpan: 12,
+                              },
+                              activeTabId: geographyTab,
+                              setTabId: actions.setGeographyTab,
+                              tabs: [
+                                  {
+                                      id: GeographyTab.MAP,
+                                      title: 'World map',
+                                      linkText: 'Map',
+                                      query: {
+                                          kind: NodeKind.InsightVizNode,
+                                          source: {
+                                              kind: NodeKind.TrendsQuery,
+                                              breakdown: {
+                                                  breakdown: '$geoip_country_code',
+                                                  breakdown_type: 'person',
+                                              },
+                                              dateRange,
+                                              series: [
+                                                  {
+                                                      event: '$pageview',
+                                                      kind: NodeKind.EventsNode,
+                                                      math: BaseMathType.UniqueUsers,
+                                                  },
+                                              ],
+                                              trendsFilter: {
+                                                  display: ChartDisplayType.WorldMap,
+                                              },
+                                              filterTestAccounts: true,
+                                              properties: webAnalyticsFilters,
+                                          },
+                                          hidePersonsModal: true,
+                                      },
+                                  },
+                                  {
+                                      id: GeographyTab.COUNTRIES,
+                                      title: 'Top countries',
+                                      linkText: 'Countries',
+                                      query: {
+                                          full: true,
+                                          kind: NodeKind.DataTableNode,
+                                          source: {
+                                              kind: NodeKind.WebStatsTableQuery,
+                                              properties: webAnalyticsFilters,
+                                              breakdownBy: WebStatsBreakdown.Country,
+                                              dateRange,
+                                          },
+                                      },
+                                  },
+                                  {
+                                      id: GeographyTab.REGIONS,
+                                      title: 'Top regions',
+                                      linkText: 'Regions',
+                                      query: {
+                                          full: true,
+                                          kind: NodeKind.DataTableNode,
+                                          source: {
+                                              kind: NodeKind.WebStatsTableQuery,
+                                              properties: webAnalyticsFilters,
+                                              breakdownBy: WebStatsBreakdown.Region,
+                                              dateRange,
+                                          },
+                                      },
+                                  },
+                                  {
+                                      id: GeographyTab.CITIES,
+                                      title: 'Top cities',
+                                      linkText: 'Cities',
+                                      query: {
+                                          full: true,
+                                          kind: NodeKind.DataTableNode,
+                                          source: {
+                                              kind: NodeKind.WebStatsTableQuery,
+                                              properties: webAnalyticsFilters,
+                                              breakdownBy: WebStatsBreakdown.City,
+                                              dateRange,
+                                          },
+                                      },
+                                  },
+                              ],
+                          }
+                        : null,
                 ]
+                return tiles.filter(isNotNil)
             },
         ],
     })),
@@ -637,8 +643,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         ? pageleaveResult.value.results.find((r) => r.name === '$pageleave')
                         : undefined
 
-                const shouldWarnAboutNoPageviews = !pageviewEntry || isEventDefinitionStale(pageviewEntry)
-                const shouldWarnAboutNoPageleaves = !pageleaveEntry || isEventDefinitionStale(pageleaveEntry)
+                const shouldWarnAboutNoPageviews = !pageviewEntry || isDefinitionStale(pageviewEntry)
+                const shouldWarnAboutNoPageleaves = !pageleaveEntry || isDefinitionStale(pageleaveEntry)
 
                 return {
                     shouldWarnAboutNoPageviews,
@@ -646,18 +652,30 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 }
             },
         },
+        shouldShowGeographyTile: {
+            _default: null as boolean | null,
+            loadShouldShowGeographyTile: async (): Promise<boolean> => {
+                const response = await api.propertyDefinitions.list({
+                    event_names: ['$pageview'],
+                    properties: ['$geoip_country_code'],
+                })
+                const countryCodeDefinition = response.results.find((r) => r.name === '$geoip_country_code')
+                return !!countryCodeDefinition && !isDefinitionStale(countryCodeDefinition)
+            },
+        },
     })),
 
     // start the loaders after mounting the logic
     afterMount(({ actions }) => {
         actions.loadStatusCheck()
+        actions.loadShouldShowGeographyTile()
     }),
     windowValues({
         isGreaterThanMd: (window: Window) => window.innerWidth > 768,
     }),
 ])
 
-const isEventDefinitionStale = (definition: EventDefinition): boolean => {
+const isDefinitionStale = (definition: EventDefinition | PropertyDefinition): boolean => {
     const parsedLastSeen = definition.last_seen_at ? dayjs(definition.last_seen_at) : null
     return !!parsedLastSeen && dayjs().diff(parsedLastSeen, 'seconds') > STALE_EVENT_SECONDS
 }

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -613,6 +613,12 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 return tiles.filter(isNotNil)
             },
         ],
+        hasCountryFilter: [
+            (s) => [s.webAnalyticsFilters],
+            (webAnalyticsFilters: WebAnalyticsPropertyFilters) => {
+                return webAnalyticsFilters.some((filter) => filter.key === '$geoip_country_code')
+            },
+        ],
     })),
     loaders(() => ({
         // load the status check query here and pass the response into the component, so the response


### PR DESCRIPTION
## Problem
https://posthoghelp.zendesk.com/agent/tickets/7329 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/13438)

## Changes

Hit the event_property API, and hide the geography tab if country codes haven't been sent recently

## How did you test this code?
Manual
