### PR TITLE
fix(cohorts): Use temporal for long running flag-copy task

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -1,18 +1,8 @@
 import csv
 import json
 
-from django.db import DatabaseError
-from sentry_sdk import start_span
 import structlog
 
-from posthog.models.feature_flag.flag_matching import (
-    FeatureFlagMatcher,
-    FlagsMatcherCache,
-    get_feature_flag_hash_key_overrides,
-)
-from posthog.models.person.person import PersonDistinctId
-from posthog.models.property.property import Property, PropertyGroup
-from posthog.queries.base import property_group_to_Q
 from posthog.queries.insight import insight_sync_execute
 import posthoganalytics
 from posthog.metrics import LABEL_TEAM_ID
@@ -21,7 +11,7 @@ from datetime import datetime
 from typing import Any, Dict, cast
 
 from django.conf import settings
-from django.db.models import QuerySet, Prefetch, prefetch_related_objects, OuterRef, Subquery
+from django.db.models import QuerySet
 from django.db.models.expressions import F
 from django.utils import timezone
 from rest_framework import serializers, viewsets
@@ -49,7 +39,6 @@ from posthog.constants import (
     INSIGHT_TRENDS,
     LIMIT,
     OFFSET,
-    PropertyOperatorType,
 )
 from posthog.event_usage import report_user_action
 from posthog.hogql.context import HogQLContext
