### PR TITLE
feat: Option for overflow consumer to split by distinct ID

### DIFF
--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.ts
@@ -1,4 +1,5 @@
 import { Message } from 'node-rdkafka'
+import { isOverflowBatchByDistinctId } from 'utils/env-utils'
 
 import { buildStringMatcher } from '../../config/config'
 import { KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW, prefix as KAFKA_PREFIX } from '../../config/kafka-topics'
@@ -31,8 +32,11 @@ export const startAnalyticsEventsIngestionOverflowConsumer = async ({
     // group id. In these cases, updating to this version will result in the
     // re-exporting of events still in Kafka `clickhouse_events_json` topic.
     const tokenBlockList = buildStringMatcher(hub.DROP_EVENTS_BY_TOKEN, false)
+    const overflowMode = isOverflowBatchByDistinctId()
+        ? IngestionOverflowMode.ConsumeSplitByDistinctId
+        : IngestionOverflowMode.ConsumeSplitEvenly
     const batchHandler = async (messages: Message[], queue: IngestionConsumer): Promise<void> => {
-        await eachBatchParallelIngestion(tokenBlockList, messages, queue, IngestionOverflowMode.Consume)
+        await eachBatchParallelIngestion(tokenBlockList, messages, queue, overflowMode)
     }
 
     const queue = new IngestionConsumer(

--- a/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.ts
@@ -1,9 +1,9 @@
 import { Message } from 'node-rdkafka'
-import { isOverflowBatchByDistinctId } from 'utils/env-utils'
 
 import { buildStringMatcher } from '../../config/config'
 import { KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW, prefix as KAFKA_PREFIX } from '../../config/kafka-topics'
 import { Hub } from '../../types'
+import { isOverflowBatchByDistinctId } from '../../utils/env-utils'
 import { status } from '../../utils/status'
 import { eachBatchParallelIngestion, IngestionOverflowMode } from './batch-processing/each-batch-ingestion'
 import { IngestionConsumer } from './kafka-queue'

--- a/plugin-server/src/utils/env-utils.ts
+++ b/plugin-server/src/utils/env-utils.ts
@@ -46,3 +46,8 @@ export function isIngestionOverflowEnabled(): boolean {
     const ingestionOverflowEnabled = process.env.INGESTION_OVERFLOW_ENABLED
     return stringToBoolean(ingestionOverflowEnabled)
 }
+
+export function isOverflowBatchByDistinctId(): boolean {
+    const overflowBatchByDistinctId = process.env.INGESTION_OVERFLOW_BATCH_BY_DISTINCT_ID
+    return stringToBoolean(overflowBatchByDistinctId)
+}

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
@@ -102,32 +102,6 @@ describe('eachBatchParallelIngestion with overflow consume', () => {
     )
 
     it.each([IngestionOverflowMode.ConsumeSplitByDistinctId, IngestionOverflowMode.ConsumeSplitEvenly])(
-        'raises ingestion warning when consuming from overflow with batching by distinctId %s',
-        async (mode) => {
-            const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent1])
-            const consume = jest.spyOn(OverflowWarningLimiter, 'consume').mockImplementation(() => true)
-
-            queue.pluginsServer.teamManager.getTeamForEvent.mockResolvedValueOnce({ id: 1 })
-            const tokenBlockList = buildStringMatcher('another_token,more_token', false)
-            await eachBatchParallelIngestion(tokenBlockList, batch, queue, mode)
-
-            expect(queue.pluginsServer.teamManager.getTeamForEvent).toHaveBeenCalledTimes(1)
-            expect(consume).toHaveBeenCalledWith('1:id', 1)
-            expect(captureIngestionWarning).toHaveBeenCalledWith(
-                queue.pluginsServer.db,
-                1,
-                'ingestion_capacity_overflow',
-                {
-                    overflowDistinctId: captureEndpointEvent1['distinct_id'],
-                }
-            )
-
-            // Event is processed
-            expect(runEventPipeline).toHaveBeenCalled()
-        }
-    )
-
-    it.each([IngestionOverflowMode.ConsumeSplitByDistinctId, IngestionOverflowMode.ConsumeSplitEvenly])(
         'does not raise ingestion warning when under threshold %s',
         async (mode) => {
             const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent1])

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
@@ -75,57 +75,97 @@ describe('eachBatchParallelIngestion with overflow consume', () => {
         }
     })
 
-    it('raises ingestion warning when consuming from overflow', async () => {
-        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent1])
-        const consume = jest.spyOn(OverflowWarningLimiter, 'consume').mockImplementation(() => true)
+    it.each([IngestionOverflowMode.ConsumeSplitByDistinctId, IngestionOverflowMode.ConsumeSplitEvenly])(
+        'raises ingestion warning when consuming from overflow %s',
+        async (mode) => {
+            const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent1])
+            const consume = jest.spyOn(OverflowWarningLimiter, 'consume').mockImplementation(() => true)
 
-        queue.pluginsServer.teamManager.getTeamForEvent.mockResolvedValueOnce({ id: 1 })
-        const tokenBlockList = buildStringMatcher('another_token,more_token', false)
-        await eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Consume)
+            queue.pluginsServer.teamManager.getTeamForEvent.mockResolvedValueOnce({ id: 1 })
+            const tokenBlockList = buildStringMatcher('another_token,more_token', false)
+            await eachBatchParallelIngestion(tokenBlockList, batch, queue, mode)
 
