### PR TITLE
chore(data-warehouse): differentiate paths for pipeline

### DIFF
--- a/posthog/warehouse/data_load/pipeline.py
+++ b/posthog/warehouse/data_load/pipeline.py
@@ -10,6 +10,7 @@ from dlt.pipeline.exceptions import PipelineStepFailed
 from posthog.warehouse.models import ExternalDataSource
 
 from .stripe import ENDPOINTS, stripe_source
+import os
 
 
 @dataclass
@@ -20,8 +21,11 @@ class PipelineInputs:
 
 
 def create_pipeline(inputs: PipelineInputs):
+    pipeline_name = f"{inputs.job_type}_pipeline_{inputs.team_id}"
+    pipelines_dir = f"{os.getcwd()}/.dlt/{inputs.team_id}/{inputs.job_type}"
     return dlt.pipeline(
-        pipeline_name=f"{inputs.job_type}_pipeline",
+        pipeline_name=pipeline_name,
+        pipelines_dir=pipelines_dir,  # workers can be created and destroyed so it doesn't matter where the metadata gets put temporarily
         destination="filesystem",
         dataset_name=inputs.dataset_name,
         credentials={


### PR DESCRIPTION
## Problem

- paths were trying to use root directory and weren't differentiated by teams

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- explicitly define paths to be within current direc

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
