### PR TITLE
fix: Paste rules into notebooks

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/utils.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/utils.tsx
@@ -28,13 +28,15 @@ export function posthogNodePasteRule(options: {
         handler: ({ match, chain, range }) => {
             if (match.input) {
                 chain().deleteRange(range).run()
-                const attributes = options.getAttributes(match)
-                if (attributes) {
-                    options.editor.commands.insertContent({
-                        type: options.type.name,
-                        attrs: attributes,
-                    })
-                }
+
+                void Promise.resolve(options.getAttributes(match)).then((attributes) => {
+                    if (attributes) {
+                        options.editor.commands.insertContent({
+                            type: options.type.name,
+                            attrs: attributes,
+                        })
+                    }
+                })
             }
         },
     })


### PR DESCRIPTION
## Problem

We had code to handle promises / not promises and this accidentally got clobbered in the eslint refactor

## Changes

* Reverts back to the promise trick to make sure we handle all types.
* Should fix @andyvan-ph 's issue

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
