### PR TITLE
fix(trends): fix breakdowns persons label

### DIFF
--- a/frontend/src/lib/components/InsightLegend/InsightLegendRow.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegendRow.tsx
@@ -1,11 +1,16 @@
+import { useValues } from 'kea'
 import { getSeriesColor } from 'lib/colors'
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
 import { useEffect, useRef } from 'react'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
+import { isTrendsFilter } from 'scenes/insights/sharedUtils'
+import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { formatCompareLabel } from 'scenes/insights/views/InsightsTable/columns/SeriesColumn'
 import { IndexedTrendResult } from 'scenes/trends/types'
 
+import { cohortsModel } from '~/models/cohortsModel'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { TrendsFilter } from '~/queries/schema'
 import { ChartDisplayType } from '~/types'
 
@@ -32,6 +37,9 @@ export function InsightLegendRow({
     trendsFilter,
     highlighted,
 }: InsightLegendRowProps): JSX.Element {
+    const { cohorts } = useValues(cohortsModel)
+    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
+
     const highlightStyle: Record<string, any> = highlighted
         ? {
               style: { backgroundColor: getSeriesColor(item.seriesIndex, false, true) },
@@ -44,6 +52,15 @@ export function InsightLegendRow({
             rowRef.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
         }
     }, [highlighted])
+
+    const formattedBreakdownValue = formatBreakdownLabel(
+        cohorts,
+        formatPropertyValueForDisplay,
+        item.breakdown_value,
+        item.filter?.breakdown,
+        item.filter?.breakdown_type,
+        item.filter && isTrendsFilter(item.filter) && item.filter?.breakdown_histogram_bin_count !== undefined
+    )
 
     return (
         <div key={item.id} className="InsightLegendMenu-item p-2 flex flex-row" ref={rowRef} {...highlightStyle}>
@@ -61,7 +78,7 @@ export function InsightLegendRow({
                             action={item.action}
                             fallbackName={item.breakdown_value === '' ? 'None' : item.label}
                             hasMultipleSeries={hasMultipleSeries}
-                            breakdownValue={item.breakdown_value === '' ? 'None' : item.breakdown_value?.toString()}
+                            breakdownValue={formattedBreakdownValue}
                             compareValue={compare ? formatCompareLabel(item) : undefined}
                             pillMidEllipsis={item?.filter?.breakdown === '$current_url'} // TODO: define set of breakdown values that would benefit from mid ellipsis truncation
                             hideIcon

--- a/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
+++ b/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
@@ -5,10 +5,13 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { dayjs } from 'lib/dayjs'
 import { capitalizeFirstLetter, pluralize, toParams } from 'lib/utils'
 import md5 from 'md5'
-import { isFunnelsFilter, isPathsFilter } from 'scenes/insights/sharedUtils'
+import { isFunnelsFilter, isPathsFilter, isTrendsFilter } from 'scenes/insights/sharedUtils'
+import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
 
+import { FormatPropertyValueForDisplayFunction } from '~/models/propertyDefinitionsModel'
 import {
+    CohortType,
     FunnelsFilterType,
     FunnelVizType,
     GraphDataset,
@@ -60,7 +63,9 @@ export const pathsTitle = (props: { isDropOff: boolean; label: string }): React.
 
 export const urlsForDatasets = (
     crossDataset: GraphDataset[] | undefined,
-    index: number
+    index: number,
+    cohorts: CohortType[],
+    formatPropertyValueForDisplay: FormatPropertyValueForDisplayFunction
 ): { value: string; label: JSX.Element }[] => {
     const showCountedByTag = !!crossDataset?.find(({ action }) => action?.math && action.math !== 'total')
     const hasMultipleSeries = !!crossDataset?.find(({ action }) => action?.order)
@@ -88,29 +93,37 @@ export const urlsForDatasets = (
 
     return (
         crossDataset
-            ?.map((dataset) => ({
-                value: dataset.persons_urls?.[index].url || dataset.personsValues?.[index]?.url || '',
-                label: (
-                    <InsightLabel
-                        seriesColor={
-                            dataset.status
-                                ? getBarColorFromStatus(dataset.status as LifecycleToggle)
-                                : getSeriesColor(dataset.id)
-                        }
-                        action={dataset.action}
-                        breakdownValue={
-                            dataset.status
-                                ? capitalizeFirstLetter(dataset.status)
-                                : dataset.breakdown_value === ''
-                                ? 'None'
-                                : dataset.breakdown_value?.toString()
-                        }
-                        showCountedByTag={showCountedByTag}
-                        hasMultipleSeries={hasMultipleSeries}
-                        showEventName
-                    />
-                ),
-            }))
+            ?.map((dataset) => {
+                const formattedBreakdownValue = dataset.status
+                    ? capitalizeFirstLetter(dataset.status)
+                    : formatBreakdownLabel(
+                          cohorts,
+                          formatPropertyValueForDisplay,
+                          dataset.breakdown_value,
+                          dataset.filter?.breakdown,
+                          dataset.filter?.breakdown_type,
+                          dataset.filter &&
+                              isTrendsFilter(dataset.filter) &&
+                              dataset.filter?.breakdown_histogram_bin_count !== undefined
+                      )
+                return {
+                    value: dataset.persons_urls?.[index].url || dataset.personsValues?.[index]?.url || '',
+                    label: (
+                        <InsightLabel
+                            seriesColor={
+                                dataset.status
+                                    ? getBarColorFromStatus(dataset.status as LifecycleToggle)
+                                    : getSeriesColor(dataset.id)
+                            }
+                            action={dataset.action}
+                            breakdownValue={formattedBreakdownValue}
+                            showCountedByTag={showCountedByTag}
+                            hasMultipleSeries={hasMultipleSeries}
+                            showEventName
+                        />
+                    ),
+                }
+            })
             .filter((x) => x.value) || []
     )
 }

--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -90,7 +90,7 @@ export function ActionsHorizontalBar({ showPersonsModal = true }: ChartParams): 
 
                           const dataset = points.referencePoint.dataset
                           const label = dataset.labels?.[point.index]
-                          const urls = urlsForDatasets(crossDataset, index)
+                          const urls = urlsForDatasets(crossDataset, index, cohorts, formatPropertyValueForDisplay)
                           const selectedUrl = urls[index]?.value
 
                           if (selectedUrl) {

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -7,6 +7,8 @@ import { capitalizeFirstLetter, isMultiSeriesFormula } from 'lib/utils'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
+import { cohortsModel } from '~/models/cohortsModel'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { NodeKind } from '~/queries/schema'
 import { isInsightVizNode, isLifecycleQuery } from '~/queries/utils'
 import { ChartDisplayType, ChartParams, GraphType } from '~/types'
@@ -24,6 +26,8 @@ export function ActionsLineGraph({
 }: ChartParams): JSX.Element | null {
     const { insightProps, hiddenLegendKeys } = useValues(insightLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+    const { cohorts } = useValues(cohortsModel)
+    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
     const { query } = useValues(insightDataLogic(insightProps))
     const {
         indexedResults,
@@ -126,7 +130,12 @@ export function ActionsLineGraph({
                                   },
                               })
                           } else {
-                              const datasetUrls = urlsForDatasets(crossDataset, index)
+                              const datasetUrls = urlsForDatasets(
+                                  crossDataset,
+                                  index,
+                                  cohorts,
+                                  formatPropertyValueForDisplay
+                              )
                               if (datasetUrls?.length) {
                                   openPersonsModal({
                                       urls: datasetUrls,

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -92,7 +92,7 @@ export function ActionsPie({
                   const dataset = points.referencePoint.dataset
                   const label = dataset.labels?.[index]
 
-                  const urls = urlsForDatasets(crossDataset, index)
+                  const urls = urlsForDatasets(crossDataset, index, cohorts, formatPropertyValueForDisplay)
                   const selectedUrl = urls[index]?.value
 
                   if (selectedUrl) {


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/pull/19533.

  <img width="538" alt="Screenshot 2023-12-28 at 11 09 16" src="https://github.com/PostHog/posthog/assets/1851359/b4d11c0c-3710-4cea-ba80-5230d10975e9">

## Changes

This fixes the persons modal to work with the new magic values for breakdowns.

## How did you test this code?

:eyes: