### PR TITLE
fix: correct materialized view definition for session replay events snapshot source

### DIFF
--- a/posthog/clickhouse/migrations/0051_session_replay_source_mv_fix.py
+++ b/posthog/clickhouse/migrations/0051_session_replay_source_mv_fix.py
@@ -1,0 +1,15 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.session_recordings.sql.session_replay_event_migrations_sql import (
+    DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+)
+from posthog.session_recordings.sql.session_replay_event_sql import (
+    SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+)
+
+operations = [
+    # we have to drop materialized view because 0050 created it incorrectly
+    run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
+    # now we can recreate it with explicit column definitions
+    # that correctly identifies snapshot source as LowCardinality(Nullable(String))
+    run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
+]

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -1495,7 +1495,19 @@
   '
   
   CREATE MATERIALIZED VIEW IF NOT EXISTS session_replay_events_mv ON CLUSTER 'posthog'
-  TO posthog_test.writable_session_replay_events
+  TO posthog_test.writable_session_replay_events (
+  `session_id` String, `team_id` Int64, `distinct_id` String,
+  `min_first_timestamp` DateTime64(6, 'UTC'),
+  `max_last_timestamp` DateTime64(6, 'UTC'),
+  `first_url` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
+  `click_count` Int64, `keypress_count` Int64,
+  `mouse_activity_count` Int64, `active_milliseconds` Int64,
+  `console_log_count` Int64, `console_warn_count` Int64,
+  `console_error_count` Int64, `size` Int64, `message_count` Int64,
+  `event_count` Int64,
+  `snapshot_source` AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
+  `_timestamp` Nullable(DateTime)
+  )
   AS SELECT
   session_id,
   team_id,


### PR DESCRIPTION
follow-up to https://github.com/PostHog/posthog/pull/19260

When allowing CH to expand the column definition for the materialized view it detected snapshot source as `Nullable(String)` even though the table in question was `LowCardinality(Nullable(String))`

Explicitly defining the columns works fine

Tested by ingesting recordings locally and seeing that I could run 

```
select argMinMerge(session_replay_events.snapshot_source) from session_replay_events
```