### PR TITLE
fix: Issue with notebookNodeLogic not being bound for settings

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/NotebookColumnLeft.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookColumnLeft.tsx
@@ -1,9 +1,12 @@
 import { LemonButton } from '@posthog/lemon-ui'
 import clsx from 'clsx'
-import { BuiltLogic, useActions, useValues } from 'kea'
+import { BindLogic, BuiltLogic, useActions, useValues } from 'kea'
 import { LemonWidget } from 'lib/lemon-ui/LemonWidget'
 import { useEffect, useRef, useState } from 'react'
 
+import { ErrorBoundary } from '~/layout/ErrorBoundary'
+
+import { notebookNodeLogic } from '../Nodes/notebookNodeLogic'
 import { notebookNodeLogicType } from '../Nodes/notebookNodeLogicType'
 import { NotebookHistory } from './NotebookHistory'
 import { notebookLogic } from './notebookLogic'
@@ -85,11 +88,15 @@ export const NotebookNodeSettingsWidget = ({ logic }: { logic: BuiltLogic<notebo
         >
             <div onClick={() => selectNode()}>
                 {Settings ? (
-                    <Settings
-                        key={nodeAttributes.nodeId}
-                        attributes={nodeAttributes}
-                        updateAttributes={updateAttributes}
-                    />
+                    <ErrorBoundary>
+                        <BindLogic logic={notebookNodeLogic} props={{ attributes: nodeAttributes }}>
+                            <Settings
+                                key={nodeAttributes.nodeId}
+                                attributes={nodeAttributes}
+                                updateAttributes={updateAttributes}
+                            />
+                        </BindLogic>
+                    </ErrorBoundary>
                 ) : null}
             </div>
         </LemonWidget>


### PR DESCRIPTION
## Problem

The Settings are rendered outside of the heirachy of the NodeWrapper so the logic needs to be re-bounded

## Changes

* Fixes that
* Adds an ErrorBoundary to the settings.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 