### PR TITLE
fix(tooltips): fix tooltips on dashboards

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -166,7 +166,6 @@ export const LineGraph = (): JSX.Element => {
                         tooltipEl.classList.remove('above', 'below', 'no-transform')
                         tooltipEl.classList.add(tooltip.yAlign || 'no-transform')
                         tooltipEl.style.opacity = '1'
-                        tooltipEl.style.display = 'initial'
 
                         if (tooltip.body) {
                             const referenceDataPoint = tooltip.dataPoints[0] // Use this point as reference to get the date
@@ -225,8 +224,8 @@ export const LineGraph = (): JSX.Element => {
                                 ? chartClientLeft + tooltip.caretX - tooltipEl.clientWidth - 8 // If tooltip is too large (or close to the edge), show it to the left of the data point instead
                                 : defaultOffsetLeft
 
-                        tooltipEl.style.top = Math.min(tooltipClientTop, window.innerHeight) + 'px'
-                        tooltipEl.style.left = Math.min(tooltipClientLeft, window.innerWidth) + 'px'
+                        tooltipEl.style.top = tooltipClientTop + 'px'
+                        tooltipEl.style.left = tooltipClientLeft + 'px'
                     },
                 },
             },

--- a/frontend/src/scenes/funnels/useFunnelTooltip.tsx
+++ b/frontend/src/scenes/funnels/useFunnelTooltip.tsx
@@ -112,9 +112,6 @@ export function useFunnelTooltip(showPersonsModal: boolean): React.RefObject<HTM
         const svgRect = vizRef.current?.getBoundingClientRect()
         const [tooltipRoot, tooltipEl] = ensureTooltip()
         tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
-        if (isTooltipShown) {
-            tooltipEl.style.display = 'initial'
-        }
         const tooltipRect = tooltipEl.getBoundingClientRect()
         if (tooltipOrigin) {
             tooltipRoot.render(

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -43,9 +43,6 @@ function useBoldNumberTooltip({
 
     useLayoutEffect(() => {
         tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
-        if (isTooltipShown) {
-            tooltipEl.style.display = 'initial'
-        }
 
         const seriesResult = insightData?.result?.[0]
 
@@ -73,10 +70,10 @@ function useBoldNumberTooltip({
     useEffect(() => {
         const tooltipRect = tooltipEl.getBoundingClientRect()
         if (divRect) {
-            const desiredTop = window.scrollY + divRect.top - tooltipRect.height - BOLD_NUMBER_TOOLTIP_OFFSET_PX
-            const desiredLeft = divRect.left + divRect.width / 2 - tooltipRect.width / 2
-            tooltipEl.style.top = `${Math.min(desiredTop, window.innerHeight)}px`
-            tooltipEl.style.left = `${Math.min(desiredLeft, window.innerWidth)}px`
+            tooltipEl.style.top = `${
+                window.scrollY + divRect.top - tooltipRect.height - BOLD_NUMBER_TOOLTIP_OFFSET_PX
+            }px`
+            tooltipEl.style.left = `${divRect.left + divRect.width / 2 - tooltipRect.width / 2}px`
         }
     })
 

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -51,7 +51,6 @@ export function ensureTooltip(): [Root, HTMLElement] {
             tooltipEl = document.createElement('div')
             tooltipEl.id = 'InsightTooltipWrapper'
             tooltipEl.classList.add('InsightTooltipWrapper')
-            tooltipEl.style.display = 'none'
             document.body.appendChild(tooltipEl)
         }
 
@@ -461,7 +460,6 @@ export function LineGraph_({
                         tooltipEl.classList.remove('above', 'below', 'no-transform')
                         tooltipEl.classList.add(tooltip.yAlign || 'no-transform')
                         tooltipEl.style.opacity = '1'
-                        tooltipEl.style.display = 'initial'
 
                         if (tooltip.body) {
                             const referenceDataPoint = tooltip.dataPoints[0] // Use this point as reference to get the date
@@ -549,8 +547,8 @@ export function LineGraph_({
                                 ? chartClientLeft + tooltip.caretX - tooltipEl.clientWidth - 8 // If tooltip is too large (or close to the edge), show it to the left of the data point instead
                                 : defaultOffsetLeft
 
-                        tooltipEl.style.top = Math.min(tooltipClientTop, window.innerHeight) + 'px'
-                        tooltipEl.style.left = Math.min(tooltipClientLeft, window.innerWidth) + 'px'
+                        tooltipEl.style.top = tooltipClientTop + 'px'
+                        tooltipEl.style.left = tooltipClientLeft + 'px'
                     },
                 },
                 ...(!isBar

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -203,7 +203,6 @@ export function PieChart({
                             tooltipEl.classList.remove('above', 'below', 'no-transform')
                             tooltipEl.classList.add(tooltip.yAlign || 'no-transform')
                             tooltipEl.style.opacity = '1'
-                            tooltipEl.style.display = 'initial'
 
                             if (tooltip.body) {
                                 const referenceDataPoint = tooltip.dataPoints[0] // Use this point as reference to get the date

--- a/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
@@ -36,9 +36,6 @@ function useWorldMapTooltip(showPersonsModal: boolean): React.RefObject<SVGSVGEl
 
     useEffect(() => {
         tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
-        if (isTooltipShown) {
-            tooltipEl.style.display = 'initial'
-        }
 
         if (tooltipCoordinates) {
             tooltipRoot.render(


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/19381 the tooltip isn't displayed when scrolling beyond the screen height.

## Changes

This PR reverts https://github.com/PostHog/posthog/pull/17906, which fixes the issue mentioned above. We all (@robbie-c , @benjackwhite and me haven't been able to reproduce the orginal issue any more. I think it might have been fixed with the React 18 upgrade and moving parts from layoutEffect to effect https://github.com/PostHog/posthog/commit/6070407dfa300ca8c429014b7aa8c528a568f8b9#diff-4e9ee68aa367eb18f567f0152f03571e91b57fb6a8d614644b4ad5669a735e52.

## How did you test this code?

Tested on a shared dashboard