### PR TITLE
feat(plugin-server): add (opt-in) ability to submit webhooks to rusty…

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -131,6 +131,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         POE_DEFERRED_WRITES_ENABLED: false,
         POE_EMBRACE_JOIN_FOR_TEAMS: '',
         RELOAD_PLUGIN_JITTER_MAX_MS: 60000,
+        RUSTY_HOOK_FOR_TEAMS: '',
+        RUSTY_HOOK_URL: '',
 
         STARTUP_PROFILE_DURATION_SECONDS: 300, // 5 minutes
         STARTUP_PROFILE_CPU: false,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -201,6 +201,8 @@ export interface PluginsServerConfig {
     POE_EMBRACE_JOIN_FOR_TEAMS: string
     POE_DEFERRED_WRITES_ENABLED: boolean
     RELOAD_PLUGIN_JITTER_MAX_MS: number
+    RUSTY_HOOK_FOR_TEAMS: string
+    RUSTY_HOOK_URL: string
     SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
 
     // dump profiles to disk, covering the first N seconds of runtime
@@ -276,6 +278,7 @@ export interface Hub extends PluginsServerConfig {
     // ValueMatchers used for various opt-in/out features
     pluginConfigsToSkipElementsParsing: ValueMatcher<number>
     poeEmbraceJoinForTeams: ValueMatcher<number>
+    rustyHookForTeams: ValueMatcher<number>
     // lookups
     eventsToDropByToken: Map<string, string[]>
 }

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -188,6 +188,7 @@ export async function createHub(
         conversionBufferEnabledTeams,
         pluginConfigsToSkipElementsParsing: buildIntegerMatcher(process.env.SKIP_ELEMENTS_PARSING_PLUGINS, true),
         poeEmbraceJoinForTeams: buildIntegerMatcher(process.env.POE_EMBRACE_JOIN_FOR_TEAMS, true),
+        rustyHookForTeams: buildIntegerMatcher(process.env.RUSTY_HOOK_FOR_TEAMS, true),
         eventsToDropByToken: createEventsToDropByToken(process.env.DROP_EVENTS_BY_TOKEN_DISTINCT_ID),
     }
 

--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -1,11 +1,13 @@
 import { PluginEvent, PostHogEvent, ProcessedPluginEvent, Webhook } from '@posthog/plugin-scaffold'
+import * as Sentry from '@sentry/node'
+import fetch from 'node-fetch'
 import { Summary } from 'prom-client'
 
 import { Hub, PluginConfig, PluginTaskType, VMMethods } from '../../types'
 import { processError } from '../../utils/db/error'
 import { trackedFetch } from '../../utils/fetch'
 import { status } from '../../utils/status'
-import { IllegalOperationError } from '../../utils/utils'
+import { IllegalOperationError, sleep } from '../../utils/utils'
 
 const pluginActionMsSummary = new Summary({
     name: 'plugin_action_ms',
@@ -71,6 +73,59 @@ export async function runOnEvent(hub: Hub, event: ProcessedPluginEvent): Promise
     )
 }
 
+const RUSTY_HOOK_BASE_DELAY_MS = 100
+const MAX_RUSTY_HOOK_DELAY_MS = 30_000
+
+async function enqueueInRustyHook(hub: Hub, webhook: Webhook, pluginIdStr: string) {
+    webhook.method ??= 'POST'
+    webhook.headers ??= {}
+    const body = JSON.stringify(webhook, undefined, 4)
+    let attempt = 0
+
+    // We attempt to enqueue into the rusty-hook service until we succeed. This is deliberatly
+    // designed to block up the consumer if rusty-hook is down or if we deploy code that
+    // sends malformed requests. The entire purpose of rusty-hook is to reliably deliver webhooks,
+    // so we'd rather leave items in the Kafka topic until we manage to get them into rusty-hook.
+    while (true) {
+        const timer = new Date()
+        try {
+            attempt += 1
+            const response = await fetch(hub.RUSTY_HOOK_URL, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body,
+
+                // Sure, it's not an external request, but we should have a timeout and this is as
+                // good as any.
+                timeout: hub.EXTERNAL_REQUEST_TIMEOUT_MS,
+            })
+
+            if (response.ok) {
+                // Success, exit the loop.
+                pluginActionMsSummary
+                    .labels(pluginIdStr, 'enqueueRustyHook', 'success')
+                    .observe(new Date().getTime() - timer.getTime())
+
+                break
+            }
+
+            // Throw to unify error handling below.
+            throw new Error(`rusty-hook returned ${response.status} ${response.statusText}: ${await response.text()}`)
+        } catch (error) {
+            pluginActionMsSummary
+                .labels(pluginIdStr, 'enqueueRustyHook', 'error')
+                .observe(new Date().getTime() - timer.getTime())
+
+            const redactedWebhook = { ...webhook, body: '<redacted>' }
+            status.error('🔴', 'Webhook enqueue to rusty-hook failed', { error, redactedWebhook, attempt })
+            Sentry.captureException(error, { extra: { redactedWebhook } })
+        }
+
+        const delayMs = Math.min(2 ** (attempt - 1) * RUSTY_HOOK_BASE_DELAY_MS, MAX_RUSTY_HOOK_DELAY_MS)
+        await sleep(delayMs)
+    }
+}
+
 async function runSingleTeamPluginComposeWebhook(
     hub: Hub,
     event: PostHogEvent,
@@ -98,6 +153,11 @@ async function runSingleTeamPluginComposeWebhook(
                 })
                 return
             }
+
+            if (hub.rustyHookForTeams?.(event.team_id)) {
+                return await enqueueInRustyHook(hub, webhook, pluginConfig.plugin?.id.toString() ?? '?')
+            }
+
             const request = await trackedFetch(webhook.url, {
                 method: webhook.method || 'POST',
                 body: JSON.stringify(webhook.body, undefined, 4),


### PR DESCRIPTION
…-hook service

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We want to send Webhooks to our new rusty-hook service. And we want to slowly opt specific teams into it.

## Changes

Add opt-in that tries to submit a team's jobs to rusty-hook until it succeeds.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
