### PR TITLE
fix(experiments): Improve legibility of secondary metrics variants

### DIFF
--- a/frontend/src/scenes/experiments/SecondaryMetrics.tsx
+++ b/frontend/src/scenes/experiments/SecondaryMetrics.tsx
@@ -55,14 +55,15 @@ export function SecondaryMetrics({
             render: function Key(_, item: TabularSecondaryMetricResults): JSX.Element {
                 return (
                     <div
+                        className="flex items-center w-fit h-5 px-1 rounded text-white text-xs"
                         // eslint-disable-next-line react/forbid-dom-props
                         style={{
-                            color: getSeriesColor(
+                            background: getSeriesColor(
                                 getIndexForVariant(item.variant, experiment.filters?.insight || InsightType.TRENDS)
                             ),
                         }}
                     >
-                        <span className="text-sm">{capitalizeFirstLetter(item.variant)}</span>
+                        {capitalizeFirstLetter(item.variant)}
                     </div>
                 )
             },


### PR DESCRIPTION
## Problem
Before:

<img width="167" alt="Screenshot 2023-12-12 at 21 18 55" src="https://github.com/PostHog/posthog/assets/4550621/df80489a-ce5a-4dd9-99ed-c1101c5f62d4">

## Changes

After:

<img width="162" alt="Screenshot 2023-12-12 at 21 17 03" src="https://github.com/PostHog/posthog/assets/4550621/3a103f92-b7ea-494a-be31-2cc5c1759120">
