### PR TITLE
fix: click count better than activity count

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
@@ -154,11 +154,11 @@ function ActivityIndicators({
             <PropertyIcons recordingProperties={iconProperties} loading={loading} {...props} />
 
             <span
-                title={`Mouse activity: ${recording.mouse_activity_count}`}
+                title={`Mouse clicks: ${recording.click_count}`}
                 className="flex items-center gap-1  overflow-hidden shrink-0"
             >
                 <IconAutocapture />
-                {recording.mouse_activity_count}
+                {recording.click_count}
             </span>
 
             <span


### PR DESCRIPTION
I switched click count to mouse activity count. 2 people have already asked why the value is so high.

Let's switch back, check the value is right, and then figure out if/how to roll this out