### PR TITLE
fix(flags): Dont locally match cohorts when id property is provided

### DIFF
--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -1759,7 +1759,7 @@
          "posthog_user"."toolbar_mode",
          "posthog_user"."events_column_config"
   FROM "posthog_featureflag"
-  INNER JOIN "posthog_user" ON ("posthog_featureflag"."created_by_id" = "posthog_user"."id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_featureflag"."created_by_id" = "posthog_user"."id")
   WHERE ("posthog_featureflag"."team_id" = 2
          AND "posthog_featureflag"."id" = 2)
   LIMIT 21 /*controller='project_feature_flags-create-static-cohort-for-flag',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/feature_flags/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/create_static_cohort_for_flag/%3F%24'*/

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -588,6 +588,10 @@ class FeatureFlagMatcher:
                 self.cache.group_type_index_to_name[group_type_index], {}
             )
         for property in properties:
+            # can't locally compute if property is a cohort
+            # need to atleast fetch the cohort
+            if property.type == "cohort":
+                return False
             if property.key not in target_properties:
                 return False
             if property.operator == "is_not_set":


### PR DESCRIPTION
## Problem

When an 'id' property override is provided, it matches the feature flag definition of `{"key": "id", "value": cohort1.pk, "type": "cohort"}` which then tries to compare the 'id' property value to the cohort pk.

This is incorrect, and results in incorrect computation of flags. Fixes this by not matching cohort property types in the local check.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

unit test
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
