### PR TITLE
feat(django): Remove allowlist for elements_chain in decide

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -231,12 +231,8 @@ def get_decide(request: HttpRequest):
                         response["analytics"] = {"endpoint": settings.NEW_ANALYTICS_CAPTURE_ENDPOINT}
 
             if (
-                settings.ELEMENT_CHAIN_AS_STRING_TEAMS
-                and str(team.id) in settings.ELEMENT_CHAIN_AS_STRING_TEAMS
-                and (
-                    settings.ELEMENT_CHAIN_AS_STRING_EXCLUDED_TEAMS is None
-                    or str(team.id) not in settings.ELEMENT_CHAIN_AS_STRING_EXCLUDED_TEAMS
-                )
+                settings.ELEMENT_CHAIN_AS_STRING_EXCLUDED_TEAMS
+                and str(team.id) not in settings.ELEMENT_CHAIN_AS_STRING_EXCLUDED_TEAMS
             ):
                 response["elementsChainAsString"] = True
 

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -3008,17 +3008,6 @@ class TestDecide(BaseTest, QueryMatchingTest):
 
     def test_decide_element_chain_as_string(self, *args):
         self.client.logout()
-        with self.settings(ELEMENT_CHAIN_AS_STRING_TEAMS={str(self.team.id)}):
-            response = self._post_decide(api_version=3)
-            self.assertEqual(response.status_code, 200)
-            self.assertTrue("elementsChainAsString" in response.json())
-            self.assertTrue(response.json()["elementsChainAsString"])
-
-        with self.settings(ELEMENT_CHAIN_AS_STRING_TEAMS={"0"}):
-            response = self._post_decide(api_version=3)
-            self.assertEqual(response.status_code, 200)
-            self.assertFalse("elementsChainAsString" in response.json())
-
         with self.settings(
             ELEMENT_CHAIN_AS_STRING_TEAMS={str(self.team.id)}, ELEMENT_CHAIN_AS_STRING_EXCLUDED_TEAMS={"0"}
         ):


### PR DESCRIPTION
## Problem

Next step in enabling elements_chain processing on client.  Previously had both allowlist and denylist.  Large teams already in denylist.  Removing allowlist now.  Clients need to be on `posthog-js > 1.92.0` to send `elements_chain` directly so we'll still see the old behavior for a while until clients get updated.

Related PRs:
https://github.com/PostHog/posthog-js/pull/823
https://github.com/PostHog/posthog/pull/18701
https://github.com/PostHog/posthog/pull/19193

## Changes

Removed allowlist check in decide

## How did you test this code?

Updated tests to be denylist only