@@ -558,152 +547,3 @@ def insert_actors_into_cohort_by_query(cohort: Cohort, query: str, params: Dict[
         cohort.errors_calculating = F("errors_calculating") + 1
         cohort.save(update_fields=["errors_calculating", "is_calculating"])
         capture_exception(err)
-
-
-def get_cohort_actors_for_feature_flag(cohort_id: int, flag: str, team_id: int, batchsize: int = 1_000):
-    # :TODO: Find a way to incorporate this into the same code path as feature flag evaluation
-    try:
-        feature_flag = FeatureFlag.objects.get(team_id=team_id, key=flag)
-    except FeatureFlag.DoesNotExist:
-        return []
-
-    if not feature_flag.active or feature_flag.deleted or feature_flag.aggregation_group_type_index is not None:
-        return []
-
-    cohort = Cohort.objects.get(pk=cohort_id)
-    matcher_cache = FlagsMatcherCache(team_id)
-    uuids_to_add_to_cohort = []
-    cohorts_cache = {}
-
-    if feature_flag.uses_cohorts:
-        # TODO: Consider disabling flags with cohorts for creating static cohorts
-        # because this is currently a lot more inefficient for flag matching,
-        # as we're required to go to the database for each person.
-        cohorts_cache = {cohort.pk: cohort for cohort in Cohort.objects.filter(team_id=team_id, deleted=False)}
-
-    default_person_properties = {}
-    for condition in feature_flag.conditions:
-        property_list = Filter(data=condition).property_groups.flat
-        for property in property_list:
-            default_person_properties.update(get_default_person_property(property, cohorts_cache))
-
-    flag_property_conditions = [Filter(data=condition).property_groups for condition in feature_flag.conditions]
-    flag_property_group = PropertyGroup(type=PropertyOperatorType.OR, values=flag_property_conditions)
-
-    try:
-        # QuerySet.Iterator() doesn't work with pgbouncer, it will load everything into memory and then stream
-        # which doesn't work for us, so need a manual chunking here.
-        # Because of this pgbouncer transaction pooling mode, we can't use server-side cursors.
-        # We pre-filter all persons to be ones that will match the feature flag, so that we don't have to
-        # iterate through all persons
-        queryset = (
-            Person.objects.filter(team_id=team_id)
-            .filter(property_group_to_Q(flag_property_group, cohorts_cache=cohorts_cache))
-            .order_by("id")
-        )
-        # get batchsize number of people at a time
-        start = 0
-        batch_of_persons = queryset[start : start + batchsize]
-        while batch_of_persons:
-            # TODO: Check if this subquery bulk fetch limiting is better than just doing a join for all distinct ids
-            # OR, if row by row getting single distinct id is better
-            # distinct_id = PersonDistinctId.objects.filter(person=person, team_id=team_id).values_list(
-            #     "distinct_id", flat=True
-            # )[0]
-            distinct_id_subquery = Subquery(
-                PersonDistinctId.objects.filter(person_id=OuterRef("person_id")).values_list("id", flat=True)[:3]
-            )
-            prefetch_related_objects(
-                batch_of_persons,
-                Prefetch(
-                    "persondistinctid_set",
-                    to_attr="distinct_ids_cache",
-                    queryset=PersonDistinctId.objects.filter(id__in=distinct_id_subquery),
-                ),
-            )
-
-            all_persons = list(batch_of_persons)
-            if len(all_persons) == 0:
-                break
-
-            with start_span(op="batch_flag_matching_with_overrides"):
-                for person in all_persons:
-                    # ignore almost-deleted persons / persons with no distinct ids
-                    if len(person.distinct_ids) == 0:
-                        continue
-
-                    distinct_id = person.distinct_ids[0]
-                    person_overrides = {}
-                    if feature_flag.ensure_experience_continuity:
-                        # :TRICKY: This is inefficient because it tries to get the hashkey overrides one by one.
-                        # But reusing functions is better for maintainability. Revisit optimising if this becomes a bottleneck.
-                        person_overrides = get_feature_flag_hash_key_overrides(
-                            team_id, [distinct_id], person_id_to_distinct_id_mapping={person.id: distinct_id}
-                        )
-
-                    try:
-                        match = FeatureFlagMatcher(
-                            [feature_flag],
-                            distinct_id,
-                            groups={},
-                            cache=matcher_cache,
-                            hash_key_overrides=person_overrides,
-                            property_value_overrides={**default_person_properties, **person.properties},
-                            group_property_value_overrides={},
-                            cohorts_cache=cohorts_cache,
-                        ).get_match(feature_flag)
-                        if match.match:
-                            uuids_to_add_to_cohort.append(str(person.uuid))
-                    except (DatabaseError, ValueError, ValidationError):
-                        logger.exception(
-                            "Error evaluating feature flag for person", person_uuid=str(person.uuid), team_id=team_id
-                        )
-                    except Exception as err:
-                        # matching errors are not fatal, so we just log them and move on.
-                        # Capturing in sentry for now just in case there are some unexpected errors
-                        # we did not account for.
-                        capture_exception(err)
-
-                    if len(uuids_to_add_to_cohort) >= batchsize:
-                        cohort.insert_users_list_by_uuid(
-                            uuids_to_add_to_cohort, insert_in_clickhouse=True, batchsize=batchsize
-                        )
-                        uuids_to_add_to_cohort = []
-
-            start += batchsize
-            batch_of_persons = queryset[start : start + batchsize]
-
-        if len(uuids_to_add_to_cohort) > 0:
-            cohort.insert_users_list_by_uuid(uuids_to_add_to_cohort, insert_in_clickhouse=True, batchsize=batchsize)
-
-    except Exception as err:
-        if settings.DEBUG or settings.TEST:
-            raise err
-        capture_exception(err)
-
-
-def get_default_person_property(prop: Property, cohorts_cache: Dict[int, Cohort]):
-    default_person_properties = {}
-
-    if prop.operator not in ("is_set", "is_not_set") and prop.type == "person":
-        default_person_properties[prop.key] = ""
-    elif prop.type == "cohort" and not isinstance(prop.value, list):
-        try:
-            parsed_cohort_id = int(prop.value)
-        except (ValueError, TypeError):
-            return None
-        cohort = cohorts_cache.get(parsed_cohort_id)
-        if cohort:
-            return get_default_person_properties_for_cohort(cohort, cohorts_cache)
-    return default_person_properties
-
-
-def get_default_person_properties_for_cohort(cohort: Cohort, cohorts_cache: Dict[int, Cohort]) -> Dict[str, str]:
-    """
-    Returns a dictionary of default person properties to use when evaluating a feature flag
-    """
-    default_person_properties = {}
-    for property in cohort.properties.flat:
-        default_person_properties.update(get_default_person_property(property, cohorts_cache))
-
-    return default_person_properties

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -1474,35 +1474,6 @@
   LIMIT 21
   '
 ---
-# name: TestFeatureFlag.test_creating_static_cohort
-  '
-  SELECT "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."pending_email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."is_email_verified",
-         "posthog_user"."has_seen_product_intro_for",
-         "posthog_user"."email_opt_in",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."events_column_config"
-  FROM "posthog_user"
-  WHERE "posthog_user"."id" = 2
-  LIMIT 21 /**/
-  '
----
 # name: TestFeatureFlag.test_creating_static_cohort.1
   '
   SELECT "posthog_team"."id",

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -12,7 +12,6 @@ from django.utils import timezone
 from freezegun.api import freeze_time
 from rest_framework import status
 from posthog import redis
-from posthog.api.cohort import get_cohort_actors_for_feature_flag
 
 from posthog.api.feature_flag import FeatureFlagSerializer
 from posthog.constants import AvailableFeature
@@ -31,6 +30,7 @@ from posthog.models.person import Person
 from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
 from posthog.models.team.team import Team
 from posthog.models.utils import generate_random_token_personal
+from posthog.temporal.workflows.cohort_for_flag import get_cohort_actors_for_feature_flag
 from posthog.test.base import (
     APIBaseTest,
     ClickhouseTestMixin,

--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -79,6 +79,7 @@ class Command(BaseCommand):
                             rollout_percentage=100,
                             name=flag,
                             key=flag,
+                            filters={"groups": [{"properties": [], "rollout_percentage": None}]},
                             created_by=first_user,
                             active=is_enabled,
                         )

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -8,9 +8,16 @@ from django.conf import settings
 from django.db.models import F
 from django.utils import timezone
 
+from asgiref.sync import async_to_sync
+from temporalio.client import Client
+
 from posthog.models import Cohort
 from posthog.models.cohort import get_and_update_pending_version
 from posthog.models.cohort.util import clear_stale_cohortpeople
+from posthog.temporal.client import sync_connect
+
+from posthog.temporal.workflows.cohort_for_flag import CreateCohortForFlagWorkflowInputs
+
 
 logger = structlog.get_logger(__name__)
 
@@ -75,6 +82,21 @@ def insert_cohort_from_insight_filter(cohort_id: int, filter_data: Dict[str, Any
 
 @shared_task(ignore_result=True, max_retries=1)
 def insert_cohort_from_feature_flag(cohort_id: int, flag_key: str, team_id: int) -> None:
-    from posthog.api.cohort import get_cohort_actors_for_feature_flag
+    client = sync_connect()
 
-    get_cohort_actors_for_feature_flag(cohort_id, flag_key, team_id, batchsize=10_000)
+    start_cohort_from_flag_workflow(
+        client, CreateCohortForFlagWorkflowInputs(team_id=team_id, cohort_id=cohort_id, flag=flag_key, batchsize=10_000)
+    )
+
+
+@async_to_sync
+async def start_cohort_from_flag_workflow(temporal: Client, inputs: CreateCohortForFlagWorkflowInputs) -> str:
+    workflow_id = f"{inputs.team_id}-cohort-{inputs.cohort_id}-for-flag-{inputs.flag}"
+    await temporal.start_workflow(
+        "cohort_for_flag",
+        inputs,
+        id=workflow_id,
+        task_queue=settings.TEMPORAL_TASK_QUEUE,
+    )
+
+    return workflow_id

--- a/posthog/temporal/workflows/__init__.py
+++ b/posthog/temporal/workflows/__init__.py
@@ -15,6 +15,7 @@ from posthog.temporal.workflows.bigquery_batch_export import (
     BigQueryBatchExportWorkflow,
     insert_into_bigquery_activity,
 )
+from posthog.temporal.workflows.cohort_for_flag import CreateCohortForFlagWorkflow, cohort_for_flag
 from posthog.temporal.workflows.noop import NoOpWorkflow, noop_activity
 from posthog.temporal.workflows.postgres_batch_export import (
     PostgresBatchExportWorkflow,
@@ -43,6 +44,7 @@ WORKFLOWS = [
     S3BatchExportWorkflow,
     SnowflakeBatchExportWorkflow,
     SquashPersonOverridesWorkflow,
+    CreateCohortForFlagWorkflow,
 ]
 
 ACTIVITIES: Sequence[Callable] = [
@@ -65,4 +67,5 @@ ACTIVITIES: Sequence[Callable] = [
     squash_events_partition,
     update_batch_export_backfill_model_status,
     update_export_run_status,
+    cohort_for_flag,
 ]

--- a/posthog/temporal/workflows/cohort_for_flag.py
+++ b/posthog/temporal/workflows/cohort_for_flag.py
@@ -101,10 +101,6 @@ class CohortForFlagInputs:
     batchsize: int
 
 
-# TODO: Maybe it's better for the activity to be for a specific batch?
-# So if we need to retry, due to say network partitions, it's only that specific batch that is retried, and not the whole thing.
-# and then we can have much smaller timeouts per batch
-# TODO: Does logging & sentry capture exception work as usual?
 @activity.defn
 async def cohort_for_flag(inputs: CohortForFlagInputs) -> None:
     """Populate a cohort with persons that match a feature flag.

--- a/posthog/temporal/workflows/cohort_for_flag.py
+++ b/posthog/temporal/workflows/cohort_for_flag.py
@@ -1,0 +1,263 @@
+import dataclasses
+import datetime
+import json
+from typing import Dict
+from django.conf import settings
+from django.db import DatabaseError
+from rest_framework.exceptions import ValidationError
+from asgiref.sync import sync_to_async
+import structlog
+from posthog.models.feature_flag.flag_matching import (
+    FeatureFlagMatcher,
+    FlagsMatcherCache,
+    get_feature_flag_hash_key_overrides,
+)
+from posthog.models.filters.filter import Filter
+from posthog.models.person.person import PersonDistinctId
+from posthog.models.property.property import Property, PropertyGroup
+from posthog.queries.base import property_group_to_Q
+from django.db.models import Prefetch, prefetch_related_objects, OuterRef, Subquery
+from posthog.constants import PropertyOperatorType
+from sentry_sdk import capture_exception
+from posthog.models import Cohort, FeatureFlag, Person
+from temporalio import activity, workflow
+
+from posthog.temporal.workflows.base import PostHogWorkflow
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclasses.dataclass
+class CreateCohortForFlagWorkflowInputs:
+    """Inputs to the cohort_for_flag activity.
+
+    Attributes:
+        team_id: The id of the team
+        cohort_id: The id of the cohort to populate.
+        flag: The feature flag to use for matching persons.
+        batchsize: The number of persons to process at a time.
+    """
+
+    team_id: int
+    cohort_id: int
+    flag: str
+    batchsize: int
+
+
+@workflow.defn(name="cohort_for_flag")
+class CreateCohortForFlagWorkflow(PostHogWorkflow):
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> CreateCohortForFlagWorkflowInputs:
+        """Parse inputs from the management command CLI."""
+        loaded = json.loads(inputs[0])
+        return CreateCohortForFlagWorkflowInputs(**loaded)
+
+    @workflow.run
+    async def run(self, inputs: CreateCohortForFlagWorkflowInputs):
+        """Workflow implementation to create cohort from feature flag."""
+        cohort_for_flag_inputs = CohortForFlagInputs(
+            team_id=inputs.team_id,
+            cohort_id=inputs.cohort_id,
+            flag=inputs.flag,
+            batchsize=inputs.batchsize,
+        )
+
+        await workflow.execute_activity(
+            cohort_for_flag,
+            cohort_for_flag_inputs,
+            schedule_to_close_timeout=datetime.timedelta(hours=10),
+            # start_to_close_timeout=datetime.timedelta(minutes=5),
+            # retry_policy=RetryPolicy(
+            #     initial_interval=dt.timedelta(seconds=10),
+            #     maximum_interval=dt.timedelta(seconds=60),
+            #     maximum_attempts=0,
+            #     non_retryable_error_types=["NotNullViolation", "IntegrityError"],
+            # ),
+        )
+
+
+@dataclasses.dataclass
+class CohortForFlagInputs:
+    """Inputs to the cohort_for_flag activity.
+
+    Attributes:
+        team_id: The id of the team
+        cohort_id: The id of the cohort to populate.
+        flag: The feature flag to use for matching persons.
+        batchsize: The number of persons to process at a time.
+    """
+
+    team_id: int
+    cohort_id: int
+    flag: str
+    batchsize: int
+
+
+# TODO: Maybe it's better for the activity to be for a specific batch?
+# So if we need to retry, due to say network partitions, it's only that specific batch that is retried, and not the whole thing.
+# and then we can have much smaller timeouts per batch
+# TODO: Does logging & sentry capture exception work as usual?
+# TODO: Confirm the temporal worker is in a django-like environment, with same setup as posthog-web,
+#  so it has sentry configured & access to all models
+@activity.defn
+async def cohort_for_flag(inputs: CohortForFlagInputs) -> None:
+    """Populate a cohort with persons that match a feature flag.
+
+    Args:
+        inputs: The inputs to the activity.
+    """
+
+    return await sync_to_async(get_cohort_actors_for_feature_flag)(
+        cohort_id=inputs.cohort_id,
+        flag=inputs.flag,
+        team_id=inputs.team_id,
+        batchsize=inputs.batchsize,
+    )
+
+
+def get_cohort_actors_for_feature_flag(cohort_id: int, flag: str, team_id: int, batchsize: int = 1_000):
+    # :TODO: Find a way to incorporate this into the same code path as feature flag evaluation
+    try:
+        feature_flag = FeatureFlag.objects.get(team_id=team_id, key=flag)
+    except FeatureFlag.DoesNotExist:
+        return []
+
+    if not feature_flag.active or feature_flag.deleted or feature_flag.aggregation_group_type_index is not None:
+        return []
+
+    cohort = Cohort.objects.get(pk=cohort_id)
+    matcher_cache = FlagsMatcherCache(team_id)
+    uuids_to_add_to_cohort = []
+    cohorts_cache = {}
+
+    if feature_flag.uses_cohorts:
+        # TODO: Consider disabling flags with cohorts for creating static cohorts
+        # because this is currently a lot more inefficient for flag matching,
+        # as we're required to go to the database for each person.
+        cohorts_cache = {cohort.pk: cohort for cohort in Cohort.objects.filter(team_id=team_id, deleted=False)}
+
+    default_person_properties = {}
+    for condition in feature_flag.conditions:
+        property_list = Filter(data=condition).property_groups.flat
+        for property in property_list:
+            default_person_properties.update(get_default_person_property(property, cohorts_cache))
+
+    flag_property_conditions = [Filter(data=condition).property_groups for condition in feature_flag.conditions]
+    flag_property_group = PropertyGroup(type=PropertyOperatorType.OR, values=flag_property_conditions)
+
+    try:
+        # QuerySet.Iterator() doesn't work with pgbouncer, it will load everything into memory and then stream
+        # which doesn't work for us, so need a manual chunking here.
+        # Because of this pgbouncer transaction pooling mode, we can't use server-side cursors.
+        # We pre-filter all persons to be ones that will match the feature flag, so that we don't have to
+        # iterate through all persons
+        queryset = (
+            Person.objects.filter(team_id=team_id)
+            .filter(property_group_to_Q(flag_property_group, cohorts_cache=cohorts_cache))
+            .order_by("id")
+        )
+        # get batchsize number of people at a time
+        start = 0
+        batch_of_persons = queryset[start : start + batchsize]
+        while batch_of_persons:
+            # TODO: Check if this subquery bulk fetch limiting is better than just doing a join for all distinct ids
+            # OR, if row by row getting single distinct id is better
+            # distinct_id = PersonDistinctId.objects.filter(person=person, team_id=team_id).values_list(
+            #     "distinct_id", flat=True
+            # )[0]
+            distinct_id_subquery = Subquery(
+                PersonDistinctId.objects.filter(person_id=OuterRef("person_id")).values_list("id", flat=True)[:3]
+            )
+            prefetch_related_objects(
+                batch_of_persons,
+                Prefetch(
+                    "persondistinctid_set",
+                    to_attr="distinct_ids_cache",
+                    queryset=PersonDistinctId.objects.filter(id__in=distinct_id_subquery),
+                ),
+            )
+
+            all_persons = list(batch_of_persons)
+            if len(all_persons) == 0:
+                break
+
+            for person in all_persons:
+                # ignore almost-deleted persons / persons with no distinct ids
+                if len(person.distinct_ids) == 0:
+                    continue
+
+                distinct_id = person.distinct_ids[0]
+                person_overrides = {}
+                if feature_flag.ensure_experience_continuity:
+                    # :TRICKY: This is inefficient because it tries to get the hashkey overrides one by one.
+                    # But reusing functions is better for maintainability. Revisit optimising if this becomes a bottleneck.
+                    person_overrides = get_feature_flag_hash_key_overrides(
+                        team_id, [distinct_id], person_id_to_distinct_id_mapping={person.id: distinct_id}
+                    )
+
+                try:
+                    match = FeatureFlagMatcher(
+                        [feature_flag],
+                        distinct_id,
+                        groups={},
+                        cache=matcher_cache,
+                        hash_key_overrides=person_overrides,
+                        property_value_overrides={**default_person_properties, **person.properties},
+                        group_property_value_overrides={},
+                        cohorts_cache=cohorts_cache,
+                    ).get_match(feature_flag)
+                    if match.match:
+                        uuids_to_add_to_cohort.append(str(person.uuid))
+                except (DatabaseError, ValueError, ValidationError):
+                    logger.exception(
+                        "Error evaluating feature flag for person", person_uuid=str(person.uuid), team_id=team_id
+                    )
+                except Exception as err:
+                    # matching errors are not fatal, so we just log them and move on.
+                    # Capturing in sentry for now just in case there are some unexpected errors
+                    # we did not account for.
+                    capture_exception(err)
+
+                if len(uuids_to_add_to_cohort) >= batchsize:
+                    cohort.insert_users_list_by_uuid(
+                        uuids_to_add_to_cohort, insert_in_clickhouse=True, batchsize=batchsize
+                    )
+                    uuids_to_add_to_cohort = []
+
+            start += batchsize
+            batch_of_persons = queryset[start : start + batchsize]
+
+        if len(uuids_to_add_to_cohort) > 0:
+            cohort.insert_users_list_by_uuid(uuids_to_add_to_cohort, insert_in_clickhouse=True, batchsize=batchsize)
+
+    except Exception as err:
+        if settings.DEBUG or settings.TEST:
+            raise err
+        capture_exception(err)
+
+
+def get_default_person_property(prop: Property, cohorts_cache: Dict[int, Cohort]):
+    default_person_properties = {}
+
+    if prop.operator not in ("is_set", "is_not_set") and prop.type == "person":
+        default_person_properties[prop.key] = ""
+    elif prop.type == "cohort" and not isinstance(prop.value, list):
+        try:
+            parsed_cohort_id = int(prop.value)
+        except (ValueError, TypeError):
+            return None
+        cohort = cohorts_cache.get(parsed_cohort_id)
+        if cohort:
+            return get_default_person_properties_for_cohort(cohort, cohorts_cache)
+    return default_person_properties
+
+
+def get_default_person_properties_for_cohort(cohort: Cohort, cohorts_cache: Dict[int, Cohort]) -> Dict[str, str]:
+    """
+    Returns a dictionary of default person properties to use when evaluating a feature flag
+    """
+    default_person_properties = {}
+    for property in cohort.properties.flat:
+        default_person_properties.update(get_default_person_property(property, cohorts_cache))
+
+    return default_person_properties


### PR DESCRIPTION
## Problem

Celery isn't reliable for running copy tasks, so switching this over to temporal. The basic flow now works, but needs temporal level tests.

Want to get early feedback on this before I continue going down this path

Curious about how observability works in this case - can I use sentry profiling within the workflow somehow? This worked decently with celery thanks to the sentry integration, but not sure about here yet.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
