### PR TITLE
fix(insights): Support "Save as" for query node-based insights

### DIFF
--- a/frontend/src/lib/logic/promptLogic.tsx
+++ b/frontend/src/lib/logic/promptLogic.tsx
@@ -4,14 +4,12 @@ import { createRoot } from 'react-dom/client'
 
 import type { promptLogicType } from './promptLogicType'
 
-// This logic creates a modal to ask for an input. It's unique in that when the logic is unmounted,
-// for example when changing the URL, the modal is also closed. That would normally happen with the antd prompt.
-//
-// props:
-// - key - unique key for this logic
-//
-// actions:
-// - prompt({ title, placeholder, value, error, success, failure })
+/**
+ * This logic creates a modal to ask for an input. It's unique in that when the logic is unmounted,
+ * for example when changing the URL, the modal is also closed. That would normally happen with the antd prompt.
+ *
+ * @deprecated Use LemonDialog or, more broadly, LemonModal instead.
+ */
 export const promptLogic = kea<promptLogicType>([
     path((key) => ['lib', 'logic', 'prompt', key]),
     props({} as { key: string }),

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -696,6 +696,7 @@ export const insightLogic = kea<insightLogicType>([
             const insight: InsightModel = await api.create(`api/projects/${teamLogic.values.currentTeamId}/insights/`, {
                 name,
                 filters: values.filters,
+                query: values.insight.query,
                 saved: true,
             })
             lemonToast.info(`You're now working on a copy of ${values.insight.name ?? values.insight.derived_name}`)


### PR DESCRIPTION
## Problem

Solves ZEN-7744: "Save as" didn't work with `query`-based insights, which means SQL insights in particular currently.

## Changes

We now support `query` in "Save as".