### PR TITLE
fix: fix typos in demo matrix and adjust taxonomic tab hint to reflect reality

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -102,10 +102,10 @@ export function TaxonomicFilter({
                                         <>
                                             You can easily navigate between tabs with your keyboard.{' '}
                                             <div>
-                                                Use <b>tab</b> or <b>right arrow</b> to move to the next tab.
+                                                Use <b>tab</b> to move to the next tab.
                                             </div>
                                             <div>
-                                                Use <b>shift + tab</b> or <b>left arrow</b> to move to the previous tab.
+                                                Use <b>shift + tab</b> to move to the previous tab.
                                             </div>
                                         </>
                                     }

--- a/posthog/demo/matrix/matrix.py
+++ b/posthog/demo/matrix/matrix.py
@@ -66,7 +66,7 @@ class Cluster(ABC):
         self.datetime_provider = matrix.datetime_provider
         self.finance_provider = matrix.finance_provider
         self.file_provider = matrix.file_provider
-        self.start = matrix.start + (matrix.end - matrix.start) * self.initation_distribution()
+        self.start = matrix.start + (matrix.end - matrix.start) * self.initiation_distribution()
         self.now = matrix.now
         self.end = matrix.end
         self.radius = int(self.MIN_RADIUS + self.radius_distribution() * (self.MAX_RADIUS - self.MIN_RADIUS))
@@ -94,7 +94,7 @@ class Cluster(ABC):
         """Return a value between 0 and 1 signifying where the radius should fall between MIN_RADIUS and MAX_RADIUS."""
         return self.random.uniform(self.MIN_RADIUS, self.MAX_RADIUS)
 
-    def initation_distribution(self) -> float:
+    def initiation_distribution(self) -> float:
         """Return a value between 0 and 1 determining how far into the overall simulation should this cluster be initiated."""
         return self.random.random()
 

--- a/posthog/demo/products/hedgebox/matrix.py
+++ b/posthog/demo/products/hedgebox/matrix.py
@@ -30,7 +30,7 @@ from .taxonomy import *
 
 
 @dataclass
-class HedgdboxCompany:
+class HedgeboxCompany:
     name: str
     industry: Industry
 
@@ -42,7 +42,7 @@ class HedgeboxCluster(Cluster):
     MAX_RADIUS: int = 6
 
     # Properties
-    company: Optional[HedgdboxCompany]  # None means the cluster is a social circle instead of a company
+    company: Optional[HedgeboxCompany]  # None means the cluster is a social circle instead of a company
 
     # Internal state - plain
     _business_account: Optional[HedgeboxAccount]  # In social circle clusters the person-level account is used
@@ -51,7 +51,7 @@ class HedgeboxCluster(Cluster):
         super().__init__(*args, **kwargs)
         is_company = self.random.random() < COMPANY_CLUSTERS_PROPORTION
         if is_company:
-            self.company = HedgdboxCompany(
+            self.company = HedgeboxCompany(
                 name=self.finance_provider.company(),
                 industry=self.properties_provider.industry(),
             )
@@ -65,7 +65,7 @@ class HedgeboxCluster(Cluster):
     def radius_distribution(self) -> float:
         return self.random.betavariate(1.5, 5)
 
-    def initation_distribution(self) -> float:
+    def initiation_distribution(self) -> float:
         return self.random.betavariate(1.8, 1)
 
 

--- a/posthog/demo/test/test_matrix_manager.py
+++ b/posthog/demo/test/test_matrix_manager.py
@@ -33,7 +33,7 @@ class DummyCluster(Cluster):
     MIN_RADIUS = 0
     MAX_RADIUS = 0
 
-    def initation_distribution(self) -> float:
+    def initiation_distribution(self) -> float:
         return 0  # Start every cluster at the same time
 
 


### PR DESCRIPTION
Being the pettiest of PRs, this fixes:
- some typos in the demo matrix
- a shortcut hint in the taxonomic filter (you could only use tab and shift-tab to switch between tabs, unlike the existing hint says.