### PR TITLE
feat(query-engine): Remove expression fields from asterisk expansion

### DIFF
--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -95,10 +95,15 @@ class Table(FieldOrTable):
         for key, field in self.fields.items():
             if key in fields_to_avoid:
                 continue
-            if isinstance(field, DatabaseField):
+            if (
+                isinstance(field, Table)
+                or isinstance(field, LazyJoin)
+                or isinstance(field, FieldTraverser)
+                or isinstance(field, ExpressionField)
+            ):
+                pass  # ignore virtual tables and columns for now
+            elif isinstance(field, DatabaseField):
                 asterisk[key] = field
-            elif isinstance(field, Table) or isinstance(field, LazyJoin) or isinstance(field, FieldTraverser):
-                pass  # ignore virtual tables for now
             else:
                 raise HogQLException(f"Unknown field type {type(field).__name__} for asterisk")
         return asterisk

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -110,9 +110,7 @@ class TestDatabase(BaseTest):
             == "SELECT double FROM (SELECT multiply(numbers.number, 2) AS double FROM numbers(2) AS numbers) LIMIT 10000"
         ), query
 
-        sql = "select double from (select * from numbers(2))"
+        # expression fields are not included in select *
+        sql = "select * from (select * from numbers(2))"
         query = print_ast(parse_select(sql), context, dialect="clickhouse")
-        assert (
-            query
-            == "SELECT double FROM (SELECT numbers.number, plus(1, 1) AS expression, multiply(numbers.number, 2) AS double FROM numbers(2) AS numbers) LIMIT 10000"
-        ), query
+        assert query == "SELECT number FROM (SELECT numbers.number FROM numbers(2) AS numbers) LIMIT 10000", query


### PR DESCRIPTION
## Problem

Needed for https://github.com/PostHog/posthog/pull/19085

## Changes

Remove expression fields from asterisk expansion

## How did you test this code?

Already had a test suite, just fixed the test that this change broke
