### PR TITLE
fix: CORS proxy plugin style element handling

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/index.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/index.ts
@@ -27,7 +27,20 @@ export const CorsPlugin: ReplayPlugin & {
     onBuild: (node) => {
         if (node.nodeName === 'STYLE') {
             const styleElement = node as HTMLStyleElement
-            styleElement.textContent = CorsPlugin._replaceFontCssUrls(styleElement.textContent)
+            const childNodes = styleElement.childNodes
+            for (let i = 0; i < childNodes.length; i++) {
+                // not every node in a style element is text
+                // e.g. formatted text might cause some <br/> elements to be present
+                // separating lines of text
+                if (childNodes[i].nodeType == 3) {
+                    // then this is a text node
+                    // TODO what about CSS import URLs we could replace those too?
+                    const updatedContent = CorsPlugin._replaceFontCssUrls(childNodes[i].textContent)
+                    if (updatedContent !== childNodes[i].textContent) {
+                        childNodes[i].textContent = updatedContent
+                    }
+                }
+            }
         }
 
         if (node.nodeName === 'LINK') {


### PR DESCRIPTION
We were still seeing failed mutation removal at playback after fixing the plugin to replace textContent not innerText in #19373 

Turned out this was because `textContent` changes apply to all children. So, if a style element had three lines of text separated by <br/> then we'd replace them with one line of text

rrweb mutations then couldn't remove the individual lines of text because they weren't matchable

TODO - can rrweb mutations remove a node where we've changed the URL 🤔  