### PR TITLE
fix: protect against null in copytoclipboard

### DIFF
--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
@@ -283,7 +283,7 @@ export function PropertiesTable({
             title: '',
             width: 0,
             render: function Copy(_, item: any): JSX.Element | false {
-                if (Array.isArray(item[1]) || item[1] instanceof Object) {
+                if (Array.isArray(item[1]) || item[1] instanceof Object || item[1] === null) {
                     return false
                 }
                 return (


### PR DESCRIPTION
## Problem

Some pages in the app are showing this error
<img width="1145" alt="Screenshot 2023-11-17 at 15 45 53" src="https://github.com/PostHog/posthog/assets/6685876/c2684c52-5996-4d63-a06b-928bd7907c62">


## Changes

Protect against a `null` value

## How did you test this code?

By eye 👁️  Will follow up with a proper fix if necessary