### PR TITLE
fix: screenshot flapping from missing mock

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.stories.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.stories.tsx
@@ -6,7 +6,7 @@ import { useEffect } from 'react'
 import { App } from 'scenes/App'
 import { urls } from 'scenes/urls'
 
-import { setFeatureFlags } from '~/mocks/browser'
+import { mswDecorator, setFeatureFlags } from '~/mocks/browser'
 import { SidePanelTab } from '~/types'
 
 import { sidePanelStateLogic } from './sidePanelStateLogic'
@@ -18,6 +18,14 @@ const meta: Meta = {
         viewMode: 'story',
         mockDate: '2023-07-04', // To stabilize relative dates
     },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:team_id/dashboard_templates/': {},
+                '/api/projects/:id/integrations': { results: [] },
+            },
+        }),
+    ],
 }
 export default meta
 


### PR DESCRIPTION
## Problem

We are seeing some snapshots flipping because of error messages e.g. unrelated changes in [this PR](https://github.com/PostHog/posthog/pull/18914)

<img width="1054" alt="Screenshot 2023-12-04 at 12 40 14" src="https://github.com/PostHog/posthog/assets/6685876/21f3a88b-a227-4df1-9375-030ed5904c94">

## Changes

- Mock the calls to `dashboard_templates` and `integrations` in the Story
 
## How did you test this code?

Loading the Story locally used to always show the errors (flipping happened because sometimes the errors were still visible when screenshotting). Now the errors are gone