### PR TITLE
fix: debug partition parsing for recordings consumer

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -128,6 +128,9 @@ export class SessionRecordingIngester {
         private objectStorage: ObjectStorage
     ) {
         this.debugPartition = globalServerConfig.SESSION_RECORDING_DEBUG_PARTITION
+            ? parseInt(globalServerConfig.SESSION_RECORDING_DEBUG_PARTITION)
+            : undefined
+
         // NOTE: globalServerConfig contains the default pluginServer values, typically not pointing at dedicated resources like kafka or redis
         // We still connect to some of the non-dedicated resources such as postgres or the Replay events kafka.
         this.config = sessionRecordingConsumerConfig(globalServerConfig)

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -223,7 +223,7 @@ export interface PluginsServerConfig {
     SESSION_RECORDING_CONSOLE_LOGS_INGESTION_ENABLED: boolean
     // a single partition which will output many more log messages to the console
     // useful when that partition is lagging unexpectedly
-    SESSION_RECORDING_DEBUG_PARTITION: number | undefined
+    SESSION_RECORDING_DEBUG_PARTITION: string | undefined
 
     // Dedicated infra values
     SESSION_RECORDING_KAFKA_HOSTS: string | undefined

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -142,6 +142,24 @@ describe('ingester', () => {
         )
     }
 
+    it('can parse debug partition config', () => {
+        const config = {
+            SESSION_RECORDING_KAFKA_DEBUG_PARTITION: '103',
+        }
+
+        const ingester = new SessionRecordingIngester(config as any, hub.postgres, hub.objectStorage)
+        expect(ingester['debugPartition']).toEqual(103)
+    })
+
+    it('can parse absence of debug partition config', () => {
+        const config = {
+            SESSION_RECORDING_KAFKA_DEBUG_PARTITION: '103',
+        }
+
+        const ingester = new SessionRecordingIngester(config as any, hub.postgres, hub.objectStorage)
+        expect(ingester['debugPartition']).toBeUndefined()
+    })
+
     it('creates a new session manager if needed', async () => {
         const event = createIncomingRecordingMessage()
         await ingester.consume(event)

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -144,19 +144,19 @@ describe('ingester', () => {
 
     it('can parse debug partition config', () => {
         const config = {
-            SESSION_RECORDING_KAFKA_DEBUG_PARTITION: '103',
-        }
+            SESSION_RECORDING_DEBUG_PARTITION: '103',
+        } satisfies Partial<PluginsServerConfig> as PluginsServerConfig
 
-        const ingester = new SessionRecordingIngester(config as any, hub.postgres, hub.objectStorage)
+        const ingester = new SessionRecordingIngester(config, hub.postgres, hub.objectStorage)
         expect(ingester['debugPartition']).toEqual(103)
     })
 
     it('can parse absence of debug partition config', () => {
         const config = {
-            SESSION_RECORDING_KAFKA_DEBUG_PARTITION: '103',
-        }
+            SESSION_RECORDING_DEBUG_PARTITION: '103',
+        } satisfies Partial<PluginsServerConfig> as PluginsServerConfig
 
-        const ingester = new SessionRecordingIngester(config as any, hub.postgres, hub.objectStorage)
+        const ingester = new SessionRecordingIngester(config, hub.postgres, hub.objectStorage)
         expect(ingester['debugPartition']).toBeUndefined()
     })
 

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -152,9 +152,7 @@ describe('ingester', () => {
     })
 
     it('can parse absence of debug partition config', () => {
-        const config = {
-            SESSION_RECORDING_DEBUG_PARTITION: '103',
-        } satisfies Partial<PluginsServerConfig> as PluginsServerConfig
+        const config = {} satisfies Partial<PluginsServerConfig> as PluginsServerConfig
 
         const ingester = new SessionRecordingIngester(config, hub.postgres, hub.objectStorage)
         expect(ingester['debugPartition']).toBeUndefined()


### PR DESCRIPTION
TS having types is so seductive... except JS will accept any old value

Properly set the debugPartition value