### PR TITLE
fix(queries): Fix query async time measurements

### DIFF
--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -84,7 +84,7 @@ def execute_process_query(
 
     pickup_time = datetime.datetime.utcnow()
     if query_status.start_time:
-        wait_duration = (pickup_time - query_status.start_time) / datetime.timedelta(milliseconds=1000000)
+        wait_duration = (pickup_time - query_status.start_time) / datetime.timedelta(seconds=1)
         QUERY_WAIT_TIME.observe(wait_duration)
 
     try:
@@ -98,7 +98,7 @@ def execute_process_query(
         query_status.results = results
         query_status.end_time = datetime.datetime.utcnow()
         query_status.expiration_time = query_status.end_time + datetime.timedelta(seconds=manager.STATUS_TTL_SECONDS)
-        process_duration = (query_status.end_time - pickup_time) / datetime.timedelta(milliseconds=1000000)
+        process_duration = (query_status.end_time - pickup_time) / datetime.timedelta(seconds=1)
         QUERY_PROCESS_TIME.observe(process_duration)
     except Exception as err:
         query_status.results = None  # Clear results in case they are faulty


### PR DESCRIPTION
## Problem

Dividing by miliseconds=1000000 is wrong, should have been microseconds, or a smaller value. 

## Changes

- just use seconds=1

## How did you test this code?

- with debugger