### PR TITLE
fix: player meta links

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.stories.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.stories.tsx
@@ -27,10 +27,15 @@ WebRecording.args = {
     loading: false,
     onPropertyClick: () => {},
     recordingProperties: [
-        { value: 'Mac OS X', property: '$os', tooltipValue: 'Mac OS X' },
-        { value: 'Chrome', property: '$browser', tooltipValue: 'Chrome' },
-        { value: 'United States', property: '$geoip_country_code', tooltipValue: 'United States' },
-        { value: 'Desktop', property: '$device_type', tooltipValue: 'Desktop' },
+        { label: 'Mac OS X', value: 'Mac OS X', property: '$os', tooltipValue: 'Mac OS X' },
+        { label: 'Chrome', value: 'Chrome', property: '$browser', tooltipValue: 'Chrome' },
+        {
+            label: 'United States',
+            value: 'United States',
+            property: '$geoip_country_code',
+            tooltipValue: 'United States',
+        },
+        { label: 'Desktop', value: 'Desktop', property: '$device_type', tooltipValue: 'Desktop' },
     ],
 }
 
@@ -40,10 +45,15 @@ AndroidRecording.args = {
     loading: false,
     onPropertyClick: () => {},
     recordingProperties: [
-        { value: 'Android', property: '$os_name', tooltipValue: 'Android' },
-        { value: 'Awesome Fun App', property: '$app_name', tooltipValue: 'Awesome Fun App' },
-        { value: 'United States', property: '$geoip_country_code', tooltipValue: 'United States' },
-        { value: 'Mobile', property: '$device_type', tooltipValue: 'Mobile' },
+        { label: 'Android', value: 'Android', property: '$os_name', tooltipValue: 'Android' },
+        { label: 'Awesome Fun App', value: 'Awesome Fun App', property: '$app_name', tooltipValue: 'Awesome Fun App' },
+        {
+            label: 'United States',
+            value: 'United States',
+            property: '$geoip_country_code',
+            tooltipValue: 'United States',
+        },
+        { label: 'Mobile', value: 'Mobile', property: '$device_type', tooltipValue: 'Mobile' },
     ],
 }
 


### PR DESCRIPTION
see https://github.com/PostHog/posthog/issues/19037

 * Apps don't have URLs so don't link to them - fixes "Replay title (inferred from href) always leads to Recording not found"
 * changing that made me realise that the player meta area generated the property icons itself so I'd missed them in https://github.com/PostHog/posthog/pull/18973

now shows the same icons 

### full screen

<img width="292" alt="Screenshot 2023-12-05 at 13 31 02" src="https://github.com/PostHog/posthog/assets/984817/56a77c45-79c3-4bee-97f6-a8eda2f510d8">

### not full screen

<img width="353" alt="Screenshot 2023-12-05 at 13 30 53" src="https://github.com/PostHog/posthog/assets/984817/0b3a21c0-3737-4227-9361-a33fd80c7417">
