### PR TITLE
fix: Dump properties with multi byte characters

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
@@ -72,7 +72,7 @@ async def assert_events_in_redshift(connection, schema, table_name, events, excl
             "elements": json.dumps(elements_chain) if elements_chain else None,
             "event": event_name,
             "ip": properties.get("$ip", None) if properties else None,
-            "properties": json.dumps(properties) if properties else None,
+            "properties": json.dumps(properties, ensure_ascii=False) if properties else None,
             "set": properties.get("$set", None) if properties else None,
             "set_once": properties.get("$set_once", None) if properties else None,
             # Kept for backwards compatibility, but not exported anymore.
@@ -185,9 +185,10 @@ async def test_insert_into_redshift_activity_inserts_data_into_redshift_table(
         properties={
             "$browser": "Chrome",
             "$os": "Mac OS X",
-            "newline": "\n\n",
-            "nested_newline": {"newline": "\n\n"},
-            "sequence": {"mucho_whitespace": ["\n\n", "\t\t", "\f\f"]},
+            "whitespace": "hi\t\n\r\f\bhi",
+            "nested_whitespace": {"whitespace": "hi\t\n\r\f\bhi"},
+            "sequence": {"mucho_whitespace": ["hi", "hi\t\n\r\f\bhi", "hi\t\n\r\f\bhi", "hi"]},
+            "multi-byte": "é",
         },
         person_properties={"utm_medium": "referral", "$initial_os": "Linux"},
     )

--- a/posthog/temporal/workflows/redshift_batch_export.py
+++ b/posthog/temporal/workflows/redshift_batch_export.py
@@ -279,7 +279,7 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs):
         def map_to_record(row: dict) -> dict:
             """Map row to a record to insert to Redshift."""
             return {
-                key: json.dumps(remove_escaped_whitespace_recursive(row[key]))
+                key: json.dumps(remove_escaped_whitespace_recursive(row[key]), ensure_ascii=False)
                 if key in json_columns and row[key] is not None
                 else row[key]
                 for key in schema_columns


### PR DESCRIPTION
## Problem

The problem was not exactly whitespace, but multi-byte characters produced by `json.dumps`. Redshift can handle multi-byte, so just pass them as is by setting `ensure_ascii=False`.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unit tests + real test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
