### PR TITLE
chore(plugin-server): add prometheus metrics to match statsd ones, remove unused metrics

### DIFF
--- a/plugin-server/src/main/graphile-worker/graphile-worker.ts
+++ b/plugin-server/src/main/graphile-worker/graphile-worker.ts
@@ -16,6 +16,7 @@ import { instrument } from '../../utils/metrics'
 import { runRetriableFunction } from '../../utils/retries'
 import { status } from '../../utils/status'
 import { createPostgresPool } from '../../utils/utils'
+import { graphileEnqueueJobCounter } from './metrics'
 
 export interface InstrumentationContext {
     key: string
@@ -80,10 +81,7 @@ export class GraphileWorker {
             enqueueFn = () =>
                 runRetriableFunction({
                     hub: this.hub,
-                    metricName: 'job_queues_enqueue',
-                    metricTags: {
-                        jobName,
-                    },
+                    metricName: `job_queues_enqueue_${jobName}`,
                     maxAttempts: 10,
                     retryBaseMs: 6000,
                     retryMultiplier: 2,
@@ -110,8 +108,10 @@ export class GraphileWorker {
         try {
             await this.addJob(jobName, job)
             this.hub.statsd?.increment('enqueue_job.success', { jobName })
+            graphileEnqueueJobCounter.labels({ status: 'success', job: jobName }).inc()
         } catch (error) {
             this.hub.statsd?.increment('enqueue_job.fail', { jobName })
+            graphileEnqueueJobCounter.labels({ status: 'fail', job: jobName }).inc()
             throw error
         }
     }

--- a/plugin-server/src/main/graphile-worker/metrics.ts
+++ b/plugin-server/src/main/graphile-worker/metrics.ts
@@ -1,0 +1,13 @@
+import { Counter } from 'prom-client'
+
+export const graphileEnqueueJobCounter = new Counter({
+    name: 'graphile_enqueue_job',
+    help: 'Result status of enqueueing a job to the graphile worker queue',
+    labelNames: ['status', 'job'],
+})
+
+export const graphileScheduledTaskCounter = new Counter({
+    name: 'graphile_scheduled_task',
+    help: 'Graphile scheduled task status change',
+    labelNames: ['status', 'task'],
+})

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-onevent.ts
@@ -1,16 +1,14 @@
-import * as Sentry from '@sentry/node'
-import { EachBatchPayload, KafkaMessage } from 'kafkajs'
+import { EachBatchPayload } from 'kafkajs'
 
 import { PluginConfig, PluginMethod, RawClickHouseEvent } from '../../../types'
 import { convertToIngestionEvent, convertToPostHogEvent } from '../../../utils/event'
-import { status } from '../../../utils/status'
 import {
     processComposeWebhookStep,
     processOnEventStep,
 } from '../../../worker/ingestion/event-pipeline/runAsyncHandlersStep'
 import { runInstrumentedFunction } from '../../utils'
 import { KafkaJSIngestionConsumer } from '../kafka-queue'
-import { eventDroppedCounter, latestOffsetTimestampGauge } from '../metrics'
+import { eventDroppedCounter } from '../metrics'
 import { eachBatchHandlerHelper } from './each-batch-webhooks'
 
 // Must require as `tsc` strips unused `import` statements and just requiring this seems to init some globals
@@ -89,76 +87,4 @@ export async function eachBatchAppsOnEventHandlers(
         queue.pluginsServer.WORKER_CONCURRENCY * queue.pluginsServer.TASKS_PER_WORKER,
         'on_event'
     )
-}
-
-export async function eachBatch(
-    /**
-     * Using the provided groupIntoBatches function, split the incoming batch into micro-batches
-     * that are executed **sequentially**, committing offsets after each of them.
-     * Events within a single micro-batch are processed in parallel.
-     */
-    { batch, resolveOffset, heartbeat, commitOffsetsIfNecessary, isRunning, isStale }: EachBatchPayload,
-    queue: KafkaJSIngestionConsumer,
-    eachMessage: (message: KafkaMessage, queue: KafkaJSIngestionConsumer) => Promise<void>,
-    groupIntoBatches: (messages: KafkaMessage[], batchSize: number) => KafkaMessage[][],
-    key: string
-): Promise<void> {
-    const batchStartTimer = new Date()
-    const loggingKey = `each_batch_${key}`
-
-    const transaction = Sentry.startTransaction({ name: `eachBatch(${eachMessage.name})` }, { topic: queue.topic })
-
-    try {
-        const messageBatches = groupIntoBatches(
-            batch.messages,
-            queue.pluginsServer.WORKER_CONCURRENCY * queue.pluginsServer.TASKS_PER_WORKER
-        )
-        queue.pluginsServer.statsd?.histogram('ingest_event_batching.input_length', batch.messages.length, { key: key })
-        queue.pluginsServer.statsd?.histogram('ingest_event_batching.batch_count', messageBatches.length, { key: key })
-
-        for (const messageBatch of messageBatches) {
-            const batchSpan = transaction.startChild({ op: 'messageBatch', data: { batchLength: messageBatch.length } })
-
-            if (!isRunning() || isStale()) {
-                status.info('🚪', `Bailing out of a batch of ${batch.messages.length} events (${loggingKey})`, {
-                    isRunning: isRunning(),
-                    isStale: isStale(),
-                    msFromBatchStart: new Date().valueOf() - batchStartTimer.valueOf(),
-                })
-                await heartbeat()
-                return
-            }
-
-            const lastBatchMessage = messageBatch[messageBatch.length - 1]
-            await Promise.all(
-                messageBatch.map((message: KafkaMessage) => eachMessage(message, queue).finally(() => heartbeat()))
-            )
-
-            // this if should never be false, but who can trust computers these days
-            if (lastBatchMessage) {
-                resolveOffset(lastBatchMessage.offset)
-            }
-            await commitOffsetsIfNecessary()
-
-            // Record that latest messages timestamp, such that we can then, for
-            // instance, alert on if this value is too old.
-            latestOffsetTimestampGauge
-                .labels({ partition: batch.partition, topic: batch.topic, groupId: key })
-                .set(Number.parseInt(lastBatchMessage.timestamp))
-
-            await heartbeat()
-
-            batchSpan.finish()
-        }
-
-        status.debug(
-            '🧩',
-            `Kafka batch of ${batch.messages.length} events completed in ${
-                new Date().valueOf() - batchStartTimer.valueOf()
-            }ms (${loggingKey})`
-        )
-    } finally {
-        queue.pluginsServer.statsd?.timing(`kafka_queue.${loggingKey}`, batchStartTimer)
-        transaction.finish()
-    }
 }

--- a/plugin-server/src/main/ingestion-queues/batch-processing/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/metrics.ts
@@ -1,4 +1,4 @@
-import { Counter, exponentialBuckets, Histogram } from 'prom-client' // but fail to commit offsets, which can cause duplicate events
+import { Counter, exponentialBuckets, Histogram, Summary } from 'prom-client' // but fail to commit offsets, which can cause duplicate events
 
 // The following two counters can be used to see how often we start,
 // but fail to commit offsets, which can cause duplicate events
@@ -28,4 +28,16 @@ export const ingestionParallelismPotential = new Histogram({
     help: 'Number of eligible parts per ingestion consumer batch',
     labelNames: ['overflow_mode'],
     buckets: exponentialBuckets(1, 2, 7), // Up to 64
+})
+
+export const ingestEventBatchingInputLengthSummary = new Summary({
+    name: 'ingest_event_batching_input_length',
+    help: 'Length of input batches of events',
+    percentiles: [0.5, 0.9, 0.95, 0.99],
+})
+
+export const ingestEventBatchingBatchCountSummary = new Summary({
+    name: 'ingest_event_batching_batch_count',
+    help: 'Number of batches of events',
+    percentiles: [0.5, 0.9, 0.95, 0.99],
 })

--- a/plugin-server/src/main/ingestion-queues/kafka-metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-metrics.ts
@@ -3,20 +3,6 @@ import { StatsD } from 'hot-shots'
 import { Consumer } from 'kafkajs'
 import { KafkaConsumer } from 'node-rdkafka'
 
-import { Hub } from '../../types'
-
-type PartitionAssignment = {
-    readonly topic: string
-    readonly partitions: readonly number[]
-}
-
-type MemberAssignment = {
-    readonly version: number
-    readonly partitionAssignments: readonly PartitionAssignment[]
-    readonly userData: Buffer
-}
-
-let latestRequestQueueSize = 0
 export function addMetricsEventListeners(consumer: Consumer, statsd: StatsD | undefined): void {
     const listenEvents = [
         consumer.events.GROUP_JOIN,
@@ -37,10 +23,6 @@ export function addMetricsEventListeners(consumer: Consumer, statsd: StatsD | un
     consumer.on(consumer.events.REQUEST, ({ payload }) => {
         statsd?.timing('kafka_queue_consumer_event_request_duration', payload.duration, 0.01)
         statsd?.timing('kafka_queue_consumer_event_request_pending_duration', payload.pendingDuration, 0.01)
-    })
-
-    consumer.on(consumer.events.REQUEST_QUEUE_SIZE, ({ payload }) => {
-        latestRequestQueueSize = payload.queueSize
     })
 }
 
@@ -108,108 +90,4 @@ export function addSentryBreadcrumbsEventListeners(consumer: KafkaConsumer): voi
             },
         })
     })
