### PR TITLE
feat(web-analytics): Add channel to web dashboard

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3443,6 +3443,7 @@
             "enum": [
                 "Page",
                 "InitialPage",
+                "InitialChannelType",
                 "InitialReferringDomain",
                 "InitialUTMSource",
                 "InitialUTMCampaign",

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -711,6 +711,7 @@ export enum WebStatsBreakdown {
     Page = 'Page',
     InitialPage = 'InitialPage',
     // ExitPage = 'ExitPage'
+    InitialChannelType = 'InitialChannelType',
     InitialReferringDomain = 'InitialReferringDomain',
     InitialUTMSource = 'InitialUTMSource',
     InitialUTMCampaign = 'InitialUTMCampaign',

--- a/frontend/src/scenes/web-analytics/WebTabs.tsx
+++ b/frontend/src/scenes/web-analytics/WebTabs.tsx
@@ -1,4 +1,4 @@
-import { LemonTabs } from '@posthog/lemon-ui'
+import { LemonSelect, LemonTabs } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import React from 'react'
 
@@ -19,13 +19,24 @@ export const WebTabs = ({
         <div className={clsx(className, 'flex flex-col')}>
             <div className="flex flex-row items-center self-stretch mb-3">
                 {<h2 className="flex-1 m-0">{activeTab?.title}</h2>}
-                <LemonTabs
-                    inline
-                    borderless
-                    activeKey={activeTabId}
-                    onChange={setActiveTabId}
-                    tabs={tabs.map(({ id, linkText }) => ({ key: id, label: linkText }))}
-                />
+                {tabs.length > 3 ? (
+                    <LemonSelect
+                        size={'small'}
+                        disabled={false}
+                        value={activeTabId}
+                        dropdownMatchSelectWidth={false}
+                        onChange={setActiveTabId}
+                        options={tabs.map(({ id, linkText }) => ({ value: id, label: linkText }))}
+                    />
+                ) : (
+                    <LemonTabs
+                        inline
+                        borderless
+                        activeKey={activeTabId}
+                        onChange={setActiveTabId}
+                        tabs={tabs.map(({ id, linkText }) => ({ key: id, label: linkText }))}
+                    />
+                )}
             </div>
             <div className="flex-1 flex flex-col">{activeTab?.content}</div>
         </div>

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -65,8 +65,12 @@ export enum GraphsTab {
 
 export enum SourceTab {
     REFERRING_DOMAIN = 'REFERRING_DOMAIN',
+    CHANNEL = 'CHANNEL',
     UTM_SOURCE = 'UTM_SOURCE',
+    UTM_MEDIUM = 'UTM_MEDIUM',
     UTM_CAMPAIGN = 'UTM_CAMPAIGN',
+    UTM_CONTENT = 'UTM_CONTENT',
+    UTM_TERM = 'UTM_TERM',
 }
 
 export enum DeviceTab {
@@ -427,7 +431,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             {
                                 id: SourceTab.REFERRING_DOMAIN,
                                 title: 'Top referrers',
-                                linkText: 'Referrer',
+                                linkText: 'Referrering domain',
                                 query: {
                                     full: true,
                                     kind: NodeKind.DataTableNode,
@@ -435,6 +439,21 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         kind: NodeKind.WebStatsTableQuery,
                                         properties: webAnalyticsFilters,
                                         breakdownBy: WebStatsBreakdown.InitialReferringDomain,
+                                        dateRange,
+                                    },
+                                },
+                            },
+                            {
+                                id: SourceTab.CHANNEL,
+                                title: 'Top channels',
+                                linkText: 'Channel',
+                                query: {
+                                    full: true,
+                                    kind: NodeKind.DataTableNode,
+                                    source: {
+                                        kind: NodeKind.WebStatsTableQuery,
+                                        properties: webAnalyticsFilters,
+                                        breakdownBy: WebStatsBreakdown.InitialChannelType,
                                         dateRange,
                                     },
                                 },
@@ -455,8 +474,23 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 },
                             },
                             {
+                                id: SourceTab.UTM_MEDIUM,
+                                title: 'Top UTM medium',
+                                linkText: 'UTM medium',
+                                query: {
+                                    full: true,
+                                    kind: NodeKind.DataTableNode,
+                                    source: {
+                                        kind: NodeKind.WebStatsTableQuery,
+                                        properties: webAnalyticsFilters,
+                                        breakdownBy: WebStatsBreakdown.InitialUTMMedium,
+                                        dateRange,
+                                    },
+                                },
+                            },
+                            {
                                 id: SourceTab.UTM_CAMPAIGN,
-                                title: 'Top campaigns',
+                                title: 'Top UTM campaigns',
                                 linkText: 'UTM campaign',
                                 query: {
                                     full: true,
@@ -465,6 +499,36 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         kind: NodeKind.WebStatsTableQuery,
                                         properties: webAnalyticsFilters,
                                         breakdownBy: WebStatsBreakdown.InitialUTMCampaign,
+                                        dateRange,
+                                    },
+                                },
+                            },
+                            {
+                                id: SourceTab.UTM_CONTENT,
+                                title: 'Top UTM content',
+                                linkText: 'UTM content',
+                                query: {
+                                    full: true,
+                                    kind: NodeKind.DataTableNode,
+                                    source: {
+                                        kind: NodeKind.WebStatsTableQuery,
+                                        properties: webAnalyticsFilters,
+                                        breakdownBy: WebStatsBreakdown.InitialUTMContent,
+                                        dateRange,
+                                    },
+                                },
+                            },
+                            {
+                                id: SourceTab.UTM_TERM,
+                                title: 'Top UTM terms',
+                                linkText: 'UTM term',
+                                query: {
+                                    full: true,
+                                    kind: NodeKind.DataTableNode,
+                                    source: {
+                                        kind: NodeKind.WebStatsTableQuery,
+                                        properties: webAnalyticsFilters,
+                                        breakdownBy: WebStatsBreakdown.InitialUTMTerm,
                                         dateRange,
                                     },
                                 },

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -842,7 +842,7 @@ class _Printer(Visitor):
             validate_function_args(node.args, func_meta.min_args, func_meta.max_args, node.name)
             args = [self.visit(arg) for arg in node.args]
 
-            if self.dialect == "clickhouse":
+            if self.dialect in ("hogql", "clickhouse"):
                 if node.name == "hogql_lookupDomainType":
                     return f"dictGetOrNull('channel_definition_dict', 'domain_type', (cutToFirstSignificantSubdomain(coalesce({args[0]}, '')), 'source'))"
                 elif node.name == "hogql_lookupPaidDomainType":

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -93,6 +93,68 @@ LIMIT 10
         match self.query.breakdownBy:
             case WebStatsBreakdown.Page:
                 return ast.Field(chain=["properties", "$pathname"])
+            case WebStatsBreakdown.InitialChannelType:
+                # use this for now, switch to person.$virt_initial_channel_type when it's working. If fixing or adding
+                # anything to this, keep in sync with channel_type.py
+                return parse_expr(
+                    """
+multiIf(
+    match(person.properties.$initial_utm_campaign, 'cross-network'),
+    'Cross Network',
+
+    (
+        match(person.properties.$initial_utm_medium, '^(.*cp.*|ppc|retargeting|paid.*)$') OR
+        properties.$initial_gclid IS NOT NULL OR
+        properties.$initial_gad_source IS NOT NULL
+    ),
+    coalesce(
+        hogql_lookupPaidSourceType(person.properties.$initial_utm_source),
+        hogql_lookupPaidDomainType(person.properties.$initial_referring_domain),
+        if(
+            match(properties.$initial_utm_campaign, '^(.*(([^a-df-z]|^)shop|shopping).*)$'),
+            'Paid Shopping',
+            NULL
+        ),
+        hogql_lookupPaidMediumType(person.properties.$initial_utm_medium),
+        multiIf (
+            person.properties.$initial_gad_source = '1',
+            'Paid Search',
+
+            match(person.properties.$initial_utm_campaign, '^(.*video.*)$'),
+            'Paid Video',
+
+            'Paid Other'
+        )
+    ),
+
+    (
+        person.properties.$initial_referring_domain = '$direct'
+        AND (person.properties.$initial_utm_medium IS NULL OR person.properties.$initial_utm_medium = '')
+        AND (person.properties.$initial_utm_source IS NULL OR person.properties.$initial_utm_source IN ('', '(direct)', 'direct'))
+    ),
+    'Direct',
+
+    coalesce(
+        hogql_lookupOrganicSourceType(person.properties.$initial_utm_source),
+        hogql_lookupOrganicDomainType(person.properties.$initial_referring_domain),
+        if(
+            match(person.properties.$initial_utm_campaign, '^(.*(([^a-df-z]|^)shop|shopping).*)$'),
+            'Organic Shopping',
+            NULL
+        ),
+        hogql_lookupOrganicMediumType(person.properties.$initial_utm_medium),
+        multiIf(
+            match(person.properties.$initial_utm_campaign, '^(.*video.*)$'),
+            'Organic Video',
+
+            match(person.properties.$initial_utm_medium, 'push$'),
+            'Push',
+
+            NULL
+        )
+    )
+)"""
+                )
             case WebStatsBreakdown.InitialPage:
                 return ast.Field(chain=["person", "properties", "$initial_pathname"])
             case WebStatsBreakdown.InitialReferringDomain:
@@ -138,6 +200,8 @@ LIMIT 10
                 return parse_expr('tupleElement("context.columns.breakdown_value", 2) IS NOT NULL')
             case WebStatsBreakdown.City:
                 return parse_expr('tupleElement("context.columns.breakdown_value", 2) IS NOT NULL')
+            case WebStatsBreakdown.InitialChannelType:
+                return parse_expr("TRUE")  # actually show null values
             case WebStatsBreakdown.InitialUTMSource:
                 return parse_expr("TRUE")  # actually show null values
             case WebStatsBreakdown.InitialUTMCampaign:

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -689,6 +689,7 @@ class WebOverviewQueryResponse(BaseModel):
 class WebStatsBreakdown(str, Enum):
     Page = "Page"
     InitialPage = "InitialPage"
+    InitialChannelType = "InitialChannelType"
     InitialReferringDomain = "InitialReferringDomain"
     InitialUTMSource = "InitialUTMSource"
     InitialUTMCampaign = "InitialUTMCampaign"


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/18713

## Changes

Most of the work happened in https://github.com/PostHog/posthog/pull/19085, this just adds it to the dashboard. I also added the other major utm params (source, medium, campaign, term, content) as we only had source & medium.

## How did you test this code?

The other PR has testing of the back end side of this, the front end was manually tested (and still behind a FF)