### PR TITLE
fix(data-table): key by row id, not data

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -491,7 +491,7 @@ export function DataTable({ uniqueKey, query, setQuery, context, cachedResults }
                                     return (
                                         (result && 'uuid' in result ? (result as any).uuid : null) ??
                                         (result && 'id' in result ? (result as any).id : null) ??
-                                        JSON.stringify(result ?? rowIndex)
+                                        rowIndex
                                     )
                                 }
                                 return rowIndex

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -474,26 +474,7 @@ export function DataTable({ uniqueKey, query, setQuery, context, cachedResults }
                                 ) /* Bust the LemonTable cache when columns change */
                             }
                             dataSource={dataTableRows ?? []}
-                            rowKey={({ result }: DataTableRow, rowIndex) => {
-                                if (result) {
-                                    if (
-                                        sourceFeatures.has(QueryFeature.resultIsArrayOfArrays) &&
-                                        sourceFeatures.has(QueryFeature.columnsInResponse)
-                                    ) {
-                                        if (columnsInResponse?.includes('*')) {
-                                            return result[columnsInResponse.indexOf('*')].uuid
-                                        } else if (columnsInResponse?.includes('uuid')) {
-                                            return result[columnsInResponse.indexOf('uuid')]
-                                        } else if (columnsInResponse?.includes('id')) {
-                                            return result[columnsInResponse.indexOf('id')]
-                                        }
-                                    }
-                                    return (
-                                        (result && 'uuid' in result ? (result as any).uuid : null) ??
-                                        (result && 'id' in result ? (result as any).id : null) ??
-                                        rowIndex
-                                    )
-                                }
+                            rowKey={(_, rowIndex) => {
                                 return rowIndex
                             }}
                             sorting={null}


### PR DESCRIPTION
## Problem

Fixes https://posthog.slack.com/archives/C0368RPHLQH/p1702955395630629

With many similar columns, the data table stopped updating when data changed slightly.

## Changes

Key the table rows by their index, not by the data. We can't guarantee even columns like "uuid" to contain unique values, so stop trying. `JSON.stringify(result)` was the worst offending key.

## How did you test this code?

I could reproduce the problem case locally, and this fix solved it. I also got rid of thousands of react warnings in the console.