### PR TITLE
feat(plugin-server): Add rollout control settings for override writes

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -131,6 +131,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         POE_DEFERRED_WRITES_ENABLED: false,
         POE_DEFERRED_WRITES_USE_FLAT_OVERRIDES: false,
         POE_EMBRACE_JOIN_FOR_TEAMS: '',
+        POE_WRITES_ENABLED_MAX_TEAM_ID: 0,
         RELOAD_PLUGIN_JITTER_MAX_MS: 60000,
         RUSTY_HOOK_FOR_TEAMS: '',
         RUSTY_HOOK_URL: '',

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -132,6 +132,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         POE_DEFERRED_WRITES_USE_FLAT_OVERRIDES: false,
         POE_EMBRACE_JOIN_FOR_TEAMS: '',
         POE_WRITES_ENABLED_MAX_TEAM_ID: 0,
+        POE_WRITES_EXCLUDE_TEAMS: '',
         RELOAD_PLUGIN_JITTER_MAX_MS: 60000,
         RUSTY_HOOK_FOR_TEAMS: '',
         RUSTY_HOOK_URL: '',

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -202,6 +202,7 @@ export interface PluginsServerConfig {
     POE_DEFERRED_WRITES_ENABLED: boolean
     POE_DEFERRED_WRITES_USE_FLAT_OVERRIDES: boolean
     POE_WRITES_ENABLED_MAX_TEAM_ID: number
+    POE_WRITES_EXCLUDE_TEAMS: string
     RELOAD_PLUGIN_JITTER_MAX_MS: number
     RUSTY_HOOK_FOR_TEAMS: string
     RUSTY_HOOK_URL: string
@@ -280,6 +281,7 @@ export interface Hub extends PluginsServerConfig {
     // ValueMatchers used for various opt-in/out features
     pluginConfigsToSkipElementsParsing: ValueMatcher<number>
     poeEmbraceJoinForTeams: ValueMatcher<number>
+    poeWritesExcludeTeams: ValueMatcher<number>
     rustyHookForTeams: ValueMatcher<number>
     // lookups
     eventsToDropByToken: Map<string, string[]>

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -201,6 +201,7 @@ export interface PluginsServerConfig {
     POE_EMBRACE_JOIN_FOR_TEAMS: string
     POE_DEFERRED_WRITES_ENABLED: boolean
     POE_DEFERRED_WRITES_USE_FLAT_OVERRIDES: boolean
+    POE_WRITES_ENABLED_MAX_TEAM_ID: number
     RELOAD_PLUGIN_JITTER_MAX_MS: number
     RUSTY_HOOK_FOR_TEAMS: string
     RUSTY_HOOK_URL: string

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -188,6 +188,7 @@ export async function createHub(
         conversionBufferEnabledTeams,
         pluginConfigsToSkipElementsParsing: buildIntegerMatcher(process.env.SKIP_ELEMENTS_PARSING_PLUGINS, true),
         poeEmbraceJoinForTeams: buildIntegerMatcher(process.env.POE_EMBRACE_JOIN_FOR_TEAMS, true),
+        poeWritesExcludeTeams: buildIntegerMatcher(process.env.POE_WRITES_EXCLUDE_TEAMS, false),
         rustyHookForTeams: buildIntegerMatcher(process.env.RUSTY_HOOK_FOR_TEAMS, true),
         eventsToDropByToken: createEventsToDropByToken(process.env.DROP_EVENTS_BY_TOKEN_DISTINCT_ID),
     }

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -111,7 +111,10 @@ export class EventPipelineRunner {
     }
 
     async runEventPipelineSteps(event: PluginEvent): Promise<EventPipelineResult> {
-        if (this.hub.poeEmbraceJoinForTeams?.(event.team_id)) {
+        if (
+            this.hub.poeEmbraceJoinForTeams?.(event.team_id) ||
+            (event.team_id <= this.hub.POE_WRITES_ENABLED_MAX_TEAM_ID && !this.hub.poeWritesExcludeTeams(event.team_id))
+        ) {
             // https://docs.google.com/document/d/12Q1KcJ41TicIwySCfNJV5ZPKXWVtxT7pzpB3r9ivz_0
             // We're not using the buffer anymore
             // instead we'll (if within timeframe) merge into the newer personId


### PR DESCRIPTION
## Problem

This gives us coarser-grained control for managing the rollout of override writes for performance testing.

Teams that are in `POE_EMBRACE_JOIN_FOR_TEAMS` are _always_ written, as before. Otherwise, teams with an ID lower than than the `POE_WRITES_ENABLED_MAX_TEAM_ID` setting will have their overrides written _as long as_ they are not also part of the `POE_WRITES_EXCLUDE_TEAMS` set.

## How did you test this code?

:eyes: