### PR TITLE
fix(trends): fix "other" misalignment

### DIFF
--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -19,7 +19,7 @@
     AND notEmpty(e.person_id)
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -160,7 +160,7 @@
     AND notEmpty(e.person_id)
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -299,7 +299,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -437,7 +437,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -572,7 +572,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -707,7 +707,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -842,7 +842,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -979,7 +979,7 @@
     AND notEmpty(e.person_id)
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1120,7 +1120,7 @@
     AND notEmpty(e.person_id)
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1259,7 +1259,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1397,7 +1397,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1510,7 +1510,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1623,7 +1623,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1736,7 +1736,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1851,7 +1851,7 @@
     AND notEmpty(e.person_id)
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1992,7 +1992,7 @@
     AND notEmpty(e.person_id)
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -2131,7 +2131,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -2269,7 +2269,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -2292,7 +2292,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -2315,7 +2315,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -2547,7 +2547,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -2570,7 +2570,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -2593,7 +2593,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -2825,7 +2825,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -2848,7 +2848,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -2871,7 +2871,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -3103,7 +3103,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -3126,7 +3126,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -3149,7 +3149,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---

--- a/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
@@ -19,7 +19,7 @@
           OR NOT JSONHas(group_properties_0, 'out')))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 5
+  LIMIT 6
   OFFSET 0
   '
 ---
@@ -44,7 +44,7 @@
           OR NOT JSONHas(group_properties_0, 'out')))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 5
+  LIMIT 6
   OFFSET 0
   '
 ---
@@ -74,7 +74,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 5
+  LIMIT 6
   OFFSET 0
   '
 ---
@@ -104,7 +104,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 5
+  LIMIT 6
   OFFSET 0
   '
 ---
@@ -142,7 +142,7 @@
           OR has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', ''))))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 5
+  LIMIT 6
   OFFSET 0
   '
 ---
@@ -167,7 +167,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -206,7 +206,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -245,7 +245,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---

--- a/ee/clickhouse/queries/test/test_breakdown_props.py
+++ b/ee/clickhouse/queries/test/test_breakdown_props.py
@@ -94,7 +94,7 @@ class TestBreakdownProps(ClickhouseTestMixin, APIBaseTest):
                 "count(*)",
                 self.team,
             )
-            self.assertEqual(res, ["test"])
+            self.assertEqual(res[0], ["test"])
 
     def test_breakdown_person_props_with_entity_filter(self):
         _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"$browser": "test"})
@@ -150,7 +150,7 @@ class TestBreakdownProps(ClickhouseTestMixin, APIBaseTest):
                     }
                 )
                 res = get_breakdown_prop_values(filter, Entity(entity_params[0]), "count(*)", self.team)
-                self.assertEqual(res, ["test"])
+                self.assertEqual(res[0], ["test"])
 
     @snapshot_clickhouse_queries
     def test_breakdown_person_props_with_entity_filter_and_or_props_with_partial_pushdown(self):
@@ -243,7 +243,7 @@ class TestBreakdownProps(ClickhouseTestMixin, APIBaseTest):
                     }
                 )
                 res = sorted(get_breakdown_prop_values(filter, Entity(entity_params[0]), "count(*)", self.team))
-                self.assertEqual(res, ["test", "test2"])
+                self.assertEqual(res[0], ["test", "test2"])
 
     @snapshot_clickhouse_queries
     def test_breakdown_group_props(self):
@@ -319,7 +319,7 @@ class TestBreakdownProps(ClickhouseTestMixin, APIBaseTest):
             team=self.team,
         )
         result = get_breakdown_prop_values(filter, filter.entities[0], "count(*)", self.team)
-        self.assertEqual(result, ["finance", "technology"])
+        self.assertEqual(result[0], ["finance", "technology"])
 
         filter = Filter(
             data={
@@ -345,7 +345,7 @@ class TestBreakdownProps(ClickhouseTestMixin, APIBaseTest):
             }
         )
         result = get_breakdown_prop_values(filter, filter.entities[0], "count(*)", self.team)
