### PR TITLE
fix: data attrs for new config buttons

### DIFF
--- a/frontend/src/lib/components/FlagSelector.tsx
+++ b/frontend/src/lib/components/FlagSelector.tsx
@@ -42,7 +42,11 @@ export function FlagSelector({ value, onChange, readOnly }: FlagSelectorProps): 
             {readOnly ? (
                 <div>{featureFlag.key}</div>
             ) : (
-                <LemonButton type="secondary" onClick={() => setVisible(!visible)}>
+                <LemonButton
+                    data-attr={'session-recording-config-linked-flag-selector'}
+                    type="secondary"
+                    onClick={() => setVisible(!visible)}
+                >
                     {featureFlag.key ? featureFlag.key : 'Select flag'}
                 </LemonButton>
             )}

--- a/frontend/src/scenes/settings/project/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/project/SessionRecordingSettings.tsx
@@ -211,6 +211,7 @@ export function ReplayCostControl(): JSX.Element {
                     <div className={'flex flex-row justify-between'}>
                         <LemonLabel className="text-base">Sampling</LemonLabel>
                         <LemonSelect
+                            data-attr={'session-recording-config-sampling'}
                             onChange={(v) => {
                                 updateCurrentTeam({ session_recording_sample_rate: v })
                             }}
@@ -320,6 +321,7 @@ export function ReplayCostControl(): JSX.Element {
                     <div className={'flex flex-row justify-between'}>
                         <LemonLabel className="text-base">Minimum session duration (seconds)</LemonLabel>
                         <LemonSelect
+                            data-attr={'session-recording-config-minimum-duration'}
                             dropdownMatchSelectWidth={false}
                             onChange={(v) => {
                                 updateCurrentTeam({ session_recording_minimum_duration_milliseconds: v })
@@ -353,6 +355,7 @@ export function ReplayCostControl(): JSX.Element {
                                     type="secondary"
                                     onClick={() => updateCurrentTeam({ session_recording_linked_flag: null })}
                                     title="Clear selected flag"
+                                    data-attr={'session-recording-config-clear-linked-flag'}
                                 />
                             )}
                         </div>


### PR DESCRIPTION
I didn't add data-attrs for the new cost control config buttons so they're hard to track 🤦 

Well, not any more!