### PR TITLE
fix: migrate button with dropdown

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -1,6 +1,6 @@
 import './TaxonomicPropertyFilter.scss'
 
-import { LemonButtonWithDropdown } from '@posthog/lemon-ui'
+import { LemonButton, LemonDropdown } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { OperatorValueSelect } from 'lib/components/PropertyFilters/components/OperatorValueSelect'
@@ -159,28 +159,28 @@ export function TaxonomicPropertyFilter({
                         </div>
                     )}
                     <div className="TaxonomicPropertyFilter__row__items">
-                        <LemonButtonWithDropdown
-                            dropdown={{
-                                overlay: dropdownOpen ? taxonomicFilter : null,
-                                visible: dropdownOpen,
-                                placement: 'bottom',
-                                onClickOutside: closeDropdown,
-                            }}
-                            onClick={() => (dropdownOpen ? closeDropdown() : openDropdown())}
-                            type="secondary"
-                            status={!valuePresent ? 'primary' : 'stealth'}
-                            icon={!valuePresent ? <IconPlusMini /> : undefined}
-                            sideIcon={null}
-                            data-attr={'property-select-toggle-' + index}
+                        <LemonDropdown
+                            overlay={taxonomicFilter}
+                            placement="bottom-start"
+                            visible={dropdownOpen}
+                            onClickOutside={closeDropdown}
                         >
-                            {filter?.type === 'cohort' ? (
-                                selectedCohortName || `Cohort #${filter?.value}`
-                            ) : filter?.key ? (
-                                <PropertyKeyInfo value={filter.key} disablePopover ellipsis />
-                            ) : (
-                                addText || 'Add filter'
-                            )}
-                        </LemonButtonWithDropdown>
+                            <LemonButton
+                                type="secondary"
+                                status={!valuePresent ? 'primary' : 'stealth'}
+                                icon={!valuePresent ? <IconPlusMini /> : undefined}
+                                data-attr={'property-select-toggle-' + index}
+                                onClick={() => (dropdownOpen ? closeDropdown() : openDropdown())}
+                            >
+                                {filter?.type === 'cohort' ? (
+                                    selectedCohortName || `Cohort #${filter?.value}`
+                                ) : filter?.key ? (
+                                    <PropertyKeyInfo value={filter.key} disablePopover ellipsis />
+                                ) : (
+                                    addText || 'Add filter'
+                                )}
+                            </LemonButton>
+                        </LemonDropdown>
                         {showOperatorValueSelect ? (
                             <OperatorValueSelect
                                 propertyDefinitions={propertyDefinitionsByType(


### PR DESCRIPTION
## Problem

We're using an old style button which doesn't have an arrow to indicate it's a dropdown

## Changes

- Replace `LemonButtonWithDropdown` with a `LemonButton` and a `LemonDropdown`

## How did you test this code?

|Before|After|
|----|----|
| <img width="1005" alt="Screenshot 2023-12-04 at 12 19 33" src="https://github.com/PostHog/posthog/assets/6685876/25cded7b-2db3-4dd1-a07c-98e964c22fab"> | <img width="940" alt="Screenshot 2023-12-04 at 12 14 39" src="https://github.com/PostHog/posthog/assets/6685876/9971ea62-4611-4dc2-a95d-ee2522bf4b4e"> |