### PR TITLE
fix: Show label on data with one value

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -146,12 +146,8 @@ export function PieChart({
                         },
                         display: (context) => {
                             const percentage = getPercentageForDataPoint(context)
-                            return (showValueOnSeries !== false || // show if true or unset
-                                showLabelOnSeries) &&
-                                context.dataset.data.length > 1 &&
-                                percentage > 5
-                                ? 'auto'
-                                : false
+                            const showValueForSeries = showValueOnSeries !== false && context.dataset.data.length > 1 // show if true or unset
+                            return (showValueForSeries || showLabelOnSeries) && percentage > 5 ? 'auto' : false
                         },
                         padding: (context) => {
                             // in order to make numbers below 10 look circular we need a little padding


### PR DESCRIPTION
## Problem
Didn't make sense to show the value on the series if there was only one value, because we would show it below. It *does* make sense to show the label though!


## Changes
<img width="565" alt="Screenshot 2023-11-22 at 16 48 04" src="https://github.com/PostHog/posthog/assets/2056078/762041c4-9604-42bf-8150-a55fb42293ee">

## How did you test this code?

Manually