-}
-
-export async function emitConsumerGroupMetrics(
-    consumer: Consumer,
-    consumerGroupMemberId: string | null,
-    pluginsServer: Hub
-): Promise<void> {
-    try {
-        pluginsServer.statsd?.increment('kafka_consumer_request_queue_size', latestRequestQueueSize, {
-            instanceId: pluginsServer.instanceId.toString(),
-        })
-
-        const timer = new Date()
-        const description = await consumer.describeGroup()
-        pluginsServer.statsd?.timing('kafka_consumer_emit_describe', timer)
-
-        pluginsServer.statsd?.increment('kafka_consumer_group_state', {
-            state: description.state,
-            groupId: description.groupId,
-            instanceId: pluginsServer.instanceId.toString(),
-        })
-
-        const descriptionWithAssignment = description.members.map((member) => ({
-            ...member,
-            assignment: parseMemberAssignment(member.memberAssignment),
-        }))
-
-        const consumerDescription = descriptionWithAssignment.find(
-            (assignment) => assignment.memberId === consumerGroupMemberId
-        )
-
-        let isLive = false
-        if (consumerDescription) {
-            consumerDescription.assignment.partitionAssignments.forEach(({ topic, partitions }) => {
-                isLive = isLive || partitions.length > 0
-                pluginsServer.statsd?.gauge('kafka_consumer_group_assigned_partitions', partitions.length, {
-                    topic,
-                    memberId: consumerGroupMemberId || 'unknown',
-                    groupId: description.groupId,
-                    instanceId: pluginsServer.instanceId.toString(),
-                })
-            })
-        }
-
-        pluginsServer.statsd?.increment(isLive ? 'kafka_consumer_live' : 'kafka_consumer_group_idle', {
-            memberId: consumerGroupMemberId || 'unknown',
-            groupId: description.groupId,
-            instanceId: pluginsServer.instanceId.toString(),
-        })
-    } catch (error) {
-        pluginsServer.statsd?.increment('kafka_consumer_emit_describe_failure', {
-            memberId: consumerGroupMemberId || 'unknown',
-            instanceId: pluginsServer.instanceId.toString(),
-        })
-    }
-}
-
-// Lifted from https://github.com/tulios/kafkajs/issues/755
-const parseMemberAssignment = (data: Buffer): MemberAssignment => {
-    let currentOffset = 0
-
-    const version = data.readInt16BE(currentOffset)
-
-    currentOffset += 2
-
-    const partitionAssignmentCount = data.readInt32BE(currentOffset)
-
-    currentOffset += 4
-
-    const partitionAssignments = []
-
-    for (let n = 0; n < partitionAssignmentCount; n += 1) {
-        const topicNameLength = data.readInt16BE(currentOffset)
-
-        currentOffset += 2
-
-        const topic = data.slice(currentOffset, currentOffset + topicNameLength).toString('utf-8')
-
-        currentOffset += topicNameLength
-
-        const partitionCount = data.readInt32BE(currentOffset)
-
-        currentOffset += 4
-
-        const partitions = []
-
-        for (let n2 = 0; n2 < partitionCount; n2 += 1) {
-            const partition = data.readInt32BE(currentOffset)
-
-            currentOffset += 4
-
-            partitions.push(partition)
-        }
-
-        const partitionAssignment = { topic, partitions } as const
-
-        partitionAssignments.push(partitionAssignment)
-    }
-
-    const userData = data.slice(currentOffset)
-
-    const memberAssignment = { version, partitionAssignments, userData } as const
-
-    return memberAssignment
 }

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -11,7 +11,7 @@ import { KafkaConfig } from '../../utils/db/hub'
 import { timeoutGuard } from '../../utils/db/utils'
 import { status } from '../../utils/status'
 import { killGracefully } from '../../utils/utils'
