### PR TITLE
style(3000): Make new style switch more clickable

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.scss
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.scss
@@ -51,8 +51,8 @@
     }
 
     .posthog-3000 & {
-        --lemon-switch-width: 1.5rem;
-        --lemon-switch-height: 0.75rem;
+        --lemon-switch-height: 1.125rem;
+        --lemon-switch-width: calc(11 / 6 * var(--lemon-switch-height)); // Same proportion as in IconToggle
     }
 }
 
@@ -117,7 +117,7 @@
     justify-content: center;
 
     .posthog-3000 & {
-        --lemon-switch-handle-ratio: calc(8 / 10);
+        --lemon-switch-handle-ratio: calc(3 / 4); // Same proportion as in IconToggle
         --lemon-switch-handle-gutter: calc(var(--lemon-switch-height) * calc(1 - var(--lemon-switch-handle-ratio)) / 2);
         --lemon-switch-handle-width: calc(var(--lemon-switch-height) * var(--lemon-switch-handle-ratio));
         --lemon-switch-active-translate: translateX(

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useActions, useValues } from 'kea'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
-import { Form, Switch } from 'antd'
+import { Form } from 'antd'
 import { userLogic } from 'scenes/userLogic'
 import { PluginImage } from 'scenes/plugins/plugin/PluginImage'
 import { Drawer } from 'lib/components/Drawer'
@@ -18,7 +18,7 @@ import { MOCK_NODE_PROCESS } from 'lib/constants'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { PluginTags } from '../tabs/apps/components'
 import { IconLock } from 'lib/lemon-ui/icons'
-import { LemonButton, LemonTag, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonSwitch, LemonTag, Link } from '@posthog/lemon-ui'
 import { IconCode } from '@posthog/icons'
 
 window.process = MOCK_NODE_PROCESS
@@ -31,10 +31,10 @@ function EnabledDisabledSwitch({
     onChange?: (value: boolean) => void
 }): JSX.Element {
     return (
-        <>
-            <Switch checked={value} onChange={onChange} />
-            <strong className="pl-2.5">{value ? 'Enabled' : 'Disabled'}</strong>
-        </>
+        <div className="flex items-center gap-2">
+            <LemonSwitch checked={value || false} onChange={onChange} />
+            <strong>{value ? 'Enabled' : 'Disabled'}</strong>
+        </div>
     )
 }
 


### PR DESCRIPTION
## Problem

#18765 introduced a new style of switches for 3000 UI, inspired by `IconToggle` (that we use for the feature flags product), which I think is cool. However, I've found the restyled switches to be very hard to click, because they're _tiny_. And some margins were off, so the component was just a bit off visually.

## Changes

Tuned the styles so that proportions are _exactly_ the same as in `IconToggle`, and the switch is a bit larger for improved (restored) clickability. 

| Before | After |
| --- | --- |
| <img width="231" alt="Screenshot 2023-11-21 at 13 52 37" src="https://github.com/PostHog/posthog/assets/4550621/279d25a5-f751-4b8f-a896-dfc4a4f3ed1a"> | <img width="238" alt="Screenshot 2023-11-21 at 13 50 43" src="https://github.com/PostHog/posthog/assets/4550621/af98d80e-7b7e-41db-9441-a76dbadf3f03"> |