### PR TITLE
chore: LemonSelect caret position

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.scss
+++ b/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.scss
@@ -30,4 +30,8 @@ body:not(.posthog-3000) {
             }
         }
     }
+
+    .LemonButton.LemonSelect {
+        --lemon-button-gap: 0.1875rem;
+    }
 }

--- a/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
@@ -140,7 +140,7 @@ export function LemonSelect<T extends string | number | boolean | null>({
             closeParentPopoverOnClickInside={menu?.closeParentPopoverOnClickInside}
         >
             <LemonButton
-                className={clsx(className, isClearButtonShown && 'LemonSelect--clearable')}
+                className={clsx(className, 'LemonSelect', isClearButtonShown && 'LemonSelect--clearable')}
                 icon={activeLeaf?.icon}
                 // so that the pop-up isn't shown along with the close button
                 sideIcon={isClearButtonShown ? <></> : undefined}


### PR DESCRIPTION
## Problem

@corywatilo wants a smaller gap between the text and icon for LemonSelect

## Changes

https://github.com/PostHog/posthog/assets/6685876/e2337e30-2346-4ee8-bb6b-a1b314c74fec

## How did you test this code?

Visually