### PR TITLE
fix(3000): Top bar title fixes

### DIFF
--- a/frontend/src/layout/navigation-3000/components/TopBar.tsx
+++ b/frontend/src/layout/navigation-3000/components/TopBar.tsx
@@ -236,6 +236,7 @@ function Here({ breadcrumb }: HereProps): JSX.Element {
                     placeholder="Unnamed"
                     compactButtons="xsmall"
                     editingIndication="underlined"
+                    autoFocus
                 />
             ) : (
                 <span>{breadcrumb.name}</span>

--- a/frontend/src/lib/components/EditableField/EditableField.tsx
+++ b/frontend/src/lib/components/EditableField/EditableField.tsx
@@ -1,12 +1,13 @@
 import './EditableField.scss'
 
+import { useMergeRefs } from '@floating-ui/react'
 import clsx from 'clsx'
 import { IconEdit, IconMarkdown } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { pluralize } from 'lib/utils'
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import TextareaAutosize from 'react-textarea-autosize'
 
 export interface EditableFieldProps {
@@ -51,7 +52,7 @@ export function EditableField({
     placeholder,
     minLength,
     maxLength,
-    autoFocus = true,
+    autoFocus = false,
     multiline = false,
     markdown = false,
     compactButtons = false,
@@ -65,15 +66,29 @@ export function EditableField({
     saveButtonText = 'Save',
     notice,
 }: EditableFieldProps): JSX.Element {
-    const [localIsEditing, setLocalIsEditing] = useState(false)
+    const [localIsEditing, setLocalIsEditing] = useState(mode === 'edit')
     const [localTentativeValue, setLocalTentativeValue] = useState(value)
+    const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>()
+    const previousIsEditing = useRef<boolean>()
 
     useEffect(() => {
         setLocalTentativeValue(value)
     }, [value])
+
     useEffect(() => {
         setLocalIsEditing(mode === 'edit')
     }, [mode])
+
+    useEffect(() => {
+        // We always want to focus when switching to edit mode, but can't use autoFocus, because we don't want this to
+        // happen when the component is _initially_ rendered in edit mode.
+        if (inputRef.current && previousIsEditing.current === false && localIsEditing === true) {
+            const endOfInput = inputRef.current.value.length
+            inputRef.current.setSelectionRange(endOfInput, endOfInput)
+            inputRef.current.focus()
+        }
+        previousIsEditing.current = localIsEditing
+    }, [localIsEditing])
 
     const isSaveable = !minLength || localTentativeValue.length >= minLength
 
@@ -150,6 +165,7 @@ export function EditableField({
                                     minLength={minLength}
                                     maxLength={maxLength}
                                     autoFocus={autoFocus}
+                                    ref={inputRef as React.RefObject<HTMLTextAreaElement>}
                                 />
                             ) : (
                                 <AutosizeInput
@@ -165,6 +181,7 @@ export function EditableField({
                                     minLength={minLength}
                                     maxLength={maxLength}
                                     autoFocus={autoFocus}
+                                    ref={inputRef as React.RefObject<HTMLInputElement>}
                                 />
                             )}
                             {(!mode || !!onModeToggle) && (
@@ -242,17 +259,7 @@ export function EditableField({
     )
 }
 
-const AutosizeInput = ({
-    name,
-    value,
-    onChange,
-    placeholder,
-    onBlur,
-    onKeyDown,
-    minLength,
-    maxLength,
-    autoFocus,
-}: {
+interface AutosizeInputProps {
     name: string
     value: string
     onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
@@ -262,11 +269,18 @@ const AutosizeInput = ({
     minLength?: number
     maxLength?: number
     autoFocus?: boolean
-}): JSX.Element => {
+}
+
+const AutosizeInput = React.forwardRef<HTMLInputElement, AutosizeInputProps>(function AutosizeInput(
+    { name, value, onChange, placeholder, onBlur, onKeyDown, minLength, maxLength, autoFocus },
+    ref
+) {
     const [inputWidth, setInputWidth] = useState<number | string>(1)
-    const inputRef = useRef<HTMLInputElement>(null)
+    const [inputStyles, setInputStyles] = useState<CSSStyleDeclaration>()
     const sizerRef = useRef<HTMLDivElement>(null)
     const placeHolderSizerRef = useRef<HTMLDivElement>(null)
+    const inputRef = useRef<HTMLInputElement>(null)
+    const mergedRefs = useMergeRefs([ref, inputRef])
 
     const copyStyles = (styles: CSSStyleDeclaration, node: HTMLDivElement): void => {
         node.style.fontSize = styles.fontSize
@@ -277,21 +291,22 @@ const AutosizeInput = ({
         node.style.textTransform = styles.textTransform
     }
 
-    const inputStyles = useMemo(() => {
-        return inputRef.current ? window.getComputedStyle(inputRef.current) : null
+    useLayoutEffect(() => {
+        if (inputRef.current) {
+            setInputStyles(getComputedStyle(inputRef.current))
+        }
     }, [inputRef.current])
 
     useLayoutEffect(() => {
-        if (inputStyles && placeHolderSizerRef.current) {
-            copyStyles(inputStyles, placeHolderSizerRef.current)
+        if (inputStyles) {
+            if (sizerRef.current) {
+                copyStyles(inputStyles, sizerRef.current)
+            }
+            if (placeHolderSizerRef.current) {
+                copyStyles(inputStyles, placeHolderSizerRef.current)
+            }
         }
-    }, [placeHolderSizerRef, placeHolderSizerRef])
-
-    useLayoutEffect(() => {
-        if (inputStyles && sizerRef.current) {
-            copyStyles(inputStyles, sizerRef.current)
-        }
-    }, [inputStyles, sizerRef])
+    }, [inputStyles])
 
     useLayoutEffect(() => {
         if (!sizerRef.current || !placeHolderSizerRef.current) {
@@ -320,7 +335,7 @@ const AutosizeInput = ({
                 minLength={minLength}
                 maxLength={maxLength}
                 autoFocus={autoFocus}
-                ref={inputRef}
+                ref={mergedRefs}
                 /* eslint-disable-next-line react/forbid-dom-props */
                 style={{ boxSizing: 'content-box', width: `${inputWidth}px` }}
             />
@@ -332,4 +347,4 @@ const AutosizeInput = ({
             </div>
         </div>
     )
-}
+})

--- a/frontend/src/scenes/actions/actionEditLogic.tsx
+++ b/frontend/src/scenes/actions/actionEditLogic.tsx
@@ -69,9 +69,6 @@ export const actionEditLogic = kea<actionEditLogicType>([
     forms(({ actions, props }) => ({
         action: {
             defaults: { ...props.action } as ActionEditType,
-            errors: ({ name }) => ({
-                name: !name ? 'You need to set a name' : null,
-            }),
             submit: (action) => {
                 actions.saveAction(action)
             },

--- a/frontend/src/scenes/data-management/actions/ActionsTable.tsx
+++ b/frontend/src/scenes/data-management/actions/ActionsTable.tsx
@@ -47,7 +47,7 @@ export function ActionsTable(): JSX.Element {
                 return (
                     <>
                         <Link data-attr={'action-link-' + index} to={urls.action(action.id)} className="row-name">
-                            {name || <i>Unnamed action</i>}
+                            {name || <i>Unnamed</i>}
                         </Link>
                         {action.description && (
                             <LemonMarkdown className="row-description" lowKeyHeadings>

--- a/frontend/src/scenes/insights/summarizeInsight.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.ts
@@ -343,15 +343,14 @@ export interface SummaryContext {
 
 export function summarizeInsight(
     query: Node | undefined | null,
-    filters: Partial<FilterType>,
+    filters: Partial<FilterType> | undefined | null,
     context: SummaryContext
 ): string {
-    const hasFilters = Object.keys(filters || {}).length > 0
     return isInsightVizNode(query)
         ? summarizeInsightQuery(query.source, context)
         : !!query && !isInsightVizNode(query)
         ? summarizeQuery(query)
-        : hasFilters
+        : filters && Object.keys(filters).length > 0
         ? summarizeInsightFilters(filters, context)
         : ''
 }

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistSceneLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistSceneLogic.ts
@@ -4,6 +4,7 @@ import { actions, afterMount, connect, kea, key, listeners, path, props, reducer
 import { loaders } from 'kea-loaders'
 import { beforeUnload, router } from 'kea-router'
 import api from 'lib/api'
+import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
 import {
     deletePlaylist,
@@ -30,7 +31,7 @@ export const sessionRecordingsPlaylistSceneLogic = kea<sessionRecordingsPlaylist
     props({} as SessionRecordingsPlaylistLogicProps),
     key((props) => props.shortId),
     connect({
-        values: [cohortsModel, ['cohortsById']],
+        values: [cohortsModel, ['cohortsById'], sceneLogic, ['activeScene']],
     }),
     actions({
         updatePlaylist: (properties?: Partial<SessionRecordingPlaylistType>, silent = false) => ({
@@ -126,7 +127,10 @@ export const sessionRecordingsPlaylistSceneLogic = kea<sessionRecordingsPlaylist
     })),
 
     beforeUnload(({ values, actions }) => ({
-        enabled: (newLocation) => values.hasChanges && newLocation?.pathname !== router.values.location.pathname,
+        enabled: (newLocation) =>
+            values.activeScene === Scene.ReplayPlaylist &&
+            values.hasChanges &&
+            newLocation?.pathname !== router.values.location.pathname,
         message: 'Leave playlist?\nChanges you made will be discarded.',
         onConfirm: () => {
             actions.setFilters(values.playlist?.filters || null)

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -634,7 +634,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_1')
+                                                      'user_one_2')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -634,7 +634,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_2')
+                                                      'user_one_1')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---


### PR DESCRIPTION
## Problem

A few small problems I found while navigating around:
1. If you opened a recordings playlist and left, you got the "Leave playlist?" alert on every page navigation.
2. Insights were missing their derived names.
3. Unnamed actions couldn't be saved, and this wasn't signaled, which was very confusing
4. If you created a new action, it was the description field which was autofocused, and not the name

## Changes

These are solved now.