### PR TITLE
chore: add dependabot for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Problem

GH actions have to be updated manually, so manual steps are required.
Noticed that by reviewing the https://github.com/PostHog/posthog/pull/19552 PR wich upgrades actions/setup-python from v4 to v5

## Changes

Dependabot will open PRs weekly if there are new versions of the used GH actions, if CI is green, you just have to merge it :)
Example https://github.com/PostHog/posthog-android/pull/70

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
