### PR TITLE
fix: Dashboard filters ignored when returning to dashboard

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -136,7 +136,11 @@ function DashboardScene(): JSX.Element {
                                     )}
                                 />
                                 <PropertyFilters
-                                    onChange={setProperties}
+                                    onChange={(properties) => {
+                                        setProperties(properties);
+                                        // Fetch dashboard data when property filters change
+                                        fetchDashboardData();
+                                    }}
                                     pageKey={'dashboard_' + dashboard?.id}
                                     propertyFilters={dashboard?.filters.properties}
                                     taxonomicGroupTypes={[

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -137,9 +137,9 @@ function DashboardScene(): JSX.Element {
                                 />
                                 <PropertyFilters
                                     onChange={(properties) => {
-                                        setProperties(properties);
+                                        setProperties(properties)
                                         // Fetch dashboard data when property filters change
-                                        fetchDashboardData();
+                                        fetchDashboardData()
                                     }}
                                     pageKey={'dashboard_' + dashboard?.id}
                                     propertyFilters={dashboard?.filters.properties}

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -63,7 +63,18 @@ function DashboardScene(): JSX.Element {
         useActions(dashboardLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
+    const fetchDashboardData = async () => {
+        try {
+            // an API request to fetch updated dashboard data
+            const updatedData = await fetchData();
 
+            // Handle the updated data, e.g., update state
+            // updateStateWithDashboardData(updatedData);
+        } catch (error) {
+            console.error('Error fetching dashboard data:', error);
+            // Handle error, e.g., show an error message to the user
+        }
+    };
     useEffect(() => {
         reportDashboardViewed()
         return () => {


### PR DESCRIPTION
issue-:#18686

## Problem

Dashboard filters ignored when returning to dashboard


