### PR TITLE
fix: Insight card headings not truncating

### DIFF
--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -54,11 +54,11 @@
 
     h5 {
         margin-bottom: 0;
+        overflow: hidden;
         line-height: 1rem;
         color: var(--muted);
-        white-space: nowrap;
         text-overflow: ellipsis;
-        overflow: hidden;
+        white-space: nowrap;
     }
 
     h4 {

--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -54,7 +54,7 @@
 
     h5 {
         margin-bottom: 0;
-        line-height: 1.5rem;
+        line-height: 1rem;
         color: var(--muted);
         white-space: nowrap;
         text-overflow: ellipsis;

--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -56,6 +56,9 @@
         margin-bottom: 0;
         line-height: 1.5rem;
         color: var(--muted);
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
     }
 
     h4 {


### PR DESCRIPTION
## Problem

@joethreepwood noticed that you can get into a size that triggers a reflow that doesn't look great 

## Changes

* Truncate instead of wrap.

|Before|After|
|----|----|
| <img width="283" alt="Screenshot 2023-11-29 at 15 28 14" src="https://github.com/PostHog/posthog/assets/2536520/1cc8fac1-b0dc-40d7-b52f-db76e4c3203d"> | <img width="298" alt="Screenshot 2023-11-29 at 15 26 27" src="https://github.com/PostHog/posthog/assets/2536520/883e245b-839e-4c16-a26a-f4b7a94e86e9"> |

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
