### PR TITLE
fix(persons): fix persons modal key

### DIFF
--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -43,7 +43,6 @@ export interface ListActorsResponse {
 export const personsModalLogic = kea<personsModalLogicType>([
     path(['scenes', 'trends', 'personsModalLogic']),
     props({} as PersonModalLogicProps),
-    // key((props) => props.url),
     actions({
         setSearchTerm: (search: string) => ({ search }),
         saveAsCohort: (cohortName: string) => ({ cohortName }),

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -1,5 +1,5 @@
 import { lemonToast } from '@posthog/lemon-ui'
-import { actions, afterMount, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
 import api from 'lib/api'
@@ -43,6 +43,7 @@ export interface ListActorsResponse {
 export const personsModalLogic = kea<personsModalLogicType>([
     path(['scenes', 'trends', 'personsModalLogic']),
     props({} as PersonModalLogicProps),
+    key((props) => props.url),
     actions({
         setSearchTerm: (search: string) => ({ search }),
         saveAsCohort: (cohortName: string) => ({ cohortName }),

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -1,5 +1,5 @@
 import { lemonToast } from '@posthog/lemon-ui'
-import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, afterMount, connect, kea, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
 import api from 'lib/api'
@@ -43,7 +43,7 @@ export interface ListActorsResponse {
 export const personsModalLogic = kea<personsModalLogicType>([
     path(['scenes', 'trends', 'personsModalLogic']),
     props({} as PersonModalLogicProps),
-    key((props) => props.url),
+    // key((props) => props.url),
     actions({
         setSearchTerm: (search: string) => ({ search }),
         saveAsCohort: (cohortName: string) => ({ cohortName }),
@@ -311,4 +311,10 @@ export const personsModalLogic = kea<personsModalLogicType>([
             }
         },
     })),
+
+    propsChanged(({ props, actions }, oldProps) => {
+        if (props.url !== oldProps.url) {
+            actions.loadActors({ query: props.query, url: props.url, clear: true })
+        }
+    }),
 ])


### PR DESCRIPTION
## Problem

Switching between breakdowns does not update the persons modal list. See https://posthog.slack.com/archives/C0368RPHLQH/p1702445218677399 and https://github.com/PostHog/posthog/issues/19321.

## Changes

~This PR re-adds a key to the `personsModalLogic`, fixing the above mentioned issue, but unfortunately breaking the fix that introduced the change https://github.com/PostHog/posthog/pull/18155.~

This PR re-fetches results when props change.

Summary of discussion with @daibhin in Slack: The fix here should theoretically work for both insights and adding the replay to a notebook from the persons overlay. For some reason the `onNotebookOpened ` callback isn't called though and that why it doesn't work, also in master. @daibhin is going to have a peek. It's a edge case scenario anyway.

## How did you test this code?

Changed the series back and forth. I was a bit unsure about the query in there, so please check this still works as expected or let me know what I need to verify.