### PR TITLE
feat(ingestion): add DROP_EVENTS_BY_TOKEN option

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -131,6 +131,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CLOUD_DEPLOYMENT: null,
         EXTERNAL_REQUEST_TIMEOUT_MS: 10 * 1000, // 10 seconds
         DROP_EVENTS_BY_TOKEN_DISTINCT_ID: '',
+        DROP_EVENTS_BY_TOKEN: '',
         POE_EMBRACE_JOIN_FOR_TEAMS: '',
         RELOAD_PLUGIN_JITTER_MAX_MS: 60000,
 
@@ -240,6 +241,21 @@ export function buildIntegerMatcher(config: string | undefined, allowStar: boole
                 .filter((num) => !isNaN(num))
         )
         return (v: number) => {
+            return values.has(v)
+        }
+    }
+}
+
+export function buildStringMatcher(config: string | undefined, allowStar: boolean): ValueMatcher<string> {
+    // Builds a ValueMatcher on a comma-separated list of values.
+    // Optionally, supports a '*' value to match everything
+    if (!config || config.trim().length == 0) {
+        return () => false
+    } else if (allowStar && config === '*') {
+        return () => true
+    } else {
+        const values = new Set(config.split(','))
+        return (v: string) => {
             return values.has(v)
         }
     }

--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-historical-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-historical-consumer.ts
@@ -1,5 +1,6 @@
 import { Message } from 'node-rdkafka'
 
+import { buildStringMatcher } from '../../config/config'
 import { KAFKA_EVENTS_PLUGIN_INGESTION_HISTORICAL, prefix as KAFKA_PREFIX } from '../../config/kafka-topics'
 import { Hub } from '../../types'
 import { status } from '../../utils/status'
@@ -24,8 +25,9 @@ export const startAnalyticsEventsIngestionHistoricalConsumer = async ({
         We don't want to move events to overflow from here, it's fine for the processing to
         take longer, but we want the locality constraints to be respected like normal ingestion.
     */
+    const tokenBlockList = buildStringMatcher(hub.DROP_EVENTS_BY_TOKEN, false)
     const batchHandler = async (messages: Message[], queue: IngestionConsumer): Promise<void> => {
-        await eachBatchParallelIngestion(messages, queue, IngestionOverflowMode.Disabled)
+        await eachBatchParallelIngestion(tokenBlockList, messages, queue, IngestionOverflowMode.Disabled)
     }
 
     const queue = new IngestionConsumer(

--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.ts
@@ -1,5 +1,6 @@
 import { Message } from 'node-rdkafka'
 
+import { buildStringMatcher } from '../../config/config'
 import { KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW, prefix as KAFKA_PREFIX } from '../../config/kafka-topics'
 import { Hub } from '../../types'
 import { status } from '../../utils/status'
@@ -29,9 +30,9 @@ export const startAnalyticsEventsIngestionOverflowConsumer = async ({
     // workloads ran on the same process they would share the same consumer
     // group id. In these cases, updating to this version will result in the
     // re-exporting of events still in Kafka `clickhouse_events_json` topic.
-
+    const tokenBlockList = buildStringMatcher(hub.DROP_EVENTS_BY_TOKEN, false)
     const batchHandler = async (messages: Message[], queue: IngestionConsumer): Promise<void> => {
-        await eachBatchParallelIngestion(messages, queue, IngestionOverflowMode.Consume)
+        await eachBatchParallelIngestion(tokenBlockList, messages, queue, IngestionOverflowMode.Consume)
     }
 
     const queue = new IngestionConsumer(

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -204,6 +204,7 @@ export interface PluginsServerConfig {
     CLOUD_DEPLOYMENT: string | null
     EXTERNAL_REQUEST_TIMEOUT_MS: number
     DROP_EVENTS_BY_TOKEN_DISTINCT_ID: string
+    DROP_EVENTS_BY_TOKEN: string
     POE_EMBRACE_JOIN_FOR_TEAMS: string
     RELOAD_PLUGIN_JITTER_MAX_MS: number
 

--- a/plugin-server/tests/config.test.ts
+++ b/plugin-server/tests/config.test.ts
@@ -1,4 +1,4 @@
-import { buildIntegerMatcher, getDefaultConfig, overrideWithEnv } from '../src/config/config'
+import { buildIntegerMatcher, buildStringMatcher, getDefaultConfig, overrideWithEnv } from '../src/config/config'
 
 describe('config', () => {
     test('overrideWithEnv 1', () => {
@@ -89,5 +89,32 @@ describe('buildIntegerMatcher', () => {
         expect(matcher(3)).toBe(true)
         expect(matcher(4)).toBe(true)
         expect(matcher(5)).toBe(false)
+    })
+})
+
+describe('buildStringMatcher', () => {
+    test('empty input', () => {
+        const matcher = buildStringMatcher('', false)
+        expect(matcher('b')).toBe(false)
+    })
+    test('ignores star star when not allowed', () => {
+        const matcher = buildStringMatcher('*', false)
+        expect(matcher('b')).toBe(false)
+    })
+    test('matches star when allowed', () => {
+        const matcher = buildStringMatcher('*', true)
+        expect(matcher('b')).toBe(true)
+    })
+    test('can match on a single value', () => {
+        const matcher = buildStringMatcher('b', true)
+        expect(matcher('b')).toBe(true)
+        expect(matcher('a')).toBe(false)
+    })
+    test('can match on several values', () => {
+        const matcher = buildStringMatcher('b,c,d', true)
+        expect(matcher('b')).toBe(true)
+        expect(matcher('c')).toBe(true)
+        expect(matcher('d')).toBe(true)
+        expect(matcher('e')).toBe(false)
     })
 })

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
@@ -15,7 +15,7 @@ jest.mock('./../../../src/worker/ingestion/event-pipeline/runner', () => ({
     runEventPipeline: jest.fn().mockResolvedValue('default value'),
 }))
 
-const captureEndpointEvent = {
+const captureEndpointEvent1 = {
     uuid: 'uuid1',
     distinct_id: 'id',
     ip: null,
@@ -25,6 +25,20 @@ const captureEndpointEvent = {
         properties: {},
     }),
     token: 'mytoken',
+    now: null,
+    sent_at: null,
+}
+
+const captureEndpointEvent2 = {
+    uuid: 'uuid2',
+    distinct_id: 'id',
+    ip: null,
+    site_url: '',
+    data: JSON.stringify({
+        event: 'event',
+        properties: {},
+    }),
+    token: 'othertoken',
     now: null,
     sent_at: null,
 }
@@ -68,9 +82,9 @@ describe('eachBatchParallelIngestion with overflow reroute', () => {
             {
                 partition: 0,
                 topic: KAFKA_EVENTS_PLUGIN_INGESTION,
-                value: JSON.stringify(captureEndpointEvent),
-                timestamp: captureEndpointEvent['timestamp'],
-                offset: captureEndpointEvent['offset'],
+                value: JSON.stringify(captureEndpointEvent1),
+                timestamp: captureEndpointEvent1['timestamp'],
+                offset: captureEndpointEvent1['offset'],
                 key: null,
                 token: 'ok',
             },
@@ -85,9 +99,9 @@ describe('eachBatchParallelIngestion with overflow reroute', () => {
         expect(captureIngestionWarning).not.toHaveBeenCalled()
         expect(queue.pluginsServer.kafkaProducer.produce).toHaveBeenCalledWith({
             topic: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
-            value: JSON.stringify(captureEndpointEvent),
-            timestamp: captureEndpointEvent['timestamp'],
-            offset: captureEndpointEvent['offset'],
+            value: JSON.stringify(captureEndpointEvent1),
+            timestamp: captureEndpointEvent1['timestamp'],
+            offset: captureEndpointEvent1['offset'],
             key: null,
             waitForAck: true,
         })
@@ -98,23 +112,23 @@ describe('eachBatchParallelIngestion with overflow reroute', () => {
 
     it('reroutes excess events to OVERFLOW topic', async () => {
         const now = Date.now()
-        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent], now)
+        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent1], now)
         const consume = jest.spyOn(ConfiguredLimiter, 'consume').mockImplementation(() => false)
 
         const tokenBlockList = buildStringMatcher('another_token,more_token', false)
         await eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Reroute)
 
         expect(consume).toHaveBeenCalledWith(
-            captureEndpointEvent['token'] + ':' + captureEndpointEvent['distinct_id'],
+            captureEndpointEvent1['token'] + ':' + captureEndpointEvent1['distinct_id'],
             1,
             now
         )
         expect(captureIngestionWarning).not.toHaveBeenCalled()
         expect(queue.pluginsServer.kafkaProducer.produce).toHaveBeenCalledWith({
             topic: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
-            value: JSON.stringify(captureEndpointEvent),
-            timestamp: captureEndpointEvent['timestamp'],
-            offset: captureEndpointEvent['offset'],
+            value: JSON.stringify(captureEndpointEvent1),
+            timestamp: captureEndpointEvent1['timestamp'],
+            offset: captureEndpointEvent1['offset'],
             key: null,
             waitForAck: true,
         })
@@ -125,35 +139,47 @@ describe('eachBatchParallelIngestion with overflow reroute', () => {
 
     it('does not reroute if not over capacity limit', async () => {
         const now = Date.now()
-        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent], now)
+        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent1, captureEndpointEvent2], now)
         const consume = jest.spyOn(ConfiguredLimiter, 'consume').mockImplementation(() => true)
 
         const tokenBlockList = buildStringMatcher('another_token,more_token', false)
         await eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Reroute)
 
         expect(consume).toHaveBeenCalledWith(
-            captureEndpointEvent['token'] + ':' + captureEndpointEvent['distinct_id'],
+            captureEndpointEvent1['token'] + ':' + captureEndpointEvent1['distinct_id'],
+            1,
+            now
+        )
+        expect(consume).toHaveBeenCalledWith(
+            captureEndpointEvent2['token'] + ':' + captureEndpointEvent2['distinct_id'],
             1,
             now
         )
         expect(captureIngestionWarning).not.toHaveBeenCalled()
         expect(queue.pluginsServer.kafkaProducer.produce).not.toHaveBeenCalled()
         // Event is processed
-        expect(runEventPipeline).toHaveBeenCalled()
+        expect(runEventPipeline).toHaveBeenCalledTimes(2)
     })
 
     it('does drop events from blocked tokens', async () => {
         const now = Date.now()
-        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent], now)
+        const batch = createBatchWithMultipleEventsWithKeys(
+            [captureEndpointEvent1, captureEndpointEvent2, captureEndpointEvent1],
+            now
+        )
         const consume = jest.spyOn(ConfiguredLimiter, 'consume').mockImplementation(() => true)
 
         const tokenBlockList = buildStringMatcher('mytoken,another_token', false)
         await eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Reroute)
 
-        // Event is dropped, none of that happens
-        expect(consume).not.toHaveBeenCalled()
+        // Event captureEndpointEvent1 is dropped , captureEndpointEvent2 goes though
+        expect(consume).toHaveBeenCalledWith(
+            captureEndpointEvent2['token'] + ':' + captureEndpointEvent2['distinct_id'],
+            1,
+            now
+        )
         expect(captureIngestionWarning).not.toHaveBeenCalled()
         expect(queue.pluginsServer.kafkaProducer.produce).not.toHaveBeenCalled()
-        expect(runEventPipeline).not.toHaveBeenCalled()
+        expect(runEventPipeline).toHaveBeenCalledTimes(1)
     })
 })

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
@@ -3,7 +3,7 @@ import {
     eachBatchParallelIngestion,
     IngestionOverflowMode,
 } from '../../../src/main/ingestion-queues/batch-processing/each-batch-ingestion'
-import { ConfiguredLimiter, OverflowWarningLimiter } from '../../../src/utils/token-bucket'
+import { OverflowWarningLimiter } from '../../../src/utils/token-bucket'
 import { runEventPipeline } from './../../../src/worker/ingestion/event-pipeline/runner'
 import { captureIngestionWarning } from './../../../src/worker/ingestion/utils'
 
@@ -13,7 +13,7 @@ jest.mock('./../../../src/worker/ingestion/event-pipeline/runner', () => ({
     runEventPipeline: jest.fn().mockResolvedValue('default value'),
 }))
 
-const captureEndpointEvent = {
+const captureEndpointEvent1 = {
     uuid: 'uuid1',
     distinct_id: 'id',
     ip: null,
@@ -22,7 +22,21 @@ const captureEndpointEvent = {
         event: 'event',
         properties: {},
     }),
-    team_id: 1,
+    token: 'mytoken',
+    now: null,
+    sent_at: null,
+}
+
+const captureEndpointEvent2 = {
+    uuid: 'uuid2',
+    distinct_id: 'id',
+    ip: null,
+    site_url: '',
+    data: JSON.stringify({
+        event: 'event',
+        properties: {},
+    }),
+    token: 'othertoken',
     now: null,
     sent_at: null,
 }
@@ -62,7 +76,7 @@ describe('eachBatchParallelIngestion with overflow consume', () => {
     })
 
     it('raises ingestion warning when consuming from overflow', async () => {
-        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent])
+        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent1])
         const consume = jest.spyOn(OverflowWarningLimiter, 'consume').mockImplementation(() => true)
 
         queue.pluginsServer.teamManager.getTeamForEvent.mockResolvedValueOnce({ id: 1 })
@@ -70,35 +84,24 @@ describe('eachBatchParallelIngestion with overflow consume', () => {
         await eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Consume)
 
         expect(queue.pluginsServer.teamManager.getTeamForEvent).toHaveBeenCalledTimes(1)
-        expect(consume).toHaveBeenCalledWith(
-            captureEndpointEvent['team_id'] + ':' + captureEndpointEvent['distinct_id'],
-            1
-        )
-        expect(captureIngestionWarning).toHaveBeenCalledWith(
-            queue.pluginsServer.db,
-            captureEndpointEvent['team_id'],
-            'ingestion_capacity_overflow',
-            {
-                overflowDistinctId: captureEndpointEvent['distinct_id'],
-            }
-        )
+        expect(consume).toHaveBeenCalledWith('1:id', 1)
+        expect(captureIngestionWarning).toHaveBeenCalledWith(queue.pluginsServer.db, 1, 'ingestion_capacity_overflow', {
+            overflowDistinctId: captureEndpointEvent1['distinct_id'],
+        })
 
         // Event is processed
         expect(runEventPipeline).toHaveBeenCalled()
     })
 
     it('does not raise ingestion warning when under threshold', async () => {
-        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent])
+        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent1])
         const consume = jest.spyOn(OverflowWarningLimiter, 'consume').mockImplementation(() => false)
 
         queue.pluginsServer.teamManager.getTeamForEvent.mockResolvedValueOnce({ id: 1 })
         const tokenBlockList = buildStringMatcher('another_token,more_token', false)
         await eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Consume)
 
