### PR TITLE
fix: Redshift batch export issues

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
@@ -66,10 +66,9 @@ async def assert_events_in_redshift(connection, schema, table_name, events, excl
 
         raw_properties = event.get("properties", None)
         properties = remove_escaped_whitespace_recursive(raw_properties) if raw_properties else None
-        elements_chain = event.get("elements_chain", None)
         expected_event = {
             "distinct_id": event.get("distinct_id"),
-            "elements": json.dumps(elements_chain) if elements_chain else None,
+            "elements": "",
             "event": event_name,
             "ip": properties.get("$ip", None) if properties else None,
             "properties": json.dumps(properties, ensure_ascii=False) if properties else None,

--- a/posthog/temporal/workflows/redshift_batch_export.py
+++ b/posthog/temporal/workflows/redshift_batch_export.py
@@ -141,7 +141,6 @@ async def insert_records_to_redshift(
 
         for record in itertools.chain([first_record], records):
             batch.append(cursor.mogrify(template, record).encode("utf-8"))
-
             if len(batch) < batch_size:
                 continue
 
@@ -278,12 +277,14 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs):
 
         def map_to_record(row: dict) -> dict:
             """Map row to a record to insert to Redshift."""
-            return {
+            record = {
                 key: json.dumps(remove_escaped_whitespace_recursive(row[key]), ensure_ascii=False)
                 if key in json_columns and row[key] is not None
                 else row[key]
                 for key in schema_columns
             }
+            record["elements"] = ""
+            return record
 
         async with postgres_connection(inputs) as connection:
             await insert_records_to_redshift(


### PR DESCRIPTION
## Problem

A couple more issues:
* Elements also contains escape-able characters. Since it's basically gibberish, I'll deprecate it for Redshift.
* The batching logic could cause us to try to insert empty batches, and send negative metrics.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
