### PR TITLE
chore(data-warehouse): arbitrarily long timeout

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -163,7 +163,7 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
             await workflow.execute_activity(
                 run_external_data_job,
                 job_inputs,
-                start_to_close_timeout=dt.timedelta(minutes=120),
+                start_to_close_timeout=dt.timedelta(years=1),
                 retry_policy=RetryPolicy(maximum_attempts=10),
                 heartbeat_timeout=dt.timedelta(seconds=60),
             )


### PR DESCRIPTION
## Problem

- long running tasks are variable and 2 hours might be too short

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- allow tasks to be effectively arbitrarily long

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
