### PR TITLE
chore(data-warehouse): add temporal schedule offset

### DIFF
--- a/posthog/warehouse/data_load/service.py
+++ b/posthog/warehouse/data_load/service.py
@@ -44,7 +44,14 @@ def sync_external_data_job_workflow(external_data_source: ExternalDataSource, cr
             id=str(external_data_source.pk),
             task_queue=DATA_WAREHOUSE_TASK_QUEUE,
         ),
-        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(hours=24))]),
+        spec=ScheduleSpec(
+            intervals=[
+                ScheduleIntervalSpec(
+                    every=timedelta(hours=24), offset=timedelta(hours=external_data_source.created_at.hour)
+                )
+            ],
+            jitter=timedelta(hours=2),
+        ),
         state=ScheduleState(note=f"Schedule for external data source: {external_data_source.pk}"),
         policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.CANCEL_OTHER),
     )


### PR DESCRIPTION
## Problem

- temporal offset is 0 right now so all schedules start workflows at midnight UTC

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- use the created_at time as offset so it matches when the original schedule is triggered

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
