### PR TITLE
fix(posthog-3000): Fixed trying to mount an undefined logic

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -448,13 +448,14 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
             },
         ],
         sidebarContentsFlattened: [
-            (s) => [(state) => s.activeNavbarItem(state)?.logic.findMounted()?.selectors.contents(state) || null],
+            (s) => [(state) => s.activeNavbarItem(state)?.logic?.findMounted()?.selectors.contents(state) || null],
             (sidebarContents): BasicListItem[] | ExtendedListItem[] =>
                 sidebarContents ? sidebarContents.flatMap((item) => ('items' in item ? item.items : item)) : [],
         ],
         normalizedActiveListItemKey: [
             (s) => [
-                (state) => s.activeNavbarItem(state)?.logic.findMounted()?.selectors.activeListItemKey?.(state) || null,
+                (state) =>
+                    s.activeNavbarItem(state)?.logic?.findMounted()?.selectors.activeListItemKey?.(state) || null,
             ],
             (activeListItemKey): string | number | string[] | null =>
                 activeListItemKey
@@ -478,7 +479,7 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
         ],
         newItemCategory: [
             (s) => [
-                (state) => s.activeNavbarItem(state)?.logic.findMounted()?.selectors.contents(state) || null,
+                (state) => s.activeNavbarItem(state)?.logic?.findMounted()?.selectors.contents(state) || null,
                 s.newItemInlineCategory,
                 router.selectors.location,
             ],


### PR DESCRIPTION
## Problem
- _something_ is logging `nope` over and over again when on the posthog-3000 flag
<img width="685" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/1da31ac8-ce34-49b8-b55b-573b85ba0b24">

## Changes
- Turns out it's coming from [kea-subscriptions](https://github.com/keajs/kea-subscriptions/blob/8f8a6a38b351044e1271907a781f5d822f582942/src/index.ts#L81) (thanks @benjackwhite)
- Digging into this found that the true error was `"Cannot read properties of undefined (reading 'findMounted')"`
- Digging further found that we're trying to do a `.findMounted()` on a possibly `undefined` value
- Fixing this has stopped all the `nope` console logs locally 🙏 
