### PR TITLE
fix: base 64 should be optional in the schema

### DIFF
--- a/ee/frontend/mobile-replay/mobile.types.ts
+++ b/ee/frontend/mobile-replay/mobile.types.ts
@@ -224,9 +224,9 @@ export type wireframeText = wireframeBase & {
 export type wireframeImage = wireframeBase & {
     type: 'image'
     /**
-     * @description this will be used as base64 encoded image source, with no other attributes it is assumed to be a PNG
+     * @description this will be used as base64 encoded image source, with no other attributes it is assumed to be a PNG, if omitted a placeholder is rendered
      */
-    base64: string
+    base64?: string
 }
 
 export type wireframeRectangle = wireframeBase & {

--- a/ee/frontend/mobile-replay/schema/mobile/rr-mobile-schema.json
+++ b/ee/frontend/mobile-replay/schema/mobile/rr-mobile-schema.json
@@ -350,7 +350,7 @@
             "additionalProperties": false,
             "properties": {
                 "base64": {
-                    "description": "this will be used as base64 encoded image source, with no other attributes it is assumed to be a PNG",
+                    "description": "this will be used as base64 encoded image source, with no other attributes it is assumed to be a PNG, if omitted a placeholder is rendered",
                     "type": "string"
                 },
                 "childWireframes": {
@@ -382,7 +382,7 @@
                     "type": "number"
                 }
             },
-            "required": ["base64", "height", "id", "type", "width", "x", "y"],
+            "required": ["height", "id", "type", "width", "x", "y"],
             "type": "object"
         },
         "wireframeInput": {


### PR DESCRIPTION
Realised the schema said that base64 property on images was required but it is optional

When not present we replace the image with a placeholder