### PR TITLE
fix: only get the fields we need from teams to run reports

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -1401,7 +1401,7 @@ class SendUsageNoLicenseTest(APIBaseTest):
 
         mock_post.assert_not_called()
 
-    def test_get_teams_for_usage_reports_only_fields(self):
+    def test_get_teams_for_usage_reports_only_fields(self) -> None:
         teams = _get_teams_for_usage_reports()
         team: Team = teams[0]
 

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -37,6 +37,7 @@ from posthog.tasks.usage_report import (
     _get_full_org_usage_report,
     _get_full_org_usage_report_as_dict,
     _get_team_report,
+    _get_teams_for_usage_reports,
     capture_event,
     get_instance_metadata,
     send_all_org_usage_reports,
@@ -1399,3 +1400,18 @@ class SendUsageNoLicenseTest(APIBaseTest):
         send_all_org_usage_reports()
 
         mock_post.assert_not_called()
+
+    def test_get_teams_for_usage_reports_only_fields(self):
+        teams = _get_teams_for_usage_reports()
+        team: Team = teams[0]
+
+        # these fields are included in the query, so shouldn't require additional queries
+        with self.assertNumQueries(0):
+            _ = team.id
+            _ = team.organization.id
+            _ = team.organization.name
+            _ = team.organization.created_at
+
+        # This field is not included in the original team query, so should require an additional query
+        with self.assertNumQueries(1):
+            _ = team.organization.for_internal_metrics

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -832,9 +832,9 @@ def _get_all_usage_data_as_team_rows(period_start: datetime, period_end: datetim
 
 def _get_teams_for_usage_reports() -> Sequence[Team]:
     return list(
-        Team.objects.select_related("organization").exclude(
-            Q(organization__for_internal_metrics=True) | Q(is_demo=True)
-        )
+        Team.objects.select_related("organization")
+        .exclude(Q(organization__for_internal_metrics=True) | Q(is_demo=True))
+        .only("id", "organization__id", "organization__name", "organization__created_at")
     )
 
 


### PR DESCRIPTION
## Problem

We're running out of memory in usage report tasks because we get way too much data about the teams - we really only need a minimal amount of data to run these.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Only get the fields we need for the teams.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
