### PR TITLE
feat: Migrate from zookeeper to clickhouse-keeper

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -30,9 +30,12 @@ services:
         depends_on:
             - kafka
             - clickhouse-keeper
+
     clickhouse-keeper:
         image: clickhouse/clickhouse-keeper:23.11.2.11-alpine
         restart: on-failure
+        volumes:
+            - ./docker/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
 
     kafka:
         image: ghcr.io/posthog/kafka-container:v2.8.2

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -29,22 +29,22 @@ services:
         restart: on-failure
         depends_on:
             - kafka
-            - zookeeper
-    zookeeper:
-        image: zookeeper:3.7.0
+            - clickhouse-keeper
+    clickhouse-keeper:
+        image: clickhouse/clickhouse-keeper:23.11.2.11-alpine
         restart: on-failure
 
     kafka:
         image: ghcr.io/posthog/kafka-container:v2.8.2
         restart: on-failure
         depends_on:
-            - zookeeper
+            - clickhouse-keeper
         environment:
             KAFKA_BROKER_ID: 1001
             KAFKA_CFG_RESERVED_BROKER_MAX_ID: 1001
             KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
             KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-            KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+            KAFKA_CFG_ZOOKEEPER_CONNECT: clickhouse-keeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'
 
     object_storage:

--- a/docker-compose.dev-full.yml
+++ b/docker-compose.dev-full.yml
@@ -38,10 +38,10 @@ services:
             - ./docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
             - ./docker/clickhouse/users-dev.xml:/etc/clickhouse-server/users.xml
 
-    zookeeper:
+    clickhouse-keeper:
         extends:
             file: docker-compose.base.yml
-            service: zookeeper
+            service: clickhouse-keeper
 
     kafka:
         extends:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,10 +42,10 @@ services:
             - ./docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
             - ./docker/clickhouse/users-dev.xml:/etc/clickhouse-server/users.xml
 
-    zookeeper:
+    clickhouse-keeper:
         extends:
             file: docker-compose.base.yml
-            service: zookeeper
+            service: clickhouse-keeper
         ports:
             - '2181:2181'
 

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -33,21 +33,21 @@ services:
         restart: on-failure
         depends_on:
             - kafka
-            - zookeeper
+            - clickhouse-keeper
         volumes:
             - ./posthog/posthog/idl:/idl
             - ./posthog/docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
             - ./posthog/docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
             - ./posthog/docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml
             - clickhouse-data:/var/lib/clickhouse
-    zookeeper:
+
+    clickhouse-keeper:
         extends:
             file: docker-compose.base.yml
-            service: zookeeper
+            service: clickhouse-keeper
         volumes:
-            - zookeeper-datalog:/datalog
-            - zookeeper-data:/data
-            - zookeeper-logs:/logs
+            - clickhouse-keeper:/var/lib/clickhouse
+
     kafka:
         extends:
             file: docker-compose.base.yml
@@ -147,9 +147,7 @@ services:
             SITE_URL: https://$DOMAIN
 
 volumes:
-    zookeeper-data:
-    zookeeper-datalog:
-    zookeeper-logs:
+    clickhouse-keeper:
     object_storage:
     postgres-data:
     clickhouse-data:

--- a/docker/clickhouse-keeper/keeper_config.xml
+++ b/docker/clickhouse-keeper/keeper_config.xml
@@ -30,9 +30,9 @@
 
     <max_connections>4096</max_connections>
 
+    <listen_host>0.0.0.0</listen_host>
     <keeper_server>
         <tcp_port>2181</tcp_port>
-        <listen_host>0.0.0.0</listen_host>
 
         <!-- Must be unique among all keeper serves -->
         <server_id>1</server_id>
@@ -66,27 +66,4 @@
 
         </raft_configuration>
     </keeper_server>
-
-
-    <openSSL>
-        <server>
-            <!-- Used for secure tcp port -->
-            <!-- openssl req -subj "/CN=localhost" -new -newkey rsa:2048 -days 365 -nodes -x509
-            -keyout /etc/clickhouse-server/server.key -out /etc/clickhouse-server/server.crt -->
-            <certificateFile>/etc/clickhouse-keeper/server.crt</certificateFile>
-            <privateKeyFile>/etc/clickhouse-keeper/server.key</privateKeyFile>
-            <!-- dhparams are optional. You can delete the <dhParamsFile> element.
-                 To generate dhparams, use the following command:
-                  openssl dhparam -out /etc/clickhouse-keeper/dhparam.pem 4096
-                 Only file format with BEGIN DH PARAMETERS is supported.
-              -->
-            <dhParamsFile>/etc/clickhouse-keeper/dhparam.pem</dhParamsFile>
-            <verificationMode>none</verificationMode>
-            <loadDefaultCAFile>true</loadDefaultCAFile>
-            <cacheSessions>true</cacheSessions>
-            <disableProtocols>sslv2,sslv3</disableProtocols>
-            <preferServerCiphers>true</preferServerCiphers>
-        </server>
-    </openSSL>
-
 </clickhouse>