-        self.assertEqual(result, ["finance", "technology"])
+        self.assertEqual(result[0], ["finance", "technology"])
 
     @snapshot_clickhouse_queries
     def test_breakdown_session_props(self):
@@ -397,7 +397,7 @@ class TestBreakdownProps(ClickhouseTestMixin, APIBaseTest):
             }
         )
         result = get_breakdown_prop_values(filter, filter.entities[0], "count(*)", self.team)
-        self.assertEqual(result, [70, 20])
+        self.assertEqual(result[0], [70, 20])
 
     @snapshot_clickhouse_queries
     def test_breakdown_with_math_property_session(self):
@@ -511,10 +511,10 @@ class TestBreakdownProps(ClickhouseTestMixin, APIBaseTest):
         result = get_breakdown_prop_values(filter, filter.entities[0], aggregate_operation, self.team)
         # test should come first, based on aggregate operation, even if absolute count of events for
         # mac is higher
-        self.assertEqual(result, ["test", "mac"])
+        self.assertEqual(result[0], ["test", "mac"])
 
         result = get_breakdown_prop_values(filter, filter.entities[0], "count(*)", self.team)
-        self.assertEqual(result, ["mac", "test"])
+        self.assertEqual(result[0], ["mac", "test"])
 
 
 @pytest.mark.parametrize(

--- a/ee/clickhouse/queries/test/test_breakdown_props.py
+++ b/ee/clickhouse/queries/test/test_breakdown_props.py
@@ -242,8 +242,8 @@ class TestBreakdownProps(ClickhouseTestMixin, APIBaseTest):
                         "funnel_window_days": 14,
                     }
                 )
