### PR TITLE
feat(insights): Hide action name on bar chart if only one series

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_trends.py
+++ b/ee/clickhouse/views/test/test_clickhouse_trends.py
@@ -827,9 +827,7 @@ class ClickhouseTestTrends(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
                 ],
             )
             data_response = get_trends_time_series_ok(self.client, request, self.team)
-            person_response = get_people_from_url_ok(
-                self.client, data_response["$pageview - val"]["2012-01-14"].person_url
-            )
+            person_response = get_people_from_url_ok(self.client, data_response["val"]["2012-01-14"].person_url)
 
         assert data_response["val"]["2012-01-13"].value == 1
         assert data_response["val"]["2012-01-13"].breakdown_value == "val"
@@ -862,7 +860,7 @@ class ClickhouseTestTrends(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
                 properties=[{"type": "person", "key": "key", "value": "some_val"}],
             )
             data_response = get_trends_time_series_ok(self.client, request, self.team)
-            people = get_people_from_url_ok(self.client, data_response["$pageview - val"]["2012-01-14"].person_url)
+            people = get_people_from_url_ok(self.client, data_response["val"]["2012-01-14"].person_url)
 
         assert data_response["val"]["2012-01-13"].value == 1
         assert data_response["val"]["2012-01-13"].breakdown_value == "val"
@@ -894,7 +892,7 @@ class ClickhouseTestTrends(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
                 ],
             )
             data_response = get_trends_time_series_ok(self.client, request, self.team)
-            people = get_people_from_url_ok(self.client, data_response["$pageview - val"]["2012-01-14"].person_url)
+            people = get_people_from_url_ok(self.client, data_response["val"]["2012-01-14"].person_url)
 
         assert data_response["val"]["2012-01-13"].value == 1
         assert data_response["val"]["2012-01-13"].breakdown_value == "val"
@@ -933,12 +931,10 @@ class ClickhouseTestTrends(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
                 properties=[{"key": "key", "value": "oh", "operator": "not_icontains"}],
             )
             data_response = get_trends_time_series_ok(self.client, params, self.team)
-            person_response = get_people_from_url_ok(
-                self.client, data_response["sign up - val"]["2012-01-13"].person_url
-            )
+            person_response = get_people_from_url_ok(self.client, data_response["val"]["2012-01-13"].person_url)
 
-        assert data_response["sign up - val"]["2012-01-13"].value == 1
-        assert data_response["sign up - val"]["2012-01-13"].breakdown_value == "val"
+        assert data_response["val"]["2012-01-13"].value == 1
+        assert data_response["val"]["2012-01-13"].breakdown_value == "val"
 
         assert sorted([p["id"] for p in person_response]) == sorted([str(created_people["person1"].uuid)])
 
@@ -950,11 +946,9 @@ class ClickhouseTestTrends(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
                 events=[{"id": "sign up", "name": "sign up", "type": "events", "order": 0}],
             )
             aggregate_response = get_trends_aggregate_ok(self.client, params, self.team)
-            aggregate_person_response = get_people_from_url_ok(
-                self.client, aggregate_response["sign up - val"].person_url
-            )
+            aggregate_person_response = get_people_from_url_ok(self.client, aggregate_response["val"].person_url)
 
-        assert aggregate_response["sign up - val"].value == 1
+        assert aggregate_response["val"].value == 1
         assert sorted([p["id"] for p in aggregate_person_response]) == sorted([str(created_people["person1"].uuid)])
 
     def test_insight_trends_compare(self):

