### PR TITLE
chore: add more metrics to notebooks

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/components/NotebookNodeTitle.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/NotebookNodeTitle.tsx
@@ -4,6 +4,7 @@ import { notebookNodeLogic } from '../notebookNodeLogic'
 import { useEffect, useState } from 'react'
 import { LemonInput, Tooltip } from '@posthog/lemon-ui'
 import { notebookLogic } from 'scenes/notebooks/Notebook/notebookLogic'
+import posthog from 'posthog-js'
 
 export function NotebookNodeTitle(): JSX.Element {
     const { isEditable } = useValues(notebookLogic)
@@ -20,6 +21,10 @@ export function NotebookNodeTitle(): JSX.Element {
         updateAttributes({
             title: newValue ?? undefined,
         })
+
+        if (title != newValue) {
+            posthog.capture('notebook node title updated')
+        }
 
         setEditing(false)
     }
@@ -42,7 +47,10 @@ export function NotebookNodeTitle(): JSX.Element {
             <span
                 title={title}
                 className="NotebookNodeTitle NotebookNodeTitle--editable"
-                onDoubleClick={() => setEditing(true)}
+                onDoubleClick={() => {
+                    setEditing(true)
+                    posthog.capture('notebook editing node title')
+                }}
             >
                 {title}
             </span>

--- a/frontend/src/scenes/notebooks/NotebooksTable/ContainsTypeFilter.tsx
+++ b/frontend/src/scenes/notebooks/NotebooksTable/ContainsTypeFilter.tsx
@@ -1,6 +1,7 @@
 import { NotebookNodeType } from '~/types'
 import { LemonSelectMultiple } from 'lib/lemon-ui/LemonSelectMultiple'
 import { NotebooksListFilters } from 'scenes/notebooks/NotebooksTable/notebooksTableLogic'
+import posthog from 'posthog-js'
 
 export const fromNodeTypeToLabel: Omit<
     Record<NotebookNodeType, string>,
@@ -48,6 +49,7 @@ export function ContainsTypeFilters({
                     }, {})}
                 value={filters.contains}
                 onChange={(newValue: string[]) => {
+                    posthog.capture('notebook containing filter applied')
                     setFilters({ contains: newValue.map((x) => x as NotebookNodeType) })
                 }}
                 data-attr={'notebooks-list-contains-filters'}


### PR DESCRIPTION
## Problem

Want to track more things before launch

## Changes

- See how visible the ability to edit a node title is
- See how many people filter the notebooks list by node type

## How did you test this code?

With console logs