### PR TITLE
fix(experiments): Don't rerender on every input change

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -244,13 +244,13 @@ export function Experiment(): JSX.Element {
                                                 numbers, hyphens, and underscores.
                                             </div>
                                             <div className="variants">
-                                                {experiment.parameters.feature_flag_variants?.map((variant, index) => (
+                                                {experiment.parameters.feature_flag_variants?.map((_, index) => (
                                                     <Group
                                                         key={index}
                                                         name={['parameters', 'feature_flag_variants', index]}
                                                     >
                                                         <div
-                                                            key={`${variant.key}-${index}`}
+                                                            key={`variant-${index}`}
                                                             className={clsx(
                                                                 'feature-flag-variant',
                                                                 index === 0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/18717

For some reason I can't reproduce this locally, but I suspect what's happening is that the key here used to get converted to `[object Object]` so it wouldn't change when the variant key changes.

With the update in https://github.com/PostHog/posthog/pull/18662/files#diff-167e770c0c7fa3176a6e914200d9683f3b2b41ae8233f726eefb3b684cbadf5f to move to new ESLint rules, this bug was exposed, and now the `key` changes every time you input the variant key.

This should ensure we don't re-render.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
