### PR TITLE
fix(ui): Fix content hiding bug on page by setting height to 100%

### DIFF
--- a/frontend/src/lib/components/BridgePage/BridgePage.scss
+++ b/frontend/src/lib/components/BridgePage/BridgePage.scss
@@ -7,7 +7,7 @@
     flex-direction: column;
     flex: 1;
     overflow: hidden;
-    height: 100vh;
+    height: 100%;
 
     &::-webkit-scrollbar {
         width: 0 !important;


### PR DESCRIPTION
## Problem
Issue #18799

This pull request addresses UI changes related to the Bridgepage that is rendered on the route `/onboarding/session_replay?step=sdks` within the onboarding process. This alteration is crucial as it guides users on how to integrate PostHog with their projects.

![Inkedbug_LI](https://github.com/PostHog/posthog/assets/60285613/dceb4c9f-08f7-4d60-ae01-2e643038bfb6)

![Screenshot 2023-11-21 194001](https://github.com/PostHog/posthog/assets/60285613/9584bcaa-8015-497e-b4ec-3952813aa959)

UI changes

https://github.com/PostHog/posthog/assets/60285613/86207238-1f85-4468-b5b1-cc2594d9bd52



<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

I modified the scss file for Bridgepage that is rendered on the route `/onboarding/session_replay?step=sdks` as part of the onboarding process. This is where we are guided how to integrate PostHog with our project.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

This modification primarily focuses on minor style adjustments. I confirm that the modified styles only apply to the BridgePage.tsx component without affecting other components.

However I have a few questions.
- Has this specific bug been previously reported or experienced?
    - Given its occurrence during the onboarding process, it should have been noticed earlier.


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
