### PR TITLE
feat(plugin-server): Add capability to use deferred overrides writer and worker

### DIFF
--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -19,6 +19,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 processAsyncOnEventHandlers: true,
                 processAsyncWebhooksHandlers: true,
                 sessionRecordingBlobIngestion: true,
+                personOverrides: config.POE_DEFERRED_WRITES_ENABLED,
                 transpileFrontendApps: true,
                 preflightSchedules: true,
                 ...sharedCapabilities,
@@ -73,6 +74,11 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
             return {
                 pluginScheduledTasks: true,
                 transpileFrontendApps: true, // TODO: move this away from pod startup, into a graphile job
+                ...sharedCapabilities,
+            }
+        case PluginServerMode.person_overrides:
+            return {
+                personOverrides: true,
                 ...sharedCapabilities,
             }
     }

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -128,6 +128,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         EXTERNAL_REQUEST_TIMEOUT_MS: 10 * 1000, // 10 seconds
         DROP_EVENTS_BY_TOKEN_DISTINCT_ID: '',
         DROP_EVENTS_BY_TOKEN: '',
+        POE_DEFERRED_WRITES_ENABLED: false,
         POE_EMBRACE_JOIN_FOR_TEAMS: '',
         RELOAD_PLUGIN_JITTER_MAX_MS: 60000,
 

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -21,7 +21,7 @@ import { status } from '../utils/status'
 import { delay } from '../utils/utils'
 import { AppMetrics } from '../worker/ingestion/app-metrics'
 import { OrganizationManager } from '../worker/ingestion/organization-manager'
-import { DeferredPersonOverrideWriter } from '../worker/ingestion/person-state'
+import { DeferredPersonOverrideWorker } from '../worker/ingestion/person-state'
 import { TeamManager } from '../worker/ingestion/team-manager'
 import Piscina, { makePiscina as defaultMakePiscina } from '../worker/piscina'
 import { GraphileWorker } from './graphile-worker/graphile-worker'