-        expect(queue.pluginsServer.teamManager.getTeamForEvent).toHaveBeenCalledTimes(1)
-        expect(consume).toHaveBeenCalledWith('1:id', 1)
-        expect(captureIngestionWarning).toHaveBeenCalledWith(queue.pluginsServer.db, 1, 'ingestion_capacity_overflow', {
-            overflowDistinctId: captureEndpointEvent1['distinct_id'],
-        })
+            expect(queue.pluginsServer.teamManager.getTeamForEvent).toHaveBeenCalledTimes(1)
+            expect(consume).toHaveBeenCalledWith('1:id', 1)
+            expect(captureIngestionWarning).toHaveBeenCalledWith(
+                queue.pluginsServer.db,
+                1,
+                'ingestion_capacity_overflow',
+                {
+                    overflowDistinctId: captureEndpointEvent1['distinct_id'],
+                }
+            )
 
-        // Event is processed
-        expect(runEventPipeline).toHaveBeenCalled()
-    })
+            // Event is processed
+            expect(runEventPipeline).toHaveBeenCalled()
+        }
+    )
 
-    it('does not raise ingestion warning when under threshold', async () => {
-        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent1])
-        const consume = jest.spyOn(OverflowWarningLimiter, 'consume').mockImplementation(() => false)
+    it.each([IngestionOverflowMode.ConsumeSplitByDistinctId, IngestionOverflowMode.ConsumeSplitEvenly])(
+        'raises ingestion warning when consuming from overflow with batching by distinctId %s',
+        async (mode) => {
+            const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent1])
+            const consume = jest.spyOn(OverflowWarningLimiter, 'consume').mockImplementation(() => true)
 
-        queue.pluginsServer.teamManager.getTeamForEvent.mockResolvedValueOnce({ id: 1 })
-        const tokenBlockList = buildStringMatcher('another_token,more_token', false)
-        await eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Consume)
+            queue.pluginsServer.teamManager.getTeamForEvent.mockResolvedValueOnce({ id: 1 })
+            const tokenBlockList = buildStringMatcher('another_token,more_token', false)
+            await eachBatchParallelIngestion(tokenBlockList, batch, queue, mode)
 
-        expect(consume).toHaveBeenCalledWith('1:id', 1)
-        expect(captureIngestionWarning).not.toHaveBeenCalled()
-        expect(queue.pluginsServer.kafkaProducer.queueMessage).not.toHaveBeenCalled()
+            expect(queue.pluginsServer.teamManager.getTeamForEvent).toHaveBeenCalledTimes(1)
+            expect(consume).toHaveBeenCalledWith('1:id', 1)
+            expect(captureIngestionWarning).toHaveBeenCalledWith(
+                queue.pluginsServer.db,
+                1,
+                'ingestion_capacity_overflow',
+                {
+                    overflowDistinctId: captureEndpointEvent1['distinct_id'],
+                }
+            )
 
