### PR TITLE
test(async-migrations): Change timestamp upper bound to account for it being 2024

### DIFF
--- a/posthog/async_migrations/migrations/0007_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0007_persons_and_groups_on_events_backfill.py
@@ -104,7 +104,7 @@ class Migration(AsyncMigrationDefinition):
             str,
         ),
         "TIMESTAMP_UPPER_BOUND": (
-            "2024-01-01",
+            "2025-01-01",
             "Timestamp upper bound for events to backfill",
             str,
         ),


### PR DESCRIPTION
## Problem

Noticed this when working on #19347.

This hardcoded date started causing async migration tests to fail: https://github.com/PostHog/posthog/blob/1154121a1a08d3ab5e8c1a54e16bb435ea2c81d9/posthog/async_migrations/migrations/0007_persons_and_groups_on_events_backfill.py#L106-L110

There's probably a better fix for this (anchor it to the current date or similar) but this at least makes things go green again.

## How did you test this code?

Ran 'em.