--- a/ee/clickhouse/views/test/test_clickhouse_trends.py
+++ b/ee/clickhouse/views/test/test_clickhouse_trends.py
@@ -118,7 +118,7 @@ def test_includes_only_intervals_within_range(client: Client):
                 {
                     "action": ANY,
                     "breakdown_value": cohort["id"],
-                    "label": "$pageview - test cohort",
+                    "label": "test cohort",
                     "count": 3.0,
                     "data": [1.0, 1.0, 1.0],
                     # Prior to the fix this would also include '29-Aug-2021'

--- a/ee/clickhouse/views/test/test_clickhouse_trends.py
+++ b/ee/clickhouse/views/test/test_clickhouse_trends.py
@@ -831,10 +831,10 @@ class ClickhouseTestTrends(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
                 self.client, data_response["$pageview - val"]["2012-01-14"].person_url
             )
 
-        assert data_response["$pageview - val"]["2012-01-13"].value == 1
-        assert data_response["$pageview - val"]["2012-01-13"].breakdown_value == "val"
-        assert data_response["$pageview - val"]["2012-01-14"].value == 3
-        assert data_response["$pageview - val"]["2012-01-14"].label == "14-Jan-2012"
+        assert data_response["val"]["2012-01-13"].value == 1
+        assert data_response["val"]["2012-01-13"].breakdown_value == "val"
+        assert data_response["val"]["2012-01-14"].value == 3
+        assert data_response["val"]["2012-01-14"].label == "14-Jan-2012"
 
         assert sorted([p["id"] for p in person_response]) == sorted(
             [str(created_people["p1"].uuid), str(created_people["p3"].uuid)]
@@ -864,10 +864,10 @@ class ClickhouseTestTrends(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
             data_response = get_trends_time_series_ok(self.client, request, self.team)
             people = get_people_from_url_ok(self.client, data_response["$pageview - val"]["2012-01-14"].person_url)
 
-        assert data_response["$pageview - val"]["2012-01-13"].value == 1
-        assert data_response["$pageview - val"]["2012-01-13"].breakdown_value == "val"
-        assert data_response["$pageview - val"]["2012-01-14"].value == 3
-        assert data_response["$pageview - val"]["2012-01-14"].label == "14-Jan-2012"
+        assert data_response["val"]["2012-01-13"].value == 1
+        assert data_response["val"]["2012-01-13"].breakdown_value == "val"
+        assert data_response["val"]["2012-01-14"].value == 3
+        assert data_response["val"]["2012-01-14"].label == "14-Jan-2012"
 
         assert sorted([p["id"] for p in people]) == sorted(
             [str(created_people["p1"].uuid), str(created_people["p3"].uuid)]
@@ -896,10 +896,10 @@ class ClickhouseTestTrends(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
             data_response = get_trends_time_series_ok(self.client, request, self.team)
             people = get_people_from_url_ok(self.client, data_response["$pageview - val"]["2012-01-14"].person_url)
 
-        assert data_response["$pageview - val"]["2012-01-13"].value == 1
-        assert data_response["$pageview - val"]["2012-01-13"].breakdown_value == "val"
-        assert data_response["$pageview - val"]["2012-01-14"].value == 2
-        assert data_response["$pageview - val"]["2012-01-14"].label == "14-Jan-2012"
+        assert data_response["val"]["2012-01-13"].value == 1
+        assert data_response["val"]["2012-01-13"].breakdown_value == "val"
+        assert data_response["val"]["2012-01-14"].value == 2
+        assert data_response["val"]["2012-01-14"].label == "14-Jan-2012"
 
         assert sorted([p["id"] for p in people]) == sorted(
             [str(created_people["p1"].uuid), str(created_people["p3"].uuid)]

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -698,11 +698,19 @@ export function LineGraph_({
                         precision,
                         autoSkip: true,
                         callback: function _renderYLabel(_, i) {
-                            const labelDescriptors = [
-                                datasets?.[0]?.actions?.[i]?.custom_name ?? datasets?.[0]?.actions?.[i]?.name, // action name
-                                datasets?.[0]?.breakdownValues?.[i], // breakdown value
-                                datasets?.[0]?.compareLabels?.[i], // compare value
-                            ].filter((l) => !!l)
+                            const labelDescriptors = (
+                                datasets?.[0]?.labels?.[i]
+                                    ? [
+                                          // prefer to use the label over the action name if it exists
+                                          datasets?.[0]?.labels?.[i],
+                                          datasets?.[0]?.compareLabels?.[i],
+                                      ]
+                                    : [
+                                          datasets?.[0]?.actions?.[i]?.custom_name ?? datasets?.[0]?.actions?.[i]?.name, // action name
+                                          datasets?.[0]?.breakdownValues?.[i], // breakdown value
+                                          datasets?.[0]?.compareLabels?.[i], // compare value
+                                      ]
+                            ).filter((l) => !!l)
                             return labelDescriptors.join(' - ')
                         },
                     },

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -420,10 +420,10 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
         assert len(response.results) == 4
         assert breakdown_labels == ["Chrome", "Edge", "Firefox", "Safari"]
-        assert response.results[0]["label"] == f"$pageview - Chrome"
-        assert response.results[1]["label"] == f"$pageview - Edge"
-        assert response.results[2]["label"] == f"$pageview - Firefox"
-        assert response.results[3]["label"] == f"$pageview - Safari"
+        assert response.results[0]["label"] == f"Chrome"
+        assert response.results[1]["label"] == f"Edge"
+        assert response.results[2]["label"] == f"Firefox"
+        assert response.results[3]["label"] == f"Safari"
         assert response.results[0]["count"] == 6
         assert response.results[1]["count"] == 1
         assert response.results[2]["count"] == 2
@@ -479,11 +479,11 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             "[32.5,40.01]",
         ]
 
-        assert response.results[0]["label"] == '$pageview - ["",""]'
-        assert response.results[1]["label"] == "$pageview - [10.0,17.5]"
-        assert response.results[2]["label"] == "$pageview - [17.5,25.0]"
-        assert response.results[3]["label"] == "$pageview - [25.0,32.5]"
-        assert response.results[4]["label"] == "$pageview - [32.5,40.01]"
+        assert response.results[0]["label"] == '["",""]'
+        assert response.results[1]["label"] == "[10.0,17.5]"
+        assert response.results[2]["label"] == "[17.5,25.0]"
+        assert response.results[3]["label"] == "[25.0,32.5]"
+        assert response.results[4]["label"] == "[32.5,40.01]"
 
         assert response.results[0]["data"] == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         assert response.results[1]["data"] == [0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 0]
@@ -554,14 +554,47 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
         assert len(response.results) == 4
         assert breakdown_labels == ["Chrome", "Edge", "Firefox", "Safari"]
-        assert response.results[0]["label"] == f"$pageview - Chrome"
-        assert response.results[1]["label"] == f"$pageview - Edge"
-        assert response.results[2]["label"] == f"$pageview - Firefox"
-        assert response.results[3]["label"] == f"$pageview - Safari"
+        assert response.results[0]["label"] == f"Chrome"
+        assert response.results[1]["label"] == f"Edge"
+        assert response.results[2]["label"] == f"Firefox"
+        assert response.results[3]["label"] == f"Safari"
         assert response.results[0]["count"] == 6
         assert response.results[1]["count"] == 1
         assert response.results[2]["count"] == 2
         assert response.results[3]["count"] == 1
+
+    def test_trends_breakdowns_multiple_hogql(self):
+        self._create_test_events()
+
+        response = self._run_trends_query(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.day,
+            [EventsNode(event="$pageview"), EventsNode(event="$pageleave")],
+            None,
+            BreakdownFilter(breakdown_type=BreakdownType.hogql, breakdown="properties.$browser"),
+        )
+
+        breakdown_labels = [result["breakdown_value"] for result in response.results]
+
+        assert len(response.results) == 8
+        assert breakdown_labels == ["Chrome", "Edge", "Firefox", "Safari", "Chrome", "Edge", "Firefox", "Safari"]
+        assert response.results[0]["label"] == f"$pageview - Chrome"
+        assert response.results[1]["label"] == f"$pageview - Edge"
+        assert response.results[2]["label"] == f"$pageview - Firefox"
+        assert response.results[3]["label"] == f"$pageview - Safari"
+        assert response.results[4]["label"] == f"$pageleave - Chrome"
+        assert response.results[5]["label"] == f"$pageleave - Edge"
+        assert response.results[6]["label"] == f"$pageleave - Firefox"
+        assert response.results[7]["label"] == f"$pageleave - Safari"
+        assert response.results[0]["count"] == 6
+        assert response.results[1]["count"] == 1
+        assert response.results[2]["count"] == 2
+        assert response.results[3]["count"] == 1
+        assert response.results[4]["count"] == 3
+        assert response.results[5]["count"] == 1
+        assert response.results[6]["count"] == 1
+        assert response.results[7]["count"] == 1
 
     def test_trends_breakdowns_and_compare(self):
         self._create_test_events()
@@ -626,10 +659,10 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
         assert len(response.results) == 4
         assert breakdown_labels == ["Chrome", "Edge", "Firefox", "Safari"]
-        assert response.results[0]["label"] == f"$pageview - Chrome"
-        assert response.results[1]["label"] == f"$pageview - Edge"
-        assert response.results[2]["label"] == f"$pageview - Firefox"
-        assert response.results[3]["label"] == f"$pageview - Safari"
+        assert response.results[0]["label"] == f"Chrome"
+        assert response.results[1]["label"] == f"Edge"
+        assert response.results[2]["label"] == f"Firefox"
+        assert response.results[3]["label"] == f"Safari"
 
         assert response.results[0]["data"] == [
             0,

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -136,7 +136,7 @@ class TrendsQueryRunner(QueryRunner):
 
             timings.extend(response.timings)
 
-            res.extend(self.build_series_response(response, series_with_extra))
+            res.extend(self.build_series_response(response, series_with_extra, len(queries)))
 
         if (
             self.query.trendsFilter is not None
@@ -147,7 +147,7 @@ class TrendsQueryRunner(QueryRunner):
 
         return TrendsQueryResponse(results=res, timings=timings)
 
-    def build_series_response(self, response: HogQLQueryResponse, series: SeriesWithExtras):
+    def build_series_response(self, response: HogQLQueryResponse, series: SeriesWithExtras, series_count: int):
         if response.results is None:
             return []
 
@@ -246,7 +246,13 @@ class TrendsQueryRunner(QueryRunner):
                     series_object["label"] = "{} - {}".format(series_object["label"], cohort_name)
                     series_object["breakdown_value"] = get_value("breakdown_value", val)
                 else:
-                    series_object["label"] = "{} - {}".format(series_object["label"], get_value("breakdown_value", val))
+                    # If there's multiple series, include the object label in the series label
+                    if series_count > 1:
+                        series_object["label"] = "{} - {}".format(
+                            series_object["label"], get_value("breakdown_value", val)
+                        )
+                    else:
+                        series_object["label"] = get_value("breakdown_value", val)
                     series_object["breakdown_value"] = get_value("breakdown_value", val)
 
             res.append(series_object)

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -474,14 +474,14 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                 self.team,
             )
 
-        self.assertEqual(response[0]["label"], "sign up - none")
+        self.assertEqual(response[0]["label"], "none")
         self.assertEqual(response[0]["labels"][4], "1-Jan-2020")
         self.assertEqual(response[0]["data"], [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0])
 
-        self.assertEqual(response[1]["label"], "sign up - other_value")
+        self.assertEqual(response[1]["label"], "other_value")
         self.assertEqual(response[1]["data"], [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
 
-        self.assertEqual(response[2]["label"], "sign up - value")
+        self.assertEqual(response[2]["label"], "value")
         self.assertEqual(response[2]["data"], [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0])
 
     def test_trends_single_aggregate_dau(self):
@@ -919,13 +919,14 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             )
 
         for result in event_response:
-            if result["label"] == "sign up - cohort1":
+            if result["label"] == "cohort1":
                 self.assertEqual(result["aggregated_value"], 2)
-            elif result["label"] == "sign up - cohort2":
+            elif result["label"] == "cohort2":
                 self.assertEqual(result["aggregated_value"], 2)
-            elif result["label"] == "sign up - cohort3":
+            elif result["label"] == "cohort3":
                 self.assertEqual(result["aggregated_value"], 3)
             else:
+                self.assertEqual(result["label"], "all users")
                 self.assertEqual(result["aggregated_value"], 7)
 
     def test_trends_breakdown_single_aggregate(self):
@@ -3869,7 +3870,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                 self.team,
             )
 
-        self.assertEqual(event_response[0]["label"], "$pageview - all users")
+        self.assertEqual(event_response[0]["label"], "all users")
         self.assertEqual(sum(event_response[0]["data"]), 1)
 
     @also_test_with_person_on_events_v2
@@ -3935,15 +3936,15 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             counts[res["label"]] = sum(res["data"])
             break_val[res["label"]] = res["breakdown_value"]
 
-        self.assertEqual(counts["watched movie - cohort1"], 1)
-        self.assertEqual(counts["watched movie - cohort2"], 3)
-        self.assertEqual(counts["watched movie - cohort3"], 4)
-        self.assertEqual(counts["watched movie - all users"], 7)
+        self.assertEqual(counts["cohort1"], 1)
+        self.assertEqual(counts["cohort2"], 3)
+        self.assertEqual(counts["cohort3"], 4)
+        self.assertEqual(counts["all users"], 7)
 
-        self.assertEqual(break_val["watched movie - cohort1"], cohort.pk)
-        self.assertEqual(break_val["watched movie - cohort2"], cohort2.pk)
-        self.assertEqual(break_val["watched movie - cohort3"], cohort3.pk)
-        self.assertEqual(break_val["watched movie - all users"], "all")
+        self.assertEqual(break_val["cohort1"], cohort.pk)
+        self.assertEqual(break_val["cohort2"], cohort2.pk)
+        self.assertEqual(break_val["cohort3"], cohort3.pk)
+        self.assertEqual(break_val["all users"], "all")
 
         self.assertEntityResponseEqual(event_response, action_response)
 
@@ -4085,7 +4086,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         for response in event_response:
             if response["breakdown_value"] == "person1":
                 self.assertEqual(response["count"], 1)
-                self.assertEqual(response["label"], "watched movie - person1")
+                self.assertEqual(response["label"], "person1")
             if response["breakdown_value"] == "person2":
                 self.assertEqual(response["count"], 3)
             if response["breakdown_value"] == "person3":
@@ -4126,7 +4127,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         for response in event_response:
             if response["breakdown_value"] == "person1":
                 self.assertEqual(response["count"], 1)
-                self.assertEqual(response["label"], "watched movie - person1")
+                self.assertEqual(response["label"], "person1")
             if response["breakdown_value"] == "person2":
                 self.assertEqual(response["count"], 3)
             if response["breakdown_value"] == "person3":
@@ -4666,9 +4667,9 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                     self.team,
                 )
             self.assertEqual(daily_response[0]["data"][0], 2)
-            self.assertEqual(daily_response[0]["label"], "sign up - some_val")
+            self.assertEqual(daily_response[0]["label"], "some_val")
             self.assertEqual(daily_response[1]["data"][0], 1)
-            self.assertEqual(daily_response[1]["label"], "sign up - none")
+            self.assertEqual(daily_response[1]["label"], "none")
 
             # MAU
             with freeze_time("2019-12-31T13:00:01Z"):
@@ -4809,8 +4810,8 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             )
 
         self.assertEqual(response[0]["label"], "sign up - none")
-        self.assertEqual(response[2]["label"], "sign up - other_value")
         self.assertEqual(response[1]["label"], "sign up - value")
+        self.assertEqual(response[2]["label"], "sign up - other_value")
         self.assertEqual(response[3]["label"], "no events - none")
 
         self.assertEqual(sum(response[0]["data"]), 2)
@@ -4869,9 +4870,9 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             ),
             self.team,
         )
-        self.assertEqual(response[0]["label"], "sign up - none")
-        self.assertEqual(response[1]["label"], "sign up - test@gmail.com")
-        self.assertEqual(response[2]["label"], "sign up - test@posthog.com")
+        self.assertEqual(response[0]["label"], "none")
+        self.assertEqual(response[1]["label"], "test@gmail.com")
+        self.assertEqual(response[2]["label"], "test@posthog.com")
 
         self.assertEqual(response[0]["count"], 1)
         self.assertEqual(response[1]["count"], 1)
@@ -4927,9 +4928,9 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             ),
             self.team,
         )
-        self.assertEqual(response[0]["label"], "sign up - none")
-        self.assertEqual(response[1]["label"], "sign up - test@gmail.com")
-        self.assertEqual(response[2]["label"], "sign up - test@posthog.com")
+        self.assertEqual(response[0]["label"], "none")
+        self.assertEqual(response[1]["label"], "test@gmail.com")
+        self.assertEqual(response[2]["label"], "test@posthog.com")
 
         self.assertEqual(response[0]["count"], 1)
         self.assertEqual(response[1]["count"], 1)
@@ -5003,8 +5004,8 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             )
 
         response = sorted(response, key=lambda x: x["label"])
