### PR TITLE
fix: composeWebhook method to use passed headers

### DIFF
--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -111,7 +111,7 @@ async function runSingleTeamPluginComposeWebhook(
             const request = await trackedFetch(webhook.url, {
                 method: webhook.method || 'POST',
                 body: JSON.stringify(webhook.body, undefined, 4),
-                headers: { 'Content-Type': 'application/json' },
+                headers: webhook.headers || { 'Content-Type': 'application/json' },
                 timeout: hub.EXTERNAL_REQUEST_TIMEOUT_MS,
             })
             if (request.ok) {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
apps can pass headers, we were ignoring them

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
