### PR TITLE
feat: Add logs per event as we're processing it

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
@@ -3,6 +3,7 @@ import { Counter } from 'prom-client'
 
 import { eventDroppedCounter } from '../../../main/ingestion-queues/metrics'
 import { PipelineEvent } from '../../../types'
+import { status } from '../../../utils/status'
 import { UUID } from '../../../utils/utils'
 import { captureIngestionWarning } from '../utils'
 import { EventPipelineRunner } from './runner'
@@ -51,6 +52,12 @@ export async function populateTeamDataStep(
             throw new Error(`Not a valid UUID: "${event.uuid}"`)
         }
 
+        status.info('📥', 'Processing event: team_id was provided', {
+            team_id: event.team_id,
+            distinct_id: event.distinct_id,
+            event: event.event,
+        })
+
         return event as PluginEvent
     }
 
@@ -95,5 +102,11 @@ export async function populateTeamDataStep(
         team_id: team.id,
     }
 
+    status.info('📥', 'Processing event: token resolved successfully', {
+        team_id: event.team_id,
+        token: event.token,
+        distinct_id: event.distinct_id,
+        event: event.event,
+    })
     return event as PluginEvent
 }

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -430,7 +430,9 @@ export class PersonState {
                 targetPersonDistinctId: mergeIntoDistinctId,
                 eventUuid: this.event.uuid,
             })
-            status.warn('🤔', 'refused to merge an already identified user via an $identify or $create_alias call')
+            status.warn('🤔', 'refused to merge an already identified user via an $identify or $create_alias call', {
+                team_id: this.teamId,
+            })
             return mergeInto // We're returning the original person tied to distinct_id used for the event
         }
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We occasionally run into lag, and it would be lovely if we could rule a couple of know problems out fast:
- lots of merging or group_identify events
- same team:distinct_id spamming us
- same team spamming us

There's partition stats, but sometimes that's not working, I see a huge lag still for it in the ingestion lag graph. We also don't have access to the name here.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
