### PR TITLE
fix(hogql): uuid type visitor

### DIFF
--- a/posthog/hogql/base.py
+++ b/posthog/hogql/base.py
@@ -21,10 +21,9 @@ class AST:
         name = camel_case_pattern.sub("_", self.__class__.__name__).lower()
 
         # NOTE: Sync with ./test/test_visitor.py#test_hogql_visitor_naming_exceptions
-        if "hog_qlx" in name:
-            name = name.replace("hog_qlx", "hogqlx_")
-        if name == "uuidtype":
-            name = "uuid_type"
+        replacements = {"hog_qlxtag": "hogqlx_tag", "hog_qlxattribute": "hogqlx_attribute", "uuidtype": "uuid_type"}
+        for old, new in replacements.items():
+            name = name.replace(old, new)
         method_name = f"visit_{name}"
         if hasattr(visitor, method_name):
             visit = getattr(visitor, method_name)

--- a/posthog/hogql/base.py
+++ b/posthog/hogql/base.py
@@ -17,10 +17,12 @@ class AST:
     end: Optional[int] = field(default=None)
 
     def accept(self, visitor):
-        camel_case_name = camel_case_pattern.sub("_", self.__class__.__name__).lower()
-        if "hog_qlx" in camel_case_name:
-            camel_case_name = camel_case_name.replace("hog_qlx", "hogqlx_")
-        method_name = f"visit_{camel_case_name}"
+        name = camel_case_pattern.sub("_", self.__class__.__name__).lower()
+        if "hog_qlx" in name:
+            name = name.replace("hog_qlx", "hogqlx_")
+        if name == "uuidtype":
+            name = "uuid_type"
+        method_name = f"visit_{name}"
         if hasattr(visitor, method_name):
             visit = getattr(visitor, method_name)
             return visit(self)

--- a/posthog/hogql/base.py
+++ b/posthog/hogql/base.py
@@ -16,8 +16,11 @@ class AST:
     start: Optional[int] = field(default=None)
     end: Optional[int] = field(default=None)
 
+    # This is part of the visitor pattern from visitor.py.
     def accept(self, visitor):
         name = camel_case_pattern.sub("_", self.__class__.__name__).lower()
+
+        # NOTE: Sync with ./test/test_visitor.py#test_hogql_visitor_naming_exceptions
         if "hog_qlx" in name:
             name = name.replace("hog_qlx", "hogqlx_")
         if name == "uuidtype":

--- a/posthog/hogql/test/test_visitor.py
+++ b/posthog/hogql/test/test_visitor.py
@@ -1,4 +1,5 @@
 from posthog.hogql import ast
+from posthog.hogql.ast import UUIDType, HogQLXTag, HogQLXAttribute
 from posthog.hogql.errors import HogQLException
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.visitor import CloningVisitor, Visitor, TraversingVisitor
@@ -137,3 +138,18 @@ class TestVisitor(BaseTest):
         self.assertEqual(str(e.exception), "You tried accessing a forbidden number, perish!")
         self.assertEqual(e.exception.start, 4)
         self.assertEqual(e.exception.end, 7)
+
+    def test_hogql_visitor_naming_exceptions(self):
+        class NamingCheck(Visitor):
+            def visit_uuid_type(self, node: ast.Constant):
+                return "visit_uuid_type"
+
+            def visit_hogqlx_tag(self, node: ast.Constant):
+                return "visit_hogqlx_tag"
+
+            def visit_hogqlx_attribute(self, node: ast.Constant):
+                return "visit_hogqlx_attribute"
+
+        assert NamingCheck().visit(UUIDType()) == "visit_uuid_type"
+        assert NamingCheck().visit(HogQLXAttribute(name="a", value="a")) == "visit_hogqlx_attribute"
+        assert NamingCheck().visit(HogQLXTag(kind="", attributes=[])) == "visit_hogqlx_tag"


### PR DESCRIPTION
## Problem

The conversion of `UUIDType` to `snake_case` failed. 

`visit_uuidtype` !== `visit_uuid_type`.

## Changes

Adds a workaround.

## How did you test this code?

No more errors when breaking down in trends by `id`