### PR TITLE
fix(web-analytics): Fix bug where we tried to compare to previous results, for graph of all time

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -263,6 +263,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     date_from: dateFrom,
                     date_to: dateTo,
                 }
+                const compare = !!dateRange.date_from
+
                 const tiles: (WebDashboardTile | null)[] = [
                     {
                         layout: {
@@ -300,7 +302,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                             },
                                         ],
                                         trendsFilter: {
-                                            compare: true,
+                                            compare,
                                             display: ChartDisplayType.ActionsLineGraph,
                                         },
                                         filterTestAccounts: true,
@@ -330,7 +332,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                             },
                                         ],
                                         trendsFilter: {
-                                            compare: true,
+                                            compare,
                                             display: ChartDisplayType.ActionsLineGraph,
                                         },
                                         filterTestAccounts: true,
@@ -360,7 +362,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                             },
                                         ],
                                         trendsFilter: {
-                                            compare: true,
+                                            compare,
                                             display: ChartDisplayType.ActionsLineGraph,
                                         },
                                         filterTestAccounts: true,


### PR DESCRIPTION
## Problem

When choosing a period of All Time, the trends broke because they try to compare to previous periods.

## Changes

Set `compare` to `false` when there's no `date_from`. (No `date_to` is still allowed, as it uses the present timestamp).

## How did you test this code?

Manually, the trends themselves are very well tested though
