### PR TITLE
feat: Show activity panel if there are any unread notifications

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
@@ -1,15 +1,6 @@
 import './SidePanel.scss'
 
-import {
-    IconConfetti,
-    IconEllipsis,
-    IconFeatures,
-    IconGear,
-    IconInfo,
-    IconNotebook,
-    IconNotification,
-    IconSupport,
-} from '@posthog/icons'
+import { IconConfetti, IconEllipsis, IconFeatures, IconGear, IconInfo, IconNotebook, IconSupport } from '@posthog/icons'
 import { LemonButton, LemonMenu, LemonMenuItems } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
@@ -20,7 +11,7 @@ import { NotebookPanel } from 'scenes/notebooks/NotebookPanel/NotebookPanel'
 
 import { SidePanelTab } from '~/types'
 
-import { SidePanelActivity } from './panels/activity/SidePanelActivity'
+import { SidePanelActivity, SidePanelActivityIcon } from './panels/activity/SidePanelActivity'
 import { SidePanelActivation, SidePanelActivationIcon } from './panels/SidePanelActivation'
 import { SidePanelDocs } from './panels/SidePanelDocs'
 import { SidePanelFeaturePreviews } from './panels/SidePanelFeaturePreviews'
@@ -66,7 +57,7 @@ export const SIDE_PANEL_TABS: Record<SidePanelTab, { label: string; Icon: any; C
 
     [SidePanelTab.Activity]: {
         label: 'Activity',
-        Icon: IconNotification,
+        Icon: SidePanelActivityIcon,
         Content: SidePanelActivity,
     },
     [SidePanelTab.Welcome]: {

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
@@ -1,7 +1,9 @@
+import { IconNotification } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonSkeleton, LemonTabs, Link, Spinner } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { ActivityLogRow } from 'lib/components/ActivityLog/ActivityLog'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
+import { IconWithCount } from 'lib/lemon-ui/icons'
 import { useEffect, useRef } from 'react'
 import { urls } from 'scenes/urls'
 
@@ -13,6 +15,16 @@ import {
 import { SidePanelPaneHeader } from '../../components/SidePanelPaneHeader'
 
 const SCROLL_TRIGGER_OFFSET = 100
+
+export const SidePanelActivityIcon = (props: { className?: string }): JSX.Element => {
+    const { unreadCount } = useValues(notificationsLogic)
+
+    return (
+        <IconWithCount count={unreadCount} {...props}>
+            <IconNotification />
+        </IconWithCount>
+    )
+}
 
 export const SidePanelActivity = (): JSX.Element => {
     const {

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -87,10 +87,10 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                     tabs.push(SidePanelTab.Support)
                 }
                 tabs.push(SidePanelTab.Settings)
+                tabs.push(SidePanelTab.Activity)
                 if (isReady && !hasCompletedAllTasks) {
                     tabs.push(SidePanelTab.Activation)
                 }
-                tabs.push(SidePanelTab.Activity)
                 tabs.push(SidePanelTab.FeaturePreviews)
                 tabs.push(SidePanelTab.Welcome)
 
@@ -101,12 +101,12 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
         visibleTabs: [
             (s) => [s.enabledTabs, s.selectedTab, s.sidePanelOpen, s.unreadCount],
             (enabledTabs, selectedTab, sidePanelOpen, unreadCount): SidePanelTab[] => {
-                return enabledTabs.filter((tab: any) => {
+                return enabledTabs.filter((tab) => {
                     if (tab === selectedTab && sidePanelOpen) {
                         return true
                     }
 
-                    if (tab === SidePanelTab.Activation && unreadCount) {
+                    if (tab === SidePanelTab.Activity && unreadCount) {
                         return true
                     }
 

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -99,10 +99,14 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
         ],
 
         visibleTabs: [
-            (s) => [s.enabledTabs, s.selectedTab, s.sidePanelOpen, s.isReady, s.hasCompletedAllTasks],
-            (enabledTabs, selectedTab, sidePanelOpen): SidePanelTab[] => {
+            (s) => [s.enabledTabs, s.selectedTab, s.sidePanelOpen, s.unreadCount],
+            (enabledTabs, selectedTab, sidePanelOpen, unreadCount): SidePanelTab[] => {
                 return enabledTabs.filter((tab: any) => {
                     if (tab === selectedTab && sidePanelOpen) {
+                        return true
+                    }
+
+                    if (tab === SidePanelTab.Activation && unreadCount) {
                         return true
                     }
 

--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -9,6 +9,7 @@ interface IconWithCountProps {
     count: number
     showZero?: boolean
     status?: LemonBadgeProps['status']
+    className?: string
 }
 
 export function IconWithCount({
@@ -16,9 +17,10 @@ export function IconWithCount({
     children,
     showZero,
     status = 'primary',
+    className,
 }: PropsWithChildren<IconWithCountProps>): JSX.Element {
     return (
-        <span className="relative inline-flex">
+        <span className={clsx('relative inline-flex', className)}>
             {children}
             <LemonBadge.Number count={count} size="small" position="top-right" showZero={showZero} status={status} />
         </span>

--- a/frontend/src/scenes/notebooks/NotebookMenu.tsx
+++ b/frontend/src/scenes/notebooks/NotebookMenu.tsx
@@ -1,9 +1,10 @@
 import './NotebookScene.scss'
 
+import { IconClock, IconEllipsis, IconShare } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import { IconDelete, IconEllipsis, IconExport, IconNotification, IconShare } from 'lib/lemon-ui/icons'
+import { IconDelete, IconExport } from 'lib/lemon-ui/icons'
 import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
 import { urls } from 'scenes/urls'
 
@@ -28,7 +29,7 @@ export function NotebookMenu({ shortId }: NotebookLogicProps): JSX.Element {
                         },
                         {
                             label: 'History',
-                            icon: <IconNotification />,
+                            icon: <IconClock />,
                             onClick: () => setShowHistory(!showHistory),
                         },
                         {


### PR DESCRIPTION
## Problem

You sort of what to know about whats going on - lets show the activity panel if you have unread notifications!

## Changes

* Show the activity panel if you have unread notifications
* The only badge color we currently have is the faded one... should we change that?
* Also snuck in some icon updates for the Notebook menu 🙈 

<img width="191" alt="Screenshot 2023-12-11 at 18 18 29" src="https://github.com/PostHog/posthog/assets/2536520/b48a6584-2fb4-40b0-b8dc-bd988946c1a4">

## Follow up
* Cache the unread count so that we don't flash it on load?

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
