### PR TITLE
fix(universal-search): allow scrolling search results

### DIFF
--- a/frontend/src/lib/components/CommandBar/index.scss
+++ b/frontend/src/lib/components/CommandBar/index.scss
@@ -18,5 +18,5 @@
 
 .SearchResults {
     // offset container height by input
-    height: 'calc(100% - 2.375rem)';
+    height: calc(100% - 2.375rem);
 }


### PR DESCRIPTION
## Problem

Search results aren't scrollable (with mouse).

## Changes

Have a chuckle looking at the changed code :)

## How did you test this code?

Navigated the search results by scrolling with mouse and keyboard