### PR TITLE
fix(frontend): Properly use `BlinkMacSystemFont` again

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -10,6 +10,7 @@ module.exports = {
                 // CSS Color Module Level 3 says currentColor, Level 4 candidate says currentcolor
                 // Sticking to Level 3 for now
                 camelCaseSvgKeywords: true,
+                ignoreKeywords: ['BlinkMacSystemFont'], // BlinkMacSystemFont MUST have this particular casing
             },
         ],
         // Sadly Safari only started supporting the range syntax of media queries in 2023, so let's switch to that

--- a/frontend/src/styles/vars.scss
+++ b/frontend/src/styles/vars.scss
@@ -238,7 +238,7 @@ $_lifecycle_dormant: $_danger;
     --opacity-disabled: 0.6;
     --font-medium: 500;
     --font-semibold: 600;
-    --font-sans: -apple-system, blinkmacsystemfont, 'Inter', 'Segoe UI', 'Roboto', 'Helvetica Neue', helvetica, arial,
+    --font-sans: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto', 'Helvetica Neue', helvetica, arial,
         sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
     --font-mono: ui-monospace, 'SFMono-Regular', 'SF Mono', 'Menlo', 'Consolas', 'Liberation Mono', monospace;
 


### PR DESCRIPTION
## Problem

When reviewing #18795 I noticed that since #18627 we haven't been using the system font in Blink-based browsers properly, because `BlinkMacSystemFont` was lowercased. Normally CSS properties are case-insensitive, but apparently Blink doesn't respect this there.

## Changes

Makes is so that the property has appropriate casing now, and that Stylelint won't do this again. (See https://github.com/stylelint/stylelint/issues/4622)