--- a/docker/clickhouse-keeper/keeper_config.xml
+++ b/docker/clickhouse-keeper/keeper_config.xml
@@ -1,0 +1,92 @@
+<clickhouse>
+    <logger>
+        <!-- Possible levels [1]:
+
+          - none (turns off logging)
+          - fatal
+          - critical
+          - error
+          - warning
+          - notice
+          - information
+          - debug
+          - trace
+
+            [1]:
+        https://github.com/pocoproject/poco/blob/poco-1.9.4-release/Foundation/include/Poco/Logger.h#L105-L114
+        -->
+        <level>trace</level>
+        <log>/var/log/clickhouse-keeper/clickhouse-keeper.log</log>
+        <errorlog>/var/log/clickhouse-keeper/clickhouse-keeper.err.log</errorlog>
+        <!-- Rotation policy
+             See
+        https://github.com/pocoproject/poco/blob/poco-1.9.4-release/Foundation/include/Poco/FileChannel.h#L54-L85
+          -->
+        <size>1000M</size>
+        <count>10</count>
+        <!-- <console>1</console> --> <!-- Default behavior is autodetection (log to console if not daemon mode
+        and is tty) -->
+    </logger>
+
+    <max_connections>4096</max_connections>
+
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <listen_host>0.0.0.0</listen_host>
+
+        <!-- Must be unique among all keeper serves -->
+        <server_id>1</server_id>
+
+        <log_storage_path>/var/lib/clickhouse/coordination/logs</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <min_session_timeout_ms>10000</min_session_timeout_ms>
+            <session_timeout_ms>100000</session_timeout_ms>
+            <raft_logs_level>information</raft_logs_level>
+            <compress_logs>false</compress_logs>
+            <!-- All settings listed in
+            https://github.com/ClickHouse/ClickHouse/blob/master/src/Coordination/CoordinationSettings.h -->
+        </coordination_settings>
+
+        <!-- enable sanity hostname checks for cluster configuration (e.g. if localhost is used with
+        remote endpoints) -->
+        <hostname_checks_enabled>true</hostname_checks_enabled>
+        <raft_configuration>
+            <server>
+                <id>1</id>
+
+                <!-- Internal port and hostname -->
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+
+            <!-- Add more servers here -->
+
+        </raft_configuration>
+    </keeper_server>
+
+
+    <openSSL>
+        <server>
+            <!-- Used for secure tcp port -->
+            <!-- openssl req -subj "/CN=localhost" -new -newkey rsa:2048 -days 365 -nodes -x509
+            -keyout /etc/clickhouse-server/server.key -out /etc/clickhouse-server/server.crt -->
+            <certificateFile>/etc/clickhouse-keeper/server.crt</certificateFile>
+            <privateKeyFile>/etc/clickhouse-keeper/server.key</privateKeyFile>
+            <!-- dhparams are optional. You can delete the <dhParamsFile> element.
+                 To generate dhparams, use the following command:
+                  openssl dhparam -out /etc/clickhouse-keeper/dhparam.pem 4096
+                 Only file format with BEGIN DH PARAMETERS is supported.
+              -->
+            <dhParamsFile>/etc/clickhouse-keeper/dhparam.pem</dhParamsFile>
+            <verificationMode>none</verificationMode>
+            <loadDefaultCAFile>true</loadDefaultCAFile>
+            <cacheSessions>true</cacheSessions>
+            <disableProtocols>sslv2,sslv3</disableProtocols>
+            <preferServerCiphers>true</preferServerCiphers>
+        </server>
+    </openSSL>
+
+</clickhouse>

--- a/docker/clickhouse/config.xml
+++ b/docker/clickhouse/config.xml
@@ -755,7 +755,7 @@
 
     <zookeeper>
         <node>
-            <host>zookeeper</host>
+            <host>clickhouse-keeper</host>
             <port>2181</port>
         </node>
     </zookeeper>


### PR DESCRIPTION
## Problem

We will be moving to clickhouse-keeper for our new clusters. In order to ensure dev mirrors prod this is the first step towards that world.

## Changes

- change zookeeper to clickhouse-keeper in compose
- update clickhouse configs to point to clickhouse-keeper
- test

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
