### PR TITLE
fix: style element content replacement

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/index.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/index.ts
@@ -3,14 +3,16 @@ import { playerConfig, ReplayPlugin } from 'rrweb/typings/types'
 const PROXY_URL = 'https://replay.ph-proxy.com' as const
 
 export const CorsPlugin: ReplayPlugin & {
-    _replaceFontCssUrls: (value: string) => string
+    _replaceFontCssUrls: (value: string | null) => string | null
     _replaceFontUrl: (value: string) => string
     _replaceJSUrl: (value: string) => string
 } = {
-    _replaceFontCssUrls: (value: string): string => {
-        return value.replace(
-            /url\("(https:\/\/\S*(?:.eot|.woff2|.ttf|.woff)\S*)"\)/gi,
-            `url("${PROXY_URL}/proxy?url=$1")`
+    _replaceFontCssUrls: (value: string | null): string | null => {
+        return (
+            value?.replace(
+                /url\("(https:\/\/\S*(?:.eot|.woff2|.ttf|.woff)\S*)"\)/gi,
+                `url("${PROXY_URL}/proxy?url=$1")`
+            ) || null
         )
     },
 
@@ -25,7 +27,7 @@ export const CorsPlugin: ReplayPlugin & {
     onBuild: (node) => {
         if (node.nodeName === 'STYLE') {
             const styleElement = node as HTMLStyleElement
-            styleElement.innerText = CorsPlugin._replaceFontCssUrls(styleElement.innerText)
+            styleElement.textContent = CorsPlugin._replaceFontCssUrls(styleElement.textContent)
         }
 
         if (node.nodeName === 'LINK') {


### PR DESCRIPTION
We had a customer report of blank recordings... it turned out that a spinner element that obscured the screen wasn't being removed.

Turning off the cors reverse proxy fixed this.

On investigation the element to be removed contained a string with newlines. When passed through the cors replayer plugin the element's innerHTML contained `<br/>` instead of `\n` and its innerText contained no newlines. This meant rrweb couldn't match the element when attempting to replace it.

----

On investigation [innerText](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText) represents the _rendered_ content of an element. Nodes also have textContent  which is not the rendered text but a plain string and preserves newlines

see: https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext

setting textContent can be tricky since it replaces children, but since we only set this on a styleElement whose children are only its text this should be safe.

----

tested by plaing the previously unplayable recordings and seeing them work

JSDom tests didn't exhibit the problem so I couldn't write a regression test to prove the issue