### PR TITLE
fix(3000): Remove gap override in LemonSelects

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.scss
+++ b/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.scss
@@ -18,8 +18,6 @@ body:not(.posthog-3000) {
 
 .posthog-3000 {
     .LemonButton.LemonSelect--clearable {
-        --lemon-button-gap: 0rem;
-
         .LemonButton__content {
             gap: 0.25rem;
 
@@ -29,9 +27,5 @@ body:not(.posthog-3000) {
                 }
             }
         }
-    }
-
-    .LemonButton.LemonSelect {
-        --lemon-button-gap: 0.1875rem;
     }
 }


### PR DESCRIPTION
## Changes

Fixes this:

<img width="308" alt="Screenshot 2023-12-06 at 20 17 07" src="https://github.com/PostHog/posthog/assets/4550621/d4463779-93a1-467a-a535-735dd53e33ab">

Does it make something else misaligned? I don't know!