### PR TITLE
fix: tolerate missing rows_synced in billing response

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -225,7 +225,7 @@ class BillingManager:
             usage_info = OrganizationUsageInfo(
                 events=usage_summary["events"],
                 recordings=usage_summary["recordings"],
-                rows_synced=usage_summary["rows_synced"],
+                rows_synced=usage_summary.get("rows_synced", 0),
                 period=[
                     data["billing_period"]["current_period_start"],
                     data["billing_period"]["current_period_end"],

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -225,7 +225,7 @@ class BillingManager:
             usage_info = OrganizationUsageInfo(
                 events=usage_summary["events"],
                 recordings=usage_summary["recordings"],
-                rows_synced=usage_summary.get("rows_synced", 0),
+                rows_synced=usage_summary.get("rows_synced", None),
                 period=[
                     data["billing_period"]["current_period_start"],
                     data["billing_period"]["current_period_end"],

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -74,6 +74,8 @@ def org_quota_limited_until(organization: Organization, resource: QuotaResource)
         return None
 
     summary = organization.usage.get(resource.value, {})
+    if not summary:
+        return None
     usage = summary.get("usage", 0)
     todays_usage = summary.get("todays_usage", 0)
     limit = summary.get("limit")
@@ -146,6 +148,8 @@ def set_org_usage_summary(
 
     for field in ["events", "recordings", "rows_synced"]:
         resource_usage = new_usage[field]  # type: ignore
+        if not resource_usage:
+            continue
 
         if todays_usage:
             resource_usage["todays_usage"] = todays_usage[field]  # type: ignore


### PR DESCRIPTION
## Problem

In merging #18168 we don't have `rows_synced` coming from billing usage yet, so we were getting https://posthog.sentry.io/issues/4640315092/?project=1899813&query=is:unresolved+!url:http://billing.dev.posthog.dev&sort=date&statsPeriod=14d&stream_index=0

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Doesn't assume it exists

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
