### PR TITLE
fix: Bump psycopg

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -60,7 +60,7 @@ Pillow==9.2.0
 posthoganalytics==3.0.1
 prance==0.22.2.22.0
 psycopg2-binary==2.9.7
-psycopg==3.1
+psycopg==3.1.13
 pyarrow==12.0.1
 pydantic==2.3.0
 pyjwt==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -398,7 +398,7 @@ protobuf==4.22.1
     #   grpcio-status
     #   proto-plus
     #   temporalio
-psycopg==3.1
+psycopg==3.1.13
     # via -r requirements.in
 psycopg2-binary==2.9.7
     # via -r requirements.in


### PR DESCRIPTION
## Problem

Installing the latest psycopg version helps to make things work in MacOS.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Bump psycopg to 3.1.13. In hindsight, that bound should have been `>=` instead of `==`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

`pip installed` locally, run `DEBUG=1 ./bin/migrate` check all works.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
