### PR TITLE
fix(3000): Require interaction to acknowledge 3000 welcome

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -44,7 +44,7 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
             { persist: true },
             {
                 closeSidePanel: () => true,
-                openSidePanel: () => true,
+                openSidePanel: (_, { tab }) => tab !== SidePanelTab.Welcome,
             },
         ],
     })),


### PR DESCRIPTION
## Changes

We've been basically auto-acknowledging the welcome panel since https://github.com/PostHog/posthog/pull/19126/commits/ce7b50fb9078dd10f60273febea6c17c1c112045, but that wasn't fully intended – we should only acknowledge if the user either closes the side panel, or opens a _different_ tab.