### PR TITLE
fix: data colors for plugins

### DIFF
--- a/frontend/src/scenes/apps/AppMetricsGraph.tsx
+++ b/frontend/src/scenes/apps/AppMetricsGraph.tsx
@@ -32,21 +32,21 @@ export function AppMetricsGraph({ tab, metrics, metricsLoading }: AppMetricsGrap
                             label: descriptions.successes,
                             data: metrics.successes,
                             borderColor: '',
-                            ...colorConfig('data-brand-blue'),
+                            ...colorConfig('data-color-1'),
                         },
                         ...(descriptions.successes_on_retry
                             ? [
                                   {
                                       label: descriptions.successes_on_retry,
                                       data: metrics.successes_on_retry,
-                                      ...colorConfig('data-yellow'),
+                                      ...colorConfig('data-color-13'),
                                   },
                               ]
                             : []),
                         {
                             label: descriptions.failures,
                             data: metrics.failures,
-                            ...colorConfig('data-vermilion'),
+                            ...colorConfig('data-color-5'),
                         },
                     ],
                 },


### PR DESCRIPTION
## Problem

`processEvents metrics` are not loading
<img width="947" alt="Screenshot 2023-11-21 at 10 19 08" src="https://github.com/PostHog/posthog/assets/6685876/0cedde21-9414-47ec-8e62-a0965bf322c3">

## Changes

Use the new colors added in https://github.com/PostHog/posthog/pull/18753

## How did you test this code?

Loads now
<img width="961" alt="Screenshot 2023-11-21 at 10 18 10" src="https://github.com/PostHog/posthog/assets/6685876/51f3161d-a507-480b-b55b-92b566908a13">