-        self.assertEqual(response[0]["label"], "sign up - first url")
-        self.assertEqual(response[1]["label"], "sign up - second url")
+        self.assertEqual(response[0]["label"], "first url")
+        self.assertEqual(response[1]["label"], "second url")
 
         self.assertEqual(sum(response[0]["data"]), 1)
         self.assertEqual(response[0]["breakdown_value"], "first url")
@@ -5086,7 +5087,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             )
 
         response = sorted(response, key=lambda x: x["label"])
-        self.assertEqual(response[0]["label"], "sign up - second url")
+        self.assertEqual(response[0]["label"], "second url")
 
         self.assertEqual(sum(response[0]["data"]), 1)
         self.assertEqual(response[0]["breakdown_value"], "second url")
@@ -5170,8 +5171,8 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                 self.team,
             )
 
-        self.assertEqual(event_response[0]["label"], "sign up - some_val")
-        self.assertEqual(event_response[1]["label"], "sign up - some_val2")
+        self.assertEqual(event_response[0]["label"], "some_val")
+        self.assertEqual(event_response[1]["label"], "some_val2")
 
         self.assertEqual(sum(event_response[0]["data"]), 2)
         self.assertEqual(event_response[0]["data"][5], 1)
@@ -5211,8 +5212,8 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                 self.team,
             )
 
