### PR TITLE
fix(django): Fix MiddlewareMixin get_response missing

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -374,7 +374,7 @@ class CaptureMiddleware:
             # as this connection is created on import
             from django_statsd.middleware import StatsdMiddlewareTimer
 
-            self.CAPTURE_MIDDLEWARE.append(StatsdMiddlewareTimer())
+            self.CAPTURE_MIDDLEWARE.append(StatsdMiddlewareTimer(get_response=get_response))
 
     def __call__(self, request: HttpRequest):
         if request.path in (


### PR DESCRIPTION
## Problem

Getting error 

```
Traceback (most recent call last):
  File "/code/./posthog/wsgi.py", line 16, in <module>
    application = get_wsgi_application()
  File "/python-runtime/django/core/wsgi.py", line 13, in get_wsgi_application
    return WSGIHandler()
  File "/python-runtime/django/core/handlers/wsgi.py", line 125, in __init__
    self.load_middleware()
  File "/python-runtime/django/core/handlers/base.py", line 61, in load_middleware
    mw_instance = middleware(adapted_handler)
  File "/code/./posthog/middleware.py", line 377, in __init__
    self.CAPTURE_MIDDLEWARE.append(StatsdMiddlewareTimer())
TypeError: MiddlewareMixin.__init__() missing 1 required positional argument: 'get_response'
```

## Changes

- pass the `get_response`

## How did you test this code?

- just guessing