### PR TITLE
fix: send verification email synchronously

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -119,7 +119,7 @@ def send_email_verification(user_id: int, token: str) -> None:
         },
     )
     message.add_recipient(user.pending_email if user.pending_email is not None else user.email)
-    message.send()
+    message.send(send_async=False)
     posthoganalytics.capture(
         user.distinct_id,
         "verification email sent",


### PR DESCRIPTION
## Problem

Needed to set another flag for the actual celery task to not be sent async. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
