### PR TITLE
feat(colors): add dark variants of data-color-1

### DIFF
--- a/frontend/src/styles/vars.scss
+++ b/frontend/src/styles/vars.scss
@@ -457,6 +457,8 @@ $_lifecycle_dormant: $_danger;
     --danger-3000-button-border: var(--danger-3000-button-border-dark);
     --danger-3000-button-border-hover: var(--danger-3000-button-border-hover-dark);
     --tooltip-bg: var(--tooltip-bg-dark);
+    --data-color-1: #2f80fa;
+    --data-color-1-hover: #2576ef;
     --data-color-2: #7f26d9;
     --data-color-3: #3e7a76;
     --data-color-4: #bf0d6c;


### PR DESCRIPTION
## Problem

The brand blue color we use for insights and in various other places is still difficult to read in dark mode.

## Changes

There are two ways to solve this:
1. Making the brand blue color lighter in dark mode, which in turn will also make it more white
2. Making the background grays darker

This PR tries option 1 by taking the brand blue color we use in dark mode on the website and deriving a "hover" variant by using the same lightness distance as in light mode in OKLCH color space.

## How did you test this code?

Clicked around in the interface. Imo this works well when there isn't too much of the color present e.g. line charts, billing gauge. It doesn't work so well for funnels, at least with their currently huge size.