### PR TITLE
fix: set metadata when level change

### DIFF
--- a/ee/api/test/test_organization.py
+++ b/ee/api/test/test_organization.py
@@ -110,7 +110,7 @@ class TestOrganizationEnterpriseAPI(APILicensedTest):
                 call(
                     self.user.distinct_id,
                     "membership level changed",
-                    properties={"new_level": 15, "previous_level": 1},
+                    properties={"new_level": 15, "previous_level": 1, "$set": mock.ANY},
                     groups=mock.ANY,
                 ),
                 call(

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -225,7 +225,7 @@ class TestTeamAPI(APIBaseTest):
                 call(
                     self.user.distinct_id,
                     "membership level changed",
-                    properties={"new_level": 8, "previous_level": 1},
+                    properties={"new_level": 8, "previous_level": 1, "$set": mock.ANY},
                     groups=mock.ANY,
                 ),
                 call(self.user.distinct_id, "team deleted", properties={}, groups=mock.ANY),

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -1,6 +1,7 @@
 import datetime
 import uuid
-from typing import cast, Dict, List
+from typing import Dict, List, cast
+from unittest import mock
 from unittest.mock import ANY, Mock, patch
 from urllib.parse import quote
 
@@ -13,7 +14,7 @@ from freezegun.api import freeze_time
 from rest_framework import status
 
 from posthog.api.email_verification import email_verification_token_generator
-from posthog.models import Team, User, Dashboard
+from posthog.models import Dashboard, Team, User
 from posthog.models.instance_setting import set_instance_setting
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.test.base import APIBaseTest
@@ -204,7 +205,8 @@ class TestUserAPI(APIBaseTest):
                     "first_name",
                     "has_seen_product_intro_for",
                     "partial_notification_settings",
-                ]
+                ],
+                "$set": mock.ANY,
             },
             groups={
                 "instance": ANY,
@@ -470,7 +472,7 @@ class TestUserAPI(APIBaseTest):
         mock_capture.assert_called_once_with(
             self.user.distinct_id,
             "user updated",
-            properties={"updated_attrs": ["current_organization", "current_team"]},
+            properties={"updated_attrs": ["current_organization", "current_team"], "$set": mock.ANY},
             groups={
                 "instance": ANY,
                 "organization": str(self.new_org.id),
@@ -498,7 +500,7 @@ class TestUserAPI(APIBaseTest):
         mock_capture.assert_called_once_with(
             self.user.distinct_id,
             "user updated",
-            properties={"updated_attrs": ["current_organization", "current_team"]},
+            properties={"updated_attrs": ["current_organization", "current_team"], "$set": mock.ANY},
             groups={
                 "instance": ANY,
                 "organization": str(self.new_org.id),
@@ -640,7 +642,7 @@ class TestUserAPI(APIBaseTest):
         mock_capture.assert_called_once_with(
             user.distinct_id,
             "user updated",
-            properties={"updated_attrs": ["password"]},
+            properties={"updated_attrs": ["password"], "$set": mock.ANY},
             groups={
                 "instance": ANY,
                 "organization": str(self.team.organization_id),
@@ -679,7 +681,7 @@ class TestUserAPI(APIBaseTest):
         mock_capture.assert_called_once_with(
             user.distinct_id,
             "user updated",
-            properties={"updated_attrs": ["password"]},
+            properties={"updated_attrs": ["password"], "$set": mock.ANY},
             groups={
                 "instance": ANY,
                 "organization": str(self.team.organization_id),

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -211,6 +211,7 @@ def report_user_organization_membership_level_changed(
         properties={
             "new_level": new_level,
             "previous_level": previous_level,
+            "$set": user.get_analytics_metadata(),
         },
         groups=groups(organization),
     )

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -116,7 +116,7 @@ def report_user_updated(user: User, updated_attrs: List[str]) -> None:
     posthoganalytics.capture(
         user.distinct_id,
         "user updated",
-        properties={"updated_attrs": updated_attrs},
+        properties={"updated_attrs": updated_attrs, "$set": user.get_analytics_metadata()},
         groups=groups(user.current_organization, user.current_team),
     )
 

--- a/posthog/models/test/test_organization_model.py
+++ b/posthog/models/test/test_organization_model.py
@@ -98,9 +98,6 @@ class TestOrganizationMembership(BaseTest):
         mock_capture.assert_called_once_with(
             user.distinct_id,
             "membership level changed",
-            properties={
-                "new_level": 15,
-                "previous_level": 1,
-            },
+            properties={"new_level": 15, "previous_level": 1, "$set": mock.ANY},
             groups=mock.ANY,
         )


### PR DESCRIPTION
## Problem

We weren't actually updating the user's analytics metadata when the user changes.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

When the user level changes, and when the user is updated (which includes switching current org), $set the user's properties from their analytics_metadata

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Updated tests. Because we test the analytics metadata function elsewhere it felt unnecessary to check here that it is called in $set super specifically, so set them all to `mock.ANY`

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
