### PR TITLE
fix(hogql): make EventQuery-s return sync

### DIFF
--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -103,7 +103,7 @@ async function executeQuery<N extends DataNode = DataNode>(
     queryId?: string
 ): Promise<NonNullable<N['response']>> {
     const queryAsyncEnabled = Boolean(featureFlagLogic.findMounted()?.values.featureFlags?.[FEATURE_FLAGS.QUERY_ASYNC])
-    const excludedKinds = ['HogQLMetadata']
+    const excludedKinds = ['HogQLMetadata', 'EventsQuery']
     const queryAsync = queryAsyncEnabled && !excludedKinds.includes(queryNode.kind)
     const response = await api.query(queryNode, methodOptions, queryId, refresh, queryAsync)
 


### PR DESCRIPTION
## Problem

The event explorer doesn't work with async queries.

## Changes

Disables `EventsQuery` from going to the async lane.

The reason is that slow lanes set the export context flag to true, causing the query to return with the default export limit, not the default frontend limit. This makes the query load longer, and crash the browser when the results are back.

## How did you test this code?

Locally.