### PR TITLE
chore: replace deprecated nodesource install scripts

### DIFF
--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -251,13 +251,11 @@ RUN apt-get update && \
     "libxml2"
 
 # Install NodeJS 18.
-RUN apt-get install -y --no-install-recommends \
-    "curl" \
-    && \
-    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
-    apt-get install -y --no-install-recommends \
-    "nodejs" \
-    && \
+RUN apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    mkdir -p /etc/apt/keyrings/ && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
 # Install and use a non-root user.


### PR DESCRIPTION
## Problem

NodeSource have [deprecated their Node.js installation scripts](https://github.com/nodesource/distributions#new-update-%EF%B8%8F) in favour of installing the DEB packages directly. To encourage this migration, the installation scripts now print a deprecation warning with an artificial 60-second delay. 🐢 

## Changes

This PR replaces the installation scripts in both `Dockerfile`s with [the new NodeSource installation instructions](https://github.com/nodesource/distributions#installation-instructions). This should remove the 60-second delay. 🐇 

## How did you test this code?

I've run a successful container build with the changed `RUN` step. ⚡ 