-                res = sorted(get_breakdown_prop_values(filter, Entity(entity_params[0]), "count(*)", self.team))
-                self.assertEqual(res[0], ["test", "test2"])
+                res = sorted(get_breakdown_prop_values(filter, Entity(entity_params[0]), "count(*)", self.team)[0])
+                self.assertEqual(res, ["test", "test2"])
 
     @snapshot_clickhouse_queries
     def test_breakdown_group_props(self):

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
@@ -22,7 +22,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -83,7 +83,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -10,7 +10,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -212,7 +212,7 @@
     AND toTimeZone(timestamp, 'Europe/Amsterdam') <= toDateTime('2020-01-06 10:00:00', 'Europe/Amsterdam')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -414,7 +414,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -616,7 +616,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -819,7 +819,7 @@
     AND (has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', '')))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -883,7 +883,7 @@
          AND has(['a-b-test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag'), '^"|"$', '')))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1111,7 +1111,7 @@
     AND (has(['control', 'test_1', 'test_2', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', '')))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1175,7 +1175,7 @@
          AND has(['a-b-test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag'), '^"|"$', '')))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1296,7 +1296,7 @@
     AND (has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', '')))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1360,7 +1360,7 @@
          AND has(['a-b-test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag'), '^"|"$', '')))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1589,7 +1589,7 @@
          AND (ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'hogql'), ''), 'null'), '^"|"$', ''), 'true'), 0)))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1654,7 +1654,7 @@
          AND has(['a-b-test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag'), '^"|"$', '')))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -225,7 +225,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -398,7 +398,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -511,7 +511,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -25,7 +25,7 @@
     AND (and(ifNull(less(toInt64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', '')), 10), 0), 1))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -258,7 +258,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -319,7 +319,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---

--- a/posthog/queries/breakdown_props.py
+++ b/posthog/queries/breakdown_props.py
@@ -50,7 +50,7 @@ def get_breakdown_prop_values(
     column_optimizer: Optional[ColumnOptimizer] = None,
     person_properties_mode: PersonPropertiesMode = PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
     use_all_funnel_entities: bool = False,
-):
+) -> (List[str], bool):
     """
     Returns the top N breakdown prop values for event/person breakdown
 
@@ -216,7 +216,7 @@ def get_breakdown_prop_values(
         elements_query,
         {
             "key": filter.breakdown,
-            "limit": filter.breakdown_limit_or_default,
+            "limit": filter.breakdown_limit_or_default + 1,
             "team_id": team.pk,
             "offset": filter.offset,
             "timezone": team.timezone,
@@ -236,9 +236,11 @@ def get_breakdown_prop_values(
     )
 
     if filter.using_histogram:
-        return response[0][0]
+        return response[0][0], False
     else:
-        return [row[0] for row in response]
+        return [row[0] for row in response[0 : filter.breakdown_limit_or_default]], len(
+            response
+        ) > filter.breakdown_limit_or_default
 
 
 def _to_value_expression(

--- a/posthog/queries/breakdown_props.py
+++ b/posthog/queries/breakdown_props.py
@@ -50,7 +50,7 @@ def get_breakdown_prop_values(
     column_optimizer: Optional[ColumnOptimizer] = None,
     person_properties_mode: PersonPropertiesMode = PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
     use_all_funnel_entities: bool = False,
-) -> Tuple[List[str], bool]:
+) -> Tuple[List[Any], bool]:
     """
     Returns the top N breakdown prop values for event/person breakdown
 

--- a/posthog/queries/breakdown_props.py
+++ b/posthog/queries/breakdown_props.py
@@ -50,7 +50,7 @@ def get_breakdown_prop_values(
     column_optimizer: Optional[ColumnOptimizer] = None,
     person_properties_mode: PersonPropertiesMode = PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
     use_all_funnel_entities: bool = False,
-) -> (List[str], bool):
+) -> Tuple[List[str], bool]:
     """
     Returns the top N breakdown prop values for event/person breakdown
 

--- a/posthog/queries/funnels/base.py
+++ b/posthog/queries/funnels/base.py
@@ -862,7 +862,7 @@ class ClickhouseFunnelBase(ABC):
             ):
                 target_entity = self._filter.entities[self._filter.breakdown_attribution_value]
 
-            return get_breakdown_prop_values(
+            values, has_more_values = get_breakdown_prop_values(
                 self._filter,
                 target_entity,
                 "count(*)",
@@ -871,6 +871,7 @@ class ClickhouseFunnelBase(ABC):
                 use_all_funnel_entities=use_all_funnel_entities,
                 person_properties_mode=get_person_properties_mode(self._team),
             )
+            return values
 
         return None
 

--- a/posthog/queries/funnels/base.py
+++ b/posthog/queries/funnels/base.py
@@ -834,7 +834,7 @@ class ClickhouseFunnelBase(ABC):
             ON events.distinct_id = cohort_join.distinct_id
         """
 
-    def _get_breakdown_conditions(self) -> Optional[str]:
+    def _get_breakdown_conditions(self) -> Optional[List[str]]:
         """
         For people, pagination sets the offset param, which is common across filters
         and gives us the wrong breakdown values here, so we override it.

--- a/posthog/queries/funnels/test/__snapshots__/test_breakdowns_by_current_url.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_breakdowns_by_current_url.ambr
@@ -12,7 +12,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 100
+  LIMIT 101
   OFFSET 0
   '
 ---
@@ -104,7 +104,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 100
+  LIMIT 101
   OFFSET 0
   '
 ---

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -1021,7 +1021,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1111,7 +1111,7 @@
     AND (has(['xyz'], replaceRegexpAll(JSONExtractRaw(e.properties, '$version'), '^"|"$', '')))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1204,7 +1204,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -10,7 +10,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -97,7 +97,7 @@
     AND (has(['xyz'], replaceRegexpAll(JSONExtractRaw(e.properties, '$version'), '^"|"$', '')))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -187,7 +187,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -10,7 +10,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -26,7 +26,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -159,7 +159,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -175,7 +175,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -316,7 +316,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -332,7 +332,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -169,7 +169,7 @@
     AND notEmpty(e.person_id)
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -279,7 +279,7 @@
     AND notEmpty(e.person_id)
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -353,7 +353,7 @@
          AND (has(['Mac'], replaceRegexpAll(JSONExtractRaw(e.properties, '$os'), '^"|"$', ''))))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -420,7 +420,7 @@
          AND (has(['Mac'], replaceRegexpAll(JSONExtractRaw(e.properties, '$os'), '^"|"$', ''))))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -451,7 +451,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-11 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -497,7 +497,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-11 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -563,7 +563,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -682,7 +682,7 @@
     AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -780,7 +780,7 @@
     AND notEmpty(e.person_id)
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -857,7 +857,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -925,7 +925,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1244,7 +1244,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1356,7 +1356,7 @@
     AND notEmpty(e.person_id)
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1494,7 +1494,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -1593,7 +1593,7 @@
     AND notEmpty(e.person_id)
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -2257,7 +2257,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -2459,7 +2459,7 @@
     AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 23:59:59', 'America/Phoenix')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -2661,7 +2661,7 @@
     AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 23:59:59', 'Asia/Tokyo')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -3297,7 +3297,7 @@
           OR (has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', '')))))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -3407,7 +3407,7 @@
     AND ((has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', ''))))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -3578,7 +3578,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -3737,7 +3737,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -3850,7 +3850,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -3933,7 +3933,7 @@
     AND notEmpty(e.person_id)
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -4019,7 +4019,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -4076,7 +4076,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -4308,7 +4308,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -4516,7 +4516,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -4735,7 +4735,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -4826,7 +4826,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -440,7 +440,7 @@ class TrendsBreakdown:
         return params, breakdown_filter, breakdown_filter_params, "value"
 
     def _breakdown_prop_params(self, aggregate_operation: str, math_params: Dict):
-        values_arr = get_breakdown_prop_values(
+        values_arr, has_more_values = get_breakdown_prop_values(
             self.filter,
             self.entity,
             aggregate_operation,
@@ -490,7 +490,7 @@ class TrendsBreakdown:
 
         return (
             {
-                "values": values_arr,
+                "values": [*values_arr, breakdown_other_value] if has_more_values else values_arr,
                 "breakdown_other_value": breakdown_other_value,
                 "breakdown_null_value": breakdown_null_value,
             },

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -490,7 +490,9 @@ class TrendsBreakdown:
 
         return (
             {
-                "values": [*values_arr, breakdown_other_value] if has_more_values else values_arr,
+                "values": [*values_arr, breakdown_other_value]
+                if has_more_values and not self.filter.breakdown_hide_other_aggregation
+                else values_arr,
                 "breakdown_other_value": breakdown_other_value,
                 "breakdown_null_value": breakdown_null_value,
             },

--- a/posthog/queries/trends/test/__snapshots__/test_breakdowns.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_breakdowns.ambr
@@ -152,7 +152,7 @@
     AND (sessions.session_duration > 30.0)
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -233,7 +233,7 @@
     AND (NOT has(['https://test.com'], replaceRegexpAll(JSONExtractRaw(e.properties, '$current_url'), '^"|"$', '')))
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -450,7 +450,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -666,7 +666,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 2
+  LIMIT 3
   OFFSET 0
   '
 ---
@@ -693,13 +693,13 @@
            CROSS JOIN
              (SELECT breakdown_value
               FROM
-                (SELECT [1, 2] as breakdown_value) ARRAY
+                (SELECT [9007199254740990, 19, 9007199254740991] as breakdown_value) ARRAY
               JOIN breakdown_value) as sec
            ORDER BY breakdown_value,
                     day_start
            UNION ALL SELECT count(*) as total,
                             toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
-                            transform(ifNull(length(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', '')), 9007199254740990), ([9007199254740990, 19]), ([9007199254740990, 19]), 9007199254740991) as breakdown_value
+                            transform(ifNull(length(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', '')), 9007199254740990), ([9007199254740990, 19, 9007199254740991]), ([9007199254740990, 19, 9007199254740991]), 9007199254740991) as breakdown_value
            FROM events e
            WHERE e.team_id = 2
              AND event = 'watched movie'
@@ -727,7 +727,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 2
+  LIMIT 3
   OFFSET 0
   '
 ---
@@ -789,7 +789,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 3
+  LIMIT 4
   OFFSET 0
   '
 ---
@@ -851,7 +851,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 2
+  LIMIT 3
   OFFSET 0
   '
 ---
@@ -878,13 +878,13 @@
            CROSS JOIN
              (SELECT breakdown_value
               FROM
-                (SELECT ['$$_posthog_breakdown_null_$$', 'https://example.com'] as breakdown_value) ARRAY
+                (SELECT ['$$_posthog_breakdown_null_$$', 'https://example.com', '$$_posthog_breakdown_other_$$'] as breakdown_value) ARRAY
               JOIN breakdown_value) as sec
            ORDER BY breakdown_value,
                     day_start
            UNION ALL SELECT count(*) as total,
                             toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
-                            transform(ifNull(nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '$$_posthog_breakdown_null_$$'), (['$$_posthog_breakdown_null_$$', 'https://example.com']), (['$$_posthog_breakdown_null_$$', 'https://example.com']), '$$_posthog_breakdown_other_$$') as breakdown_value
+                            transform(ifNull(nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '$$_posthog_breakdown_null_$$'), (['$$_posthog_breakdown_null_$$', 'https://example.com', '$$_posthog_breakdown_other_$$']), (['$$_posthog_breakdown_null_$$', 'https://example.com', '$$_posthog_breakdown_other_$$']), '$$_posthog_breakdown_other_$$') as breakdown_value
            FROM events e
            WHERE e.team_id = 2
              AND event = 'watched movie'
@@ -912,7 +912,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 2
+  LIMIT 3
   OFFSET 0
   '
 ---
@@ -974,7 +974,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 3
+  LIMIT 4
   OFFSET 0
   '
 ---

--- a/posthog/queries/trends/test/__snapshots__/test_breakdowns_by_current_url.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_breakdowns_by_current_url.ambr
@@ -12,7 +12,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -77,7 +77,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -30,7 +30,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -46,7 +46,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -152,7 +152,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -168,7 +168,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -371,7 +371,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -401,7 +401,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -535,7 +535,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---
@@ -551,7 +551,7 @@
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
   GROUP BY value
   ORDER BY count DESC, value DESC
-  LIMIT 25
+  LIMIT 26
   OFFSET 0
   '
 ---

--- a/posthog/queries/trends/test/test_breakdowns.py
+++ b/posthog/queries/trends/test/test_breakdowns.py
@@ -507,7 +507,7 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
             [
                 (BREAKDOWN_NULL_NUMERIC_LABEL, 6.0, [1.0, 0.0, 1.0, 4.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
                 (19, 2.0, [2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
-                (BREAKDOWN_OTHER_NUMERIC_LABEL, 1.0, [1.0]),
+                (BREAKDOWN_OTHER_NUMERIC_LABEL, 1.0, [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
             ],
         )
 
@@ -559,7 +559,7 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
             [
                 (BREAKDOWN_NULL_STRING_LABEL, 6.0, [1.0, 0.0, 1.0, 4.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
                 ("https://example.com", 2.0, [2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
-                (BREAKDOWN_OTHER_STRING_LABEL, 1.0, [1.0]),
+                (BREAKDOWN_OTHER_STRING_LABEL, 1.0, [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
             ],
         )
 


### PR DESCRIPTION
## Problem

The "Other" value was not properly included in a CROSS JOIN in the trends query, causing it to skip columns with no data in the response. This misalignment shifted the rest of the data when "other" was the first returned column.

## Changes

Include "Other" in the breakdown values array.

## How did you test this code?

Locally in the browser. Updated tests that included bad data.

Before:

<img width="867" alt="Screenshot 2023-12-21 at 16 30 22" src="https://github.com/PostHog/posthog/assets/53387/103846a2-fff5-4b00-b720-52133a7bea52">

After:

<img width="863" alt="Screenshot 2023-12-21 at 16 30 40" src="https://github.com/PostHog/posthog/assets/53387/733622b3-4177-471a-9a43-416a707e60be">
