### PR TITLE
fix: attach tooltips to toolbar shadow root

### DIFF
--- a/frontend/src/toolbar/bar/ToolbarButton.tsx
+++ b/frontend/src/toolbar/bar/ToolbarButton.tsx
@@ -7,6 +7,8 @@ import { capitalizeFirstLetter } from 'lib/utils'
 import { FunctionComponent, useEffect } from 'react'
 import React from 'react'
 
+import { getShadowRootPopoverContainer } from '~/toolbar/utils'
+
 import { MenuState, toolbarLogic } from './toolbarLogic'
 
 export type ToolbarButtonProps = {
@@ -61,7 +63,9 @@ export const ToolbarButton: FunctionComponent<ToolbarButtonProps> = React.forwar
         </div>
     )
     return ((minimized && titleMinimized) || theTitle) && !active && !isDragging ? (
-        <Tooltip title={minimized ? titleMinimized : theTitle}>{theButton}</Tooltip>
+        <Tooltip title={minimized ? titleMinimized : theTitle} getPopupContainer={getShadowRootPopoverContainer}>
+            {theButton}
+        </Tooltip>
     ) : (
         theButton
     )


### PR DESCRIPTION
attach toolbar tooltips to the correct popover container