### PR TITLE
feat(lifecycle): timezone aware lifecycle persons query

### DIFF
--- a/posthog/hogql_queries/insights/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle_query_runner.py
@@ -100,7 +100,13 @@ class LifecycleQueryRunner(QueryRunner):
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.Eq,
                         left=ast.Field(chain=["start_of_period"]),
-                        right=ast.Constant(value=day),
+                        right=parse_expr(
+                            "dateTrunc({interval}, toDateTime({day}))",
+                            placeholders={
+                                "interval": self.query_date_range.interval_period_string_as_hogql_constant(),
+                                "day": ast.Constant(value=day),
+                            },
+                        ),
                     )
                 )
             if status is not None:

--- a/posthog/hogql_queries/insights/test/test_insight_persons_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_insight_persons_query_runner.py
@@ -62,6 +62,8 @@ class TestInsightPersonsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
     def test_insight_persons_lifecycle_query(self):
         self._create_test_events()
+        self.team.timezone = "US/Pacific"
+        self.team.save()
 
         date_from = "2020-01-09"
         date_to = "2020-01-19"


### PR DESCRIPTION
## Problem

The lifecycle persons modal only worked if your project was in UTC.

## Changes

Supports other timezones.

## How did you test this code?

Clicked locally in the browser. Things that showed 0 results now work.