### PR TITLE
fix: remove deprecated pip cache action

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -44,9 +44,11 @@ runs:
           run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
 
         - name: Set up Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
               python-version: ${{ inputs.python-version }}
+              cache: pip
+              cache-dependency-path: '**/requirements*.txt'
               token: ${{ inputs.token }}
 
         - name: Determine if hogql-parser has changed compared to master
@@ -84,9 +86,6 @@ runs:
           id: cache-backend-tests
           with:
               custom_cache_key_element: v2
-
-        - uses: syphar/restore-pip-download-cache@v1
-          if: steps.cache-backend-tests.outputs.cache-hit != 'true'
 
         - name: Install Python dependencies
           if: steps.cache-backend-tests.outputs.cache-hit != 'true'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,7 +56,7 @@ jobs:
               with:
                   python-version: 3.10.10
                   cache: 'pip'
-                  cache-dependency-path: 'requirements*.txt'
+                  cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,16 +52,15 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.10.10
+                  cache: 'pip'
+                  cache-dependency-path: 'requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
               id: cache-benchmark-tests
-
-            - uses: syphar/restore-pip-download-cache@v1
-              if: steps.cache-benchmark-tests.outputs.cache-hit != 'true'
 
             - name: Install SAML (python3-saml) dependencies
               shell: bash

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -107,7 +107,7 @@ jobs:
               with:
                   python-version: 3.10.10
                   cache: 'pip'
-                  cache-dependency-path: 'requirements*.txt'
+                  cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
@@ -184,7 +184,7 @@ jobs:
               with:
                   python-version: 3.10.10
                   cache: 'pip'
-                  cache-dependency-path: 'requirements*.txt'
+                  cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
@@ -327,7 +327,7 @@ jobs:
               with:
                   python-version: 3.10.10
                   cache: 'pip'
-                  cache-dependency-path: 'requirements*.txt'
+                  cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -103,18 +103,17 @@ jobs:
                   fetch-depth: 1
 
             - name: Set up Python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.10.10
+                  cache: 'pip'
+                  cache-dependency-path: 'requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests
               with:
                   custom_cache_key_element: v2-
-
-            - uses: syphar/restore-pip-download-cache@v1
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
 
             - name: Install SAML (python3-saml) dependencies
               run: |
@@ -181,18 +180,17 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.10.10
+                  cache: 'pip'
+                  cache-dependency-path: 'requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests
               with:
                   custom_cache_key_element: v1-
-
-            - uses: syphar/restore-pip-download-cache@v1
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
 
             - name: Install SAML (python3-saml) dependencies
               run: |
@@ -325,18 +323,17 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.10.10
+                  cache: 'pip'
+                  cache-dependency-path: 'requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests
               with:
                   custom_cache_key_element: v2-
-
-            - uses: syphar/restore-pip-download-cache@v1
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
 
             - name: Install SAML (python3-saml) dependencies
               run: |

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -31,7 +31,7 @@ jobs:
               with:
                   python-version: '3.8'
                   cache: 'pip' # caching pip dependencies
-                  cache-dependency-path: 'requirements*.txt'
+                  cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
             - name: Get python deps
               run: pip install python-digitalocean==1.17.0 requests==2.28.1

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -31,6 +31,7 @@ jobs:
               with:
                   python-version: '3.8'
                   cache: 'pip' # caching pip dependencies
+                  cache-dependency-path: 'requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
             - name: Get python deps
               run: pip install python-digitalocean==1.17.0 requests==2.28.1

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -115,9 +115,11 @@ jobs:
 
             - name: Set up Python
               if: needs.changes.outputs.plugin-server == 'true'
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.10.10
+                  cache: 'pip'
+                  cache-dependency-path: 'requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
@@ -125,9 +127,6 @@ jobs:
               id: cache-backend-tests
               with:
                   custom_cache_key_element: v1-
-
-            - uses: syphar/restore-pip-download-cache@v1
-              if: needs.changes.outputs.plugin-server == 'true' && steps.cache-backend-tests.outputs.cache-hit != 'true'
 
             - name: Install SAML (python3-saml) dependencies
               if: needs.changes.outputs.plugin-server == 'true'
@@ -213,18 +212,17 @@ jobs:
               run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
 
             - name: Set up Python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.10.10
+                  cache: 'pip'
+                  cache-dependency-path: 'requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests
               with:
                   custom_cache_key_element: v1-
-
-            - uses: syphar/restore-pip-download-cache@v1
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
 
             - name: Install SAML (python3-saml) dependencies
               run: |

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -119,7 +119,7 @@ jobs:
               with:
                   python-version: 3.10.10
                   cache: 'pip'
-                  cache-dependency-path: 'requirements*.txt'
+                  cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1
@@ -216,7 +216,7 @@ jobs:
               with:
                   python-version: 3.10.10
                   cache: 'pip'
-                  cache-dependency-path: 'requirements*.txt'
+                  cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - uses: syphar/restore-virtualenv@v1


### PR DESCRIPTION
we use https://github.com/syphar/restore-pip-download-cache which was deprecated 9 months ago

let's switch to its recommendation of the default python action cache

----

we see the cache used on a second run

![Screenshot 2024-01-02 at 13 39 54](https://github.com/PostHog/posthog/assets/984817/f5f6426f-8eab-4dd1-8511-0fe43b5d7bc2)
