### PR TITLE
fix: Ignore schedule not found when deleting batch export

### DIFF
--- a/posthog/api/test/batch_exports/test_delete.py
+++ b/posthog/api/test/batch_exports/test_delete.py
@@ -241,3 +241,48 @@ def test_deletes_are_partitioned_by_team_id(client: HttpClient):
         # Make sure we can still get the export with the right user
         response = get_batch_export(client, team.pk, batch_export_id)
         assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db(transaction=True)
+def test_delete_batch_export_even_without_underlying_schedule(client: HttpClient):
+    """Test deleting a BatchExport completes even if underlying Schedule was already deleted."""
+    temporal = sync_connect()
+
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "my-production-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "posthog-events/",
+            "aws_access_key_id": "abc123",
+            "aws_secret_access_key": "secret",
+        },
+    }
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    organization = create_organization("Test Org")
+    team = create_team(organization)
+    user = create_user("test@user.com", "Test User", organization)
+    client.force_login(user)
+
+    with start_test_worker(temporal):
+        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+        batch_export_id = batch_export["id"]
+
+        handle = temporal.get_schedule_handle(batch_export_id)
+        async_to_sync(handle.delete)()
+
+        with pytest.raises(RPCError):
+            describe_schedule(temporal, batch_export_id)
+
+        delete_batch_export_ok(client, team.pk, batch_export_id)
+
+        response = get_batch_export(client, team.pk, batch_export_id)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    with pytest.raises(RPCError):
+        describe_schedule(temporal, batch_export_id)

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -2,6 +2,7 @@ import datetime as dt
 from typing import Any
 
 import posthoganalytics
+import structlog
 from django.db import transaction
 from django.utils.timezone import now
 from rest_framework import mixins, request, response, serializers, viewsets
@@ -27,6 +28,7 @@ from posthog.batch_exports.service import (
     BatchExportIdError,
     BatchExportServiceError,
     BatchExportServiceRPCError,
+    BatchExportServiceScheduleNotFound,
     backfill_export,
     cancel_running_batch_export_backfill,
     delete_schedule,
@@ -48,6 +50,8 @@ from posthog.permissions import (
 )
 from posthog.temporal.client import sync_connect
 from posthog.utils import relative_date_parse
+
+logger = structlog.get_logger(__name__)
 
 
 def validate_date_input(date_input: Any) -> dt.datetime:
@@ -320,10 +324,22 @@ class BatchExportViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         return response.Response({"paused": False})
 
     def perform_destroy(self, instance: BatchExport):
-        """Perform a BatchExport destroy by clearing Temporal and Django state."""
-        instance.deleted = True
+        """Perform a BatchExport destroy by clearing Temporal and Django state.
+
+        If the underlying Temporal Schedule doesn't exist, we ignore the error and proceed with the delete anyways.
+        The Schedule could have been manually deleted causing Django and Temporal to go out of sync. For whatever reason,
+        since we are deleting, we assume that we can recover from this state by finishing the delete operation by calling
+        instance.save().
+        """
         temporal = sync_connect()
-        delete_schedule(temporal, str(instance.pk))
+
+        instance.deleted = True
+
+        try:
+            delete_schedule(temporal, str(instance.pk))
+        except BatchExportServiceScheduleNotFound as e:
+            logger.warning("The Schedule %s could not be deleted as it was not found", e.schedule_id)
+
         instance.save()
 
         for backfill in BatchExportBackfill.objects.filter(batch_export=instance):


### PR DESCRIPTION
## Problem

When we are deleting a batch export, we also delete the underlying Temporal Schedule. For whatever reason (maybe it was manually deleted), the Temporal Schedule could not be found. In this case, we assume it's safe to continue with the delete and ignore the error as in the final state we would end up with a deleted Temporal Schedule anyways.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Ignore TemporalSchedule not found errors (but log a warning) on batch export destroy.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
