### PR TITLE
feat(web-analytics): Attempt to shore up the stats table broken down by initial channel type

### DIFF
--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -226,7 +226,7 @@ multiIf(
     ),
 
     (
-        any(any(person.properties.$initial_referring_domain)) = '$direct'
+        any(person.properties.$initial_referring_domain) = '$direct'
         AND (any(person.properties.$initial_utm_medium) IS NULL OR any(person.properties.$initial_utm_medium) = '')
         AND (any(person.properties.$initial_utm_source) IS NULL OR any(person.properties.$initial_utm_source) IN ('', '(direct)', 'direct'))
     ),

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -35,9 +35,9 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 )
         return person_result
 
-    def _run_web_stats_table_query(self, date_from, date_to):
+    def _run_web_stats_table_query(self, date_from, date_to, breakdown_by=WebStatsBreakdown.Page):
         query = WebStatsTableQuery(
-            dateRange=DateRange(date_from=date_from, date_to=date_to), properties=[], breakdownBy=WebStatsBreakdown.Page
+            dateRange=DateRange(date_from=date_from, date_to=date_to), properties=[], breakdownBy=breakdown_by
         )
         runner = WebStatsTableQueryRunner(team=self.team, query=query)
         return runner.calculate()
@@ -91,5 +91,23 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(
             [],
+            results,
+        )
+
+    def test_breakdown_channel_type_doesnt_throw(self):
+        # not really testing the functionality yet, which is tested elsewhere, just that it runs
+        self._create_events(
+            [
+                ("p1", [("2023-12-02", "s1a", "/"), ("2023-12-03", "s1a", "/login"), ("2023-12-13", "s1b", "/docs")]),
+                ("p2", [("2023-12-10", "s2", "/")]),
+            ]
+        )
+
+        results = self._run_web_stats_table_query(
+            "2023-12-01", "2023-12-03", breakdown_by=WebStatsBreakdown.InitialChannelType
+        ).results
+
+        self.assertEqual(
+            [(None, 2, 1, 0)],
             results,
         )


### PR DESCRIPTION
## Problem

https://posthog.sentry.io/issues/4728688879/?project=1899813&query=is%3Aunresolved&referrer=issue-stream&stream_index=5
https://posthog.slack.com/archives/C0368RPHLQH/p1702655135616619?thread_ts=1702651487.934809&cid=C0368RPHLQH

## Changes

Both before and after worked fine on my machine, so unclear how this will improve things, but it does make the bounce_breakdown work slightly different, as it's pushing the `any` further inside

## How did you test this code?
Wrote a test, but it would have passed both before and after these changes. Sadly with this breaking on prod but not locally, it's hard to know if this will make a difference
