### PR TITLE
fix(frontend): Use the border box in `useResizeBreakpoints`

### DIFF
--- a/frontend/src/lib/hooks/useResizeObserver.ts
+++ b/frontend/src/lib/hooks/useResizeObserver.ts
@@ -42,6 +42,7 @@ export function useResizeBreakpoints<T>(
                 setSize(newSize)
             }
         },
+        box: 'border-box',
     })
 
     return { ref: options?.ref || refCb, size }


### PR DESCRIPTION
## Problem

![2023-12-07 16 07 16](https://github.com/PostHog/posthog/assets/4550621/f53bc7d3-feb7-40fc-a5f0-d1f4af979108)

## Changes

Closes #19182. While I would be unsure about making border-box the default for `useResizeObserver`, I think this absolutely should be the case for `useResizeBreakpoints`. Breakpoints are based on _containers_, which obviously include padding and borders.
