### PR TITLE
fix: weird overflow of input in rolling date filter

### DIFF
--- a/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.scss
+++ b/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.scss
@@ -11,6 +11,10 @@
     cursor: pointer;
     transition: background 0.3s ease;
 
+    .posthog-3000 & {
+        height: 1.6875rem;
+    }
+
     &:hover {
         background-color: var(--mid);
     }
@@ -45,11 +49,20 @@
     border: 1px solid var(--border);
     border-radius: var(--radius);
 
+    .posthog-3000 & {
+        height: 1.6875rem;
+        line-height: 1.5rem;
+    }
+
     .LemonInput {
         width: 3rem;
         min-height: 0;
         padding: 0;
         border: none;
+
+        .posthog-3000 & {
+            height: unset;
+        }
 
         input {
             text-align: center;
@@ -61,8 +74,35 @@
         margin: 0 0.25rem;
         border-radius: var(--radius);
 
+        &:first-child {
+            .posthog-3000 & {
+                border-top-right-radius: 0;
+                border-bottom-right-radius: 0;
+            }
+        }
+
+        &:last-child {
+            .posthog-3000 & {
+                border-top-left-radius: 0;
+                border-bottom-left-radius: 0;
+            }
+        }
+
+        .posthog-3000 & {
+            width: 1.25rem;
+            height: 100%;
+            padding: 0;
+            margin: 0;
+            text-align: center;
+            border-radius: calc(var(--radius) - 1px);
+        }
+
         &:hover {
             background-color: var(--primary-highlight);
+
+            .posthog-3000 & {
+                background-color: var(--accent-3000);
+            }
         }
     }
 }

--- a/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.tsx
@@ -4,6 +4,7 @@ import { LemonButton, LemonInput, LemonSelect, LemonSelectOptions } from '@posth
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { dayjs } from 'lib/dayjs'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
 import { DateOption, rollingDateRangeFilterLogic } from './rollingDateRangeFilterLogic'
@@ -38,6 +39,7 @@ export function RollingDateRangeFilter({
     const { increaseCounter, decreaseCounter, setCounter, setDateOption, toggleDateOptionsSelector, select } =
         useActions(rollingDateRangeFilterLogic(logicProps))
     const { counter, dateOption, formattedDate } = useValues(rollingDateRangeFilterLogic(logicProps))
+    const is3000 = useFeatureFlag('POSTHOG_3000')
 
     return (
         <Tooltip title={makeLabel ? makeLabel(formattedDate) : undefined}>
@@ -89,7 +91,7 @@ export function RollingDateRangeFilter({
                         ...popover,
                         className: 'RollingDateRangeFilter__popover',
                     }}
-                    size="small"
+                    size={is3000 ? 'xsmall' : 'small'}
                 />
             </LemonButton>
         </Tooltip>

--- a/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
@@ -74,7 +74,7 @@ export interface LemonSelectPropsBase<T>
     dropdownPlacement?: PopoverProps['placement']
     className?: string
     placeholder?: string
-    size?: 'small' | 'medium'
+    size?: LemonButtonProps['size']
     menu?: Pick<LemonMenuProps, 'className' | 'closeParentPopoverOnClickInside'>
 }
 


### PR DESCRIPTION
## Problem

The rolling date filter looks broken in 3000

https://github.com/PostHog/posthog/assets/6685876/c5ddc0e6-3ba9-4543-9827-f5482bfe9285

## Changes

Cleaned up styling in the new version

https://github.com/PostHog/posthog/assets/6685876/4e04c397-fee2-4e49-8b93-3700ff916806

## How did you test this code?

Manually