### PR TITLE
fix: Minimal response for notebook list api

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -40,6 +40,7 @@ import {
     IntegrationType,
     MediaUploadResponse,
     NewEarlyAccessFeatureType,
+    NotebookListItemType,
     NotebookNodeResource,
     NotebookType,
     OrganizationFeatureFlags,
@@ -1596,7 +1597,7 @@ const api = {
                 offset?: number
                 limit?: number
             } = {}
-        ): Promise<CountedPaginatedResponse<NotebookType>> {
+        ): Promise<CountedPaginatedResponse<NotebookListItemType>> {
             // TODO attrs could be a union of types like NotebookNodeRecordingAttributes
             const apiRequest = new ApiRequest().notebooks()
             const { contains, ...queryParams } = objectClean(params)

--- a/posthog/api/notebook.py
+++ b/posthog/api/notebook.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Type
 from django.db.models import Q
 import structlog
 from django.db import transaction
@@ -17,6 +17,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.serializers import BaseSerializer
 
 from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.routing import StructuredViewSetMixin
@@ -76,7 +77,26 @@ def log_notebook_activity(
     )
 
 
-class NotebookSerializer(serializers.ModelSerializer):
+class NotebookMinimalSerializer(serializers.ModelSerializer):
+    created_by = UserBasicSerializer(read_only=True)
+    last_modified_by = UserBasicSerializer(read_only=True)
+
+    class Meta:
+        model = Notebook
+        fields = [
+            "id",
+            "short_id",
+            "title",
+            "deleted",
+            "created_at",
+            "created_by",
+            "last_modified_at",
+            "last_modified_by",
+        ]
+        read_only_fields = fields
+
+
+class NotebookSerializer(NotebookMinimalSerializer):
     class Meta:
         model = Notebook
         fields = [
@@ -100,9 +120,6 @@ class NotebookSerializer(serializers.ModelSerializer):
             "last_modified_at",
             "last_modified_by",
         ]
-
-    created_by = UserBasicSerializer(read_only=True)
-    last_modified_by = UserBasicSerializer(read_only=True)
 
     def create(self, validated_data: Dict, *args, **kwargs) -> Notebook:
         request = self.context["request"]
@@ -223,7 +240,6 @@ class NotebookSerializer(serializers.ModelSerializer):
 )
 class NotebookViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):
     queryset = Notebook.objects.all()
-    serializer_class = NotebookSerializer
     permission_classes = [
         IsAuthenticated,
         ProjectMembershipNecessaryPermissions,
@@ -234,6 +250,9 @@ class NotebookViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.Model
     # TODO: Remove this once we have released notebooks
     include_in_docs = DEBUG
     lookup_field = "short_id"
+
+    def get_serializer_class(self) -> Type[BaseSerializer]:
+        return NotebookMinimalSerializer if self.action == "list" else NotebookSerializer
 
     def get_queryset(self) -> QuerySet:
         queryset = super().get_queryset()


### PR DESCRIPTION
## Problem

Noticed the request was getting a little slow thanks to the fact we load way more than we need for listing.


## Changes

* Same as dashboards, use a different serializer for listing

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
