### PR TITLE
fix(performance): Fix performance issue when parsing large list of network events

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -257,7 +257,10 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 // NOTE: Possible perf improvement here would be to have a selector to parse the items
                 // and then do the filtering of what items are shown, elsewhere
                 // ALSO: We could move the individual filtering logic into the MiniFilters themselves
+                // WARNING: Be careful of dayjs functions - they can be slow due to the size of the loop.
                 const items: InspectorListItem[] = []
+
+                const startMs = start?.valueOf() ?? 0
 
                 // PERFORMANCE EVENTS
                 const performanceEventsArr = performanceEvents || []
@@ -287,7 +290,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                     items.push({
                         type: SessionRecordingPlayerTab.NETWORK,
                         timestamp,
-                        timeInRecording: timestamp.diff(start, 'ms'),
+                        timeInRecording: timestamp.valueOf() - startMs,
                         search: event.name || '',
                         data: event,
                         highlightColor: responseStatus >= 400 ? 'danger' : undefined,
@@ -301,7 +304,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                     items.push({
                         type: SessionRecordingPlayerTab.CONSOLE,
                         timestamp,
-                        timeInRecording: timestamp.diff(start, 'ms'),
+                        timeInRecording: timestamp.valueOf() - startMs,
                         search: event.content,
                         data: event,
                         highlightColor:
@@ -327,7 +330,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                     items.push({
                         type: SessionRecordingPlayerTab.EVENTS,
                         timestamp,
-                        timeInRecording: timestamp.diff(start, 'ms'),
+                        timeInRecording: timestamp.valueOf() - startMs,
                         search: search,
                         data: event,
                         highlightColor: isMatchingEvent
@@ -340,7 +343,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 }
 
                 // NOTE: Native JS sorting is relatively slow here - be careful changing this
-                items.sort((a, b) => (a.timestamp.isAfter(b.timestamp) ? 1 : -1))
+                items.sort((a, b) => (a.timestamp.valueOf() > b.timestamp.valueOf() ? 1 : -1))
 
                 return items
             },


### PR DESCRIPTION
## Problem

Noticed some really bad slow down and when inspecting the perf it was mostly down to the `allItems` selector - turns out a lot of dayjs methods are pretty expensive!

## Changes

* Uses simple math functions for comparisons in the events, rather than the dayjs funcs. 
* With huge list sizes the perf difference is ridiculous

### Before

* More red freezes 

<img width="2302" alt="Screenshot 2023-12-15 at 12 41 28" src="https://github.com/PostHog/posthog/assets/2536520/086da4b4-3320-42bd-b06c-17d53b725fdb">

### After

* Fewer red freezes (the remaining ones are actually due to the experimental mobile parser)

<img width="2303" alt="Screenshot 2023-12-15 at 12 40 33" src="https://github.com/PostHog/posthog/assets/2536520/b0a11677-f830-417c-827a-15bdbb7c1a67">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
