### PR TITLE
fix(3000): fix various layout issues

### DIFF
--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -126,7 +126,7 @@ export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): 
                                     />
                                 )}
                             </Field>
-                            <Field name="tags">
+                            <Field name="tags" className="mt-2">
                                 {({ value, onChange }) => (
                                     <ObjectTags
                                         tags={value ?? []}

--- a/frontend/src/scenes/instance/SystemStatus/index.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/index.tsx
@@ -56,7 +56,7 @@ export function SystemStatus(): JSX.Element {
                 label: (
                     <>
                         Settings{' '}
-                        <LemonTag type="warning" className="uppercase">
+                        <LemonTag type="warning" className="uppercase ml-1">
                             Beta
                         </LemonTag>
                     </>
@@ -76,7 +76,7 @@ export function SystemStatus(): JSX.Element {
                 label: (
                     <>
                         Kafka Inspector{' '}
-                        <LemonTag type="warning" className="uppercase">
+                        <LemonTag type="warning" className="uppercase ml-1">
                             Beta
                         </LemonTag>
                     </>


### PR DESCRIPTION
## Problem

We have various layout issues following the 3000 re-design.

## Changes

This PR:
- fix spacing for tags on internal metrics page - see [broken layout](https://posthog.slack.com/archives/C04L2CV12V9/p1702060840431259)

  **before**  
  <img width="703" alt="Screenshot 2023-12-12 at 22 34 59" src="https://github.com/PostHog/posthog/assets/1851359/9e5bcced-99f6-4175-913b-64ea620c0a1b">

  **after**
  <img width="704" alt="Screenshot 2023-12-12 at 22 32 57" src="https://github.com/PostHog/posthog/assets/1851359/994ea712-0e73-4ecb-be9e-18174e286574">

- adjust spacing for tags on actions page - see [broken layout](https://posthog.slack.com/archives/C04L2CV12V9/p1702041221989299)

  **before**
  <img width="211" alt="Screenshot 2023-12-12 at 22 35 32" src="https://github.com/PostHog/posthog/assets/1851359/a1014f53-66bb-48c1-97da-85436a201b01">

  **after** same as e.g. on the feature flags page
  <img width="215" alt="Screenshot 2023-12-12 at 22 23 42" src="https://github.com/PostHog/posthog/assets/1851359/d832bf25-8a39-4608-aa8a-d96613b907ac">

## How did you test this code?

:eyes: