### PR TITLE
fix: use tertiary buttons for notebook timestamp buttons

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeReplayTimestamp.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeReplayTimestamp.tsx
@@ -44,7 +44,8 @@ const Component = (props: NodeViewProps): JSX.Element => {
             <LemonButton
                 size="small"
                 noPadding
-                type="secondary"
+                type="tertiary"
+                active
                 status="primary-alt"
                 onClick={
                     relatedNodeInNotebook ? handlePlayInNotebook : () => openNotebook(shortId, NotebookTarget.Popover)

--- a/frontend/src/scenes/notebooks/Suggestions/ReplayTimestamp.tsx
+++ b/frontend/src/scenes/notebooks/Suggestions/ReplayTimestamp.tsx
@@ -38,7 +38,8 @@ const Component = ({ previousNode, editor }: InsertionSuggestionViewProps): JSX.
             <LemonButton
                 size="small"
                 noPadding
-                type="secondary"
+                type="tertiary"
+                active
                 status="primary-alt"
                 onClick={() => insertTimestamp({ previousNode, editor })}
             >


### PR DESCRIPTION
## Problem

The 3D buttons look weird on notebooks

<img width="329" alt="Screenshot 2023-12-04 at 18 04 03" src="https://github.com/PostHog/posthog/assets/6685876/23962692-e7af-4db9-98ca-84fd8b471acc">


## Changes

Use an active tertiary button instead

<img width="288" alt="Screenshot 2023-12-04 at 18 04 25" src="https://github.com/PostHog/posthog/assets/6685876/ffff011c-9a38-42f1-a454-02c58dcdfa63">

## How did you test this code?

By eye