### PR TITLE
feat: Added check for multivariate when syncing flags

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -140,7 +140,7 @@ export const FEATURE_FLAGS = {
     QUERY_RUNNING_TIME: 'query_running_time', // owner: @mariusandra
     QUERY_TIMINGS: 'query-timings', // owner: @mariusandra
     QUERY_ASYNC: 'query-async', // owner: @webjunkie
-    POSTHOG_3000: 'posthog-3000', // owner: @Twixes
+    POSTHOG_3000: 'posthog-3000', // owner: @Twixes multivariate
     POSTHOG_3000_NAV: 'posthog-3000-nav', // owner: @Twixes
     POSTHOG_3000_WELCOME_ANNOUNCEMENT: 'posthog-3000-welcome-announcement', // owner: #posthog-3000
     ENABLE_PROMPTS: 'enable-prompts', // owner: @lharries

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -119,6 +119,9 @@ export const WEBHOOK_SERVICES: Record<string, string> = {
     Teams: 'office.com',
 }
 
+// NOTE: Run `DEBUG=1 python manage.py sync_feature_flags` locally to sync these flags into your local project
+// By default all flags are boolean but you can add `multivariate` to the comment to have it created as multivariate with "test" and "control" values
+
 export const FEATURE_FLAGS = {
     // Cloud-only
     CLOUD_ANNOUNCEMENT: 'cloud-announcement',

--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
                     else:
                         try:
                             flag = line.split("'")[1]
-                            if flag.endswith("_EXPERIMENT"):
+                            if flag.endswith("_EXPERIMENT") or "multivariate" in line:
                                 flags[flag] = "multivariate"
                             else:
                                 flags[flag] = "boolean"


### PR DESCRIPTION
## Problem

Extends the sync command to support configurable multivariate creation locally

## Changes

* Extends the sync command to support configurable multivariate creation locally
* Adds a comment to make this clearer

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