-        self.assertEqual(event_response[1]["label"], "sign up - other_value")
-        self.assertEqual(event_response[2]["label"], "sign up - value")
+        self.assertEqual(event_response[1]["label"], "other_value")
+        self.assertEqual(event_response[2]["label"], "value")
 
         self.assertEqual(sum(event_response[1]["data"]), 1)
         self.assertEqual(event_response[1]["data"][5], 1)
@@ -5256,8 +5257,8 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                 self.team,
             )
 
-        self.assertEqual(event_response[1]["label"], "sign up - other_value")
-        self.assertEqual(event_response[2]["label"], "sign up - value")
+        self.assertEqual(event_response[1]["label"], "other_value")
+        self.assertEqual(event_response[2]["label"], "value")
 
         self.assertEqual(sum(event_response[1]["data"]), 1)
         self.assertEqual(event_response[1]["data"][5], 1)
@@ -5301,7 +5302,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                 self.team,
             )
 
-        self.assertEqual(event_response[0]["label"], "sign up - other_value")
+        self.assertEqual(event_response[0]["label"], "other_value")
 
         self.assertEqual(sum(event_response[0]["data"]), 1)
         self.assertEqual(event_response[0]["data"][5], 1)  # property not defined

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -676,7 +676,11 @@ class TrendsBreakdown:
         extra_label = self._determine_breakdown_label(
             breakdown_value, filter.breakdown_type, filter.breakdown, breakdown_value
         )
