### PR TITLE
refactor(paths): Remove unused filter mixins

### DIFF
--- a/posthog/models/filters/mixins/paths.py
+++ b/posthog/models/filters/mixins/paths.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List, Literal, Optional, Tuple, cast
+from typing import Dict, List, Literal, Optional
 
 from posthog.constants import (
     CUSTOM_EVENT,
@@ -67,41 +67,6 @@ class EndPointMixin(BaseParamMixin):
     @include_dict
     def end_point_to_dict(self):
         return {"end_point": self.end_point} if self.end_point else {}
-
-
-class PropTypeDerivedMixin(PathTypeMixin):
-    @cached_property
-    def prop_type(self) -> str:
-        if self.path_type == SCREEN_EVENT:
-            return "properties->> '$screen_name'"
-        elif self.path_type == CUSTOM_EVENT:
-            return "event"
-        elif self.path_type == HOGQL:
-            return "event"
-        else:
-            return "properties->> '$current_url'"
-
-
-class ComparatorDerivedMixin(PropTypeDerivedMixin):
-    @cached_property
-    def comparator(self) -> str:
-        if self.path_type == SCREEN_EVENT:
-            return "{} =".format(self.prop_type)
-        elif self.path_type == CUSTOM_EVENT:
-            return "event ="
-        else:
-            return "{} =".format(self.prop_type)
-
-
-class TargetEventDerivedMixin(PropTypeDerivedMixin):
-    @cached_property
-    def target_event(self) -> Tuple[Optional[PathType], Dict[str, str]]:
-        if self.path_type == SCREEN_EVENT:
-            return cast(PathType, SCREEN_EVENT), {"event": SCREEN_EVENT}
-        elif self.path_type == HOGQL or self.path_type == CUSTOM_EVENT:
-            return None, {}
-        else:
-            return cast(PathType, PAGEVIEW_EVENT), {"event": PAGEVIEW_EVENT}
 
 
 class PathsHogQLExpressionMixin(PathTypeMixin):

--- a/posthog/models/filters/path_filter.py
+++ b/posthog/models/filters/path_filter.py
@@ -25,7 +25,6 @@ from .mixins.funnel import (
 from .mixins.groups import GroupsAggregationMixin
 from .mixins.interval import IntervalMixin
 from .mixins.paths import (
-    ComparatorDerivedMixin,
     EndPointMixin,
     FunnelPathsMixin,
     LocalPathCleaningFiltersMixin,
@@ -34,9 +33,7 @@ from .mixins.paths import (
     PathPersonsMixin,
     PathReplacementMixin,
     PathStepLimitMixin,
-    PropTypeDerivedMixin,
     StartPointMixin,
-    TargetEventDerivedMixin,
     TargetEventsMixin,
     PathsHogQLExpressionMixin,
 )
@@ -47,9 +44,6 @@ from .mixins.simplify import SimplifyFilterMixin
 class PathFilter(
     StartPointMixin,
     EndPointMixin,
-    TargetEventDerivedMixin,
-    ComparatorDerivedMixin,
-    PropTypeDerivedMixin,
     PropertyMixin,
     IntervalMixin,
     InsightMixin,


### PR DESCRIPTION
## Problem

I looked into the code of User Paths while investigating a customer report. This made me realize we have a few completely unused filter mixins. I think they were relevant back when we used Postgres for analytics, but not anymore. 

## Changes

Removed dead code.

## How did you test this code?

Existing tests seem alright.