### PR TITLE
style(insights): Constrain insight viz height

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightViz.scss
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.scss
@@ -23,7 +23,7 @@
 }
 
 .InsightVizDisplay {
-    --insight-viz-min-height: calc(80vh - 6rem);
+    --insight-viz-min-height: min(calc(80vh - 6rem), 32rem);
 
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Problem

Insight visualizations can be absurdly tall in tall viewports, like here:

<img width="1401" alt="image (1)" src="https://github.com/PostHog/posthog/assets/4550621/d7d55b65-e652-4499-af47-b96248828380">

## Changes

This keeps the viewport height-dependent math, but puts an upper limit on it.