### PR TITLE
feat(web-analytics): Use 'Other' for unknown channel type

### DIFF
--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -88,7 +88,7 @@ multiIf(
             match(properties.$initial_utm_medium, 'push$'),
             'Push',
 
-            NULL
+            'Other'
         )
     )
 )""",

--- a/posthog/hogql/database/schema/test/test_channel_type.py
+++ b/posthog/hogql/database/schema/test/test_channel_type.py
@@ -204,6 +204,22 @@ class TestChannelType(ClickhouseTestMixin, APIBaseTest):
             ),
         )
 
+    def test_no_info_is_other(self):
+        self.assertEqual(
+            "Other",
+            self._get_initial_channel_type({}),
+        )
+
+    def test_unknown_domain_is_other(self):
+        self.assertEqual(
+            "Other",
+            self._get_initial_channel_type(
+                {
+                    "$initial_referring_domain": "some-unknown-domain.example.com",
+                }
+            ),
+        )
+
     def _get_initial_channel_type_from_wild_clicks(self, url: str, referrer: str):
         parsed_url = urlparse(url)
         query = parse_qs(parsed_url.query)

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -225,7 +225,7 @@ FROM
                     match(initial_utm_medium, 'push$'),
                     'Push',
 
-                    NULL
+                    'Other'
                 )
             )
         ) AS breakdown_value,


### PR DESCRIPTION
## Problem

The `-` would be confusing
![image](https://github.com/PostHog/posthog/assets/2056078/9e484b47-99e9-400a-a69a-52129de39b8d)


## Changes

Change it to `Other` (which works well with the existing `Paid Other`

## How did you test this code?

Added 2 tests