### PR TITLE
fix: unparseable line noise

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -50,6 +50,10 @@ const parseEncodedSnapshots = async (
         postHogEEModule = await posthogEE()
     }
     return items.flatMap((l) => {
+        if (!l) {
+            // blob files have an empty line at the end
+            return []
+        }
         try {
             const snapshotLine = typeof l === 'string' ? (JSON.parse(l) as EncodedRecordingSnapshot) : l
             const snapshotData = snapshotLine['data']


### PR DESCRIPTION
We're gathering way too much data about unparseable lines to be able to analyze it...

It turns out that we're also gathering some of that data unnecessarily since it is valid for recording data to have empty lines

Let's ignore them