-import { addMetricsEventListeners, emitConsumerGroupMetrics } from './kafka-metrics'
+import { addMetricsEventListeners } from './kafka-metrics'
 
 type ConsumerManagementPayload = {
     topic: string
@@ -151,10 +151,6 @@ export class KafkaJSIngestionConsumer {
         } catch {}
 
         this.consumerReady = false
-    }
-
-    emitConsumerGroupMetrics(): Promise<void> {
-        return emitConsumerGroupMetrics(this.consumer, this.consumerGroupMemberId, this.pluginsServer)
     }
 
     private static buildConsumer(

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -294,6 +294,7 @@ export const instrumentEachBatch = async (
         statsd?.increment('kafka_queue_each_batch_failed_events', eventCount, {
             topic: topic,
         })
+        kafkaConsumerEachBatchFailedCounter.labels({ topic_name: topic }).inc(eventCount)
         status.warn('💀', `Kafka batch of ${eventCount} events for topic ${topic} failed!`)
         throw error
     }
@@ -314,6 +315,7 @@ export const instrumentEachBatchKafkaJS = async (
         statsd?.increment('kafka_queue_each_batch_failed_events', eventCount, {
             topic: topic,
         })
+        kafkaConsumerEachBatchFailedCounter.labels({ topic_name: topic }).inc(eventCount)
         status.warn('💀', `Kafka batch of ${eventCount} events for topic ${topic} failed!`, {
             stack: error.stack,
             error: error,
@@ -329,9 +331,8 @@ export const instrumentEachBatchKafkaJS = async (
                 'Could not find person with distinct id': 'person_not_found',
                 'The coordinator is not aware of this member': 'not_aware_of_member',
             }
-            for (const [msg, metricSuffix] of Object.entries(messagesToIgnore)) {
+            for (const [msg, _] of Object.entries(messagesToIgnore)) {
                 if (error.message.includes(msg)) {
-                    statsd?.increment('each_batch_error_' + metricSuffix)
                     logToSentry = false
                 }
             }
@@ -354,5 +355,11 @@ export const kafkaConsumerMessagesReadCounter = new Counter({
 export const kafkaConsumerMessagesProcessedCounter = new Counter({
     name: 'kafka_consumer_messages_processed_total',
     help: 'Count of messages successfully processed by Kafka consumer, by source topic.',
+    labelNames: ['topic_name'],
+})
+
+export const kafkaConsumerEachBatchFailedCounter = new Counter({
+    name: 'kafka_consumer_each_batch_failed_total',
+    help: 'Count of each batch failures by source topic.',
     labelNames: ['topic_name'],
 })

--- a/plugin-server/src/main/ingestion-queues/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/metrics.ts
@@ -1,6 +1,6 @@
 // Metrics that make sense across all Kafka consumers
 
-import { Counter, Gauge } from 'prom-client'
+import { Counter, Gauge, Summary } from 'prom-client'
 
 export const kafkaRebalancePartitionCount = new Gauge({
     name: 'kafka_rebalance_partition_count',
@@ -19,4 +19,28 @@ export const eventDroppedCounter = new Counter({
     name: 'ingestion_event_dropped_total',
     help: 'Count of events dropped by the ingestion pipeline, by type and cause.',
     labelNames: ['event_type', 'drop_cause'],
+})
+
+export const kafkaConsumerEventCounter = new Counter({
+    name: 'kafka_consumer_event_total',
+    help: 'Count of events emitted by the Kafka consumer by event type',
+    labelNames: ['event'],
+})
+
+export const kafkaConsumerEventRequestMsSummary = new Summary({
+    name: 'kafka_consumer_event_request_ms',
+    help: 'Duration of Kafka consumer event requests',
+    percentiles: [0.5, 0.9, 0.95, 0.99],
+})
+
+export const kafkaConsumerEventRequestPendingMsSummary = new Summary({
+    name: 'kafka_consumer_event_request_pending_ms',
+    help: 'Pending duration of Kafka consumer event requests',
+    percentiles: [0.5, 0.9, 0.95, 0.99],
+})
+
+export const scheduledTaskCounter = new Counter({
+    name: 'scheduled_task',
+    help: 'Scheduled task status change',
+    labelNames: ['status', 'task'],
 })

--- a/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
@@ -37,10 +37,6 @@ export const startAsyncOnEventHandlerConsumer = async ({
 
     await queue.start()
 
-    schedule.scheduleJob('0 * * * * *', async () => {
-        await queue.emitConsumerGroupMetrics()
-    })
-
     const isHealthy = makeHealthCheck(queue.consumer, queue.sessionTimeout)
 
     return { queue, isHealthy: () => isHealthy() }

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -52,6 +52,11 @@ export type ServerInstance = {
     stop: () => Promise<void>
 }
 
+const pluginServerStartupTimeMs = new Counter({
+    name: 'plugin_server_startup_time_ms',
+    help: 'Time taken to start the plugin server, in milliseconds',
+})
+
 export async function startPluginsServer(
     config: Partial<PluginsServerConfig>,
     makePiscina: (serverConfig: PluginsServerConfig, hub: Hub) => Promise<Piscina> = defaultMakePiscina,
@@ -405,6 +410,7 @@ export async function startPluginsServer(
             serverInstance.stop = closeJobs
 
             hub.statsd?.timing('total_setup_time', timer)
+            pluginServerStartupTimeMs.inc(Date.now() - timer.valueOf())
             status.info('🚀', 'All systems go')
 
             hub.lastActivity = new Date().valueOf()

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -7,6 +7,7 @@ import Redis from 'ioredis'
 import { ProducerRecord } from 'kafkajs'
 import { DateTime } from 'luxon'
 import { QueryResult } from 'pg'
+import { Counter } from 'prom-client'
 
 import { CELERY_DEFAULT_QUEUE } from '../../config/constants'
 import { KAFKA_GROUPS, KAFKA_PERSON_DISTINCT_ID, KAFKA_PLUGIN_LOG_ENTRIES } from '../../config/kafka-topics'
@@ -139,6 +140,28 @@ export const POSTGRES_UNAVAILABLE_ERROR_MESSAGES = [
     'ETIMEDOUT',
     'query_wait_timeout', // Waiting on PG bouncer to give us a slot
 ]
+
+const groupInfoCacheResultCounter = new Counter({
+    name: 'group_info_cache_result',
+    help: 'Group info cache result',
+    labelNames: ['result'],
+})
+
+const groupDataMissingCounter = new Counter({
+    name: 'group_data_missing',
+    help: 'Group data missing',
+})
+
+const personUpdateVersionMismatchCounter = new Counter({
+    name: 'person_update_version_mismatch',
+    help: 'Person update version mismatch',
+})
+
+const pluginLogEntryCounter = new Counter({
+    name: 'plugin_log_entry',
+    help: 'Plugin log entry created by plugin',
+    labelNames: ['plugin_id', 'source'],
+})
 
 /** The recommended way of accessing the database. */
 export class DB {
@@ -497,6 +520,7 @@ export class DB {
 
                 if (cachedGroupData) {
                     this.statsd?.increment('group_info_cache.hit')
+                    groupInfoCacheResultCounter.labels({ result: 'hit' }).inc()
                     groupPropertiesColumns[propertiesColumnName] = JSON.stringify(cachedGroupData.properties)
                     groupCreatedAtColumns[createdAtColumnName] = cachedGroupData.created_at
 
@@ -507,6 +531,7 @@ export class DB {
             }
 
             this.statsd?.increment('group_info_cache.miss')
+            groupInfoCacheResultCounter.labels({ result: 'miss' }).inc()
 
             // If we didn't find cached data, lookup the group from Postgres
             const storedGroupData = await this.fetchGroup(teamId, groupTypeIndex as GroupTypeIndex, groupKey)
@@ -534,6 +559,7 @@ export class DB {
             } else {
                 // We couldn't find the data from the cache nor Postgres, so record this in a metric and in Sentry
                 this.statsd?.increment('groups_data_missing_entirely')
+                groupDataMissingCounter.inc()
                 status.debug('🔍', `Could not find group data for group ${groupCacheKey} in cache or storage`)
 
                 groupPropertiesColumns[propertiesColumnName] = '{}'
@@ -774,6 +800,7 @@ export class DB {
         const versionDisparity = updatedPerson.version - person.version - 1
         if (versionDisparity > 0) {
             this.statsd?.increment('person_update_version_mismatch', { versionDisparity: String(versionDisparity) })
+            personUpdateVersionMismatchCounter.inc()
         }
 
         const kafkaMessages = []
@@ -1099,11 +1126,6 @@ export class DB {
         if (parsedEntry.message.length > 50_000) {
             const { message, ...rest } = parsedEntry
             status.warn('⚠️', 'Plugin log entry too long, ignoring.', rest)
-            this.statsd?.increment('logs.entries_too_large', {
-                source,
-                team_id: pluginConfig.team_id.toString(),
-                plugin_id: pluginConfig.plugin_id.toString(),
-            })
             return
         }
 
@@ -1112,11 +1134,7 @@ export class DB {
             team_id: pluginConfig.team_id.toString(),
             plugin_id: pluginConfig.plugin_id.toString(),
         })
-        this.statsd?.increment('logs.entries_size', {
-            source,
-            team_id: pluginConfig.team_id.toString(),
-            plugin_id: pluginConfig.plugin_id.toString(),
-        })
+        pluginLogEntryCounter.labels({ plugin_id: String(pluginConfig.plugin_id), source }).inc()
 
         try {
             await this.kafkaProducer.queueSingleJsonMessage(

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -7,7 +7,6 @@ import Redis from 'ioredis'
 import { ProducerRecord } from 'kafkajs'
 import { DateTime } from 'luxon'
 import { QueryResult } from 'pg'
-import { Counter } from 'prom-client'
 
 import { CELERY_DEFAULT_QUEUE } from '../../config/constants'
 import { KAFKA_GROUPS, KAFKA_PERSON_DISTINCT_ID, KAFKA_PLUGIN_LOG_ENTRIES } from '../../config/kafka-topics'
@@ -67,6 +66,12 @@ import {
 } from '../utils'
 import { OrganizationPluginsAccessLevel } from './../../types'
 import { KafkaProducerWrapper } from './kafka-producer-wrapper'
+import {
+    groupDataMissingCounter,
+    groupInfoCacheResultCounter,
+    personUpdateVersionMismatchCounter,
+    pluginLogEntryCounter,
+} from './metrics'
 import { PostgresRouter, PostgresUse, TransactionClient } from './postgres'
 import {
     generateKafkaPersonUpdateMessage,
@@ -140,28 +145,6 @@ export const POSTGRES_UNAVAILABLE_ERROR_MESSAGES = [
     'ETIMEDOUT',
     'query_wait_timeout', // Waiting on PG bouncer to give us a slot
 ]
-
-const groupInfoCacheResultCounter = new Counter({
-    name: 'group_info_cache_result',
-    help: 'Group info cache result',
-    labelNames: ['result'],
-})
-
-const groupDataMissingCounter = new Counter({
-    name: 'group_data_missing',
-    help: 'Group data missing',
-})
-
-const personUpdateVersionMismatchCounter = new Counter({
-    name: 'person_update_version_mismatch',
-    help: 'Person update version mismatch',
-})
-
-const pluginLogEntryCounter = new Counter({
-    name: 'plugin_log_entry',
-    help: 'Plugin log entry created by plugin',
-    labelNames: ['plugin_id', 'source'],
-})
 
 /** The recommended way of accessing the database. */
 export class DB {

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -135,7 +135,7 @@ export async function createHub(
         status.warn('🪣', `Object storage could not be created`)
     }
 
-    const promiseManager = new PromiseManager(serverConfig, statsd)
+    const promiseManager = new PromiseManager(serverConfig)
 
     const db = new DB(
         postgres,

--- a/plugin-server/src/utils/db/metrics.ts
+++ b/plugin-server/src/utils/db/metrics.ts
@@ -1,0 +1,23 @@
+import { Counter } from 'prom-client'
+
+export const groupInfoCacheResultCounter = new Counter({
+    name: 'group_info_cache_result',
+    help: 'Group info cache result',
+    labelNames: ['result'],
+})
+
+export const groupDataMissingCounter = new Counter({
+    name: 'group_data_missing',
+    help: 'Group data missing',
+})
+
+export const personUpdateVersionMismatchCounter = new Counter({
+    name: 'person_update_version_mismatch',
+    help: 'Person update version mismatch',
+})
+
+export const pluginLogEntryCounter = new Counter({
+    name: 'plugin_log_entry',
+    help: 'Plugin log entry created by plugin',
+    labelNames: ['plugin_id', 'source'],
+})

--- a/plugin-server/src/worker/ingestion/event-pipeline/metrics.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/metrics.ts
@@ -1,10 +1,5 @@
 import { Counter, Summary } from 'prom-client'
 
-export const pipelineStepCompletionCounter = new Counter({
-    name: 'events_pipeline_step_executed_total',
-    help: 'Number of events that have completed the step',
-    labelNames: ['step_name'],
-})
 export const pipelineLastStepCounter = new Counter({
     name: 'events_pipeline_last_step_total',
     help: 'Number of events that have entered the last step',

--- a/plugin-server/src/worker/ingestion/event-pipeline/metrics.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/metrics.ts
@@ -1,0 +1,55 @@
+import { Counter, Summary } from 'prom-client'
+
+export const pipelineStepCompletionCounter = new Counter({
+    name: 'events_pipeline_step_executed_total',
+    help: 'Number of events that have completed the step',
+    labelNames: ['step_name'],
+})
+export const pipelineLastStepCounter = new Counter({
+    name: 'events_pipeline_last_step_total',
+    help: 'Number of events that have entered the last step',
+    labelNames: ['step_name'],
+})
+export const pipelineStepErrorCounter = new Counter({
+    name: 'events_pipeline_step_error_total',
+    help: 'Number of events that have errored in the step',
+    labelNames: ['step_name'],
+})
+export const pipelineStepMsSummary = new Summary({
+    name: 'events_pipeline_step_ms',
+    help: 'Duration spent in each step',
+    percentiles: [0.5, 0.9, 0.95, 0.99],
+    labelNames: ['step_name'],
+})
+export const pipelineStepThrowCounter = new Counter({
+    name: 'events_pipeline_step_throw_total',
+    help: 'Number of events that have thrown error in the step',
+    labelNames: ['step_name'],
+})
+export const pipelineStepDLQCounter = new Counter({
+    name: 'events_pipeline_step_dlq_total',
+    help: 'Number of events that have been sent to DLQ in the step',
+    labelNames: ['step_name'],
+})
+
+export const eventProcessedAndIngestedCounter = new Counter({
+    name: 'event_processed_and_ingested',
+    help: 'Count of events processed and ingested',
+})
+
+export const invalidTimestampCounter = new Counter({
+    name: 'invalid_timestamp_total',
+    help: 'Count of events with invalid timestamp',
+    labelNames: ['type'],
+})
+
+export const droppedEventCounter = new Counter({
+    name: 'event_pipeline_dropped_events_total',
+    help: 'Count of events dropped by plugin server',
+})
+
+export const tokenOrTeamPresentCounter = new Counter({
+    name: 'ingestion_event_hasauthinfo_total',
+    help: 'Count of events by presence of the team_id and token field.',
+    labelNames: ['team_id_present', 'token_present'],
+})

--- a/plugin-server/src/worker/ingestion/event-pipeline/pluginsProcessEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/pluginsProcessEventStep.ts
@@ -1,14 +1,9 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import { Counter } from 'prom-client'
 
 import { runInstrumentedFunction } from '../../../main/utils'
 import { runProcessEvent } from '../../plugins/run'
+import { droppedEventCounter } from './metrics'
 import { EventPipelineRunner } from './runner'
-
-const droppedEventCounter = new Counter({
-    name: 'event_pipeline_dropped_events_total',
-    help: 'Count of events dropped by plugin server',
-})
 
 export async function pluginsProcessEventStep(
     runner: EventPipelineRunner,

--- a/plugin-server/src/worker/ingestion/event-pipeline/pluginsProcessEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/pluginsProcessEventStep.ts
@@ -1,8 +1,14 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
+import { Counter } from 'prom-client'
 
 import { runInstrumentedFunction } from '../../../main/utils'
 import { runProcessEvent } from '../../plugins/run'
 import { EventPipelineRunner } from './runner'
+
+const droppedEventCounter = new Counter({
+    name: 'event_pipeline_dropped_events_total',
+    help: 'Count of events dropped by plugin server',
+})
 
 export async function pluginsProcessEventStep(
     runner: EventPipelineRunner,
@@ -25,6 +31,7 @@ export async function pluginsProcessEventStep(
         runner.hub.statsd?.increment('kafka_queue.dropped_event', {
             teamID: String(event.team_id),
         })
+        droppedEventCounter.inc()
         return null
     }
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
@@ -1,17 +1,11 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import { Counter } from 'prom-client'
 
 import { eventDroppedCounter } from '../../../main/ingestion-queues/metrics'
 import { PipelineEvent } from '../../../types'
 import { UUID } from '../../../utils/utils'
 import { captureIngestionWarning } from '../utils'
+import { tokenOrTeamPresentCounter } from './metrics'
 import { EventPipelineRunner } from './runner'
-
-export const tokenOrTeamPresentCounter = new Counter({
-    name: 'ingestion_event_hasauthinfo_total',
-    help: 'Count of events by presence of the team_id and token field.',
-    labelNames: ['team_id_present', 'token_present'],
-})
 
 export async function populateTeamDataStep(
     runner: EventPipelineRunner,

--- a/plugin-server/src/worker/ingestion/event-pipeline/prepareEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/prepareEventStep.ts
@@ -1,16 +1,10 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import { Counter } from 'prom-client'
 import { PreIngestionEvent } from 'types'
 
 import { parseEventTimestamp } from '../timestamps'
 import { captureIngestionWarning } from '../utils'
+import { invalidTimestampCounter } from './metrics'
 import { EventPipelineRunner } from './runner'
-
-const invalidTimestampCounter = new Counter({
-    name: 'invalid_timestamp_total',
-    help: 'Count of events with invalid timestamp',
-    labelNames: ['type'],
-})
 
 export async function prepareEventStep(runner: EventPipelineRunner, event: PluginEvent): Promise<PreIngestionEvent> {
     const { team_id, uuid } = event

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -12,7 +12,6 @@ import { createEventStep } from './createEventStep'
 import {
     eventProcessedAndIngestedCounter,
     pipelineLastStepCounter,
-    pipelineStepCompletionCounter,
     pipelineStepDLQCounter,
     pipelineStepErrorCounter,
     pipelineStepMsSummary,
@@ -176,7 +175,6 @@ export class EventPipelineRunner {
                 )
                 try {
                     const result = await step(...args)
-                    pipelineStepCompletionCounter.labels(step.name).inc()
                     pipelineStepMsSummary.labels(step.name).observe(Date.now() - timer.getTime())
                     this.hub.statsd?.increment('kafka_queue.event_pipeline.step', { step: step.name })
                     this.hub.statsd?.timing('kafka_queue.event_pipeline.step.timing', timer, { step: step.name })

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -319,10 +319,6 @@ export class HookCommander {
                     await Promise.all(restHookRequests).catch((error) =>
                         captureException(error, { tags: { team_id: event.teamId } })
                     )
-
-                    this.statsd?.increment('zapier_hooks_fired', {
-                        team_id: String(team.id),
-                    })
                 }
             })
         }
@@ -397,9 +393,6 @@ export class HookCommander {
                         successes: 1,
                     })
                 }
-            })
-            this.statsd?.increment('webhook_firings', {
-                team_id: event.teamId.toString(),
             })
         } catch (error) {
             await this.appMetrics.queueError(
@@ -478,7 +471,6 @@ export class HookCommander {
                     successes: 1,
                 })
             }
-            this.statsd?.increment('rest_hook_firings')
         } catch (error) {
             await this.appMetrics.queueError(
                 {

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -329,7 +329,6 @@ export class PersonState {
             return undefined
         }
         if (isDistinctIdIllegal(mergeIntoDistinctId)) {
-            this.statsd?.increment('illegal_distinct_ids.total', { distinctId: mergeIntoDistinctId })
             await captureIngestionWarning(this.db, teamId, 'cannot_merge_with_illegal_distinct_id', {
                 illegalDistinctId: mergeIntoDistinctId,
                 otherDistinctId: otherPersonDistinctId,
@@ -338,7 +337,6 @@ export class PersonState {
             return undefined
         }
         if (isDistinctIdIllegal(otherPersonDistinctId)) {
-            this.statsd?.increment('illegal_distinct_ids.total', { distinctId: otherPersonDistinctId })
             await captureIngestionWarning(this.db, teamId, 'cannot_merge_with_illegal_distinct_id', {
                 illegalDistinctId: otherPersonDistinctId,
                 otherDistinctId: mergeIntoDistinctId,

--- a/plugin-server/src/worker/ingestion/property-definitions-cache.ts
+++ b/plugin-server/src/worker/ingestion/property-definitions-cache.ts
@@ -58,10 +58,6 @@ export class PropertyDefinitionsCache {
         }
 
         this.propertyDefinitionsCache.set(teamId, teamPropertyDefinitionsCache)
-
-        this.statsd?.gauge('propertyDefinitionsCache.length', teamPropertyDefinitionsCache.length ?? 0, {
-            team_id: teamId.toString(),
-        })
     }
 
     has(teamId: number): boolean {
@@ -91,10 +87,6 @@ export class PropertyDefinitionsCache {
             this.key(property, type, groupTypeIndex),
             detectedPropertyType ?? NULL_AFTER_PROPERTY_TYPE_DETECTION
         )
-
-        this.statsd?.gauge('propertyDefinitionsCache.length', teamCache?.length ?? 0, {
-            team_id: teamId.toString(),
-        })
     }
 
     get(teamId: number): LRUCache<string, string | symbol> | undefined {

--- a/plugin-server/src/worker/plugins/loadSchedule.ts
+++ b/plugin-server/src/worker/plugins/loadSchedule.ts
@@ -1,5 +1,12 @@
+import { Summary } from 'prom-client'
+
 import { Hub, PluginConfigId } from '../../types'
 import { status } from '../../utils/status'
+
+const loadScheduleMsSummary = new Summary({
+    name: 'load_schedule_ms',
+    help: 'Time to load schedule',
+})
 
 export async function loadSchedule(server: Hub): Promise<void> {
     const timer = new Date()
@@ -26,4 +33,5 @@ export async function loadSchedule(server: Hub): Promise<void> {
 
     server.pluginSchedule = pluginSchedule
     server.statsd?.timing('load_schedule.success', timer)
+    loadScheduleMsSummary.observe(new Date().getTime() - timer.getTime())
 }

--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -1,4 +1,5 @@
 import { PluginEvent, PostHogEvent, ProcessedPluginEvent, Webhook } from '@posthog/plugin-scaffold'
+import { Summary } from 'prom-client'
 
 import { Hub, PluginConfig, PluginTaskType, VMMethods } from '../../types'
 import { processError } from '../../utils/db/error'
@@ -6,6 +7,13 @@ import { trackedFetch } from '../../utils/fetch'
 import { instrument } from '../../utils/metrics'
 import { status } from '../../utils/status'
 import { IllegalOperationError } from '../../utils/utils'
+
+const pluginActionMsSummary = new Summary({
+    name: 'plugin_action_ms',
+    help: 'Time to run plugin action',
+    labelNames: ['plugin_id', 'action', 'status'],
+    percentiles: [0.5, 0.9, 0.95, 0.99],
+})
 
 async function runSingleTeamPluginOnEvent(
     hub: Hub,
@@ -27,6 +35,9 @@ async function runSingleTeamPluginOnEvent(
         const timer = new Date()
         try {
             await onEvent!(event)
+            pluginActionMsSummary
+                .labels(pluginConfig.id.toString(), 'onEvent', 'success')
+                .observe(new Date().getTime() - timer.getTime())
             await hub.appMetrics.queueMetric({
                 teamId: event.team_id,
                 pluginConfigId: pluginConfig.id,
@@ -35,6 +46,9 @@ async function runSingleTeamPluginOnEvent(
             })
         } catch (error) {
             hub.statsd?.increment(`${metricName}.ERROR`, metricTags)
+            pluginActionMsSummary
+                .labels(pluginConfig.id.toString(), 'onEvent', 'error')
+                .observe(new Date().getTime() - timer.getTime())
             await processError(hub, pluginConfig, error, event)
             await hub.appMetrics.queueError(
                 {
@@ -115,6 +129,9 @@ async function runSingleTeamPluginComposeWebhook(
                 timeout: hub.EXTERNAL_REQUEST_TIMEOUT_MS,
             })
             if (request.ok) {
+                pluginActionMsSummary
+                    .labels(pluginConfig.id.toString(), 'composeWebhook', 'success')
+                    .observe(new Date().getTime() - timer.getTime())
                 await hub.appMetrics.queueMetric({
                     teamId: event.team_id,
                     pluginConfigId: pluginConfig.id,
@@ -123,6 +140,9 @@ async function runSingleTeamPluginComposeWebhook(
                 })
             } else {
                 hub.statsd?.increment(`${metricName}.ERROR`, metricTags)
+                pluginActionMsSummary
+                    .labels(pluginConfig.id.toString(), 'composeWebhook', 'success')
+                    .observe(new Date().getTime() - timer.getTime())
                 const error = `Fetch to ${webhook.url} failed with ${request.statusText}`
                 await processError(hub, pluginConfig, error, event)
                 await hub.appMetrics.queueError(
@@ -140,6 +160,10 @@ async function runSingleTeamPluginComposeWebhook(
             }
         } catch (error) {
             hub.statsd?.increment(`${metricName}.ERROR`, metricTags)
+            pluginActionMsSummary
+                .labels(pluginConfig.id.toString(), 'composeWebhook', 'error')
+                .observe(new Date().getTime() - timer.getTime())
+
             await processError(hub, pluginConfig, error, event)
             await hub.appMetrics.queueError(
                 {
@@ -215,6 +239,9 @@ export async function runProcessEvent(hub: Hub, event: PluginEvent): Promise<Plu
                     throw new IllegalOperationError('Plugin tried to change event.team_id')
                 }
                 pluginsSucceeded.push(pluginIdentifier)
+                pluginActionMsSummary
+                    .labels(pluginConfig.id.toString(), 'processEvent', 'success')
+                    .observe(new Date().getTime() - timer.getTime())
                 await hub.appMetrics.queueMetric({
                     teamId,
                     pluginConfigId: pluginConfig.id,
@@ -223,6 +250,10 @@ export async function runProcessEvent(hub: Hub, event: PluginEvent): Promise<Plu
                 })
             } catch (error) {
                 await processError(hub, pluginConfig, error, returnedEvent)
+                pluginActionMsSummary
+                    .labels(pluginConfig.id.toString(), 'processEvent', 'error')
+                    .observe(new Date().getTime() - timer.getTime())
+
                 hub.statsd?.increment(`plugin.process_event.ERROR`, {
                     plugin: pluginConfig.plugin?.name ?? '?',
                     teamId: String(event.team_id),
@@ -314,6 +345,9 @@ export async function runPluginTask(
             () => (payload ? task?.exec(payload) : task?.exec())
         )
 
+        pluginActionMsSummary
+            .labels(String(pluginConfig?.plugin?.id), 'task', 'success')
+            .observe(new Date().getTime() - timer.getTime())
         if (shouldQueueAppMetric && teamId) {
             await hub.appMetrics.queueMetric({
                 teamId: teamId,
@@ -332,6 +366,9 @@ export async function runPluginTask(
             teamId: teamId?.toString() ?? '?',
         })
 
+        pluginActionMsSummary
+            .labels(String(pluginConfig?.plugin?.id), 'task', 'error')
+            .observe(new Date().getTime() - timer.getTime())
         if (shouldQueueAppMetric && teamId) {
             await hub.appMetrics.queueError(
                 {

--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -141,7 +141,7 @@ async function runSingleTeamPluginComposeWebhook(
             } else {
                 hub.statsd?.increment(`${metricName}.ERROR`, metricTags)
                 pluginActionMsSummary
-                    .labels(pluginConfig.id.toString(), 'composeWebhook', 'success')
+                    .labels(pluginConfig.id.toString(), 'composeWebhook', 'error')
                     .observe(new Date().getTime() - timer.getTime())
                 const error = `Fetch to ${webhook.url} failed with ${request.statusText}`
                 await processError(hub, pluginConfig, error, event)
@@ -163,7 +163,6 @@ async function runSingleTeamPluginComposeWebhook(
             pluginActionMsSummary
                 .labels(pluginConfig.id.toString(), 'composeWebhook', 'error')
                 .observe(new Date().getTime() - timer.getTime())
-
             await processError(hub, pluginConfig, error, event)
             await hub.appMetrics.queueError(
                 {
@@ -253,7 +252,6 @@ export async function runProcessEvent(hub: Hub, event: PluginEvent): Promise<Plu
                 pluginActionMsSummary
                     .labels(pluginConfig.id.toString(), 'processEvent', 'error')
                     .observe(new Date().getTime() - timer.getTime())
-
                 hub.statsd?.increment(`plugin.process_event.ERROR`, {
                     plugin: pluginConfig.plugin?.name ?? '?',
                     teamId: String(event.team_id),
@@ -358,14 +356,12 @@ export async function runPluginTask(
         }
     } catch (error) {
         await processError(hub, pluginConfig || null, error)
-
         hub.statsd?.increment(`plugin.task.ERROR`, {
             taskType: taskType,
             taskName: taskName,
             pluginConfigId: pluginConfigId.toString(),
             teamId: teamId?.toString() ?? '?',
         })
-
         pluginActionMsSummary
             .labels(String(pluginConfig?.plugin?.id), 'task', 'error')
             .observe(new Date().getTime() - timer.getTime())

--- a/plugin-server/src/worker/vm/extensions/jobs.ts
+++ b/plugin-server/src/worker/vm/extensions/jobs.ts
@@ -1,3 +1,5 @@
+import { Counter } from 'prom-client'
+
 import { Hub, PluginConfig, PluginLogEntryType } from '../../../types'
 
 type JobRunner = {
@@ -37,6 +39,12 @@ export function durationToMs(duration: number, unit: string): number {
     return durations[unit] * duration
 }
 
+const pluginJobEnqueueCounter = new Counter({
+    name: 'plugin_job_enqueue_total',
+    help: 'Count of plugin jobs enqueued',
+    labelNames: ['plugin_id'],
+})
+
 export function createJobs(server: Hub, pluginConfig: PluginConfig): Jobs {
     /**
      * Helper function to enqueue jobs to be executed by the jobs pool.
@@ -53,8 +61,8 @@ export function createJobs(server: Hub, pluginConfig: PluginConfig): Jobs {
                 pluginConfigId: pluginConfig.id,
                 pluginConfigTeam: pluginConfig.team_id,
             }
-            // TODO: port to Prometheus, once we have multi-process metrics collection (running in piscina worker here)
             server.statsd?.increment('job_enqueue_attempt')
+            pluginJobEnqueueCounter.labels(String(pluginConfig.plugin?.id)).inc()
             await server.enqueuePluginJob(job)
         } catch (e) {
             await pluginConfig.vm?.createLogEntry(

--- a/plugin-server/src/worker/vm/extensions/posthog.ts
+++ b/plugin-server/src/worker/vm/extensions/posthog.ts
@@ -1,6 +1,7 @@
 import { Properties } from '@posthog/plugin-scaffold'
 import crypto from 'crypto'
 import { DateTime } from 'luxon'
+import { Counter } from 'prom-client'
 import { Hub, PluginConfig, RawEventMessage } from 'types'
 
 import { UUIDT } from '../../../utils/utils'
@@ -47,6 +48,12 @@ async function queueEvent(hub: Hub, pluginConfig: PluginConfig, data: InternalDa
     })
 }
 
+const vmPosthogExtensionCaptureCalledCounter = new Counter({
+    name: 'vm_posthog_extension_capture_called_total',
+    help: 'Count of times vm posthog extension capture was called',
+    labelNames: ['plugin_id'],
+})
+
 export function createPosthog(hub: Hub, pluginConfig: PluginConfig): DummyPostHog {
     const distinctId = pluginConfig.plugin?.name || `plugin-id-${pluginConfig.plugin_id}`
 
@@ -68,6 +75,7 @@ export function createPosthog(hub: Hub, pluginConfig: PluginConfig): DummyPostHo
             }
             await queueEvent(hub, pluginConfig, data)
             hub.statsd?.increment('vm_posthog_extension_capture_called')
+            vmPosthogExtensionCaptureCalledCounter.labels(String(pluginConfig.plugin?.id)).inc()
         },
         api: createApi(hub, pluginConfig),
     }

--- a/plugin-server/src/worker/vm/extensions/storage.ts
+++ b/plugin-server/src/worker/vm/extensions/storage.ts
@@ -1,8 +1,21 @@
 import { StorageExtension } from '@posthog/plugin-scaffold'
+import { Counter, Summary } from 'prom-client'
 
 import { Hub, PluginConfig } from '../../../types'
 import { PostgresUse } from '../../../utils/db/postgres'
 import { postgresGet } from '../utils'
+
+const vmExtensionStorageGetCounter = new Counter({
+    name: 'vm_extension_storage_get_total',
+    help: 'Count of times vm extension storage get was called',
+    labelNames: ['plugin_id'],
+})
+const vmExtensionStorageSetMsSummary = new Summary({
+    name: 'vm_extension_storage_set_ms',
+    help: 'Time to set storage value',
+    labelNames: ['plugin_id'],
+    percentiles: [0.5, 0.9, 0.95, 0.99],
+})
 
 export function createStorage(server: Hub, pluginConfig: PluginConfig): StorageExtension {
     const get = async function (key: string, defaultValue: unknown): Promise<unknown> {
@@ -10,6 +23,7 @@ export function createStorage(server: Hub, pluginConfig: PluginConfig): StorageE
             plugin: pluginConfig.plugin?.name ?? '?',
             team_id: pluginConfig.team_id.toString(),
         })
+        vmExtensionStorageGetCounter.labels(String(pluginConfig.plugin?.id)).inc()
 
         const result = await postgresGet(server.db, pluginConfig.id, key)
         return result?.rows.length === 1 ? JSON.parse(result.rows[0].value) : defaultValue
@@ -40,6 +54,9 @@ export function createStorage(server: Hub, pluginConfig: PluginConfig): StorageE
             plugin: pluginConfig.plugin?.name ?? '?',
             team_id: pluginConfig.team_id.toString(),
         })
+        vmExtensionStorageSetMsSummary
+            .labels(String(pluginConfig.plugin?.id))
+            .observe(new Date().getTime() - timer.getTime())
     }
 
     const del = async function (key: string): Promise<void> {

--- a/plugin-server/src/worker/vm/promise-manager.ts
+++ b/plugin-server/src/worker/vm/promise-manager.ts
@@ -1,17 +1,13 @@
-import { StatsD } from 'hot-shots'
-
 import { PluginsServerConfig } from '../../types'
 import { status } from '../../utils/status'
 
 export class PromiseManager {
     pendingPromises: Set<Promise<any>>
     config: PluginsServerConfig
-    statsd?: StatsD
 
-    constructor(config: PluginsServerConfig, statsd?: StatsD) {
+    constructor(config: PluginsServerConfig) {
         this.pendingPromises = new Set()
         this.config = config
-        this.statsd = statsd
     }
 
     public trackPromise(promise: Promise<any>, key: string): void {
@@ -20,14 +16,12 @@ export class PromiseManager {
         }
 
         status.info('🤝', `Tracking promise ${key} count = ${this.pendingPromises.size}`)
-        this.statsd?.increment(`worker_promise_manager_promise_start`, { key })
         this.pendingPromises.add(promise)
 
         promise.finally(() => {
             this.pendingPromises.delete(promise)
         })
         status.info('✅', `Tracking promise finished ${key}`)
-        this.statsd?.increment(`worker_promise_manager_promise_end`, { key })
     }
 
     public async awaitPromisesIfNeeded(): Promise<void> {
@@ -35,7 +29,6 @@ export class PromiseManager {
         while (this.pendingPromises.size > this.config.MAX_PENDING_PROMISES_PER_WORKER) {
             status.info('🤝', `looping in awaitPromise since ${startTime} count = ${this.pendingPromises.size}`)
             await Promise.race(this.pendingPromises)
-            this.statsd?.increment('worker_promise_manager_promises_awaited')
         }
         status.info('🕐', `Finished awaiting promises ${performance.now() - startTime}`)
     }

--- a/plugin-server/src/worker/vm/upgrades/export-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/export-events.ts
@@ -92,13 +92,8 @@ export function upgradeExportEvents(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         meta: PluginMeta<ExportEventsUpgrade>
     ) => {
-        const start = new Date()
         try {
             await methods.exportEvents?.(payload.batch)
-            hub.statsd?.timing('plugin.export_events.success', start, {
-                plugin: pluginConfig.plugin?.name ?? '?',
-                teamId: pluginConfig.team_id.toString(),
-            })
             await hub.appMetrics.queueMetric({
                 teamId: pluginConfig.team_id,
                 pluginConfigId: pluginConfig.id,

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -220,10 +220,6 @@ export function addHistoricalEventsExportCapabilityV2(
             createLog(`Starting export ${dateFrom} - ${dateTo}. id=${id}, parallelism=${parallelism}`, {
                 type: PluginLogEntryType.Info,
             })
-            hub.statsd?.increment('historical_export.started', {
-                teamId: pluginConfig.team_id.toString(),
-                plugin: pluginConfig.plugin?.name ?? '?',
-            })
 
             await coordinateHistoricalExport()
         },
@@ -300,10 +296,6 @@ export function addHistoricalEventsExportCapabilityV2(
                         )} seems inactive, restarting!`,
                         { type: PluginLogEntryType.Debug }
                     )
-                    hub.statsd?.increment('historical_export.chunks_resumed', {
-                        teamId: pluginConfig.team_id.toString(),
-                        plugin: pluginConfig.plugin?.name ?? '?',
-                    })
                     await startChunk(payload, payload.progress)
                 })
             )
@@ -488,10 +480,6 @@ export function addHistoricalEventsExportCapabilityV2(
                     successes: payload.retriesPerformedSoFar == 0 ? events.length : 0,
                     successesOnRetry: payload.retriesPerformedSoFar == 0 ? 0 : events.length,
                 })
-                hub.statsd?.increment('historical_export.chunks_success', {
-                    teamId: pluginConfig.team_id.toString(),
-                    plugin: pluginConfig.plugin?.name ?? '?',
-                })
             } catch (error) {
                 clearInterval(interval)
 
@@ -533,11 +521,6 @@ export function addHistoricalEventsExportCapabilityV2(
                     type: PluginLogEntryType.Warn,
                 }
             )
-            hub.statsd?.increment('historical_export.chunks_error', {
-                teamId: pluginConfig.team_id.toString(),
-                plugin: pluginConfig.plugin?.name ?? '?',
-                retriable: 'true',
-            })
 
             await meta.jobs
                 .exportHistoricalEventsV2({
@@ -556,11 +539,6 @@ export function addHistoricalEventsExportCapabilityV2(
                 await stopExport(params, `exportEvents returned unknown error, stopping export. error=${error}`, 'fail')
                 await processError(hub, pluginConfig, error)
             }
-            hub.statsd?.increment('historical_export.chunks_error', {
-                teamId: pluginConfig.team_id.toString(),
-                plugin: pluginConfig.plugin?.name ?? '?',
-                retriable: 'false',
-            })
             await hub.appMetrics.queueError(
                 {
                     teamId: pluginConfig.team_id,
@@ -594,10 +572,6 @@ export function addHistoricalEventsExportCapabilityV2(
                     type: PluginLogEntryType.Warn,
                 }
             )
-            hub.statsd?.increment('historical_export.fetch_fail', {
-                teamId: pluginConfig.team_id.toString(),
-                plugin: pluginConfig.plugin?.name ?? '?',
-            })
 
             await meta.jobs
                 .exportHistoricalEventsV2({
@@ -616,11 +590,6 @@ export function addHistoricalEventsExportCapabilityV2(
                 await processError(hub, pluginConfig, error)
                 await stopExport(params, 'Failed fetching events. Stopping export - please try again later.', 'fail')
             }
-            hub.statsd?.increment('historical_export.chunks_error', {
-                teamId: pluginConfig.team_id.toString(),
-                plugin: pluginConfig.plugin?.name ?? '?',
-                retriable: 'false',
-            })
             await hub.appMetrics.queueError(
                 {
                     teamId: pluginConfig.team_id,
@@ -664,11 +633,6 @@ export function addHistoricalEventsExportCapabilityV2(
 
         createLog(message, {
             type: status === 'success' ? PluginLogEntryType.Info : PluginLogEntryType.Error,
-        })
-
-        hub.statsd?.increment(`historical_export.${status}`, {
-            teamId: pluginConfig.team_id.toString(),
-            plugin: pluginConfig.plugin?.name ?? '?',
         })
     }
 

--- a/plugin-server/src/worker/vm/upgrades/utils/export-events-buffer.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/export-events-buffer.ts
@@ -49,8 +49,6 @@ export class ExportEventsBuffer {
     }
 
     public async flush(): Promise<void> {
-        this.hub.statsd?.increment(`buffer_voided_promises`, { instanceId: this.hub.instanceId.toString() })
-
         const oldBuffer = this.buffer
         const oldPoints = this.points
         this.buffer = []
@@ -63,7 +61,7 @@ export class ExportEventsBuffer {
         await this.hub.promiseManager.awaitPromisesIfNeeded()
     }
 
-    public async _flush(oldBuffer: any[], oldPoints: number, timer: Date): Promise<void> {
+    public async _flush(oldBuffer: any[], oldPoints: number, _: Date): Promise<void> {
         if (this.timeout) {
             clearTimeout(this.timeout)
             this.timeout = null
@@ -91,7 +89,5 @@ export class ExportEventsBuffer {
         } finally {
             clearTimeout(slowTimeout)
         }
-
-        this.hub.statsd?.timing(`buffer_promise_duration`, timer)
     }
 }

--- a/plugin-server/tests/main/ingestion-queues/kafka-queue.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/kafka-queue.test.ts
@@ -70,16 +70,6 @@ describe.skip('IngestionConsumer', () => {
         const events = await hub.db.fetchEvents()
 
         expect(events.length).toEqual(1)
-
-        const statsdTimingCalls = (hub.statsd?.timing as any).mock.calls
-
-        const mainIngestionCalls = statsdTimingCalls.filter(
-            (item: string[]) => item[0] === 'kafka_queue.single_ingestion'
-        )
-        expect(mainIngestionCalls.length).toEqual(1)
-
-        const bufferCalls = statsdTimingCalls.filter((item: string[]) => item[0] === 'kafka_queue.ingest_buffer_event')
-        expect(bufferCalls.length).toEqual(1)
     })
 })
 

--- a/plugin-server/tests/main/jobs/graphile-worker.test.ts
+++ b/plugin-server/tests/main/jobs/graphile-worker.test.ts
@@ -46,9 +46,8 @@ describe('graphileWorker', () => {
             expect(runRetriableFunction).toHaveBeenCalled()
             const runRetriableFunctionArgs = jest.mocked(runRetriableFunction).mock.calls[0][0]
 
-            expect(runRetriableFunctionArgs.metricName).toEqual('job_queues_enqueue')
+            expect(runRetriableFunctionArgs.metricName).toEqual('job_queues_enqueue_pluginJob')
             expect(runRetriableFunctionArgs.payload).toEqual({ type: 'foo' })
-            expect(runRetriableFunctionArgs.metricTags).toEqual({ jobName: 'pluginJob' })
             expect(runRetriableFunctionArgs.tryFn).not.toBeUndefined()
             expect(runRetriableFunctionArgs.catchFn).not.toBeUndefined()
             expect(runRetriableFunctionArgs.finallyFn).toBeUndefined()

--- a/plugin-server/tests/worker/ingestion/event-pipeline/pluginsProcessEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/pluginsProcessEventStep.test.ts
@@ -1,5 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
+import { droppedEventCounter } from '../../../../src/worker/ingestion/event-pipeline/metrics'
 import { pluginsProcessEventStep } from '../../../../src/worker/ingestion/event-pipeline/pluginsProcessEventStep'
 import { runProcessEvent } from '../../../../src/worker/plugins/run'
 
@@ -43,10 +44,12 @@ describe('pluginsProcessEventStep()', () => {
 
     it('does not forward but counts dropped events by plugins', async () => {
         jest.mocked(runProcessEvent).mockResolvedValue(null)
+        const droppedEventCounterSpy = jest.spyOn(droppedEventCounter, 'inc')
 
         const response = await pluginsProcessEventStep(runner, pluginEvent)
 
         expect(response).toEqual(null)
         expect(runner.hub.statsd.increment).toHaveBeenCalledWith('kafka_queue.dropped_event', { teamID: '2' })
+        expect(droppedEventCounterSpy).toHaveBeenCalledTimes(1)
     })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -157,7 +157,6 @@ describe('EventPipelineRunner', () => {
         })
 
         it('emits metrics for every step', async () => {
-            const pipelineStepCompletionCounterSpy = jest.spyOn(metrics.pipelineStepCompletionCounter, 'labels')
             const pipelineLastStepCounterSpy = jest.spyOn(metrics.pipelineLastStepCounter, 'labels')
             const eventProcessedAndIngestedCounterSpy = jest.spyOn(metrics.eventProcessedAndIngestedCounter, 'inc')
             const pipelineStepMsSummarySpy = jest.spyOn(metrics.pipelineStepMsSummary, 'labels')
@@ -170,14 +169,13 @@ describe('EventPipelineRunner', () => {
             expect(pipelineStepMsSummarySpy).toHaveBeenCalledTimes(5)
 
             expect(hub.statsd.increment).toHaveBeenCalledTimes(7)
-            expect(pipelineStepCompletionCounterSpy).toHaveBeenCalledTimes(5)
             expect(pipelineLastStepCounterSpy).toHaveBeenCalledTimes(1)
             expect(eventProcessedAndIngestedCounterSpy).toHaveBeenCalledTimes(1)
 
             expect(hub.statsd.increment).toHaveBeenCalledWith('kafka_queue.event_pipeline.step', {
                 step: 'createEventStep',
             })
-            expect(pipelineStepCompletionCounterSpy).toHaveBeenCalledWith('createEventStep')
+            expect(pipelineStepMsSummarySpy).toHaveBeenCalledWith('createEventStep')
 
             expect(hub.statsd.increment).toHaveBeenCalledWith('kafka_queue.event_pipeline.step.last', {
                 step: 'createEventStep',
@@ -225,7 +223,7 @@ describe('EventPipelineRunner', () => {
             const error = new Error('testError')
 
             it('runs and increments metrics', async () => {
-                const pipelineStepCompletionCounterSpy = jest.spyOn(metrics.pipelineStepCompletionCounter, 'labels')
+                const pipelineStepMsSummarySpy = jest.spyOn(metrics.pipelineStepMsSummary, 'labels')
                 const pipelineLastStepCounterSpy = jest.spyOn(metrics.pipelineLastStepCounter, 'labels')
                 const pipelineStepErrorCounterSpy = jest.spyOn(metrics.pipelineStepErrorCounter, 'labels')
 
@@ -236,17 +234,17 @@ describe('EventPipelineRunner', () => {
                 expect(hub.statsd.increment).toHaveBeenCalledWith('kafka_queue.event_pipeline.step', {
                     step: 'populateTeamDataStep',
                 })
-                expect(pipelineStepCompletionCounterSpy).toHaveBeenCalledWith('populateTeamDataStep')
+                expect(pipelineStepMsSummarySpy).toHaveBeenCalledWith('populateTeamDataStep')
 
                 expect(hub.statsd.increment).toHaveBeenCalledWith('kafka_queue.event_pipeline.step', {
                     step: 'pluginsProcessEventStep',
                 })
-                expect(pipelineStepCompletionCounterSpy).toHaveBeenCalledWith('pluginsProcessEventStep')
+                expect(pipelineStepMsSummarySpy).toHaveBeenCalledWith('pluginsProcessEventStep')
 
                 expect(hub.statsd.increment).not.toHaveBeenCalledWith('kafka_queue.event_pipeline.step', {
                     step: 'prepareEventStep',
                 })
-                expect(pipelineStepCompletionCounterSpy).not.toHaveBeenCalledWith('prepareEventStep')
+                expect(pipelineStepMsSummarySpy).not.toHaveBeenCalledWith('prepareEventStep')
 
                 expect(hub.statsd.increment).not.toHaveBeenCalledWith('kafka_queue.event_pipeline.step.last')
                 expect(pipelineLastStepCounterSpy).not.toHaveBeenCalled()

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon'
 import { ISOTimestamp, Person, PipelineEvent, PreIngestionEvent } from '../../../../src/types'
 import { createEventsToDropByToken } from '../../../../src/utils/db/hub'
 import { createEventStep } from '../../../../src/worker/ingestion/event-pipeline/createEventStep'
+import * as metrics from '../../../../src/worker/ingestion/event-pipeline/metrics'
 import { pluginsProcessEventStep } from '../../../../src/worker/ingestion/event-pipeline/pluginsProcessEventStep'
 import { populateTeamDataStep } from '../../../../src/worker/ingestion/event-pipeline/populateTeamDataStep'
 import { prepareEventStep } from '../../../../src/worker/ingestion/event-pipeline/prepareEventStep'
@@ -156,20 +157,36 @@ describe('EventPipelineRunner', () => {
         })
 
         it('emits metrics for every step', async () => {
+            const pipelineStepCompletionCounterSpy = jest.spyOn(metrics.pipelineStepCompletionCounter, 'labels')
+            const pipelineLastStepCounterSpy = jest.spyOn(metrics.pipelineLastStepCounter, 'labels')
+            const eventProcessedAndIngestedCounterSpy = jest.spyOn(metrics.eventProcessedAndIngestedCounter, 'inc')
+            const pipelineStepMsSummarySpy = jest.spyOn(metrics.pipelineStepMsSummary, 'labels')
+            const pipelineStepErrorCounterSpy = jest.spyOn(metrics.pipelineStepErrorCounter, 'labels')
+
             const result = await runner.runEventPipeline(pipelineEvent)
             expect(result.error).toBeUndefined()
 
             expect(hub.statsd.timing).toHaveBeenCalledTimes(5)
-            expect(hub.statsd.increment).toHaveBeenCalledTimes(8)
+            expect(pipelineStepMsSummarySpy).toHaveBeenCalledTimes(5)
+
+            expect(hub.statsd.increment).toHaveBeenCalledTimes(7)
+            expect(pipelineStepCompletionCounterSpy).toHaveBeenCalledTimes(5)
+            expect(pipelineLastStepCounterSpy).toHaveBeenCalledTimes(1)
+            expect(eventProcessedAndIngestedCounterSpy).toHaveBeenCalledTimes(1)
 
             expect(hub.statsd.increment).toHaveBeenCalledWith('kafka_queue.event_pipeline.step', {
                 step: 'createEventStep',
             })
+            expect(pipelineStepCompletionCounterSpy).toHaveBeenCalledWith('createEventStep')
+
             expect(hub.statsd.increment).toHaveBeenCalledWith('kafka_queue.event_pipeline.step.last', {
                 step: 'createEventStep',
                 team_id: '2',
             })
+            expect(pipelineLastStepCounterSpy).toHaveBeenCalledWith('createEventStep')
+
             expect(hub.statsd.increment).not.toHaveBeenCalledWith('kafka_queue.event_pipeline.step.error')
+            expect(pipelineStepErrorCounterSpy).not.toHaveBeenCalled()
         })
 
         describe('early exits from pipeline', () => {
@@ -184,14 +201,23 @@ describe('EventPipelineRunner', () => {
             })
 
             it('reports metrics and last step correctly', async () => {
+                const pipelineLastStepCounterSpy = jest.spyOn(metrics.pipelineLastStepCounter, 'labels')
+                const pipelineStepMsSummarySpy = jest.spyOn(metrics.pipelineStepMsSummary, 'labels')
+                const pipelineStepErrorCounterSpy = jest.spyOn(metrics.pipelineStepErrorCounter, 'labels')
+
                 await runner.runEventPipeline(pipelineEvent)
 
                 expect(hub.statsd.timing).toHaveBeenCalledTimes(2)
+                expect(pipelineStepMsSummarySpy).toHaveBeenCalledTimes(2)
+
                 expect(hub.statsd.increment).toHaveBeenCalledWith('kafka_queue.event_pipeline.step.last', {
                     step: 'pluginsProcessEventStep',
                     team_id: '2',
                 })
+                expect(pipelineLastStepCounterSpy).toHaveBeenCalledWith('pluginsProcessEventStep')
+
                 expect(hub.statsd.increment).not.toHaveBeenCalledWith('kafka_queue.event_pipeline.step.error')
+                expect(pipelineStepErrorCounterSpy).not.toHaveBeenCalled()
             })
         })
 
@@ -199,6 +225,10 @@ describe('EventPipelineRunner', () => {
             const error = new Error('testError')
 
             it('runs and increments metrics', async () => {
+                const pipelineStepCompletionCounterSpy = jest.spyOn(metrics.pipelineStepCompletionCounter, 'labels')
+                const pipelineLastStepCounterSpy = jest.spyOn(metrics.pipelineLastStepCounter, 'labels')
+                const pipelineStepErrorCounterSpy = jest.spyOn(metrics.pipelineStepErrorCounter, 'labels')
+
                 jest.mocked(prepareEventStep).mockRejectedValue(error)
 
                 await runner.runEventPipeline(pipelineEvent)
@@ -206,19 +236,29 @@ describe('EventPipelineRunner', () => {
                 expect(hub.statsd.increment).toHaveBeenCalledWith('kafka_queue.event_pipeline.step', {
                     step: 'populateTeamDataStep',
                 })
+                expect(pipelineStepCompletionCounterSpy).toHaveBeenCalledWith('populateTeamDataStep')
+
                 expect(hub.statsd.increment).toHaveBeenCalledWith('kafka_queue.event_pipeline.step', {
                     step: 'pluginsProcessEventStep',
                 })
+                expect(pipelineStepCompletionCounterSpy).toHaveBeenCalledWith('pluginsProcessEventStep')
+
                 expect(hub.statsd.increment).not.toHaveBeenCalledWith('kafka_queue.event_pipeline.step', {
                     step: 'prepareEventStep',
                 })
+                expect(pipelineStepCompletionCounterSpy).not.toHaveBeenCalledWith('prepareEventStep')
+
                 expect(hub.statsd.increment).not.toHaveBeenCalledWith('kafka_queue.event_pipeline.step.last')
+                expect(pipelineLastStepCounterSpy).not.toHaveBeenCalled()
+
                 expect(hub.statsd.increment).toHaveBeenCalledWith('kafka_queue.event_pipeline.step.error', {
                     step: 'prepareEventStep',
                 })
+                expect(pipelineStepErrorCounterSpy).toHaveBeenCalledWith('prepareEventStep')
             })
 
             it('emits failures to dead letter queue until createEvent', async () => {
+                const pipelineStepDLQCounterSpy = jest.spyOn(metrics.pipelineStepDLQCounter, 'labels')
                 jest.mocked(prepareEventStep).mockRejectedValue(error)
 
                 await runner.runEventPipeline(pipelineEvent)
@@ -231,15 +271,18 @@ describe('EventPipelineRunner', () => {
                     error_location: 'plugin_server_ingest_event:prepareEventStep',
                 })
                 expect(hub.statsd.increment).toHaveBeenCalledWith('events_added_to_dead_letter_queue')
+                expect(pipelineStepDLQCounterSpy).toHaveBeenCalledWith('prepareEventStep')
             })
 
             it('does not emit to dead letter queue for runAsyncHandlersStep', async () => {
+                const pipelineStepDLQCounterSpy = jest.spyOn(metrics.pipelineStepDLQCounter, 'labels')
                 jest.mocked(processOnEventStep).mockRejectedValue(error)
 
                 await runner.runEventPipeline(pipelineEvent)
 
                 expect(hub.db.kafkaProducer.queueMessage).not.toHaveBeenCalled()
                 expect(hub.statsd.increment).not.toHaveBeenCalledWith('events_added_to_dead_letter_queue')
+                expect(pipelineStepDLQCounterSpy).not.toHaveBeenCalled()
             })
         })
     })

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -1105,10 +1105,6 @@ describe('PersonState.update()', () => {
             expect(person).toEqual(undefined)
             const persons = await fetchPostgresPersonsH()
             expect(persons.length).toEqual(0)
-
-            expect(hub.statsd!.increment).toHaveBeenCalledWith('illegal_distinct_ids.total', {
-                distinctId: illegalId,
-            })
         })
 
         it.each(illegalIds)('stops $identify if $anon_distinct_id is illegal: `%s`', async (illegalId: string) => {
@@ -1123,10 +1119,6 @@ describe('PersonState.update()', () => {
             expect(person).toEqual(undefined)
             const persons = await fetchPostgresPersonsH()
             expect(persons.length).toEqual(0)
-
-            expect(hub.statsd!.increment).toHaveBeenCalledWith('illegal_distinct_ids.total', {
-                distinctId: illegalId,
-            })
         })
 
         it('stops $create_alias if current distinct_id is illegal', async () => {
@@ -1141,10 +1133,6 @@ describe('PersonState.update()', () => {
             expect(person).toEqual(undefined)
             const persons = await fetchPostgresPersonsH()
             expect(persons.length).toEqual(0)
-
-            expect(hub.statsd!.increment).toHaveBeenCalledWith('illegal_distinct_ids.total', {
-                distinctId: 'false',
-            })
         })
 
         it('stops $create_alias if alias is illegal', async () => {
@@ -1159,8 +1147,6 @@ describe('PersonState.update()', () => {
             expect(person).toEqual(undefined)
             const persons = await fetchPostgresPersonsH()
             expect(persons.length).toEqual(0)
-
-            expect(hub.statsd!.increment).toHaveBeenCalledWith('illegal_distinct_ids.total', { distinctId: 'null' })
         })
     })
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We want to destroy [metrics.posthog.com](https://metrics.posthog.com/), which AFAIK only exists because it supports StatsD. In order to do this, we need to port StatsD-only metrics over to Prometheus.

## Changes

This PR adds sibling metrics to all StatsD metrics in `plugin-server`, where applicable, and removes some metrics that were unused. Note that super-high cardinality metrics (like ones that used the `team_id`) need to drop their high-cardinality aspect to become Prometheus metrics.

(Note that I exported all dashboards in US, EU and Metrics in order to grep for metrics usage across dashboards.)

The steps in my head are:

1. Deploy this PR, which should have no negative effects and should add a bunch of Prometheus metrics.
2. Add dashboards to US/EU (via Git JSON) to make the new metrics visible.
3. Deploy another PR that removes all StatsD calls in `plugin-server`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

CI, local. This should only add metrics and remove unused ones.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
