### PR TITLE
fix(surveys): remove link in user interview template

### DIFF
--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -177,7 +177,6 @@ export const defaultSurveyTemplates = [
                 type: SurveyQuestionType.Link,
                 question: 'Would you be interested in participating in a customer interview?',
                 description: 'We are looking for feedback on our product and would love to hear from you!',
-                link: 'https://calendly.com/',
                 buttonText: 'Schedule',
             },
         ],


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
External link in the template is distracting

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
