### PR TITLE
chore(trends): Remove filter and actions from the comparison objects

### DIFF
--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -199,14 +199,17 @@ export async function query<N extends DataNode = DataNode>(
                         fetchLegacyInsights(),
                     ])
 
-                    const res1 = response?.result || response?.results
-                    const res2 = legacyResponse?.result || legacyResponse?.results
+                    let res1 = response?.result || response?.results
+                    let res2 = legacyResponse?.result || legacyResponse?.results
 
                     if (isLifecycleQuery(queryNode)) {
                         // Results don't come back in a predetermined order for the legacy lifecycle insight
                         const order = { new: 1, returning: 2, resurrecting: 3, dormant: 4 }
                         res1.sort((a: any, b: any) => order[a.status] - order[b.status])
                         res2.sort((a: any, b: any) => order[a.status] - order[b.status])
+                    } else if (isTrendsQuery(queryNode)) {
+                        res1 = res1?.map((n: any) => ({ ...n, filter: undefined, action: undefined }))
+                        res2 = res2?.map((n: any) => ({ ...n, filter: undefined, action: undefined }))
                     }
 
                     const results = flattenObject(res1)


### PR DESCRIPTION
## Problem
- When comparing trends objects with the insights compare flag, we want to ignore the filter and actions objects, as we know these are wrong right now

## Changes
- Removes `action` and `filter` during comparison
