### PR TITLE
feat(insights): start of week for lifecycle queries

### DIFF
--- a/posthog/hogql_queries/insights/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle_query_runner.py
@@ -78,8 +78,8 @@ class LifecycleQueryRunner(QueryRunner):
                             FROM {events_query}
                             GROUP BY start_of_period, status
                         )
-                        WHERE start_of_period <= dateTrunc({interval}, {date_to})
-                            AND start_of_period >= dateTrunc({interval}, {date_from})
+                        WHERE start_of_period <= {date_to_start_of_interval}
+                            AND start_of_period >= {date_from_start_of_interval}
                         GROUP BY start_of_period, status
                         ORDER BY start_of_period ASC
                     )
@@ -100,12 +100,8 @@ class LifecycleQueryRunner(QueryRunner):
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.Eq,
                         left=ast.Field(chain=["start_of_period"]),
-                        right=parse_expr(
-                            "dateTrunc({interval}, toDateTime({day}))",
-                            placeholders={
-                                "interval": self.query_date_range.interval_period_string_as_hogql_constant(),
-                                "day": ast.Constant(value=day),
-                            },
+                        right=self.query_date_range.date_to_start_of_interval_hogql(
+                            ast.Call(name="toDateTime", args=[ast.Constant(value=day)])
                         ),
                     )
                 )
@@ -210,22 +206,20 @@ class LifecycleQueryRunner(QueryRunner):
         with self.timings.measure("date_range"):
             event_filters.append(
                 parse_expr(
-                    "timestamp >= dateTrunc({interval}, {date_from}) - {one_interval}",
+                    "timestamp >= {from} - {one_interval}",
                     {
-                        "interval": self.query_date_range.interval_period_string_as_hogql_constant(),
+                        "from": self.query_date_range.date_from_to_start_of_interval_hogql(),
                         "one_interval": self.query_date_range.one_interval_period(),
-                        "date_from": self.query_date_range.date_from_as_hogql(),
                     },
                     timings=self.timings,
                 )
             )
             event_filters.append(
                 parse_expr(
-                    "timestamp < dateTrunc({interval}, {date_to}) + {one_interval}",
+                    "timestamp < {to} + {one_interval}",
                     {
-                        "interval": self.query_date_range.interval_period_string_as_hogql_constant(),
+                        "to": self.query_date_range.date_to_to_start_of_interval_hogql(),
                         "one_interval": self.query_date_range.one_interval_period(),
-                        "date_to": self.query_date_range.date_to_as_hogql(),
                     },
                     timings=self.timings,
                 )
@@ -275,9 +269,9 @@ class LifecycleQueryRunner(QueryRunner):
                     SELECT
                         events.person.id as person_id,
                         min(events.person.created_at) AS created_at,
-                        arraySort(groupUniqArray(dateTrunc({interval}, events.timestamp))) AS all_activity,
-                        arrayPopBack(arrayPushFront(all_activity, dateTrunc({interval}, created_at))) as previous_activity,
-                        arrayPopFront(arrayPushBack(all_activity, dateTrunc({interval}, toDateTime('1970-01-01 00:00:00')))) as following_activity,
+                        arraySort(groupUniqArray({trunc_timestamp})) AS all_activity,
+                        arrayPopBack(arrayPushFront(all_activity, {trunc_created_at})) as previous_activity,
+                        arrayPopFront(arrayPushBack(all_activity, {trunc_epoch})) as following_activity,
                         arrayMap((previous, current, index) -> (previous = current ? 'new' : ((current - {one_interval_period}) = previous AND index != 1) ? 'returning' : 'resurrecting'), previous_activity, all_activity, arrayEnumerate(all_activity)) as initial_status,
                         arrayMap((current, next) -> (current + {one_interval_period} = next ? '' : 'dormant'), all_activity, following_activity) as dormant_status,
                         arrayMap(x -> x + {one_interval_period}, arrayFilter((current, is_dormant) -> is_dormant = 'dormant', all_activity, dormant_status)) as dormant_periods,
@@ -293,6 +287,15 @@ class LifecycleQueryRunner(QueryRunner):
                 placeholders={
                     **self.query_date_range.to_placeholders(),
                     "event_filter": self.event_filter,
+                    "trunc_timestamp": self.query_date_range.date_to_start_of_interval_hogql(
+                        ast.Field(chain=["events", "timestamp"])
+                    ),
+                    "trunc_created_at": self.query_date_range.date_to_start_of_interval_hogql(
+                        ast.Field(chain=["created_at"])
+                    ),
+                    "trunc_epoch": self.query_date_range.date_to_start_of_interval_hogql(
+                        ast.Call(name="toDateTime", args=[ast.Constant(value="1970-01-01 00:00:00")])
+                    ),
                 },
                 timings=self.timings,
             )
