### PR TITLE
feat: Add stale bot exempt label

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -23,5 +23,6 @@ jobs:
                   close-pr-message: "This PR was closed due to lack of activity. Feel free to reopen if it's still relevant."
                   stale-pr-label: stale
                   remove-pr-stale-when-updated: true
+                  exempt-pr-labels: 'waiting'
                   operations-per-run: 250
                   repo-token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Some long running efforts, like upgrading to Django 4.2 #18653 should never get stale, because somehow we ultimately need to do it.

## Changes

- provide way to not have stalebot flag the PR
- exempt PRs with label `waiting`
