### PR TITLE
feat(web-analytics): Disable world map when geoip app is not enabled

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -71,6 +71,7 @@ import { getCurrentExporterData } from '~/exporter/exporterViewLogic'
 import { encodeParams } from 'kea-router'
 
 export const ACTIVITY_PAGE_SIZE = 20
+const PAGINATION_DEFAULT_MAX_PAGES = 10
 
 export interface PaginatedResponse<T> {
     results: T[]
@@ -1862,6 +1863,23 @@ const api = {
             throw { status: response.status, ...data }
         }
         return response
+    },
+
+    async loadPaginatedResults(
+        url: string | null,
+        maxIterations: number = PAGINATION_DEFAULT_MAX_PAGES
+    ): Promise<any[]> {
+        let results: any[] = []
+        for (let i = 0; i <= maxIterations; ++i) {
+            if (!url) {
+                break
+            }
+
+            const { results: partialResults, next } = await api.get(url)
+            results = results.concat(partialResults)
+            url = next
+        }
+        return results
     },
 }
 

--- a/frontend/src/scenes/pipeline/transformationsLogic.tsx
+++ b/frontend/src/scenes/pipeline/transformationsLogic.tsx
@@ -36,7 +36,7 @@ export const pipelineTransformationsLogic = kea<pipelineTransformationsLogicType
             {} as Record<number, PluginType>,
             {
                 loadPlugins: async () => {
-                    const results: PluginType[] = await loadPaginatedResults(
+                    const results: PluginType[] = await api.loadPaginatedResults(
                         `api/organizations/@current/pipeline_transformations`
                     )
                     const plugins: Record<number, PluginType> = {}
@@ -60,7 +60,7 @@ export const pipelineTransformationsLogic = kea<pipelineTransformationsLogicType
             {
                 loadPluginConfigs: async () => {
                     const pluginConfigs: Record<number, PluginConfigTypeNew> = {}
-                    const results = await loadPaginatedResults(
+                    const results = await api.loadPaginatedResults(
                         `api/projects/${values.currentTeamId}/pipeline_transformations_configs`
                     )
 
@@ -185,21 +185,3 @@ export const pipelineTransformationsLogic = kea<pipelineTransformationsLogicType
         actions.loadPluginConfigs()
     }),
 ])
-
-const PAGINATION_DEFAULT_MAX_PAGES = 10
-async function loadPaginatedResults(
-    url: string | null,
-    maxIterations: number = PAGINATION_DEFAULT_MAX_PAGES
-): Promise<any[]> {
-    let results: any[] = []
-    for (let i = 0; i <= maxIterations; ++i) {
-        if (!url) {
-            break
-        }
-
-        const { results: partialResults, next } = await api.get(url)
-        results = results.concat(partialResults)
-        url = next
-    }
-    return results
-}

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -29,8 +29,6 @@ export interface PluginSelectionType {
     url?: string
 }
 
-const PAGINATION_DEFAULT_MAX_PAGES = 10
-
 function capturePluginEvent(event: string, plugin: PluginType, type?: PluginInstallationType): void {
     posthog.capture(event, {
         plugin_name: plugin.name,
@@ -38,23 +36,6 @@ function capturePluginEvent(event: string, plugin: PluginType, type?: PluginInst
         plugin_tag: plugin.tag,
         ...(type && { plugin_installation_type: type }),
     })
-}
-
-async function loadPaginatedResults(
-    url: string | null,
-    maxIterations: number = PAGINATION_DEFAULT_MAX_PAGES
-): Promise<any[]> {
-    let results: any[] = []
-    for (let i = 0; i <= maxIterations; ++i) {
-        if (!url) {
-            break
-        }
-
-        const { results: partialResults, next } = await api.get(url)
-        results = results.concat(partialResults)
-        url = next
-    }
-    return results
 }
 
 export const pluginsLogic = kea<pluginsLogicType>([
@@ -102,7 +83,7 @@ export const pluginsLogic = kea<pluginsLogicType>([
             {} as Record<number, PluginType>,
             {
                 loadPlugins: async () => {
-                    const results: PluginType[] = await loadPaginatedResults('api/organizations/@current/plugins')
+                    const results: PluginType[] = await api.loadPaginatedResults('api/organizations/@current/plugins')
                     const plugins: Record<string, PluginType> = {}
                     for (const plugin of results) {
                         plugins[plugin.id] = plugin
@@ -160,7 +141,7 @@ export const pluginsLogic = kea<pluginsLogicType>([
             {
                 loadPluginConfigs: async () => {
                     const pluginConfigs: Record<string, PluginConfigType> = {}
-                    const results: PluginConfigType[] = await loadPaginatedResults('api/plugin_config')
+                    const results: PluginConfigType[] = await api.loadPaginatedResults('api/plugin_config')
 
                     for (const pluginConfig of results) {
                         pluginConfigs[pluginConfig.plugin] = { ...pluginConfig }


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/7339 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/10659)
A user was seeing the world map with a tiny number of users with GeoIP.

## Changes

Hide the geography tile (incl world map) if the user doesn't have the geoIp app enabled.

## How did you test this code?
Manually