### PR TITLE
fix(3000): Configure error scenes to show up properly in the top bar

### DIFF
--- a/frontend/src/layout/navigation-3000/components/TopBar.tsx
+++ b/frontend/src/layout/navigation-3000/components/TopBar.tsx
@@ -85,19 +85,21 @@ export function TopBar(): JSX.Element | null {
                     />
                 )}
                 <div className="TopBar3000__breadcrumbs">
-                    <div className="TopBar3000__trail">
-                        {breadcrumbs.slice(0, -1).map((breadcrumb, index) => (
-                            <React.Fragment key={breadcrumb.name || '…'}>
-                                <Breadcrumb breadcrumb={breadcrumb} index={index} />
-                                <div className="TopBar3000__separator" />
-                            </React.Fragment>
-                        ))}
-                        <Breadcrumb
-                            breadcrumb={breadcrumbs[breadcrumbs.length - 1]}
-                            index={breadcrumbs.length - 1}
-                            here
-                        />
-                    </div>
+                    {breadcrumbs.length > 1 && (
+                        <div className="TopBar3000__trail">
+                            {breadcrumbs.slice(0, -1).map((breadcrumb, index) => (
+                                <React.Fragment key={breadcrumb.name || '…'}>
+                                    <Breadcrumb breadcrumb={breadcrumb} index={index} />
+                                    <div className="TopBar3000__separator" />
+                                </React.Fragment>
+                            ))}
+                            <Breadcrumb
+                                breadcrumb={breadcrumbs[breadcrumbs.length - 1]}
+                                index={breadcrumbs.length - 1}
+                                here
+                            />
+                        </div>
+                    )}
                     <Here breadcrumb={breadcrumbs[breadcrumbs.length - 1]} />
                 </div>
                 <div className="TopBar3000__actions" ref={setActionsContainer} />

--- a/frontend/src/scenes/sceneLogic.test.tsx
+++ b/frontend/src/scenes/sceneLogic.test.tsx
@@ -54,7 +54,7 @@ describe('sceneLogic', () => {
 
     it('persists the loaded scenes', async () => {
         const expectedAnnotation = partial({
-            name: Scene.DataManagement,
+            id: Scene.DataManagement,
             component: expect.any(Function),
             logic: expect.any(Function),
             sceneParams: { hashParams: {}, params: {}, searchParams: {} },
@@ -62,7 +62,7 @@ describe('sceneLogic', () => {
         })
 
         const expectedSettings = partial({
-            name: Scene.Settings,
+            id: Scene.Settings,
             component: expect.any(Function),
             sceneParams: {
                 hashParams: {},

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -77,7 +77,7 @@ export const sceneLogic = kea<sceneLogicType>([
                         : state,
                 setLoadedScene: (state, { loadedScene }) => ({
                     ...state,
-                    [loadedScene.name]: { ...loadedScene, lastTouch: new Date().valueOf() },
+                    [loadedScene.id]: { ...loadedScene, lastTouch: new Date().valueOf() },
                 }),
             },
         ],
@@ -289,11 +289,11 @@ export const sceneLogic = kea<sceneLogicType>([
                 const { default: defaultExport, logic, scene: _scene, ...others } = importedScene
 
                 if (_scene) {
-                    loadedScene = { name: scene, ...(_scene as SceneExport), sceneParams: params }
+                    loadedScene = { id: scene, ...(_scene as SceneExport), sceneParams: params }
                 } else if (defaultExport) {
                     console.warn(`Scene ${scene} not yet converted to use SceneExport!`)
                     loadedScene = {
-                        name: scene,
+                        id: scene,
                         component: defaultExport,
                         logic: logic,
                         sceneParams: params,
@@ -301,7 +301,7 @@ export const sceneLogic = kea<sceneLogicType>([
                 } else {
                     console.warn(`Scene ${scene} not yet converted to use SceneExport!`)
                     loadedScene = {
-                        name: scene,
+                        id: scene,
                         component:
                             Object.keys(others).length === 1
                                 ? others[Object.keys(others)[0]]

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -94,7 +94,7 @@ export interface SceneExport {
 }
 
 export interface LoadedScene extends SceneExport {
-    name: string
+    id: string
     sceneParams: SceneParams
 }
 

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -15,17 +15,17 @@ export const emptySceneParams = { params: {}, searchParams: {}, hashParams: {} }
 
 export const preloadedScenes: Record<string, LoadedScene> = {
     [Scene.Error404]: {
-        name: Scene.Error404,
+        id: Scene.Error404,
         component: Error404Component,
         sceneParams: emptySceneParams,
     },
     [Scene.ErrorNetwork]: {
-        name: Scene.ErrorNetwork,
+        id: Scene.ErrorNetwork,
         component: ErrorNetworkComponent,
         sceneParams: emptySceneParams,
     },
     [Scene.ErrorProjectUnavailable]: {
-        name: Scene.ErrorProjectUnavailable,
+        id: Scene.ErrorProjectUnavailable,
         component: ErrorProjectUnavailableComponent,
         sceneParams: emptySceneParams,
     },

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -31,7 +31,17 @@ export const preloadedScenes: Record<string, LoadedScene> = {
     },
 }
 
-export const sceneConfigurations: Partial<Record<Scene, SceneConfig>> = {
+export const sceneConfigurations: Record<Scene, SceneConfig> = {
+    [Scene.Error404]: {
+        name: 'Not found',
+        projectBased: true,
+    },
+    [Scene.ErrorNetwork]: {
+        name: 'Network error',
+    },
+    [Scene.ErrorProjectUnavailable]: {
+        name: 'Project unavailable',
+    },
     // Project-based routes
     [Scene.Dashboards]: {
         projectBased: true,


### PR DESCRIPTION
## Problem

This didn't look great if you tried something like https://app.posthog.com/thispagedoesnotexist:

<img width="105" alt="Screenshot 2023-11-29 at 18 55 21" src="https://github.com/PostHog/posthog/assets/4550621/109a0589-acf0-4ac4-a617-e62fd3d505d8">

## Changes

This looks better:

<img width="228" alt="Screenshot 2023-11-29 at 13 04 17" src="https://github.com/PostHog/posthog/assets/4550621/5d039dd7-1749-49c3-ad10-3ee2dd1cc873">

