### PR TITLE
fix(insights): Fix custom labels on bar chart

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -702,20 +702,24 @@ export function LineGraph_({
                         precision,
                         autoSkip: true,
                         callback: function _renderYLabel(_, i) {
-                            const labelDescriptors = (
-                                datasets?.[0]?.labels?.[i]
-                                    ? [
-                                          // prefer to use the label over the action name if it exists
-                                          datasets?.[0]?.labels?.[i],
-                                          datasets?.[0]?.compareLabels?.[i],
-                                      ]
-                                    : [
-                                          datasets?.[0]?.actions?.[i]?.custom_name ?? datasets?.[0]?.actions?.[i]?.name, // action name
-                                          datasets?.[0]?.breakdownValues?.[i], // breakdown value
-                                          datasets?.[0]?.compareLabels?.[i], // compare value
-                                      ]
-                            ).filter((l) => !!l)
-                            return labelDescriptors.join(' - ')
+                            const d = datasets?.[0]
+                            if (!d) {
+                                return ''
+                            }
+                            // prefer custom name, then label, then action name
+                            let labelDescriptors: (string | number | undefined | null)[]
+                            if (d.actions?.[i]?.custom_name) {
+                                labelDescriptors = [
+                                    d.actions?.[i]?.custom_name,
+                                    d.breakdownValues?.[i],
+                                    d.compareLabels?.[i],
+                                ]
+                            } else if (d.labels?.[i]) {
+                                labelDescriptors = [d.labels[i], d.compareLabels?.[i]]
+                            } else {
+                                labelDescriptors = [d.actions?.[i]?.name, d.breakdownValues?.[i], d.compareLabels?.[i]]
+                            }
+                            return labelDescriptors.filter((l) => !!l).join(' - ')
                         },
                     },
                     grid: {


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/7857 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/11854)

## Changes

Change the order of prioritising which thing to show as the label

Single series, custom label
<img width="1404" alt="Screenshot 2023-12-18 at 14 14 43" src="https://github.com/PostHog/posthog/assets/2056078/3adcb4d2-eb95-403d-80ee-e3fa424b9f5e">

Single series, action
<img width="1387" alt="Screenshot 2023-12-18 at 14 15 03" src="https://github.com/PostHog/posthog/assets/2056078/548955ba-6b44-45b0-906f-9ccc6644c10c">

Single series, event
<img width="1376" alt="Screenshot 2023-12-18 at 14 15 28" src="https://github.com/PostHog/posthog/assets/2056078/0987b2d7-4770-47b8-bb27-e9228dbdb7ba">

Single series, breakdown, custom label (we don't hide the series name here)
<img width="1381" alt="Screenshot 2023-12-18 at 14 16 07" src="https://github.com/PostHog/posthog/assets/2056078/1effffe4-7b84-4168-82b5-46dc2365d104">

Single series, breakdown, action
<img width="1396" alt="Screenshot 2023-12-18 at 14 18 57" src="https://github.com/PostHog/posthog/assets/2056078/ae9ba7fa-1bf1-4842-b572-47dc2ec322d4">

Single series, breakdown, event
<img width="1385" alt="Screenshot 2023-12-18 at 14 19 28" src="https://github.com/PostHog/posthog/assets/2056078/5afb8a39-ffe9-487f-9ef2-24675654476d">

Combined series
<img width="1385" alt="Screenshot 2023-12-18 at 14 22 03" src="https://github.com/PostHog/posthog/assets/2056078/1035b140-ec97-488d-a170-fd25a9cd0aff">

Combined series, breakdown
<img width="1383" alt="Screenshot 2023-12-18 at 14 20 14" src="https://github.com/PostHog/posthog/assets/2056078/281703b0-433d-43be-ba7d-0672b984fe28">

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
