### PR TITLE
feat(web-analytics): Sync web analytics state with url

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsTile.tsx
@@ -184,7 +184,7 @@ export const WebStatsTrendTile = ({
     query: InsightVizNode
     showIntervalTile?: boolean
 }): JSX.Element => {
-    const { togglePropertyFilter, setGeographyTab, setDeviceTab, setInterval } = useActions(webAnalyticsLogic)
+    const { togglePropertyFilter, setInterval } = useActions(webAnalyticsLogic)
     const {
         hasCountryFilter,
         deviceTab,
@@ -201,11 +201,9 @@ export const WebStatsTrendTile = ({
             if (!worldMapPropertyName) {
                 return
             }
-            togglePropertyFilter(PropertyFilterType.Event, worldMapPropertyName, breakdownValue)
-            if (!hasCountryFilter) {
-                // if we just added a country filter, switch to the region tab, as the world map will not be useful
-                setGeographyTab(GeographyTab.REGIONS)
-            }
+            togglePropertyFilter(PropertyFilterType.Event, worldMapPropertyName, breakdownValue, {
+                geographyTab: hasCountryFilter ? undefined : GeographyTab.REGIONS,
+            })
         },
         [togglePropertyFilter, worldMapPropertyName]
     )
@@ -226,16 +224,20 @@ export const WebStatsTrendTile = ({
             if (!deviceTypePropertyName) {
                 return
             }
-            togglePropertyFilter(PropertyFilterType.Event, deviceTypePropertyName, breakdownValue)
 
             // switch to a different tab if we can, try them in this order: DeviceType Browser OS
+            let newTab: DeviceTab | undefined = undefined
             if (deviceTab !== DeviceTab.DEVICE_TYPE && !hasDeviceTypeFilter) {
-                setDeviceTab(DeviceTab.DEVICE_TYPE)
+                newTab = DeviceTab.DEVICE_TYPE
             } else if (deviceTab !== DeviceTab.BROWSER && !hasBrowserFilter) {
-                setDeviceTab(DeviceTab.BROWSER)
+                newTab = DeviceTab.BROWSER
             } else if (deviceTab !== DeviceTab.OS && !hasOSFilter) {
-                setDeviceTab(DeviceTab.OS)
+                newTab = DeviceTab.OS
             }
+
+            togglePropertyFilter(PropertyFilterType.Event, deviceTypePropertyName, breakdownValue, {
+                deviceTab: newTab,
+            })
         },
         [togglePropertyFilter, deviceTypePropertyName, deviceTab, hasDeviceTypeFilter, hasBrowserFilter, hasOSFilter]
     )


### PR DESCRIPTION
## Problem

Some feedback asking a few related things:
* Want to preserve filters across a refresh
* Want to bookmark certain filters

An example zendesk ticket: https://posthoghelp.zendesk.com/agent/tickets/8277 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/11858)

## Changes

Store relevant parts of the state in the url. 

## How did you test this code?

Manually, spending a lot of time making sure that the back button behaviour is correct. A few edge cases:
* clicking on the device type pie chart changes filters AND changes the tab, and the back button should revert both
* using the back button to remove the last filters should work, even though no filters are in the url bar

