### PR TITLE
fix: Do not use E escape in Redshift batch exports

### DIFF
--- a/posthog/temporal/workflows/redshift_batch_export.py
+++ b/posthog/temporal/workflows/redshift_batch_export.py
@@ -133,8 +133,10 @@ async def insert_records_to_redshift(
         pre_query_str = pre_query.as_string(cursor).encode("utf-8")
 
         async def flush_to_redshift(batch):
-            await cursor.execute(pre_query_str + b",".join(batch))
-            rows_exported.add(len(batch) - 1)
+            values = b",".join(batch).replace(b" E'", b" '")
+
+            await cursor.execute(pre_query_str + values)
+            rows_exported.add(len(batch))
             # It would be nice to record BYTES_EXPORTED for Redshift, but it's not worth estimating
             # the byte size of each batch the way things are currently written. We can revisit this
             # in the future if we decide it's useful enough.


### PR DESCRIPTION
## Problem

Redshift doesn't support `E'` escape syntax. Eventually, we should switch to the `redshift_connector` as `psycopg` doesn't appear to be the recommended way to connect to Redshift (mostly because Redshift hasn't kept up with Postgres).

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Replace ` E'` in queries to Redshift.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
