### PR TITLE
chore: drop kafka_skip_broken_messages from kafka_events_json

### DIFF
--- a/posthog/clickhouse/migrations/0050_drop_skip_messages.py
+++ b/posthog/clickhouse/migrations/0050_drop_skip_messages.py
@@ -1,0 +1,13 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.event.sql import (
+    EVENTS_TABLE_JSON_MV_SQL,
+    KAFKA_EVENTS_TABLE_JSON_SQL,
+)
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+operations = [
+    run_sql_with_exceptions(f"DROP TABLE IF EXISTS events_json_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    run_sql_with_exceptions(f"DROP TABLE IF EXISTS kafka_events_json ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    run_sql_with_exceptions(KAFKA_EVENTS_TABLE_JSON_SQL()),
+    run_sql_with_exceptions(EVENTS_TABLE_JSON_MV_SQL()),
+]

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -29,8 +29,6 @@
       
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_events_json_test', 'group1', 'JSONEachRow')
   
-      SETTINGS kafka_skip_broken_messages = 100
-  
   '
 ---
 # name: test_create_kafka_table_with_different_kafka_host[kafka_app_metrics]
@@ -110,8 +108,6 @@
       
       
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_events_json_test', 'group1', 'JSONEachRow')
-  
-      SETTINGS kafka_skip_broken_messages = 100
   
   '
 ---
@@ -727,8 +723,6 @@
       
       
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_events_json_test', 'group1', 'JSONEachRow')
-  
-      SETTINGS kafka_skip_broken_messages = 100
   
   '
 ---

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -106,16 +106,7 @@ ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64
     storage_policy=STORAGE_POLICY(),
 )
 
-# we add the settings to prevent poison pills from stopping ingestion
-# kafka_skip_broken_messages is an int, not a boolean, so we explicitly set
-# the max block size to consume from kafka such that we skip _all_ broken messages
-# this is an added safety mechanism given we control payloads to this topic
-KAFKA_EVENTS_TABLE_JSON_SQL = lambda: (
-    EVENTS_TABLE_BASE_SQL
-    + """
-    SETTINGS kafka_skip_broken_messages = 100
-"""
-).format(
+KAFKA_EVENTS_TABLE_JSON_SQL = lambda: EVENTS_TABLE_BASE_SQL.format(
     table_name="kafka_events_json",
     cluster=settings.CLICKHOUSE_CLUSTER,
     engine=kafka_engine(topic=KAFKA_EVENTS_JSON),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We _shouldn't_ be sending any messages that don't deserialize properly, and so we'd like to go back to `kafka_skip_broken_messages = 0` in prod.

## Changes

Remake virtual Kafka table (and MV that's based on it) without the `kafka_skip_broken_messages` setting.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

This is modeled after [a previous migration](https://github.com/PostHog/posthog/blob/1f8de249a91ba5726db98a52c4f7b8cd888e6d66/posthog/clickhouse/migrations/0047_add_insertion_timestamp_to_events.py) and should be reversible. Since it could pause the pipeline we should probably deploy early on a Monday and monitor it (with a revert PR ready).

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
