### PR TITLE
fix: session replay naming

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
@@ -142,7 +142,7 @@ type NotebookNodeRecordingAttributes = {
 
 export const NotebookNodeRecording = createPostHogWidgetNode<NotebookNodeRecordingAttributes>({
     nodeType: NotebookNodeType.Recording,
-    titlePlaceholder: 'Session replay',
+    titlePlaceholder: 'Session recording',
     Component,
     heightEstimate: HEIGHT,
     minHeight: MIN_HEIGHT,


### PR DESCRIPTION
## Problem

We use inconsistent naming between `Session replay` and `Session recording`

## Changes

Use `Session recording` to denote individual recordings (and `Session replay` to signify the product)

## How did you test this code?

Just text