### PR TITLE
fix(funnels): fix funnel label

### DIFF
--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -138,7 +138,11 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
     })
 
     const [floatingElement, setFloatingElement] = useState<HTMLElement | null>(null)
-    const mergedReferenceRef = useMergeRefs([referenceRef, extraReferenceRef || null]) as React.RefCallback<HTMLElement>
+    const mergedReferenceRef = useMergeRefs([
+        referenceRef,
+        extraReferenceRef || null,
+        (children as any)?.ref,
+    ]) as React.RefCallback<HTMLElement>
 
     const arrowStyle = middlewareData.arrow
         ? {

--- a/frontend/src/scenes/funnels/FunnelBarGraph/Bar.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph/Bar.tsx
@@ -94,42 +94,37 @@ export function Bar({
                 </LEGACY_InsightTooltip>
             }
         >
-            <>
-                {/** :HACKY: This fragment is necessary for the ref to work within LemonDropdown. */}
-                <div
-                    ref={barRef}
-                    className={`funnel-bar ${getSeriesPositionName(breakdownIndex, breakdownMaxIndex)}`}
-                    // eslint-disable-next-line react/forbid-dom-props
-                    style={{
-                        flex: `${conversionPercentage} 1 0`,
-                        cursor: cursorType,
-                        backgroundColor: getSeriesColor(breakdownIndex ?? 0),
-                    }}
-                    onClick={() => {
-                        if (!disabled && onBarClick) {
-                            onBarClick()
+            <div
+                ref={barRef}
+                className={`funnel-bar ${getSeriesPositionName(breakdownIndex, breakdownMaxIndex)}`}
+                // eslint-disable-next-line react/forbid-dom-props
+                style={{
+                    flex: `${conversionPercentage} 1 0`,
+                    cursor: cursorType,
+                    backgroundColor: getSeriesColor(breakdownIndex ?? 0),
+                }}
+                onClick={() => {
+                    if (!disabled && onBarClick) {
+                        onBarClick()
+                    }
+                }}
+            >
+                {shouldShowLabel && (
+                    <div
+                        ref={labelRef}
+                        className={`funnel-bar-percentage ${labelPosition}`}
+                        title={
+                            name ? `${capitalizeFirstLetter(aggregationTargetLabel.plural)} who did ${name}` : undefined
                         }
-                    }}
-                >
-                    {shouldShowLabel && (
-                        <div
-                            ref={labelRef}
-                            className={`funnel-bar-percentage ${labelPosition}`}
-                            title={
-                                name
-                                    ? `${capitalizeFirstLetter(aggregationTargetLabel.plural)} who did ${name}`
-                                    : undefined
-                            }
-                            role="progressbar"
-                            aria-valuemin={0}
-                            aria-valuemax={100}
-                            aria-valuenow={(breakdownSumPercentage ?? conversionPercentage) * 100}
-                        >
-                            {percentage(breakdownSumPercentage ?? conversionPercentage, 1, true)}
-                        </div>
-                    )}
-                </div>
-            </>
+                        role="progressbar"
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                        aria-valuenow={(breakdownSumPercentage ?? conversionPercentage) * 100}
+                    >
+                        {percentage(breakdownSumPercentage ?? conversionPercentage, 1, true)}
+                    </div>
+                )}
+            </div>
         </LemonDropdown>
     )
 }

--- a/frontend/src/scenes/funnels/FunnelBarGraph/Bar.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph/Bar.tsx
@@ -94,37 +94,42 @@ export function Bar({
                 </LEGACY_InsightTooltip>
             }
         >
-            <div
-                ref={barRef}
-                className={`funnel-bar ${getSeriesPositionName(breakdownIndex, breakdownMaxIndex)}`}
-                // eslint-disable-next-line react/forbid-dom-props
-                style={{
-                    flex: `${conversionPercentage} 1 0`,
-                    cursor: cursorType,
-                    backgroundColor: getSeriesColor(breakdownIndex ?? 0),
-                }}
-                onClick={() => {
-                    if (!disabled && onBarClick) {
-                        onBarClick()
-                    }
-                }}
-            >
-                {shouldShowLabel && (
-                    <div
-                        ref={labelRef}
-                        className={`funnel-bar-percentage ${labelPosition}`}
-                        title={
-                            name ? `${capitalizeFirstLetter(aggregationTargetLabel.plural)} who did ${name}` : undefined
+            <>
+                {/** :HACKY: This fragment is necessary for the ref to work within LemonDropdown. */}
+                <div
+                    ref={barRef}
+                    className={`funnel-bar ${getSeriesPositionName(breakdownIndex, breakdownMaxIndex)}`}
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{
+                        flex: `${conversionPercentage} 1 0`,
+                        cursor: cursorType,
+                        backgroundColor: getSeriesColor(breakdownIndex ?? 0),
+                    }}
+                    onClick={() => {
+                        if (!disabled && onBarClick) {
+                            onBarClick()
                         }
-                        role="progressbar"
-                        aria-valuemin={0}
-                        aria-valuemax={100}
-                        aria-valuenow={(breakdownSumPercentage ?? conversionPercentage) * 100}
-                    >
-                        {percentage(breakdownSumPercentage ?? conversionPercentage, 1, true)}
-                    </div>
-                )}
-            </div>
+                    }}
+                >
+                    {shouldShowLabel && (
+                        <div
+                            ref={labelRef}
+                            className={`funnel-bar-percentage ${labelPosition}`}
+                            title={
+                                name
+                                    ? `${capitalizeFirstLetter(aggregationTargetLabel.plural)} who did ${name}`
+                                    : undefined
+                            }
+                            role="progressbar"
+                            aria-valuemin={0}
+                            aria-valuemax={100}
+                            aria-valuenow={(breakdownSumPercentage ?? conversionPercentage) * 100}
+                        >
+                            {percentage(breakdownSumPercentage ?? conversionPercentage, 1, true)}
+                        </div>
+                    )}
+                </div>
+            </>
         </LemonDropdown>
     )
 }


### PR DESCRIPTION
## Problem

Some percentage figures on top to bottom funnel view are not visible when the figure is very small.
https://posthoghelp.zendesk.com/agent/tickets/8196 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/11857)

![image](https://github.com/PostHog/posthog/assets/1851359/e5074d2a-81ae-4f3f-b30a-cfaae7579999)

## Changes

We calculate wether the label fits inside the bar or not and set a css class based on that. This calculation was broken when we wrapped the bar in a LemonDropdown, as the Popover used by LemonDropdown did not pass on the ref of children. This PR changes that.

<img width="1232" alt="Screenshot 2023-12-20 at 09 12 12" src="https://github.com/PostHog/posthog/assets/1851359/c9f884b4-6c1a-4d93-a0ff-568ba7cca0e1">

## How did you test this code?

Created an insight locally