### PR TITLE
feat(3000): replace retention reference picker with lemon ui

### DIFF
--- a/frontend/src/scenes/insights/filters/RetentionReferencePicker.tsx
+++ b/frontend/src/scenes/insights/filters/RetentionReferencePicker.tsx
@@ -1,6 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import { PercentageOutlined } from '@ant-design/icons'
-import { Select } from 'antd'
+import { LemonSelect } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
@@ -11,41 +9,27 @@ export function RetentionReferencePicker(): JSX.Element {
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
 
     const { retention_reference } = retentionFilter || {}
+
     return (
-        <Select
+        <LemonSelect
+            className="w-60"
+            size="small"
             value={retention_reference || 'total'}
             onChange={(retention_reference) => {
                 updateInsightFilter({ retention_reference })
             }}
-            bordered={false}
-            dropdownMatchSelectWidth={false}
-            data-attr="reference-selector"
-            optionLabelProp="label"
-        >
-            {[
+            options={[
                 {
                     value: 'total',
-                    icon: <PercentageOutlined />,
-                    label: 'Overall cohort',
+                    labelInMenu: 'Overall cohort',
+                    label: '% Overall cohort',
                 },
                 {
                     value: 'previous',
-                    icon: <PercentageOutlined />,
-                    label: 'Relative to previous period',
+                    labelInMenu: 'Relative to previous period',
+                    label: '% Relative to previous period',
                 },
-            ].map((option) => (
-                <Select.Option
-                    key={option.value}
-                    value={option.value}
-                    label={
-                        <>
-                            {option.icon} {option.label}
-                        </>
-                    }
-                >
-                    {option.label}
-                </Select.Option>
-            ))}
-        </Select>
+            ]}
+        />
     )
 }


### PR DESCRIPTION
## Problem

Antd doesn't look good in 3000.

## Changes

This PR replaces the retention reference picker with Lemon UI.

<img width="493" alt="Screenshot 2023-11-23 at 19 01 42" src="https://github.com/PostHog/posthog/assets/1851359/ffaf3f40-c385-4a8d-81c6-7351d3800452">

## How did you test this code?

Clicking around
