### PR TITLE
feat(3000): Make nav usable on mobile

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.scss
+++ b/frontend/src/layout/navigation-3000/Navigation.scss
@@ -1,8 +1,9 @@
+@import '../../styles/vars';
+
 .Navigation3000 {
     --breadcrumbs-height-full: 3.75rem;
     --breadcrumbs-height-compact: 2.75rem;
-    --scene-padding-y: 1rem;
-    --scene-padding-x: 1rem;
+    --scene-padding: 1rem;
 
     display: flex;
     width: 100%;
@@ -21,17 +22,20 @@
         overflow: visible;
         background: none;
     }
+
+    @media screen and (max-width: $lg) {
+        --scene-padding: 0.5rem;
+    }
 }
 
 .Navigation3000__scene {
     // `relative` is for positioning of the scene-level spinner
     position: relative;
-    min-height: calc(100vh - var(--breadcrumbs-height-full) - var(--scene-padding-y) * 2);
-    margin: var(--scene-padding-y) var(--scene-padding-x);
+    min-height: calc(100vh - var(--breadcrumbs-height-full) - var(--scene-padding) * 2);
+    margin: var(--scene-padding);
 
     &.Navigation3000__scene--raw {
-        --scene-padding-y: 0px;
-        --scene-padding-x: 0px;
+        --scene-padding: 0px;
 
         display: flex;
         flex-direction: column;
@@ -45,6 +49,23 @@
     display: flex;
     flex-direction: column;
     border-right-width: 1px;
+
+    // This terrible hack makes it so that the .Navbar3000__overlay background is rendered also _underneath_ .Navbar3000
+    // Otherwise when hiding the mobile navbar, there's a flash of un-dimmed area below the navbar as it slides out
+    opacity: 0.99999;
+    transition: transform 100ms ease-out;
+
+    .Navigation3000--mobile & {
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        z-index: var(--z-lemon-sidebar);
+    }
+
+    &.Navbar3000--hidden {
+        transform: translateX(-100%);
+    }
 
     .Navbar3000__content {
         z-index: var(--z-main-nav);
@@ -74,6 +95,23 @@
         li + li {
             margin-top: -1px;
         }
+    }
+}
+
+.Navbar3000__overlay {
+    position: fixed;
+    z-index: var(--z-mobile-nav-overlay);
+    width: 100%;
+    height: 100%;
+    background-color: var(--modal-backdrop-color);
+    backdrop-filter: blur(var(--modal-backdrop-blur));
+    opacity: 1;
+    transition: background-color 100ms ease-out, backdrop-filter 100ms ease-out;
+
+    &.Navbar3000--hidden {
+        pointer-events: none;
+        background-color: transparent;
+        backdrop-filter: blur(0);
     }
 }
 

--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -8,10 +8,11 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { ReactNode, useEffect } from 'react'
 import { SceneConfig } from 'scenes/sceneTypes'
 
-import { Breadcrumbs } from './components/Breadcrumbs'
+import { navigationLogic } from '../navigation/navigationLogic'
 import { MinimalNavigation } from './components/MinimalNavigation'
 import { Navbar } from './components/Navbar'
 import { Sidebar } from './components/Sidebar'
+import { TopBar } from './components/TopBar'
 import { navigation3000Logic } from './navigationLogic'
 import { SidePanel } from './sidepanel/SidePanel'
 import { themeLogic } from './themeLogic'
@@ -24,6 +25,7 @@ export function Navigation({
     sceneConfig: SceneConfig | null
 }): JSX.Element {
     useMountedLogic(themeLogic)
+    const { mobileLayout } = useValues(navigationLogic)
     const { activeNavbarItem, mode } = useValues(navigation3000Logic)
 
     useEffect(() => {
@@ -41,13 +43,13 @@ export function Navigation({
     }
 
     return (
-        <div className="Navigation3000">
+        <div className={clsx('Navigation3000', mobileLayout && 'Navigation3000--mobile')}>
             <Navbar />
             <FlaggedFeature flag={FEATURE_FLAGS.POSTHOG_3000_NAV}>
                 {activeNavbarItem && <Sidebar key={activeNavbarItem.identifier} navbarItem={activeNavbarItem} />}
             </FlaggedFeature>
             <main>
-                <Breadcrumbs />
+                <TopBar />
                 <div
                     className={clsx(
                         'Navigation3000__scene',
@@ -58,7 +60,7 @@ export function Navigation({
                     {children}
                 </div>
             </main>
-            <SidePanel />
+            {!mobileLayout && <SidePanel />}
             <CommandPalette />
         </div>
     )

--- a/frontend/src/layout/navigation-3000/components/Navbar.tsx
+++ b/frontend/src/layout/navigation-3000/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import { IconAsterisk, IconDay, IconGear, IconNight, IconSearch } from '@posthog/icons'
 import { LemonBadge } from '@posthog/lemon-ui'
+import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { commandBarLogic } from 'lib/components/CommandBar/commandBarLogic'
 import { Resizer } from 'lib/components/Resizer/Resizer'
@@ -37,8 +38,8 @@ export function Navbar(): JSX.Element {
     const { user } = useValues(userLogic)
     const { isSitePopoverOpen } = useValues(navigationLogic)
     const { closeSitePopover, toggleSitePopover } = useActions(navigationLogic)
-    const { isSidebarShown, activeNavbarItemId, navbarItems } = useValues(navigation3000Logic)
-    const { showSidebar, hideSidebar, toggleNavCollapsed } = useActions(navigation3000Logic)
+    const { isNavShown, isSidebarShown, activeNavbarItemId, navbarItems, mobileLayout } = useValues(navigation3000Logic)
+    const { showSidebar, hideSidebar, toggleNavCollapsed, hideNavOnMobile } = useActions(navigation3000Logic)
     const { darkModeSavedPreference, darkModeSystemPreference } = useValues(themeLogic)
     const { toggleTheme } = useActions(themeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -47,95 +48,108 @@ export function Navbar(): JSX.Element {
     const containerRef = useRef<HTMLDivElement | null>(null)
 
     return (
-        <nav className="Navbar3000" ref={containerRef}>
-            <div className="Navbar3000__content">
-                <div className="Navbar3000__top">
-                    {navbarItems.map((section, index) => (
-                        <ul key={index}>
-                            {section.map((item) =>
-                                item.featureFlag && !featureFlags[item.featureFlag] ? null : (
-                                    <NavbarButton
-                                        key={item.identifier}
-                                        title={item.label}
-                                        identifier={item.identifier}
-                                        icon={item.icon}
-                                        tag={item.tag}
-                                        to={'to' in item ? item.to : undefined}
-                                        onClick={
-                                            'logic' in item
-                                                ? () => {
-                                                      if (activeNavbarItemId === item.identifier && isSidebarShown) {
-                                                          hideSidebar()
-                                                      } else {
-                                                          showSidebar(item.identifier)
+        <>
+            <nav className={clsx('Navbar3000', !isNavShown && 'Navbar3000--hidden')} ref={containerRef}>
+                <div className="Navbar3000__content">
+                    <div className="Navbar3000__top">
+                        {navbarItems.map((section, index) => (
+                            <ul key={index}>
+                                {section.map((item) =>
+                                    item.featureFlag && !featureFlags[item.featureFlag] ? null : (
+                                        <NavbarButton
+                                            key={item.identifier}
+                                            title={item.label}
+                                            identifier={item.identifier}
+                                            icon={item.icon}
+                                            tag={item.tag}
+                                            to={'to' in item ? item.to : undefined}
+                                            onClick={
+                                                'logic' in item
+                                                    ? () => {
+                                                          if (
+                                                              activeNavbarItemId === item.identifier &&
+                                                              isSidebarShown
+                                                          ) {
+                                                              hideSidebar()
+                                                          } else {
+                                                              showSidebar(item.identifier)
+                                                          }
                                                       }
-                                                  }
-                                                : undefined
-                                        }
-                                        active={activeNavbarItemId === item.identifier && isSidebarShown}
-                                    />
-                                )
-                            )}
-                        </ul>
-                    ))}
-                </div>
-                <div className="Navbar3000__bottom">
-                    <ul>
-                        <NavbarButton
-                            identifier="search-button"
-                            icon={<IconSearch />}
-                            title="Search"
-                            onClick={toggleSearchBar}
-                            keyboardShortcut={{ command: true, k: true }}
-                        />
-                        <NavbarButton
-                            icon={<ThemeIcon />}
-                            identifier="theme-button"
-                            title={
-                                darkModeSavedPreference === false
-                                    ? `Sync theme with system preference (${
-                                          darkModeSystemPreference ? 'dark' : 'light'
-                                      } mode)`
-                                    : darkModeSavedPreference
-                                    ? 'Switch to light mode'
-                                    : 'Switch to dark mode'
-                            }
-                            shortTitle="Toggle theme"
-                            forceTooltipOnHover
-                            onClick={() => toggleTheme()}
-                            persistentTooltip
-                        />
-                        <NavbarButton
-                            icon={<IconGear />}
-                            identifier={Scene.Settings}
-                            title="Project settings"
-                            to={urls.settings('project')}
-                        />
-
-                        <Popover
-                            overlay={<SitePopoverOverlay />}
-                            visible={isSitePopoverOpen}
-                            onClickOutside={closeSitePopover}
-                            placement="right-end"
-                        >
+                                                    : undefined
+                                            }
+                                            active={activeNavbarItemId === item.identifier && isSidebarShown}
+                                        />
+                                    )
+                                )}
+                            </ul>
+                        ))}
+                    </div>
+                    <div className="Navbar3000__bottom">
+                        <ul>
                             <NavbarButton
-                                icon={<ProfilePicture name={user?.first_name} email={user?.email} size="md" />}
-                                identifier="me"
-                                title={`Hi${user?.first_name ? `, ${user?.first_name}` : ''}!`}
-                                shortTitle={user?.first_name || user?.email}
-                                onClick={toggleSitePopover}
+                                identifier="search-button"
+                                icon={<IconSearch />}
+                                title="Search"
+                                onClick={toggleSearchBar}
+                                keyboardShortcut={{ command: true, k: true }}
                             />
-                        </Popover>
-                    </ul>
+                            <NavbarButton
+                                icon={<ThemeIcon />}
+                                identifier="theme-button"
+                                title={
+                                    darkModeSavedPreference === false
+                                        ? `Sync theme with system preference (${
+                                              darkModeSystemPreference ? 'dark' : 'light'
+                                          } mode)`
+                                        : darkModeSavedPreference
+                                        ? 'Switch to light mode'
+                                        : 'Switch to dark mode'
+                                }
+                                shortTitle="Toggle theme"
+                                forceTooltipOnHover
+                                onClick={() => toggleTheme()}
+                                persistentTooltip
+                            />
+                            <NavbarButton
+                                icon={<IconGear />}
+                                identifier={Scene.Settings}
+                                title="Project settings"
+                                to={urls.settings('project')}
+                            />
+
+                            <Popover
+                                overlay={<SitePopoverOverlay />}
+                                visible={isSitePopoverOpen}
+                                onClickOutside={closeSitePopover}
+                                placement="right-end"
+                            >
+                                <NavbarButton
+                                    icon={<ProfilePicture name={user?.first_name} email={user?.email} size="md" />}
+                                    identifier="me"
+                                    title={`Hi${user?.first_name ? `, ${user?.first_name}` : ''}!`}
+                                    shortTitle={user?.first_name || user?.email}
+                                    onClick={toggleSitePopover}
+                                />
+                            </Popover>
+                        </ul>
+                    </div>
                 </div>
-            </div>
-            <Resizer
-                placement={'right'}
-                containerRef={containerRef}
-                closeThreshold={100}
-                onToggleClosed={(shouldBeClosed) => toggleNavCollapsed(shouldBeClosed)}
-                onDoubleClick={() => toggleNavCollapsed()}
-            />
-        </nav>
+                {!mobileLayout && (
+                    <Resizer
+                        placement={'right'}
+                        containerRef={containerRef}
+                        closeThreshold={100}
+                        onToggleClosed={(shouldBeClosed) => toggleNavCollapsed(shouldBeClosed)}
+                        onDoubleClick={() => toggleNavCollapsed()}
+                    />
+                )}
+            </nav>
+            {mobileLayout && (
+                <div
+                    className={clsx('Navbar3000__overlay', !isNavShown && 'Navbar3000--hidden')}
+                    onClick={() => hideNavOnMobile()}
+                />
+            )}
+        </>
     )
 }

--- a/frontend/src/layout/navigation-3000/components/NavbarButton.tsx
+++ b/frontend/src/layout/navigation-3000/components/NavbarButton.tsx
@@ -1,6 +1,6 @@
 import { LemonTag } from '@posthog/lemon-ui'
 import clsx from 'clsx'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
@@ -47,6 +47,7 @@ export const NavbarButton: FunctionComponent<NavbarButtonProps> = React.forwardR
     ): JSX.Element => {
         const { activeScene } = useValues(sceneLogic)
         const { sceneBreadcrumbKeys } = useValues(breadcrumbsLogic)
+        const { hideNavOnMobile } = useActions(navigation3000Logic)
         const { isNavCollapsed } = useValues(navigation3000Logic)
         const isUsingNewNav = useFeatureFlag('POSTHOG_3000_NAV')
 
@@ -91,6 +92,9 @@ export const NavbarButton: FunctionComponent<NavbarButtonProps> = React.forwardR
                 data-attr={`menu-item-${identifier.toString().toLowerCase()}`}
                 onMouseEnter={() => setHasBeenClicked(false)}
                 onClick={() => {
+                    if (buttonProps.to) {
+                        hideNavOnMobile()
+                    }
                     setHasBeenClicked(true)
                     onClick?.()
                 }}

--- a/frontend/src/layout/navigation-3000/components/TopBar.scss
+++ b/frontend/src/layout/navigation-3000/components/TopBar.scss
@@ -1,9 +1,9 @@
-.Breadcrumbs3000 {
+.TopBar3000 {
     --breadcrumbs-compaction-rate: 0;
 
     position: sticky;
     top: 0;
-    z-index: var(--z-main-nav);
+    z-index: var(--z-top-navigation);
     display: flex;
     align-items: start;
     height: var(--breadcrumbs-height-full);
@@ -11,8 +11,9 @@
     pointer-events: none;
 }
 
-.Breadcrumbs3000__content {
+.TopBar3000__content {
     display: flex;
+    gap: 0.5rem;
     align-items: center;
     width: 100%;
     height: calc(
@@ -29,13 +30,17 @@
     border-bottom: 1px solid var(--glass-border-3000);
 }
 
-.Breadcrumbs3000__trail {
+.TopBar3000__hamburger {
+    margin-left: -0.5rem;
+}
+
+.TopBar3000__breadcrumbs {
     flex-grow: 1;
     flex-shrink: 1;
     min-width: 0;
 }
 
-.Breadcrumbs3000__crumbs {
+.TopBar3000__trail {
     display: flex;
     align-items: center;
     height: 1rem;
@@ -43,7 +48,7 @@
     overflow: visible;
 }
 
-.Breadcrumbs3000__here {
+.TopBar3000__here {
     position: relative;
     box-sizing: content-box;
     height: calc(1.2em * (1 - var(--breadcrumbs-compaction-rate)));
@@ -63,7 +68,7 @@
     }
 }
 
-.Breadcrumbs3000__breadcrumb {
+.TopBar3000__breadcrumb {
     display: flex;
     flex-shrink: 0;
     align-items: center;
@@ -76,7 +81,7 @@
         color: inherit;
     }
 
-    &.Breadcrumbs3000__breadcrumb--here {
+    &.TopBar3000__breadcrumb--here {
         cursor: default;
         visibility: var(--breadcrumbs-title-small-visibility);
 
@@ -86,11 +91,11 @@
         }
     }
 
-    &.Breadcrumbs3000__breadcrumb--actionable {
+    &.TopBar3000__breadcrumb--actionable {
         cursor: pointer;
 
         &:hover > span,
-        &.Breadcrumbs3000__breadcrumb--open > span {
+        &.TopBar3000__breadcrumb--open > span {
             opacity: 1;
         }
     }
@@ -111,7 +116,7 @@
     }
 }
 
-.Breadcrumbs3000__separator {
+.TopBar3000__separator {
     flex-shrink: 0;
     margin: 0 0.5rem;
     opacity: 0.5;
@@ -121,15 +126,14 @@
     }
 }
 
-.Breadcrumbs3000__more {
+.TopBar3000__more {
     margin-left: 0.5rem;
 }
 
-.Breadcrumbs3000__actions {
+.TopBar3000__actions {
     display: flex;
     flex-grow: 1;
     gap: 0.5rem;
     align-items: center;
     justify-content: flex-end;
-    margin-left: 0.5rem;
 }

--- a/frontend/src/layout/navigation-3000/components/TopBar.tsx
+++ b/frontend/src/layout/navigation-3000/components/TopBar.tsx
@@ -1,29 +1,32 @@
-import './Breadcrumbs.scss'
+import './TopBar.scss'
 
-import { LemonSkeleton } from '@posthog/lemon-ui'
+import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { EditableField } from 'lib/components/EditableField/EditableField'
-import { IconArrowDropDown } from 'lib/lemon-ui/icons'
+import { IconArrowDropDown, IconMenu } from 'lib/lemon-ui/icons'
 import { Link } from 'lib/lemon-ui/Link'
 import { Popover } from 'lib/lemon-ui/Popover/Popover'
 import React, { useLayoutEffect, useState } from 'react'
 
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
+import { navigationLogic } from '~/layout/navigation/navigationLogic'
 import { FinalizedBreadcrumb } from '~/types'
+
+import { navigation3000Logic } from '../navigationLogic'
 
 const COMPACTION_DISTANCE = 44
 
-/**
- * In PostHog 3000 breadcrumbs also serve as the top bar. This is marked by theses two features:
- * - The "More scene actions" button (vertical ellipsis)
- * - The "Quick scene actions" buttons (zero or more buttons on the right)
- */
-export function Breadcrumbs(): JSX.Element | null {
+export function TopBar(): JSX.Element | null {
+    const { mobileLayout } = useValues(navigationLogic)
+    const { showNavOnMobile } = useActions(navigation3000Logic)
     const { breadcrumbs, renameState } = useValues(breadcrumbsLogic)
     const { setActionsContainer } = useActions(breadcrumbsLogic)
 
     const [compactionRate, setCompactionRate] = useState(0)
+
+    // Always show in full on mobile, as there we are very constrained in width, but not so much height
+    const effectiveCompactionRate = mobileLayout ? 0 : compactionRate
 
     useLayoutEffect(() => {
         function handleScroll(): void {
@@ -52,25 +55,33 @@ export function Breadcrumbs(): JSX.Element | null {
 
     return breadcrumbs.length ? (
         <div
-            className="Breadcrumbs3000"
+            className="TopBar3000"
             // eslint-disable-next-line react/forbid-dom-props
             style={
                 {
-                    '--breadcrumbs-compaction-rate': compactionRate,
+                    '--breadcrumbs-compaction-rate': effectiveCompactionRate,
                     // It wouldn't be necessary to set visibility, but for some reason without this positioning
                     // of breadcrumbs becomes borked when entering title editing mode
-                    '--breadcrumbs-title-large-visibility': compactionRate === 1 ? 'hidden' : 'visible',
-                    '--breadcrumbs-title-small-visibility': compactionRate === 0 ? 'hidden' : 'visible',
+                    '--breadcrumbs-title-large-visibility': effectiveCompactionRate === 1 ? 'hidden' : 'visible',
+                    '--breadcrumbs-title-small-visibility': effectiveCompactionRate === 0 ? 'hidden' : 'visible',
                 } as React.CSSProperties
             }
         >
-            <div className="Breadcrumbs3000__content">
-                <div className="Breadcrumbs3000__trail">
-                    <div className="Breadcrumbs3000__crumbs">
+            <div className="TopBar3000__content">
+                {mobileLayout && (
+                    <LemonButton
+                        size="small"
+                        onClick={() => showNavOnMobile()}
+                        icon={<IconMenu />}
+                        className="TopBar3000__hamburger"
+                    />
+                )}
+                <div className="TopBar3000__breadcrumbs">
+                    <div className="TopBar3000__trail">
                         {breadcrumbs.slice(0, -1).map((breadcrumb, index) => (
                             <React.Fragment key={breadcrumb.name || '…'}>
                                 <Breadcrumb breadcrumb={breadcrumb} index={index} />
-                                <div className="Breadcrumbs3000__separator" />
+                                <div className="TopBar3000__separator" />
                             </React.Fragment>
                         ))}
                         <Breadcrumb
@@ -81,7 +92,7 @@ export function Breadcrumbs(): JSX.Element | null {
                     </div>
                     <Here breadcrumb={breadcrumbs[breadcrumbs.length - 1]} />
                 </div>
-                <div className="Breadcrumbs3000__actions" ref={setActionsContainer} />
+                <div className="TopBar3000__actions" ref={setActionsContainer} />
             </div>
         </div>
     ) : null
@@ -129,10 +140,10 @@ function Breadcrumb({ breadcrumb, index, here }: BreadcrumbProps): JSX.Element {
     const breadcrumbContent = (
         <Component
             className={clsx(
-                'Breadcrumbs3000__breadcrumb',
-                popoverShown && 'Breadcrumbs3000__breadcrumb--open',
-                (breadcrumb.path || breadcrumb.popover) && 'Breadcrumbs3000__breadcrumb--actionable',
-                here && 'Breadcrumbs3000__breadcrumb--here'
+                'TopBar3000__breadcrumb',
+                popoverShown && 'TopBar3000__breadcrumb--open',
+                (breadcrumb.path || breadcrumb.popover) && 'TopBar3000__breadcrumb--actionable',
+                here && 'TopBar3000__breadcrumb--here'
             )}
             onClick={() => {
                 breadcrumb.popover && setPopoverShown(!popoverShown)
@@ -178,7 +189,7 @@ function Here({ breadcrumb }: HereProps): JSX.Element {
     const { tentativelyRename, finishRenaming } = useActions(breadcrumbsLogic)
 
     return (
-        <h1 className="Breadcrumbs3000__here">
+        <h1 className="TopBar3000__here">
             {breadcrumb.name == null ? (
                 <LemonSkeleton className="w-40 h-4" />
             ) : breadcrumb.onRename ? (

--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -29,6 +29,7 @@ import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
+import { navigationLogic } from '../navigation/navigationLogic'
 import type { navigation3000LogicType } from './navigationLogicType'
 import { dashboardsSidebarLogic } from './sidebars/dashboards'
 import { dataManagementSidebarLogic } from './sidebars/dataManagement'
@@ -53,12 +54,14 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
     path(['layout', 'navigation-3000', 'navigationLogic']),
     props({} as { inputElement?: HTMLInputElement | null }),
     connect(() => ({
-        values: [sceneLogic, ['sceneConfig']],
+        values: [sceneLogic, ['sceneConfig'], navigationLogic, ['mobileLayout']],
     })),
     actions({
         hideSidebar: true,
         showSidebar: (newNavbarItemId?: string) => ({ newNavbarItemId }),
         toggleNavCollapsed: (override?: boolean) => ({ override }),
+        showNavOnMobile: true,
+        hideNavOnMobile: true,
         toggleSidebar: true,
         setSidebarWidth: (width: number) => ({ width }),
         setSidebarOverslide: (overslide: number) => ({ overslide }),
@@ -92,13 +95,6 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                 toggleSidebar: (isSidebarShown) => !isSidebarShown,
             },
         ],
-        isNavCollapsed: [
-            false,
-            { persist: true },
-            {
-                toggleNavCollapsed: (state, { override }) => override ?? !state,
-            },
-        ],
         sidebarWidth: [
             DEFAULT_SIDEBAR_WIDTH_PX,
             { persist: true },
@@ -118,6 +114,21 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
             {
                 beginResize: () => true,
                 endResize: () => false,
+            },
+        ],
+        isNavCollapsedDesktop: [
+            false,
+            { persist: true },
+            {
+                toggleNavCollapsed: (state, { override }) => override ?? !state,
+            },
+        ],
+        isNavShownMobile: [
+            false,
+            { persist: true },
+            {
+                showNavOnMobile: () => true,
+                hideNavOnMobile: () => false,
             },
         ],
         isSidebarKeyboardShortcutAcknowledged: [
@@ -292,6 +303,14 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                     ? 'full'
                     : 'none'
             },
+        ],
+        isNavShown: [
+            (s) => [s.isNavShownMobile, s.mobileLayout],
+            (isNavShownMobile, mobileLayout): boolean => !mobileLayout || isNavShownMobile,
+        ],
+        isNavCollapsed: [
+            (s) => [s.isNavCollapsedDesktop, s.mobileLayout],
+            (isNavCollapsedDesktop, mobileLayout): boolean => !mobileLayout && isNavCollapsedDesktop,
         ],
         navbarItems: [
             () => [featureFlagLogic.selectors.featureFlags],

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButtonLegacy.scss
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButtonLegacy.scss
@@ -25,7 +25,7 @@ body:not(.posthog-3000) {
         }
 
         &.LemonButton--small,
-        .Breadcrumbs3000 & {
+        .TopBar3000 & {
             --lemon-button-height: 2rem;
 
             padding: 0.125rem 0.5rem;

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1054,12 +1054,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
             eventUsageLogic.actions.reportDashboardPropertiesChanged()
         },
         setDashboardMode: async ({ mode, source }) => {
-            // Edit mode special handling
-            if (mode === DashboardMode.Fullscreen) {
-                document.body.classList.add('fullscreen-scroll')
-            } else {
-                document.body.classList.remove('fullscreen-scroll')
-            }
             if (mode === DashboardMode.Edit) {
                 clearDOMTextSelection()
             }

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -490,12 +490,6 @@ input::-ms-clear {
     }
 }
 
-// Main app/body styles
-
-.fullscreen-scroll {
-    overflow-y: auto;
-}
-
 .main-app-content {
     position: relative; // So that scene-level <SpinnerOverlay /> is positioned correctly.
     flex: 1;


### PR DESCRIPTION
## Problem

This is what PostHog 3000 looked like on an iPhone 12 Pro-sized device:

| Before |
| --- |
| <img src="https://github.com/PostHog/posthog/assets/4550621/3be0ca24-25e3-4d07-8da4-affb187c7f02" height="844"> |

Rather unusable.

## Changes

| After with navbar hidden | After with navbar shown |
| --- | --- |
| <img src="https://github.com/PostHog/posthog/assets/4550621/72bcf515-8e07-4d9f-919b-bdf40f532238" height="844"> | <img src="https://github.com/PostHog/posthog/assets/4550621/7b35fac3-7195-4dce-9af3-3b6037000e73" height="844"> |