### PR TITLE
fix: allow disabling matching events query

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -194,6 +194,7 @@ export const FEATURE_FLAGS = {
     YEAR_IN_HOG: 'year-in-hog', // owner: #team-replay
     SESSION_REPLAY_EXPORT_MOBILE_DATA: 'session-replay-export-mobile-data', // owner: #team-replay
     REDIRECT_INGESTION_PRODUCT_ANALYTICS_ONBOARDING: 'redirect-ingestion-product-analytics-onboarding', // owner: @biancayang
+    DISABLE_MATCHING_EVENTS_API_CALL: 'disable-matching-events-api-call', // owner: @pauldambra
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 


### PR DESCRIPTION
see inc-2023-12-20-eu-ch-nodes-oom-and-unresponsive

The query behind this API call is causing an OOM error in ClickHouse. We can't tell if this is a symptom or a cause.

Allow disabling by flag