### PR TITLE
feat: debug logging for lagging partitions

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -155,6 +155,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         POSTHOG_SESSION_RECORDING_REDIS_HOST: undefined,
         POSTHOG_SESSION_RECORDING_REDIS_PORT: undefined,
         SESSION_RECORDING_CONSOLE_LOGS_INGESTION_ENABLED: true,
+        SESSION_RECORDING_DEBUG_PARTITION: undefined,
     }
 }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
@@ -105,25 +105,13 @@ export class ConsoleLogsIngester {
             return
         }
 
-        const logDebug = (text: string, labels: Record<string, any> = {}) =>
-            status.debug('⚠️', `[console-log-events-ingester] ${text}`, {
-                offset: event.metadata.offset,
-                partition: event.metadata.partition,
-                ...labels,
-            })
-
-        const drop = (reason: string, labels: Record<string, any> = {}) => {
+        const drop = (reason: string) => {
             eventDroppedCounter
                 .labels({
                     event_type: 'session_recordings_console_log_events',
                     drop_cause: reason,
                 })
                 .inc()
-
-            logDebug(reason, {
-                reason,
-                ...labels,
-            })
         }
 
         // capture the producer so that TypeScript knows it's not null below this check

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
@@ -80,25 +80,13 @@ export class ReplayEventsIngester {
     }
 
     public async consume(event: IncomingRecordingMessage): Promise<Promise<number | null | undefined>[] | void> {
-        const logDebug = (text: string, labels: Record<string, any> = {}) =>
-            status.debug('⚠️', `[replay-events] ${text}`, {
-                offset: event.metadata.offset,
-                partition: event.metadata.partition,
-                ...labels,
-            })
-
-        const drop = (reason: string, labels: Record<string, any> = {}) => {
+        const drop = (reason: string) => {
             eventDroppedCounter
                 .labels({
                     event_type: 'session_recordings_replay_events',
                     drop_cause: reason,
                 })
                 .inc()
-
-            logDebug(reason, {
-                reason,
-                ...labels,
-            })
         }
 
         if (!this.producer) {

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
@@ -222,7 +222,7 @@ export class SessionManager {
         }
 
         if (this.debug) {
-            status.info('🚽', `[session-manager] debug mode - flushIfSessionBufferIsOld?`, { logContext })
+            status.info('🚽', `[session-manager]  - [PARTITION DEBUG] - flushIfSessionBufferIsOld?`, { logContext })
         }
 
         if (this.buffer.oldestKafkaTimestamp === null) {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -438,11 +438,6 @@ export class SessionRecordingIngester {
             // TODO: immediately die? or just keep going?
         })
 
-        // Make sure to disconnect the producer after we've finished consuming.
-        this.batchConsumer.join().finally(() => {
-            status.debug('🔁', 'blob_ingester_consumer - batch consumer has finished')
-        })
-
         this.batchConsumer.consumer.on('disconnected', async (err) => {
             // since we can't be guaranteed that the consumer will be stopped before some other code calls disconnect
             // we need to listen to disconnect and make sure we're stopped

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -118,12 +118,16 @@ export class SessionRecordingIngester {
     totalNumPartitions = 0
 
     private promises: Set<Promise<any>> = new Set()
+    // if ingestion is lagging on a single partition it is often hard to identify _why_,
+    // this allows us to output more information for that partition
+    private debugPartition: number | undefined = undefined
 
     constructor(
         globalServerConfig: PluginsServerConfig,
         private postgres: PostgresRouter,
         private objectStorage: ObjectStorage
     ) {
+        this.debugPartition = globalServerConfig.SESSION_RECORDING_DEBUG_PARTITION
         // NOTE: globalServerConfig contains the default pluginServer values, typically not pointing at dedicated resources like kafka or redis
         // We still connect to some of the non-dedicated resources such as postgres or the Replay events kafka.
         this.config = sessionRecordingConsumerConfig(globalServerConfig)
@@ -244,7 +248,8 @@ export class SessionRecordingIngester {
                 team_id,
                 session_id,
                 partition,
-                topic
+                topic,
+                this.debugPartition === partition
             )
         }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -210,7 +210,15 @@ export class SessionRecordingIngester {
         const { team_id, session_id } = event
         const key = `${team_id}-${session_id}`
 
-        const { offset } = event.metadata
+        const { offset, partition } = event.metadata
+        if (this.debugPartition === partition) {
+            status.info('🔁', '[blob_ingester_consumer] - [PARTITION DEBUG] - consuming event', {
+                team_id,
+                session_id,
+                partition,
+                offset,
+            })
+        }
 
         // Check that we are not below the high-water mark for this partition (another consumer may have flushed further than us when revoking)
         if (

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -670,14 +670,22 @@ export class SessionRecordingIngester {
                     : metrics.lastMessageOffset // Or the last message we have seen as it is no longer blocked
 
                 if (!highestOffsetToCommit) {
-                    status.debug('🤔', 'blob_ingester_consumer - no highestOffsetToCommit for partition', {
-                        blockingSession: potentiallyBlockingSession?.sessionId,
-                        blockingSessionTeamId: potentiallyBlockingSession?.teamId,
-                        partition: partition,
-                        // committedHighOffset,
-                        lastMessageOffset: metrics.lastMessageOffset,
-                        highestOffsetToCommit,
-                    })
+                    const partitionDebug = this.debugPartition === partition
+                    const logMethod = partitionDebug ? status.info : status.debug
+                    logMethod(
+                        '🤔',
+                        `[blob_ingester_consumer]${
+                            partitionDebug ? ' - [PARTITION DEBUG] - ' : ' - '
+                        }no highestOffsetToCommit for partition`,
+                        {
+                            blockingSession: potentiallyBlockingSession?.sessionId,
+                            blockingSessionTeamId: potentiallyBlockingSession?.teamId,
+                            partition: partition,
+                            // committedHighOffset,
+                            lastMessageOffset: metrics.lastMessageOffset,
+                            highestOffsetToCommit,
+                        }
+                    )
                     return
                 }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -219,6 +219,9 @@ export interface PluginsServerConfig {
     SESSION_RECORDING_PARTITION_REVOKE_OPTIMIZATION: boolean
     SESSION_RECORDING_PARALLEL_CONSUMPTION: boolean
     SESSION_RECORDING_CONSOLE_LOGS_INGESTION_ENABLED: boolean
+    // a single partition which will output many more log messages to the console
+    // useful when that partition is lagging unexpectedly
+    SESSION_RECORDING_DEBUG_PARTITION: number | undefined
 
     // Dedicated infra values
     SESSION_RECORDING_KAFKA_HOSTS: string | undefined

--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
@@ -187,17 +187,6 @@ describe('console log ingester', () => {
     describe('when disabled on team', () => {
         test('it drops console logs', async () => {
             await consoleLogIngester.consume(makeIncomingMessage([{ plugin: 'rrweb/console@1' }], false))
-            expect(jest.mocked(status.debug).mock.calls).toEqual([
-                [
-                    '⚠️',
-                    '[console-log-events-ingester] console_log_ingestion_disabled',
-                    {
-                        offset: 0,
-                        partition: 0,
-                        reason: 'console_log_ingestion_disabled',
-                    },
-                ],
-            ])
             expect(jest.mocked(produce)).not.toHaveBeenCalled()
         })
         test('it does not drop events with no console logs', async () => {


### PR DESCRIPTION
Often blob ingestion is lagging on one partition an it is very tricky to figure out why

We don't want more detailed logging generally as that is too noisy.

Let's allow ourselves to mark a single partition for debug logging via an environment variable