### PR TITLE
fix(bi): quick fix for ensuring future events dont show in team apps default q…

### DIFF
--- a/frontend/src/queries/examples.ts
+++ b/frontend/src/queries/examples.ts
@@ -321,7 +321,7 @@ const HogQLForDataVisualization: HogQLQuery = {
     kind: NodeKind.HogQLQuery,
     query: `select toDate(timestamp) as timestamp, count()
 from events
-where {filters}
+where {filters} and timestamp <= now()
 group by timestamp
 order by timestamp asc
 limit 100`,


### PR DESCRIPTION
## Problem
- In the team posthog app, we have a handful of events in the _future_ which show when loading up the default BI query

<img width="1516" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/86e6fa40-9bc2-44f7-9e49-db725b32da24">


## Changes
- Add a fixed `timestamp` filter to ensure all events are before `now()`
