### PR TITLE
fix: button overflow

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.scss
@@ -52,6 +52,7 @@
         padding-left: 0.5rem;
         padding-right: 0.5rem;
 
+        > span,
         .LemonButton__content {
             overflow: hidden;
         }


### PR DESCRIPTION
## Problem

Buttons were not obeying overflows because of a new nested `span` element to support 3000 buttons

## Changes

|Before|After|
|----|----|
| <img width="396" alt="Screenshot 2023-11-20 at 13 21 14" src="https://github.com/PostHog/posthog/assets/6685876/4ddbcaaa-463e-49ed-82c5-501f5582a4ff"> | <img width="388" alt="Screenshot 2023-11-20 at 13 20 56" src="https://github.com/PostHog/posthog/assets/6685876/73527908-b208-407a-9466-5ffc13d90cd2"> |

## How did you test this code?

Visually