### PR TITLE
feat(web-analytics): Make paths wider and add scroll depth

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -37,6 +37,7 @@ export function loadPostHogJS(): void {
                         posthog.opt_in_capturing()
                     }
                 },
+                __preview_measure_pageview_stats: true,
             })
         )
 

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3490,6 +3490,9 @@
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
                 },
+                "includeScrollDepth": {
+                    "type": "boolean"
+                },
                 "kind": {
                     "const": "WebStatsTableQuery",
                     "type": "string"

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -740,6 +740,7 @@ export interface WebStatsTableQuery extends WebAnalyticsQueryBase {
     kind: NodeKind.WebStatsTableQuery
     breakdownBy: WebStatsBreakdown
     response?: WebStatsTableQueryResponse
+    includeScrollDepth?: boolean
 }
 export interface WebStatsTableQueryResponse extends QueryResponse {
     results: unknown[]

--- a/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
@@ -11,12 +11,12 @@ export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
         return null
     }
 
-    if (statusCheck.shouldWarnAboutNoPageviews) {
+    if (!statusCheck.isSendingPageViews) {
         return (
             <LemonBanner type={'warning'} className={'mt-2'}>
                 <p>
                     No <code>$pageview</code>{' '}
-                    {statusCheck.shouldWarnAboutNoPageleaves ? (
+                    {!statusCheck.isSendingPageLeaves ? (
                         <>
                             or <code>$pageleave</code>{' '}
                         </>
@@ -30,7 +30,7 @@ export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
                 </p>
             </LemonBanner>
         )
-    } else if (statusCheck.shouldWarnAboutNoPageleaves) {
+    } else if (!statusCheck.isSendingPageLeaves) {
         return (
             <LemonBanner type={'warning'} className={'mt-2'}>
                 <p>

--- a/frontend/src/scenes/web-analytics/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsTile.tsx
@@ -174,6 +174,11 @@ export const webAnalyticsDataTableQueryContext: QueryContext = {
             render: NumericCell,
             align: 'right',
         },
+        average_scroll_percentage: {
+            title: 'Average Scroll',
+            render: PercentageCell,
+            align: 'right',
+        },
     },
 }
 

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -94,7 +94,7 @@ const Tiles = (): JSX.Element => {
     const { tiles } = useValues(webAnalyticsLogic)
 
     return (
-        <div className="mt-8 grid grid-cols-1 md:grid-cols-12 gap-x-4 gap-y-10">
+        <div className="mt-8 grid grid-cols-1 md:grid-cols-2 xxl:grid-cols-3 gap-x-4 gap-y-10">
             {tiles.map((tile, i) => {
                 if ('query' in tile) {
                     const { query, title, layout } = tile
@@ -128,7 +128,7 @@ const TabsTileItem = ({ tile }: { tile: TabsTile }): JSX.Element => {
         <WebTabs
             className={clsx(
                 'col-span-1 row-span-1',
-                `md:col-span-${layout.colSpan ?? 6} md:row-span-${layout.rowSpan ?? 1}`,
+                `md:col-span-${layout.colSpan ?? 1} md:row-span-${layout.rowSpan ?? 1}`,
                 layout.className
             )}
             activeTabId={tile.activeTabId}

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -104,6 +104,7 @@ const Tiles = (): JSX.Element => {
                             className={clsx(
                                 'col-span-1 row-span-1 flex flex-col',
                                 `md:col-span-${layout.colSpan ?? 6} md:row-span-${layout.rowSpan ?? 1}`,
+                                `xxl:order-${layout.orderLarge ?? 12}`,
                                 layout.className
                             )}
                         >
@@ -129,6 +130,7 @@ const TabsTileItem = ({ tile }: { tile: TabsTile }): JSX.Element => {
             className={clsx(
                 'col-span-1 row-span-1',
                 `md:col-span-${layout.colSpan ?? 1} md:row-span-${layout.rowSpan ?? 1}`,
+                `xxl:order-${layout.orderLarge ?? 12}`,
                 layout.className
             )}
             activeTabId={tile.activeTabId}

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -30,7 +30,7 @@ import {
 import type { webAnalyticsLogicType } from './webAnalyticsLogicType'
 
 export interface WebTileLayout {
-    colSpan?: number
+    colSpan?: number | 'full'
     rowSpan?: number
     className?: string
 }
@@ -321,7 +321,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 const tiles: (WebDashboardTile | null)[] = [
                     {
                         layout: {
-                            colSpan: 12,
+                            colSpan: 'full',
                         },
                         query: {
                             kind: NodeKind.WebOverviewQuery,
@@ -331,7 +331,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     },
                     {
                         layout: {
-                            colSpan: 6,
+                            colSpan: 1,
                         },
                         activeTabId: graphsTab,
                         setTabId: actions.setGraphsTab,
@@ -431,7 +431,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     },
                     {
                         layout: {
-                            colSpan: 6,
+                            colSpan: 1,
                         },
                         activeTabId: pathTab,
                         setTabId: actions.setPathTab,
@@ -472,7 +472,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     },
                     {
                         layout: {
-                            colSpan: 6,
+                            colSpan: 1,
                         },
                         activeTabId: sourceTab,
                         setTabId: actions.setSourceTab,
@@ -586,15 +586,15 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     },
                     {
                         layout: {
-                            colSpan: 6,
+                            colSpan: 1,
                         },
                         activeTabId: deviceTab,
                         setTabId: actions.setDeviceTab,
                         tabs: [
                             {
                                 id: DeviceTab.DEVICE_TYPE,
-                                title: 'Top Device Types',
-                                linkText: 'Device Type',
+                                title: 'Device types',
+                                linkText: 'Device type',
                                 query: {
                                     kind: NodeKind.InsightVizNode,
                                     source: {
@@ -662,7 +662,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     {
                         title: 'Retention',
                         layout: {
-                            colSpan: 12,
+                            colSpan: 2,
                         },
                         query: {
                             kind: NodeKind.InsightVizNode,
@@ -691,7 +691,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     shouldShowGeographyTile
                         ? {
                               layout: {
-                                  colSpan: 12,
+                                  colSpan: 2,
                               },
                               activeTabId: geographyTab || GeographyTab.MAP,
                               setTabId: actions.setGeographyTab,

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -33,6 +33,7 @@ export interface WebTileLayout {
     colSpan?: number | 'full'
     rowSpan?: number
     className?: string
+    orderLarge?: number
 }
 
 interface BaseTile {
@@ -93,8 +94,8 @@ export enum GeographyTab {
 }
 
 export interface WebAnalyticsStatusCheck {
-    shouldWarnAboutNoPageviews: boolean
-    shouldWarnAboutNoPageleaves: boolean
+    isSendingPageViews: boolean
+    isSendingPageLeaves: boolean
 }
 
 export const GEOIP_PLUGIN_URLS = [
@@ -322,6 +323,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     {
                         layout: {
                             colSpan: 'full',
+                            orderLarge: 0,
                         },
                         query: {
                             kind: NodeKind.WebOverviewQuery,
@@ -331,7 +333,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     },
                     {
                         layout: {
-                            colSpan: 1,
+                            colSpan: 2,
+                            orderLarge: 1,
                         },
                         activeTabId: graphsTab,
                         setTabId: actions.setGraphsTab,
@@ -431,7 +434,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     },
                     {
                         layout: {
-                            colSpan: 1,
+                            colSpan: 2,
+                            orderLarge: 4,
                         },
                         activeTabId: pathTab,
                         setTabId: actions.setPathTab,
@@ -448,6 +452,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         properties: webAnalyticsFilters,
                                         breakdownBy: WebStatsBreakdown.Page,
                                         dateRange,
+                                        includeScrollDepth: true,
                                     },
                                     embedded: false,
                                 },
@@ -464,6 +469,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         properties: webAnalyticsFilters,
                                         breakdownBy: WebStatsBreakdown.InitialPage,
                                         dateRange,
+                                        includeScrollDepth: true,
                                     },
                                     embedded: false,
                                 },
@@ -473,6 +479,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     {
                         layout: {
                             colSpan: 1,
+                            orderLarge: 2,
                         },
                         activeTabId: sourceTab,
                         setTabId: actions.setSourceTab,
@@ -587,6 +594,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     {
                         layout: {
                             colSpan: 1,
+                            orderLarge: 3,
                         },
                         activeTabId: deviceTab,
                         setTabId: actions.setDeviceTab,
@@ -659,39 +667,11 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                         ],
                     },
-                    {
-                        title: 'Retention',
-                        layout: {
-                            colSpan: 2,
-                        },
-                        query: {
-                            kind: NodeKind.InsightVizNode,
-                            source: {
-                                kind: NodeKind.RetentionQuery,
-                                properties: webAnalyticsFilters,
-                                dateRange,
-                                filterTestAccounts: true,
-                                retentionFilter: {
-                                    retention_type: RETENTION_FIRST_TIME,
-                                    retention_reference: 'total',
-                                    total_intervals: isGreaterThanMd ? 8 : 5,
-                                    period: RetentionPeriod.Week,
-                                },
-                            },
-                            vizSpecificOptions: {
-                                [InsightType.RETENTION]: {
-                                    hideLineGraph: true,
-                                    hideSizeColumn: !isGreaterThanMd,
-                                    useSmallLayout: !isGreaterThanMd,
-                                },
-                            },
-                            embedded: true,
-                        },
-                    },
+
                     shouldShowGeographyTile
                         ? {
                               layout: {
-                                  colSpan: 2,
+                                  colSpan: 'full',
                               },
                               activeTabId: geographyTab || GeographyTab.MAP,
                               setTabId: actions.setGeographyTab,
@@ -774,6 +754,35 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                               ],
                           }
                         : null,
+                    {
+                        title: 'Retention',
+                        layout: {
+                            colSpan: 2,
+                        },
+                        query: {
+                            kind: NodeKind.InsightVizNode,
+                            source: {
+                                kind: NodeKind.RetentionQuery,
+                                properties: webAnalyticsFilters,
+                                dateRange,
+                                filterTestAccounts: true,
+                                retentionFilter: {
+                                    retention_type: RETENTION_FIRST_TIME,
+                                    retention_reference: 'total',
+                                    total_intervals: isGreaterThanMd ? 8 : 5,
+                                    period: RetentionPeriod.Week,
+                                },
+                            },
+                            vizSpecificOptions: {
+                                [InsightType.RETENTION]: {
+                                    hideLineGraph: true,
+                                    hideSizeColumn: !isGreaterThanMd,
+                                    useSmallLayout: !isGreaterThanMd,
+                                },
+                            },
+                            embedded: true,
+                        },
+                    },
                 ]
                 return tiles.filter(isNotNil)
             },
@@ -832,12 +841,12 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         ? pageleaveResult.value.results.find((r) => r.name === '$pageleave')
                         : undefined
 
-                const shouldWarnAboutNoPageviews = !pageviewEntry || isDefinitionStale(pageviewEntry)
-                const shouldWarnAboutNoPageleaves = !pageleaveEntry || isDefinitionStale(pageleaveEntry)
+                const isSendingPageViews = !!pageviewEntry && !isDefinitionStale(pageviewEntry)
+                const isSendingPageLeaves = !!pageleaveEntry && !isDefinitionStale(pageleaveEntry)
 
                 return {
-                    shouldWarnAboutNoPageviews,
-                    shouldWarnAboutNoPageleaves,
+                    isSendingPageViews,
+                    isSendingPageLeaves,
                 }
             },
         },

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -467,6 +467,10 @@ input::-ms-clear {
     &.main-app-content--container {
         align-self: center;
         max-width: 72rem;
+
+        @include screen($xxl) {
+            max-width: 108rem;
+        }
     }
 
     @include screen($sm) {

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -854,6 +854,13 @@ $decorations: underline, overline, line-through, no-underline;
                 row-gap: #{$space * 0.25}rem;
             }
         }
+
+        // Order
+        @for $i from 1 through 12 {
+            .#{$prefix}order-#{$i} {
+                order: #{$i};
+            }
+        }
     }
 }
 

--- a/posthog/hogql_queries/web_analytics/ctes.py
+++ b/posthog/hogql_queries/web_analytics/ctes.py
@@ -4,7 +4,7 @@
 
 PATHNAME_SCROLL_CTE = """
 SELECT
-    events.properties.`$prev_pageview_pathname` AS $pathname,
+    events.properties.`$prev_pageview_pathname` AS pathname,
     avg(CASE
         WHEN toFloat(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage')) IS NULL THEN NULL
         WHEN toFloat(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage')) > 0.8 THEN 100
@@ -16,7 +16,7 @@ FROM
 WHERE
     (event = '$pageview' OR event = '$pageleave') AND events.properties.`$prev_pageview_pathname` IS NOT NULL
     AND ({pathname_scroll_where})
-GROUP BY $pathname
+GROUP BY pathname
 """
 
 COUNTS_CTE = """

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -4,6 +4,7 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.hogql_queries.web_analytics.ctes import (
     COUNTS_CTE,
     BOUNCE_RATE_CTE,
+    PATHNAME_SCROLL_CTE,
 )
 from posthog.hogql_queries.web_analytics.web_analytics_query_runner import (
     WebAnalyticsQueryRunner,
@@ -45,20 +46,35 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner):
                 },
                 backend="cpp",
             )
-        with self.timings.measure("top_pages_query"):
-            top_sources_query = parse_select(
+        if self.query.includeScrollDepth:
+            with self.timings.measure("scroll_depth_query"):
+                scroll_depth_query = parse_select(
+                    PATHNAME_SCROLL_CTE,
+                    timings=self.timings,
+                    placeholders={
+                        "pathname_scroll_where": self.events_where(),
+                        "breakdown_by": self.counts_breakdown(),
+                    },
+                    backend="cpp",
+                )
+            return parse_select(
                 """
 SELECT
     counts.breakdown_value as "context.columns.breakdown_value",
     counts.total_pageviews as "context.columns.views",
     counts.unique_visitors as "context.columns.visitors",
-    bounce_rate.bounce_rate as "context.columns.bounce_rate"
+    bounce_rate.bounce_rate as "context.columns.bounce_rate",
+    scroll_depth.average_scroll_percentage as "context.columns.average_scroll_percentage"
 FROM
     {counts_query} AS counts
 LEFT OUTER JOIN
     {bounce_rate_query} AS bounce_rate
 ON
     counts.breakdown_value = bounce_rate.breakdown_value
+LEFT OUTER JOIN
+    {scroll_depth_query} AS scroll_depth
+ON
+    counts.breakdown_value = scroll_depth.pathname
 WHERE
     {where_breakdown}
 ORDER BY
@@ -70,11 +86,41 @@ LIMIT 10
                 placeholders={
                     "counts_query": counts_query,
                     "bounce_rate_query": bounce_rate_query,
+                    "scroll_depth_query": scroll_depth_query,
                     "where_breakdown": self.where_breakdown(),
                 },
                 backend="cpp",
             )
-        return top_sources_query
+        else:
+            with self.timings.measure("stats_table_query"):
+                return parse_select(
+                    """
+    SELECT
+        counts.breakdown_value as "context.columns.breakdown_value",
+        counts.total_pageviews as "context.columns.views",
+        counts.unique_visitors as "context.columns.visitors",
+        bounce_rate.bounce_rate as "context.columns.bounce_rate"
+    FROM
+        {counts_query} AS counts
+    LEFT OUTER JOIN
+        {bounce_rate_query} AS bounce_rate
+    ON
+        counts.breakdown_value = bounce_rate.breakdown_value
+    WHERE
+        {where_breakdown}
+    ORDER BY
+        "context.columns.views" DESC,
+        "context.columns.breakdown_value" DESC
+    LIMIT 10
+                    """,
+                    timings=self.timings,
+                    placeholders={
+                        "counts_query": counts_query,
+                        "bounce_rate_query": bounce_rate_query,
+                        "where_breakdown": self.where_breakdown(),
+                    },
+                    backend="cpp",
+                )
 
     def calculate(self):
         response = execute_hogql_query(

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1097,6 +1097,7 @@ class WebStatsTableQuery(BaseModel):
     )
     breakdownBy: WebStatsBreakdown
     dateRange: Optional[DateRange] = None
+    includeScrollDepth: Optional[bool] = None
     kind: Literal["WebStatsTableQuery"] = "WebStatsTableQuery"
     properties: List[Union[EventPropertyFilter, PersonPropertyFilter]]
     response: Optional[WebStatsTableQueryResponse] = None


### PR DESCRIPTION
## Problem

Joke answer: I got sniped by @benjackwhite https://posthog.slack.com/archives/C05LJK1N3CP/p1703082213619949?thread_ts=1703081449.990729&cid=C05LJK1N3CP

Real answer: a customer asked for scroll depth, it's something we've been meaning to add for a while anyway.

## Changes

* Add a scroll depth enabled version of the stats query, and use that for path and initial path
* Add a 3-tile layout for web analytics with xxl viewports
* Make the paths table double-width

In the example below, only /web actually has scroll depth data, as that's my usage, and generate_demo_data doesn't add it. But you can see what the wide layout will look like.
<img width="1679" alt="Screenshot 2023-12-20 at 16 25 34" src="https://github.com/PostHog/posthog/assets/2056078/58fd1fb7-84c3-4069-bc46-33b2d5d68ce2">

## How did you test this code?

Very manually for now
