### PR TITLE
fix: Activation panel not closing after onboarding completed

### DIFF
--- a/frontend/src/lib/components/ActivationSidebar/activationLogic.ts
+++ b/frontend/src/lib/components/ActivationSidebar/activationLogic.ts
@@ -377,6 +377,10 @@ export const activationLogic = kea<activationLogicType>([
             if (params?.onboarding_completed && !values.hasCompletedAllTasks) {
                 actions.toggleActivationSideBar()
                 actions.openSidePanel(SidePanelTab.Activation)
+                router.actions.replace(router.values.location.pathname, {
+                    ...router.values.searchParams,
+                    onboarding_completed: undefined,
+                })
             } else {
                 actions.hideActivationSideBar()
             }


### PR DESCRIPTION
## Problem

The activation panel doesn't close because the url param re-opens it.

## Changes

* Remove the onboarding-completed param after triggering the necessary actions

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
