### PR TITLE
fix(surveys): button text default value next for backwards compatibility

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -527,7 +527,10 @@ export default function SurveyEdit(): JSX.Element {
                                                                     <LemonInput
                                                                         value={
                                                                             question.buttonText === undefined
-                                                                                ? survey.appearance.submitButtonText
+                                                                                ? survey.questions.length > 1 &&
+                                                                                  index !== survey.questions.length - 1
+                                                                                    ? 'Next'
+                                                                                    : survey.appearance.submitButtonText
                                                                                 : question.buttonText
                                                                         }
                                                                     />


### PR DESCRIPTION
## Problem

For button text fields that don't have the new field yet, we want it to reflect what the preview/survey will show

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
