### PR TITLE
fix: Fix geoip not containing postal_code for UK

### DIFF
--- a/posthog/api/test/test_geoip.py
+++ b/posthog/api/test/test_geoip.py
@@ -16,15 +16,16 @@ local_ip = "127.0.0.1"
 @pytest.mark.parametrize(
     "test_input,expected",
     [
-        (australia_ip, "Australia"),
-        (uk_ip, "United Kingdom"),
-        (us_ip_v6, "United States"),
+        (australia_ip, ("Australia", 6)),
+        (uk_ip, ("United Kingdom", 5)),
+        (us_ip_v6, ("United States", 6)),
     ],
 )
 def test_geoip_results(test_input, expected):
     properties = get_geoip_properties(test_input)
-    assert properties["$geoip_country_name"] == expected
-    assert len(properties) == 6
+    name, length = expected
+    assert properties["$geoip_country_name"] == name
+    assert len(properties) == length
 
 
 class TestGeoIPDBError(TestCase):


### PR DESCRIPTION
## Problem

Got error in tests
```
FAILED posthog/api/test/test_geoip.py::test_geoip_results[31.28.64.3-United Kingdom] - AssertionError: assert 5 == 6
 +  where 5 = len({'$geoip_continent_code': 'EU', '$geoip_continent_name': 'Europe', '$geoip_country_code': 'GB', '$geoip_country_name': 'United Kingdom', ...})
 ```

## Changes

- seems like only UK does not contain postal code anymore, hence property count changed

## How did you test this code?

- tests