-        label = "{} - {}".format(entity.name, extra_label)
+        if len(filter.entities) > 1:
+            # if there are multiple entities in the query, include the entity name in the labels
+            label = "{} - {}".format(entity.name, extra_label)
+        else:
+            label = extra_label
         additional_values = {"label": label}
         if filter.breakdown_type == "cohort":
             additional_values["breakdown_value"] = "all" if breakdown_value == ALL_USERS_COHORT_ID else breakdown_value


### PR DESCRIPTION
## Problem
This is unnecessary:
<img width="930" alt="Screenshot 2023-11-17 at 16 10 15" src="https://github.com/PostHog/posthog/assets/2056078/8f61a39d-bcf1-4af2-a83e-7822caee145d">
Wouldn't this be better:
<img width="920" alt="Screenshot 2023-11-17 at 16 11 08" src="https://github.com/PostHog/posthog/assets/2056078/07409661-b4e5-4359-b45d-0d13c147ae91">
Of course it should still keep the origin behaviour if there are multiple events/actions
<img width="909" alt="Screenshot 2023-11-17 at 16 11 47" src="https://github.com/PostHog/posthog/assets/2056078/454b0b2a-44bb-452d-89b0-bc240037ca0b">

## Changes

Change both the old trends query and the new hogql version to only add the entity/object name to the label if there are more than one.

## How did you test this code?

Manual + existing test suite
