### PR TITLE
fix: no console logging on schema

### DIFF
--- a/ee/frontend/mobile-replay/index.ts
+++ b/ee/frontend/mobile-replay/index.ts
@@ -36,7 +36,7 @@ function couldBeEventWithTime(x: unknown): x is eventWithTime | mobileEventWithT
     return typeof x === 'object' && x !== null && 'type' in x && 'timestamp' in x
 }
 
-export function transformEventToWeb(event: unknown): eventWithTime {
+export function transformEventToWeb(event: unknown, validateTransformation?: boolean): eventWithTime {
     // the transformation needs to never break a recording itself
     // so, we default to returning what we received
     // replacing it only if there's a valid transformation
@@ -46,7 +46,9 @@ export function transformEventToWeb(event: unknown): eventWithTime {
             const transformer = transformers[event.type]
             if (transformer) {
                 const transformed = transformer(event)
-                validateAgainstWebSchema(transformed)
+                if (validateTransformation) {
+                    validateAgainstWebSchema(transformed)
+                }
                 result = transformed
             }
         } else {

--- a/ee/frontend/mobile-replay/index.ts
+++ b/ee/frontend/mobile-replay/index.ts
@@ -1,5 +1,5 @@
 import { eventWithTime } from '@rrweb/types'
-import { captureException } from '@sentry/react'
+import { captureException, captureMessage } from '@sentry/react'
 import Ajv, { ErrorObject } from 'ajv'
 
 import { mobileEventWithTime } from './mobile.types'
@@ -50,7 +50,7 @@ export function transformEventToWeb(event: unknown): eventWithTime {
                 result = transformed
             }
         } else {
-            console.warn(`No type in event: ${JSON.stringify(event)}`)
+            captureMessage(`No type in event`, { extra: { event } })
         }
     } catch (e) {
         captureException(e, { extra: { event } })
@@ -70,8 +70,7 @@ export function validateAgainstWebSchema(data: unknown): boolean {
     const validationResult = webSchemaValidator(data)
     if (!validationResult) {
         // we are passing all data through this validation now and don't know how safe the schema is
-        console.error(webSchemaValidator.errors)
-        captureException(new Error('transformation did not match schema'), {
+        captureMessage('transformation did not match schema', {
             extra: { data, errors: webSchemaValidator.errors },
         })
     }

--- a/frontend/@posthog/ee/types.ts
+++ b/frontend/@posthog/ee/types.ts
@@ -5,8 +5,7 @@ import { eventWithTime } from '@rrweb/types'
 export type PostHogEE = {
     enabled: boolean
     mobileReplay?: {
-        // defined as unknown while the mobileEventWithTime type is in the ee folder
-        transformEventToWeb(x: unknown): eventWithTime | null
+        transformEventToWeb(x: unknown, validationTransformation?: boolean): eventWithTime | null
         transformToWeb(x: unknown[]): eventWithTime[]
     }
 }

--- a/frontend/@posthog/ee/types.ts
+++ b/frontend/@posthog/ee/types.ts
@@ -5,7 +5,7 @@ import { eventWithTime } from '@rrweb/types'
 export type PostHogEE = {
     enabled: boolean
     mobileReplay?: {
-        transformEventToWeb(x: unknown, validationTransformation?: boolean): eventWithTime | null
+        transformEventToWeb(x: unknown, validateTransformation?: boolean): eventWithTime | null
         transformToWeb(x: unknown[]): eventWithTime[]
     }
 }


### PR DESCRIPTION
The console logging of schema validation hasn't been helping...

And the schema validation itself might only be useful as a debug signal anyway

Let's tone it right down for now