### PR TITLE
chore: Track live batch exports

### DIFF
--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -1759,7 +1759,7 @@
          "posthog_user"."toolbar_mode",
          "posthog_user"."events_column_config"
   FROM "posthog_featureflag"
-  INNER JOIN "posthog_user" ON ("posthog_featureflag"."created_by_id" = "posthog_user"."id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_featureflag"."created_by_id" = "posthog_user"."id")
   WHERE ("posthog_featureflag"."team_id" = 2
          AND "posthog_featureflag"."id" = 2)
   LIMIT 21 /*controller='project_feature_flags-create-static-cohort-for-flag',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/feature_flags/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/create_static_cohort_for_flag/%3F%24'*/

--- a/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
@@ -291,7 +291,7 @@ async def test_bigquery_export_workflow(
         team_id=ateam.pk,
         start_time=data_interval_start,
         end_time=data_interval_end,
-        count=100,
+        count=100000,
         count_outside_range=10,
         count_other_team=10,
         duplicate=True,
@@ -340,7 +340,7 @@ async def test_bigquery_export_workflow(
                     id=workflow_id,
                     task_queue=settings.TEMPORAL_TASK_QUEUE,
                     retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=dt.timedelta(seconds=10),
+                    execution_timeout=dt.timedelta(seconds=240),
                 )
 
         runs = await afetch_batch_export_runs(batch_export_id=bigquery_batch_export.id)


### PR DESCRIPTION
## Problem

We have a big advantage when it comes to auto-scaling: We can know how many batch exports will trigger at every hour, day, etc... This way, we can scale up capacity before we hit the next interval mark (i.e. the beginning of the next hour, day, etc...) as we see this number cross certain thresholds.

However, we are currently not tracking this metric. 
 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Add a  prom gauge that:
  * Is incremented when a batch export is created or unpaused.
  * Is decremented when a batch export is deleted or paused.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
