### PR TITLE
feat(3000): style antd number inputs according to 3000

### DIFF
--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -681,6 +681,11 @@ body {
         }
     }
 
+    .ant-input-number:hover,
+    .ant-input-number-focused {
+        border-color: var(--primary-3000);
+    }
+
     .ant-input-number-group-addon {
         background: var(--bg-3000);
     }

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -683,7 +683,7 @@ body {
 
     .ant-input-number:hover,
     .ant-input-number-focused {
-        border-color: var(--primary-3000);
+        border-color: var(--border-bold);
     }
 
     .ant-input-number-group-addon {


### PR DESCRIPTION
## Problem

The antd number input still had a primary-blue border in 3000. Lemon Inputs are kind of broken for the number type (size small doesn't work & the up/down arrows don't look great in dark mode), so I went for the easier fix of overriding the border.

## Changes

<img width="460" alt="Screenshot 2023-11-24 at 10 43 20" src="https://github.com/PostHog/posthog/assets/1851359/f344c4dc-1018-4b8d-b507-2f4bed245831">

## How did you test this code?

:eyes: