### PR TITLE
chore(event-explorer): Restore turbo mode

### DIFF
--- a/frontend/src/scenes/events/Events.tsx
+++ b/frontend/src/scenes/events/Events.tsx
@@ -2,13 +2,11 @@ import { PageHeader } from 'lib/components/PageHeader'
 import { EventsScene } from 'scenes/events/EventsScene'
 import { SceneExport } from 'scenes/sceneTypes'
 
+import { eventsSceneLogic } from './eventsSceneLogic'
+
 export const scene: SceneExport = {
     component: Events,
-    // TODO!
-    // NOTE: Removing the lines below because turbo mode messes up having two separate versions of this scene.
-    //       It's a small price to pay. Put this back when the flag is removed.
-    // logic: eventsTableLogic,
-    // paramsToProps: ({ params: { fixedFilters } }) => ({ fixedFilters, key: 'EventsTable', sceneUrl: urls.events() }),
+    logic: eventsSceneLogic,
 }
 
 export function Events(): JSX.Element {


### PR DESCRIPTION
## Problem

We disabled turbo mode for the event explorer scene in https://github.com/PostHog/posthog/pull/12950 and didn't enable it again.

## Changes

Turbo mode on.