### PR TITLE
feat: add caddy volumes; bump caddy to latest

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -85,13 +85,15 @@ services:
             SECRET_KEY: $POSTHOG_SECRET
 
     caddy:
-        image: caddy:2.6.1
+        image: caddy:2.7.5
         restart: unless-stopped
         ports:
             - '80:80'
             - '443:443'
         volumes:
             - ./Caddyfile:/etc/caddy/Caddyfile
+            - caddy-data:/data
+            - caddy-config:/config
         depends_on:
             - web
     object_storage:
@@ -153,3 +155,5 @@ volumes:
     object_storage:
     postgres-data:
     clickhouse-data:
+    caddy-data:
+    caddy-config:


### PR DESCRIPTION
* added caddy storage volumes so that LE certs survive container updates/restarts cleanly
* bumped caddy to latest (2.7.5)