@@ -309,17 +312,18 @@ class LifecycleQueryRunner(QueryRunner):
             periods_query = parse_select(
                 """
                     SELECT (
-                        dateTrunc({interval}, {date_to}) - {number_interval_period}
+                        {date_to_start_of_interval} - {number_interval_period}
                     ) AS start_of_period
-                    FROM numbers(
-                        dateDiff(
-                            {interval},
-                            dateTrunc({interval}, {date_from}),
-                            dateTrunc({interval}, {date_to} + {one_interval_period})
-                        )
-                    )
+                    FROM numbers(dateDiff({interval}, {date_from_start_of_interval}, {date_to_plus_interval}))
                 """,
-                placeholders=self.query_date_range.to_placeholders(),
+                placeholders={
+                    **self.query_date_range.to_placeholders(),
+                    "date_to_plus_interval": self.query_date_range.date_to_start_of_interval_hogql(
+                        parse_expr(
+                            "{date_to} + {one_interval_period}", placeholders=self.query_date_range.to_placeholders()
+                        )
+                    ),
+                },
                 timings=self.timings,
             )
         return periods_query

--- a/posthog/hogql_queries/insights/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle_query_runner.py
@@ -206,21 +206,15 @@ class LifecycleQueryRunner(QueryRunner):
         with self.timings.measure("date_range"):
             event_filters.append(
                 parse_expr(
-                    "timestamp >= {from} - {one_interval}",
-                    {
-                        "from": self.query_date_range.date_from_to_start_of_interval_hogql(),
-                        "one_interval": self.query_date_range.one_interval_period(),
-                    },
+                    "timestamp >= {date_from_start_of_interval} - {one_interval_period}",
+                    self.query_date_range.to_placeholders(),
                     timings=self.timings,
                 )
             )
             event_filters.append(
                 parse_expr(
-                    "timestamp < {to} + {one_interval}",
-                    {
-                        "to": self.query_date_range.date_to_to_start_of_interval_hogql(),
-                        "one_interval": self.query_date_range.one_interval_period(),
-                    },
+                    "timestamp < {date_to_start_of_interval} + {one_interval_period}",
+                    self.query_date_range.to_placeholders(),
                     timings=self.timings,
                 )
             )
