### PR TITLE
fix: rows synced doesn't exist

### DIFF
--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -147,12 +147,12 @@ def set_org_usage_summary(
     new_usage = copy.deepcopy(new_usage)
 
     for field in ["events", "recordings", "rows_synced"]:
-        resource_usage = new_usage.get(field, None)
+        resource_usage = new_usage.get(field, {"limit": None, "usage": 0, "todays_usage": 0})
         if not resource_usage:
             continue
 
         if todays_usage:
-            resource_usage["todays_usage"] = todays_usage.get(field, None)
+            resource_usage["todays_usage"] = todays_usage.get(field, 0)
         else:
             # TRICKY: If we are not explictly setting todays_usage, we want to reset it to 0 IF the incoming new_usage is different
             if (organization.usage or {}).get(field, {}).get("usage") != resource_usage.get("usage"):

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -147,12 +147,12 @@ def set_org_usage_summary(
     new_usage = copy.deepcopy(new_usage)
 
     for field in ["events", "recordings", "rows_synced"]:
-        resource_usage = new_usage[field]  # type: ignore
+        resource_usage = new_usage.get(field, None)
         if not resource_usage:
             continue
 
         if todays_usage:
-            resource_usage["todays_usage"] = todays_usage[field]  # type: ignore
+            resource_usage["todays_usage"] = todays_usage.get(field, None)
         else:
             # TRICKY: If we are not explictly setting todays_usage, we want to reset it to 0 IF the incoming new_usage is different
             if (organization.usage or {}).get(field, {}).get("usage") != resource_usage.get("usage"):


### PR DESCRIPTION
## Problem

I noticed a few days ago (and then forgot 😬 ) that we are getting a ton of errors for missing `rows_synced` key. https://posthog.sentry.io/issues/4640389037/?project=1899813&query=is:unresolved+!url:http://billing.dev.posthog.dev+usage&statsPeriod=14d&stream_index=0

Then today Cameron found [this](https://posthog.slack.com/archives/C04866B8W2J/p1703119153183339), which led me down a rabbit hole to realize that orgs aren't getting properly quota limited. Someone's billing limit will be set, but they are still accruing usage (and not being charged for it, thankfully).

I'm wondering if this is the culprit. I don't really know if my fix here is the right solution... does the key not exist in the usage record because it doesn't exist in billing?

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

`.get()`s the key instead of assuming it's there.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
