### PR TITLE
feat: Switch 3000

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.scss
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.scss
@@ -1,4 +1,7 @@
 .LemonSwitch {
+    --lemon-switch-height: 1.25rem;
+    --lemon-switch-width: 2.25rem;
+
     width: fit-content;
     font-weight: 500;
     line-height: 1.5rem;
@@ -46,6 +49,11 @@
             cursor: not-allowed; // A label with for=* also toggles the switch, so it shouldn't have the text select cursor
         }
     }
+
+    .posthog-3000 & {
+        --lemon-switch-width: 1.5rem;
+        --lemon-switch-height: 0.75rem;
+    }
 }
 
 .LemonSwitch__button {
@@ -53,8 +61,8 @@
     display: inline-block;
     flex-shrink: 0;
     padding: 0;
-    width: 2.25rem;
-    height: 1.25rem;
+    width: var(--lemon-switch-width);
+    height: var(--lemon-switch-height);
     background: none;
     border: none;
     cursor: pointer;
@@ -75,8 +83,21 @@
     background-color: var(--border);
     transition: background-color 100ms ease;
 
+    .posthog-3000 & {
+        border-radius: var(--lemon-switch-height);
+        height: 100%;
+        width: 100%;
+        top: 0px;
+        pointer-events: none;
+        background-color: var(--border-bold);
+    }
+
     .LemonSwitch--checked & {
         background-color: var(--primary-highlight);
+
+        .posthog-3000 & {
+            background-color: var(--primary-3000);
+        }
     }
 }
 
@@ -89,23 +110,53 @@
     border-radius: 0.625rem;
     background-color: #fff;
     border: 2px solid var(--border);
-    transition: background-color 100ms ease, transform 100ms ease, border-color 100ms ease;
+    transition: background-color 100ms ease, transform 100ms ease, width 100ms ease, border-color 100ms ease;
     cursor: inherit;
     display: flex;
     align-items: center;
     justify-content: center;
 
+    .posthog-3000 & {
+        --lemon-switch-handle-ratio: calc(8 / 10);
+        --lemon-switch-handle-gutter: calc(var(--lemon-switch-height) * calc(1 - var(--lemon-switch-handle-ratio)) / 2);
+        --lemon-switch-handle-width: calc(var(--lemon-switch-height) * var(--lemon-switch-handle-ratio));
+        --lemon-switch-active-translate: translateX(
+            calc(var(--lemon-switch-width) - var(--lemon-switch-handle-width) - var(--lemon-switch-handle-gutter) * 2)
+        );
+        top: var(--lemon-switch-handle-gutter);
+        left: var(--lemon-switch-handle-gutter);
+        width: var(--lemon-switch-handle-width);
+        height: calc(var(--lemon-switch-height) * var(--lemon-switch-handle-ratio));
+        border: none;
+        pointer-events: none;
+        background-color: #fff;
+    }
+
     .LemonSwitch--checked & {
         background-color: var(--primary);
         border-color: var(--primary);
         transform: translateX(1rem);
+
+        .posthog-3000 & {
+            transform: var(--lemon-switch-active-translate);
+            background-color: #fff;
+        }
     }
 
     .LemonSwitch--active & {
         transform: scale(1.1);
+
+        .posthog-3000 & {
+            --lemon-switch-handle-width: calc(var(--lemon-switch-height) * var(--lemon-switch-handle-ratio) * 1.2);
+            transform: none;
+        }
     }
 
     .LemonSwitch--active.LemonSwitch--checked & {
         transform: translateX(1rem) scale(1.1);
+
+        .posthog-3000 & {
+            transform: var(--lemon-switch-active-translate);
+        }
     }
 }

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.scss
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.scss
@@ -87,7 +87,7 @@
         border-radius: var(--lemon-switch-height);
         height: 100%;
         width: 100%;
-        top: 0px;
+        top: 0;
         pointer-events: none;
         background-color: var(--border-bold);
     }
@@ -123,6 +123,7 @@
         --lemon-switch-active-translate: translateX(
             calc(var(--lemon-switch-width) - var(--lemon-switch-handle-width) - var(--lemon-switch-handle-gutter) * 2)
         );
+
         top: var(--lemon-switch-handle-gutter);
         left: var(--lemon-switch-handle-gutter);
         width: var(--lemon-switch-handle-width);
@@ -148,6 +149,7 @@
 
         .posthog-3000 & {
             --lemon-switch-handle-width: calc(var(--lemon-switch-height) * var(--lemon-switch-handle-ratio) * 1.2);
+
             transform: none;
         }
     }

--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
@@ -79,7 +79,7 @@ export function LemonSwitch({
         buttonComponent = (
             <Tooltip title={tooltipContent}>
                 {/* wrap it in a div so that the tooltip works even when disabled */}
-                <div>{buttonComponent}</div>
+                <div className="flex items-center">{buttonComponent}</div>
             </Tooltip>
         )
     }


### PR DESCRIPTION
## Problem

The switch looked a little outdated given all the other changes and tidying.
Took inspiration from the feature flags icon as that is where I noticed it (whilst toggling them on and off in Toolbar 3000).

## Changes

* New styles
* A little bit messy as I'm overriding the old styles. When we are fully on 3000 we can come in and clean it up.

![2023-11-21 10 41 20](https://github.com/PostHog/posthog/assets/2536520/daff30f8-8aab-4958-915f-752f6d2d90e6)

**Before**
<img width="1014" alt="Screenshot 2023-11-21 at 10 42 16" src="https://github.com/PostHog/posthog/assets/2536520/01bb994c-5f32-4300-83f7-22423aebf9d1">

**After**
<img width="1022" alt="Screenshot 2023-11-21 at 10 42 47" src="https://github.com/PostHog/posthog/assets/2536520/1e89d8cf-d4ff-40b8-9b6e-e1b51ca104aa">




👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
