### PR TITLE
fix(retention): fix period in retetion csv title column

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -869,6 +869,7 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
                 "result": people,
                 "next": next_url,
                 "missing_persons": raw_count - len(people),
+                "filters": filter.to_dict(),
             }
         )
 

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -120,11 +120,12 @@ def _convert_response_to_csv_data(data: Any) -> List[Any]:
             return csv_rows
         elif first_result.get("appearances") and first_result.get("person"):
             # RETENTION PERSONS LIKE
+            period = data["filters"]["period"] or "Day"
             csv_rows = []
             for item in items:
                 line = {"person": item["person"]["name"]}
                 for index, data in enumerate(item["appearances"]):
-                    line[f"Day {index}"] = data
+                    line[f"{period} {index}"] = data
 
                 csv_rows.append(line)
             return csv_rows

--- a/posthog/tasks/exports/test/csv_renders/persons_modal_retention.json
+++ b/posthog/tasks/exports/test/csv_renders/persons_modal_retention.json
@@ -1,6 +1,6 @@
 {
     "csv_rows": [
-        "person,Day 0,Day 1,Day 2,Day 3,Day 4,Day 5,Day 6,Day 7,Day 8,Day 9,Day 10",
+        "person,Week 0,Week 1,Week 2,Week 3,Week 4,Week 5,Week 6,Week 7,Week 8,Week 9,Week 10",
         "talent1974@yahoo.com,1,1,1,1,1,1,1,1,1,1,0",
         "few2035@protonmail.com,1,1,1,1,1,1,1,1,1,0,0",
         ""
@@ -47,6 +47,43 @@
             }
         ],
         "next": null,
-        "missing_persons": 0
+        "missing_persons": 0,
+        "filters": {
+            "breakdown_attribution_type": "first_touch",
+            "breakdown_normalize_url": false,
+            "breakdown_values": [0],
+            "date_from": "-11d",
+            "display": "ActionsTable",
+            "insight": "RETENTION",
+            "limit": 100,
+            "period": "Week",
+            "retention_type": "retention_first_time",
+            "returning_entity": {
+                "id": "$pageview",
+                "type": "events",
+                "order": null,
+                "name": "$pageview",
+                "custom_name": null,
+                "math": null,
+                "math_property": null,
+                "math_hogql": null,
+                "math_group_type_index": null,
+                "properties": {}
+            },
+            "sampling_factor": "",
+            "target_entity": {
+                "id": "$pageview",
+                "type": "events",
+                "order": null,
+                "name": "$pageview",
+                "custom_name": null,
+                "math": null,
+                "math_property": null,
+                "math_hogql": null,
+                "math_group_type_index": null,
+                "properties": {}
+            },
+            "total_intervals": 11
+        }
     }
 }


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0368RPHLQH/p1702879128504429 - weekly csv exports are labelled as daily

## Changes

This PR adds filters to the response of the persons retention endpoint used in exports and takes these to determine the period.

## How did you test this code?

Ran the export locally