### PR TITLE
chore(toolbar): relabel "logout" to "close toolbar"

### DIFF
--- a/frontend/src/toolbar/bar/Toolbar.tsx
+++ b/frontend/src/toolbar/bar/Toolbar.tsx
@@ -73,7 +73,7 @@ function MoreMenu(): JSX.Element {
                             window.open(HELP_URL, '_blank')?.focus()
                         },
                     },
-                    { icon: <IconX />, label: 'Logout', onClick: logout },
+                    { icon: <IconX />, label: 'Close toolbar', onClick: logout },
                 ].filter(Boolean) as LemonMenuItems
             }
             maxContentWidth={true}


### PR DESCRIPTION
"Logout" in the toolbar makes it sounds like you might be logging out of the entire app.

<img width="448" alt="image" src="https://github.com/PostHog/posthog/assets/154479/5b770a94-021b-4c6a-9481-a53414392f92">

This relabels it to say "Close toolbar".