### PR TITLE
chore: Use system.parts table to get count of rows. much cheaper

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -689,7 +689,7 @@ def clickhouse_row_count():
         for table in CLICKHOUSE_TABLES:
             try:
                 QUERY = """SELECT sum(rows) rows from system.parts
-                       WHERE table = '{table}' and is_active;"""
+                       WHERE table = '{table}' and active;"""
                 query = QUERY.format(table=table)
                 rows = sync_execute(query)[0][0]
                 row_count_gauge.labels(table_name=table).set(rows)
@@ -746,6 +746,7 @@ def clickhouse_part_count():
     QUERY = """
         SELECT table, count(1) freq
         FROM system.parts
+        WHERE active
         GROUP BY table
         ORDER BY freq DESC;
     """

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -541,8 +541,7 @@ def clickhouse_lag():
         for table in CLICKHOUSE_TABLES:
             try:
                 QUERY = """SELECT max(_timestamp) observed_ts, now() now_ts, now() - max(_timestamp) as lag
-                    FROM {table}
-                    WHERE timestamp >= now() -  toIntervalDay(3);"""
+                    FROM {table}"""
                 query = QUERY.format(table=table)
                 lag = sync_execute(query)[0][2]
                 statsd.gauge(

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -688,9 +688,8 @@ def clickhouse_row_count():
         )
         for table in CLICKHOUSE_TABLES:
             try:
-                QUERY = (
-                    """select count(1) freq from {table} where _timestamp >= toStartOfDay(date_sub(DAY, 2, now()));"""
-                )
+                QUERY = """SELECT sum(rows) rows from system.parts
+                       WHERE table = '{table}' and is_active;"""
                 query = QUERY.format(table=table)
                 rows = sync_execute(query)[0][0]
                 row_count_gauge.labels(table_name=table).set(rows)

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -540,9 +540,9 @@ def clickhouse_lag():
         )
         for table in CLICKHOUSE_TABLES:
             try:
-                QUERY = (
-                    """select max(_timestamp) observed_ts, now() now_ts, now() - max(_timestamp) as lag from {table};"""
-                )
+                QUERY = """SELECT max(_timestamp) observed_ts, now() now_ts, now() - max(_timestamp) as lag
+                    FROM {table}
+                    WHERE timestamp >= now() -  toIntervalDay(3);"""
                 query = QUERY.format(table=table)
                 lag = sync_execute(query)[0][2]
                 statsd.gauge(
@@ -744,10 +744,10 @@ def clickhouse_part_count():
     from posthog.client import sync_execute
 
     QUERY = """
-        select table, count(1) freq
-        from system.parts
-        group by table
-        order by freq desc;
+        SELECT table, count(1) freq
+        FROM system.parts
+        GROUP BY table
+        ORDER BY freq DESC;
     """
     rows = sync_execute(QUERY)
 

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -515,10 +515,10 @@ def pg_row_count():
 
 
 CLICKHOUSE_TABLES = [
-    "events",
+    "sharded_events",
     "person",
     "person_distinct_id2",
-    "session_replay_events",
+    "sharded_session_replay_events",
     "log_entries",
 ]
 if not is_cloud():


### PR DESCRIPTION
## Problem

We are currently doing a huge scan of rows to get counts from clickhouse stats. We really should just query the metadata store for this as it's faster and cheaper...
and less likely to blow out the cache.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
