### PR TITLE
chore: don't throw on inserts into too many parts on dev

### DIFF
--- a/docker/clickhouse/users-dev.xml
+++ b/docker/clickhouse/users-dev.xml
@@ -15,13 +15,16 @@
                   with minimum number of different symbols between replica's hostname and local hostname
                   (Hamming distance).
                  in_order - first live replica is chosen in specified order.
-                 first_or_random - if first replica one has higher number of errors, pick a random one from replicas with minimum number of errors.
+                 first_or_random - if first replica one has higher number of errors, pick a random one from replicas
+            with minimum number of errors.
             -->
             <load_balancing>random</load_balancing>
 
             <allow_nondeterministic_mutations>1</allow_nondeterministic_mutations>
 
             <stream_poll_timeout_ms>50</stream_poll_timeout_ms>
+
+            <throw_on_max_partitions_per_insert_block>0</throw_on_max_partitions_per_insert_block>
 
         </default>
 
@@ -45,30 +48,39 @@
                  Password could be empty.
 
                  If you want to specify SHA256, place it in 'password_sha256_hex' element.
-                 Example: <password_sha256_hex>65e84be33532fb784c48129675f9eff3a682b27168c0ea744b2cf58ee02337c5</password_sha256_hex>
-                 Restrictions of SHA256: impossibility to connect to ClickHouse using MySQL JS client (as of July 2019).
+                 Example:
+            <password_sha256_hex>65e84be33532fb784c48129675f9eff3a682b27168c0ea744b2cf58ee02337c5</password_sha256_hex>
+                 Restrictions of SHA256: impossibility to connect to ClickHouse using MySQL JS client (as of July
+            2019).
 
                  If you want to specify double SHA1, place it in 'password_double_sha1_hex' element.
-                 Example: <password_double_sha1_hex>e395796d6546b1b65db9d665cd43f0e858dd4303</password_double_sha1_hex>
+                 Example:
+            <password_double_sha1_hex>e395796d6546b1b65db9d665cd43f0e858dd4303</password_double_sha1_hex>
 
-                 If you want to specify a previously defined LDAP server (see 'ldap_servers' in the main config) for authentication,
+                 If you want to specify a previously defined LDAP server (see 'ldap_servers' in the main config) for
+            authentication,
                   place its name in 'server' element inside 'ldap' element.
                  Example: <ldap><server>my_ldap_server</server></ldap>
 
-                 If you want to authenticate the user via Kerberos (assuming Kerberos is enabled, see 'kerberos' in the main config),
+                 If you want to authenticate the user via Kerberos (assuming Kerberos is enabled, see 'kerberos' in
+            the main config),
                   place 'kerberos' element instead of 'password' (and similar) elements.
-                 The name part of the canonical principal name of the initiator must match the user name for authentication to succeed.
-                 You can also place 'realm' element inside 'kerberos' element to further restrict authentication to only those requests
+                 The name part of the canonical principal name of the initiator must match the user name for
+            authentication to succeed.
+                 You can also place 'realm' element inside 'kerberos' element to further restrict authentication to
+            only those requests
                   whose initiator's realm matches it.
                  Example: <kerberos />
                  Example: <kerberos><realm>EXAMPLE.COM</realm></kerberos>
 
                  How to generate decent password:
-                 Execute: PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" | sha256sum | tr -d '-'
+                 Execute: PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" |
+            sha256sum | tr -d '-'
                  In first line will be password and in second - corresponding SHA256.
 
                  How to generate double SHA1:
-                 Execute: PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" | sha1sum | tr -d '-' | xxd -r -p | sha1sum | tr -d '-'
+                 Execute: PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" |
+            sha1sum | tr -d '-' | xxd -r -p | sha1sum | tr -d '-'
                  In first line will be password and in second - corresponding double SHA1.
             -->
             <password></password>
@@ -89,7 +101,8 @@
                      To check access, DNS query is performed, and all received addresses compared to peer address.
                  <host_regexp> Regular expression for host names. Example, ^server\d\d-\d\d-\d\.yandex\.ru$
                      To check access, DNS PTR query is performed for peer address and then regexp is applied.
-                     Then, for result of PTR query, another DNS query is performed and all received addresses compared to peer address.
+                     Then, for result of PTR query, another DNS query is performed and all received addresses compared
+            to peer address.
                      Strongly recommended that regexp is ends with $
                  All results of DNS requests are cached till server restart.
             -->

