### PR TITLE
fix(groups): add debounce to search

### DIFF
--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -41,7 +41,9 @@ export const groupsListLogic = kea<groupsListLogicType>([
         groups: [
             { next: null, previous: null, results: [] } as GroupsPaginatedResponse,
             {
-                loadGroups: async ({ url }) => {
+                loadGroups: async ({ url }, breakpoint) => {
+                    await breakpoint(300)
+
                     if (!values.groupsEnabled) {
                         return values.groups
                     }


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C011L071P8U/p1701098014480859.

## Changes

This PR adds a debounce/breakpoint to the search, which should fix the issue.

## How did you test this code?

Hard to replicate locally - let's try this once it's in