### PR TITLE
fix: fixed hogql insights refresh button

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
@@ -16,7 +16,7 @@ export function ComputationTimeWithRefresh({ disableRefresh }: { disableRefresh?
 
     usePeriodicRerender(15000) // Re-render every 15 seconds for up-to-date `insightRefreshButtonDisabledReason`
 
-    if (!response || !response.result) {
+    if (!response || (!response.result && !response.results)) {
         return null
     }
 


### PR DESCRIPTION
## Problem
- HogQL insights didn't show the "refresh" button in the UI due to the renaming from `result` => `results` in the API response

## Changes
**Old:**
<img width="1624" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/3423a542-0ed5-4b4b-ae13-af3c7a597362">

**New:**
<img width="1767" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/3c85a150-9bbc-4dfe-9690-cc174ca9a7e7">


## How did you test this code?
Clicking around