### PR TITLE
fix(insights): remove retention people_url from comparisons

### DIFF
--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -223,7 +223,7 @@ export async function query<N extends DataNode = DataNode>(
                     const results = flattenObject(res1)
                     const legacyResults = flattenObject(res2)
                     const sortedKeys = Array.from(new Set([...Object.keys(results), ...Object.keys(legacyResults)]))
-                        .filter((key) => !key.includes('.persons_urls.'))
+                        .filter((key) => !key.includes('.persons_urls.') && !key.includes('.people_url'))
                         .sort()
                     const tableData = [['', 'key', 'HOGQL', 'LEGACY']]
                     let matchCount = 0


### PR DESCRIPTION
## Problem

When running the HogQL retention query in production with the comparison flag on, there's too much noise:

<img width="850" alt="image" src="https://github.com/PostHog/posthog/assets/53387/49725d24-9f73-4542-9534-249df4cca178">

## Changes

Removes all mentions of people_url from the comparison.

## How did you test this code?

Locally in the browser