-        expect(consume).toHaveBeenCalledWith(
-            captureEndpointEvent['team_id'] + ':' + captureEndpointEvent['distinct_id'],
-            1
-        )
+        expect(consume).toHaveBeenCalledWith('1:id', 1)
         expect(captureIngestionWarning).not.toHaveBeenCalled()
         expect(queue.pluginsServer.kafkaProducer.queueMessage).not.toHaveBeenCalled()
 
@@ -107,17 +110,22 @@ describe('eachBatchParallelIngestion with overflow consume', () => {
     })
 
     it('does drop events from blocked tokens', async () => {
-        const now = Date.now()
-        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent], now)
-        const consume = jest.spyOn(ConfiguredLimiter, 'consume').mockImplementation(() => true)
+        const batch = createBatchWithMultipleEventsWithKeys([
+            captureEndpointEvent1,
+            captureEndpointEvent2,
+            captureEndpointEvent1,
+        ])
+        const consume = jest.spyOn(OverflowWarningLimiter, 'consume').mockImplementation(() => false)
 
-        const tokenBlockList = buildStringMatcher('mytoken,another_token', false)
+        queue.pluginsServer.teamManager.getTeamForEvent.mockResolvedValueOnce({ id: 1 })
+        const tokenBlockList = buildStringMatcher('mytoken,more_token', false)
         await eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Consume)
 
