### PR TITLE
chore: remove lemon tab params

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivity.tsx
@@ -121,7 +121,6 @@ export const SidePanelActivity = (): JSX.Element => {
             <div className="flex flex-col overflow-hidden flex-1">
                 <div className="shrink-0 mx-2">
                     <LemonTabs
-                        inline
                         activeKey={activeTab as SidePanelActivityTab}
                         onChange={(key) => setActiveTab(key)}
                         tabs={[
@@ -138,7 +137,7 @@ export const SidePanelActivity = (): JSX.Element => {
                 </div>
 
                 {/* Controls */}
-                <div className="shrink-0 space-y-2 p-2">
+                <div className="shrink-0 space-y-2 px-2 pb-2">
                     {activeTab === SidePanelActivityTab.Unread ? (
                         <>
                             <LemonBanner type="info" dismissKey="notifications-introduction">

--- a/frontend/src/lib/lemon-ui/LemonTabs/LemonTabs.scss
+++ b/frontend/src/lib/lemon-ui/LemonTabs/LemonTabs.scss
@@ -13,10 +13,6 @@
         margin-top: -0.75rem;
     }
 
-    &.LemonTabs--inline {
-        --lemon-tabs-margin-bottom: 0;
-    }
-
     .LemonTabs__bar {
         position: relative;
         display: flex;

--- a/frontend/src/lib/lemon-ui/LemonTabs/LemonTabs.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTabs/LemonTabs.tsx
@@ -29,7 +29,6 @@ export interface LemonTabsProps<T extends string | number> {
     onChange?: (key: T) => void
     /** List of tabs. Falsy entries are ignored - they're there to make conditional tabs convenient. */
     tabs: (LemonTab<T> | null | false)[]
-    inline?: boolean
     'data-attr'?: string
 }
 
@@ -54,7 +53,6 @@ export function LemonTabs<T extends string | number>({
     activeKey,
     onChange,
     tabs,
-    inline = false,
     'data-attr': dataAttr,
 }: LemonTabsProps<T>): JSX.Element {
     const { containerRef, selectionRef, sliderWidth, sliderOffset, transitioning } = useSliderPositioning<
@@ -68,7 +66,7 @@ export function LemonTabs<T extends string | number>({
 
     return (
         <div
-            className={clsx('LemonTabs', transitioning && 'LemonTabs--transitioning', inline && 'LemonTabs--inline')}
+            className={clsx('LemonTabs', transitioning && 'LemonTabs--transitioning')}
             // eslint-disable-next-line react/forbid-dom-props
             style={
                 {


### PR DESCRIPTION
## Problem

Because we no longer require the `inline` prop thanks to https://github.com/PostHog/posthog/pull/19475 we can just remove it

## Changes

- Remove `inline` prop from `LemonTabs`
- Replace `LemonTabs` with `LemonSegmentedButtons`

## How did you test this code?

Made sure it wasn't in use anywhere