### PR TITLE
fix: Remove spinner from mark as read button

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
@@ -101,11 +101,7 @@ export const SidePanelActivity = (): JSX.Element => {
 
                             {hasUnread ? (
                                 <div className="flex justify-end mb-2">
-                                    <LemonButton
-                                        type="secondary"
-                                        onClick={() => markAllAsRead()}
-                                        loading={importantChangesLoading}
-                                    >
+                                    <LemonButton type="secondary" onClick={() => markAllAsRead()}>
                                         Mark all as read
                                     </LemonButton>
                                 </div>


### PR DESCRIPTION
## Problem

We had a spinner but it's confusing as it shows immediately as the data is being loaded in the background which gets in the way of the button unncessarily.

## Changes

* Remove the loading prop

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Hard to test as its based on other users but its a simple change