-        // Event is dropped, none of that happens
-        expect(consume).not.toHaveBeenCalled()
         expect(captureIngestionWarning).not.toHaveBeenCalled()
         expect(queue.pluginsServer.kafkaProducer.queueMessage).not.toHaveBeenCalled()
-        expect(runEventPipeline).not.toHaveBeenCalled()
+
+        // captureEndpointEvent2 is processed, captureEndpointEvent1 are dropped
+        expect(runEventPipeline).toHaveBeenCalledTimes(1)
+        expect(consume).toHaveBeenCalledTimes(1)
     })
 })

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -1,4 +1,4 @@
-import { buildIntegerMatcher } from '../../../src/config/config'
+import { buildIntegerMatcher, buildStringMatcher } from '../../../src/config/config'
 import { KAFKA_EVENTS_PLUGIN_INGESTION } from '../../../src/config/kafka-topics'
 import {
     eachBatchParallelIngestion,
@@ -23,6 +23,7 @@ import { ActionMatcher } from '../../../src/worker/ingestion/action-matcher'
 import { HookCommander } from '../../../src/worker/ingestion/hooks'
 import { runOnEvent } from '../../../src/worker/plugins/run'
 import { pluginConfig39 } from '../../helpers/plugins'
+import { runEventPipeline } from './../../../src/worker/ingestion/event-pipeline/runner'
 
 jest.mock('../../../src/worker/plugins/run')
 
@@ -39,7 +40,6 @@ jest.mock('./../../../src/worker/ingestion/event-pipeline/runner', () => ({
     runEventPipeline: jest.fn().mockResolvedValue('default value'),
     // runEventPipeline: jest.fn().mockRejectedValue('default value'),
 }))
-import { runEventPipeline } from './../../../src/worker/ingestion/event-pipeline/runner'
 
 const event: PostIngestionEvent = {
     eventUuid: 'uuid1',
@@ -408,7 +408,8 @@ describe('eachBatchX', () => {
         })
         it('calls runEventPipeline', async () => {
             const batch = createBatch(captureEndpointEvent)
-            await eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Disabled)
+            const tokenBlockList = buildStringMatcher('another_token,more_token', false)
+            await eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Disabled)
 
             expect(runEventPipeline).toHaveBeenCalledWith(expect.anything(), {
                 distinct_id: 'id',
@@ -430,7 +431,8 @@ describe('eachBatchX', () => {
         it("doesn't fail the batch if runEventPipeline rejects once then succeeds on retry", async () => {
             const batch = createBatch(captureEndpointEvent)
             runEventPipelineSpy.mockImplementationOnce(() => Promise.reject('runEventPipeline nopes out'))
-            await eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Disabled)
+            const tokenBlockList = buildStringMatcher('another_token,more_token', false)
+            await eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Disabled)
             expect(runEventPipeline).toHaveBeenCalledTimes(2)
         })
 
@@ -441,9 +443,10 @@ describe('eachBatchX', () => {
                     promises: [Promise.resolve(), Promise.reject('deferred nopes out')],
                 })
             )
-            await expect(eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Disabled)).rejects.toBe(
-                'deferred nopes out'
-            )
+            const tokenBlockList = buildStringMatcher('another_token,more_token', false)
+            await expect(
+                eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Disabled)
+            ).rejects.toBe('deferred nopes out')
             expect(runEventPipeline).toHaveBeenCalledTimes(1)
         })
 
