### PR TITLE
feat(web-analytics): Add deep scroll rate

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsTile.tsx
@@ -179,6 +179,11 @@ export const webAnalyticsDataTableQueryContext: QueryContext = {
             render: PercentageCell,
             align: 'right',
         },
+        scroll_gt80_percentage: {
+            title: 'Deep Scroll Rate',
+            render: PercentageCell,
+            align: 'right',
+        },
     },
 }
 

--- a/posthog/hogql_queries/web_analytics/ctes.py
+++ b/posthog/hogql_queries/web_analytics/ctes.py
@@ -7,7 +7,7 @@ SELECT
     events.properties.`$prev_pageview_pathname` AS pathname,
     avg(CASE
         WHEN toFloat(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage')) IS NULL THEN NULL
-        WHEN toFloat(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage')) > 0.8 THEN 100
+        WHEN toFloat(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage')) > 0.8 THEN 1
         ELSE 0
     END) AS scroll_gt80_percentage,
     avg(toFloat(JSONExtractRaw(events.properties, '$prev_pageview_max_scroll_percentage'))) as average_scroll_percentage

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -64,7 +64,8 @@ SELECT
     counts.total_pageviews as "context.columns.views",
     counts.unique_visitors as "context.columns.visitors",
     bounce_rate.bounce_rate as "context.columns.bounce_rate",
-    scroll_depth.average_scroll_percentage as "context.columns.average_scroll_percentage"
+    scroll_depth.average_scroll_percentage as "context.columns.average_scroll_percentage",
+    scroll_depth.scroll_gt80_percentage as "context.columns.scroll_gt80_percentage"
 FROM
     {counts_query} AS counts
 LEFT OUTER JOIN


### PR DESCRIPTION
## Problem

Continue https://github.com/PostHog/posthog/pull/19458

## Changes

* Add % of users who scrolled enough to see 80% of the content on a page, or "deep scroll rate"
* Hide scroll depth for users who've never sent us the relevant properties

## How did you test this code?

Just manually, but it'll only be enabled on posthog for now
