### PR TITLE
fix: broken notebooks cypress test

### DIFF
--- a/cypress/e2e/notebooks.cy.ts
+++ b/cypress/e2e/notebooks.cy.ts
@@ -43,12 +43,12 @@ describe('Notebooks', () => {
 
     it('Insertion suggestions can be dismissed', () => {
         cy.visit(urls.notebook('h11RoiwV'))
-        cy.get('.node-ph-replay-timestamp').click()
-        cy.get('.NotebookEditor').type('{enter}')
+        cy.get('.SessionRecordingPlayer').click()
+        cy.get('.ProseMirror').type('{enter}')
 
         cy.get('.NotebookRecordingTimestamp.opacity-50').should('exist')
 
-        cy.get('.NotebookEditor').type('{esc}')
+        cy.get('.ProseMirror').type('{esc}')
         cy.get('.NotebookRecordingTimestamp.opacity-50').should('not.exist')
     })
 


### PR DESCRIPTION
## Problem

The notebooks test was failing

## Changes

Somehow the `NotebookEditor` class was being targeted which is not the contenteditable DOM element for notebooks. It's probably that the structure of notebooks changed elsewhere and somehow this managed to get past tests. Fixed things up to target the `.ProseMirror` element instead

## How did you test this code?

😉 