### PR TITLE
feat(experiments): Warn before leaving unsaved new experiment

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.scss
+++ b/frontend/src/scenes/experiments/Experiment.scss
@@ -176,6 +176,7 @@
 }
 
 .preview-conversion-goal-num {
+    flex-shrink: 0;
     width: 24px;
     height: 24px;
     margin-right: 0.5rem;

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -245,6 +245,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
             }
 
             if (values.isDev) {
+                // TRICKY: We disable beforeUnload handling in dev, but ONLY for insights
                 return false
             }
 


### PR DESCRIPTION
## Problem

When creating the 3000 experiment, I navigated away to somewhere else in the app… and only then realized that I lost all my changes.

## Changes

This adds unload confirmation for new experiments.
Also tried to add this for all experiments, but this was unreliable because `experimentValuesChangedLocally` is often wrong for reasons to do with connected logics.