@@ -311,9 +305,7 @@ class LifecycleQueryRunner(QueryRunner):
         with self.timings.measure("periods_query"):
             periods_query = parse_select(
                 """
-                    SELECT (
-                        {date_to_start_of_interval} - {number_interval_period}
-                    ) AS start_of_period
+                    SELECT ({date_to_start_of_interval} - {number_interval_period}) AS start_of_period
                     FROM numbers(dateDiff({interval}, {date_from_start_of_interval}, {date_to_plus_interval}))
                 """,
                 placeholders={

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_lifecycle_query_runner.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_lifecycle_query_runner.ambr
@@ -12,8 +12,8 @@
                0 AS counts,
                sec.status
         FROM
-          (SELECT minus(dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC'))), toIntervalDay(numbers.number)) AS start_of_period
-           FROM numbers(dateDiff('day', dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'UTC'))), dateTrunc('day', plus(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC')), toIntervalDay(1))))) AS numbers) AS periods
+          (SELECT minus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC'))), toIntervalDay(numbers.number)) AS start_of_period
+           FROM numbers(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'UTC'))), toStartOfDay(plus(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC')), toIntervalDay(1))))) AS numbers) AS periods
         CROSS JOIN
           (SELECT status
            FROM
@@ -26,9 +26,9 @@
         FROM
           (SELECT events__pdi__person.id AS person_id,
                   min(toTimeZone(events__pdi__person.created_at, 'UTC')) AS created_at,
-                  arraySort(groupUniqArray(dateTrunc('day', toTimeZone(events.timestamp, 'UTC')))) AS all_activity,
-                  arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', created_at))) AS previous_activity,
-                  arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', parseDateTime64BestEffortOrNull('1970-01-01 00:00:00', 6, 'UTC')))) AS following_activity,
+                  arraySort(groupUniqArray(toStartOfDay(toTimeZone(events.timestamp, 'UTC')))) AS all_activity,
+                  arrayPopBack(arrayPushFront(all_activity, toStartOfDay(created_at))) AS previous_activity,
+                  arrayPopFront(arrayPushBack(all_activity, toStartOfDay(parseDateTime64BestEffortOrNull('1970-01-01 00:00:00', 6, 'UTC')))) AS following_activity,
                   arrayMap((previous, current, index) -> if(ifNull(equals(previous, current), isNull(previous)
                                                                    and isNull(current)), 'new', if(and(ifNull(equals(minus(current, toIntervalDay(1)), previous), isNull(minus(current, toIntervalDay(1)))
                                                                                                               and isNull(previous)), ifNull(notEquals(index, 1), 1)), 'returning', 'resurrecting')), previous_activity, all_activity, arrayEnumerate(all_activity)) AS initial_status,
@@ -55,11 +55,11 @@
               WHERE equals(person.team_id, 2)
               GROUP BY person.id
               HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
-           WHERE and(equals(events.team_id, 2), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), minus(dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'UTC'))), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), plus(dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC'))), toIntervalDay(1))), equals(events.event, '$pageview'))
+           WHERE and(equals(events.team_id, 2), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), minus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'UTC'))), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC'))), toIntervalDay(1))), equals(events.event, '$pageview'))
            GROUP BY person_id)
         GROUP BY start_of_period,
                  status)
-     WHERE and(ifNull(lessOrEquals(start_of_period, dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC')))), 0), ifNull(greaterOrEquals(start_of_period, dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'UTC')))), 0))
+     WHERE and(ifNull(lessOrEquals(start_of_period, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC')))), 0), ifNull(greaterOrEquals(start_of_period, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'UTC')))), 0))
      GROUP BY start_of_period,
               status
      ORDER BY start_of_period ASC)
@@ -83,8 +83,8 @@
                0 AS counts,
                sec.status
         FROM
-          (SELECT minus(dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC'))), toIntervalDay(numbers.number)) AS start_of_period
-           FROM numbers(dateDiff('day', dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'UTC'))), dateTrunc('day', plus(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC')), toIntervalDay(1))))) AS numbers) AS periods
+          (SELECT minus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC'))), toIntervalDay(numbers.number)) AS start_of_period
+           FROM numbers(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'UTC'))), toStartOfDay(plus(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC')), toIntervalDay(1))))) AS numbers) AS periods
         CROSS JOIN
           (SELECT status
            FROM
@@ -97,9 +97,9 @@
         FROM
           (SELECT events__pdi__person.id AS person_id,
                   min(toTimeZone(events__pdi__person.created_at, 'UTC')) AS created_at,
-                  arraySort(groupUniqArray(dateTrunc('day', toTimeZone(events.timestamp, 'UTC')))) AS all_activity,
-                  arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', created_at))) AS previous_activity,
-                  arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', parseDateTime64BestEffortOrNull('1970-01-01 00:00:00', 6, 'UTC')))) AS following_activity,
+                  arraySort(groupUniqArray(toStartOfDay(toTimeZone(events.timestamp, 'UTC')))) AS all_activity,
+                  arrayPopBack(arrayPushFront(all_activity, toStartOfDay(created_at))) AS previous_activity,
+                  arrayPopFront(arrayPushBack(all_activity, toStartOfDay(parseDateTime64BestEffortOrNull('1970-01-01 00:00:00', 6, 'UTC')))) AS following_activity,
                   arrayMap((previous, current, index) -> if(ifNull(equals(previous, current), isNull(previous)
                                                                    and isNull(current)), 'new', if(and(ifNull(equals(minus(current, toIntervalDay(1)), previous), isNull(minus(current, toIntervalDay(1)))
                                                                                                               and isNull(previous)), ifNull(notEquals(index, 1), 1)), 'returning', 'resurrecting')), previous_activity, all_activity, arrayEnumerate(all_activity)) AS initial_status,
@@ -126,11 +126,11 @@
               WHERE equals(person.team_id, 2)
               GROUP BY person.id
               HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
-           WHERE and(equals(events.team_id, 2), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), minus(dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'UTC'))), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), plus(dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC'))), toIntervalDay(1))), equals(events.event, '$pageview'))
+           WHERE and(equals(events.team_id, 2), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), minus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'UTC'))), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC'))), toIntervalDay(1))), equals(events.event, '$pageview'))
            GROUP BY person_id)
         GROUP BY start_of_period,
                  status)
-     WHERE and(ifNull(lessOrEquals(start_of_period, dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC')))), 0), ifNull(greaterOrEquals(start_of_period, dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'UTC')))), 0))
+     WHERE and(ifNull(lessOrEquals(start_of_period, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'UTC')))), 0), ifNull(greaterOrEquals(start_of_period, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'UTC')))), 0))
      GROUP BY start_of_period,
               status
      ORDER BY start_of_period ASC)
@@ -154,8 +154,8 @@
                0 AS counts,
                sec.status
         FROM
-          (SELECT minus(dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'US/Pacific'))), toIntervalDay(numbers.number)) AS start_of_period
-           FROM numbers(dateDiff('day', dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'US/Pacific'))), dateTrunc('day', plus(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'US/Pacific')), toIntervalDay(1))))) AS numbers) AS periods
+          (SELECT minus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'US/Pacific'))), toIntervalDay(numbers.number)) AS start_of_period
+           FROM numbers(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'US/Pacific'))), toStartOfDay(plus(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'US/Pacific')), toIntervalDay(1))))) AS numbers) AS periods
         CROSS JOIN
           (SELECT status
            FROM
@@ -168,9 +168,9 @@
         FROM
           (SELECT events__pdi__person.id AS person_id,
                   min(toTimeZone(events__pdi__person.created_at, 'US/Pacific')) AS created_at,
-                  arraySort(groupUniqArray(dateTrunc('day', toTimeZone(events.timestamp, 'US/Pacific')))) AS all_activity,
-                  arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', created_at))) AS previous_activity,
-                  arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', parseDateTime64BestEffortOrNull('1970-01-01 00:00:00', 6, 'US/Pacific')))) AS following_activity,
+                  arraySort(groupUniqArray(toStartOfDay(toTimeZone(events.timestamp, 'US/Pacific')))) AS all_activity,
+                  arrayPopBack(arrayPushFront(all_activity, toStartOfDay(created_at))) AS previous_activity,
+                  arrayPopFront(arrayPushBack(all_activity, toStartOfDay(parseDateTime64BestEffortOrNull('1970-01-01 00:00:00', 6, 'US/Pacific')))) AS following_activity,
                   arrayMap((previous, current, index) -> if(ifNull(equals(previous, current), isNull(previous)
                                                                    and isNull(current)), 'new', if(and(ifNull(equals(minus(current, toIntervalDay(1)), previous), isNull(minus(current, toIntervalDay(1)))
                                                                                                               and isNull(previous)), ifNull(notEquals(index, 1), 1)), 'returning', 'resurrecting')), previous_activity, all_activity, arrayEnumerate(all_activity)) AS initial_status,
@@ -197,11 +197,11 @@
               WHERE equals(person.team_id, 2)
               GROUP BY person.id
               HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi__person ON equals(events__pdi.person_id, events__pdi__person.id)
-           WHERE and(equals(events.team_id, 2), greaterOrEquals(toTimeZone(events.timestamp, 'US/Pacific'), minus(dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'US/Pacific'))), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'US/Pacific'), plus(dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'US/Pacific'))), toIntervalDay(1))), equals(events.event, '$pageview'))
+           WHERE and(equals(events.team_id, 2), greaterOrEquals(toTimeZone(events.timestamp, 'US/Pacific'), minus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'US/Pacific'))), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'US/Pacific'), plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'US/Pacific'))), toIntervalDay(1))), equals(events.event, '$pageview'))
            GROUP BY person_id)
         GROUP BY start_of_period,
                  status)