@@ -436,11 +436,11 @@ export async function startPluginsServer(
         if (capabilities.personOverrides) {
             const postgres = hub?.postgres ?? new PostgresRouter(serverConfig)
             const kafkaProducer = hub?.kafkaProducer ?? (await createKafkaProducerWrapper(serverConfig))
-            const overridesWriter = new DeferredPersonOverrideWriter(postgres)
+            const overridesWorker = new DeferredPersonOverrideWorker(postgres)
 
             personOverridesWorker = new PeriodicTask(async () => {
                 status.debug('👥', 'Processing pending overrides...')
-                const overridesCount = await overridesWriter.processPendingOverrides(kafkaProducer)
+                const overridesCount = await overridesWorker.processPendingOverrides(kafkaProducer)
                 ;(overridesCount > 0 ? status.info : status.debug)(
                     '👥',
                     `Processed ${overridesCount} pending overrides.`

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -447,7 +447,11 @@ export async function startPluginsServer(
                 )
             })
 
-            healthChecks['person-overrides'] = () => personOverridesWorker!.isRunning()
+            personOverridesWorker.promise.catch(async () => {
+                status.error('⚠️', 'Person override writer crashed! Requesting shutdown...')
+                await closeJobs()
+                process.exit(1)
+            })
         }
 
         if (capabilities.http) {

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -437,7 +437,7 @@ export async function startPluginsServer(
             const postgres = hub?.postgres ?? new PostgresRouter(serverConfig)
             const kafkaProducer = hub?.kafkaProducer ?? (await createKafkaProducerWrapper(serverConfig))
 
-            personOverridesPeriodicTask = new DeferredPersonOverrideWorker(postgres, kafkaProducer).runTask()
+            personOverridesPeriodicTask = new DeferredPersonOverrideWorker(postgres, kafkaProducer).runTask(5000)
             personOverridesPeriodicTask.promise.catch(async () => {
                 status.error('⚠️', 'Person override worker task crashed! Requesting shutdown...')
                 await closeJobs()

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -436,17 +436,8 @@ export async function startPluginsServer(
         if (capabilities.personOverrides) {
             const postgres = hub?.postgres ?? new PostgresRouter(serverConfig)
             const kafkaProducer = hub?.kafkaProducer ?? (await createKafkaProducerWrapper(serverConfig))
-            const overridesWorker = new DeferredPersonOverrideWorker(postgres, kafkaProducer)
 
-            personOverridesWorker = new PeriodicTask(async () => {
-                status.debug('👥', 'Processing pending overrides...')
-                const overridesCount = await overridesWorker.processPendingOverrides()
-                ;(overridesCount > 0 ? status.info : status.debug)(
-                    '👥',
-                    `Processed ${overridesCount} pending overrides.`
-                )
-            })
-
+            personOverridesWorker = new DeferredPersonOverrideWorker(postgres, kafkaProducer).run()
             personOverridesWorker.promise.catch(async () => {
                 status.error('⚠️', 'Person override writer crashed! Requesting shutdown...')
                 await closeJobs()

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -436,11 +436,11 @@ export async function startPluginsServer(
         if (capabilities.personOverrides) {
             const postgres = hub?.postgres ?? new PostgresRouter(serverConfig)
             const kafkaProducer = hub?.kafkaProducer ?? (await createKafkaProducerWrapper(serverConfig))
-            const overridesWorker = new DeferredPersonOverrideWorker(postgres)
+            const overridesWorker = new DeferredPersonOverrideWorker(postgres, kafkaProducer)
 
             personOverridesWorker = new PeriodicTask(async () => {
                 status.debug('👥', 'Processing pending overrides...')
-                const overridesCount = await overridesWorker.processPendingOverrides(kafkaProducer)
+                const overridesCount = await overridesWorker.processPendingOverrides()
                 ;(overridesCount > 0 ? status.info : status.debug)(
                     '👥',
                     `Processed ${overridesCount} pending overrides.`

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -198,6 +198,7 @@ export interface PluginsServerConfig {
     DROP_EVENTS_BY_TOKEN_DISTINCT_ID: string
     DROP_EVENTS_BY_TOKEN: string
     POE_EMBRACE_JOIN_FOR_TEAMS: string
+    POE_DEFERRED_WRITES_ENABLED: boolean
     RELOAD_PLUGIN_JITTER_MAX_MS: number
     SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -76,6 +76,7 @@ export enum PluginServerMode {
     scheduler = 'scheduler',
     analytics_ingestion = 'analytics-ingestion',
     recordings_blob_ingestion = 'recordings-blob-ingestion',
+    person_overrides = 'person-overrides',
 }
 
 export const stringToPluginServerMode = Object.fromEntries(
@@ -287,6 +288,7 @@ export interface PluginServerCapabilities {
     processAsyncOnEventHandlers?: boolean
     processAsyncWebhooksHandlers?: boolean
     sessionRecordingBlobIngestion?: boolean
+    personOverrides?: boolean
     transpileFrontendApps?: boolean // TODO: move this away from pod startup, into a graphile job
     preflightSchedules?: boolean // Used for instance health checks on hobby deploy, not useful on cloud
     http?: boolean

--- a/plugin-server/src/utils/periodic-task.ts
+++ b/plugin-server/src/utils/periodic-task.ts
@@ -6,7 +6,7 @@ export class PeriodicTask {
     private running = true
     private abortController: AbortController
 
-    constructor(task: () => Promise<void> | void, intervalMs = 1000, minimumWaitMs = 1000) {
+    constructor(task: () => Promise<void> | void, intervalMs: number, minimumWaitMs = 0) {
         this.abortController = new AbortController()
 
         const abortRequested = new Promise((resolve) => {

--- a/plugin-server/src/utils/periodic-task.ts
+++ b/plugin-server/src/utils/periodic-task.ts
@@ -17,10 +17,15 @@ export class PeriodicTask {
             try {
                 status.debug('🔄', 'Periodic task starting...', { task })
                 while (!this.abortController.signal.aborted) {
-                    const startTimeMs = +Date.now()
+                    const startTimeMs = Date.now()
                     await task()
-                    const waitTimeMs = Math.max(intervalMs - startTimeMs, minimumWaitMs)
-                    status.debug('🔄', `Next evaluation in ${waitTimeMs / 1000}s`, { task })
+                    const durationMs = Date.now() - startTimeMs
+                    const waitTimeMs = Math.max(intervalMs - durationMs, minimumWaitMs)
+                    status.debug(
+                        '🔄',
+                        `Task completed in ${durationMs / 1000}s, next evaluation in ${waitTimeMs / 1000}s`,
+                        { task }
+                    )
                     await Promise.race([sleep(waitTimeMs), abortRequested])
                 }
                 status.info('✅', 'Periodic task stopped by request.', { task })

--- a/plugin-server/src/utils/periodic-task.ts
+++ b/plugin-server/src/utils/periodic-task.ts
@@ -1,0 +1,47 @@
+import { status } from './status'
+import { sleep } from './utils'
+
+export class PeriodicTask {
+    private promise: Promise<void>
+    private running = true
+    private abortController: AbortController
+
+    constructor(task: () => Promise<void> | void, intervalMs = 1000, minimumWaitMs = 1000) {
+        this.abortController = new AbortController()
+
+        const abortRequested = new Promise((resolve) => {
+            this.abortController.signal.addEventListener('abort', resolve, { once: true })
+        })
+
+        this.promise = new Promise<void>(async (resolve, reject) => {
+            try {
+                status.debug('🔄', 'Periodic task starting...', { task })
+                while (!this.abortController.signal.aborted) {
+                    const startTimeMs = +Date.now()
+                    await task()
+                    const waitTimeMs = Math.max(intervalMs - startTimeMs, minimumWaitMs)
+                    status.debug('🔄', `Next evaluation in ${waitTimeMs / 1000}s`, { task })
+                    await Promise.race([sleep(waitTimeMs), abortRequested])
+                }
+                status.info('✅', 'Periodic task stopped by request.', { task })
+                resolve()
+            } catch (error) {
+                status.warn('⚠️', 'Error in periodic task!', { task, error })
+                reject(error)
+            } finally {
+                this.running = false
+            }
+        })
+    }
+
+    public isRunning(): boolean {
+        return this.running
+    }
+
+    public async stop(): Promise<void> {
+        this.abortController.abort()
+        try {
+            await this.promise
+        } catch {}
+    }
+}

--- a/plugin-server/src/utils/periodic-task.ts
+++ b/plugin-server/src/utils/periodic-task.ts
@@ -16,7 +16,7 @@ export class PeriodicTask {
 
         this.promise = new Promise(async (resolve, reject) => {
             try {
-                status.debug('🔄', 'Periodic task starting...', { task })
+                status.debug('🔄', `${this}: Starting...`)
                 while (!this.abortController.signal.aborted) {
                     const startTimeMs = Date.now()
                     await instrument({ metricName: this.name }, task)
@@ -24,15 +24,14 @@ export class PeriodicTask {
                     const waitTimeMs = Math.max(intervalMs - durationMs, minimumWaitMs)
                     status.debug(
                         '🔄',
-                        `Task completed in ${durationMs / 1000}s, next evaluation in ${waitTimeMs / 1000}s`,
-                        { task }
+                        `${this}: Task completed in ${durationMs / 1000}s, next evaluation in ${waitTimeMs / 1000}s`
                     )
                     await Promise.race([sleep(waitTimeMs), abortRequested])
                 }
-                status.info('✅', 'Periodic task stopped by request.', { task })
+                status.info('🔴', `${this}: Stopped by request.`)
                 resolve()
             } catch (error) {
-                status.warn('⚠️', 'Error in periodic task!', { task, error })
+                status.warn('⚠️', `${this}: Unexpected error!`, { error })
                 reject(error)
             } finally {
                 this.running = false
@@ -40,11 +39,16 @@ export class PeriodicTask {
         })
     }
 
+    public toString(): string {
+        return `Periodic Task (${this.name})`
+    }
+
     public isRunning(): boolean {
         return this.running
     }
 
     public async stop(): Promise<void> {
+        status.info(`⏳`, `${this}: Stop requested...`)
         this.abortController.abort()
         try {
             await this.promise

--- a/plugin-server/src/utils/periodic-task.ts
+++ b/plugin-server/src/utils/periodic-task.ts
@@ -2,7 +2,7 @@ import { status } from './status'
 import { sleep } from './utils'
 
 export class PeriodicTask {
-    private promise: Promise<void>
+    public readonly promise: Promise<void>
     private running = true
     private abortController: AbortController
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -2,7 +2,6 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 import { Person } from 'types'
 
-import { defaultConfig } from '../../../config/config'
 import { normalizeEvent } from '../../../utils/event'
 import { status } from '../../../utils/status'
 import { DeferredPersonOverrideWriter, PersonOverrideWriter, PersonState } from '../person-state'
@@ -25,7 +24,7 @@ export async function processPersonsStep(
 
     let overridesWriter: PersonOverrideWriter | DeferredPersonOverrideWriter | undefined = undefined
     if (runner.poEEmbraceJoin) {
-        if (defaultConfig.POE_DEFERRED_WRITES_ENABLED) {
+        if (runner.hub.POE_DEFERRED_WRITES_ENABLED) {
             overridesWriter = new DeferredPersonOverrideWriter(runner.hub.db.postgres)
         } else {
             overridesWriter = new PersonOverrideWriter(runner.hub.db.postgres)

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -2,9 +2,10 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 import { Person } from 'types'
 
+import { defaultConfig } from '../../../config/config'
 import { normalizeEvent } from '../../../utils/event'
 import { status } from '../../../utils/status'
-import { PersonOverrideWriter, PersonState } from '../person-state'
+import { DeferredPersonOverrideWriter, PersonOverrideWriter, PersonState } from '../person-state'
 import { parseEventTimestamp } from '../timestamps'
 import { EventPipelineRunner } from './runner'
 
@@ -22,13 +23,22 @@ export async function processPersonsStep(
         throw error
     }
 
+    let overridesWriter: PersonOverrideWriter | DeferredPersonOverrideWriter | undefined = undefined
+    if (runner.poEEmbraceJoin) {
+        if (defaultConfig.POE_DEFERRED_WRITES_ENABLED) {
+            overridesWriter = new DeferredPersonOverrideWriter(runner.hub.db.postgres)
+        } else {
+            overridesWriter = new PersonOverrideWriter(runner.hub.db.postgres)
+        }
+    }
+
     const person = await new PersonState(
         event,
         event.team_id,
         String(event.distinct_id),
         timestamp,
         runner.hub.db,
-        runner.poEEmbraceJoin ? new PersonOverrideWriter(runner.hub.db.postgres) : undefined
+        overridesWriter
     ).update()
 
     return [event, person]

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -740,11 +740,11 @@ export class DeferredPersonOverrideWriter {
 }
 
 export class DeferredPersonOverrideWorker {
-    /**
-     * @param lockId the lock identifier/key used to ensure that only one
-     *               process is updating the overrides at a time
-     */
-    constructor(private postgres: PostgresRouter, private lockId: number = 567) {}
+    // The advisory lock identifier/key used to ensure that only one process is
+    // updating the overrides at a time.
+    public readonly lockId = 567
+
+    constructor(private postgres: PostgresRouter) {}
 
     /**
      * Process all (or up to the given limit) pending overrides.

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -10,6 +10,7 @@ import { Person, PropertyUpdateOperation, TimestampFormat } from '../../types'
 import { DB } from '../../utils/db/db'
 import { PostgresRouter, PostgresUse, TransactionClient } from '../../utils/db/postgres'
 import { timeoutGuard } from '../../utils/db/utils'
+import { PeriodicTask } from '../../utils/periodic-task'
 import { promiseRetry } from '../../utils/retries'
 import { status } from '../../utils/status'
 import { castTimestampOrNow, UUIDT } from '../../utils/utils'
@@ -804,6 +805,14 @@ export class DeferredPersonOverrideWorker {
             await this.kafkaProducer.queueMessages(messages, true)
 
             return rows.length
+        })
+    }
+
+    public run(): PeriodicTask {
+        return new PeriodicTask(async () => {
+            status.debug('👥', 'Processing pending overrides...')
+            const overridesCount = await this.processPendingOverrides()
+            ;(overridesCount > 0 ? status.info : status.debug)('👥', `Processed ${overridesCount} pending overrides.`)
         })
     }
 }

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -751,8 +751,12 @@ const deferredPersonOverridesProcessedCounter = new Counter({
 })
 
 export class DeferredPersonOverrideWorker {
-    // The advisory lock identifier/key used to ensure that only one process is
-    // updating the overrides at a time.
+    // This lock ID is used as an advisory lock identifier/key for a lock that
+    // ensures only one worker is able to update the overrides table at a time.
+    // (We do this to make it simpler to ensure that we maintain the consistency
+    // of transitive updates.) There isn't any special significance to this
+    // particular value (other than Postgres requires it to be a numeric one),
+    // it just needs to be consistent across all processes.
     public readonly lockId = 567
 
     private writer: PersonOverrideWriter

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -808,12 +808,12 @@ export class DeferredPersonOverrideWorker {
         })
     }
 
-    public runTask(): PeriodicTask {
+    public runTask(intervalMs: number): PeriodicTask {
         return new PeriodicTask(async () => {
             status.debug('👥', 'Processing pending overrides...')
             const overridesCount = await this.processPendingOverrides()
             ;(overridesCount > 0 ? status.info : status.debug)('👥', `Processed ${overridesCount} pending overrides.`)
-        })
+        }, intervalMs)
     }
 }
 

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -808,7 +808,7 @@ export class DeferredPersonOverrideWorker {
         })
     }
 
-    public run(): PeriodicTask {
+    public runTask(): PeriodicTask {
         return new PeriodicTask(async () => {
             status.debug('👥', 'Processing pending overrides...')
             const overridesCount = await this.processPendingOverrides()

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -10,6 +10,7 @@ import { Person, PropertyUpdateOperation, TimestampFormat } from '../../types'
 import { DB } from '../../utils/db/db'
 import { PostgresRouter, PostgresUse, TransactionClient } from '../../utils/db/postgres'
 import { timeoutGuard } from '../../utils/db/utils'
+import { instrument } from '../../utils/metrics'
 import { PeriodicTask } from '../../utils/periodic-task'
 import { promiseRetry } from '../../utils/retries'
 import { status } from '../../utils/status'
@@ -813,7 +814,9 @@ export class DeferredPersonOverrideWorker {
     public runTask(intervalMs: number): PeriodicTask {
         return new PeriodicTask(async () => {
             status.debug('👥', 'Processing pending overrides...')
-            const overridesCount = await this.processPendingOverrides()
+            const overridesCount = await instrument({ metricName: 'processPendingOverrides' }, () =>
+                this.processPendingOverrides()
+            )
             ;(overridesCount > 0 ? status.info : status.debug)('👥', `Processed ${overridesCount} pending overrides.`)
         }, intervalMs)
     }

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -708,11 +708,7 @@ export class PersonOverrideWriter {
 }
 
 export class DeferredPersonOverrideWriter {
-    /**
-     * @param lockId the lock identifier/key used to ensure that only one
-     *               process is updating the overrides at a time
-     */
-    constructor(private postgres: PostgresRouter, private lockId: number = 567) {}
+    constructor(private postgres: PostgresRouter) {}
 
     /**
      * Enqueue an override for deferred processing.
@@ -741,6 +737,14 @@ export class DeferredPersonOverrideWriter {
 
         return []
     }
+}
+
+export class DeferredPersonOverrideWorker {
+    /**
+     * @param lockId the lock identifier/key used to ensure that only one
+     *               process is updating the overrides at a time
+     */
+    constructor(private postgres: PostgresRouter, private lockId: number = 567) {}
 
     /**
      * Process all (or up to the given limit) pending overrides.

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -712,7 +712,7 @@ export class DeferredPersonOverrideWriter {
      * @param lockId the lock identifier/key used to ensure that only one
      *               process is updating the overrides at a time
      */
-    constructor(private postgres: PostgresRouter, private lockId: number) {}
+    constructor(private postgres: PostgresRouter, private lockId: number = 567) {}
 
     /**
      * Enqueue an override for deferred processing.

--- a/plugin-server/tests/utils/periodic-task.test.ts
+++ b/plugin-server/tests/utils/periodic-task.test.ts
@@ -4,7 +4,7 @@ describe('PeriodicTask', () => {
     describe('updates completion status', () => {
         it('on success', async () => {
             const fn = jest.fn()
-            const task = new PeriodicTask(fn)
+            const task = new PeriodicTask(fn, 1000)
             expect(fn).toBeCalled()
             expect(task.isRunning()).toEqual(true)
             await task.stop()
@@ -15,7 +15,7 @@ describe('PeriodicTask', () => {
             const fn = jest.fn(() => {
                 throw new Error()
             })
-            const task = new PeriodicTask(fn)
+            const task = new PeriodicTask(fn, 1000)
             expect(fn).toBeCalled()
             await task.stop()
             expect(task.isRunning()).toEqual(false)

--- a/plugin-server/tests/utils/periodic-task.test.ts
+++ b/plugin-server/tests/utils/periodic-task.test.ts
@@ -1,0 +1,24 @@
+import { PeriodicTask } from '../../src/utils/periodic-task'
+
+describe('PeriodicTask', () => {
+    describe('updates completion status', () => {
+        it('on success', async () => {
+            const fn = jest.fn()
+            const task = new PeriodicTask(fn)
+            expect(fn).toBeCalled()
+            expect(task.isRunning()).toEqual(true)
+            await task.stop()
+            expect(task.isRunning()).toEqual(false)
+        })
+
+        it('on failure', async () => {
+            const fn = jest.fn(() => {
+                throw new Error()
+            })
+            const task = new PeriodicTask(fn)
+            expect(fn).toBeCalled()
+            await task.stop()
+            expect(task.isRunning()).toEqual(false)
+        })
+    })
+})

--- a/plugin-server/tests/utils/periodic-task.test.ts
+++ b/plugin-server/tests/utils/periodic-task.test.ts
@@ -4,7 +4,7 @@ describe('PeriodicTask', () => {
     describe('updates completion status', () => {
         it('on success', async () => {
             const fn = jest.fn()
-            const task = new PeriodicTask(fn, 1000)
+            const task = new PeriodicTask('test', fn, 1000)
             expect(fn).toBeCalled()
             expect(task.isRunning()).toEqual(true)
             await task.stop()
@@ -15,7 +15,7 @@ describe('PeriodicTask', () => {
             const fn = jest.fn(() => {
                 throw new Error()
             })
-            const task = new PeriodicTask(fn, 1000)
+            const task = new PeriodicTask('test', fn, 1000)
             expect(fn).toBeCalled()
             await task.stop()
             expect(task.isRunning()).toEqual(false)

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -73,7 +73,7 @@ const PersonOverridesModes: Record<string, PersonOverridesMode | undefined> = {
     deferred: {
         getWriter: (hub) => new DeferredPersonOverrideWriter(hub.db.postgres),
         fetchPostgresPersonIdOverrides: async (hub, teamId) => {
-            await new DeferredPersonOverrideWorker(hub.db.postgres).processPendingOverrides(hub.db.kafkaProducer)
+            await new DeferredPersonOverrideWorker(hub.db.postgres, hub.db.kafkaProducer).processPendingOverrides()
             return await fetchPostgresPersonIdOverrides(hub, teamId)
         },
     },
@@ -2110,7 +2110,7 @@ describe('deferred person overrides', () => {
         ;[hub, closeHub] = await createHub({})
         organizationId = await createOrganization(hub.db.postgres)
         writer = new DeferredPersonOverrideWriter(hub.db.postgres)
-        worker = new DeferredPersonOverrideWorker(hub.db.postgres)
+        worker = new DeferredPersonOverrideWorker(hub.db.postgres, hub.db.kafkaProducer)
     })
 
     beforeEach(async () => {
@@ -2144,7 +2144,7 @@ describe('deferred person overrides', () => {
     }
 
     it('moves overrides from the pending table to the overrides table', async () => {
-        const { postgres, kafkaProducer } = hub.db
+        const { postgres } = hub.db
 
         const override = {
             old_person_id: new UUIDT().toString(),
@@ -2157,7 +2157,7 @@ describe('deferred person overrides', () => {
 
         expect(await getPendingPersonOverrides()).toEqual([override])
 
-        expect(await worker.processPendingOverrides(kafkaProducer)).toEqual(1)
+        expect(await worker.processPendingOverrides()).toEqual(1)
 
         expect(await getPendingPersonOverrides()).toMatchObject([])
 
@@ -2181,7 +2181,7 @@ describe('deferred person overrides', () => {
     })
 
     it('rolls back on kafka producer error', async () => {
-        const { postgres, kafkaProducer } = hub.db
+        const { postgres } = hub.db
 
         const override = {
             old_person_id: new UUIDT().toString(),
@@ -2194,17 +2194,17 @@ describe('deferred person overrides', () => {
 
         expect(await getPendingPersonOverrides()).toEqual([override])
 
-        jest.spyOn(kafkaProducer, 'queueMessages').mockImplementation(() => {
+        jest.spyOn(hub.db.kafkaProducer, 'queueMessages').mockImplementation(() => {
             throw new Error('something bad happened')
         })
 
-        await expect(worker.processPendingOverrides(kafkaProducer)).rejects.toThrow()
+        await expect(worker.processPendingOverrides()).rejects.toThrow()
 
         expect(await getPendingPersonOverrides()).toEqual([override])
     })
 
     it('ensures advisory lock is held before processing', async () => {
-        const { postgres, kafkaProducer } = hub.db
+        const { postgres } = hub.db
 
         let acquiredLock: boolean
         const tryLockComplete = new WaitEvent()
@@ -2229,18 +2229,18 @@ describe('deferred person overrides', () => {
         try {
             await tryLockComplete.wait()
             expect(acquiredLock!).toBe(true)
-            await expect(worker.processPendingOverrides(kafkaProducer)).rejects.toThrow(Error('could not acquire lock'))
+            await expect(worker.processPendingOverrides()).rejects.toThrow(Error('could not acquire lock'))
         } finally {
             readyToReleaseLock.set()
             await transactionHolder
         }
 
         expect(acquiredLock!).toBe(false)
-        await expect(worker.processPendingOverrides(kafkaProducer)).resolves.toEqual(0)
+        await expect(worker.processPendingOverrides()).resolves.toEqual(0)
     })
 
     it('respects limit if provided', async () => {
-        const { postgres, kafkaProducer } = hub.db
+        const { postgres } = hub.db
 
         const overrides = [...Array(3)].map(() => ({
             old_person_id: new UUIDT().toString(),
@@ -2262,10 +2262,10 @@ describe('deferred person overrides', () => {
 
         expect(await getPendingPersonOverrides()).toEqual(overrides)
 
-        expect(await worker.processPendingOverrides(kafkaProducer, 2)).toEqual(2)
+        expect(await worker.processPendingOverrides(2)).toEqual(2)
         expect(await getPendingPersonOverrides()).toMatchObject(overrides.slice(-1))
 
-        expect(await worker.processPendingOverrides(kafkaProducer, 2)).toEqual(1)
+        expect(await worker.processPendingOverrides(2)).toEqual(1)
         expect(await getPendingPersonOverrides()).toEqual([])
     })
 })

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -634,7 +634,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_1')
+                                                      'user_one_2')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -634,7 +634,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_2')
+                                                      'user_one_1')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---


### PR DESCRIPTION
## Problem

This adds the ability for the plugin server use the deferred person overrides as implemented in #19007, disabled by default.

Both the deferred override writer (in the ingest-consumer) and worker paths are off by default unless the `POE_DEFERRED_WRITES_ENABLED` configuration setting is enabled (and in that case, the `POE_EMBRACE_JOIN_FOR_TEAMS` still controls which teams actually are opted in to writes.) The `person-overrides` plugin-server mode can also be used to start an overrides-only worker, bypassing the `POE_DEFERRED_WRITES_ENABLED` check.

## How did you test this code?

1. Ran functional tests with `POE_DEFERRED_WRITES_ENABLED=1` and `POE_EMBRACE_JOIN_FOR_TEAMS=*`, watched override logs happening,
2. Added unit tests for `PeriodicTask`.