### PR TITLE
fix(surveys): add min version requirement for version banner so it stops always showing after every update

### DIFF
--- a/frontend/src/lib/components/VersionChecker/VersionCheckerBanner.tsx
+++ b/frontend/src/lib/components/VersionChecker/VersionCheckerBanner.tsx
@@ -7,7 +7,9 @@ export function VersionCheckerBanner({ minVersionAccepted }: { minVersionAccepte
     // We don't want to show a message if the diff is too small (we might be still deploying the changes out)
     if (
         !versionWarning ||
-        (minVersionAccepted ? versionWarning.currentVersion >= minVersionAccepted : versionWarning.diff < 5)
+        (minVersionAccepted
+            ? versionWarning.currentVersion.localeCompare(minVersionAccepted) >= 0
+            : versionWarning.diff < 5)
     ) {
         return <></>
     }

--- a/frontend/src/lib/components/VersionChecker/VersionCheckerBanner.tsx
+++ b/frontend/src/lib/components/VersionChecker/VersionCheckerBanner.tsx
@@ -7,7 +7,7 @@ export function VersionCheckerBanner({ minVersionAccepted }: { minVersionAccepte
     // We don't want to show a message if the diff is too small (we might be still deploying the changes out)
     if (
         !versionWarning ||
-        (minVersionAccepted
+        (minVersionAccepted && versionWarning.currentVersion
             ? versionWarning.currentVersion.localeCompare(minVersionAccepted) >= 0
             : versionWarning.diff < 5)
     ) {

--- a/frontend/src/lib/components/VersionChecker/VersionCheckerBanner.tsx
+++ b/frontend/src/lib/components/VersionChecker/VersionCheckerBanner.tsx
@@ -2,11 +2,13 @@ import { useValues } from 'kea'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { versionCheckerLogic } from './versionCheckerLogic'
 
-export function VersionCheckerBanner(): JSX.Element {
+export function VersionCheckerBanner({ minVersionAccepted }: { minVersionAccepted?: string }): JSX.Element {
     const { versionWarning } = useValues(versionCheckerLogic)
-
     // We don't want to show a message if the diff is too small (we might be still deploying the changes out)
-    if (!versionWarning || versionWarning.diff < 5) {
+    if (
+        !versionWarning ||
+        (minVersionAccepted ? versionWarning.currentVersion >= minVersionAccepted : versionWarning.diff < 5)
+    ) {
         return <></>
     }
 

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -1101,6 +1101,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             posthog.capture('survey created', {
                 name: survey.name,
                 id: survey.id,
+                survey_type: survey.type,
                 questions_length: survey.questions.length,
                 question_types: survey.questions.map((question) => question.type),
             })
@@ -1109,6 +1110,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             posthog.capture('survey launched', {
                 name: survey.name,
                 id: survey.id,
+                survey_type: survey.type,
                 question_types: survey.questions.map((question) => question.type),
                 created_at: survey.created_at,
                 start_date: survey.start_date,

--- a/frontend/src/scenes/surveys/Surveys.tsx
+++ b/frontend/src/scenes/surveys/Surveys.tsx
@@ -117,7 +117,7 @@ export function Surveys(): JSX.Element {
                 ]}
             />
             <div className="space-y-2">
-                <VersionCheckerBanner />
+                <VersionCheckerBanner minVersionAccepted="1.83.0" />
 
                 {showSurveysDisabledBanner ? (
                     <LemonBanner


### PR DESCRIPTION
## Problem

We only need to make sure the user is on version 1.83.0+ for surveys. We don't have to keep spamming them they need to update unless we have a critical reason to for surveys related work~

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
