### PR TITLE
fix: correctly pick attribute selector

### DIFF
--- a/frontend/src/toolbar/actions/SelectorCount.tsx
+++ b/frontend/src/toolbar/actions/SelectorCount.tsx
@@ -2,10 +2,10 @@ import { querySelectorAllDeep } from 'query-selector-shadow-dom'
 import { useMemo } from 'react'
 
 interface SelectorCountProps {
-    selector: string
+    selector: string | null
 }
 
-export function SelectorCount({ selector }: SelectorCountProps): JSX.Element {
+export function SelectorCount({ selector }: SelectorCountProps): JSX.Element | null {
     const [matches, selectorError] = useMemo(() => {
         let _selectorError = false
         let _matches = 0
@@ -19,7 +19,7 @@ export function SelectorCount({ selector }: SelectorCountProps): JSX.Element {
         return [_matches, _selectorError]
     }, [selector])
 
-    return (
+    return selector === null ? null : (
         <small className={`float-right ${selectorError && 'text-danger'}`}>
             {selectorError ? 'Invalid selector' : `Matches ${matches} element${matches === 1 ? '' : 's'}`}
         </small>

--- a/frontend/src/toolbar/actions/StepField.tsx
+++ b/frontend/src/toolbar/actions/StepField.tsx
@@ -20,22 +20,22 @@ interface StepFieldProps {
 
 function hrefSelector(step: ActionStepForm): string | null {
     if (!step.href) {
-        return ''
+        return null
     }
     // see https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#links
-    const matchOperator = step.href_matching
-        ? {
-              // Link whose value is exactly step.href.
-              [StringMatching.Exact]: '=',
-              // Links with step.href anywhere in the URL
-              [StringMatching.Contains]: '*=',
-              // CSS selector can't match on regex
-              [StringMatching.Regex]: null,
-          }[step.href_matching]
-        : null
+    const matchOperator = {
+        // Link whose value is exactly step.href.
+        [StringMatching.Exact]: '=',
+        // Links with step.href anywhere in the URL
+        [StringMatching.Contains]: '*=',
+        // CSS selector can't match on regex
+        [StringMatching.Regex]: null,
+    }[step.href_matching || StringMatching.Exact]
+
     if (!matchOperator) {
         return null
     }
+
     return `a[href${matchOperator}"${cssEscape(step.href)}"]`
 }
 

--- a/frontend/src/toolbar/actions/StepField.tsx
+++ b/frontend/src/toolbar/actions/StepField.tsx
@@ -18,6 +18,27 @@ interface StepFieldProps {
     caption?: string | JSX.Element
 }
 
+function hrefSelector(step: ActionStepForm): string | null {
+    if (!step.href) {
+        return ''
+    }
+    // see https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#links
+    const matchOperator = step.href_matching
+        ? {
+              // Link whose value is exactly step.href.
+              [StringMatching.Exact]: '=',
+              // Links with step.href anywhere in the URL
+              [StringMatching.Contains]: '*=',
+              // CSS selector can't match on regex
+              [StringMatching.Regex]: null,
+          }[step.href_matching]
+        : null
+    if (!matchOperator) {
+        return null
+    }
+    return `a[href${matchOperator}"${cssEscape(step.href)}"]`
+}
+
 export function StepField({ step, item, label, caption }: StepFieldProps): JSX.Element {
     const selected = step && step[`${item}_selected`]
 
@@ -25,7 +46,7 @@ export function StepField({ step, item, label, caption }: StepFieldProps): JSX.E
         <>
             <div className={clsx('action-field my-1', selected && 'action-field-selected')}>
                 <div>
-                    {item === 'href' && step?.href && <SelectorCount selector={`a[href="${cssEscape(step.href)}"]`} />}
+                    {item === 'href' && step?.href && <SelectorCount selector={hrefSelector(step)} />}
                     {item === 'selector' && step?.selector && <SelectorCount selector={step.selector} />}
                     <Field name={`${item}_selected`} noStyle>
                         {({ onChange, value }) => <LemonCheckbox label={label} onChange={onChange} checked={value} />}


### PR DESCRIPTION
In the toolbar when matching on a link we were always checking an exact match.

We can check for contains, but can't check for regex the way that actions will. 

So, we hide the selector count when regex and choose the right operator otherwise

![2023-11-28 17 32 58](https://github.com/PostHog/posthog/assets/984817/01baf5b6-6dbb-4865-a1eb-eb0c2442f03c)
