### PR TITLE
fix(plugin-server): don't sent app debug logs to CH

### DIFF
--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -16,6 +16,7 @@ export CONVERSION_BUFFER_ENABLED=true
 export BUFFER_CONVERSION_SECONDS=2 # Make sure we don't have to wait for the default 60 seconds
 export KAFKA_MAX_MESSAGE_BATCH_SIZE=0
 export APP_METRICS_GATHERED_FOR_ALL=true
+export PLUGINS_DEFAULT_LOG_LEVEL=0 # All logs, as debug logs are used in synchronization barriers
 export NODE_ENV=production-functional-tests
 
 # Not important at all, but I like to see nice red/green for tests

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -1,4 +1,4 @@
-import { LogLevel, PluginsServerConfig, stringToPluginServerMode, ValueMatcher } from '../types'
+import { LogLevel, PluginLogLevel, PluginsServerConfig, stringToPluginServerMode, ValueMatcher } from '../types'
 import { isDevEnv, isTestEnv, stringToBoolean } from '../utils/env-utils'
 import { KAFKAJS_LOG_LEVEL_MAPPING } from './constants'
 import {
@@ -72,6 +72,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         TASKS_PER_WORKER: 10,
         INGESTION_CONCURRENCY: 10,
         INGESTION_BATCH_SIZE: 500,
+        PLUGINS_DEFAULT_LOG_LEVEL: isTestEnv() ? PluginLogLevel.Full : PluginLogLevel.Log,
         LOG_LEVEL: isTestEnv() ? LogLevel.Warn : LogLevel.Info,
         SENTRY_DSN: null,
         SENTRY_PLUGIN_SERVER_TRACING_SAMPLE_RATE: 0,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -146,6 +146,7 @@ export interface PluginsServerConfig {
     APP_METRICS_FLUSH_MAX_QUEUE_SIZE: number
     BASE_DIR: string // base path for resolving local plugins
     PLUGINS_RELOAD_PUBSUB_CHANNEL: string // Redis channel for reload events'
+    PLUGINS_DEFAULT_LOG_LEVEL: PluginLogLevel
     LOG_LEVEL: LogLevel
     SENTRY_DSN: string | null
     SENTRY_PLUGIN_SERVER_TRACING_SAMPLE_RATE: number // Rate of tracing in plugin server (between 0 and 1)

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -451,9 +451,10 @@ export enum PluginLogEntryType {
 
 export enum PluginLogLevel {
     Full = 0, // all logs
-    Debug = 1, // all except log
-    Warn = 2, // all except log and info
-    Critical = 3, // only error type and system source
+    Log = 1, // all except debug
+    Info = 2, // all expect log and debug
+    Warn = 3, // all except log, debug and info
+    Critical = 4, // only error type and system source
 }
 
 export interface PluginLogEntry {

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -158,8 +158,8 @@ export class DB {
     /** How many unique group types to allow per team */
     MAX_GROUP_TYPES_PER_TEAM = 5
 
-    /** Whether to write to clickhouse_person_unique_id topic */
-    writeToPersonUniqueId?: boolean
+    /** Default log level for plugins that don't specify it */
+    pluginsDefaultLogLevel: PluginLogLevel
 
     /** How many seconds to keep person info in Redis cache */
     PERSONS_AND_GROUPS_CACHE_TTL: number
@@ -170,6 +170,7 @@ export class DB {
         kafkaProducer: KafkaProducerWrapper,
         clickhouse: ClickHouse,
         statsd: StatsD | undefined,
+        pluginsDefaultLogLevel: PluginLogLevel,
         personAndGroupsCacheTtl = 1
     ) {
         this.postgres = postgres
@@ -177,6 +178,7 @@ export class DB {
         this.kafkaProducer = kafkaProducer
         this.clickhouse = clickhouse
         this.statsd = statsd
+        this.pluginsDefaultLogLevel = pluginsDefaultLogLevel
         this.PERSONS_AND_GROUPS_CACHE_TTL = personAndGroupsCacheTtl
     }
 
@@ -1076,7 +1078,7 @@ export class DB {
 
     public async queuePluginLogEntry(entry: LogEntryPayload): Promise<void> {
         const { pluginConfig, source, message, type, timestamp, instanceId } = entry
-        const configuredLogLevel = pluginConfig.plugin?.log_level || PluginLogLevel.Log
+        const configuredLogLevel = pluginConfig.plugin?.log_level || this.pluginsDefaultLogLevel
 
         if (!shouldStoreLog(configuredLogLevel, type)) {
             return

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1076,10 +1076,9 @@ export class DB {
 
     public async queuePluginLogEntry(entry: LogEntryPayload): Promise<void> {
         const { pluginConfig, source, message, type, timestamp, instanceId } = entry
+        const configuredLogLevel = pluginConfig.plugin?.log_level || PluginLogLevel.Log
 
-        const logLevel = pluginConfig.plugin?.log_level
-
-        if (!shouldStoreLog(logLevel || PluginLogLevel.Full, source, type)) {
+        if (!shouldStoreLog(configuredLogLevel, type)) {
             return
         }
 

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -137,7 +137,15 @@ export async function createHub(
 
     const promiseManager = new PromiseManager(serverConfig, statsd)
 
-    const db = new DB(postgres, redisPool, kafkaProducer, clickhouse, statsd, serverConfig.PERSON_INFO_CACHE_TTL)
+    const db = new DB(
+        postgres,
+        redisPool,
+        kafkaProducer,
+        clickhouse,
+        statsd,
+        serverConfig.PLUGINS_DEFAULT_LOG_LEVEL,
+        serverConfig.PERSON_INFO_CACHE_TTL
+    )
     const teamManager = new TeamManager(postgres, serverConfig, statsd)
     const organizationManager = new OrganizationManager(postgres, teamManager)
     const pluginsApiKeyManager = new PluginsApiKeyManager(db)

--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -6,10 +6,9 @@ import { Counter } from 'prom-client'
 
 import { defaultConfig } from '../../config/config'
 import { KAFKA_PERSON } from '../../config/kafka-topics'
-import { BasePerson, Person, RawPerson, TimestampFormat } from '../../types'
+import { BasePerson, Person, PluginLogEntryType, PluginLogLevel, RawPerson, TimestampFormat } from '../../types'
 import { status } from '../../utils/status'
 import { castTimestampOrNow } from '../../utils/utils'
-import { PluginLogEntrySource, PluginLogEntryType, PluginLogLevel } from './../../types'
 
 export function unparsePersonPartial(person: Partial<Person>): Partial<RawPerson> {
     return { ...(person as BasePerson), ...(person.created_at ? { created_at: person.created_at.toISO() } : {}) }
@@ -127,24 +126,19 @@ export function getFinalPostgresQuery(queryString: string, values: any[]): strin
     return queryString.replace(/\$([0-9]+)/g, (m, v) => JSON.stringify(values[parseInt(v) - 1]))
 }
 
-export function shouldStoreLog(
-    pluginLogLevel: PluginLogLevel,
-    source: PluginLogEntrySource,
-    type: PluginLogEntryType
-): boolean {
-    if (source === PluginLogEntrySource.System) {
-        return true
+export function shouldStoreLog(pluginLogLevel: PluginLogLevel, type: PluginLogEntryType): boolean {
+    switch (pluginLogLevel) {
+        case PluginLogLevel.Full:
+            return true
+        case PluginLogLevel.Log:
+            return type !== PluginLogEntryType.Debug
+        case PluginLogLevel.Info:
+            return type !== PluginLogEntryType.Log && type !== PluginLogEntryType.Debug
+        case PluginLogLevel.Warn:
+            return type === PluginLogEntryType.Warn || type === PluginLogEntryType.Error
+        case PluginLogLevel.Critical:
+            return type === PluginLogEntryType.Error
     }
-
-    if (pluginLogLevel === PluginLogLevel.Critical) {
-        return type === PluginLogEntryType.Error
-    } else if (pluginLogLevel === PluginLogLevel.Warn) {
-        return type !== PluginLogEntryType.Log && type !== PluginLogEntryType.Info
-    } else if (pluginLogLevel === PluginLogLevel.Debug) {
-        return type !== PluginLogEntryType.Log
-    }
-
-    return true
 }
 
 // keep in sync with posthog/posthog/api/utils.py::safe_clickhouse_string

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -11266,17 +11266,6 @@
 ---
 # name: TestDashboard.test_retrieve_dashboard_list.28
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list.29
-  '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
@@ -11299,6 +11288,14 @@
   LIMIT 21 /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
   '
 ---
+# name: TestDashboard.test_retrieve_dashboard_list.29
+  '
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_dashboard"
+  WHERE (NOT ("posthog_dashboard"."deleted")
+         AND "posthog_dashboard"."team_id" = 2) /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
+  '
+---
 # name: TestDashboard.test_retrieve_dashboard_list.3
   '
   SELECT "posthog_instancesetting"."id",
@@ -11311,14 +11308,6 @@
   '
 ---
 # name: TestDashboard.test_retrieve_dashboard_list.30
-  '
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_dashboard"
-  WHERE (NOT ("posthog_dashboard"."deleted")
-         AND "posthog_dashboard"."team_id" = 2) /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list.31
   '
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -11437,7 +11426,7 @@
   LIMIT 100 /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.32
+# name: TestDashboard.test_retrieve_dashboard_list.31
   '
   SELECT "posthog_taggeditem"."id",
          "posthog_taggeditem"."tag_id",
@@ -11457,6 +11446,24 @@
                                                 3,
                                                 4,
                                                 5 /* ... */) /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list.32
+  '
+  SELECT "posthog_sharingconfiguration"."id",
+         "posthog_sharingconfiguration"."team_id",
+         "posthog_sharingconfiguration"."dashboard_id",
+         "posthog_sharingconfiguration"."insight_id",
+         "posthog_sharingconfiguration"."recording_id",
+         "posthog_sharingconfiguration"."created_at",
+         "posthog_sharingconfiguration"."enabled",
+         "posthog_sharingconfiguration"."access_token"
+  FROM "posthog_sharingconfiguration"
+  WHERE "posthog_sharingconfiguration"."dashboard_id" IN (1,
+                                                          2,
+                                                          3,
+                                                          4,
+                                                          5 /* ... */) /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
   '
 ---
 # name: TestDashboard.test_retrieve_dashboard_list.33

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -11266,6 +11266,17 @@
 ---
 # name: TestDashboard.test_retrieve_dashboard_list.28
   '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list.29
+  '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
@@ -11288,14 +11299,6 @@
   LIMIT 21 /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.29
-  '
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_dashboard"
-  WHERE (NOT ("posthog_dashboard"."deleted")
-         AND "posthog_dashboard"."team_id" = 2) /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
-  '
----
 # name: TestDashboard.test_retrieve_dashboard_list.3
   '
   SELECT "posthog_instancesetting"."id",
@@ -11308,6 +11311,14 @@
   '
 ---
 # name: TestDashboard.test_retrieve_dashboard_list.30
+  '
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_dashboard"
+  WHERE (NOT ("posthog_dashboard"."deleted")
+         AND "posthog_dashboard"."team_id" = 2) /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list.31
   '
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -11426,7 +11437,7 @@
   LIMIT 100 /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.31
+# name: TestDashboard.test_retrieve_dashboard_list.32
   '
   SELECT "posthog_taggeditem"."id",
          "posthog_taggeditem"."tag_id",
@@ -11446,24 +11457,6 @@
                                                 3,
                                                 4,
                                                 5 /* ... */) /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list.32
-  '
-  SELECT "posthog_sharingconfiguration"."id",
-         "posthog_sharingconfiguration"."team_id",
-         "posthog_sharingconfiguration"."dashboard_id",
-         "posthog_sharingconfiguration"."insight_id",
-         "posthog_sharingconfiguration"."recording_id",
-         "posthog_sharingconfiguration"."created_at",
-         "posthog_sharingconfiguration"."enabled",
-         "posthog_sharingconfiguration"."access_token"
-  FROM "posthog_sharingconfiguration"
-  WHERE "posthog_sharingconfiguration"."dashboard_id" IN (1,
-                                                          2,
-                                                          3,
-                                                          4,
-                                                          5 /* ... */) /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
   '
 ---
 # name: TestDashboard.test_retrieve_dashboard_list.33


### PR DESCRIPTION
## Problem

We are sending 120M debug logs to CH per week, which creates a significant Kafka and CH load spike during ingestion rollouts:

![image](https://github.com/PostHog/posthog/assets/6241083/e1808d96-65cc-4ed7-80ba-db15adeea967)

These logs are not that actionable, and pod logs are enough to track these. The log level per plugin is configurable in PG, but no plugin currently specify it, so plugin-server fallbacks to full. I propose falling-back to "all but debug", and allowing debug log level by changing the plugin row.

## Changes

- Skip debug logs from apps by default, can be overridden by setting the `log_level` column in the `posthog_plugins` PG table. They are still logged to stdout and queryable though monitoring.
- Skip debug logs from "system source" too (which are the noisy "Plugin loaded" / "Plugin unloaded")
- Fix the order of `PluginLogLevel` to match our UI:

![image](https://github.com/PostHog/posthog/assets/6241083/2ec88fd7-3760-4111-bb10-80105f89fe48)

The whole level system is very janky, but I don't this it's worth investing time in fixing it further this quarter.