### PR TITLE
fix: Height of bridge page

### DIFF
--- a/frontend/src/lib/components/BridgePage/BridgePage.scss
+++ b/frontend/src/lib/components/BridgePage/BridgePage.scss
@@ -7,6 +7,7 @@
     flex-direction: column;
     flex: 1;
     overflow: hidden;
+    min-height: 100vh;
     height: 100%;
 
     &::-webkit-scrollbar {


### PR DESCRIPTION
## Problem

[This PR](https://github.com/PostHog/posthog/pull/18804) solved the bridge page for one area but broke it for another

## Changes

* Adds back in the 100vh as a min-height

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
