### PR TITLE
chore: Replace datetime.utcnow()

### DIFF
--- a/posthog/api/test/batch_exports/test_log_entry.py
+++ b/posthog/api/test/batch_exports/test_log_entry.py
@@ -38,7 +38,7 @@ def create_batch_export_log_entry(
             "log_source": "batch_exports",
             "log_source_id": batch_export_id,
             "instance_id": run_id,
-            "timestamp": dt.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f"),
+            "timestamp": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f"),
             "level": level,
             "message": message,
         },
@@ -147,7 +147,7 @@ def test_log_level_filter(batch_export, team, level):
 
     results = []
     timeout = 10
-    start = dt.datetime.utcnow()
+    start = dt.datetime.now(dt.timezone.utc)
 
     while not results:
         results = fetch_batch_export_log_entries(
@@ -157,7 +157,7 @@ def test_log_level_filter(batch_export, team, level):
             after=dt.datetime(2023, 9, 22, 0, 59, 59),
             before=dt.datetime(2023, 9, 22, 1, 0, 1),
         )
-        if (dt.datetime.utcnow() - start) > dt.timedelta(seconds=timeout):
+        if (dt.datetime.now(dt.timezone.utc) - start) > dt.timedelta(seconds=timeout):
             break
 
     results.sort(key=lambda record: record.message)
@@ -195,7 +195,7 @@ def test_log_level_filter_with_lowercase(batch_export, team, level):
 
     results = []
     timeout = 10
-    start = dt.datetime.utcnow()
+    start = dt.datetime.now(dt.timezone.utc)
 
     while not results:
         results = fetch_batch_export_log_entries(
@@ -205,7 +205,7 @@ def test_log_level_filter_with_lowercase(batch_export, team, level):
             after=dt.datetime(2023, 9, 22, 0, 59, 59),
             before=dt.datetime(2023, 9, 22, 1, 0, 1),
         )
-        if (dt.datetime.utcnow() - start) > dt.timedelta(seconds=timeout):
+        if (dt.datetime.now(dt.timezone.utc) - start) > dt.timedelta(seconds=timeout):
             break
 
     results.sort(key=lambda record: record.message)

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -310,7 +310,7 @@ class TestCapture(BaseTest):
             capacity=1,
             storage=MemoryStorage(),
         )
