### PR TITLE
feat: App metrics page for composeWebhook apps

### DIFF
--- a/frontend/src/scenes/apps/AppMetricsScene.tsx
+++ b/frontend/src/scenes/apps/AppMetricsScene.tsx
@@ -80,6 +80,11 @@ export function AppMetrics(): JSX.Element {
                             label: <>onEvent metrics</>,
                             content: <MetricsTab tab={AppMetricsTab.OnEvent} />,
                         },
+                        showTab(AppMetricsTab.ComposeWebhook) && {
+                            key: AppMetricsTab.ComposeWebhook,
+                            label: <>composeWebhook metrics</>,
+                            content: <MetricsTab tab={AppMetricsTab.ComposeWebhook} />,
+                        },
                         showTab(AppMetricsTab.ExportEvents) && {
                             key: AppMetricsTab.ExportEvents,
                             label: <>exportEvents metrics</>,

--- a/frontend/src/scenes/apps/appMetricsSceneLogic.ts
+++ b/frontend/src/scenes/apps/appMetricsSceneLogic.ts
@@ -28,6 +28,7 @@ export enum AppMetricsTab {
     Logs = 'logs',
     ProcessEvent = 'processEvent',
     OnEvent = 'onEvent',
+    ComposeWebhook = 'composeWebhook',
     ExportEvents = 'exportEvents',
     ScheduledTask = 'scheduledTask',
     HistoricalExports = 'historical_exports',
@@ -36,6 +37,7 @@ export enum AppMetricsTab {
 export const TabsWithMetrics = [
     AppMetricsTab.ProcessEvent,
     AppMetricsTab.OnEvent,
+    AppMetricsTab.ComposeWebhook,
     AppMetricsTab.ExportEvents,
     AppMetricsTab.ScheduledTask,
     AppMetricsTab.HistoricalExports,
@@ -95,6 +97,7 @@ const DEFAULT_DATE_FROM = '-30d'
 const INITIAL_TABS: Array<AppMetricsTab> = [
     AppMetricsTab.ProcessEvent,
     AppMetricsTab.OnEvent,
+    AppMetricsTab.ComposeWebhook,
     AppMetricsTab.ExportEvents,
     AppMetricsTab.ScheduledTask,
 ]

--- a/frontend/src/scenes/apps/constants.tsx
+++ b/frontend/src/scenes/apps/constants.tsx
@@ -47,6 +47,26 @@ export const DescriptionColumns: Record<string, Description> = {
             </>
         ),
     },
+    [AppMetricsTab.ComposeWebhook]: {
+        successes: 'Events processed',
+        successes_tooltip: (
+            <>
+                These events were successfully processed by the <i>composeWebhook</i> app method on the first try.
+            </>
+        ),
+        successes_on_retry: 'Events processed on retry',
+        successes_on_retry_tooltip: (
+            <>
+                These events were successfully processed by the <i>composeWebhook</i> app method after being retried.
+            </>
+        ),
+        failures: 'Failed events',
+        failures_tooltip: (
+            <>
+                These events had errors when being processed by the <i>composeWebhook</i> app method.
+            </>
+        ),
+    },
     [AppMetricsTab.ExportEvents]: {
         successes: 'Events delivered',
         successes_tooltip: (


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We weren't showing users metrics for composeWebhook. While the UI will change this will unblock converting apps to composeWebhook

## Changes
<img width="1058" alt="Screenshot 2023-11-17 at 15 26 55" src="https://github.com/PostHog/posthog/assets/890921/a7c240f5-ccf8-4fe0-a7e1-056a817fb4c4">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
