### PR TITLE
feat(hogql): group aggregation for retention

### DIFF
--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -102,33 +102,33 @@ export function AggregationSelect({
             value: 'properties.$session_id',
             label: `Unique sessions`,
         })
-    }
-    optionSections[0].options.push({
-        label: 'Custom HogQL expression',
-        options: [
-            {
-                // This is a bit of a hack so that the HogQL option is only highlighted as active when the user has
-                // set a custom value (because actually _all_ the options are HogQL)
-                value: !value || baseValues.includes(value) ? '' : value,
-                label: <span className="font-mono">{value}</span>,
-                labelInMenu: function CustomHogQLOptionWrapped({ onSelect }) {
-                    return (
-                        // eslint-disable-next-line react/forbid-dom-props
-                        <div className="w-120" style={{ maxWidth: 'max(60vw, 20rem)' }}>
-                            <HogQLEditor
-                                onChange={onSelect}
-                                value={value}
-                                disablePersonProperties
-                                placeholder={
-                                    "Enter HogQL expression, such as:\n- distinct_id\n- properties.$session_id\n- concat(distinct_id, ' ', properties.$session_id)\n- if(1 < 2, 'one', 'two')"
-                                }
-                            />
-                        </div>
-                    )
+        optionSections[0].options.push({
+            label: 'Custom HogQL expression',
+            options: [
+                {
+                    // This is a bit of a hack so that the HogQL option is only highlighted as active when the user has
+                    // set a custom value (because actually _all_ the options are HogQL)
+                    value: !value || baseValues.includes(value) ? '' : value,
+                    label: <span className="font-mono">{value}</span>,
+                    labelInMenu: function CustomHogQLOptionWrapped({ onSelect }) {
+                        return (
+                            // eslint-disable-next-line react/forbid-dom-props
+                            <div className="w-120" style={{ maxWidth: 'max(60vw, 20rem)' }}>
+                                <HogQLEditor
+                                    onChange={onSelect}
+                                    value={value}
+                                    disablePersonProperties
+                                    placeholder={
+                                        "Enter HogQL expression, such as:\n- distinct_id\n- properties.$session_id\n- concat(distinct_id, ' ', properties.$session_id)\n- if(1 < 2, 'one', 'two')"
+                                    }
+                                />
+                            </div>
+                        )
+                    },
                 },
-            },
-        ],
-    })
+            ],
+        })
+    }
 
     return (
         <LemonSelect

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -70,8 +70,11 @@ class RetentionQueryRunner(QueryRunner):
         else:
             event_date_expr = start_of_interval_sql
 
+        group_index = None
         if self.query.aggregation_group_type_index is not None:
             group_index = int(self.query.aggregation_group_type_index)
+
+        if group_index is not None and 0 <= group_index <= 4:
             target_field = ast.Field(chain=["events", f"$group_{group_index}"])
         else:
             target_field = ast.Field(chain=["events", "person_id"])

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -70,9 +70,15 @@ class RetentionQueryRunner(QueryRunner):
         else:
             event_date_expr = start_of_interval_sql
 
+        if self.query.aggregation_group_type_index is not None:
+            group_index = int(self.query.aggregation_group_type_index)
+            target_field = ast.Field(chain=["events", f"$group_{group_index}"])
+        else:
+            target_field = ast.Field(chain=["events", "person_id"])
+
         fields = [
             ast.Alias(alias="event_date", expr=event_date_expr),
-            ast.Alias(alias="target", expr=ast.Field(chain=["events", "person_id"])),
+            ast.Alias(alias="target", expr=target_field),
         ]
 
         if event_query_type in [RetentionQueryType.TARGET, RetentionQueryType.TARGET_FIRST_TIME]:

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -70,18 +70,15 @@ class RetentionQueryRunner(QueryRunner):
         else:
             event_date_expr = start_of_interval_sql
 
-        group_index = None
+        target_field = "person_id"
         if self.query.aggregation_group_type_index is not None:
             group_index = int(self.query.aggregation_group_type_index)
-
-        if group_index is not None and 0 <= group_index <= 4:
-            target_field = ast.Field(chain=["events", f"$group_{group_index}"])
-        else:
-            target_field = ast.Field(chain=["events", "person_id"])
+            if 0 <= group_index <= 4:
+                target_field = f"$group_{group_index}"
 
         fields = [
             ast.Alias(alias="event_date", expr=event_date_expr),
-            ast.Alias(alias="target", expr=target_field),
+            ast.Alias(alias="target", expr=ast.Field(chain=["events", target_field])),
         ]
 
         if event_query_type in [RetentionQueryType.TARGET, RetentionQueryType.TARGET_FIRST_TIME]:


### PR DESCRIPTION
## Problem

- Group aggregation didn't work.
- The interface offered to aggregate retention insights by custom HogQL expressions, without supporting it in the backend.

## Changes

Fixes both points.

## How did you test this code?

In the browser for now.