### PR TITLE
feat(3000): replace command icons

### DIFF
--- a/frontend/src/lib/components/CommandPalette/CommandPalette.scss
+++ b/frontend/src/lib/components/CommandPalette/CommandPalette.scss
@@ -121,5 +121,5 @@
 .palette__icon {
     display: flex;
     align-items: center;
-    font-size: 1rem;
+    font-size: 1.25rem;
 }

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -17,30 +17,22 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 import {
-    IconAction,
-    IconApps,
     IconCalculate,
     IconCheckmark,
     IconCohort,
     IconComment,
-    IconCorporate,
-    IconCottage,
-    IconFlag,
     IconGithub,
     IconKeyboard,
-    IconLive,
     IconLockOpen,
     IconLogout,
     IconOpenInNew,
-    IconPerson,
     IconPersonFilled,
     IconRecording,
-    IconServer,
-    IconSettings,
     IconTableChart,
     IconTools,
 } from 'lib/lemon-ui/icons'
 import {
+    IconHome,
     IconDashboard,
     IconGraph,
     IconTrends,
@@ -50,20 +42,24 @@ import {
     IconStickiness,
     IconLifecycle,
     IconHogQL,
-    // IconApps,
-    // IconDatabase,
-    // IconHome,
-    // IconLive,
-    // IconPeople,
-    // IconPieChart,
-    // IconRewindPlay,
-    // IconTestTube,
-    // IconToggle,
-    // IconToolbar,
-    // IconNotebook,
-    // IconRocket,
-    // IconServer,
-    // IconChat,
+    IconNotebook,
+    IconLive,
+    IconDatabase,
+    IconCursor,
+    IconList,
+    IconThoughtBubble,
+    IconPeople,
+    IconPeopleFilled,
+    IconPieChart,
+    IconServer,
+    IconRewindPlay,
+    IconChat,
+    IconToggle,
+    IconTestTube,
+    IconRocket,
+    IconApps,
+    IconToolbar,
+    IconGear,
 } from '@posthog/icons'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -446,6 +442,13 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                         },
                     },
                     {
+                        icon: IconHome,
+                        display: 'Go to Project homepage',
+                        executor: () => {
+                            push(urls.projectHomepage())
+                        },
+                    },
+                    {
                         icon: IconGraph,
                         display: 'Go to Insights',
                         executor: () => {
@@ -454,7 +457,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                     },
                     {
                         icon: IconTrends,
-                        display: 'Create a new trend insight',
+                        display: 'Create a new Trend insight',
                         executor: () => {
                             // TODO: Don't reset insight on change
                             push(urls.insightNew({ insight: InsightType.TRENDS }))
@@ -462,7 +465,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                     },
                     {
                         icon: IconFunnels,
-                        display: 'Create a new funnel insight',
+                        display: 'Create a new Funnel insight',
                         executor: () => {
                             // TODO: Don't reset insight on change
                             push(urls.insightNew({ insight: InsightType.FUNNELS }))
@@ -470,7 +473,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                     },
                     {
                         icon: IconRetention,
-                        display: 'Create a new retention insight',
+                        display: 'Create a new Retention insight',
                         executor: () => {
                             // TODO: Don't reset insight on change
                             push(urls.insightNew({ insight: InsightType.RETENTION }))
@@ -478,7 +481,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                     },
                     {
                         icon: IconUserPaths,
-                        display: 'Create a new paths insight',
+                        display: 'Create a new Paths insight',
                         executor: () => {
                             // TODO: Don't reset insight on change
                             push(urls.insightNew({ insight: InsightType.PATHS }))
@@ -486,7 +489,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                     },
                     {
                         icon: IconStickiness,
-                        display: 'Create a new stickiness insight',
+                        display: 'Create a new Stickiness insight',
                         executor: () => {
                             // TODO: Don't reset insight on change
                             push(urls.insightNew({ insight: InsightType.STICKINESS }))
@@ -494,7 +497,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                     },
                     {
                         icon: IconLifecycle,
-                        display: 'Create a new lifecycle insight',
+                        display: 'Create a new Lifecycle insight',
                         executor: () => {
                             // TODO: Don't reset insight on change
                             push(urls.insightNew({ insight: InsightType.LIFECYCLE }))
@@ -510,21 +513,50 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                         },
                     },
                     {
+                        icon: IconNotebook,
+                        display: 'Go to Notebooks',
+                        executor: () => {
+                            push(urls.notebooks())
+                        },
+                    },
+                    {
                         icon: IconLive,
-                        display: 'Go to Events',
+                        display: 'Go to Events explorer',
                         executor: () => {
                             push(urls.events())
                         },
                     },
                     {
-                        icon: IconAction,
+                        icon: IconDatabase,
+                        display: 'Go to Data management',
+                        synonyms: ['events'],
+                        executor: () => {
+                            push(urls.eventDefinitions())
+                        },
+                    },
+                    {
+                        icon: IconCursor,
                         display: 'Go to Actions',
                         executor: () => {
                             push(urls.actions())
                         },
                     },
                     {
-                        icon: IconPerson,
+                        icon: IconList,
+                        display: 'Go to Properties',
+                        executor: () => {
+                            push(urls.propertyDefinitions())
+                        },
+                    },
+                    {
+                        icon: IconThoughtBubble,
+                        display: 'Go to Annotations',
+                        executor: () => {
+                            push(urls.annotations())
+                        },
+                    },
+                    {
+                        icon: IconPeople,
                         display: 'Go to Persons',
                         synonyms: ['people'],
                         executor: () => {
@@ -538,51 +570,61 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                             push(urls.cohorts())
                         },
                     },
+                    ...(values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS]
+                        ? [
+                              {
+                                  icon: IconPieChart,
+                                  display: 'Go to Web analytics',
+                                  executor: () => {
+                                      push(urls.webAnalytics())
+                                  },
+                              },
+                          ]
+                        : []),
+                    ...(values.featureFlags[FEATURE_FLAGS.DATA_WAREHOUSE]
+                        ? [
+                              {
+                                  icon: IconServer,
+                                  display: 'Go to Data warehouse',
+                                  executor: () => {
+                                      push(urls.dataWarehouse())
+                                  },
+                              },
+                          ]
+                        : []),
                     {
-                        icon: IconFlag,
-                        display: 'Go to Feature Flags',
-                        synonyms: ['feature flags', 'a/b tests'],
+                        display: 'Go to Session replay',
+                        icon: IconRewindPlay,
+                        executor: () => {
+                            push(urls.replay())
+                        },
+                    },
+                    {
+                        display: 'Go to Surveys',
+                        icon: IconChat,
+                        executor: () => {
+                            push(urls.surveys())
+                        },
+                    },
+                    {
+                        icon: IconToggle,
+                        display: 'Go to Feature flags',
                         executor: () => {
                             push(urls.featureFlags())
                         },
                     },
                     {
-                        icon: IconComment,
-                        display: 'Go to Annotations',
+                        icon: IconTestTube,
+                        display: 'Go to A/B testing',
                         executor: () => {
-                            push(urls.annotations())
+                            push(urls.experiments())
                         },
                     },
                     {
-                        icon: IconCorporate,
-                        display: 'Go to Team members',
-                        synonyms: ['organization', 'members', 'invites', 'teammates'],
+                        icon: IconRocket,
+                        display: 'Go to Early access features',
                         executor: () => {
-                            push(urls.settings('organization'))
-                        },
-                    },
-                    {
-                        icon: IconCottage,
-                        display: 'Go to project homepage',
-                        executor: () => {
-                            push(urls.projectHomepage())
-                        },
-                    },
-                    {
-                        icon: IconSettings,
-                        display: 'Go to Project settings',
-                        executor: () => {
-                            push(urls.settings('project'))
-                        },
-                    },
-                    {
-                        icon: () => (
-                            <ProfilePicture name={values.user?.first_name} email={values.user?.email} size="xs" />
-                        ),
-                        display: 'Go to My settings',
-                        synonyms: ['account'],
-                        executor: () => {
-                            push(urls.settings('user'))
+                            push(urls.earlyAccessFeatures())
                         },
                     },
                     {
@@ -594,11 +636,34 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                         },
                     },
                     {
-                        icon: IconServer,
-                        display: 'Go to Instance status & settings',
-                        synonyms: ['redis', 'celery', 'django', 'postgres', 'backend', 'service', 'online'],
+                        icon: IconToolbar,
+                        display: 'Go to Toolbar',
                         executor: () => {
-                            push(urls.instanceStatus())
+                            push(urls.toolbarLaunch())
+                        },
+                    },
+                    {
+                        icon: IconGear,
+                        display: 'Go to Project settings',
+                        executor: () => {
+                            push(urls.settings('project'))
+                        },
+                    },
+                    {
+                        icon: IconGear,
+                        display: 'Go to Organization settings',
+                        executor: () => {
+                            push(urls.settings('organization'))
+                        },
+                    },
+                    {
+                        icon: () => (
+                            <ProfilePicture name={values.user?.first_name} email={values.user?.email} size="xs" />
+                        ),
+                        display: 'Go to User settings',
+                        synonyms: ['account', 'profile'],
+                        executor: () => {
+                            push(urls.settings('user'))
                         },
                     },
                     {

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -19,7 +19,6 @@ import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 import {
     IconAction,
     IconApps,
-    IconBarChart,
     IconCalculate,
     IconCheckmark,
     IconCohort,
@@ -29,7 +28,6 @@ import {
     IconEmojiPeople,
     IconFlag,
     IconFunnelHorizontal,
-    IconGauge,
     IconGithub,
     IconKeyboard,
     IconLive,
@@ -46,6 +44,24 @@ import {
     IconTrendingFlat,
     IconTrendingUp,
 } from 'lib/lemon-ui/icons'
+import {
+    // IconApps,
+    IconDashboard,
+    // IconDatabase,
+    IconGraph,
+    // IconHome,
+    // IconLive,
+    // IconPeople,
+    // IconPieChart,
+    // IconRewindPlay,
+    // IconTestTube,
+    // IconToggle,
+    // IconToolbar,
+    // IconNotebook,
+    // IconRocket,
+    // IconServer,
+    // IconChat,
+} from '@posthog/icons'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -419,14 +435,14 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                 prefixes: ['open', 'visit'],
                 resolver: [
                     {
-                        icon: IconGauge,
+                        icon: IconDashboard,
                         display: 'Go to Dashboards',
                         executor: () => {
                             push(urls.dashboards())
                         },
                     },
                     {
-                        icon: IconBarChart,
+                        icon: IconGraph,
                         display: 'Go to Insights',
                         executor: () => {
                             push(urls.savedInsights())
@@ -689,7 +705,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                 key: 'create-dashboard',
                 scope: GLOBAL_COMMAND_SCOPE,
                 resolver: {
-                    icon: IconGauge,
+                    icon: IconDashboard,
                     display: 'Create Dashboard',
                     executor: () => ({
                         instruction: 'Name your new dashboard',
@@ -698,7 +714,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                         resolver: (argument) => {
                             if (argument?.length) {
                                 return {
-                                    icon: IconGauge,
+                                    icon: IconDashboard,
                                     display: `Create Dashboard "${argument}"`,
                                     executor: () => {
                                         newDashboardLogic.actions.addDashboard({ name: argument })

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -16,21 +16,7 @@ import { openCHQueriesDebugModal } from './DebugCHQueries'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
-import {
-    IconCalculate,
-    IconCheckmark,
-    IconCohort,
-    IconComment,
-    IconGithub,
-    IconKeyboard,
-    IconLockOpen,
-    IconLogout,
-    IconOpenInNew,
-    IconPersonFilled,
-    IconRecording,
-    IconTableChart,
-    IconTools,
-} from 'lib/lemon-ui/icons'
+import { IconCalculate, IconCohort, IconGithub, IconTools, IconKeyboard, IconTableChart } from 'lib/lemon-ui/icons'
 import {
     IconHome,
     IconDashboard,
@@ -60,6 +46,10 @@ import {
     IconApps,
     IconToolbar,
     IconGear,
+    IconLeave,
+    IconExternal,
+    IconUnlock,
+    IconCheck,
 } from '@posthog/icons'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -411,7 +401,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                         key: `person-${person.distinct_ids[0]}`,
                         resolver: [
                             {
-                                icon: IconPersonFilled,
+                                icon: IconPeopleFilled,
                                 display: `View person ${input}`,
                                 executor: () => {
                                     const { push } = router.actions
@@ -667,7 +657,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                         },
                     },
                     {
-                        icon: IconLogout,
+                        icon: IconLeave,
                         display: 'Log out',
                         executor: () => {
                             userLogic.actions.logout()
@@ -696,7 +686,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                 key: 'debug-copy-session-recording-url',
                 scope: GLOBAL_COMMAND_SCOPE,
                 resolver: {
-                    icon: IconRecording,
+                    icon: IconRewindPlay,
                     display: 'Debug: Copy the session recording link to clipboard',
                     executor: () => {
                         const url = posthog.get_session_replay_url({ withTimestamp: true, timestampLookBack: 30 })
@@ -738,7 +728,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                 resolver: (argument) => {
                     const results: CommandResultTemplate[] = (teamLogic.values.currentTeam?.app_urls ?? []).map(
                         (url: string) => ({
-                            icon: IconOpenInNew,
+                            icon: IconExternal,
                             display: `Open ${url}`,
                             synonyms: [`Visit ${url}`],
                             executor: () => {
@@ -748,7 +738,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                     )
                     if (argument && isURL(argument)) {
                         results.push({
-                            icon: IconOpenInNew,
+                            icon: IconExternal,
                             display: `Open ${argument}`,
                             synonyms: [`Visit ${argument}`],
                             executor: () => {
@@ -757,7 +747,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                         })
                     }
                     results.push({
-                        icon: IconOpenInNew,
+                        icon: IconExternal,
                         display: 'Open PostHog Docs',
                         synonyms: ['technical documentation'],
                         executor: () => {
@@ -772,7 +762,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                 key: 'create-personal-api-key',
                 scope: GLOBAL_COMMAND_SCOPE,
                 resolver: {
-                    icon: IconLockOpen,
+                    icon: IconUnlock,
                     display: 'Create Personal API Key',
                     executor: () => ({
                         instruction: 'Give your key a label',
@@ -781,7 +771,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                         resolver: (argument) => {
                             if (argument?.length) {
                                 return {
-                                    icon: IconLockOpen,
+                                    icon: IconUnlock,
                                     display: `Create Key "${argument}"`,
                                     executor: () => {
                                         personalAPIKeysLogic.actions.createKey(argument)
@@ -825,7 +815,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                 key: 'share-feedback',
                 scope: GLOBAL_COMMAND_SCOPE,
                 resolver: {
-                    icon: IconComment,
+                    icon: IconThoughtBubble,
                     display: 'Share Feedback',
                     synonyms: ['send opinion', 'ask question', 'message posthog', 'github issue'],
                     executor: () => ({
@@ -833,12 +823,12 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                         resolver: [
                             {
                                 display: 'Send Message Directly to PostHog',
-                                icon: IconComment,
+                                icon: IconThoughtBubble,
                                 executor: () => ({
                                     instruction: "What's on your mind?",
-                                    icon: IconComment,
+                                    icon: IconThoughtBubble,
                                     resolver: (argument) => ({
-                                        icon: IconComment,
+                                        icon: IconThoughtBubble,
                                         display: 'Send',
                                         executor: !argument?.length
                                             ? undefined
@@ -846,7 +836,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                                                   posthog.capture('palette feedback', { message: argument })
                                                   return {
                                                       resolver: {
-                                                          icon: IconCheckmark,
+                                                          icon: IconCheck,
                                                           display: 'Message Sent!',
                                                           executor: true,
                                                       },

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -25,9 +25,7 @@ import {
     IconComment,
     IconCorporate,
     IconCottage,
-    IconEmojiPeople,
     IconFlag,
-    IconFunnelHorizontal,
     IconGithub,
     IconKeyboard,
     IconLive,
@@ -41,14 +39,19 @@ import {
     IconSettings,
     IconTableChart,
     IconTools,
-    IconTrendingFlat,
-    IconTrendingUp,
 } from 'lib/lemon-ui/icons'
 import {
-    // IconApps,
     IconDashboard,
-    // IconDatabase,
     IconGraph,
+    IconTrends,
+    IconFunnels,
+    IconRetention,
+    IconUserPaths,
+    IconStickiness,
+    IconLifecycle,
+    IconHogQL,
+    // IconApps,
+    // IconDatabase,
     // IconHome,
     // IconLive,
     // IconPeople,
@@ -65,6 +68,7 @@ import {
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { insightTypeURL } from 'scenes/insights/utils'
 
 // If CommandExecutor returns CommandFlow, flow will be entered
 export type CommandExecutor = () => CommandFlow | void
@@ -449,35 +453,60 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                         },
                     },
                     {
-                        icon: IconTrendingUp,
-                        display: 'Go to Trends',
+                        icon: IconTrends,
+                        display: 'Create a new trend insight',
                         executor: () => {
                             // TODO: Don't reset insight on change
                             push(urls.insightNew({ insight: InsightType.TRENDS }))
                         },
                     },
                     {
-                        icon: IconFunnelHorizontal,
-                        display: 'Go to Funnels',
+                        icon: IconFunnels,
+                        display: 'Create a new funnel insight',
                         executor: () => {
                             // TODO: Don't reset insight on change
                             push(urls.insightNew({ insight: InsightType.FUNNELS }))
                         },
                     },
                     {
-                        icon: IconTrendingFlat,
-                        display: 'Go to Retention',
+                        icon: IconRetention,
+                        display: 'Create a new retention insight',
                         executor: () => {
                             // TODO: Don't reset insight on change
                             push(urls.insightNew({ insight: InsightType.RETENTION }))
                         },
                     },
                     {
-                        icon: IconEmojiPeople,
-                        display: 'Go to Paths',
+                        icon: IconUserPaths,
+                        display: 'Create a new paths insight',
                         executor: () => {
                             // TODO: Don't reset insight on change
                             push(urls.insightNew({ insight: InsightType.PATHS }))
+                        },
+                    },
+                    {
+                        icon: IconStickiness,
+                        display: 'Create a new stickiness insight',
+                        executor: () => {
+                            // TODO: Don't reset insight on change
+                            push(urls.insightNew({ insight: InsightType.STICKINESS }))
+                        },
+                    },
+                    {
+                        icon: IconLifecycle,
+                        display: 'Create a new lifecycle insight',
+                        executor: () => {
+                            // TODO: Don't reset insight on change
+                            push(urls.insightNew({ insight: InsightType.LIFECYCLE }))
+                        },
+                    },
+                    {
+                        icon: IconHogQL,
+                        display: 'Create a new HogQL insight',
+                        synonyms: ['hogql', 'sql'],
+                        executor: () => {
+                            // TODO: Don't reset insight on change
+                            push(insightTypeURL[InsightType.SQL])
                         },
                     },
                     {

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -16,40 +16,43 @@ import { openCHQueriesDebugModal } from './DebugCHQueries'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
-import { IconCalculate, IconCohort, IconGithub, IconTools, IconKeyboard, IconTableChart } from 'lib/lemon-ui/icons'
 import {
-    IconHome,
-    IconDashboard,
-    IconGraph,
-    IconTrends,
-    IconFunnels,
-    IconRetention,
-    IconUserPaths,
-    IconStickiness,
-    IconLifecycle,
-    IconHogQL,
-    IconNotebook,
-    IconLive,
-    IconDatabase,
+    IconApps,
+    IconCalculator,
+    IconChat,
+    IconCheck,
     IconCursor,
+    IconDashboard,
+    IconDatabase,
+    IconExternal,
+    IconFunnels,
+    IconGear,
+    IconGithub,
+    IconGraph,
+    IconHogQL,
+    IconHome,
+    IconKeyboard,
+    IconLeave,
+    IconLifecycle,
     IconList,
-    IconThoughtBubble,
+    IconLive,
+    IconNotebook,
+    IconPageChart,
     IconPeople,
     IconPeopleFilled,
     IconPieChart,
-    IconServer,
+    IconRetention,
     IconRewindPlay,
-    IconChat,
-    IconToggle,
-    IconTestTube,
     IconRocket,
-    IconApps,
+    IconServer,
+    IconStickiness,
+    IconTestTube,
+    IconThoughtBubble,
+    IconToggle,
     IconToolbar,
-    IconGear,
-    IconLeave,
-    IconExternal,
+    IconTrends,
     IconUnlock,
-    IconCheck,
+    IconUserPaths,
 } from '@posthog/icons'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -246,7 +249,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                         key: 'custom_dashboards',
                         resolver: dashboards.map((dashboard: DashboardType) => ({
                             key: `dashboard_${dashboard.id}`,
-                            icon: IconTableChart,
+                            icon: IconPageChart,
                             display: `Go to dashboard: ${dashboard.name}`,
                             executor: () => {
                                 const { push } = router.actions
@@ -554,7 +557,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                         },
                     },
                     {
-                        icon: IconCohort,
+                        icon: IconPeople,
                         display: 'Go to Cohorts',
                         executor: () => {
                             push(urls.cohorts())
@@ -675,7 +678,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                     preflightLogic.values.preflight?.is_debug ||
                     preflightLogic.values.preflight?.instance_preferences?.debug_queries
                         ? {
-                              icon: IconTools,
+                              icon: IconDatabase,
                               display: 'Debug ClickHouse Queries',
                               executor: () => openCHQueriesDebugModal(),
                           }
@@ -708,7 +711,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                         return isNaN(result)
                             ? null
                             : {
-                                  icon: IconCalculate,
+                                  icon: IconCalculator,
                                   display: `= ${result}`,
                                   guarantee: true,
                                   executor: () => {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "@medv/finder": "^2.1.0",
         "@microlink/react-json-view": "^1.21.3",
         "@monaco-editor/react": "4.4.6",
-        "@posthog/icons": "0.4.1",
+        "@posthog/icons": "0.4.10",
         "@posthog/plugin-scaffold": "^1.4.4",
         "@react-hook/size": "^2.1.2",
         "@rrweb/types": "^2.0.0-alpha.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -36,8 +36,8 @@ dependencies:
     specifier: 4.4.6
     version: 4.4.6(monaco-editor@0.39.0)(react-dom@18.2.0)(react@18.2.0)
   '@posthog/icons':
-    specifier: 0.4.1
-    version: 0.4.1(react-dom@18.2.0)(react@18.2.0)
+    specifier: 0.4.10
+    version: 0.4.10(react-dom@18.2.0)(react@18.2.0)
   '@posthog/plugin-scaffold':
     specifier: ^1.4.4
     version: 1.4.4
@@ -3422,8 +3422,8 @@ packages:
     resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
     dev: false
 
-  /@posthog/icons@0.4.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-sR7lDltjoAeExsOMZOZvCz8Z1rHbBqhZo8RABCCvx00MoBCUuydE1y2xpSoP5BVfMogY4ycDktnihw4ICUsb3Q==}
+  /@posthog/icons@0.4.10(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-92/pvHxVSWpNri8XoT9cfLfzf7RRvYGn8qMM6vUhMwkebBiurg8/oQHY1rZ0GcKLvCvzyAtgIr4o/N7ma9kWlQ==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
@@ -5353,7 +5353,7 @@ packages:
     resolution: {integrity: sha512-iu5W0Kdd6nysN5CPkY4GRl+0BpxRTdSfBIJak7mb6xCIHSB5t1tw4BOuqMQ5EgpikRY3MWJ4gY647QkWBX3MNQ==}
     dependencies:
       '@storybook/channels': 7.5.3
-      '@types/babel__core': 7.20.4
+      '@types/babel__core': 7.20.5
       '@types/express': 4.17.21
       file-system-cache: 2.3.0
     dev: true
@@ -5898,8 +5898,8 @@ packages:
       '@types/babel__traverse': 7.20.3
     dev: true
 
-  /@types/babel__core@7.20.4:
-    resolution: {integrity: sha512-mLnSC22IC4vcWiuObSRjrLd9XcBTGf59vUSoq2jkQDJ/QQ8PMI9rSuzE+aEV8karUMbskw07bKYoUJCKTUaygg==}
+  /@types/babel__core@7.20.5:
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
     dependencies:
       '@babel/parser': 7.23.4
       '@babel/types': 7.23.4
@@ -5957,7 +5957,7 @@ packages:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 18.11.9
+      '@types/node': 18.18.11
     dev: true
 
   /@types/chart.js@2.9.37:
@@ -5985,7 +5985,7 @@ packages:
   /@types/connect@3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
-      '@types/node': 18.11.9
+      '@types/node': 18.18.11
     dev: true
 
   /@types/cookie@0.4.1:
@@ -6263,7 +6263,7 @@ packages:
   /@types/express-serve-static-core@4.17.41:
     resolution: {integrity: sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==}
     dependencies:
-      '@types/node': 18.11.9
+      '@types/node': 18.18.11
       '@types/qs': 6.9.10
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -6448,6 +6448,12 @@ packages:
     resolution: {integrity: sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==}
     dev: true
 
+  /@types/node@18.18.11:
+    resolution: {integrity: sha512-c1vku6qnTeujJneYH94/4aq73XrVcsJe35UPyAsSok1ijiKrkRzK+AxQPSpNMUnC03roWBBwJx/9I8V7lQoxmA==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
+
   /@types/node@18.18.4:
     resolution: {integrity: sha512-t3rNFBgJRugIhackit2mVcLfF6IRc0JE4oeizPQL8Zrm8n2WY/0wOdpOPhdtG0V9Q2TlW/axbF1MJ6z+Yj/kKQ==}
     dev: true
@@ -6597,7 +6603,7 @@ packages:
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 18.11.9
+      '@types/node': 18.18.11
     dev: true
 
   /@types/serve-static@1.15.4:
@@ -6613,7 +6619,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.4
       '@types/mime': 3.0.4
-      '@types/node': 18.11.9
+      '@types/node': 18.18.11
     dev: true
 
   /@types/set-cookie-parser@2.4.2:
@@ -19011,6 +19017,10 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+    dev: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
   /unicode-canonical-property-names-ecmascript@2.0.0:


### PR DESCRIPTION
## Problem

Commands still use legacy icons.

## Changes

This PR replaces the icons and adds/updates commands to reflect the new navigation structure and items.

More icons are following here, and I'll replace these once the PR is in https://github.com/PostHog/icons/pull/35.

## How did you test this code?

👀 