### PR TITLE
fix(navigation): use min-width for site popover

### DIFF
--- a/frontend/src/layout/navigation-3000/components/Navbar.tsx
+++ b/frontend/src/layout/navigation-3000/components/Navbar.tsx
@@ -104,6 +104,7 @@ export function Navbar(): JSX.Element {
                                 visible={isSitePopoverOpen}
                                 onClickOutside={closeSitePopover}
                                 placement="right-end"
+                                className="min-w-70"
                             >
                                 <NavbarButton
                                     icon={<ProfilePicture name={user?.first_name} email={user?.email} size="md" />}

--- a/frontend/src/styles/vars.scss
+++ b/frontend/src/styles/vars.scss
@@ -15,7 +15,7 @@ $screens: (
     'xxl': $xxl,
 );
 $tiny_spaces: 0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20;
-$humongous_spaces: 24, 30, 32, 40, 50, 60, 80, 100, 120, 140, 160, 180, 200;
+$humongous_spaces: 24, 30, 32, 40, 50, 60, 70, 80, 100, 120, 140, 160, 180, 200;
 $all_spaces: list.join($tiny_spaces, $humongous_spaces);
 $flex_sizes: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10;
 $leadings: 3, 4, 5, 6, 7, 8, 9, 10;


### PR DESCRIPTION
## Problem

I still think the site popover could use some additional space when the instance settings are missing (i.e. most users). Might be subjective..

## Changes

**Before**
<img width="521" alt="Screenshot 2023-12-19 at 20 05 42" src="https://github.com/PostHog/posthog/assets/1851359/aa179d34-83ee-4dc5-b089-646246aa07a8">

**After**
<img width="542" alt="Screenshot 2023-12-19 at 20 05 22" src="https://github.com/PostHog/posthog/assets/1851359/70a820cb-6166-4a9b-8d31-9f0286eb4943">

## How did you test this code?

:eyes: when removing the instance settings