### PR TITLE
fix: Default event name

### DIFF
--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -281,16 +281,16 @@ class TestRelativeDateParse(TestCase):
 
 class TestDefaultEventName(BaseTest):
     def test_no_events(self):
-        self.assertEqual(get_default_event_name(), "$pageview")
+        self.assertEqual(get_default_event_name(self.team), "$pageview")
 
     def test_take_screen(self):
         EventDefinition.objects.create(name="$screen", team=self.team)
-        self.assertEqual(get_default_event_name(), "$screen")
+        self.assertEqual(get_default_event_name(self.team), "$screen")
 
     def test_prefer_pageview(self):
         EventDefinition.objects.create(name="$pageview", team=self.team)
         EventDefinition.objects.create(name="$screen", team=self.team)
-        self.assertEqual(get_default_event_name(), "$pageview")
+        self.assertEqual(get_default_event_name(self.team), "$pageview")
 
 
 class TestLoadDataFromRequest(TestCase):

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -371,7 +371,7 @@ def render_template(
             "current_user": None,
             "current_team": None,
             "preflight": json.loads(preflight_check(request).getvalue()),
-            "default_event_name": get_default_event_name(),
+            "default_event_name": "$pageview",
             "switched_team": getattr(request, "switched_team", None),
             **posthog_app_context,
         }
@@ -399,6 +399,7 @@ def render_template(
                 )
                 posthog_app_context["current_team"] = team_serialized.data
                 posthog_app_context["frontend_apps"] = get_frontend_apps(user.team.pk)
+                posthog_app_context["default_event_name"] = get_default_event_name(user.team)
 
     context["posthog_app_context"] = json.dumps(posthog_app_context, default=json_uuid_convert)
 
@@ -456,12 +457,12 @@ def get_self_capture_api_token(request: Optional[HttpRequest]) -> Optional[str]:
     return None
 
 
-def get_default_event_name():
+def get_default_event_name(team: Team):
     from posthog.models import EventDefinition
 
-    if EventDefinition.objects.filter(name="$pageview").exists():
+    if EventDefinition.objects.filter(team=team, name="$pageview").exists():
         return "$pageview"
-    elif EventDefinition.objects.filter(name="$screen").exists():
+    elif EventDefinition.objects.filter(team=team, name="$screen").exists():
         return "$screen"
     return "$pageview"
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -457,7 +457,7 @@ def get_self_capture_api_token(request: Optional[HttpRequest]) -> Optional[str]:
     return None
 
 
-def get_default_event_name(team: Team):
+def get_default_event_name(team: "Team"):
     from posthog.models import EventDefinition
 
     if EventDefinition.objects.filter(team=team, name="$pageview").exists():


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
If you're only using mobile events we were still defaulting to pageview

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
