### PR TITLE
fix: button destroy states in 3000

### DIFF
--- a/frontend/src/lib/components/NotFound/index.tsx
+++ b/frontend/src/lib/components/NotFound/index.tsx
@@ -18,7 +18,7 @@ interface NotFoundProps {
 export function NotFound({ object, caption }: NotFoundProps): JSX.Element {
     const { preflight } = useValues(preflightLogic)
     const { openSupportForm } = useActions(supportLogic)
-    const is3000 = useFeatureFlag('POSTHOG_3000')
+    const is3000 = useFeatureFlag('POSTHOG_3000', 'test')
 
     const nodeLogic = useNotebookNode()
 

--- a/frontend/src/lib/components/NotFound/index.tsx
+++ b/frontend/src/lib/components/NotFound/index.tsx
@@ -2,6 +2,7 @@ import './NotFound.scss'
 
 import { LemonButton } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { Link } from 'lib/lemon-ui/Link'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { useNotebookNode } from 'scenes/notebooks/Nodes/NotebookNodeContext'
@@ -17,6 +18,7 @@ interface NotFoundProps {
 export function NotFound({ object, caption }: NotFoundProps): JSX.Element {
     const { preflight } = useValues(preflightLogic)
     const { openSupportForm } = useActions(supportLogic)
+    const is3000 = useFeatureFlag('POSTHOG_3000')
 
     const nodeLogic = useNotebookNode()
 
@@ -47,7 +49,11 @@ export function NotFound({ object, caption }: NotFoundProps): JSX.Element {
             </p>
             <div className="flex justify-center">
                 {nodeLogic && (
-                    <LemonButton type="primary" status="danger" onClick={() => nodeLogic.actions.deleteNode()}>
+                    <LemonButton
+                        type={is3000 ? 'secondary' : 'primary'}
+                        status="danger"
+                        onClick={() => nodeLogic.actions.deleteNode()}
+                    >
                         Remove from Notebook
                     </LemonButton>
                 )}

--- a/frontend/src/scenes/billing/BillingLimitInput.tsx
+++ b/frontend/src/scenes/billing/BillingLimitInput.tsx
@@ -140,7 +140,6 @@ export const BillingLimitInput = ({ product }: { product: BillingProductV2Type }
                             </LemonButton>
                             {customLimitUsd ? (
                                 <LemonButton
-                                    // icon={<IconDelete />}
                                     status="danger"
                                     size="small"
                                     tooltip="Remove billing limit"

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -94,9 +94,7 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                                 data-attr="delete-cohort"
                                                 fullWidth
                                                 status="danger"
-                                                onClick={() => {
-                                                    deleteCohort()
-                                                }}
+                                                onClick={deleteCohort}
                                             >
                                                 Delete cohort
                                             </LemonButton>

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
@@ -57,7 +57,7 @@ export function InstanceConfigSaveModal({ onClose, isOpen }: { onClose: () => vo
         useValues(systemStatusLogic)
     const { saveInstanceConfig } = useActions(systemStatusLogic)
     const loading = updatedInstanceConfigCount !== null
-    const is3000 = useFeatureFlag('POSTHOG_3000')
+    const is3000 = useFeatureFlag('POSTHOG_3000', 'test')
 
     const isChangingEnabledEmailSettings =
         instanceConfigEditingState.EMAIL_ENABLED !== false &&

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
@@ -1,5 +1,6 @@
 import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { pluralize } from 'lib/utils'
 
@@ -56,6 +57,7 @@ export function InstanceConfigSaveModal({ onClose, isOpen }: { onClose: () => vo
         useValues(systemStatusLogic)
     const { saveInstanceConfig } = useActions(systemStatusLogic)
     const loading = updatedInstanceConfigCount !== null
+    const is3000 = useFeatureFlag('POSTHOG_3000')
 
     const isChangingEnabledEmailSettings =
         instanceConfigEditingState.EMAIL_ENABLED !== false &&
@@ -79,7 +81,12 @@ export function InstanceConfigSaveModal({ onClose, isOpen }: { onClose: () => vo
                     >
                         Cancel
                     </LemonButton>
-                    <LemonButton type="primary" status="danger" loading={loading} onClick={saveInstanceConfig}>
+                    <LemonButton
+                        type={is3000 ? 'secondary' : 'primary'}
+                        status="danger"
+                        loading={loading}
+                        onClick={saveInstanceConfig}
+                    >
                         Apply {changeNoun}
                     </LemonButton>
                 </>

--- a/frontend/src/scenes/instance/SystemStatus/StaffUsersTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/StaffUsersTab.tsx
@@ -54,7 +54,7 @@ export function StaffUsersTab(): JSX.Element {
                         data-attr="invite-delete"
                         icon={<IconDelete />}
                         status="danger"
-                        disabledReason={staffUsers.length < 2 && 'You cannot remove the last staff user'}
+                        disabledReason={staffUsers.length < 2 && 'At least one staff user must remain'}
                         title={
                             staffUsers.length < 2
                                 ? 'You should always have at least one staff user.'

--- a/frontend/src/scenes/instance/SystemStatus/StaffUsersTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/StaffUsersTab.tsx
@@ -54,7 +54,7 @@ export function StaffUsersTab(): JSX.Element {
                         data-attr="invite-delete"
                         icon={<IconDelete />}
                         status="danger"
-                        disabled={staffUsers.length < 2}
+                        disabledReason={staffUsers.length < 2 && 'You cannot remove the last staff user'}
                         title={
                             staffUsers.length < 2
                                 ? 'You should always have at least one staff user.'

--- a/frontend/src/scenes/persons/PersonDeleteModal.tsx
+++ b/frontend/src/scenes/persons/PersonDeleteModal.tsx
@@ -10,7 +10,7 @@ import { asDisplay } from './person-utils'
 export function PersonDeleteModal(): JSX.Element | null {
     const { personDeleteModal } = useValues(personDeleteModalLogic)
     const { deletePerson, showPersonDeleteModal } = useActions(personDeleteModalLogic)
-    const is3000 = useFeatureFlag('POSTHOG_3000')
+    const is3000 = useFeatureFlag('POSTHOG_3000', 'test')
 
     return (
         <LemonModal

--- a/frontend/src/scenes/persons/PersonDeleteModal.tsx
+++ b/frontend/src/scenes/persons/PersonDeleteModal.tsx
@@ -1,5 +1,6 @@
 import { LemonButton, LemonModal, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { personDeleteModalLogic } from 'scenes/persons/personDeleteModalLogic'
 
 import { PersonType } from '~/types'
@@ -9,6 +10,7 @@ import { asDisplay } from './person-utils'
 export function PersonDeleteModal(): JSX.Element | null {
     const { personDeleteModal } = useValues(personDeleteModalLogic)
     const { deletePerson, showPersonDeleteModal } = useActions(personDeleteModalLogic)
+    const is3000 = useFeatureFlag('POSTHOG_3000')
 
     return (
         <LemonModal
@@ -35,7 +37,7 @@ export function PersonDeleteModal(): JSX.Element | null {
                 <>
                     <LemonButton
                         status="danger"
-                        type="secondary"
+                        type={is3000 ? 'tertiary' : 'secondary'}
                         onClick={() => {
                             deletePerson(personDeleteModal as PersonType, true)
                         }}
@@ -51,7 +53,7 @@ export function PersonDeleteModal(): JSX.Element | null {
                         Cancel
                     </LemonButton>
                     <LemonButton
-                        type="primary"
+                        type={is3000 ? 'secondary' : 'primary'}
                         status="danger"
                         onClick={() => {
                             deletePerson(personDeleteModal as PersonType, false)

--- a/frontend/src/scenes/pipeline/AppsManagement.tsx
+++ b/frontend/src/scenes/pipeline/AppsManagement.tsx
@@ -75,7 +75,7 @@ type RenderAppsTable = {
 function AppsTable({ plugins }: RenderAppsTable): JSX.Element {
     const { unusedPlugins } = useValues(appsManagementLogic)
     const { uninstallPlugin, patchPlugin } = useActions(appsManagementLogic)
-    const is3000 = useFeatureFlag('POSTHOG_3000')
+    const is3000 = useFeatureFlag('POSTHOG_3000', 'test')
 
     // TODO: row expansion to show the source code and allow updating source apps
 

--- a/frontend/src/scenes/pipeline/AppsManagement.tsx
+++ b/frontend/src/scenes/pipeline/AppsManagement.tsx
@@ -1,6 +1,7 @@
 import { LemonBanner, LemonDivider, LemonTable, Tooltip } from '@posthog/lemon-ui'
 import { Popconfirm } from 'antd'
 import { useActions, useValues } from 'kea'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconDelete, IconLock, IconLockOpen } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
@@ -74,6 +75,7 @@ type RenderAppsTable = {
 function AppsTable({ plugins }: RenderAppsTable): JSX.Element {
     const { unusedPlugins } = useValues(appsManagementLogic)
     const { uninstallPlugin, patchPlugin } = useActions(appsManagementLogic)
+    const is3000 = useFeatureFlag('POSTHOG_3000')
 
     // TODO: row expansion to show the source code and allow updating source apps
 
@@ -174,7 +176,7 @@ function AppsTable({ plugins }: RenderAppsTable): JSX.Element {
                                         className="Plugins__Popconfirm"
                                     >
                                         <LemonButton
-                                            type="primary"
+                                            type={is3000 ? 'secondary' : 'primary'}
                                             status="danger"
                                             size="small"
                                             icon={<IconDelete />}

--- a/frontend/src/scenes/plugins/tabs/apps/AppManagementView.tsx
+++ b/frontend/src/scenes/plugins/tabs/apps/AppManagementView.tsx
@@ -20,7 +20,7 @@ export function AppManagementView({
     plugin: PluginTypeWithConfig | PluginType | PluginRepositoryEntry
 }): JSX.Element {
     const { user } = useValues(userLogic)
-    const is3000 = useFeatureFlag('POSTHOG_3000')
+    const is3000 = useFeatureFlag('POSTHOG_3000', 'test')
 
     if (!canGloballyManagePlugins(user?.organization)) {
         return <></>

--- a/frontend/src/scenes/plugins/tabs/apps/AppManagementView.tsx
+++ b/frontend/src/scenes/plugins/tabs/apps/AppManagementView.tsx
@@ -80,7 +80,7 @@ export function AppManagementView({
                                 }
                                 data-attr="plugin-uninstall"
                             >
-                                Uninstall me
+                                Uninstall
                             </LemonButton>
                         </Popconfirm>
                         {plugin.is_global ? (

--- a/frontend/src/scenes/plugins/tabs/apps/AppManagementView.tsx
+++ b/frontend/src/scenes/plugins/tabs/apps/AppManagementView.tsx
@@ -1,6 +1,7 @@
 import { LemonButton, Link } from '@posthog/lemon-ui'
 import { Popconfirm } from 'antd'
 import { useActions, useValues } from 'kea'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconCheckmark, IconCloudDownload, IconDelete, IconReplay, IconWeb } from 'lib/lemon-ui/icons'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { canGloballyManagePlugins } from 'scenes/plugins/access'
@@ -19,6 +20,7 @@ export function AppManagementView({
     plugin: PluginTypeWithConfig | PluginType | PluginRepositoryEntry
 }): JSX.Element {
     const { user } = useValues(userLogic)
+    const is3000 = useFeatureFlag('POSTHOG_3000')
 
     if (!canGloballyManagePlugins(user?.organization)) {
         return <></>
@@ -69,7 +71,7 @@ export function AppManagementView({
                             className="Plugins__Popconfirm"
                         >
                             <LemonButton
-                                type="primary"
+                                type={is3000 ? 'secondary' : 'primary'}
                                 status="danger"
                                 size="small"
                                 icon={<IconDelete />}
@@ -78,7 +80,7 @@ export function AppManagementView({
                                 }
                                 data-attr="plugin-uninstall"
                             >
-                                Uninstall
+                                Uninstall me
                             </LemonButton>
                         </Popconfirm>
                         {plugin.is_global ? (

--- a/frontend/src/scenes/settings/organization/OrganizationDangerZone.tsx
+++ b/frontend/src/scenes/settings/organization/OrganizationDangerZone.tsx
@@ -16,7 +16,7 @@ export function DeleteOrganizationModal({
 }): JSX.Element {
     const { currentOrganization, organizationBeingDeleted } = useValues(organizationLogic)
     const { deleteOrganization } = useActions(organizationLogic)
-    const is3000 = useFeatureFlag('POSTHOG_3000')
+    const is3000 = useFeatureFlag('POSTHOG_3000', 'test')
 
     const [isDeletionConfirmed, setIsDeletionConfirmed] = useState(false)
     const isDeletionInProgress = !!currentOrganization && organizationBeingDeleted?.id === currentOrganization.id

--- a/frontend/src/scenes/settings/organization/OrganizationDangerZone.tsx
+++ b/frontend/src/scenes/settings/organization/OrganizationDangerZone.tsx
@@ -2,6 +2,7 @@ import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { useRestrictedArea } from 'lib/components/RestrictedArea'
 import { OrganizationMembershipLevel } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconDelete } from 'lib/lemon-ui/icons'
 import { Dispatch, SetStateAction, useState } from 'react'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -15,6 +16,7 @@ export function DeleteOrganizationModal({
 }): JSX.Element {
     const { currentOrganization, organizationBeingDeleted } = useValues(organizationLogic)
     const { deleteOrganization } = useActions(organizationLogic)
+    const is3000 = useFeatureFlag('POSTHOG_3000')
 
     const [isDeletionConfirmed, setIsDeletionConfirmed] = useState(false)
     const isDeletionInProgress = !!currentOrganization && organizationBeingDeleted?.id === currentOrganization.id
@@ -29,7 +31,7 @@ export function DeleteOrganizationModal({
                         Cancel
                     </LemonButton>
                     <LemonButton
-                        type="primary"
+                        type={is3000 ? 'secondary' : 'primary'}
                         disabled={!isDeletionConfirmed}
                         loading={isDeletionInProgress}
                         data-attr="delete-organization-ok"

--- a/frontend/src/scenes/settings/project/ProjectDangerZone.tsx
+++ b/frontend/src/scenes/settings/project/ProjectDangerZone.tsx
@@ -18,7 +18,7 @@ export function DeleteProjectModal({
 }): JSX.Element {
     const { currentTeam, teamBeingDeleted } = useValues(teamLogic)
     const { deleteTeam } = useActions(teamLogic)
-    const is3000 = useFeatureFlag('POSTHOG_3000')
+    const is3000 = useFeatureFlag('POSTHOG_3000', 'test')
 
     const [isDeletionConfirmed, setIsDeletionConfirmed] = useState(false)
     const isDeletionInProgress = !!currentTeam && teamBeingDeleted?.id === currentTeam.id

--- a/frontend/src/scenes/settings/project/ProjectDangerZone.tsx
+++ b/frontend/src/scenes/settings/project/ProjectDangerZone.tsx
@@ -2,6 +2,7 @@ import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { OrganizationMembershipLevel } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconDelete } from 'lib/lemon-ui/icons'
 import { Dispatch, SetStateAction, useState } from 'react'
 import { teamLogic } from 'scenes/teamLogic'
@@ -17,6 +18,7 @@ export function DeleteProjectModal({
 }): JSX.Element {
     const { currentTeam, teamBeingDeleted } = useValues(teamLogic)
     const { deleteTeam } = useActions(teamLogic)
+    const is3000 = useFeatureFlag('POSTHOG_3000')
 
     const [isDeletionConfirmed, setIsDeletionConfirmed] = useState(false)
     const isDeletionInProgress = !!currentTeam && teamBeingDeleted?.id === currentTeam.id
@@ -31,7 +33,7 @@ export function DeleteProjectModal({
                         Cancel
                     </LemonButton>
                     <LemonButton
-                        type="primary"
+                        type={is3000 ? 'secondary' : 'primary'}
                         disabled={!isDeletionConfirmed}
                         loading={isDeletionInProgress}
                         data-attr="delete-project-ok"

--- a/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
@@ -74,7 +74,7 @@ function CreateKeyModal({
 function PersonalAPIKeysTable(): JSX.Element {
     const { keys } = useValues(personalAPIKeysLogic) as { keys: PersonalAPIKeyType[] }
     const { deleteKey, loadKeys } = useActions(personalAPIKeysLogic)
-    const is3000 = useFeatureFlag('POSTHOG_3000')
+    const is3000 = useFeatureFlag('POSTHOG_3000', 'test')
 
     useEffect(() => loadKeys(), [])
 

--- a/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
+++ b/frontend/src/scenes/settings/user/PersonalAPIKeys.tsx
@@ -1,5 +1,6 @@
 import { LemonDialog, LemonInput, LemonModal, LemonTable, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconPlus } from 'lib/lemon-ui/icons'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -73,6 +74,7 @@ function CreateKeyModal({
 function PersonalAPIKeysTable(): JSX.Element {
     const { keys } = useValues(personalAPIKeysLogic) as { keys: PersonalAPIKeyType[] }
     const { deleteKey, loadKeys } = useActions(personalAPIKeysLogic)
+    const is3000 = useFeatureFlag('POSTHOG_3000')
 
     useEffect(() => loadKeys(), [])
 
@@ -121,8 +123,8 @@ function PersonalAPIKeysTable(): JSX.Element {
                         return (
                             <LemonButton
                                 status="danger"
-                                type="primary"
-                                size="small"
+                                type={is3000 ? 'tertiary' : 'primary'}
+                                size="xsmall"
                                 onClick={() => {
                                     LemonDialog.open({
                                         title: `Permanently delete key "${key.label}"?`,

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -634,7 +634,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_1')
+                                                      'user_one_2')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -634,7 +634,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_2')
+                                                      'user_one_1')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---


### PR DESCRIPTION
## Problem

We do not support the `type=primary` & `status=danger` combo in PostHog 3000 (yet... until we decide on the new button system)

## Changes

- Replace any instance of danger buttons where the type is primary with `type="secondary"` only in 3000

|Before|After|
|----|----|
| <img width="366" alt="Screenshot 2023-12-05 at 11 16 49" src="https://github.com/PostHog/posthog/assets/6685876/e704108a-c70d-4212-8293-496a89fae12e"> | <img width="385" alt="Screenshot 2023-12-05 at 11 18 14" src="https://github.com/PostHog/posthog/assets/6685876/cf903fcb-005b-426c-a5b5-9cb9b2426459"> |

|Before|After|
|----|----|
| <img width="940" alt="Screenshot 2023-12-05 at 11 22 12" src="https://github.com/PostHog/posthog/assets/6685876/df35d8fa-08bd-4e0b-92a5-69609b21ff99"> | <img width="947" alt="Screenshot 2023-12-05 at 11 23 22" src="https://github.com/PostHog/posthog/assets/6685876/11de03c0-7e06-4c14-81b8-cb6e9edb9643"> |

Needed to change one place we had two danger buttons next to each other because we no longer have a primary & secondary danger button. Decided to use tertiary instead, for now

|Before|After|
|----|----|
| <img width="1061" alt="Screenshot 2023-12-05 at 11 27 55" src="https://github.com/PostHog/posthog/assets/6685876/9aef530e-e809-4b76-87a2-97c3e5f43137"> | <img width="997" alt="Screenshot 2023-12-05 at 11 34 51" src="https://github.com/PostHog/posthog/assets/6685876/d2f31fd8-0894-4c03-8b7f-df09f22471e7"> |

## How did you test this code?

By 👁️ 