### PR TITLE
fix(insights): small tweaks for advanced options in 3000

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -159,7 +159,7 @@ export function InsightDisplayConfig(): JSX.Element {
                 {advancedOptions.length > 0 && (
                     <LemonMenu items={advancedOptions} closeOnClickInside={false}>
                         <LemonButton size="small" status="stealth">
-                            <span className="font-medium whitespace-nowrap">
+                            <span className="font-medium whitespace-nowrap ligatures-none">
                                 Options{advancedOptionsCount ? ` (${advancedOptionsCount})` : null}
                             </span>
                         </LemonButton>

--- a/frontend/src/scenes/insights/EditorFilters/ShowLegendFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/ShowLegendFilter.tsx
@@ -18,7 +18,7 @@ export function ShowLegendFilter(): JSX.Element | null {
             className="p-1 px-2"
             onChange={toggleShowLegend}
             checked={!!showLegend}
-            label={<span className="font-normal">{showLegend ? 'Hide' : 'Show'} legend</span>}
+            label={<span className="font-normal">Show legend</span>}
             size="small"
         />
     )

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -1140,6 +1140,10 @@ $decorations: underline, overline, line-through, no-underline;
     font-family: var(--font-mono);
 }
 
+.ligatures-none {
+    font-variant-ligatures: none;
+}
+
 .opacity-0 {
     opacity: 0;
 }


### PR DESCRIPTION
## Problem

Matter font ligatures for numbers in brackets don't look good and changing the text for a checkbox doesn't make sense (we don't do so for other options).

## Changes

<img width="267" alt="Screenshot 2023-12-20 at 16 17 01" src="https://github.com/PostHog/posthog/assets/1851359/2f5583e9-f38c-4f02-a947-f97638d834f9">

## How did you test this code?

:eyes: