### PR TITLE
fix: selected row sticky cell background color in dark mode

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
@@ -192,7 +192,10 @@
             &.LemonTable__row--status-highlighted {
                 font-weight: 600;
                 color: var(--default);
-                background: var(--primary-bg-hover);
+
+                > td:not(.LemonTable__cell--sticky) {
+                    background: var(--primary-bg-hover);
+                }
             }
 
             > td {
@@ -363,7 +366,7 @@ body:not(.storybook-test-runner) {
     }
 
     tr.LemonTable__row--status-highlighted .LemonTable__cell--sticky::before {
-        background: #e8ecff; // TRICKY: This is a one-off opaque form of --primary-bg-hover, keep in sync with source
+        background: var(--primary-bg-hover);
     }
 
     .scrollable--left {

--- a/frontend/src/scenes/experiments/ExperimentPreview.tsx
+++ b/frontend/src/scenes/experiments/ExperimentPreview.tsx
@@ -463,9 +463,11 @@ export function MetricDisplay({ filters }: { filters?: FilterType }): JSX.Elemen
                                 />
                             </b>
                         </div>
-                        {event.properties?.map((prop: AnyPropertyFilter) => (
-                            <PropertyFilterButton key={prop.key} item={prop} />
-                        ))}
+                        <div className="space-y-1">
+                            {event.properties?.map((prop: AnyPropertyFilter) => (
+                                <PropertyFilterButton key={prop.key} item={prop} />
+                            ))}
+                        </div>
                     </div>
                 ))}
         </>


### PR DESCRIPTION
## Problem

The custom color didn't work in dark mode
<img width="307" alt="Screenshot 2023-12-12 at 13 51 25" src="https://github.com/PostHog/posthog/assets/6685876/b9b6cd0e-dd5a-46fc-a545-e0cfca833eae">


## Changes

Do not apply the background to the whole row but individual cells. And apply the sticky cell separately

<img width="277" alt="Screenshot 2023-12-12 at 14 00 58" src="https://github.com/PostHog/posthog/assets/6685876/c6dfaebf-1f3e-4083-8b44-2daaf89a430b">


Also fixed a padding issue in experiments

|Before|After|
|----|----|
| <img width="395" alt="Screenshot 2023-12-12 at 13 47 57" src="https://github.com/PostHog/posthog/assets/6685876/955090b7-53ec-44e6-9adc-60b9031feb35"> | <img width="356" alt="Screenshot 2023-12-12 at 13 47 49" src="https://github.com/PostHog/posthog/assets/6685876/7f79c81b-b0c4-4a84-858b-f25b5fe06860"> |

## How did you test this code?

Visually