### PR TITLE
feat(hogql): split lifecycle and trends insight flags

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -161,7 +161,8 @@ export const FEATURE_FLAGS = {
     REDIRECT_SIGNUPS_TO_INSTANCE: 'redirect-signups-to-instance', // owner: @raquelmsmith
     APPS_AND_EXPORTS_UI: 'apps-and-exports-ui', // owner: @benjackwhite
     SESSION_REPLAY_CORS_PROXY: 'session-replay-cors-proxy', // owner: #team-monitoring
-    HOGQL_INSIGHTS: 'hogql-insights', // owner: @mariusandra
+    HOGQL_INSIGHTS_LIFECYCLE: 'hogql-insights-lifecycle', // owner: @mariusandra
+    HOGQL_INSIGHTS_TRENDS: 'hogql-insights-trends', // owner: @Gilbert09
     HOGQL_INSIGHT_LIVE_COMPARE: 'hogql-insight-live-compare', // owner: @mariusandra
     WEBHOOKS_DENYLIST: 'webhooks-denylist', // owner: #team-pipeline
     SURVEYS_MULTIPLE_QUESTIONS: 'surveys-multiple-questions', // owner: @liyiy

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -42,9 +42,10 @@ import {
 import {
     isEventsQuery,
     isInsightQueryNode,
+    isLifecycleQuery,
     isPersonsNode,
     isPersonsQuery,
-    isQueryWithHogQLSupport,
+    isTrendsQuery,
 } from '~/queries/utils'
 
 import { filtersToQueryNode } from '../InsightQuery/utils/filtersToQueryNode'
@@ -119,7 +120,8 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                     }
                     if (
                         isInsightQueryNode(props.query) &&
-                        !(values.hogQLInsightsFlagEnabled && isQueryWithHogQLSupport(props.query)) &&
+                        !(values.hogQLInsightsLifecycleFlagEnabled && isLifecycleQuery(props.query)) &&
+                        !(values.hogQLInsightsTrendsFlagEnabled && isTrendsQuery(props.query)) &&
                         props.cachedResults &&
                         props.cachedResults['id'] &&
                         props.cachedResults['filters'] &&
@@ -339,9 +341,13 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
             () => [(_, props) => props.cachedResults ?? null],
             (cachedResults: AnyResponseType | null): boolean => !!cachedResults,
         ],
-        hogQLInsightsFlagEnabled: [
+        hogQLInsightsLifecycleFlagEnabled: [
             (s) => [s.featureFlags],
-            (featureFlags) => featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS],
+            (featureFlags) => !!featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_LIFECYCLE],
+        ],
+        hogQLInsightsTrendsFlagEnabled: [
+            (s) => [s.featureFlags],
+            (featureFlags) => !!featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_TRENDS],
         ],
         query: [(_, p) => [p.query], (query) => query],
         newQuery: [

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -29,10 +29,10 @@ import {
     isLifecycleQuery,
     isPersonsNode,
     isPersonsQuery,
-    isQueryWithHogQLSupport,
     isTimeToSeeDataQuery,
     isTimeToSeeDataSessionsNode,
     isTimeToSeeDataSessionsQuery,
+    isTrendsQuery,
 } from './utils'
 
 const QUERY_ASYNC_MAX_INTERVAL_SECONDS = 5
@@ -142,8 +142,11 @@ export async function query<N extends DataNode = DataNode>(
     const logParams: Record<string, any> = {}
     const startTime = performance.now()
 
-    const hogQLInsightsFlagEnabled = Boolean(
-        featureFlagLogic.findMounted()?.values.featureFlags?.[FEATURE_FLAGS.HOGQL_INSIGHTS]
+    const hogQLInsightsLifecycleFlagEnabled = Boolean(
+        featureFlagLogic.findMounted()?.values.featureFlags?.[FEATURE_FLAGS.HOGQL_INSIGHTS_LIFECYCLE]
+    )
+    const hogQLInsightsTrendsFlagEnabled = Boolean(
+        featureFlagLogic.findMounted()?.values.featureFlags?.[FEATURE_FLAGS.HOGQL_INSIGHTS_TRENDS]
     )
     const hogQLInsightsLiveCompareEnabled = Boolean(
         featureFlagLogic.findMounted()?.values.featureFlags?.[FEATURE_FLAGS.HOGQL_INSIGHT_LIVE_COMPARE]
@@ -185,7 +188,10 @@ export async function query<N extends DataNode = DataNode>(
                 methodOptions
             )
         } else if (isInsightQueryNode(queryNode)) {
-            if (hogQLInsightsFlagEnabled && isQueryWithHogQLSupport(queryNode)) {
+            if (
+                (hogQLInsightsLifecycleFlagEnabled && isLifecycleQuery(queryNode)) ||
+                (hogQLInsightsTrendsFlagEnabled && isTrendsQuery(queryNode))
+            ) {
                 if (hogQLInsightsLiveCompareEnabled) {
                     let legacyResponse
                     ;[response, legacyResponse] = await Promise.all([

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -160,10 +160,6 @@ export function isLifecycleQuery(node?: Node | null): node is LifecycleQuery {
     return node?.kind === NodeKind.LifecycleQuery
 }
 
-export function isQueryWithHogQLSupport(node?: Node | null): node is LifecycleQuery {
-    return isLifecycleQuery(node) || isTrendsQuery(node)
-}
-
 export function isInsightQueryWithDisplay(node?: Node | null): node is TrendsQuery | StickinessQuery {
     return isTrendsQuery(node) || isStickinessQuery(node)
 }

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -87,10 +87,12 @@ export function ActionsLineGraph({
                           const day = dataset?.days?.[index] ?? ''
                           const label = dataset?.label ?? dataset?.labels?.[index] ?? ''
 
-                          const hogQLInsightsFlagEnabled = Boolean(featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS])
+                          const hogQLInsightsLifecycleFlagEnabled = Boolean(
+                              featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_LIFECYCLE]
+                          )
 
                           if (
-                              hogQLInsightsFlagEnabled &&
+                              hogQLInsightsLifecycleFlagEnabled &&
                               isLifecycle &&
                               query &&
                               isInsightVizNode(query) &&


### PR DESCRIPTION
## Problem

Trends and Lifecycle won't be equally ready at the same time, so we want to split the feature flag and test them independently.

## Changes

Splits the HogQL insights feature flag into two, one for insights, one for lifecycle. We'll need to add one more for retention and the other queries once they're testable.

## How did you test this code?

Locally. Enabled/disabled flags and watched that the right insight was loading.