### PR TITLE
feat: Heartbeating and asyncio for BigQuery batch exports

### DIFF
--- a/posthog/temporal/workflows/bigquery_batch_export.py
+++ b/posthog/temporal/workflows/bigquery_batch_export.py
@@ -309,6 +309,4 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
                 "NotFound",
             ],
             update_inputs=update_inputs,
-            # Disable heartbeat timeout until we add heartbeat support.
-            heartbeat_timeout_seconds=None,
         )


### PR DESCRIPTION
## Problem

We have refactored the following destinations to use async calls for blocking io:
* Postgres and Redshift (#18631)
* Snowflake (#18427)
* S3 (#17673)

This is the final one, BigQuery.

## Changes

* Wrap blocking IO in asyncio.to_thread
* Add heartbeatting.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manual tests:

```
DEBUG=1 pytest posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py -vv 
===================================================== test session starts =====================================================
platform linux -- Python 3.10.10, pytest-7.4.0, pluggy-0.13.1 -- ./.direnv/python-3.10.10/bin/python
cachedir: .pytest_cache
django: settings: posthog.settings (from ini)
rootdir: .
configfile: pytest.ini
plugins: asyncio-0.21.1, icdiff-0.6, flaky-3.7.0, env-0.8.2, Faker-17.5.0, syrupy-1.7.4, mock-3.11.1, split-0.8.1, django-4.5.2, cov-4.1.0
asyncio: mode=strict
collected 8 items                                                                                                             

posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py::test_insert_into_bigquery_activity_inserts_data_into_bigquery_table[None] PASSED [ 12%]
posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py::test_insert_into_bigquery_activity_inserts_data_into_bigquery_table[exclude_events1] PASSED [ 25%]
posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py::test_bigquery_export_workflow[None-hour] PASSED [ 37%]
posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py::test_bigquery_export_workflow[None-day] PASSED [ 50%]
posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py::test_bigquery_export_workflow[exclude_events1-hour] PASSED [ 62%]
posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py::test_bigquery_export_workflow[exclude_events1-day] PASSED [ 75%]
posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py::test_bigquery_export_workflow_handles_insert_activity_errors PASSED [ 87%]
posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py::test_bigquery_export_workflow_handles_cancellation PASSED [100%]

--------------------------------------------------- snapshot report summary ---------------------------------------------------

===================================================== 8 passed in 57.52s ======================================================
```
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
