### PR TITLE
fix: Respect configured `LOG_LEVEL` during plugin-server setup

### DIFF
--- a/plugin-server/src/utils/status.ts
+++ b/plugin-server/src/utils/status.ts
@@ -15,7 +15,6 @@ export interface StatusBlueprint {
 
 export class Status implements StatusBlueprint {
     mode?: string
-    explicitLogLevel?: LogLevel
     logger: pino.Logger
     prompt: string
     transport: any
@@ -23,7 +22,7 @@ export class Status implements StatusBlueprint {
     constructor(mode?: string) {
         this.mode = mode
 
-        const logLevel: LogLevel = this.explicitLogLevel || defaultConfig.LOG_LEVEL
+        const logLevel: LogLevel = defaultConfig.LOG_LEVEL
         if (isProdEnv()) {
             this.logger = pino({
                 // By default pino will log the level number. So we can easily unify

--- a/plugin-server/src/utils/status.ts
+++ b/plugin-server/src/utils/status.ts
@@ -1,5 +1,6 @@
 import pino from 'pino'
 
+import { defaultConfig } from '../config/config'
 import { LogLevel, PluginsServerConfig } from '../types'
 import { isProdEnv } from './env-utils'
 
@@ -22,7 +23,7 @@ export class Status implements StatusBlueprint {
     constructor(mode?: string) {
         this.mode = mode
 
-        const logLevel: LogLevel = this.explicitLogLevel || LogLevel.Info
+        const logLevel: LogLevel = this.explicitLogLevel || defaultConfig.LOG_LEVEL
         if (isProdEnv()) {
             this.logger = pino({
                 // By default pino will log the level number. So we can easily unify


### PR DESCRIPTION
## Problem

The `LOG_LEVEL` setting/environment variable wasn't being used to control the `pino` (`status`) logger.

## How did you test this code?

Run plugin server with `LOG_LEVEL=debug` environment variable, observe debug level logs; run without environment, observe no debug level logs.