### PR TITLE
fix(web-analytics): Fix overview not filtering test users

### DIFF
--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -58,7 +58,8 @@ ON
 WHERE
     {where_breakdown}
 ORDER BY
-    "context.columns.views" DESC
+    "context.columns.views" DESC,
+    "context.columns.breakdown_value" DESC
 LIMIT 10
                 """,
                 timings=self.timings,

--- a/posthog/hogql_queries/web_analytics/test/test_web_overview.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_overview.py
@@ -1,12 +1,150 @@
+from freezegun import freeze_time
+
 from posthog.hogql_queries.web_analytics.web_overview import WebOverviewQueryRunner
-from posthog.schema import WebOverviewQuery
-from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+from posthog.schema import WebOverviewQuery, DateRange
+from posthog.test.base import (
+    APIBaseTest,
+    ClickhouseTestMixin,
+    _create_event,
+    _create_person,
+)
 
 
 class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
-    def _create_runner(self, query: WebOverviewQuery) -> WebOverviewQueryRunner:
-        return WebOverviewQueryRunner(team=self.team, query=query)
+    def _create_events(self, data, event="$pageview"):
+        person_result = []
+        for id, timestamps in data:
+            with freeze_time(timestamps[0][0]):
+                person_result.append(
+                    _create_person(
+                        team_id=self.team.pk,
+                        distinct_ids=[id],
+                        properties={
+                            "name": id,
+                            **({"email": "test@posthog.com"} if id == "test" else {}),
+                        },
+                    )
+                )
+            for timestamp, session_id in timestamps:
+                _create_event(
+                    team=self.team,
+                    event=event,
+                    distinct_id=id,
+                    timestamp=timestamp,
+                    properties={"$session_id": session_id},
+                )
+        return person_result
+
+    def _run_web_overview_query(self, date_from, date_to):
+        query = WebOverviewQuery(
+            dateRange=DateRange(date_from=date_from, date_to=date_to),
+            properties=[],
+        )
+        runner = WebOverviewQueryRunner(team=self.team, query=query)
+        return runner.calculate()
 
     def test_no_crash_when_no_data(self):
-        response = self._create_runner(WebOverviewQuery(kind="WebOverviewQuery", properties=[])).calculate()
-        self.assertEqual(5, len(response.results))
+        results = self._run_web_overview_query("2023-12-08", "2023-12-15").results
+        self.assertEqual(5, len(results))
+
+    def test_increase_in_users(self):
+        self._create_events(
+            [
+                ("p1", [("2023-12-02", "s1a"), ("2023-12-03", "s1a"), ("2023-12-12", "s1b")]),
+                ("p2", [("2023-12-11", "s2")]),
+            ]
+        )
+
+        results = self._run_web_overview_query("2023-12-08", "2023-12-15").results
+
+        visitors = results[0]
+        self.assertEqual("visitors", visitors.key)
+        self.assertEqual(2, visitors.value)
+        self.assertEqual(1, visitors.previous)
+        self.assertEqual(100, visitors.changeFromPreviousPct)
+
+        views = results[1]
+        self.assertEqual("views", views.key)
+        self.assertEqual(2, views.value)
+        self.assertEqual(2, views.previous)
+        self.assertEqual(0, views.changeFromPreviousPct)
+
+        sessions = results[2]
+        self.assertEqual("sessions", sessions.key)
+        self.assertEqual(2, sessions.value)
+        self.assertEqual(1, sessions.previous)
+        self.assertEqual(100, sessions.changeFromPreviousPct)
+
+        duration_s = results[3]
+        self.assertEqual("session duration", duration_s.key)
+        self.assertEqual(0, duration_s.value)
+        self.assertEqual(60 * 60 * 24, duration_s.previous)
+        self.assertEqual(-100, duration_s.changeFromPreviousPct)
+
+        bounce = results[4]
+        self.assertEqual("bounce rate", bounce.key)
+        self.assertEqual(100, bounce.value)
+        self.assertEqual(0, bounce.previous)
+        self.assertEqual(None, bounce.changeFromPreviousPct)
+
+    def test_all_time(self):
+        self._create_events(
+            [
+                ("p1", [("2023-12-02", "s1a"), ("2023-12-03", "s1a"), ("2023-12-12", "s1b")]),
+                ("p2", [("2023-12-11", "s2")]),
+            ]
+        )
+
+        results = self._run_web_overview_query("all", "2023-12-15").results
+
+        visitors = results[0]
+        self.assertEqual("visitors", visitors.key)
+        self.assertEqual(2, visitors.value)
+        self.assertEqual(0, visitors.previous)
+        self.assertEqual(None, visitors.changeFromPreviousPct)
+
+        views = results[1]
+        self.assertEqual("views", views.key)
+        self.assertEqual(4, views.value)
+        self.assertEqual(0, views.previous)
+        self.assertEqual(None, views.changeFromPreviousPct)
+
+        sessions = results[2]
+        self.assertEqual("sessions", sessions.key)
+        self.assertEqual(3, sessions.value)
+        self.assertEqual(0, sessions.previous)
+        self.assertEqual(None, sessions.changeFromPreviousPct)
+
+        duration_s = results[3]
+        self.assertEqual("session duration", duration_s.key)
+        self.assertEqual(60 * 60 * 24 / 3, duration_s.value)
+        self.assertEqual(None, duration_s.previous)
+        self.assertEqual(None, duration_s.changeFromPreviousPct)
+
+        bounce = results[4]
+        self.assertEqual("bounce rate", bounce.key)
+        self.assertAlmostEqual(100 * 2 / 3, bounce.value)
+        self.assertEqual(None, bounce.previous)
+        self.assertEqual(None, bounce.changeFromPreviousPct)
+
+    def test_filter_test_accounts(self):
+        # Create 1 test account
+        self._create_events([("test", [("2023-12-02", "s1"), ("2023-12-03", "s1")])])
+
+        results = self._run_web_overview_query("2023-12-01", "2023-12-03").results
+
+        visitors = results[0]
+        self.assertEqual(0, visitors.value)
+
+        views = results[1]
+        self.assertEqual(0, views.value)
+
+        sessions = results[2]
+        self.assertEqual(0, sessions.value)
+
+        duration_s = results[3]
+        self.assertEqual(None, duration_s.value)
+
+        bounce = results[4]
+        self.assertEqual("bounce rate", bounce.key)
+        self.assertEqual(None, bounce.value)

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -1,0 +1,95 @@
+from freezegun import freeze_time
+
+from posthog.hogql_queries.web_analytics.stats_table import WebStatsTableQueryRunner
+from posthog.schema import DateRange, WebStatsTableQuery, WebStatsBreakdown
+from posthog.test.base import (
+    APIBaseTest,
+    ClickhouseTestMixin,
+    _create_event,
+    _create_person,
+)
+
+
+class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
+    def _create_events(self, data, event="$pageview"):
+        person_result = []
+        for id, timestamps in data:
+            with freeze_time(timestamps[0][0]):
+                person_result.append(
+                    _create_person(
+                        team_id=self.team.pk,
+                        distinct_ids=[id],
+                        properties={
+                            "name": id,
+                            **({"email": "test@posthog.com"} if id == "test" else {}),
+                        },
+                    )
+                )
+            for timestamp, session_id, pathname in timestamps:
+                _create_event(
+                    team=self.team,
+                    event=event,
+                    distinct_id=id,
+                    timestamp=timestamp,
+                    properties={"$session_id": session_id, "$pathname": pathname},
+                )
+        return person_result
+
+    def _run_web_overview_query(self, date_from, date_to):
+        query = WebStatsTableQuery(
+            dateRange=DateRange(date_from=date_from, date_to=date_to), properties=[], breakdownBy=WebStatsBreakdown.Page
+        )
+        runner = WebStatsTableQueryRunner(team=self.team, query=query)
+        return runner.calculate()
+
+    def test_no_crash_when_no_data(self):
+        results = self._run_web_overview_query("2023-12-08", "2023-12-15").results
+        self.assertEqual(5, len(results))
+
+    def test_increase_in_users(self):
+        self._create_events(
+            [
+                ("p1", [("2023-12-02", "s1a", "/"), ("2023-12-03", "s1a", "/login"), ("2023-12-13", "s1b", "/docs")]),
+                ("p2", [("2023-12-10", "s2", "/")]),
+            ]
+        )
+
+        results = self._run_web_overview_query("2023-12-01", "2023-12-11").results
+
+        self.assertEqual(
+            [
+                ("/", 2, 2, 0),
+                ("/login", 1, 1, 0),
+            ],
+            results,
+        )
+
+    def test_all_time(self):
+        self._create_events(
+            [
+                ("p1", [("2023-12-02", "s1a", "/"), ("2023-12-03", "s1a", "/login"), ("2023-12-13", "s1b", "/docs")]),
+                ("p2", [("2023-12-10", "s2", "/")]),
+            ]
+        )
+
+        results = self._run_web_overview_query("all", "2023-12-15").results
+
+        self.assertEqual(
+            [
+                ("/", 2, 2, 0),
+                ("/login", 1, 1, 0),
+                ("/docs", 1, 1, 0),
+            ],
+            results,
+        )
+
+    def test_filter_test_accounts(self):
+        # Create 1 test account
+        self._create_events([("test", [("2023-12-02", "s1", "/"), ("2023-12-03", "s1", "/login")])])
+
+        results = self._run_web_overview_query("2023-12-01", "2023-12-03").results
+
+        self.assertEqual(
+            [],
+            results,
+        )

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -35,7 +35,7 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 )
         return person_result
 
-    def _run_web_overview_query(self, date_from, date_to):
+    def _run_web_stats_table_query(self, date_from, date_to):
         query = WebStatsTableQuery(
             dateRange=DateRange(date_from=date_from, date_to=date_to), properties=[], breakdownBy=WebStatsBreakdown.Page
         )
@@ -43,8 +43,8 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
         return runner.calculate()
 
     def test_no_crash_when_no_data(self):
-        results = self._run_web_overview_query("2023-12-08", "2023-12-15").results
-        self.assertEqual(5, len(results))
+        results = self._run_web_stats_table_query("2023-12-08", "2023-12-15").results
+        self.assertEqual([], results)
 
     def test_increase_in_users(self):
         self._create_events(
@@ -54,7 +54,7 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
             ]
         )
 
-        results = self._run_web_overview_query("2023-12-01", "2023-12-11").results
+        results = self._run_web_stats_table_query("2023-12-01", "2023-12-11").results
 
         self.assertEqual(
             [
@@ -72,7 +72,7 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
             ]
         )
 
-        results = self._run_web_overview_query("all", "2023-12-15").results
+        results = self._run_web_stats_table_query("all", "2023-12-15").results
 
         self.assertEqual(
             [
@@ -87,7 +87,7 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
         # Create 1 test account
         self._create_events([("test", [("2023-12-02", "s1", "/"), ("2023-12-03", "s1", "/login")])])
 
-        results = self._run_web_overview_query("2023-12-01", "2023-12-03").results
+        results = self._run_web_stats_table_query("2023-12-01", "2023-12-03").results
 
         self.assertEqual(
             [],

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -100,7 +100,11 @@ class WebAnalyticsQueryRunner(QueryRunner, ABC):
                 parse_expr(
                     "events.timestamp >= {date_from}",
                     placeholders={"date_from": self.query_date_range.date_from_as_hogql()},
-                )
+                ),
+                parse_expr(
+                    "events.timestamp < {date_to}",
+                    placeholders={"date_to": self.query_date_range.date_to_as_hogql()},
+                ),
             ]
             + self.query.properties
             + self._test_account_filters

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -44,10 +44,10 @@ WITH pages_query AS (
     ),
 sessions_query AS (
     SELECT
-        avg(if(min_timestamp > {mid}, duration_s, NULL)) AS avg_duration_s,
-        avg(if(min_timestamp <= {mid}, duration_s, NULL)) AS prev_avg_duration_s,
-        avg(if(min_timestamp > {mid}, is_bounce, NULL)) AS bounce_rate,
-        avg(if(min_timestamp <= {mid}, is_bounce, NULL)) AS prev_bounce_rate
+        avg(if(min_timestamp >= {mid}, duration_s, NULL)) AS avg_duration_s,
+        avg(if(min_timestamp < {mid}, duration_s, NULL)) AS prev_avg_duration_s,
+        avg(if(min_timestamp >= {mid}, is_bounce, NULL)) AS bounce_rate,
+        avg(if(min_timestamp < {mid}, is_bounce, NULL)) AS prev_bounce_rate
     FROM (SELECT
             events.properties.`$session_id` AS session_id,
             min(events.timestamp) AS min_timestamp,
@@ -129,7 +129,7 @@ CROSS JOIN sessions_query
         )
 
     def event_properties(self) -> ast.Expr:
-        return property_to_expr(self.query.properties, team=self.team)
+        return property_to_expr(self.query.properties + self._test_account_filters, team=self.team)
 
 
 def to_data(


### PR DESCRIPTION
## Problem
Received some support tickets about not filtering test users in web analytics, e.g. https://posthoghelp.zendesk.com/agent/tickets/8231 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/10980)

## Changes
Found a place where the test filter logic was missing, fixed it, added tests

## How did you test this code?
Wrote some tests