### PR TITLE
fix: ensure clicks have an element

### DIFF
--- a/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
+++ b/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
@@ -519,3 +519,36 @@ exports[`replay/transform transform child wireframes are processed 1`] = `
   },
 ]
 `;
+
+exports[`replay/transform transform respect incremental ids, replace with body otherwise 1`] = `
+[
+  {
+    "data": {
+      "id": 5,
+      "pointerType": 2,
+      "source": 2,
+      "type": 7,
+      "x": 523,
+      "y": 683,
+    },
+    "delay": 2160,
+    "timestamp": 1701355473313,
+    "type": 3,
+    "windowId": "ddc9c89d-2272-4b07-a280-c00db3a9182f",
+  },
+  {
+    "data": {
+      "id": 145,
+      "pointerType": 2,
+      "source": 2,
+      "type": 7,
+      "x": 523,
+      "y": 683,
+    },
+    "delay": 2160,
+    "timestamp": 1701355473313,
+    "type": 3,
+    "windowId": "ddc9c89d-2272-4b07-a280-c00db3a9182f",
+  },
+]
+`;

--- a/ee/frontend/mobile-replay/index.ts
+++ b/ee/frontend/mobile-replay/index.ts
@@ -5,15 +5,16 @@ import Ajv, { ErrorObject } from 'ajv'
 import { mobileEventWithTime } from './mobile.types'
 import mobileSchema from './schema/mobile/rr-mobile-schema.json'
 import webSchema from './schema/web/rr-web-schema.json'
-import { makeFullEvent, makeMetaEvent } from './transformers'
+import { makeFullEvent, makeIncrementalEvent, makeMetaEvent } from './transformers'
 
 const ajv = new Ajv({
     allowUnionTypes: true,
 }) // options can be passed, e.g. {allErrors: true}
 
 const transformers: Record<number, (x: any) => eventWithTime> = {
-    4: makeMetaEvent,
     2: makeFullEvent,
+    3: makeIncrementalEvent,
+    4: makeMetaEvent,
 }
 
 const mobileSchemaValidator = ajv.compile(mobileSchema)

--- a/ee/frontend/mobile-replay/mobile.types.ts
+++ b/ee/frontend/mobile-replay/mobile.types.ts
@@ -163,6 +163,11 @@ export type fullSnapshotEvent = {
     }
 }
 
+export type incrementalSnapshotEvent = {
+    type: EventType.IncrementalSnapshot
+    data: any // TODO: this will change as we implement incremental snapshots
+}
+
 export type metaEvent = {
     type: EventType.Meta
     data: {
@@ -172,7 +177,7 @@ export type metaEvent = {
     }
 }
 
-export type mobileEvent = fullSnapshotEvent | metaEvent | customEvent
+export type mobileEvent = fullSnapshotEvent | metaEvent | customEvent | incrementalSnapshotEvent
 
 export type mobileEventWithTime = mobileEvent & {
     timestamp: number

--- a/ee/frontend/mobile-replay/schema/mobile/rr-mobile-schema.json
+++ b/ee/frontend/mobile-replay/schema/mobile/rr-mobile-schema.json
@@ -102,6 +102,23 @@
             },
             "required": ["data", "timestamp", "type"],
             "type": "object"
+        },
+        {
+            "additionalProperties": false,
+            "properties": {
+                "data": {},
+                "delay": {
+                    "type": "number"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "type": {
+                    "$ref": "#/definitions/EventType.IncrementalSnapshot"
+                }
+            },
+            "required": ["data", "timestamp", "type"],
+            "type": "object"
         }
     ],
     "definitions": {
@@ -111,6 +128,10 @@
         },
         "EventType.FullSnapshot": {
             "const": 2,
+            "type": "number"
+        },
+        "EventType.IncrementalSnapshot": {
+            "const": 3,
             "type": "number"
         },
         "EventType.Meta": {

--- a/ee/frontend/mobile-replay/transform.test.ts
+++ b/ee/frontend/mobile-replay/transform.test.ts
@@ -312,5 +312,39 @@ describe('replay/transform', () => {
             ])
             expect(textEvent).toMatchSnapshot()
         })
+
+        test('respect incremental ids, replace with body otherwise', () => {
+            const textEvent = posthogEEModule.mobileReplay?.transformToWeb([
+                {
+                    windowId: 'ddc9c89d-2272-4b07-a280-c00db3a9182f',
+                    data: {
+                        id: 0, // must be an element id - replace with body
+                        pointerType: 2,
+                        source: 2,
+                        type: 7,
+                        x: 523,
+                        y: 683,
+                    },
+                    timestamp: 1701355473313,
+                    type: 3,
+                    delay: 2160,
+                },
+                {
+                    windowId: 'ddc9c89d-2272-4b07-a280-c00db3a9182f',
+                    data: {
+                        id: 145, // element provided - respected without validation
+                        pointerType: 2,
+                        source: 2,
+                        type: 7,
+                        x: 523,
+                        y: 683,
+                    },
+                    timestamp: 1701355473313,
+                    type: 3,
+                    delay: 2160,
+                },
+            ])
+            expect(textEvent).toMatchSnapshot()
+        })
     })
 })


### PR DESCRIPTION
Android/the mobile SDK doesn't associate a click with an element in the way that rrweb expects. 

It might not completely make sense to spend processing power making that association 

If an incremental snapshot has an ID of 0 then we associate it with the body element. 

This will probably become less loose when we start to implement mutations but will cover us for now