### PR TITLE
fix: WebAnalytics insight styles

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsTile.tsx
@@ -252,13 +252,7 @@ export const WebStatsTrendTile = ({
     }, [onWorldMapClick])
 
     return (
-        <div
-            className={'border'}
-            // eslint-disable-next-line react/forbid-dom-props
-            style={{
-                borderRadius: 'var(--radius)',
-            }}
-        >
+        <div className="border rounded bg-bg-light">
             {showIntervalTile && (
                 <div className="flex flex-row items-center justify-end m-2 mr-4">
                     <div className="flex flex-row items-center">

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -394,6 +394,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         breakdownBy: WebStatsBreakdown.Page,
                                         dateRange,
                                     },
+                                    embedded: false,
                                 },
                             },
                             {
@@ -409,6 +410,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         breakdownBy: WebStatsBreakdown.InitialPage,
                                         dateRange,
                                     },
+                                    embedded: false,
                                 },
                             },
                         ],
@@ -505,6 +507,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                             hideAggregation: true,
                                         },
                                     },
+                                    embedded: true,
                                 },
                             },
                             {
@@ -520,6 +523,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         breakdownBy: WebStatsBreakdown.Browser,
                                         dateRange,
                                     },
+                                    embedded: false,
                                 },
                             },
                             {
@@ -535,6 +539,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         breakdownBy: WebStatsBreakdown.OS,
                                         dateRange,
                                     },
+                                    embedded: false,
                                 },
                             },
                         ],
@@ -565,6 +570,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                     useSmallLayout: !isGreaterThanMd,
                                 },
                             },
+                            embedded: true,
                         },
                     },
                     shouldShowGeographyTile
@@ -602,6 +608,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                               properties: webAnalyticsFilters,
                                           },
                                           hidePersonsModal: true,
+                                          embedded: true,
                                       },
                                   },
                                   {


### PR DESCRIPTION
## Problem

Web Analytics dashboard has a lot of overrides to get it to work as designed and some of them didn't work...

Closes https://github.com/PostHog/posthog/issues/19244

## Changes

* Fixes the wrapper style for the ones that need to be embedded
* Fix the choice of "embedded" in the queries depending on the wrapper (before it was creating a double-bordered effect)

|Before|After|
|----|----|
| <img width="1665" alt="Screenshot 2023-12-11 at 13 03 56" src="https://github.com/PostHog/posthog/assets/2536520/002e5b6a-70ce-4dde-8a6f-d859f64ba5db"> | <img width="1666" alt="Screenshot 2023-12-11 at 13 03 04" src="https://github.com/PostHog/posthog/assets/2536520/44bd0a65-83bf-43fd-8b63-2f97dc629ddb"> |




👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