-        // Event is processed
-        expect(runEventPipeline).toHaveBeenCalled()
-    })
+            // Event is processed
+            expect(runEventPipeline).toHaveBeenCalled()
+        }
+    )
 
-    it('does drop events from blocked tokens', async () => {
-        const batch = createBatchWithMultipleEventsWithKeys([
-            captureEndpointEvent1,
-            captureEndpointEvent2,
-            captureEndpointEvent1,
-        ])
-        const consume = jest.spyOn(OverflowWarningLimiter, 'consume').mockImplementation(() => false)
+    it.each([IngestionOverflowMode.ConsumeSplitByDistinctId, IngestionOverflowMode.ConsumeSplitEvenly])(
+        'does not raise ingestion warning when under threshold %s',
+        async (mode) => {
+            const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent1])
+            const consume = jest.spyOn(OverflowWarningLimiter, 'consume').mockImplementation(() => false)
 
-        queue.pluginsServer.teamManager.getTeamForEvent.mockResolvedValueOnce({ id: 1 })
-        const tokenBlockList = buildStringMatcher('mytoken,more_token', false)
-        await eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Consume)
+            queue.pluginsServer.teamManager.getTeamForEvent.mockResolvedValueOnce({ id: 1 })
+            const tokenBlockList = buildStringMatcher('another_token,more_token', false)
+            await eachBatchParallelIngestion(tokenBlockList, batch, queue, mode)
 
-        expect(captureIngestionWarning).not.toHaveBeenCalled()
-        expect(queue.pluginsServer.kafkaProducer.queueMessage).not.toHaveBeenCalled()
+            expect(consume).toHaveBeenCalledWith('1:id', 1)
+            expect(captureIngestionWarning).not.toHaveBeenCalled()
+            expect(queue.pluginsServer.kafkaProducer.queueMessage).not.toHaveBeenCalled()
 
-        // captureEndpointEvent2 is processed, captureEndpointEvent1 are dropped
-        expect(runEventPipeline).toHaveBeenCalledTimes(1)
-        expect(consume).toHaveBeenCalledTimes(1)
-    })
+            // Event is processed
+            expect(runEventPipeline).toHaveBeenCalled()
+        }
+    )
+
+    it.each([IngestionOverflowMode.ConsumeSplitByDistinctId, IngestionOverflowMode.ConsumeSplitEvenly])(
+        'does drop events from blocked tokens %s',
+        async (mode) => {
+            const batch = createBatchWithMultipleEventsWithKeys([
+                captureEndpointEvent1,
+                captureEndpointEvent2,
+                captureEndpointEvent1,
+            ])
+            const consume = jest.spyOn(OverflowWarningLimiter, 'consume').mockImplementation(() => false)
+
+            queue.pluginsServer.teamManager.getTeamForEvent.mockResolvedValueOnce({ id: 1 })
+            const tokenBlockList = buildStringMatcher('mytoken,more_token', false)
+            await eachBatchParallelIngestion(tokenBlockList, batch, queue, mode)
+
+            expect(captureIngestionWarning).not.toHaveBeenCalled()
+            expect(queue.pluginsServer.kafkaProducer.queueMessage).not.toHaveBeenCalled()
+
+            // captureEndpointEvent2 is processed, captureEndpointEvent1 are dropped
+            expect(runEventPipeline).toHaveBeenCalledTimes(1)
+            expect(consume).toHaveBeenCalledTimes(1)
+        }
+    )
 })


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Sometimes we have a lot of the same distinctID messages in overflow and they can all contain person updates, if that's the case it might be more efficient to do the batching the same way normal ingestion does it. 
Having a flag for this allows us to change between modes depending on the queue backlog.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
