### PR TITLE
feat(persons-query): fetch person distinct_id and name from postgres

### DIFF
--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -222,8 +222,11 @@ export function renderColumn(
             displayProps.href = urls.personByDistinctId(personRecord.distinct_ids[0])
         }
 
-        if (isPersonsQuery(query.source)) {
-            displayProps.href = urls.personByUUID(personRecord.id ?? '-')
+        if (isPersonsQuery(query.source) && value) {
+            displayProps.person = value
+            displayProps.href = value.id
+                ? urls.personByUUID(value.id)
+                : urls.personByDistinctId(value.distinct_ids?.[0] ?? '-')
         }
 
         return <PersonDisplay {...displayProps} />

--- a/posthog/hogql_queries/test/test_persons_query_runner.py
+++ b/posthog/hogql_queries/test/test_persons_query_runner.py
@@ -65,14 +65,7 @@ class TestPersonsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         query = clear_locations(query)
         expected = ast.SelectQuery(
             select=[
-                ast.Tuple(
-                    exprs=[
-                        ast.Field(chain=["id"]),
-                        ast.Field(chain=["properties"]),
-                        ast.Field(chain=["created_at"]),
-                        ast.Field(chain=["is_identified"]),
-                    ]
-                ),
+                ast.Field(chain=["id"]),
                 ast.Field(chain=["id"]),
                 ast.Field(chain=["created_at"]),
                 ast.Constant(value=1),
@@ -83,9 +76,13 @@ class TestPersonsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             offset=ast.Constant(value=0),
             order_by=[ast.OrderExpr(expr=ast.Field(chain=["created_at"]), order="DESC")],
         )
-        self.assertEqual(clear_locations(query), expected)
+        assert clear_locations(query) == expected
         response = runner.calculate()
-        self.assertEqual(len(response.results), 10)
+        assert len(response.results) == 10
+
+        assert set(response.results[0][0].keys()) == {"id", "created_at", "distinct_ids", "properties", "is_identified"}
+        assert response.results[0][0].get("properties").get("random_uuid") == self.random_uuid
+        assert len(response.results[0][0].get("distinct_ids")) > 0
 
     def test_persons_query_properties(self):
         self.random_uuid = self._create_random_persons()


### PR DESCRIPTION
## Problem

Split out from https://github.com/PostHog/posthog/pull/19198

We want to change the "People" page to load data from ClickHouse, not Postgres. This way we can join in data from different insights (e.g. lifecycle results). I had already rewritten the query, but it was slow. Joining the distinct_ids table was unavoidable, yet extremely slow for one of our biggest clients.

## Changes

When requesting a "person" column, on `calculate()` the runner makes an extra query with the returned "person_id"-s to Postgres, and returns their `distinct_id`-s and `properties`. As a result, these `distinct_id`-s are once again used as the default display name if no e-mail or other priority field is present.

All of this is behind the flag `persons-hogql-query`. All users still see the old persons page that ONLY uses postgres. 

I'd like to get this in, and benchmark if this solves problems I had with the previous query for our bigger clients.

Before:

<img width="1460" alt="image" src="https://github.com/PostHog/posthog/assets/53387/bc43450d-461b-4b38-a118-1eeb0d265b39">


After:

<img width="1454" alt="image" src="https://github.com/PostHog/posthog/assets/53387/40d9bcb0-a8e6-4162-a6df-5369e7a37244">


## How did you test this code?

Updated a test, made sure the returned data is correct and still there.