### PR TITLE
fix: kill the plugin-server process if the graphile worker stops unexpectedly

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -29,6 +29,9 @@
         "services:clean": "cd .. && docker compose -f docker-compose.dev.yml rm -v",
         "services": "pnpm services:stop && pnpm services:clean && pnpm services:start"
     },
+    "graphile-worker": {
+        "maxContiguousErrors": 300
+    },
     "bin": {
         "posthog-plugin-server": "bin/posthog-plugin-server"
     },

--- a/plugin-server/src/main/graphile-worker/graphile-worker.ts
+++ b/plugin-server/src/main/graphile-worker/graphile-worker.ts
@@ -145,7 +145,7 @@ export class GraphileWorker {
                 parsedCronItems: this.crontab,
             })
             status.info('✅', 'Graphile worker runner created.')
-            this.runner.events.on('worker:stop', ({ error }) => {
+            this.runner.events?.on('worker:stop', ({ error }) => {
                 if (this.started) {
                     status.error('💀', `Graphile worker loop stopped unexpectedly`)
                     process.emit('uncaughtException', error ?? new Error(`Graphile worker loop stopped with no error`))

--- a/plugin-server/src/main/graphile-worker/graphile-worker.ts
+++ b/plugin-server/src/main/graphile-worker/graphile-worker.ts
@@ -145,10 +145,10 @@ export class GraphileWorker {
                 parsedCronItems: this.crontab,
             })
             status.info('✅', 'Graphile worker runner created.')
-            this.runner.events.on('worker:stop', () => {
+            this.runner.events.on('worker:stop', ({ error }) => {
                 if (this.started) {
                     status.error('💀', `Graphile worker loop stopped unexpectedly`)
-                    process.emit('uncaughtException', new Error(`Graphile worker loop stopped unexpectedly`))
+                    process.emit('uncaughtException', error ?? new Error(`Graphile worker loop stopped with no error`))
                 } else {
                     status.info('🛑', 'Graphile worker loop stopped')
                 }

--- a/plugin-server/src/main/graphile-worker/graphile-worker.ts
+++ b/plugin-server/src/main/graphile-worker/graphile-worker.ts
@@ -145,6 +145,14 @@ export class GraphileWorker {
                 parsedCronItems: this.crontab,
             })
             status.info('✅', 'Graphile worker runner created.')
+            this.runner.events.on('worker:stop', () => {
+                if (this.started) {
+                    status.error('💀', `Graphile worker loop stopped unexpectedly`)
+                    process.emit('uncaughtException', new Error(`Graphile worker loop stopped unexpectedly`))
+                } else {
+                    status.info('🛑', 'Graphile worker loop stopped')
+                }
+            })
             return
         }
 

--- a/plugin-server/src/main/graphile-worker/graphile-worker.ts
+++ b/plugin-server/src/main/graphile-worker/graphile-worker.ts
@@ -129,6 +129,9 @@ export class GraphileWorker {
         if (this.started && !this.paused && !this.runner) {
             status.info('🔄', 'Creating new Graphile worker runner...')
             this.consumerPool = await this.createPool()
+            // KLUDGE: maxContiguousErrors is not configurable programmatically,
+            // it is set to 300 via package.json, which leads the worker to retry
+            // for 10 minutes (300 * pollInterval) before giving up and killing the pod.
             this.runner = await run({
                 // graphile's types refer to a local node_modules version of Pool
                 pgPool: this.consumerPool as Pool as any,


### PR DESCRIPTION
## Problem

When PG is unavailable for a few minutes, the graphile worker reaches the `maxContiguousErrors` (default value 10) and silently stops. This makes the scheduler pods sit around, with their kafka consumer healthy, but not producing any tasks.

## Changes

- Listen for `worker:stop` events, and if not stopped, propagate these as an `uncaughtException` to kill the process
- Increase `maxContiguousErrors` to 300 via the `package.json` properties. Should allow to retry for 10 minutes before killing the process and restarting the pod

We should revamp the graphile wrapper to implement the `BatchConsumer` interface, and have a common code logic detect it returning.

## How did you test this code?
`PLUGIN_SERVER_MODE=scheduler DEBUG=1 ./bin/plugin-server`, then `docker stop posthog-db-1` to trigger PG errors.