### PR TITLE
fix(usage-reports): use startTime not start_time

### DIFF
--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -267,7 +267,7 @@
      FROM events
      WHERE team_id = 2
        AND event = 'external data sync job'
-       AND parseDateTimeBestEffort(JSONExtractString(properties, 'start_time')) BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+       AND parseDateTimeBestEffort(JSONExtractString(properties, 'startTime')) BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
      GROUP BY job_id,
               team)
   GROUP BY team

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -1017,7 +1017,7 @@ class TestExternalDataSyncUsageReport(ClickhouseDestroyTablesMixin, TestCase, Cl
                 properties={
                     "count": 10,
                     "job_id": 10924,
-                    "start_time": start_time,
+                    "startTime": start_time,
                 },
                 timestamp=now() - relativedelta(hours=i),
                 team=self.analytics_team,
@@ -1029,7 +1029,7 @@ class TestExternalDataSyncUsageReport(ClickhouseDestroyTablesMixin, TestCase, Cl
                 properties={
                     "count": 10,
                     "job_id": 10924,
-                    "start_time": start_time,
+                    "startTime": start_time,
                 },
                 timestamp=now() - relativedelta(hours=i, minutes=i),
                 team=self.analytics_team,
@@ -1042,7 +1042,7 @@ class TestExternalDataSyncUsageReport(ClickhouseDestroyTablesMixin, TestCase, Cl
                 properties={
                     "count": 10,
                     "job_id": 10924,
-                    "start_time": (now() - relativedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "startTime": (now() - relativedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 },
                 timestamp=now() - relativedelta(hours=i),
                 team=self.analytics_team,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -16,7 +16,6 @@ from typing import (
 )
 
 import requests
-from retry import retry
 import structlog
 from dateutil import parser
 from django.conf import settings
@@ -24,6 +23,7 @@ from django.db import connection
 from django.db.models import Count, Q
 from posthoganalytics.client import Client
 from psycopg2 import sql
+from retry import retry
 from sentry_sdk import capture_exception
 
 from posthog import version_requirement
@@ -604,7 +604,7 @@ def get_teams_with_rows_synced_in_period(begin: datetime, end: datetime) -> List
         SELECT team, sum(rows_synced) FROM (
             SELECT JSONExtractString(properties, 'job_id') AS job_id, distinct_id AS team, any(JSONExtractInt(properties, 'count')) AS rows_synced
             FROM events
-            WHERE team_id = %(team_to_query)s AND event = 'external data sync job' AND parseDateTimeBestEffort(JSONExtractString(properties, 'start_time')) BETWEEN %(begin)s AND %(end)s
+            WHERE team_id = %(team_to_query)s AND event = 'external data sync job' AND parseDateTimeBestEffort(JSONExtractString(properties, 'startTime')) BETWEEN %(begin)s AND %(end)s
             GROUP BY job_id, team
         )
         GROUP BY team


### PR DESCRIPTION
## Problem

Usage reports were failing at the data warehouse query. i think it's because they we're looking for the wrong property - the events have a `startTime` prop but not a `start_time` property.

<img width="632" alt="image" src="https://github.com/PostHog/posthog/assets/18598166/8363dc10-e638-4f50-a4e2-0c68ae1094d4">


<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

use startTime and not start_time in query

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Updated tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
