### PR TITLE
fix: assume typeless series nodes are of type events node

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
@@ -72,6 +72,14 @@ describe('actionsAndEventsToSeries', () => {
         expect(result[1].name).toEqual('item1')
         expect(result[2].name).toEqual('item2')
     })
+
+    it('assumes typeless series is an event series', () => {
+        const events: ActionFilter[] = [{ id: '$pageview', order: 0, name: 'item1' } as any]
+
+        const result = actionsAndEventsToSeries({ events })
+
+        expect(result[0].kind === NodeKind.EventsNode)
+    })
 })
 
 describe('cleanHiddenLegendIndexes', () => {

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -73,7 +73,7 @@ export const actionsAndEventsToSeries = ({
                     id: f.id,
                     ...shared,
                 }
-            } else if (f.type === 'events') {
+            } else {
                 return {
                     kind: NodeKind.EventsNode,
                     event: f.id,


### PR DESCRIPTION
## Problem
- A customer had an insight with series without a type (e.g. `events` or `actions`
  - **Bug** `{"events": [{"id": "$pageview", "math": "dau", "name": "$pageview"}, {"id": "$pageview", "math": "weekly_active", "name": "$pageview"}, {"id": "$pageview", "math": "monthly_active", "name": "$pageview"}], "actions": [], "date_to": null, "display": "ActionsLineGraph", "insight": "TRENDS", "interval": "day", "date_from": "-90d", "new_entity": [], "properties": [], "filter_test_accounts": false}`
  - **Correct** `{"events": [{"id": "$pageview", "math": "dau", "name": "$pageview", "type": "events", "order": 0}, {"id": "$pageview", "math": "weekly_active", "name": "$pageview", "type": "events", "order": 1}, {"id": "$pageview", "math": "monthly_active", "name": "$pageview", "type": "events", "order": 2}], "date_to": null, "display": "ActionsLineGraph", "insight": "TRENDS", "interval": "day", "date_from": "-90d", "entity_type": "events"}`
- Causing the filter to query logic to break and return `undefined` for the series nodes

[Support ticket](https://posthoghelp.zendesk.com/agent/tickets/8699)

## Changes
- Assume typeless nodes are of the kind `events`

- Question: why do these need to be typed in the db when we have a `events` and `actions` array in the filters? Has something changed somewhere recently

## How did you test this code?
- Replicated the bug locally
- Wrote a unit test for typeless nodes