### PR TITLE
fix(bi): fixed some of the query duplications

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -2,12 +2,10 @@ import { LemonButton, LemonLabel, LemonSelect } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { IconDelete, IconPlusMini } from 'lib/lemon-ui/icons'
 
-import { dataNodeLogic } from '../../DataNode/dataNodeLogic'
 import { dataVisualizationLogic } from '../dataVisualizationLogic'
 
 export const SeriesTab = (): JSX.Element => {
-    const { columns, xData, yData } = useValues(dataVisualizationLogic)
-    const { responseLoading } = useValues(dataNodeLogic)
+    const { columns, xData, yData, responseLoading } = useValues(dataVisualizationLogic)
     const { updateXSeries, updateYSeries, addYSeries, deleteYSeries } = useActions(dataVisualizationLogic)
 
     const options = columns.map(({ name, label }) => ({

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -46,7 +46,6 @@ export function DataTableVisualization(props: DataTableVisualizationProps): JSX.
         setQuery: props.setQuery,
         cachedResults: props.cachedResults,
     }
-    const builtDataVisualizationLogic = dataVisualizationLogic(dataVisualizationLogicProps)
 
     const dataNodeLogicProps: DataNodeLogicProps = {
         query: props.query.source,
@@ -54,8 +53,20 @@ export function DataTableVisualization(props: DataTableVisualizationProps): JSX.
         cachedResults: props.cachedResults,
     }
 
+    return (
+        <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
+            <BindLogic logic={dataVisualizationLogic} props={dataVisualizationLogicProps}>
+                <BindLogic logic={displayLogic} props={{ key: dataVisualizationLogicProps.key }}>
+                    <InternalDataTableVisualization {...props} uniqueKey={key} />
+                </BindLogic>
+            </BindLogic>
+        </BindLogic>
+    )
+}
+
+function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX.Element {
     const { query, visualizationType, showEditingUI, showResultControls, sourceFeatures, response, responseLoading } =
-        useValues(builtDataVisualizationLogic)
+        useValues(dataVisualizationLogic)
 
     const setQuerySource = useCallback(
         (source: HogQLQuery) => props.setQuery?.({ ...props.query, source }),
@@ -72,7 +83,7 @@ export function DataTableVisualization(props: DataTableVisualizationProps): JSX.
     } else if (visualizationType === ChartDisplayType.ActionsTable) {
         component = (
             <DataTable
-                uniqueKey={key}
+                uniqueKey={props.uniqueKey}
                 query={{ kind: NodeKind.DataTableNode, source: query.source }}
                 cachedResults={props.cachedResults}
                 context={{
@@ -89,48 +100,42 @@ export function DataTableVisualization(props: DataTableVisualizationProps): JSX.
     }
 
     return (
-        <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
-            <BindLogic logic={dataVisualizationLogic} props={dataVisualizationLogicProps}>
-                <BindLogic logic={displayLogic} props={{ key: dataVisualizationLogicProps.key }}>
-                    <div className="DataVisualization flex flex-1">
-                        <div className="relative w-full flex flex-col gap-4 flex-1 overflow-hidden">
-                            {showEditingUI && (
-                                <>
-                                    <HogQLQueryEditor query={query.source} setQuery={setQuerySource} embedded />
-                                    {sourceFeatures.has(QueryFeature.dateRangePicker) && (
-                                        <div className="flex gap-4 items-center flex-wrap">
-                                            <DateRange
-                                                key="date-range"
-                                                query={query.source}
-                                                setQuery={(query) => {
-                                                    if (query.kind === NodeKind.HogQLQuery) {
-                                                        setQuerySource(query)
-                                                    }
-                                                }}
-                                            />
-                                        </div>
-                                    )}
-                                </>
-                            )}
-                            {showResultControls && (
-                                <>
-                                    <LemonDivider className="my-0" />
-                                    <div className="flex gap-4 justify-between flex-wrap">
-                                        <div className="flex gap-4 items-center">
-                                            <Reload />
-                                            <ElapsedTime />
-                                        </div>
-                                        <div className="flex gap-4 items-center">
-                                            <TableDisplay />
-                                        </div>
-                                    </div>
-                                </>
-                            )}
-                            {component}
+        <div className="DataVisualization flex flex-1">
+            <div className="relative w-full flex flex-col gap-4 flex-1 overflow-hidden">
+                {showEditingUI && (
+                    <>
+                        <HogQLQueryEditor query={query.source} setQuery={setQuerySource} embedded />
+                        {sourceFeatures.has(QueryFeature.dateRangePicker) && (
+                            <div className="flex gap-4 items-center flex-wrap">
+                                <DateRange
+                                    key="date-range"
+                                    query={query.source}
+                                    setQuery={(query) => {
+                                        if (query.kind === NodeKind.HogQLQuery) {
+                                            setQuerySource(query)
+                                        }
+                                    }}
+                                />
+                            </div>
+                        )}
+                    </>
+                )}
+                {showResultControls && (
+                    <>
+                        <LemonDivider className="my-0" />
+                        <div className="flex gap-4 justify-between flex-wrap">
+                            <div className="flex gap-4 items-center">
+                                <Reload />
+                                <ElapsedTime />
+                            </div>
+                            <div className="flex gap-4 items-center">
+                                <TableDisplay />
+                            </div>
                         </div>
-                    </div>
-                </BindLogic>
-            </BindLogic>
-        </BindLogic>
+                    </>
+                )}
+                {component}
+            </div>
+        </div>
     )
 }

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -107,7 +107,7 @@ async function executeQuery<N extends DataNode = DataNode>(
     queryId?: string
 ): Promise<NonNullable<N['response']>> {
     const queryAsyncEnabled = Boolean(featureFlagLogic.findMounted()?.values.featureFlags?.[FEATURE_FLAGS.QUERY_ASYNC])
-    const excludedKinds = ['HogQLMetadata', 'EventsQuery', 'DataVisualizationNode']
+    const excludedKinds = ['HogQLMetadata', 'EventsQuery']
     const queryAsync = queryAsyncEnabled && !excludedKinds.includes(queryNode.kind)
     const response = await api.query(queryNode, methodOptions, queryId, refresh, queryAsync)
 


### PR DESCRIPTION
## Problem
- Loading the BI sql tab would make 4 requests to the `query` endpoint for the same data
- I managed to get this down to 2 now

## Changes
- Separate the logic binding components out of the UI rendering logic, adding a wrapper around the actual Data vis component
- This has reduced the amount of queries run by half, but, we're still seeing 2 queries sent. I think this is due to us mounting `dataNodeLogic` as well as connecting to it via `dataVisualizationLogic` (both with the same key). Unsure if there's a way around this, but some of the child components require `dataNodeLogic` to be mounted, such as the reload functionality
