### PR TITLE
fix(3000): use page background for replay canvas

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerFrame.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrame.scss
@@ -10,6 +10,10 @@
     overflow: hidden;
     background-color: var(--bg-charcoal);
 
+    .posthog-3000 & {
+        background-color: var(--bg-3000);
+    }
+
     .PlayerFrame__content {
         position: absolute;
 

--- a/frontend/src/scenes/session-recordings/player/PlayerFrame.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrame.scss
@@ -11,7 +11,7 @@
     background-color: var(--bg-charcoal);
 
     .posthog-3000 & {
-        background-color: var(--bg-3000);
+        background-color: var(--bg-3000-dark);
     }
 
     .PlayerFrame__content {

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -634,7 +634,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_0')
+                                                      'user_one_2')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -634,7 +634,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_2')
+                                                      'user_one_0')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C04L2CV12V9/p1702667892126749.

## Changes

This PR changes the replay background to the page background in both dark **and** light mode.

<img width="902" alt="Screenshot 2023-12-18 at 15 22 44" src="https://github.com/PostHog/posthog/assets/1851359/e40e3854-4de5-4829-85bb-85b3506f813f">
<img width="908" alt="Screenshot 2023-12-18 at 15 22 31" src="https://github.com/PostHog/posthog/assets/1851359/459080b0-9f04-4ef4-aca3-00eb6fd94e70">

## How did you test this code?

👀 