### PR TITLE
fix(surveys): json stringify only if value is not a string

### DIFF
--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -484,7 +484,9 @@ export function OpenTextViz({
                             return (
                                 <div key={`open-text-${questionIndex}-${i}`} className="masonry-item border rounded">
                                     <div className="max-h-80 overflow-y-auto text-center italic font-semibold px-5 py-4">
-                                        {JSON.stringify(event.properties[surveyResponseField])}
+                                        {typeof event.properties[surveyResponseField] !== 'string'
+                                            ? JSON.stringify(event.properties[surveyResponseField])
+                                            : event.properties[surveyResponseField]}
                                     </div>
                                     <div className="bg-bg-light items-center px-5 py-4 border-t rounded-b truncate w-full">
                                         <PersonDisplay


### PR DESCRIPTION
## Problem

Stringify only if value isn't a string because weird characters otherwise

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
