### PR TITLE
fix(trends): convert any missing property operators to the default of exact

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
@@ -519,6 +519,55 @@ describe('filtersToQueryNode', () => {
         })
     })
 
+    describe('malformed properties', () => {
+        it('converts properties', () => {
+            const properties: any = {
+                type: FilterLogicalOperator.And,
+                values: [
+                    {
+                        type: FilterLogicalOperator.And,
+                        values: [
+                            {
+                                key: 'event',
+                                type: PropertyFilterType.Event,
+                                value: 'value',
+                            },
+                        ],
+                    },
+                ],
+            }
+
+            const filters: Partial<FilterType> = {
+                insight: InsightType.TRENDS,
+                properties,
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: InsightQueryNode = {
+                kind: NodeKind.TrendsQuery,
+                properties: {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        {
+                            type: FilterLogicalOperator.And,
+                            values: [
+                                {
+                                    key: 'event',
+                                    type: PropertyFilterType.Event,
+                                    value: 'value',
+                                    operator: PropertyOperator.Exact,
+                                },
+                            ],
+                        },
+                    ],
+                },
+                series: [],
+            }
+            expect(result).toEqual(query)
+        })
+    })
+
     describe('example insights', () => {
         it('converts `New user retention` insight', () => {
             const filters: Partial<RetentionFilterType> = {

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -106,7 +106,7 @@ export const cleanHiddenLegendSeries = (
 }
 
 const cleanProperties = (parentProperties: FilterType['properties']): InsightsQueryBase['properties'] => {
-    if (!parentProperties) {
+    if (!parentProperties || !parentProperties.values) {
         return parentProperties
     }
 

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -132,7 +132,7 @@ const cleanProperties = (parentProperties: FilterType['properties']): InsightsQu
     const processPropertyGroupFilterValue = (
         propertyGroupFilterValue: PropertyGroupFilterValue
     ): PropertyGroupFilterValue => {
-        if (propertyGroupFilterValue.values.length === 0) {
+        if (propertyGroupFilterValue.values?.length === 0 || !propertyGroupFilterValue.values) {
             return propertyGroupFilterValue
         }
 

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -28,7 +28,16 @@ import {
     isStickinessQuery,
     isTrendsQuery,
 } from '~/queries/utils'
-import { ActionFilter, FilterType, InsightType } from '~/types'
+import {
+    ActionFilter,
+    AnyPropertyFilter,
+    FilterLogicalOperator,
+    FilterType,
+    InsightType,
+    PropertyFilterType,
+    PropertyGroupFilterValue,
+    PropertyOperator,
+} from '~/types'
 
 const reverseInsightMap: Record<Exclude<InsightType, InsightType.JSON | InsightType.SQL>, InsightNodeKind> = {
     [InsightType.TRENDS]: NodeKind.TrendsQuery,
@@ -52,7 +61,7 @@ export const actionsAndEventsToSeries = ({
             const shared = objectCleanWithEmpty({
                 name: f.name || undefined,
                 custom_name: f.custom_name,
-                properties: f.properties,
+                properties: cleanProperties(f.properties),
                 math: f.math || 'total',
                 math_property: f.math_property,
                 math_hogql: f.math_hogql,
@@ -96,6 +105,74 @@ export const cleanHiddenLegendSeries = (
         : undefined
 }
 
+const cleanProperties = (parentProperties: FilterType['properties']): InsightsQueryBase['properties'] => {
+    if (!parentProperties) {
+        return parentProperties
+    }
+
+    const processAnyPropertyFilter = (filter: AnyPropertyFilter): AnyPropertyFilter => {
+        if (
+            filter.type === PropertyFilterType.Event ||
+            filter.type === PropertyFilterType.Person ||
+            filter.type === PropertyFilterType.Element ||
+            filter.type === PropertyFilterType.Session ||
+            filter.type === PropertyFilterType.Group ||
+            filter.type === PropertyFilterType.Feature ||
+            filter.type === PropertyFilterType.Recording
+        ) {
+            return {
+                ...filter,
+                operator: filter.operator ?? PropertyOperator.Exact,
+            }
+        }
+
+        return filter
+    }
+
+    const processPropertyGroupFilterValue = (
+        propertyGroupFilterValue: PropertyGroupFilterValue
+    ): PropertyGroupFilterValue => {
+        if (propertyGroupFilterValue.values.length === 0) {
+            return propertyGroupFilterValue
+        }
+
+        // Check whether the first values type is an AND or OR
+        const firstValueType = propertyGroupFilterValue.values[0].type
+
+        if (firstValueType === FilterLogicalOperator.And || firstValueType === FilterLogicalOperator.Or) {
+            // propertyGroupFilterValue.values is PropertyGroupFilterValue[]
+            const values = (propertyGroupFilterValue.values as PropertyGroupFilterValue[]).map(
+                processPropertyGroupFilterValue
+            )
+
+            return {
+                ...propertyGroupFilterValue,
+                values,
+            }
+        }
+
+        // propertyGroupFilterValue.values is AnyPropertyFilter[]
+        const values = (propertyGroupFilterValue.values as AnyPropertyFilter[]).map(processAnyPropertyFilter)
+
+        return {
+            ...propertyGroupFilterValue,
+            values,
+        }
+    }
+
+    if (Array.isArray(parentProperties)) {
+        // parentProperties is AnyPropertyFilter[]
+        return parentProperties.map(processAnyPropertyFilter)
+    }
+
+    // parentProperties is PropertyGroupFilter
+    const values = parentProperties.values.map(processPropertyGroupFilterValue)
+    return {
+        ...parentProperties,
+        values,
+    }
+}
+
 export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNode => {
     const captureException = (message: string): void => {
         Sentry.captureException(new Error(message), {
@@ -110,7 +187,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
 
     const query: InsightsQueryBase = {
         kind: reverseInsightMap[filters.insight],
-        properties: filters.properties,
+        properties: cleanProperties(filters.properties),
         filterTestAccounts: filters.filter_test_accounts,
         samplingFactor: filters.sampling_factor,
     }


### PR DESCRIPTION
## Problem
- Some saved insights that use property filters don't always have an `operator` pre-defined. Using the old/current trends, the backend defaults this in the trends serializer to `Exact` (see here: https://github.com/PostHog/posthog/blob/master/posthog/api/documentation.py#L33-L39)
- In the new trends, we expect the query node to be a fully validated node, and so loading some saved insights causes the backend to throw validation errors (see [here](https://app.posthog.com/insights/Jd8SzwhK) on the posthog team - you need the `hogql-insights-trends` flag enabled to see the error here)

## Changes
- Populate any missing `operators` on the front end when transforming a `Filter` to a `Query` object

## How did you test this code?
- Added a unit test for this