-     WHERE and(ifNull(lessOrEquals(start_of_period, dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'US/Pacific')))), 0), ifNull(greaterOrEquals(start_of_period, dateTrunc('day', assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'US/Pacific')))), 0))
+     WHERE and(ifNull(lessOrEquals(start_of_period, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-19 23:59:59', 6, 'US/Pacific')))), 0), ifNull(greaterOrEquals(start_of_period, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 00:00:00', 6, 'US/Pacific')))), 0))
      GROUP BY start_of_period,
               status
      ORDER BY start_of_period ASC)

--- a/posthog/hogql_queries/insights/test/test_insight_persons_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_insight_persons_query_runner.py
@@ -4,6 +4,7 @@ from freezegun import freeze_time
 
 from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
+from posthog.models.team import WeekStartDay
 from posthog.test.base import (
     APIBaseTest,
     ClickhouseTestMixin,
@@ -85,3 +86,59 @@ class TestInsightPersonsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertEqual([("p1",)], response.results)
+
+    def test_insight_persons_lifecycle_query_week_monday(self):
+        self._create_test_events()
+        self.team.timezone = "US/Pacific"
+        self.team.week_start_day = WeekStartDay.MONDAY
+        self.team.save()
+
+        date_from = "2020-01-09"
+        date_to = "2020-01-19"
+
+        response = self.select(
+            """
+            select * from (
+                <PersonsQuery select={['properties.name as n']}>
+                    <InsightPersonsQuery day='2020-01-13' status='returning'>
+                        <LifecycleQuery
+                            interval='week'
+                            dateRange={<DateRange date_from={{date_from}} date_to={{date_to}} />}
+                            series={[<EventsNode event='$pageview' math='total' />]}
+                        />
+                    </InsightPersonsQuery>
+                </PersonsQuery>
+            )
+            """,
+            {"date_from": ast.Constant(value=date_from), "date_to": ast.Constant(value=date_to)},
+        )
+
+        self.assertEqual([("p1",)], response.results)
+
+    def test_insight_persons_lifecycle_query_week_sunday(self):
+        self._create_test_events()
+        self.team.timezone = "US/Pacific"
+        self.team.week_start_day = WeekStartDay.SUNDAY
+        self.team.save()
+
+        date_from = "2020-01-09"
+        date_to = "2020-01-19"
+
+        response = self.select(
+            """
+            select * from (
+                <PersonsQuery select={['properties.name as n']}>
+                    <InsightPersonsQuery day='2020-01-12' status='returning'>
+                        <LifecycleQuery
+                            interval='week'
+                            dateRange={<DateRange date_from={{date_from}} date_to={{date_to}} />}
+                            series={[<EventsNode event='$pageview' math='total' />]}
+                        />
+                    </InsightPersonsQuery>
+                </PersonsQuery>
+            )
+            """,
+            {"date_from": ast.Constant(value=date_from), "date_to": ast.Constant(value=date_to)},
+        )
+
+        self.assertEqual([("p1",), ("p2",)], response.results)

--- a/posthog/hogql_queries/insights/test/test_lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_lifecycle_query_runner.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from freezegun import freeze_time
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql_queries.insights.lifecycle_query_runner import LifecycleQueryRunner
+from posthog.models.team import WeekStartDay
 from posthog.models.utils import UUIDT
 from posthog.schema import (
     DateRange,
@@ -941,7 +942,69 @@ class TestLifecycleQueryRunner(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    def test_lifecycle_trend_weeks(self):
+    def test_lifecycle_trend_weeks_sunday(self):
+        self.team.week_start_day = WeekStartDay.SUNDAY
+        self.team.save()
+
+        # lifecycle weeks rounds the date to the nearest following week  2/5 -> 2/10
+        self._create_events(
+            data=[
+                (
+                    "p1",
+                    [
+                        "2020-02-01T12:00:00Z",
+                        "2020-02-05T12:00:00Z",
+                        "2020-02-10T12:00:00Z",
+                        "2020-02-15T12:00:00Z",
+                        "2020-02-27T12:00:00Z",
+                        "2020-03-02T12:00:00Z",
+                    ],
+                ),
+                ("p2", ["2020-02-11T12:00:00Z", "2020-02-18T12:00:00Z"]),
+                ("p3", ["2020-02-12T12:00:00Z"]),
+                ("p4", ["2020-02-27T12:00:00Z"]),
+            ]
+        )
+
+        result = (
+            LifecycleQueryRunner(
+                team=self.team,
+                query=LifecycleQuery(
+                    dateRange=DateRange(date_from="2020-02-05T00:00:00Z", date_to="2020-03-09T00:00:00Z"),
+                    interval=IntervalType.week,
+                    series=[EventsNode(event="$pageview")],
+                ),
+            )
+            .calculate()
+            .results
+        )
+
+        self.assertEqual(
+            result[0]["days"],
+            [
+                "2020-02-02",
+                "2020-02-09",
+                "2020-02-16",
+                "2020-02-23",
+                "2020-03-01",
+                "2020-03-08",
+            ],
+        )
+
+        assertLifecycleResults(
+            result,
+            [
+                {"status": "dormant", "data": [0, 0, -2, -1, -1, -1]},
+                {"status": "new", "data": [0, 2, 0, 1, 0, 0]},
+                {"status": "resurrecting", "data": [0, 0, 0, 1, 0, 0]},
+                {"status": "returning", "data": [1, 1, 1, 0, 1, 0]},
+            ],
+        )
+
+    def test_lifecycle_trend_weeks_monday(self):
+        self.team.week_start_day = WeekStartDay.MONDAY
+        self.team.save()
+
         # lifecycle weeks rounds the date to the nearest following week  2/5 -> 2/10
         self._create_events(
             data=[

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -185,31 +185,24 @@ class QueryDateRange:
 
         return True
 
-    def date_from_to_start_of_interval_hogql(self) -> ast.Call:
+    def date_to_start_of_interval_hogql(self, date: ast.Expr) -> ast.Call:
         match self.interval_name:
             case "hour":
-                return ast.Call(name="toStartOfHour", args=[self.date_from_as_hogql()])
+                return ast.Call(name="toStartOfHour", args=[date])
             case "day":
-                return ast.Call(name="toStartOfDay", args=[self.date_from_as_hogql()])
+                return ast.Call(name="toStartOfDay", args=[date])
             case "week":
-                return ast.Call(name="toStartOfWeek", args=[self.date_from_as_hogql()])
+                return ast.Call(name="toStartOfWeek", args=[date])
             case "month":
-                return ast.Call(name="toStartOfMonth", args=[self.date_from_as_hogql()])
+                return ast.Call(name="toStartOfMonth", args=[date])
             case _:
                 raise HogQLException(message="Unknown interval name")
 
+    def date_from_to_start_of_interval_hogql(self) -> ast.Call:
+        return self.date_to_start_of_interval_hogql(self.date_from_as_hogql())
+
     def date_to_to_start_of_interval_hogql(self) -> ast.Call:
-        match self.interval_name:
-            case "hour":
-                return ast.Call(name="toStartOfHour", args=[self.date_to_as_hogql()])
-            case "day":
-                return ast.Call(name="toStartOfDay", args=[self.date_to_as_hogql()])
-            case "week":
-                return ast.Call(name="toStartOfWeek", args=[self.date_to_as_hogql()])
-            case "month":
-                return ast.Call(name="toStartOfMonth", args=[self.date_to_as_hogql()])
-            case _:
-                raise HogQLException(message="Unknown interval name")
+        return self.date_to_start_of_interval_hogql(self.date_to_as_hogql())
 
     def to_placeholders(self) -> Dict[str, ast.Expr]:
         return {


### PR DESCRIPTION
## Problem

The lifecycle insight used `dateTrunc`, instead of `toStartOfWeek`, for which we have implemented magical Sunday/Monday support.

## Changes

Updates the query to use `toStartOf` methods instead.

## How did you test this code?

Wrote tests.