### PR TITLE
feat: Move web analytics to segmented button

### DIFF
--- a/frontend/src/scenes/web-analytics/WebTabs.tsx
+++ b/frontend/src/scenes/web-analytics/WebTabs.tsx
@@ -1,4 +1,4 @@
-import { LemonSelect, LemonTabs } from '@posthog/lemon-ui'
+import { LemonSegmentedButton, LemonSelect } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import React from 'react'
 
@@ -29,12 +29,11 @@ export const WebTabs = ({
                         options={tabs.map(({ id, linkText }) => ({ value: id, label: linkText }))}
                     />
                 ) : (
-                    <LemonTabs
-                        inline
-                        borderless
-                        activeKey={activeTabId}
-                        onChange={setActiveTabId}
-                        tabs={tabs.map(({ id, linkText }) => ({ key: id, label: linkText }))}
+                    <LemonSegmentedButton
+                        size="small"
+                        options={tabs.map(({ id, linkText }) => ({ label: linkText, value: id }))}
+                        onChange={(value) => setActiveTabId(value)}
+                        value={activeTabId}
                     />
                 )}
             </div>


### PR DESCRIPTION
## Problem

Trying to work with LemonTabs stylings and it started to feel clear that were using it in the wrong place.

## Changes

* Change web analytics to use the new segmented button which fits the theme much better

|Before|After|
|----|----|
| <img width="1356" alt="Screenshot 2023-12-21 at 12 29 49" src="https://github.com/PostHog/posthog/assets/2536520/98b0e1d3-bcb6-4205-8b40-6c26afbc987c"> | <img width="1354" alt="Screenshot 2023-12-21 at 12 29 01" src="https://github.com/PostHog/posthog/assets/2536520/e7b3244f-8b1d-47fb-b5be-bd8c2b38b9bf"> |



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
