### PR TITLE
feat(3000): replace exclusion steps picker with lemon ui

### DIFF
--- a/frontend/src/scenes/insights/filters/FunnelExclusionsFilter/ExclusionRowSuffix.tsx
+++ b/frontend/src/scenes/insights/filters/FunnelExclusionsFilter/ExclusionRowSuffix.tsx
@@ -1,9 +1,7 @@
-import { LemonButton } from '@posthog/lemon-ui'
-import { Select } from 'antd'
+import { LemonButton, LemonSelect } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { IconDelete } from 'lib/lemon-ui/icons'
-import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
 import { getClampedStepRangeFilterDataExploration } from 'scenes/funnels/funnelUtils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
@@ -70,47 +68,27 @@ export function ExclusionRowSuffix({
     return (
         <div className={clsx('flex items-center flex-nowrap pl-1 mx-0', isVertical ? 'w-full my-1' : 'w-auto my-0')}>
             between
-            <Select
-                defaultValue={0}
-                disabled={!isFunnelWithEnoughSteps}
-                dropdownMatchSelectWidth={false}
-                dropdownAlign={ANTD_TOOLTIP_PLACEMENTS.bottomRight}
-                data-attr="funnel-exclusion-funnel_from_step-selector"
-                optionLabelProp="label"
-                value={stepRange.funnel_from_step}
-                onChange={(fromStep: number) => onChange(fromStep)}
-                onBlur={() => onChange}
-                style={{ marginLeft: 4, marginRight: 4 }}
-            >
-                {Array.from(Array(numberOfSeries).keys())
+            <LemonSelect
+                className="mx-1"
+                size="small"
+                value={stepRange.funnel_from_step || 0}
+                onChange={onChange}
+                options={Array.from(Array(numberOfSeries).keys())
                     .slice(0, -1)
-                    .map((stepIndex) => (
-                        <Select.Option key={stepIndex} value={stepIndex} label={`Step ${stepIndex + 1}`}>
-                            Step {stepIndex + 1}
-                        </Select.Option>
-                    ))}
-            </Select>
-            and
-            <Select
-                defaultValue={(stepRange.funnel_from_step ?? 0) + 1}
+                    .map((stepIndex) => ({ value: stepIndex, label: `Step ${stepIndex + 1}` }))}
                 disabled={!isFunnelWithEnoughSteps}
-                dropdownMatchSelectWidth={false}
-                dropdownAlign={ANTD_TOOLTIP_PLACEMENTS.bottomRight}
-                data-attr="funnel-exclusion-funnel_to_step-selector"
-                optionLabelProp="label"
-                value={stepRange.funnel_to_step}
+            />
+            and
+            <LemonSelect
+                className="ml-1"
+                size="small"
+                value={stepRange.funnel_to_step || (stepRange.funnel_from_step ?? 0) + 1}
                 onChange={(toStep: number) => onChange(stepRange.funnel_from_step, toStep)}
-                onBlur={() => onChange}
-                style={{ marginLeft: 4 }}
-            >
-                {Array.from(Array(numberOfSeries).keys())
+                options={Array.from(Array(numberOfSeries).keys())
                     .slice((stepRange.funnel_from_step ?? 0) + 1)
-                    .map((stepIndex) => (
-                        <Select.Option key={stepIndex} value={stepIndex} label={`Step ${stepIndex + 1}`}>
-                            Step {stepIndex + 1}
-                        </Select.Option>
-                    ))}
-            </Select>
+                    .map((stepIndex) => ({ value: stepIndex, label: `Step ${stepIndex + 1}` }))}
+                disabled={!isFunnelWithEnoughSteps}
+            />
             <LemonButton
                 icon={<IconDelete />}
                 status="primary-alt"


### PR DESCRIPTION
## Problem

Antd doesn't look good in 3000.

## Changes

This PR replaces the funnel exclusion steps picker with Lemon UI.

<img width="548" alt="Screenshot 2023-11-23 at 18 51 50" src="https://github.com/PostHog/posthog/assets/1851359/cccbb438-b6ac-469e-8932-9f7b1b2670a4">

## How did you test this code?

Clicking around