### PR TITLE
feat: populate plugin capabilities on install and edit

### DIFF
--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -20,7 +20,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 processAsyncWebhooksHandlers: true,
                 sessionRecordingBlobIngestion: true,
                 personOverrides: config.POE_DEFERRED_WRITES_ENABLED,
-                transpileFrontendApps: true,
+                appManagementSingleton: true,
                 preflightSchedules: true,
                 ...sharedCapabilities,
             }
@@ -73,7 +73,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
         case PluginServerMode.scheduler:
             return {
                 pluginScheduledTasks: true,
-                transpileFrontendApps: true, // TODO: move this away from pod startup, into a graphile job
+                appManagementSingleton: true,
                 ...sharedCapabilities,
             }
         case PluginServerMode.person_overrides:

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -399,7 +399,7 @@ export async function startPluginsServer(
                 },
                 'populate-plugin-capabilities': async (message) => {
                     // We need this to be done in only once
-                    if (hub?.capabilities.pluginScheduledTasks && piscina) {
+                    if (hub?.capabilities.appManagementSingleton && piscina) {
                         await piscina?.broadcastTask({ task: 'populatePluginCapabilities', args: JSON.parse(message) })
                     }
                 },

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -397,6 +397,12 @@ export async function startPluginsServer(
                 'reset-available-features-cache': async (message) => {
                     await piscina?.broadcastTask({ task: 'resetAvailableFeaturesCache', args: JSON.parse(message) })
                 },
+                'populate-plugin-capabilities': async (message) => {
+                    // We need this to be done in only once
+                    if (hub?.capabilities.pluginScheduledTasks && piscina) {
+                        await piscina?.broadcastTask({ task: 'populatePluginCapabilities', args: JSON.parse(message) })
+                    }
+                },
             })
 
             await pubSub.start()

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -296,7 +296,7 @@ export interface PluginServerCapabilities {
     processAsyncWebhooksHandlers?: boolean
     sessionRecordingBlobIngestion?: boolean
     personOverrides?: boolean
-    transpileFrontendApps?: boolean // TODO: move this away from pod startup, into a graphile job
+    appManagementSingleton?: boolean
     preflightSchedules?: boolean // Used for instance health checks on hobby deploy, not useful on cloud
     http?: boolean
     mmdb?: boolean

--- a/plugin-server/src/utils/db/sql.ts
+++ b/plugin-server/src/utils/db/sql.ts
@@ -68,11 +68,6 @@ export async function getPlugin(hub: Hub, pluginId: number): Promise<Plugin | un
 export async function getPluginRows(hub: Hub): Promise<Plugin[]> {
     const { rows }: { rows: Plugin[] } = await hub.db.postgres.query(
         PostgresUse.COMMON_READ,
-        // `posthog_plugin` columns have to be listed individually, as we want to exclude a few columns
-        // and Postgres syntax unfortunately doesn't have a column exclusion feature. The excluded columns are:
-        // - archive - this is a potentially large blob, only extracted in Django as a plugin server optimization
-        // - latest_tag - not used in this service
-        // - latest_tag_checked_at - not used in this service
         `${PLUGIN_SELECT}
         WHERE posthog_plugin.id IN (${pluginConfigsInForceQuery('plugin_id')}
         GROUP BY posthog_pluginconfig.plugin_id)`,

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -8,6 +8,7 @@ import { loadSchedule } from './plugins/loadSchedule'
 import { runPluginTask, runProcessEvent } from './plugins/run'
 import { setupPlugins } from './plugins/setup'
 import { teardownPlugins } from './plugins/teardown'
+import { populatePluginCapabilities } from './vm/lazy'
 
 type TaskRunner = (hub: Hub, args: any) => Promise<any> | any
 
@@ -87,6 +88,9 @@ export const workerTasks: Record<string, TaskRunner> = {
     },
     resetAvailableFeaturesCache: (hub, args: { organization_id: string }) => {
         hub.organizationManager.resetAvailableFeatureCache(args.organization_id)
+    },
+    populatePluginCapabilities: async (hub, args: { plugin_id: string }) => {
+        await populatePluginCapabilities(hub, Number(args.plugin_id))
     },
     // Exported only for tests
     _testsRunProcessEvent: async (hub, args: { event: PluginEvent }) => {

--- a/plugin-server/src/worker/vm/capabilities.ts
+++ b/plugin-server/src/worker/vm/capabilities.ts
@@ -1,13 +1,13 @@
-import { PluginCapabilities, PluginConfigVMResponse, VMMethods } from '../../types'
+import { PluginCapabilities, PluginTask, PluginTaskType, VMMethods } from '../../types'
 import { PluginServerCapabilities } from './../../types'
 
 const PROCESS_EVENT_CAPABILITIES = new Set(['ingestion', 'ingestionOverflow', 'ingestionHistorical'])
 
-export function getVMPluginCapabilities(vm: PluginConfigVMResponse): PluginCapabilities {
+export function getVMPluginCapabilities(
+    methods: VMMethods,
+    tasks: Record<PluginTaskType, Record<string, PluginTask>>
+): PluginCapabilities {
     const capabilities: Required<PluginCapabilities> = { scheduled_tasks: [], jobs: [], methods: [] }
-
-    const tasks = vm?.tasks
-    const methods = vm?.methods
 
     if (methods) {
         for (const [key, value] of Object.entries(methods)) {

--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -14,7 +14,7 @@ import {
     VMMethods,
 } from '../../types'
 import { processError } from '../../utils/db/error'
-import { disablePlugin, setPluginCapabilities } from '../../utils/db/sql'
+import { disablePlugin, getPlugin, setPluginCapabilities } from '../../utils/db/sql'
 import { instrument } from '../../utils/metrics'
 import { getNextRetryMs } from '../../utils/retries'
 import { status } from '../../utils/status'
@@ -307,12 +307,46 @@ export class LazyPluginVM {
     }
 
     private async updatePluginCapabilitiesIfNeeded(vm: PluginConfigVMResponse): Promise<void> {
-        const capabilities = getVMPluginCapabilities(vm)
+        const capabilities = getVMPluginCapabilities(vm.methods, vm.tasks)
 
         const prevCapabilities = this.pluginConfig.plugin!.capabilities
         if (!equal(prevCapabilities, capabilities)) {
-            await setPluginCapabilities(this.hub, this.pluginConfig, capabilities)
+            await setPluginCapabilities(this.hub, this.pluginConfig.plugin_id, capabilities)
             this.pluginConfig.plugin!.capabilities = capabilities
         }
+    }
+}
+
+export async function populatePluginCapabilities(hub: Hub, pluginId: number): Promise<void> {
+    status.info('🔌', `Populating plugin capabilities for plugin ID ${pluginId}...`)
+    const plugin = await getPlugin(hub, pluginId)
+    if (!plugin) {
+        status.error('🔌', `Plugin with ID ${pluginId} not found for populating capabilities.`)
+        return
+    }
+    if (!plugin.source__index_ts) {
+        status.error('🔌', `Plugin with ID ${pluginId} has no index.ts file for populating capabilities.`)
+        return
+    }
+
+    const { methods, tasks } = createPluginConfigVM(
+        hub,
+        {
+            id: 0,
+            plugin: plugin,
+            plugin_id: plugin.id,
+            team_id: 0,
+            enabled: false,
+            order: 0,
+            created_at: '0',
+            config: {},
+        },
+        plugin.source__index_ts || ''
+    )
+    const capabilities = getVMPluginCapabilities(methods, tasks)
+
+    const prevCapabilities = plugin.capabilities
+    if (!equal(prevCapabilities, capabilities)) {
+        await setPluginCapabilities(hub, pluginId, capabilities)
     }
 }

--- a/plugin-server/tests/worker/capabilities.test.ts
+++ b/plugin-server/tests/worker/capabilities.test.ts
@@ -28,7 +28,7 @@ describe('capabilities', () => {
     describe('getVMPluginCapabilities()', () => {
         function getCapabilities(indexJs: string): PluginCapabilities {
             const vm = createPluginConfigVM(hub, pluginConfig39, indexJs)
-            return getVMPluginCapabilities(vm)
+            return getVMPluginCapabilities(vm.methods, vm.tasks)
         }
 
         it('handles processEvent', () => {

--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 from dataclasses import dataclass
 from enum import Enum
@@ -29,6 +30,7 @@ from posthog.plugins.utils import (
     load_json_file,
     parse_url,
 )
+from posthog.redis import get_client
 
 from .utils import UUIDModel, sane_repr
 
@@ -129,6 +131,10 @@ class PluginManager(models.Manager):
         plugin = Plugin.objects.create(**kwargs)
         if plugin_json:
             PluginSourceFile.objects.sync_from_plugin_archive(plugin, plugin_json)
+        get_client().publish(
+            "populate-plugin-capabilities",
+            json.dumps({"plugin_id": str(plugin.id)}),
+        )
         return plugin
 
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
When we install or edit source plugins we don't have their capabilities set. This was fine in the old UI, where everything was together, but in the new pipeline UI we separate transformation plugins from destinations, so in order of the right plugins to show up we'll want to have the capabilities populated.
Using the scheduler pod as we don't have that many tasks there.
Note that normally the capabilities get populated on first usage of the app.

context: https://posthog.slack.com/archives/C0374DA782U/p1701960067687139

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Created some source apps and edited their code and verified that capabilities were updated correctly.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
