### PR TITLE
fix: Padding on bullet lists

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/Notebook.scss
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.scss
@@ -91,11 +91,11 @@
 
             > ul,
             > ol {
-                padding-left: 1rem;
+                padding-left: 2rem;
 
                 ul,
                 ol {
-                    padding-left: 1rem;
+                    padding-left: 2rem;
                 }
 
                 li {


### PR DESCRIPTION
## Problem

Andy noticed the padding is off

## Changes

* Double it (matches githubs styling)

|Before|After|
|----|----|
| <img width="308" alt="Screenshot 2024-01-02 at 18 40 32" src="https://github.com/PostHog/posthog/assets/2536520/6745a271-a4d2-4c99-b5c1-955a21704cf5"> | <img width="272" alt="Screenshot 2024-01-02 at 18 40 01" src="https://github.com/PostHog/posthog/assets/2536520/45226ef1-3db9-440e-845f-6846c675aeb3"> |




## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
