### PR TITLE
fix(navigation): alignment of settings icons

### DIFF
--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -76,7 +76,7 @@ function AccountInfo(): JSX.Element {
             >
                 <ProfilePicture name={user?.first_name} email={user?.email} size="xl" />
                 <div className="AccountInfo__identification SitePopover__main-info font-sans font-normal">
-                    <div className="font-medium mb-1">{user?.first_name}</div>
+                    <div className="font-semibold mb-1">{user?.first_name}</div>
                     <div className="supplement" title={user?.email}>
                         {user?.email}
                     </div>

--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -64,22 +64,24 @@ function AccountInfo(): JSX.Element {
 
     return (
         <div className="AccountInfo">
-            <ProfilePicture name={user?.first_name} email={user?.email} size="xl" />
-            <div className="AccountInfo__identification SitePopover__main-info">
-                <strong>{user?.first_name}</strong>
-                <div className="supplement" title={user?.email}>
-                    {user?.email}
+            <LemonButton
+                to={urls.settings('user')}
+                onClick={closeSitePopover}
+                data-attr="top-menu-item-me"
+                status="stealth"
+                fullWidth
+                tooltip="Account settings"
+                tooltipPlacement="left"
+                sideIcon={<IconSettings className="text-2xl" />}
+            >
+                <ProfilePicture name={user?.first_name} email={user?.email} size="xl" />
+                <div className="AccountInfo__identification SitePopover__main-info">
+                    <strong>{user?.first_name}</strong>
+                    <div className="supplement" title={user?.email}>
+                        {user?.email}
+                    </div>
                 </div>
-            </div>
-            <Tooltip title="Account settings" placement="left">
-                <LemonButton
-                    to={urls.settings('user')}
-                    onClick={closeSitePopover}
-                    data-attr="top-menu-item-me"
-                    status="stealth"
-                    icon={<IconSettings className="text-2xl" />}
-                />
-            </Tooltip>
+            </LemonButton>
         </div>
     )
 }

--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -75,8 +75,8 @@ function AccountInfo(): JSX.Element {
                 sideIcon={<IconSettings className="text-2xl" />}
             >
                 <ProfilePicture name={user?.first_name} email={user?.email} size="xl" />
-                <div className="AccountInfo__identification SitePopover__main-info">
-                    <strong>{user?.first_name}</strong>
+                <div className="AccountInfo__identification SitePopover__main-info font-sans font-normal">
+                    <div className="font-medium mb-1">{user?.first_name}</div>
                     <div className="supplement" title={user?.email}>
                         {user?.email}
                     </div>
@@ -101,7 +101,7 @@ function CurrentOrganization({ organization }: { organization: OrganizationBasic
                 onClick={closeSitePopover}
             >
                 <div className="SitePopover__main-info SitePopover__organization">
-                    <strong>{organization.name}</strong>
+                    <span className="font-medium">{organization.name}</span>
                     <AccessLevelIndicator organization={organization} />
                 </div>
             </LemonButton>

--- a/frontend/src/layout/navigation/TopBar/TopBar.scss
+++ b/frontend/src/layout/navigation/TopBar/TopBar.scss
@@ -180,7 +180,6 @@
 .AccountInfo {
     display: flex;
     align-items: center;
-    margin: 0.5rem;
 }
 
 .AccountInfo__identification {


### PR DESCRIPTION
## Problem

> One other thing but probably beyond the scope of this PR - the settings icon next to the person feels like it should be right aligned so that it is inline with the one below it
-- @daibhin https://github.com/PostHog/posthog/pull/19415#pullrequestreview-1790548362

## Changes

**before**
<img width="346" alt="Screenshot 2023-12-20 at 11 56 45" src="https://github.com/PostHog/posthog/assets/1851359/b43831b6-e32f-4344-96da-4242d8316692">

**after**
<img width="344" alt="Screenshot 2023-12-20 at 12 08 03" src="https://github.com/PostHog/posthog/assets/1851359/09cc5173-88b2-4edd-8936-7d8e1c7be66d">

## How did you test this code?

:eyes: