### PR TITLE
feat: inline totp device info in user admin

### DIFF
--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -7,10 +7,15 @@ from django.contrib.auth.forms import UserChangeForm as DjangoUserChangeForm
 from django.contrib.auth.tokens import default_token_generator
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
+from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from posthog.models import (
     Action,
     AsyncDeletion,
+    Cohort,
+    Dashboard,
+    DashboardTile,
+    Experiment,
     FeatureFlag,
     GroupTypeMapping,
     Insight,
@@ -22,12 +27,8 @@ from posthog.models import (
     Plugin,
     PluginAttachment,
     PluginConfig,
-    Team,
-    Cohort,
-    Experiment,
     Survey,
-    Dashboard,
-    DashboardTile,
+    Team,
     Text,
     User,
 )
@@ -39,6 +40,11 @@ class DashboardTileInline(admin.TabularInline):
     model = DashboardTile
     autocomplete_fields = ("insight", "text")
     readonly_fields = ("filters_hash",)
+
+
+class TOTPDeviceInline(admin.TabularInline):
+    model = TOTPDevice
+    extra = 0
 
 
 @admin.register(Dashboard)
@@ -463,7 +469,7 @@ class UserAdmin(DjangoUserAdmin):
     change_password_form = None  # This view is not exposed in our subclass of UserChangeForm
     change_form_template = "loginas/change_form.html"
 
-    inlines = [OrganizationMemberInline]
+    inlines = [OrganizationMemberInline, TOTPDeviceInline]
     fieldsets = (
         (
             None,


### PR DESCRIPTION
## Problem

When users have issues with 2FA, we currently have to search through all the TOTP devices for the one associated with their email. It should be listed in the user admin.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Inlines totp device info in user admin. Can delete easily with checkbox and saving.

![image](https://github.com/PostHog/posthog/assets/18598166/543e9ffc-d919-4b93-877a-a0de3d068767)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

We don't really test admin so 🤷‍♀️ 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
