### PR TITLE
fix: pin CI node version to the version we use in prod

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -70,7 +70,7 @@ runs:
         - name: Set up Node.js
           uses: actions/setup-node@v3
           with:
-              node-version: 18
+              node-version: 18.12.1
               cache: pnpm
 
         - name: Install plugin-transpiler

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -124,7 +124,7 @@ jobs:
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
               uses: actions/setup-node@v3
               with:
-                  node-version: 18
+                  node-version: 18.12.1
 
             - name: Get pnpm cache directory path
               if: needs.changes.outputs.shouldTriggerCypress == 'true'

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -32,7 +32,7 @@ jobs:
                   filters: |
                       frontend:
                         # Avoid running frontend tests for irrelevant changes
-                        # NOTE: we are at risk of missing a dependency here. 
+                        # NOTE: we are at risk of missing a dependency here.
                         - 'bin/**'
                         - 'frontend/**'
                         - 'ee/frontend/**'
@@ -68,7 +68,7 @@ jobs:
               if: needs.changes.outputs.frontend == 'true'
               uses: actions/setup-node@v3
               with:
-                  node-version: 18
+                  node-version: 18.12.1
 
             - name: Get pnpm cache directory path
               if: needs.changes.outputs.frontend == 'true'
@@ -151,7 +151,7 @@ jobs:
               if: needs.changes.outputs.frontend == 'true'
               uses: actions/setup-node@v3
               with:
-                  node-version: 18
+                  node-version: 18.12.1
                   cache: pnpm
 
             - name: Install package.json dependencies with pnpm

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -70,7 +70,7 @@ jobs:
             - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 18
+                  node-version: 18.12.1
                   cache: pnpm
 
             - name: Install package.json dependencies with pnpm
@@ -151,7 +151,7 @@ jobs:
               if: needs.changes.outputs.plugin-server == 'true'
               uses: actions/setup-node@v3
               with:
-                  node-version: 18
+                  node-version: 18.12.1
                   cache: pnpm
                   cache-dependency-path: plugin-server/pnpm-lock.yaml
 
@@ -246,7 +246,7 @@ jobs:
             - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 18
+                  node-version: 18.12.1
                   cache: pnpm
                   cache-dependency-path: plugin-server/pnpm-lock.yaml
 

--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -35,7 +35,7 @@ jobs:
             - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 18
+                  node-version: 18.12.1
                   cache: pnpm
 
             - name: Install dependencies and Chromatic
@@ -114,7 +114,7 @@ jobs:
             - name: Set up Node.js
               uses: buildjet/setup-node@v3
               with:
-                  node-version: 18
+                  node-version: 18.12.1
                   cache: pnpm
 
             - name: Install package.json dependencies with pnpm
@@ -180,12 +180,12 @@ jobs:
                     echo "Snapshots updated ($ADDED new, $MODIFIED changed), running OptiPNG"
                     apt update && apt install -y optipng
                     optipng -clobber -o4 -strip all
-                    
+
                     # we don't want to _always_ run OptiPNG
                     # so, we run it after checking for a diff
                     # but, the files we diffed might then be changed by OptiPNG
                     # and as a result they might no longer be different...
-                    
+
                     # we check again
                     git diff --name-status frontend/__snapshots__/ # For debugging
                     ADDED=$(git diff --name-status frontend/__snapshots__/ | grep '^A' | wc -l)

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 18
+                  node-version: 18.12.1
                   cache: pnpm
                   cache-dependency-path: posthog/pnpm-lock.yaml
 


### PR DESCRIPTION
## Problem

We were using a different version of Node in CI than we run in prod.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Pin to the same version:

https://github.com/PostHog/posthog/blob/102828f729d48fc126d3f7ba026a4f0e2d4fdbb9/production.Dockerfile#L24

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
