### PR TITLE
fix(web-analytics): Support github geoip plugin url

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -90,6 +90,11 @@ export interface WebAnalyticsStatusCheck {
     shouldWarnAboutNoPageleaves: boolean
 }
 
+export const GEOIP_PLUGIN_URLS = [
+    'https://github.com/PostHog/posthog-plugin-geoip',
+    'https://www.npmjs.com/package/@posthog/geoip-plugin',
+]
+
 export const initialWebAnalyticsFilter = [] as WebAnalyticsPropertyFilters
 
 export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
@@ -718,9 +723,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 
                 const geoIpPlugin =
                     pluginsResponse.status === 'fulfilled' &&
-                    pluginsResponse.value.find(
-                        (plugin) => plugin.url === 'https://www.npmjs.com/package/@posthog/geoip-plugin'
-                    )
+                    pluginsResponse.value.find((plugin) => GEOIP_PLUGIN_URLS.includes(plugin.url))
                 const geoIpPluginId = geoIpPlugin ? geoIpPlugin.id : undefined
 
                 const geoIpPluginConfig =


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C05LJK1N3CP/p1700679811999299?thread_ts=1700675952.652149&cid=C05LJK1N3CP

## Changes

Support the plugin url being specific by github url rather than just npm url.

## How did you test this code?

Manually
