### PR TITLE
fix: Fix product intro wrap

### DIFF
--- a/frontend/src/lib/components/ProductIntroduction/ProductIntroduction.tsx
+++ b/frontend/src/lib/components/ProductIntroduction/ProductIntroduction.tsx
@@ -54,7 +54,7 @@ export const ProductIntroduction = ({
                     </div>
                 </div>
             )}
-            <div className="flex items-center gap-x-8 w-full justify-center">
+            <div className="flex items-center gap-x-8 w-full justify-center flex-wrap">
                 <div>
                     <div className="w-50 mx-auto mb-4">
                         {CustomHog ? (
@@ -83,7 +83,7 @@ export const ProductIntroduction = ({
                             started yourself.
                         </p>
                     )}
-                    <div className="flex items-center gap-x-4 mt-6">
+                    <div className="flex items-center gap-x-4 gap-y-2 mt-6 flex-wrap">
                         {action ? (
                             <LemonButton
                                 type="primary"


### PR DESCRIPTION
## Problem

The product intro doesn't wrap well.

## Changes

* Add some wrapping
* WONT FIX - centering the buttons, too much effort for an edge case

|Before|After|
|----|----|
| <img width="563" alt="Screenshot 2023-12-07 at 12 21 22" src="https://github.com/PostHog/posthog/assets/2536520/75f6cd53-82c2-4f7f-b064-78729a05e850"> | <img width="475" alt="Screenshot 2023-12-07 at 12 20 52" src="https://github.com/PostHog/posthog/assets/2536520/b8b6de58-02ba-458a-8731-73b475165719"> |



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
