### PR TITLE
fix: URL vs Name display for Performance Entries

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/performance-event-utils.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/performance-event-utils.ts
@@ -134,6 +134,11 @@ export function mapRRWebNetworkRequest(
         }
     })
 
+    // KLUDGE: this shouldn't be necessary but let's display correctly while we figure out why it is.
+    if (!data.name && 'url' in capturedRequest) {
+        data.name = capturedRequest.url as string | undefined
+    }
+
     return data as PerformanceEvent
 }
 


### PR DESCRIPTION
We're still getting events from rrweb/network@1 with url instead of name. This shouldn't be possible but let's at least display them correctly while we figure out what is happening