### PR TITLE
feat: Added theme switcher to settings page

### DIFF
--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -1,5 +1,5 @@
-import { IconChevronDown, IconDay, IconFeatures, IconLaptop, IconLive, IconNight } from '@posthog/icons'
-import { LemonButtonPropsBase, LemonSelect } from '@posthog/lemon-ui'
+import { IconChevronDown, IconFeatures, IconLive } from '@posthog/icons'
+import { LemonButtonPropsBase } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'

--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -283,7 +283,7 @@ export function SitePopoverOverlay(): JSX.Element {
             )}
             <SitePopoverSection>
                 <FlaggedFeature flag={FEATURE_FLAGS.POSTHOG_3000} match="test">
-                    <ThemeSwitcher />
+                    <ThemeSwitcher fullWidth type="tertiary" />
                 </FlaggedFeature>
                 <LemonButton
                     onClick={closeSitePopover}

--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -25,6 +25,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
 import { inviteLogic } from 'scenes/settings/organization/inviteLogic'
+import { ThemeSwitcher } from 'scenes/settings/user/ThemeSwitcher'
 
 import { featurePreviewsLogic } from '~/layout/FeaturePreviews/featurePreviewsLogic'
 import {
@@ -221,36 +222,6 @@ function FeaturePreviewsButton(): JSX.Element {
         >
             Feature previews
         </LemonButton>
-    )
-}
-
-function ThemeSwitcher(): JSX.Element {
-    const { user } = useValues(userLogic)
-    const { updateUser } = useActions(userLogic)
-
-    return (
-        <LemonSelect
-            options={[
-                { icon: <IconLaptop />, value: null, label: `Sync with system` },
-                { icon: <IconDay />, value: 'light', label: 'Light mode' },
-                { icon: <IconNight />, value: 'dark', label: 'Dark mode' },
-            ]}
-            value={user?.theme_mode}
-            renderButtonContent={(leaf) => {
-                return (
-                    <>
-                        <span className="flex-1 flex justify-between items-baseline">
-                            <span>Color theme</span>
-                            <span className="font-normal text-xs">{leaf ? leaf.label : 'Sync with system'}</span>
-                        </span>
-                    </>
-                )
-            }}
-            onChange={(value) => updateUser({ theme_mode: value })}
-            type="tertiary"
-            fullWidth
-            dropdownPlacement="right-start"
-        />
     )
 }
 

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -344,7 +344,7 @@ export const SettingsMap: SettingSection[] = [
             {
                 id: 'theme',
                 title: 'Theme',
-                component: <ThemeSwitcher type="secondary" fullWidth={false} onlyLabel />,
+                component: <ThemeSwitcher onlyLabel />,
             },
             {
                 id: 'notifications',

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -32,6 +32,7 @@ import { SettingSection } from './types'
 import { ChangePassword } from './user/ChangePassword'
 import { OptOutCapture } from './user/OptOutCapture'
 import { PersonalAPIKeys } from './user/PersonalAPIKeys'
+import { ThemeSwitcher } from './user/ThemeSwitcher'
 import { TwoFactorAuthentication } from './user/TwoFactorAuthentication'
 import { UpdateEmailPreferences } from './user/UpdateEmailPreferences'
 import { UserDetails } from './user/UserDetails'
@@ -337,9 +338,14 @@ export const SettingsMap: SettingSection[] = [
     },
     {
         level: 'user',
-        id: 'user-notifications',
-        title: 'Notifications',
+        id: 'user-customization',
+        title: 'Customization',
         settings: [
+            {
+                id: 'theme',
+                title: 'Theme',
+                component: <ThemeSwitcher type="secondary" fullWidth={false} onlyLabel />,
+            },
             {
                 id: 'notifications',
                 title: 'Notifications',

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -30,7 +30,7 @@ export type SettingSectionId =
     | 'organization-danger-zone'
     | 'user-profile'
     | 'user-api-keys'
-    | 'user-notifications'
+    | 'user-customization'
 
 export type SettingId =
     | 'display-name'
@@ -70,6 +70,7 @@ export type SettingId =
     | 'personal-api-keys'
     | 'notifications'
     | 'optout'
+    | 'theme'
 
 export type Setting = {
     id: SettingId

--- a/frontend/src/scenes/settings/user/ThemeSwitcher.tsx
+++ b/frontend/src/scenes/settings/user/ThemeSwitcher.tsx
@@ -32,8 +32,6 @@ export function ThemeSwitcher({
                 )
             }}
             onChange={(value) => updateUser({ theme_mode: value })}
-            type="tertiary"
-            fullWidth
             dropdownPlacement="right-start"
             dropdownMatchSelectWidth={false}
             {...props}

--- a/frontend/src/scenes/settings/user/ThemeSwitcher.tsx
+++ b/frontend/src/scenes/settings/user/ThemeSwitcher.tsx
@@ -1,0 +1,42 @@
+import { IconDay, IconLaptop, IconNight } from '@posthog/icons'
+import { LemonSelect, LemonSelectProps } from '@posthog/lemon-ui'
+import { useActions, useValues } from 'kea'
+import { userLogic } from 'scenes/userLogic'
+
+export function ThemeSwitcher({
+    onlyLabel,
+    ...props
+}: Partial<LemonSelectProps<any>> & { onlyLabel?: boolean }): JSX.Element {
+    const { user } = useValues(userLogic)
+    const { updateUser } = useActions(userLogic)
+
+    return (
+        <LemonSelect
+            options={[
+                { icon: <IconLaptop />, value: null, label: `Sync with system` },
+                { icon: <IconDay />, value: 'light', label: 'Light mode' },
+                { icon: <IconNight />, value: 'dark', label: 'Dark mode' },
+            ]}
+            value={user?.theme_mode}
+            renderButtonContent={(leaf) => {
+                const labelText = leaf ? leaf.label : 'Sync with system'
+                return onlyLabel ? (
+                    labelText
+                ) : (
+                    <>
+                        <span className="flex-1 flex justify-between items-baseline gap-4">
+                            <span>Color theme</span>
+                            <span className="font-normal text-xs">{leaf ? leaf.label : 'Sync with system'}</span>
+                        </span>
+                    </>
+                )
+            }}
+            onChange={(value) => updateUser({ theme_mode: value })}
+            type="tertiary"
+            fullWidth
+            dropdownPlacement="right-start"
+            dropdownMatchSelectWidth={false}
+            {...props}
+        />
+    )
+}


### PR DESCRIPTION
## Problem

Some people expect the setting to be in Settings (fair enough!) so let's have it there

## Changes

* Changes the section to "customization" as I think that is a good enough catch all
* Fixes the missing gap in the label
* Uses the same component for each

<img width="491" alt="Screenshot 2023-12-19 at 18 18 41" src="https://github.com/PostHog/posthog/assets/2536520/524dcfd0-c272-4c9f-a7a2-09e9e4a29b39">
<img width="478" alt="Screenshot 2023-12-19 at 18 18 49" src="https://github.com/PostHog/posthog/assets/2536520/70345b49-8fc1-440f-b186-2bad4252978f">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
