### PR TITLE
fix: Skeleton for nodes

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -157,10 +157,13 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
                             <ErrorBoundary>
                                 {!inView ? (
                                     <>
-                                        <div className="h-10" /> {/* Placeholder for the drag handle */}
+                                        <div className="h-10 p-2 flex justify-between">
+                                            <LemonSkeleton className="w-1/4" />
+                                            <LemonSkeleton className="w-20" />
+                                        </div>
                                         {/* eslint-disable-next-line react/forbid-dom-props */}
-                                        <div style={{ height: heightEstimate }}>
-                                            <LemonSkeleton className="h-full" />
+                                        <div className="flex items-center p-2" style={{ height: heightEstimate }}>
+                                            <LemonSkeleton className="w-full h-full" />
                                         </div>
                                     </>
                                 ) : (


### PR DESCRIPTION
## Problem

The loading states that are rarely visible look off enough that you can notice it for a flash second

## Changes

* Small tweaks so that the padding is more appropriate

|Before|After|
|----|----|
| <img width="1656" alt="Screenshot 2023-12-11 at 12 21 37" src="https://github.com/PostHog/posthog/assets/2536520/ee12f9d1-277b-4ed4-9d2f-a63b9f9f66fc"> | <img width="1660" alt="Screenshot 2023-12-11 at 12 20 29" src="https://github.com/PostHog/posthog/assets/2536520/33160993-97a7-4cbf-82ef-d1adc9fe7188"> |



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
