### PR TITLE
feat: ingest with snapshot source

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
@@ -109,7 +109,8 @@ export class ReplayEventsIngester {
                 event.team_id,
                 event.distinct_id,
                 event.session_id,
-                event.events
+                event.events,
+                event.snapshot_source
             )
 
             try {

--- a/plugin-server/src/main/ingestion-queues/session-recording/types.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/types.ts
@@ -15,6 +15,7 @@ export type IncomingRecordingMessage = {
     session_id: string
     window_id?: string
     events: RRWebEvent[]
+    snapshot_source: string | null
 }
 
 // This is the incoming message from Kafka

--- a/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
@@ -182,7 +182,7 @@ export const parseKafkaMessage = async (
         return dropMessage('invalid_json', { error })
     }
 
-    const { $snapshot_items, $session_id, $window_id } = event.properties || {}
+    const { $snapshot_items, $session_id, $window_id, $snapshot_source } = event.properties || {}
 
     // NOTE: This is simple validation - ideally we should do proper schema based validation
     if (event.event !== '$snapshot_items' || !$snapshot_items || !$session_id) {
@@ -259,5 +259,6 @@ export const parseKafkaMessage = async (
         session_id: $session_id,
         window_id: $window_id,
         events: events,
+        snapshot_source: $snapshot_source,
     }
 }

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -323,6 +323,7 @@ export interface SummarizedSessionRecordingEvent {
     size: number
     event_count: number
     message_count: number
+    snapshot_source: string | null
 }
 
 export type ConsoleLogEntry = {
@@ -441,7 +442,8 @@ export const createSessionReplayEvent = (
     team_id: number,
     distinct_id: string,
     session_id: string,
-    events: RRWebEvent[]
+    events: RRWebEvent[],
+    snapshot_source: string | null
 ) => {
     const timestamps = getTimestampsFrom(events)
 
@@ -509,6 +511,7 @@ export const createSessionReplayEvent = (
         size: Math.trunc(Buffer.byteLength(JSON.stringify(events), 'utf8')),
         event_count: Math.trunc(events.length),
         message_count: 1,
+        snapshot_source: snapshot_source || 'web',
     }
 
     return data

--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
@@ -27,6 +27,7 @@ const makeIncomingMessage = (
         },
         session_id: '',
         team_id: 0,
+        snapshot_source: 'should not effect this ingestion route',
     }
 }
 

--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/replay-events-ingester.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/replay-events-ingester.test.ts
@@ -1,0 +1,112 @@
+import { HighLevelProducer } from 'node-rdkafka'
+
+import { defaultConfig } from '../../../../../src/config/config'
+import { createKafkaProducer, produce } from '../../../../../src/kafka/producer'
+import { OffsetHighWaterMarker } from '../../../../../src/main/ingestion-queues/session-recording/services/offset-high-water-marker'
+import { ReplayEventsIngester } from '../../../../../src/main/ingestion-queues/session-recording/services/replay-events-ingester'
+import { IncomingRecordingMessage } from '../../../../../src/main/ingestion-queues/session-recording/types'
+import { PluginsServerConfig } from '../../../../../src/types'
+import { status } from '../../../../../src/utils/status'
+
+jest.mock('../../../../../src/utils/status')
+jest.mock('../../../../../src/kafka/producer')
+
+const makeIncomingMessage = (source: string | null, timestamp: number): IncomingRecordingMessage => {
+    return {
+        distinct_id: '',
+        events: [{ data: { any: 'thing' }, type: 2, timestamp: timestamp }],
+        metadata: {
+            offset: 0,
+            partition: 0,
+            topic: 'topic',
+            timestamp: timestamp,
+            consoleLogIngestionEnabled: true,
+        },
+        session_id: '',
+        team_id: 0,
+        snapshot_source: source,
+    }
+}
+
+describe('replay events ingester', () => {
+    let ingester: ReplayEventsIngester
+    const mockProducer: jest.Mock = jest.fn()
+
+    beforeEach(async () => {
+        mockProducer.mockClear()
+        mockProducer['connect'] = jest.fn()
+
+        jest.mocked(createKafkaProducer).mockImplementation(() =>
+            Promise.resolve(mockProducer as unknown as HighLevelProducer)
+        )
+
+        const mockedHighWaterMarker = { isBelowHighWaterMark: jest.fn() } as unknown as OffsetHighWaterMarker
+        ingester = new ReplayEventsIngester({ ...defaultConfig } as PluginsServerConfig, mockedHighWaterMarker)
+        await ingester.start()
+    })
+
+    test('it passes snapshot source along', async () => {
+        const ts = new Date().getTime()
+        await ingester.consume(makeIncomingMessage("mickey's fun house", ts))
+
+        expect(jest.mocked(status.debug).mock.calls).toEqual([])
+        expect(jest.mocked(produce).mock.calls).toHaveLength(1)
+        expect(jest.mocked(produce).mock.calls[0]).toHaveLength(1)
+        const call = jest.mocked(produce).mock.calls[0][0]
+        expect(call.topic).toEqual('clickhouse_session_replay_events_test')
+        // call.value is a Buffer convert it to a string
+        const value = call.value ? JSON.parse(call.value.toString()) : null
+        expect(value).toEqual({
+            active_milliseconds: 0,
+            click_count: 0,
+            console_error_count: 0,
+            console_log_count: 0,
+            console_warn_count: 0,
+            distinct_id: '',
+            event_count: 1,
+            first_timestamp: expect.any(String),
+            first_url: null,
+            keypress_count: 0,
+            last_timestamp: expect.any(String),
+            message_count: 1,
+            mouse_activity_count: 0,
+            session_id: '',
+            size: 61,
+            snapshot_source: "mickey's fun house",
+            team_id: 0,
+            uuid: expect.any(String),
+        })
+    })
+    test('it defaults snapshot source to web when absent', async () => {
+        const ts = new Date().getTime()
+        await ingester.consume(makeIncomingMessage(null, ts))
+
+        expect(jest.mocked(status.debug).mock.calls).toEqual([])
+        expect(jest.mocked(produce).mock.calls).toHaveLength(1)
+        expect(jest.mocked(produce).mock.calls[0]).toHaveLength(1)
+        const call = jest.mocked(produce).mock.calls[0][0]
+        expect(call.topic).toEqual('clickhouse_session_replay_events_test')
+        // call.value is a Buffer convert it to a string
+        const value = call.value ? JSON.parse(call.value.toString()) : null
+        expect(value).toEqual({
+            active_milliseconds: 0,
+            click_count: 0,
+            console_error_count: 0,
+            console_log_count: 0,
+            console_warn_count: 0,
+            distinct_id: '',
+            event_count: 1,
+            first_timestamp: expect.any(String),
+            first_url: null,
+            keypress_count: 0,
+            last_timestamp: expect.any(String),
+            message_count: 1,
+            mouse_activity_count: 0,
+            session_id: '',
+            size: 61,
+            snapshot_source: 'web',
+            team_id: 0,
+            uuid: expect.any(String),
+        })
+    })
+})

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -274,8 +274,8 @@ test('capture new person', async () => {
     await hub.db.postgres.query(
         PostgresUse.COMMON_WRITE,
         `UPDATE posthog_team
-             SET ingested_event = $1
-             WHERE id = $2`,
+         SET ingested_event = $1
+         WHERE id = $2`,
         [true, team.id],
         'testTag'
     )
@@ -1473,20 +1473,20 @@ const sessionReplayEventTestCases: {
         },
         snapshotSource: 'mobile',
         expected: {
-            click_count: 6,
-            keypress_count: 0,
-            mouse_activity_count: 6,
-            first_url: null,
-            first_timestamp: '2023-04-25 18:58:13.000',
-            last_timestamp: '2023-04-25 18:58:19.000',
-            active_milliseconds: 6000, // can sum up the activity across windows
+            active_milliseconds: 1,
+            click_count: 1,
+            console_error_count: 0,
             console_log_count: 0,
             console_warn_count: 0,
-            console_error_count: 0,
-            size: 433,
-            event_count: 6,
+            event_count: 1,
+            first_timestamp: '2023-04-25 18:58:13.000',
+            first_url: null,
+            keypress_count: 0,
+            last_timestamp: '2023-04-25 18:58:13.000',
             message_count: 1,
-            snapshot_source: 'web',
+            mouse_activity_count: 1,
+            size: 73,
+            snapshot_source: 'mobile',
         },
     },
 ]
@@ -3024,12 +3024,15 @@ describe('ingestion in any order', () => {
     async function ingest0() {
         await runProcessEvent(set0, setOnce0, ts0)
     }
+
     async function ingest1() {
         await runProcessEvent(set1, setOnce1, ts1)
     }
+
     async function ingest2() {
         await runProcessEvent(set2, setOnce2, ts2)
     }
+
     async function ingest3() {
         await runProcessEvent(set3, setOnce3, ts3)
     }

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1254,6 +1254,7 @@ test('snapshot event stored as session_recording_event', () => {
 })
 const sessionReplayEventTestCases: {
     snapshotData: { events_summary: RRWebEvent[] }
+    snapshotSource?: string
     expected: Pick<
         SummarizedSessionRecordingEvent,
         | 'click_count'
@@ -1269,6 +1270,7 @@ const sessionReplayEventTestCases: {
         | 'size'
         | 'event_count'
         | 'message_count'
+        | 'snapshot_source'
     >
 }[] = [
     {
@@ -1287,6 +1289,7 @@ const sessionReplayEventTestCases: {
             size: 73,
             event_count: 1,
             message_count: 1,
+            snapshot_source: 'web',
         },
     },
     {
@@ -1305,6 +1308,7 @@ const sessionReplayEventTestCases: {
             size: 73,
             event_count: 1,
             message_count: 1,
+            snapshot_source: 'web',
         },
     },
     {
@@ -1363,6 +1367,7 @@ const sessionReplayEventTestCases: {
             size: 762,
             event_count: 7,
             message_count: 1,
+            snapshot_source: 'web',
         },
     },
     {
@@ -1403,6 +1408,7 @@ const sessionReplayEventTestCases: {
             size: 213,
             event_count: 2,
             message_count: 1,
+            snapshot_source: 'web',
         },
     },
     {
@@ -1428,6 +1434,7 @@ const sessionReplayEventTestCases: {
             size: 217,
             event_count: 3,
             message_count: 1,
+            snapshot_source: 'web',
         },
     },
     {
@@ -1457,17 +1464,41 @@ const sessionReplayEventTestCases: {
             size: 433,
             event_count: 6,
             message_count: 1,
+            snapshot_source: 'web',
+        },
+    },
+    {
+        snapshotData: {
+            events_summary: [{ timestamp: 1682449093000, type: 3, data: { source: 2 }, windowId: '1' }],
+        },
+        snapshotSource: 'mobile',
+        expected: {
+            click_count: 6,
+            keypress_count: 0,
+            mouse_activity_count: 6,
+            first_url: null,
+            first_timestamp: '2023-04-25 18:58:13.000',
+            last_timestamp: '2023-04-25 18:58:19.000',
+            active_milliseconds: 6000, // can sum up the activity across windows
+            console_log_count: 0,
+            console_warn_count: 0,
+            console_error_count: 0,
+            size: 433,
+            event_count: 6,
+            message_count: 1,
+            snapshot_source: 'web',
         },
     },
 ]
-sessionReplayEventTestCases.forEach(({ snapshotData, expected }) => {
+sessionReplayEventTestCases.forEach(({ snapshotData, snapshotSource, expected }) => {
     test(`snapshot event ${JSON.stringify(snapshotData)} can be stored as session_replay_event`, () => {
         const data = createSessionReplayEvent(
             'some-id',
             team.id,
             '5AzhubH8uMghFHxXq0phfs14JOjH6SA2Ftr1dzXj7U4',
             'abcf-efg',
-            snapshotData.events_summary
+            snapshotData.events_summary,
+            snapshotSource
         )
 
         const expectedEvent: SummarizedSessionRecordingEvent = {

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1567,6 +1567,7 @@ class TestCapture(BaseTest):
                         "data": {"data": event_data, "source": snapshot_source},
                     }
                 ],
+                "$snapshot_source": "web",
                 "$session_id": session_id,
                 "$window_id": window_id,
                 "distinct_id": distinct_id,

--- a/posthog/clickhouse/migrations/0050_session_replay_source.py
+++ b/posthog/clickhouse/migrations/0050_session_replay_source.py
@@ -1,0 +1,26 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.session_recordings.sql.session_replay_event_migrations_sql import (
+    DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+    DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_SOURCE_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_SOURCE_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_SOURCE_SESSION_REPLAY_EVENTS_TABLE_SQL,
+)
+from posthog.session_recordings.sql.session_replay_event_sql import (
+    SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+    KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+)
+
+operations = [
+    # we have to drop materialized view first so that we're no longer pulling from kakfa
+    # then we drop the kafka table
+    run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
+    run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # now we can alter the target tables
+    run_sql_with_exceptions(ADD_SOURCE_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    run_sql_with_exceptions(ADD_SOURCE_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    run_sql_with_exceptions(ADD_SOURCE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # and then recreate the materialized views and kafka tables
+    run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
+]

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -367,7 +367,8 @@
       console_error_count Int64,
       size Int64,
       event_count Int64,
-      message_count Int64
+      message_count Int64,
+      snapshot_source LowCardinality(Nullable(String))
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_session_replay_events_test', 'group1', 'JSONEachRow')
   
   '
@@ -984,7 +985,8 @@
       console_error_count Int64,
       size Int64,
       event_count Int64,
-      message_count Int64
+      message_count Int64,
+      snapshot_source LowCardinality(Nullable(String))
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_session_replay_events_test', 'group1', 'JSONEachRow')
   
   '
@@ -1468,6 +1470,8 @@
       -- often very useful in incidents or debugging
       -- because we batch events we expect message_count to be lower than event_count
       event_count SimpleAggregateFunction(sum, Int64),
+      -- which source the snapshots came from Android, iOS, Mobile, Web. Web if absent
+      snapshot_source AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime)
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
@@ -1505,6 +1509,7 @@
   -- we can count the number of kafka messages instead of sending it explicitly
   sum(message_count) as message_count,
   sum(event_count) as event_count,
+  argMinState(snapshot_source, first_timestamp) as snapshot_source,
   max(_timestamp) as _timestamp
   FROM posthog_test.kafka_session_replay_events
   group by session_id, team_id
@@ -1744,6 +1749,8 @@
       -- often very useful in incidents or debugging
       -- because we batch events we expect message_count to be lower than event_count
       event_count SimpleAggregateFunction(sum, Int64),
+      -- which source the snapshots came from Android, iOS, Mobile, Web. Web if absent
+      snapshot_source AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime)
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
@@ -2405,6 +2412,8 @@
       -- often very useful in incidents or debugging
       -- because we batch events we expect message_count to be lower than event_count
       event_count SimpleAggregateFunction(sum, Int64),
+      -- which source the snapshots came from Android, iOS, Mobile, Web. Web if absent
+      snapshot_source AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
       _timestamp SimpleAggregateFunction(max, DateTime)
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   

--- a/posthog/session_recordings/session_recording_helpers.py
+++ b/posthog/session_recordings/session_recording_helpers.py
@@ -124,6 +124,7 @@ def preprocess_replay_events(
     distinct_id = events[0]["properties"]["distinct_id"]
     session_id = events[0]["properties"]["$session_id"]
     window_id = events[0]["properties"].get("$window_id")
+    snapshot_source = events[0]["properties"].get("$snapshot_source", "web")
 
     def new_event(items: List[dict] | None = None) -> Event:
         return {
@@ -135,6 +136,7 @@ def preprocess_replay_events(
                 "$window_id": window_id,
                 # We instantiate here instead of in the arg to avoid mutable default args
                 "$snapshot_items": items or [],
+                "$snapshot_source": snapshot_source,
             },
         }
 

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -93,3 +93,24 @@ ADD_EVENT_COUNT_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_A
     table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
     cluster=settings.CLICKHOUSE_CLUSTER,
 )
+
+# migration to add source column to the session replay table
+ALTER_SESSION_REPLAY_ADD_SOURCE_COLUMN = """
+    ALTER TABLE {table_name} on CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS snapshot_source AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC'))
+"""
+
+ADD_SOURCE_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_SOURCE_COLUMN.format(
+    table_name="session_replay_events",
+    cluster=settings.CLICKHOUSE_CLUSTER,
+)
+
+ADD_SOURCE_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_SOURCE_COLUMN.format(
+    table_name="writable_session_replay_events",
+    cluster=settings.CLICKHOUSE_CLUSTER,
+)
+
+ADD_SOURCE_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_SOURCE_COLUMN.format(
+    table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
+    cluster=settings.CLICKHOUSE_CLUSTER,
+)

--- a/posthog/session_recordings/test/test_session_recording_helpers.py
+++ b/posthog/session_recordings/test/test_session_recording_helpers.py
@@ -177,6 +177,50 @@ def test_new_ingestion(raw_snapshot_events, mocker: MockerFixture):
                         "something": big_payload,
                     },
                 ],
+                "$snapshot_source": "web",
+            },
+        }
+    ]
+
+
+def test_received_snapshot_source_is_respected_for_first_event(raw_snapshot_events, mocker: MockerFixture):
+    mocker.patch("time.time", return_value=0)
+
+    events = [
+        {
+            "event": "$snapshot",
+            "properties": {
+                "$session_id": "1234",
+                "$window_id": "1",
+                "$snapshot_data": {"type": 3, "timestamp": MILLISECOND_TIMESTAMP},
+                "distinct_id": "abc123",
+                "$snapshot_source": "mobile",
+            },
+        },
+        {
+            "event": "$snapshot",
+            "properties": {
+                "$session_id": "1234",
+                "$window_id": "1",
+                "$snapshot_data": {"type": 3, "timestamp": MILLISECOND_TIMESTAMP},
+                "distinct_id": "abc123",
+                "$snapshot_source": "assumed unchanged but not really",
+            },
+        },
+    ]
+
+    assert list(mock_capture_flow(events, max_size_bytes=2000)[1]) == [
+        {
+            "event": "$snapshot_items",
+            "properties": {
+                "distinct_id": "abc123",
+                "$session_id": "1234",
+                "$window_id": "1",
+                "$snapshot_items": [
+                    {"type": 3, "timestamp": 1546300800000},
+                    {"type": 3, "timestamp": 1546300800000},
+                ],
+                "$snapshot_source": "mobile",
             },
         }
     ]
@@ -221,7 +265,6 @@ def test_new_ingestion_large_full_snapshot_is_separated(raw_snapshot_events, moc
             },
         },
     ]
-
     assert list(mock_capture_flow(events, max_size_bytes=2000)[1]) == [
         {
             "event": "$snapshot_items",
@@ -236,6 +279,7 @@ def test_new_ingestion_large_full_snapshot_is_separated(raw_snapshot_events, moc
                         "something": big_payload,
                     }
                 ],
+                "$snapshot_source": "web",
             },
         },
         {
@@ -248,6 +292,7 @@ def test_new_ingestion_large_full_snapshot_is_separated(raw_snapshot_events, moc
                     {"type": 3, "timestamp": 1546300800000},
                     {"type": 3, "timestamp": 1546300800000},
                 ],
+                "$snapshot_source": "web",
             },
         },
     ]
@@ -307,6 +352,7 @@ def test_new_ingestion_large_non_full_snapshots_are_separated(raw_snapshot_event
                     }
                 ],
                 "distinct_id": "abc123",
+                "$snapshot_source": "web",
             },
         },
         {
@@ -322,6 +368,7 @@ def test_new_ingestion_large_non_full_snapshots_are_separated(raw_snapshot_event
                     }
                 ],
                 "distinct_id": "abc123",
+                "$snapshot_source": "web",
             },
         },
     ]
@@ -398,6 +445,7 @@ def test_new_ingestion_groups_using_snapshot_bytes_if_possible(raw_snapshot_even
                     small_event,
                     almost_too_big_event,
                 ],
+                "$snapshot_source": "web",
             },
         },
         {
@@ -407,6 +455,7 @@ def test_new_ingestion_groups_using_snapshot_bytes_if_possible(raw_snapshot_even
                 "$session_id": "1234",
                 "$window_id": "1",
                 "$snapshot_items": [small_event, small_event, small_event],
+                "$snapshot_source": "web",
             },
         },
     ]


### PR DESCRIPTION
To make it easier to filter mobile recordings and to report usage separately let's have a source column in the table

This lets us

* treat null as web
* ingest a small number of sources (e.g. Android, iOS, Web or better Mobile and Web)
* store them in CH
* filter in the recordings UI (follow-up to this PR)
* report usage separately (follow-up to this PR)

We only record the first source seen for a recording, it is theoretically possible that someone could pass a session id between systems and so stitch a mobile and web session together. This will be a very small minority case if it does ever happen so for simplicity the first source in the recording is the source for the entire recording

# TODO

- [ ] how should this affect billing limits?

# Tested 

locally by seeing that this query works and I can still ingest and playback

```
select session_id, argMinMerge(snapshot_source)
from sharded_session_replay_events
group by session_id;
```