### PR TITLE
chore: remove antd input

### DIFF
--- a/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.scss
+++ b/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.scss
@@ -45,9 +45,15 @@
     line-height: 1.25rem;
     align-items: center;
 
-    input {
+    .LemonInput {
         width: 3rem;
-        text-align: center;
+        min-height: 0;
+        padding: 0;
+        border: none;
+
+        input {
+            text-align: center;
+        }
     }
 
     .RollingDateRangeFilter__counter__step {

--- a/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.tsx
@@ -1,7 +1,6 @@
-import { Input } from 'antd'
 import { DateOption, rollingDateRangeFilterLogic } from './rollingDateRangeFilterLogic'
 import { useActions, useValues } from 'kea'
-import { LemonButton, LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { dayjs } from 'lib/dayjs'
 import clsx from 'clsx'
@@ -38,11 +37,6 @@ export function RollingDateRangeFilter({
         useActions(rollingDateRangeFilterLogic(logicProps))
     const { counter, dateOption, formattedDate } = useValues(rollingDateRangeFilterLogic(logicProps))
 
-    const onInputChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-        const newValue = event.target.value ? parseFloat(event.target.value) : undefined
-        setCounter(newValue)
-    }
-
     return (
         <Tooltip title={makeLabel ? makeLabel(formattedDate) : undefined}>
             <LemonButton
@@ -61,14 +55,13 @@ export function RollingDateRangeFilter({
                     >
                         -
                     </span>
-                    <Input
+                    <LemonInput
                         data-attr="rolling-date-range-input"
                         type="number"
-                        value={counter ?? ''}
-                        min="0"
+                        value={counter ?? 0}
+                        min={0}
                         placeholder="0"
-                        onChange={onInputChange}
-                        bordered={false}
+                        onChange={(value) => setCounter(value)}
                     />
                     <span
                         className="RollingDateRangeFilter__counter__step"


### PR DESCRIPTION
## Problem

We were using an old antd input

## Changes

Should be none

|Before|After|
|----|----|
| ![before](https://github.com/PostHog/posthog/assets/6685876/b9684029-b3b4-4d57-b4dc-eaabc168d6ea) | ![after](https://github.com/PostHog/posthog/assets/6685876/615896e6-beec-456f-9d42-54a778c20762) |

## How did you test this code?

Clicking around