### PR TITLE
fix: don't swallow xmlsec error in debug mode on startup

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -54,11 +54,17 @@ from .views import (
 )
 from .year_in_posthog import year_in_posthog
 
+import structlog
+
+logger = structlog.get_logger(__name__)
+
 ee_urlpatterns: List[Any] = []
 try:
     from ee.urls import extend_api_router
     from ee.urls import urlpatterns as ee_urlpatterns
 except ImportError:
+    if settings.DEBUG:
+        logger.warn(f"Could not import ee.urls", exc_info=True)
     pass
 else:
     extend_api_router(


### PR DESCRIPTION
I was setting up locally. XMLSec isn't setup correctly.

The documentation tells me what to do if I get xmlsec errors. But the error in question was swallowed so I didn't know it was happening.

Logs the error if in debug mode