### PR TITLE
feat: add mobile properties to taxonomy

### DIFF
--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -74,6 +74,11 @@ export const KEY_MAPPING: KeyMappingInterface = {
                 'PostHog process information like browser, OS, and device type from the user agent string. This is the raw user agent string.',
             examples: ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko)'],
         },
+        $user_agent: {
+            label: 'Raw User Agent',
+            description: 'Some SDKs (like Android) send the raw user agent as $user_agent.',
+            examples: ['Dalvik/2.1.0 (Linux; U; Android 11; Pixel 3 Build/RQ2A.210505.002)'],
+        },
         $screen_height: {
             label: 'Screen Height',
             description: "The height of the user's entire screen (in pixels).",
@@ -229,6 +234,31 @@ export const KEY_MAPPING: KeyMappingInterface = {
             label: 'Initial Device Type',
             description: 'The initial type of device that was used (first-touch).',
             examples: ['Mobile', 'Tablet', 'Desktop'],
+        },
+        $screen_density: {
+            label: 'Screen density',
+            description: 'WHAT IS THE DEFINITION?',
+            examples: [2.75],
+        },
+        $device_model: {
+            label: 'Device Model',
+            description: 'The model of the device that was used.',
+            examples: ['iPhone 12 Pro', 'Pixel 3'],
+        },
+        $network_wifi: {
+            label: 'Network WiFi',
+            description: 'Whether the user was on WiFi when the event was sent.',
+            examples: ['true', 'false'],
+        },
+        $network_bluetooth: {
+            label: 'Network Bluetooth',
+            description: 'Whether the user was on Bluetooth when the event was sent.',
+            examples: ['true', 'false'],
+        },
+        $network_cellular: {
+            label: 'Network Cellular',
+            description: 'Whether the user was on cellular when the event was sent.',
+            examples: ['true', 'false'],
         },
         $pageview: {
             label: 'Pageview',

--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -243,7 +243,7 @@ export const KEY_MAPPING: KeyMappingInterface = {
         $device_model: {
             label: 'Device Model',
             description: 'The model of the device that was used.',
-            examples: ['iPhone 12 Pro', 'Pixel 3'],
+            examples: ['iPhone9,3', 'SM-G965W'],
         },
         $network_wifi: {
             label: 'Network WiFi',

--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -237,7 +237,8 @@ export const KEY_MAPPING: KeyMappingInterface = {
         },
         $screen_density: {
             label: 'Screen density',
-            description: 'The logical density of the display. This is a scaling factor for the Density Independent Pixel unit, where one DIP is one pixel on an approximately 160 dpi screen (for example a 240x320, 1.5"x2" screen), providing the baseline of the system's display. Thus on a 160dpi screen this density value will be 1; on a 120 dpi screen it would be .75; etc.',
+            description:
+                'The logical density of the display. This is a scaling factor for the Density Independent Pixel unit, where one DIP is one pixel on an approximately 160 dpi screen (for example a 240x320, 1.5"x2" screen), providing the baseline of the system\'s display. Thus on a 160dpi screen this density value will be 1; on a 120 dpi screen it would be .75; etc.',
             examples: [2.75],
         },
         $device_model: {

--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -237,7 +237,7 @@ export const KEY_MAPPING: KeyMappingInterface = {
         },
         $screen_density: {
             label: 'Screen density',
-            description: 'WHAT IS THE DEFINITION?',
+            description: 'The logical density of the display. This is a scaling factor for the Density Independent Pixel unit, where one DIP is one pixel on an approximately 160 dpi screen (for example a 240x320, 1.5"x2" screen), providing the baseline of the system's display. Thus on a 160dpi screen this density value will be 1; on a 120 dpi screen it would be .75; etc.',
             examples: [2.75],
         },
         $device_model: {


### PR DESCRIPTION
I noticed that there are some mobile properties that we don't display nicely in the UI

Adds them to the taxonomy - need a definition for screen density

<img width="1034" alt="Screenshot 2023-11-29 at 23 11 17" src="https://github.com/PostHog/posthog/assets/984817/a6ecf47d-5fb8-4f07-9199-836e9faa7789">