-        start = datetime.utcnow()
+        start = datetime.now(timezone.utc)
 
         with patch("posthog.api.capture.LIMITER", new=limiter):
             with freeze_time(start):

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -196,7 +196,7 @@ def pause_batch_export(temporal: Client, batch_export_id: str, note: str | None 
         raise BatchExportServiceRPCError(f"BatchExport {batch_export_id} could not be paused") from exc
 
     batch_export.paused = True
-    batch_export.last_paused_at = dt.datetime.utcnow()
+    batch_export.last_paused_at = dt.datetime.now(dt.timezone.utc)
     batch_export.save()
 
 

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -83,7 +83,7 @@ def execute_process_query(
     query_status = manager.get_query_status()
     query_status.error = True  # Assume error in case nothing below ends up working
 
-    pickup_time = datetime.datetime.utcnow()
+    pickup_time = datetime.datetime.now(datetime.timezone.utc)
     if query_status.start_time:
         wait_duration = (pickup_time - query_status.start_time) / datetime.timedelta(seconds=1)
         QUERY_WAIT_TIME.observe(wait_duration)
@@ -97,7 +97,7 @@ def execute_process_query(
         query_status.complete = True
         query_status.error = False
         query_status.results = results
-        query_status.end_time = datetime.datetime.utcnow()
+        query_status.end_time = datetime.datetime.now(datetime.timezone.utc)
         query_status.expiration_time = query_status.end_time + datetime.timedelta(seconds=manager.STATUS_TTL_SECONDS)
         process_duration = (query_status.end_time - pickup_time) / datetime.timedelta(seconds=1)
         QUERY_PROCESS_TIME.observe(process_duration)
@@ -131,7 +131,7 @@ def enqueue_process_query_task(
         return manager.get_query_status()
 
     # Immediately set status, so we don't have race with celery
-    query_status = QueryStatus(id=query_id, team_id=team_id, start_time=datetime.datetime.utcnow())
+    query_status = QueryStatus(id=query_id, team_id=team_id, start_time=datetime.datetime.now(datetime.timezone.utc))
     manager.store_query_status(query_status)
 
     if bypass_celery:

--- a/posthog/clickhouse/test/test_person_overrides.py
+++ b/posthog/clickhouse/test/test_person_overrides.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from time import sleep
 from typing import TypedDict
 from uuid import UUID, uuid4
@@ -124,7 +124,7 @@ def test_person_overrides_dict():
         "override_person_id": uuid4(),
         "merged_at": datetime.fromisoformat("2020-01-02T00:00:00+00:00"),
         "oldest_event": datetime.fromisoformat("2020-01-01T00:00:00+00:00"),
-        "created_at": datetime.utcnow(),
+        "created_at": datetime.now(timezone.utc),
         "version": 1,
     }
 

--- a/posthog/management/commands/create_batch_export_from_app.py
+++ b/posthog/management/commands/create_batch_export_from_app.py
@@ -116,7 +116,7 @@ class Command(BaseCommand):
 
         if options.get("backfill_batch_export", False) and dry_run is False:
             client = sync_connect()
-            end_at = dt.datetime.utcnow()
+            end_at = dt.datetime.now(dt.timezone.utc)
             start_at = end_at - (dt.timedelta(hours=1) if interval == "hour" else dt.timedelta(days=1))
             backfill_export(
                 client,

--- a/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 from uuid import UUID, uuid4
 
@@ -143,7 +143,7 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
         wraps=posthog.management.commands.sync_persons_to_clickhouse.raw_create_group_ch,
     )
     def test_group_sync(self, mocked_ch_call):
-        ts = datetime.utcnow()
+        ts = datetime.now(timezone.utc)
         Group.objects.create(
             team_id=self.team.pk,
             group_type_index=2,
@@ -183,12 +183,12 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
             2,
             "group-key",
             {"a": 5},
-            timestamp=datetime.utcnow() - timedelta(hours=3),
+            timestamp=datetime.now(timezone.utc) - timedelta(hours=3),
         )
         group.group_properties = {"a": 5, "b": 3}
         group.save()
 
-        ts_before = datetime.utcnow()
+        ts_before = datetime.now(timezone.utc)
         run_group_sync(self.team.pk, live_run=True, sync=True)
         mocked_ch_call.assert_called_once()
 
@@ -213,7 +213,7 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
         )
         self.assertLessEqual(
             ch_group[4].strftime("%Y-%m-%d %H:%M:%S"),
-            datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+            datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
         )
 
         # second time it's a no-op
@@ -225,7 +225,7 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
         wraps=posthog.management.commands.sync_persons_to_clickhouse.raw_create_group_ch,
     )
     def test_group_sync_multiple_entries(self, mocked_ch_call):
-        ts = datetime.utcnow()
+        ts = datetime.now(timezone.utc)
         Group.objects.create(
             team_id=self.team.pk,
             group_type_index=2,
@@ -430,7 +430,7 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
             group_type_index=2,
             group_key="group-key",
             group_properties={"a": 1234},
-            created_at=datetime.utcnow() - timedelta(hours=3),
+            created_at=datetime.now(timezone.utc) - timedelta(hours=3),
             version=5,
         )
 

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import json
 from typing import Any, List, Type, cast, Dict, Tuple
@@ -369,7 +369,7 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
                 newest_timestamp = min(sources, key=lambda k: k["end_timestamp"])["end_timestamp"]
 
                 if might_have_realtime:
-                    might_have_realtime = oldest_timestamp + timedelta(hours=24) > datetime.utcnow()
+                    might_have_realtime = oldest_timestamp + timedelta(hours=24) > datetime.now(timezone.utc)
 
             if might_have_realtime:
                 sources.append(

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -352,7 +352,7 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
                 for full_key in blob_keys:
                     # Keys are like 1619712000-1619712060
                     blob_key = full_key.replace(blob_prefix.rstrip("/") + "/", "")
-                    time_range = [datetime.fromtimestamp(int(x) / 1000) for x in blob_key.split("-")]
+                    time_range = [datetime.fromtimestamp(int(x) / 1000, tz=timezone.utc) for x in blob_key.split("-")]
 
                     sources.append(
                         {

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -223,7 +223,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs):
                         for field in table_schema
                         if field.name != "bq_ingested_timestamp"
                     }
-                    row["bq_ingested_timestamp"] = str(dt.datetime.utcnow())
+                    row["bq_ingested_timestamp"] = str(dt.datetime.now(dt.timezone.utc))
 
                     jsonl_file.write_records_to_jsonl([row])
 

--- a/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
+++ b/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
@@ -261,7 +261,7 @@ async def test_backfill_batch_export_workflow_fails_when_schedule_deleted_after_
     """
     start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
     end_at = dt.datetime(2023, 1, 1, 0, 10, 0, tzinfo=dt.timezone.utc)
-    now = dt.datetime.utcnow()
+    now = dt.datetime.now(dt.timezone.utc)
 
     desc = await temporal_schedule.describe()
 

--- a/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
@@ -41,8 +41,7 @@ SKIP_IF_MISSING_GOOGLE_APPLICATION_CREDENTIALS = pytest.mark.skipif(
 
 pytestmark = [SKIP_IF_MISSING_GOOGLE_APPLICATION_CREDENTIALS, pytest.mark.asyncio, pytest.mark.django_db]
 
-
-TEST_TIME = dt.datetime.utcnow()
+TEST_TIME = dt.datetime.now(dt.timezone.utc)
 
 
 def assert_events_in_bigquery(

--- a/posthog/temporal/tests/batch_exports/test_logger.py
+++ b/posthog/temporal/tests/batch_exports/test_logger.py
@@ -211,13 +211,13 @@ BATCH_EXPORT_ID = str(uuid.uuid4())
     "activity_environment",
     [
         ActivityInfo(
-            workflow_id=f"{BATCH_EXPORT_ID}-{dt.datetime.utcnow()}",
+            workflow_id=f"{BATCH_EXPORT_ID}-{dt.datetime.now(dt.timezone.utc)}",
             workflow_type="s3-export",
             workflow_run_id=str(uuid.uuid4()),
             attempt=random.randint(1, 10000),
         ),
         ActivityInfo(
-            workflow_id=f"{BATCH_EXPORT_ID}-Backfill-{dt.datetime.utcnow()}",
+            workflow_id=f"{BATCH_EXPORT_ID}-Backfill-{dt.datetime.now(dt.timezone.utc)}",
             workflow_type="backfill-batch-export",
             workflow_run_id=str(uuid.uuid4()),
             attempt=random.randint(1, 10000),
@@ -262,13 +262,13 @@ async def test_batch_exports_logger_binds_activity_context(
     "activity_environment",
     [
         ActivityInfo(
-            workflow_id=f"{BATCH_EXPORT_ID}-{dt.datetime.utcnow()}",
+            workflow_id=f"{BATCH_EXPORT_ID}-{dt.datetime.now(dt.timezone.utc)}",
             workflow_type="s3-export",
             workflow_run_id=str(uuid.uuid4()),
             attempt=random.randint(1, 10000),
         ),
         ActivityInfo(
-            workflow_id=f"{BATCH_EXPORT_ID}-Backfill-{dt.datetime.utcnow()}",
+            workflow_id=f"{BATCH_EXPORT_ID}-Backfill-{dt.datetime.now(dt.timezone.utc)}",
             workflow_type="backfill-batch-export",
             workflow_run_id=str(uuid.uuid4()),
             attempt=random.randint(1, 10000),
@@ -324,13 +324,13 @@ def log_entries_table():
     "activity_environment",
     [
         ActivityInfo(
-            workflow_id=f"{BATCH_EXPORT_ID}-{dt.datetime.utcnow()}",
+            workflow_id=f"{BATCH_EXPORT_ID}-{dt.datetime.now(dt.timezone.utc)}",
             workflow_type="s3-export",
             workflow_run_id=str(uuid.uuid4()),
             attempt=random.randint(1, 10000),
         ),
         ActivityInfo(
-            workflow_id=f"{BATCH_EXPORT_ID}-Backfill-{dt.datetime.utcnow()}",
+            workflow_id=f"{BATCH_EXPORT_ID}-Backfill-{dt.datetime.now(dt.timezone.utc)}",
             workflow_type="backfill-batch-export",
             workflow_run_id=str(uuid.uuid4()),
             attempt=random.randint(1, 10000),


### PR DESCRIPTION
## Problem

`datetime.utcnow()` is going to be deprecated.

See https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow

Also, in another branch I upgrade Pydantic and it will have aware datetimes as default, so we need to move some to aware anyways for things to work cleaner.

## Changes

- update to `datetime.now(timezone.utc)`

## How did you test this code?

- tests
