### PR TITLE
fix: svg placeholder styling

### DIFF
--- a/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
+++ b/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
@@ -352,8 +352,9 @@ exports[`replay/transform transform can process unknown types without error 1`] 
                           {
                             "attributes": {
                               "fill": "grey",
-                              "height": "100%",
-                              "width": "100%",
+                              "height": 30,
+                              "style": "width: 100px;height: 30px;position: fixed;left: 25px;top: 42px;",
+                              "width": 100,
                             },
                             "childNodes": [],
                             "id": 101,
@@ -2628,8 +2629,9 @@ exports[`replay/transform transform inputs placeholder - $inputType - $value 1`]
                         {
                           "attributes": {
                             "fill": "grey",
-                            "height": "100%",
-                            "width": "100%",
+                            "height": 30,
+                            "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                            "width": 100,
                           },
                           "childNodes": [],
                           "id": 170,
@@ -3079,8 +3081,9 @@ exports[`replay/transform transform omitting x and y is equivalent to setting th
                           {
                             "attributes": {
                               "fill": "grey",
-                              "height": "100%",
-                              "width": "100%",
+                              "height": 30,
+                              "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                              "width": 100,
                             },
                             "childNodes": [],
                             "id": 115,

--- a/ee/frontend/mobile-replay/transformers.ts
+++ b/ee/frontend/mobile-replay/transformers.ts
@@ -146,8 +146,9 @@ function makePlaceholderElement(wireframe: wireframe, children: serializedNodeWi
                 type: NodeType.Element,
                 tagName: 'rect',
                 attributes: {
-                    width: '100%',
-                    height: '100%',
+                    width: wireframe.width,
+                    height: wireframe.height,
+                    style: makeStylesString(wireframe),
                     fill: wireframe.style?.backgroundColor || 'grey',
                 },
                 id: idSequence.next().value,
@@ -157,7 +158,7 @@ function makePlaceholderElement(wireframe: wireframe, children: serializedNodeWi
                 type: NodeType.Element,
                 tagName: 'text',
                 attributes: {
-                    fill: 'white',
+                    fill: wireframe.style?.color || 'white',
                     'font-size': '30',
                     x: '50%',
                     y: '50%',


### PR DESCRIPTION
follow up to #19204 with fixed image placeholders

(rectangles weren't filling their parent SVG)