@@ -463,7 +466,8 @@ describe('eachBatchX', () => {
                 { ...captureEndpointEvent, team_id: 3, distinct_id: 'a' },
             ])
             const stats = new Map()
-            for (const group of splitIngestionBatch(batch, IngestionOverflowMode.Disabled).toProcess) {
+            const tokenBlockList = buildStringMatcher('another_token,more_token', false)
+            for (const group of splitIngestionBatch(tokenBlockList, batch, IngestionOverflowMode.Disabled).toProcess) {
                 const key = `${group[0].pluginEvent.team_id}:${group[0].pluginEvent.token}:${group[0].pluginEvent.distinct_id}`
                 for (const { pluginEvent: event } of group) {
                     expect(`${event.team_id}:${event.token}:${event.distinct_id}`).toEqual(key)
@@ -492,7 +496,8 @@ describe('eachBatchX', () => {
                 { ...captureEndpointEvent, team_id: 4, distinct_id: 'a' },
                 { ...captureEndpointEvent, team_id: 4, distinct_id: 'a' },
             ])
-            const batches = splitIngestionBatch(input, IngestionOverflowMode.Consume).toProcess
+            const tokenBlockList = buildStringMatcher('another_token,more_token', false)
+            const batches = splitIngestionBatch(tokenBlockList, input, IngestionOverflowMode.Consume).toProcess
             expect(batches.length).toEqual(input.length)
             for (const group of batches) {
                 expect(group.length).toEqual(1)
@@ -516,8 +521,8 @@ describe('eachBatchX', () => {
                 { ...captureEndpointEvent, offset: 13, team_id: 3 }, // repeat
                 { ...captureEndpointEvent, offset: 14, team_id: 5 }, // repeat
             ])
-
-            await eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Disabled)
+            const tokenBlockList = buildStringMatcher('another_token,more_token', false)
+            await eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Disabled)
             expect(runEventPipeline).toHaveBeenCalledTimes(14)
             expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith(
                 'ingest_event_batching.input_length',
@@ -532,14 +537,15 @@ describe('eachBatchX', () => {
         })
 
         it('fails the batch if runEventPipeline rejects repeatedly', async () => {
+            const tokenBlockList = buildStringMatcher('another_token,more_token', false)
             const batch = createBatch(captureEndpointEvent)
             runEventPipelineSpy
                 .mockImplementationOnce(() => Promise.reject('runEventPipeline nopes out'))
                 .mockImplementationOnce(() => Promise.reject('runEventPipeline nopes out'))
                 .mockImplementationOnce(() => Promise.reject('runEventPipeline nopes out'))
-            await expect(eachBatchParallelIngestion(batch, queue, IngestionOverflowMode.Disabled)).rejects.toBe(
-                'runEventPipeline nopes out'
-            )
+            await expect(
+                eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Disabled)
+            ).rejects.toBe('runEventPipeline nopes out')
             expect(runEventPipeline).toHaveBeenCalledTimes(3)
             runEventPipelineSpy.mockRestore()
         })


### PR DESCRIPTION
## Problem

We already have DROP_EVENTS_BY_TOKEN_DISTINCT_ID, but sometimes we want to drop one team as early as possible.

## Changes
- Add a coma-separated DROP_EVENTS_BY_TOKEN envvar
- Drop events with these tokens as soon as possible, not even moving them to overflow


