### PR TITLE
fix(cohorts): Alerting functionality when user enters wrong details while creating cohort

### DIFF
--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -195,8 +195,6 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
 
     forms(({ actions }) => ({
         cohort: {
-            alwaysShowErrors: true,
-            showErrorsOnTouch: true,
             defaults: NEW_COHORT,
             errors: ({ id, name, csv, is_static, filters }) => ({
                 name: !name ? 'Cohort name cannot be empty' : undefined,
@@ -234,7 +232,6 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     }
                 },
                 saveCohort: async ({ cohortParams }, breakpoint) => {
-                    console.log("reached cohort");
                     let cohort = { ...cohortParams }
                     const cohortFormData = createCohortFormData(cohort)
 
@@ -248,7 +245,6 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                         }
                     } catch (error: any) {
                         breakpoint()
-                        console.log("failure to save", error);
                         lemonToast.error(error.detail || 'Failed to save cohort')
                         return values.cohort
                     }
@@ -280,7 +276,6 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     }
                     return processCohort(cohort)
                 },
-
             },
         ],
         duplicatedCohort: [
@@ -324,7 +319,6 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
             router.actions.push(urls.cohorts())
         },
         submitCohort: () => {
-            console.log("submit cohort", values.cohortHasErrors)
             if(values.cohortHasErrors){
                 lemonToast.error('Cohort error. There was an error submiting this cohort. Make sure the cohort filters are correct.')
             }

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -66,7 +66,6 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
         }),
         setQuery: (query: Node) => ({ query }),
         duplicateCohort: (asStatic: boolean) => ({ asStatic }),
-        submitCohort: () => Promise<any>
     }),
 
     selectors({
@@ -206,7 +205,6 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                 },
             }),
             submit: (cohort) => {
-                actions.submitCohort()
                 actions.saveCohort(cohort)
             },
         },

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -317,10 +317,9 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
             router.actions.push(urls.cohorts())
         },
         submitCohort: () => {
-            if(values.cohortHasErrors){
-                lemonToast.error('Cohort error. There was an error submiting this cohort. Make sure the cohort filters are correct.')
+            if (values.cohortHasErrors) {
+                lemonToast.error('There was an error submiting this cohort. Make sure the cohort filters are correct.')
             }
-
         },
         checkIfFinishedCalculating: async ({ cohort }, breakpoint) => {
             if (cohort.is_calculating) {
@@ -367,5 +366,4 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
             clearTimeout(values.pollTimeout)
         }
     }),
-
 ])

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -66,6 +66,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
         }),
         setQuery: (query: Node) => ({ query }),
         duplicateCohort: (asStatic: boolean) => ({ asStatic }),
+        submitCohort: () => Promise<any>
     }),
 
     selectors({
@@ -194,6 +195,8 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
 
     forms(({ actions }) => ({
         cohort: {
+            alwaysShowErrors: true,
+            showErrorsOnTouch: true,
             defaults: NEW_COHORT,
             errors: ({ id, name, csv, is_static, filters }) => ({
                 name: !name ? 'Cohort name cannot be empty' : undefined,
@@ -205,6 +208,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                 },
             }),
             submit: (cohort) => {
+                actions.submitCohort()
                 actions.saveCohort(cohort)
             },
         },
@@ -230,6 +234,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     }
                 },
                 saveCohort: async ({ cohortParams }, breakpoint) => {
+                    console.log("reached cohort");
                     let cohort = { ...cohortParams }
                     const cohortFormData = createCohortFormData(cohort)
 
@@ -243,6 +248,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                         }
                     } catch (error: any) {
                         breakpoint()
+                        console.log("failure to save", error);
                         lemonToast.error(error.detail || 'Failed to save cohort')
                         return values.cohort
                     }
@@ -274,6 +280,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     }
                     return processCohort(cohort)
                 },
+
             },
         ],
         duplicatedCohort: [
@@ -315,6 +322,13 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
         deleteCohort: () => {
             cohortsModel.findMounted()?.actions.deleteCohort({ id: values.cohort.id, name: values.cohort.name })
             router.actions.push(urls.cohorts())
+        },
+        submitCohort: () => {
+            console.log("submit cohort", values.cohortHasErrors)
+            if(values.cohortHasErrors){
+                lemonToast.error('Cohort error. There was an error submiting this cohort. Make sure the cohort filters are correct.')
+            }
+
         },
         checkIfFinishedCalculating: async ({ cohort }, breakpoint) => {
             if (cohort.is_calculating) {
@@ -361,4 +375,5 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
             clearTimeout(values.pollTimeout)
         }
     }),
+
 ])


### PR DESCRIPTION
Closes - #18620 
At present, When a user clicks on save cohort button without properly filling details, the site feels stuck. The user has to scroll down to the highlighted error box to rectify the details.

Such a situation can be avoided by a simple toast alerting the user that the details filled out in the form has errors.


https://github.com/PostHog/posthog/assets/53624363/93134ecc-9f5d-443a-a993-4b108878e28a



Testing - 
1. Go to cohorts
2. Click on add criteria group
3. The toast with error message should appear on the bottom right corner
