### PR TITLE
fix(lemon-ui): Clearable side action button sizing

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.scss
+++ b/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.scss
@@ -1,8 +1,15 @@
-.LemonSelect--button--clearable {
-    padding-left: 0.5rem !important;
-    margin-left: auto;
-}
-
 .LemonSelect--clearable {
     padding-right: 0 !important;
+
+    > span {
+        padding-right: 0 !important;
+    }
+
+    .LemonButton__content {
+        gap: 0.5rem;
+
+        .LemonSelect--button--clearable {
+            margin-left: auto;
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Clearable Lemon Select buttons did not look correct in 3000

## Changes

- Apply padding override to span used in 3000 mode too
- Fix existing issue around padding being applied to button that messed up hover

## How did you test this code?

|Before|After|
|----|----|
| <img width="280" alt="Screenshot 2023-11-20 at 16 30 35" src="https://github.com/PostHog/posthog/assets/6685876/cc070464-8dfc-4982-9211-8f4806693e81"> | <img width="308" alt="Screenshot 2023-11-20 at 16 29 11" src="https://github.com/PostHog/posthog/assets/6685876/be15a3c7-d703-4c9d-af6d-a965ff87d34a"> |

|Before|After|
|----|----|
| <img width="262" alt="Screenshot 2023-11-20 at 16 30 19" src="https://github.com/PostHog/posthog/assets/6685876/3a4084d5-53cd-4afc-b4de-ada6552a3882"> | <img width="275" alt="Screenshot 2023-11-20 at 16 29 23" src="https://github.com/PostHog/posthog/assets/6685876/68e74a6c-9f20-4c05-b6a1-80355f1a1b44"> |