### PR TITLE
fix(trends): fix breakdown legend

### DIFF
--- a/frontend/src/lib/components/InsightLegend/InsightLegendRow.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegendRow.tsx
@@ -1,11 +1,16 @@
+import { useValues } from 'kea'
 import { getSeriesColor } from 'lib/colors'
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
 import { useEffect, useRef } from 'react'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
+import { isTrendsFilter } from 'scenes/insights/sharedUtils'
+import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { formatCompareLabel } from 'scenes/insights/views/InsightsTable/columns/SeriesColumn'
 import { IndexedTrendResult } from 'scenes/trends/types'
 
+import { cohortsModel } from '~/models/cohortsModel'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { TrendsFilter } from '~/queries/schema'
 import { ChartDisplayType } from '~/types'
 
@@ -32,6 +37,9 @@ export function InsightLegendRow({
     trendsFilter,
     highlighted,
 }: InsightLegendRowProps): JSX.Element {
+    const { cohorts } = useValues(cohortsModel)
+    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
+
     const highlightStyle: Record<string, any> = highlighted
         ? {
               style: { backgroundColor: getSeriesColor(item.seriesIndex, false, true) },
@@ -44,6 +52,15 @@ export function InsightLegendRow({
             rowRef.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
         }
     }, [highlighted])
+
+    const formattedBreakdownValue = formatBreakdownLabel(
+        cohorts,
+        formatPropertyValueForDisplay,
+        item.breakdown_value,
+        item.filter?.breakdown,
+        item.filter?.breakdown_type,
+        item.filter && isTrendsFilter(item.filter) && item.filter?.breakdown_histogram_bin_count !== undefined
+    )
 
     return (
         <div key={item.id} className="InsightLegendMenu-item p-2 flex flex-row" ref={rowRef} {...highlightStyle}>
@@ -61,7 +78,7 @@ export function InsightLegendRow({
                             action={item.action}
                             fallbackName={item.breakdown_value === '' ? 'None' : item.label}
                             hasMultipleSeries={hasMultipleSeries}
-                            breakdownValue={item.breakdown_value === '' ? 'None' : item.breakdown_value?.toString()}
+                            breakdownValue={formattedBreakdownValue}
                             compareValue={compare ? formatCompareLabel(item) : undefined}
                             pillMidEllipsis={item?.filter?.breakdown === '$current_url'} // TODO: define set of breakdown values that would benefit from mid ellipsis truncation
                             hideIcon


### PR DESCRIPTION
## Problem

We've had a user report that they see `$$_posthog_breakdown_null_$$` in the insight legend. See https://posthoghelp.zendesk.com/agent/tickets/8644. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/14147)

## Changes

This PR adds appropriate breakdown label handling for the insight legend. Turns out other cases e.g. breakdown by cohort have been broken as well.

| Before                                                                                                                                                 | After                                                                                                                                                  |
|--------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="327" alt="Screenshot 2023-12-28 at 11 02 50" src="https://github.com/PostHog/posthog/assets/1851359/3c370de3-8175-46d5-a4ad-a032ecb96ffa"> | <img width="231" alt="Screenshot 2023-12-28 at 11 00 06" src="https://github.com/PostHog/posthog/assets/1851359/4c8c5825-2cb5-4c90-86fc-f089ea55d866"> |
| <img width="161" alt="Screenshot 2023-12-28 at 11 03 07" src="https://github.com/PostHog/posthog/assets/1851359/b32c10a0-8ade-49bc-b2fe-46f151db83b2"> | <img width="199" alt="Screenshot 2023-12-28 at 11 00 29" src="https://github.com/PostHog/posthog/assets/1851359/bd1cb657-b1fc-4f8d-b72a-87a4b9f8c8e1"> |

## Follow-up

We need to look into all places with `breakdown_value === 'nan'` or `breakdown_value === ''` for appropriate handling.
- [x] persons-modal-utils.tsx https://github.com/PostHog/posthog/pull/19534
  <img width="538" alt="Screenshot 2023-12-28 at 11 09 16" src="https://github.com/PostHog/posthog/assets/1851359/b4d11c0c-3710-4cea-ba80-5230d10975e9">
- [ ] SeriesColumnItem

## How did you test this code?

Local reproduction