### PR TITLE
fix: Actually send emails to team members when invited in onboarding

### DIFF
--- a/frontend/src/scenes/onboarding/OnboardingInviteTeammates.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingInviteTeammates.tsx
@@ -1,6 +1,7 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { PhonePairHogs } from 'lib/components/hedgehogs'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { inviteLogic } from 'scenes/settings/organization/inviteLogic'
 import { InviteTeamMatesComponent } from 'scenes/settings/organization/InviteModal'
 
 import { ProductKey } from '~/types'
@@ -11,6 +12,7 @@ import { OnboardingStep } from './OnboardingStep'
 export const OnboardingInviteTeammates = ({ stepKey }: { stepKey: OnboardingStepKey }): JSX.Element => {
     const { preflight } = useValues(preflightLogic)
     const { product } = useValues(onboardingLogic)
+    const { inviteTeamMembers } = useActions(inviteLogic)
 
     const titlePrefix = (): string => {
         switch (product?.type) {
@@ -47,6 +49,7 @@ export const OnboardingInviteTeammates = ({ stepKey }: { stepKey: OnboardingStep
             title={`${titlePrefix()} better with friends.`}
             stepKey={stepKey}
             hedgehog={<PhonePairHogs height={120} width={288} />}
+            continueAction={() => preflight?.email_service_available && inviteTeamMembers()}
         >
             <div className="mb-6">
                 <p>


### PR DESCRIPTION
## Problem

We forgot to wire up the onboarding step to send emails to the invited team members. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