--- a/docker/clickhouse/users.xml
+++ b/docker/clickhouse/users.xml
@@ -15,11 +15,14 @@
                   with minimum number of different symbols between replica's hostname and local hostname
                   (Hamming distance).
                  in_order - first live replica is chosen in specified order.
-                 first_or_random - if first replica one has higher number of errors, pick a random one from replicas with minimum number of errors.
+                 first_or_random - if first replica one has higher number of errors, pick a random one from replicas
+            with minimum number of errors.
             -->
             <load_balancing>random</load_balancing>
 
             <allow_nondeterministic_mutations>1</allow_nondeterministic_mutations>
+
+            <throw_on_max_partitions_per_insert_block>0</throw_on_max_partitions_per_insert_block>
 
         </default>
 
@@ -43,30 +46,39 @@
                  Password could be empty.
 
                  If you want to specify SHA256, place it in 'password_sha256_hex' element.
-                 Example: <password_sha256_hex>65e84be33532fb784c48129675f9eff3a682b27168c0ea744b2cf58ee02337c5</password_sha256_hex>
-                 Restrictions of SHA256: impossibility to connect to ClickHouse using MySQL JS client (as of July 2019).
+                 Example:
+            <password_sha256_hex>65e84be33532fb784c48129675f9eff3a682b27168c0ea744b2cf58ee02337c5</password_sha256_hex>
+                 Restrictions of SHA256: impossibility to connect to ClickHouse using MySQL JS client (as of July
+            2019).
 
                  If you want to specify double SHA1, place it in 'password_double_sha1_hex' element.
-                 Example: <password_double_sha1_hex>e395796d6546b1b65db9d665cd43f0e858dd4303</password_double_sha1_hex>
+                 Example:
+            <password_double_sha1_hex>e395796d6546b1b65db9d665cd43f0e858dd4303</password_double_sha1_hex>
 
-                 If you want to specify a previously defined LDAP server (see 'ldap_servers' in the main config) for authentication,
+                 If you want to specify a previously defined LDAP server (see 'ldap_servers' in the main config) for
+            authentication,
                   place its name in 'server' element inside 'ldap' element.
                  Example: <ldap><server>my_ldap_server</server></ldap>
 
-                 If you want to authenticate the user via Kerberos (assuming Kerberos is enabled, see 'kerberos' in the main config),
+                 If you want to authenticate the user via Kerberos (assuming Kerberos is enabled, see 'kerberos' in
+            the main config),
                   place 'kerberos' element instead of 'password' (and similar) elements.
-                 The name part of the canonical principal name of the initiator must match the user name for authentication to succeed.
-                 You can also place 'realm' element inside 'kerberos' element to further restrict authentication to only those requests
+                 The name part of the canonical principal name of the initiator must match the user name for
+            authentication to succeed.
+                 You can also place 'realm' element inside 'kerberos' element to further restrict authentication to
+            only those requests
                   whose initiator's realm matches it.
                  Example: <kerberos />
                  Example: <kerberos><realm>EXAMPLE.COM</realm></kerberos>
 
                  How to generate decent password:
-                 Execute: PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" | sha256sum | tr -d '-'
+                 Execute: PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" |
+            sha256sum | tr -d '-'
                  In first line will be password and in second - corresponding SHA256.
 
                  How to generate double SHA1:
-                 Execute: PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" | sha1sum | tr -d '-' | xxd -r -p | sha1sum | tr -d '-'
+                 Execute: PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" |
+            sha1sum | tr -d '-' | xxd -r -p | sha1sum | tr -d '-'
                  In first line will be password and in second - corresponding double SHA1.
             -->
             <password></password>
@@ -87,7 +99,8 @@
                      To check access, DNS query is performed, and all received addresses compared to peer address.
                  <host_regexp> Regular expression for host names. Example, ^server\d\d-\d\d-\d\.yandex\.ru$
                      To check access, DNS PTR query is performed for peer address and then regexp is applied.
-                     Then, for result of PTR query, another DNS query is performed and all received addresses compared to peer address.
+                     Then, for result of PTR query, another DNS query is performed and all received addresses compared
+            to peer address.
                      Strongly recommended that regexp is ends with $
                  All results of DNS requests are cached till server restart.
             -->


### PR DESCRIPTION
## Problem

Problem right now is that on dev or in tests you can insert into too many partitions for `log_entries` which is acceptable when not in production. Instead of having clickhouse throw on this we have it warn and keep going.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
