### PR TITLE
chore(ci): don't report toolbar bundle if it doesn't change

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -118,6 +118,8 @@ jobs:
                   build-script: 'build'
                   compression: 'none'
                   pattern: 'frontend/dist/toolbar.js'
+                  # we only care if the toolbar will increase a lot
+                  minimum-change-threshold: 1000
 
     jest:
         runs-on: ubuntu-latest


### PR DESCRIPTION
The toolbar bundle is reported as not changing on every PR, but we don't care... we only care if we're making it significantly bigger.

Add a threshold...