### PR TITLE
fix: survey response scrollbars

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.scss
+++ b/frontend/src/scenes/surveys/SurveyView.scss
@@ -17,8 +17,3 @@
     break-inside: avoid;
     box-sizing: border-box;
 }
-
-.masonry-item-text {
-    max-height: 305px;
-    overflow-y: scroll;
-}

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -483,7 +483,7 @@ export function OpenTextViz({
 
                             return (
                                 <div key={`open-text-${questionIndex}-${i}`} className="masonry-item border rounded">
-                                    <div className="masonry-item-text text-center italic font-semibold px-5 py-4">
+                                    <div className="max-h-80 overflow-y-auto text-center italic font-semibold px-5 py-4">
                                         {JSON.stringify(event.properties[surveyResponseField])}
                                     </div>
                                     <div className="bg-bg-light items-center px-5 py-4 border-t rounded-b truncate w-full">


### PR DESCRIPTION
## Problem

There was a strange border on the right hand side. Turns out it was a scrollbar

|Before|
|----|
| <img width="287" alt="Screenshot 2023-11-20 at 17 53 48" src="https://github.com/PostHog/posthog/assets/6685876/741cb2e2-2b8e-44f2-8a94-247aef456a60"> |

## Changes

- Use overflow classes. `overflow: auto` does not show the scrollbar if not necessary
- Remove previous class altogether because it's not really needed

## How did you test this code?

|After|
|----|
| <img width="291" alt="Screenshot 2023-11-20 at 17 53 59" src="https://github.com/PostHog/posthog/assets/6685876/5a02f3e1-3772-4ef4-b93d-c47cfc2d148c"> |