### PR TITLE
feat(insights): add loading state to sql insights

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -1,5 +1,7 @@
 import { LemonDivider } from '@posthog/lemon-ui'
 import { BindLogic, useValues } from 'kea'
+import { AnimationType } from 'lib/animations/animations'
+import { Animation } from 'lib/components/Animation/Animation'
 import { useCallback, useState } from 'react'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
@@ -52,7 +54,7 @@ export function DataTableVisualization(props: DataTableVisualizationProps): JSX.
         cachedResults: props.cachedResults,
     }
 
-    const { query, visualizationType, showEditingUI, showResultControls, sourceFeatures } =
+    const { query, visualizationType, showEditingUI, showResultControls, sourceFeatures, response, responseLoading } =
         useValues(builtDataVisualizationLogic)
 
     const setQuerySource = useCallback(
@@ -61,7 +63,13 @@ export function DataTableVisualization(props: DataTableVisualizationProps): JSX.
     )
 
     let component: JSX.Element | null = null
-    if (visualizationType === ChartDisplayType.ActionsTable) {
+    if (!response && responseLoading) {
+        return (
+            <div className="flex flex-col flex-1 justify-center items-center border rounded">
+                <Animation type={AnimationType.LaptopHog} />
+            </div>
+        )
+    } else if (visualizationType === ChartDisplayType.ActionsTable) {
         component = (
             <DataTable
                 uniqueKey={key}

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -41,7 +41,14 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
     key((props) => props.key),
     path(['queries', 'nodes', 'DataVisualization', 'dataVisualizationLogic']),
     connect({
-        values: [teamLogic, ['currentTeamId'], insightSceneLogic, ['insightMode'], dataNodeLogic, ['response']],
+        values: [
+            teamLogic,
+            ['currentTeamId'],
+            insightSceneLogic,
+            ['insightMode'],
+            dataNodeLogic,
+            ['response', 'responseLoading'],
+        ],
         actions: [dataNodeLogic, ['loadDataSuccess']],
     }),
     props({ query: {} } as DataVisualizationLogicProps),


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C04L2CV12V9/p1702545417146319

## Changes

This PR adds a basic loading hedgehog for SQL insights.

Follow up tasks:
- Investigate why we fetch the same data up to 4 times
- Maybe add a timeout state
- Maybe add an error state

tbd where we want to handle these - in the wrapper component or down in the visualization. Wrapper component has the advantage that we need to write the code only once, visualization has the advantage that we can better customize the states based on the content e.g. a loading state while display previous data.

## How did you test this code?

Added a sleep to the query api endpoint