### PR TITLE
fix: makes rrweb ids easier to see

### DIFF
--- a/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
+++ b/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
@@ -28,11 +28,14 @@ exports[`replay/transform transform can convert images 1`] = `
           },
           {
             "attributes": {
+              "data-rrweb-id": 3,
               "style": "height: 100vh; width: 100vw;",
             },
             "childNodes": [
               {
-                "attributes": {},
+                "attributes": {
+                  "data-rrweb-id": 4,
+                },
                 "childNodes": [],
                 "id": 4,
                 "tagName": "head",
@@ -40,42 +43,37 @@ exports[`replay/transform transform can convert images 1`] = `
               },
               {
                 "attributes": {
+                  "data-rrweb-id": 5,
                   "style": "height: 100vh; width: 100vw;",
                 },
                 "childNodes": [
                   {
-                    "attributes": {},
+                    "attributes": {
+                      "data-rrweb-id": 12345,
+                      "style": "color: #ffffff;width: 100px;height: 30px;position: fixed;left: 11px;top: 12px;overflow:hidden;white-space:nowrap;",
+                    },
                     "childNodes": [
                       {
-                        "attributes": {
-                          "style": "color: #ffffff;width: 100px;height: 30px;position: fixed;left: 11px;top: 12px;overflow:hidden;white-space:nowrap;",
-                        },
-                        "childNodes": [
-                          {
-                            "id": 12345,
-                            "textContent": "Ⱏ遲䩞㡛쓯잘ጫ䵤㥦鷁끞鈅毅┌빯湌Თ",
-                            "type": 3,
-                          },
-                        ],
-                        "id": 104,
-                        "tagName": "div",
-                        "type": 2,
-                      },
-                      {
-                        "attributes": {
-                          "height": 30,
-                          "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=",
-                          "style": "width: 100px;height: 30px;position: fixed;left: 25px;top: 42px;",
-                          "width": 100,
-                        },
-                        "childNodes": [],
-                        "id": 12345,
-                        "tagName": "img",
-                        "type": 2,
+                        "id": 101,
+                        "textContent": "Ⱏ遲䩞㡛쓯잘ጫ䵤㥦鷁끞鈅毅┌빯湌Თ",
+                        "type": 3,
                       },
                     ],
-                    "id": 103,
+                    "id": 12345,
                     "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 12345,
+                      "height": 30,
+                      "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=",
+                      "style": "width: 100px;height: 30px;position: fixed;left: 25px;top: 42px;",
+                      "width": 100,
+                    },
+                    "childNodes": [],
+                    "id": 12345,
+                    "tagName": "img",
                     "type": 2,
                   },
                 ],
@@ -127,11 +125,14 @@ exports[`replay/transform transform can convert rect with text 1`] = `
           },
           {
             "attributes": {
+              "data-rrweb-id": 3,
               "style": "height: 100vh; width: 100vw;",
             },
             "childNodes": [
               {
-                "attributes": {},
+                "attributes": {
+                  "data-rrweb-id": 4,
+                },
                 "childNodes": [],
                 "id": 4,
                 "tagName": "head",
@@ -139,38 +140,33 @@ exports[`replay/transform transform can convert rect with text 1`] = `
               },
               {
                 "attributes": {
+                  "data-rrweb-id": 5,
                   "style": "height: 100vh; width: 100vw;",
                 },
                 "childNodes": [
                   {
-                    "attributes": {},
+                    "attributes": {
+                      "data-rrweb-id": 12345,
+                      "style": "color: #ee3ee4;border-width: 4px;border-radius: 10px;border-color: #ee3ee4;border-style: solid;width: 100px;height: 30px;position: fixed;left: 11px;top: 12px;",
+                    },
+                    "childNodes": [],
+                    "id": 12345,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 12345,
+                      "style": "width: 100px;height: 30px;position: fixed;left: 13px;top: 17px;overflow:hidden;white-space:nowrap;",
+                    },
                     "childNodes": [
                       {
-                        "attributes": {
-                          "style": "color: #ee3ee4;border-width: 4px;border-radius: 10px;border-color: #ee3ee4;border-style: solid;width: 100px;height: 30px;position: fixed;left: 11px;top: 12px;",
-                        },
-                        "childNodes": [],
-                        "id": 12345,
-                        "tagName": "div",
-                        "type": 2,
-                      },
-                      {
-                        "attributes": {
-                          "style": "width: 100px;height: 30px;position: fixed;left: 13px;top: 17px;overflow:hidden;white-space:nowrap;",
-                        },
-                        "childNodes": [
-                          {
-                            "id": 12345,
-                            "textContent": "i am in the box",
-                            "type": 3,
-                          },
-                        ],
-                        "id": 106,
-                        "tagName": "div",
-                        "type": 2,
+                        "id": 102,
+                        "textContent": "i am in the box",
+                        "type": 3,
                       },
                     ],
-                    "id": 105,
+                    "id": 12345,
                     "tagName": "div",
                     "type": 2,
                   },
@@ -223,11 +219,14 @@ exports[`replay/transform transform can ignore unknown wireframe types 1`] = `
           },
           {
             "attributes": {
+              "data-rrweb-id": 3,
               "style": "height: 100vh; width: 100vw;",
             },
             "childNodes": [
               {
-                "attributes": {},
+                "attributes": {
+                  "data-rrweb-id": 4,
+                },
                 "childNodes": [],
                 "id": 4,
                 "tagName": "head",
@@ -235,17 +234,10 @@ exports[`replay/transform transform can ignore unknown wireframe types 1`] = `
               },
               {
                 "attributes": {
+                  "data-rrweb-id": 5,
                   "style": "height: 100vh; width: 100vw;",
                 },
-                "childNodes": [
-                  {
-                    "attributes": {},
-                    "childNodes": [],
-                    "id": 102,
-                    "tagName": "div",
-                    "type": 2,
-                  },
-                ],
+                "childNodes": [],
                 "id": 5,
                 "tagName": "body",
                 "type": 2,
@@ -306,11 +298,14 @@ exports[`replay/transform transform can process unknown types without error 1`] 
           },
           {
             "attributes": {
+              "data-rrweb-id": 3,
               "style": "height: 100vh; width: 100vw;",
             },
             "childNodes": [
               {
-                "attributes": {},
+                "attributes": {
+                  "data-rrweb-id": 4,
+                },
                 "childNodes": [],
                 "id": 4,
                 "tagName": "head",
@@ -318,29 +313,23 @@ exports[`replay/transform transform can process unknown types without error 1`] 
               },
               {
                 "attributes": {
+                  "data-rrweb-id": 5,
                   "style": "height: 100vh; width: 100vw;",
                 },
                 "childNodes": [
                   {
-                    "attributes": {},
+                    "attributes": {
+                      "data-rrweb-id": 12345,
+                      "style": "color: #35373e;background-color: #f3f4ef;width: 100px;height: 30px;position: fixed;left: 25px;top: 42px;align-items: center;justify-content: center;display: flex;",
+                    },
                     "childNodes": [
                       {
-                        "attributes": {
-                          "style": "color: #35373e;background-color: #f3f4ef;width: 100px;height: 30px;position: fixed;left: 25px;top: 42px;align-items: center;justify-content: center;display: flex;",
-                        },
-                        "childNodes": [
-                          {
-                            "id": 101,
-                            "textContent": "image",
-                            "type": 3,
-                          },
-                        ],
-                        "id": 12345,
-                        "tagName": "div",
-                        "type": 2,
+                        "id": 100,
+                        "textContent": "image",
+                        "type": 3,
                       },
                     ],
-                    "id": 100,
+                    "id": 12345,
                     "tagName": "div",
                     "type": 2,
                   },
@@ -416,11 +405,14 @@ exports[`replay/transform transform child wireframes are processed 1`] = `
           },
           {
             "attributes": {
+              "data-rrweb-id": 3,
               "style": "height: 100vh; width: 100vw;",
             },
             "childNodes": [
               {
-                "attributes": {},
+                "attributes": {
+                  "data-rrweb-id": 4,
+                },
                 "childNodes": [],
                 "id": 4,
                 "tagName": "head",
@@ -428,79 +420,77 @@ exports[`replay/transform transform child wireframes are processed 1`] = `
               },
               {
                 "attributes": {
+                  "data-rrweb-id": 5,
                   "style": "height: 100vh; width: 100vw;",
                 },
                 "childNodes": [
                   {
-                    "attributes": {},
+                    "attributes": {
+                      "data-rrweb-id": 123456789,
+                      "style": "position: fixed;left: 0px;top: 0px;overflow:hidden;white-space:nowrap;",
+                    },
                     "childNodes": [
                       {
                         "attributes": {
+                          "data-rrweb-id": 98765,
                           "style": "position: fixed;left: 0px;top: 0px;overflow:hidden;white-space:nowrap;",
                         },
                         "childNodes": [
                           {
                             "attributes": {
-                              "style": "position: fixed;left: 0px;top: 0px;overflow:hidden;white-space:nowrap;",
+                              "data-rrweb-id": 12345,
+                              "style": "color: #ffffff;background-color: #000000;border-width: 4px;border-radius: 10px;border-color: #000ddd;border-style: solid;width: 100px;height: 30px;position: fixed;left: 11px;top: 12px;overflow:hidden;white-space:nowrap;",
                             },
                             "childNodes": [
                               {
-                                "attributes": {
-                                  "style": "color: #ffffff;background-color: #000000;border-width: 4px;border-radius: 10px;border-color: #000ddd;border-style: solid;width: 100px;height: 30px;position: fixed;left: 11px;top: 12px;overflow:hidden;white-space:nowrap;",
-                                },
-                                "childNodes": [
-                                  {
-                                    "id": 12345,
-                                    "textContent": "first nested",
-                                    "type": 3,
-                                  },
-                                ],
-                                "id": 108,
-                                "tagName": "div",
-                                "type": 2,
-                              },
-                              {
-                                "attributes": {
-                                  "style": "color: #ffffff;background-color: #000000;border-width: 4px;border-radius: 10px;border-color: #000ddd;border-style: solid;width: 100px;height: 30px;position: fixed;left: 11px;top: 12px;overflow:hidden;white-space:nowrap;",
-                                },
-                                "childNodes": [
-                                  {
-                                    "id": 12345,
-                                    "textContent": "second nested",
-                                    "type": 3,
-                                  },
-                                ],
-                                "id": 109,
-                                "tagName": "div",
-                                "type": 2,
+                                "id": 103,
+                                "textContent": "first nested",
+                                "type": 3,
                               },
                             ],
-                            "id": 98765,
+                            "id": 12345,
                             "tagName": "div",
                             "type": 2,
                           },
                           {
                             "attributes": {
+                              "data-rrweb-id": 12345,
                               "style": "color: #ffffff;background-color: #000000;border-width: 4px;border-radius: 10px;border-color: #000ddd;border-style: solid;width: 100px;height: 30px;position: fixed;left: 11px;top: 12px;overflow:hidden;white-space:nowrap;",
                             },
                             "childNodes": [
                               {
-                                "id": 12345,
-                                "textContent": "third (different level) nested",
+                                "id": 104,
+                                "textContent": "second nested",
                                 "type": 3,
                               },
                             ],
-                            "id": 110,
+                            "id": 12345,
                             "tagName": "div",
                             "type": 2,
                           },
                         ],
-                        "id": 123456789,
+                        "id": 98765,
+                        "tagName": "div",
+                        "type": 2,
+                      },
+                      {
+                        "attributes": {
+                          "data-rrweb-id": 12345,
+                          "style": "color: #ffffff;background-color: #000000;border-width: 4px;border-radius: 10px;border-color: #000ddd;border-style: solid;width: 100px;height: 30px;position: fixed;left: 11px;top: 12px;overflow:hidden;white-space:nowrap;",
+                        },
+                        "childNodes": [
+                          {
+                            "id": 105,
+                            "textContent": "third (different level) nested",
+                            "type": 3,
+                          },
+                        ],
+                        "id": 12345,
                         "tagName": "div",
                         "type": 2,
                       },
                     ],
-                    "id": 107,
+                    "id": 123456789,
                     "tagName": "div",
                     "type": 2,
                   },
@@ -543,11 +533,14 @@ exports[`replay/transform transform inputs buttons with nested elements 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -555,41 +548,36 @@ exports[`replay/transform transform inputs buttons with nested elements 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 12359,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "button",
+                  },
+                  "childNodes": [],
+                  "id": 12359,
+                  "tagName": "button",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 12361,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "button",
+                  },
                   "childNodes": [
                     {
-                      "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "button",
-                      },
-                      "childNodes": [],
-                      "id": 12359,
-                      "tagName": "button",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "button",
-                      },
-                      "childNodes": [
-                        {
-                          "id": 114,
-                          "textContent": "click me",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 12361,
-                      "tagName": "button",
-                      "type": 2,
+                      "id": 107,
+                      "textContent": "click me",
+                      "type": 3,
                     },
                   ],
-                  "id": 113,
-                  "tagName": "div",
+                  "id": 12361,
+                  "tagName": "button",
                   "type": 2,
                 },
               ],
@@ -649,11 +637,14 @@ exports[`replay/transform transform inputs input - $inputType - hello 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -661,17 +652,10 @@ exports[`replay/transform transform inputs input - $inputType - hello 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [],
-                  "id": 322,
-                  "tagName": "div",
-                  "type": 2,
-                },
-              ],
+              "childNodes": [],
               "id": 5,
               "tagName": "body",
               "type": 2,
@@ -709,11 +693,14 @@ exports[`replay/transform transform inputs input - button - click me 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -721,31 +708,25 @@ exports[`replay/transform transform inputs input - button - click me 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 12358,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "button",
+                  },
                   "childNodes": [
                     {
-                      "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "button",
-                      },
-                      "childNodes": [
-                        {
-                          "id": 314,
-                          "textContent": "click me",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 12358,
-                      "tagName": "button",
-                      "type": 2,
+                      "id": 284,
+                      "textContent": "click me",
+                      "type": 3,
                     },
                   ],
-                  "id": 313,
-                  "tagName": "div",
+                  "id": 12358,
+                  "tagName": "button",
                   "type": 2,
                 },
               ],
@@ -786,11 +767,14 @@ exports[`replay/transform transform inputs input - checkbox - $value 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -798,41 +782,36 @@ exports[`replay/transform transform inputs input - checkbox - $value 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 261,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                  },
                   "childNodes": [
                     {
                       "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                        "checked": true,
+                        "data-rrweb-id": 12357,
+                        "style": null,
+                        "type": "checkbox",
                       },
-                      "childNodes": [
-                        {
-                          "attributes": {
-                            "checked": true,
-                            "style": null,
-                            "type": "checkbox",
-                          },
-                          "childNodes": [],
-                          "id": 12357,
-                          "tagName": "input",
-                          "type": 2,
-                        },
-                        {
-                          "id": 282,
-                          "textContent": "first",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 283,
-                      "tagName": "label",
+                      "childNodes": [],
+                      "id": 12357,
+                      "tagName": "input",
                       "type": 2,
                     },
+                    {
+                      "id": 260,
+                      "textContent": "first",
+                      "type": 3,
+                    },
                   ],
-                  "id": 281,
-                  "tagName": "div",
+                  "id": 261,
+                  "tagName": "label",
                   "type": 2,
                 },
               ],
@@ -873,11 +852,14 @@ exports[`replay/transform transform inputs input - checkbox - $value 2`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -885,40 +867,35 @@ exports[`replay/transform transform inputs input - checkbox - $value 2`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 263,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                  },
                   "childNodes": [
                     {
                       "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                        "data-rrweb-id": 12357,
+                        "style": null,
+                        "type": "checkbox",
                       },
-                      "childNodes": [
-                        {
-                          "attributes": {
-                            "style": null,
-                            "type": "checkbox",
-                          },
-                          "childNodes": [],
-                          "id": 12357,
-                          "tagName": "input",
-                          "type": 2,
-                        },
-                        {
-                          "id": 285,
-                          "textContent": "second",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 286,
-                      "tagName": "label",
+                      "childNodes": [],
+                      "id": 12357,
+                      "tagName": "input",
                       "type": 2,
                     },
+                    {
+                      "id": 262,
+                      "textContent": "second",
+                      "type": 3,
+                    },
                   ],
-                  "id": 284,
-                  "tagName": "div",
+                  "id": 263,
+                  "tagName": "label",
                   "type": 2,
                 },
               ],
@@ -959,11 +936,14 @@ exports[`replay/transform transform inputs input - checkbox - $value 3`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -971,42 +951,37 @@ exports[`replay/transform transform inputs input - checkbox - $value 3`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 265,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                  },
                   "childNodes": [
                     {
                       "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                        "checked": true,
+                        "data-rrweb-id": 12357,
+                        "disabled": true,
+                        "style": null,
+                        "type": "checkbox",
                       },
-                      "childNodes": [
-                        {
-                          "attributes": {
-                            "checked": true,
-                            "disabled": true,
-                            "style": null,
-                            "type": "checkbox",
-                          },
-                          "childNodes": [],
-                          "id": 12357,
-                          "tagName": "input",
-                          "type": 2,
-                        },
-                        {
-                          "id": 288,
-                          "textContent": "third",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 289,
-                      "tagName": "label",
+                      "childNodes": [],
+                      "id": 12357,
+                      "tagName": "input",
                       "type": 2,
                     },
+                    {
+                      "id": 264,
+                      "textContent": "third",
+                      "type": 3,
+                    },
                   ],
-                  "id": 287,
-                  "tagName": "div",
+                  "id": 265,
+                  "tagName": "label",
                   "type": 2,
                 },
               ],
@@ -1047,11 +1022,14 @@ exports[`replay/transform transform inputs input - checkbox - $value 4`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -1059,26 +1037,20 @@ exports[`replay/transform transform inputs input - checkbox - $value 4`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "checked": true,
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "checkbox",
-                      },
-                      "childNodes": [],
-                      "id": 12357,
-                      "tagName": "input",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 290,
-                  "tagName": "div",
+                  "attributes": {
+                    "checked": true,
+                    "data-rrweb-id": 12357,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "checkbox",
+                  },
+                  "childNodes": [],
+                  "id": 12357,
+                  "tagName": "input",
                   "type": 2,
                 },
               ],
@@ -1119,11 +1091,14 @@ exports[`replay/transform transform inputs input - email - $value 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -1131,26 +1106,20 @@ exports[`replay/transform transform inputs input - email - $value 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "email",
-                        "value": "",
-                      },
-                      "childNodes": [],
-                      "id": 12349,
-                      "tagName": "input",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 274,
-                  "tagName": "div",
+                  "attributes": {
+                    "data-rrweb-id": 12349,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "email",
+                    "value": "",
+                  },
+                  "childNodes": [],
+                  "id": 12349,
+                  "tagName": "input",
                   "type": 2,
                 },
               ],
@@ -1191,11 +1160,14 @@ exports[`replay/transform transform inputs input - number - $value 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -1203,26 +1175,20 @@ exports[`replay/transform transform inputs input - number - $value 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "number",
-                        "value": "",
-                      },
-                      "childNodes": [],
-                      "id": 12350,
-                      "tagName": "input",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 275,
-                  "tagName": "div",
+                  "attributes": {
+                    "data-rrweb-id": 12350,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "number",
+                    "value": "",
+                  },
+                  "childNodes": [],
+                  "id": 12350,
+                  "tagName": "input",
                   "type": 2,
                 },
               ],
@@ -1263,11 +1229,14 @@ exports[`replay/transform transform inputs input - password - $value 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -1275,26 +1244,20 @@ exports[`replay/transform transform inputs input - password - $value 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "password",
-                        "value": "",
-                      },
-                      "childNodes": [],
-                      "id": 12348,
-                      "tagName": "input",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 273,
-                  "tagName": "div",
+                  "attributes": {
+                    "data-rrweb-id": 12348,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "password",
+                    "value": "",
+                  },
+                  "childNodes": [],
+                  "id": 12348,
+                  "tagName": "input",
                   "type": 2,
                 },
               ],
@@ -1335,11 +1298,14 @@ exports[`replay/transform transform inputs input - progress - $value 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -1347,49 +1313,44 @@ exports[`replay/transform transform inputs input - progress - $value 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 12365,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                  },
                   "childNodes": [
                     {
                       "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                        "data-rrweb-id": 291,
+                        "style": "background-color: #f3f4ef;width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;border: 4px solid #35373e;border-radius: 50%;border-top: 4px solid #fff;animation: spin 2s linear infinite;",
                       },
                       "childNodes": [
                         {
                           "attributes": {
-                            "style": "background-color: #f3f4ef;width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;border: 4px solid #35373e;border-radius: 50%;border-top: 4px solid #fff;animation: spin 2s linear infinite;",
+                            "type": "text/css",
                           },
                           "childNodes": [
                             {
-                              "attributes": {
-                                "type": "text/css",
-                              },
-                              "childNodes": [
-                                {
-                                  "id": 325,
-                                  "textContent": "@keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }",
-                                  "type": 3,
-                                },
-                              ],
-                              "id": 324,
-                              "tagName": "style",
-                              "type": 2,
+                              "id": 290,
+                              "textContent": "@keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }",
+                              "type": 3,
                             },
                           ],
-                          "id": 326,
-                          "tagName": "div",
+                          "id": 289,
+                          "tagName": "style",
                           "type": 2,
                         },
                       ],
-                      "id": 12365,
+                      "id": 291,
                       "tagName": "div",
                       "type": 2,
                     },
                   ],
-                  "id": 323,
+                  "id": 12365,
                   "tagName": "div",
                   "type": 2,
                 },
@@ -1431,11 +1392,14 @@ exports[`replay/transform transform inputs input - progress - $value 2`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -1443,27 +1407,21 @@ exports[`replay/transform transform inputs input - progress - $value 2`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "max": null,
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": null,
-                        "value": null,
-                      },
-                      "childNodes": [],
-                      "id": 12365,
-                      "tagName": "progress",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 327,
-                  "tagName": "div",
+                  "attributes": {
+                    "data-rrweb-id": 12365,
+                    "max": null,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": null,
+                    "value": null,
+                  },
+                  "childNodes": [],
+                  "id": 12365,
+                  "tagName": "progress",
                   "type": 2,
                 },
               ],
@@ -1504,11 +1462,14 @@ exports[`replay/transform transform inputs input - progress - 0.75 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -1516,27 +1477,21 @@ exports[`replay/transform transform inputs input - progress - 0.75 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "max": null,
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": null,
-                        "value": 0.75,
-                      },
-                      "childNodes": [],
-                      "id": 12365,
-                      "tagName": "progress",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 328,
-                  "tagName": "div",
+                  "attributes": {
+                    "data-rrweb-id": 12365,
+                    "max": null,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": null,
+                    "value": 0.75,
+                  },
+                  "childNodes": [],
+                  "id": 12365,
+                  "tagName": "progress",
                   "type": 2,
                 },
               ],
@@ -1577,11 +1532,14 @@ exports[`replay/transform transform inputs input - progress - 0.75 2`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -1589,27 +1547,21 @@ exports[`replay/transform transform inputs input - progress - 0.75 2`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "max": 2.5,
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": null,
-                        "value": 0.75,
-                      },
-                      "childNodes": [],
-                      "id": 12365,
-                      "tagName": "progress",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 329,
-                  "tagName": "div",
+                  "attributes": {
+                    "data-rrweb-id": 12365,
+                    "max": 2.5,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": null,
+                    "value": 0.75,
+                  },
+                  "childNodes": [],
+                  "id": 12365,
+                  "tagName": "progress",
                   "type": 2,
                 },
               ],
@@ -1650,11 +1602,14 @@ exports[`replay/transform transform inputs input - search - $value 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -1662,26 +1617,20 @@ exports[`replay/transform transform inputs input - search - $value 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "search",
-                        "value": "",
-                      },
-                      "childNodes": [],
-                      "id": 12351,
-                      "tagName": "input",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 276,
-                  "tagName": "div",
+                  "attributes": {
+                    "data-rrweb-id": 12351,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "search",
+                    "value": "",
+                  },
+                  "childNodes": [],
+                  "id": 12351,
+                  "tagName": "input",
                   "type": 2,
                 },
               ],
@@ -1722,11 +1671,14 @@ exports[`replay/transform transform inputs input - select - hello 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -1734,55 +1686,52 @@ exports[`replay/transform transform inputs input - select - hello 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 12365,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "select",
+                    "value": "hello",
+                  },
                   "childNodes": [
                     {
                       "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "select",
-                        "value": "hello",
+                        "data-rrweb-id": 285,
+                        "selected": true,
                       },
                       "childNodes": [
                         {
-                          "attributes": {
-                            "selected": true,
-                          },
-                          "childNodes": [
-                            {
-                              "id": 319,
-                              "textContent": "hello",
-                              "type": 3,
-                            },
-                          ],
-                          "id": 318,
-                          "tagName": "option",
-                          "type": 2,
-                        },
-                        {
-                          "attributes": {},
-                          "childNodes": [
-                            {
-                              "id": 321,
-                              "textContent": "world",
-                              "type": 3,
-                            },
-                          ],
-                          "id": 320,
-                          "tagName": "option",
-                          "type": 2,
+                          "id": 286,
+                          "textContent": "hello",
+                          "type": 3,
                         },
                       ],
-                      "id": 12365,
-                      "tagName": "select",
+                      "id": 285,
+                      "tagName": "option",
+                      "type": 2,
+                    },
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 287,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 288,
+                          "textContent": "world",
+                          "type": 3,
+                        },
+                      ],
+                      "id": 287,
+                      "tagName": "option",
                       "type": 2,
                     },
                   ],
-                  "id": 317,
-                  "tagName": "div",
+                  "id": 12365,
+                  "tagName": "select",
                   "type": 2,
                 },
               ],
@@ -1823,11 +1772,14 @@ exports[`replay/transform transform inputs input - tel - $value 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -1835,27 +1787,21 @@ exports[`replay/transform transform inputs input - tel - $value 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "disabled": true,
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "tel",
-                        "value": "",
-                      },
-                      "childNodes": [],
-                      "id": 12352,
-                      "tagName": "input",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 277,
-                  "tagName": "div",
+                  "attributes": {
+                    "data-rrweb-id": 12352,
+                    "disabled": true,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "tel",
+                    "value": "",
+                  },
+                  "childNodes": [],
+                  "id": 12352,
+                  "tagName": "input",
                   "type": 2,
                 },
               ],
@@ -1896,11 +1842,14 @@ exports[`replay/transform transform inputs input - text - $value 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -1908,26 +1857,20 @@ exports[`replay/transform transform inputs input - text - $value 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "text",
-                        "value": "",
-                      },
-                      "childNodes": [],
-                      "id": 12347,
-                      "tagName": "input",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 272,
-                  "tagName": "div",
+                  "attributes": {
+                    "data-rrweb-id": 12347,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "text",
+                    "value": "",
+                  },
+                  "childNodes": [],
+                  "id": 12347,
+                  "tagName": "input",
                   "type": 2,
                 },
               ],
@@ -1968,11 +1911,14 @@ exports[`replay/transform transform inputs input - text - hello 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -1980,26 +1926,20 @@ exports[`replay/transform transform inputs input - text - hello 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "text",
-                        "value": "hello",
-                      },
-                      "childNodes": [],
-                      "id": 12346,
-                      "tagName": "input",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 271,
-                  "tagName": "div",
+                  "attributes": {
+                    "data-rrweb-id": 12346,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "text",
+                    "value": "hello",
+                  },
+                  "childNodes": [],
+                  "id": 12346,
+                  "tagName": "input",
                   "type": 2,
                 },
               ],
@@ -2040,11 +1980,14 @@ exports[`replay/transform transform inputs input - textArea - $value 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -2052,26 +1995,20 @@ exports[`replay/transform transform inputs input - textArea - $value 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "textArea",
-                        "value": "",
-                      },
-                      "childNodes": [],
-                      "id": 12364,
-                      "tagName": "input",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 316,
-                  "tagName": "div",
+                  "attributes": {
+                    "data-rrweb-id": 12364,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "textArea",
+                    "value": "",
+                  },
+                  "childNodes": [],
+                  "id": 12364,
+                  "tagName": "input",
                   "type": 2,
                 },
               ],
@@ -2112,11 +2049,14 @@ exports[`replay/transform transform inputs input - textArea - hello 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -2124,26 +2064,20 @@ exports[`replay/transform transform inputs input - textArea - hello 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "textArea",
-                        "value": "hello",
-                      },
-                      "childNodes": [],
-                      "id": 12363,
-                      "tagName": "input",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 315,
-                  "tagName": "div",
+                  "attributes": {
+                    "data-rrweb-id": 12363,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "textArea",
+                    "value": "hello",
+                  },
+                  "childNodes": [],
+                  "id": 12363,
+                  "tagName": "input",
                   "type": 2,
                 },
               ],
@@ -2184,11 +2118,14 @@ exports[`replay/transform transform inputs input - toggle - $value 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -2196,70 +2133,68 @@ exports[`replay/transform transform inputs input - toggle - $value 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 270,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                  },
                   "childNodes": [
                     {
+                      "id": 269,
+                      "textContent": "first",
+                      "type": 3,
+                    },
+                    {
                       "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                        "data-rrweb-id": 12357,
+                        "style": "height:100%;flex:1",
                       },
                       "childNodes": [
                         {
-                          "id": 295,
-                          "textContent": "first",
-                          "type": 3,
-                        },
-                        {
                           "attributes": {
-                            "style": "height:100%;flex:1",
+                            "data-rrweb-id": 266,
+                            "style": "position:relative;width:100%;height:100%;",
                           },
                           "childNodes": [
                             {
                               "attributes": {
-                                "style": "position:relative;width:100%;height:100%;",
+                                "data-rrweb-id": 267,
+                                "data-toggle-part": "slider",
+                                "style": "position:absolute;top:33%;left:5%;display:inline-block;width:75%;height:33%;background-color:#1d4aff;opacity: 0.2;border-radius:7.5%;",
                               },
-                              "childNodes": [
-                                {
-                                  "attributes": {
-                                    "data-toggle-part": "slider",
-                                    "style": "position:absolute;top:33%;left:5%;display:inline-block;width:75%;height:33%;background-color:#1d4aff;opacity: 0.2;border-radius:7.5%;",
-                                  },
-                                  "childNodes": [],
-                                  "id": 293,
-                                  "tagName": "div",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "data-toggle-part": "handle",
-                                    "style": "position:absolute;top:1.5%;right:5%;display:flex;align-items:center;justify-content:center;width:40%;height:75%;cursor:inherit;background-color:#1d4aff;border:2px solid #1d4aff;border-radius:50%;",
-                                  },
-                                  "childNodes": [],
-                                  "id": 294,
-                                  "tagName": "div",
-                                  "type": 2,
-                                },
-                              ],
-                              "id": 292,
+                              "childNodes": [],
+                              "id": 267,
+                              "tagName": "div",
+                              "type": 2,
+                            },
+                            {
+                              "attributes": {
+                                "data-rrweb-id": 268,
+                                "data-toggle-part": "handle",
+                                "style": "position:absolute;top:1.5%;right:5%;display:flex;align-items:center;justify-content:center;width:40%;height:75%;cursor:inherit;background-color:#1d4aff;border:2px solid #1d4aff;border-radius:50%;",
+                              },
+                              "childNodes": [],
+                              "id": 268,
                               "tagName": "div",
                               "type": 2,
                             },
                           ],
-                          "id": 12357,
+                          "id": 266,
                           "tagName": "div",
                           "type": 2,
                         },
                       ],
-                      "id": 296,
-                      "tagName": "label",
+                      "id": 12357,
+                      "tagName": "div",
                       "type": 2,
                     },
                   ],
-                  "id": 291,
-                  "tagName": "div",
+                  "id": 270,
+                  "tagName": "label",
                   "type": 2,
                 },
               ],
@@ -2300,11 +2235,14 @@ exports[`replay/transform transform inputs input - toggle - $value 2`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -2312,70 +2250,68 @@ exports[`replay/transform transform inputs input - toggle - $value 2`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 275,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                  },
                   "childNodes": [
                     {
+                      "id": 274,
+                      "textContent": "second",
+                      "type": 3,
+                    },
+                    {
                       "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                        "data-rrweb-id": 12357,
+                        "style": "height:100%;flex:1",
                       },
                       "childNodes": [
                         {
-                          "id": 301,
-                          "textContent": "second",
-                          "type": 3,
-                        },
-                        {
                           "attributes": {
-                            "style": "height:100%;flex:1",
+                            "data-rrweb-id": 271,
+                            "style": "position:relative;width:100%;height:100%;",
                           },
                           "childNodes": [
                             {
                               "attributes": {
-                                "style": "position:relative;width:100%;height:100%;",
+                                "data-rrweb-id": 272,
+                                "data-toggle-part": "slider",
+                                "style": "position:absolute;top:33%;left:5%;display:inline-block;width:75%;height:33%;background-color:#f3f4ef;opacity: 0.2;border-radius:7.5%;",
                               },
-                              "childNodes": [
-                                {
-                                  "attributes": {
-                                    "data-toggle-part": "slider",
-                                    "style": "position:absolute;top:33%;left:5%;display:inline-block;width:75%;height:33%;background-color:#f3f4ef;opacity: 0.2;border-radius:7.5%;",
-                                  },
-                                  "childNodes": [],
-                                  "id": 299,
-                                  "tagName": "div",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "data-toggle-part": "handle",
-                                    "style": "position:absolute;top:1.5%;left:5%;display:flex;align-items:center;justify-content:center;width:40%;height:75%;cursor:inherit;background-color:#f3f4ef;border:2px solid #f3f4ef;border-radius:50%;",
-                                  },
-                                  "childNodes": [],
-                                  "id": 300,
-                                  "tagName": "div",
-                                  "type": 2,
-                                },
-                              ],
-                              "id": 298,
+                              "childNodes": [],
+                              "id": 272,
+                              "tagName": "div",
+                              "type": 2,
+                            },
+                            {
+                              "attributes": {
+                                "data-rrweb-id": 273,
+                                "data-toggle-part": "handle",
+                                "style": "position:absolute;top:1.5%;left:5%;display:flex;align-items:center;justify-content:center;width:40%;height:75%;cursor:inherit;background-color:#f3f4ef;border:2px solid #f3f4ef;border-radius:50%;",
+                              },
+                              "childNodes": [],
+                              "id": 273,
                               "tagName": "div",
                               "type": 2,
                             },
                           ],
-                          "id": 12357,
+                          "id": 271,
                           "tagName": "div",
                           "type": 2,
                         },
                       ],
-                      "id": 302,
-                      "tagName": "label",
+                      "id": 12357,
+                      "tagName": "div",
                       "type": 2,
                     },
                   ],
-                  "id": 297,
-                  "tagName": "div",
+                  "id": 275,
+                  "tagName": "label",
                   "type": 2,
                 },
               ],
@@ -2416,11 +2352,14 @@ exports[`replay/transform transform inputs input - toggle - $value 3`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -2428,70 +2367,68 @@ exports[`replay/transform transform inputs input - toggle - $value 3`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 280,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                  },
                   "childNodes": [
                     {
+                      "id": 279,
+                      "textContent": "third",
+                      "type": 3,
+                    },
+                    {
                       "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                        "data-rrweb-id": 12357,
+                        "style": "height:100%;flex:1",
                       },
                       "childNodes": [
                         {
-                          "id": 307,
-                          "textContent": "third",
-                          "type": 3,
-                        },
-                        {
                           "attributes": {
-                            "style": "height:100%;flex:1",
+                            "data-rrweb-id": 276,
+                            "style": "position:relative;width:100%;height:100%;",
                           },
                           "childNodes": [
                             {
                               "attributes": {
-                                "style": "position:relative;width:100%;height:100%;",
+                                "data-rrweb-id": 277,
+                                "data-toggle-part": "slider",
+                                "style": "position:absolute;top:33%;left:5%;display:inline-block;width:75%;height:33%;background-color:#1d4aff;opacity: 0.2;border-radius:7.5%;",
                               },
-                              "childNodes": [
-                                {
-                                  "attributes": {
-                                    "data-toggle-part": "slider",
-                                    "style": "position:absolute;top:33%;left:5%;display:inline-block;width:75%;height:33%;background-color:#1d4aff;opacity: 0.2;border-radius:7.5%;",
-                                  },
-                                  "childNodes": [],
-                                  "id": 305,
-                                  "tagName": "div",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "data-toggle-part": "handle",
-                                    "style": "position:absolute;top:1.5%;right:5%;display:flex;align-items:center;justify-content:center;width:40%;height:75%;cursor:inherit;background-color:#1d4aff;border:2px solid #1d4aff;border-radius:50%;",
-                                  },
-                                  "childNodes": [],
-                                  "id": 306,
-                                  "tagName": "div",
-                                  "type": 2,
-                                },
-                              ],
-                              "id": 304,
+                              "childNodes": [],
+                              "id": 277,
+                              "tagName": "div",
+                              "type": 2,
+                            },
+                            {
+                              "attributes": {
+                                "data-rrweb-id": 278,
+                                "data-toggle-part": "handle",
+                                "style": "position:absolute;top:1.5%;right:5%;display:flex;align-items:center;justify-content:center;width:40%;height:75%;cursor:inherit;background-color:#1d4aff;border:2px solid #1d4aff;border-radius:50%;",
+                              },
+                              "childNodes": [],
+                              "id": 278,
                               "tagName": "div",
                               "type": 2,
                             },
                           ],
-                          "id": 12357,
+                          "id": 276,
                           "tagName": "div",
                           "type": 2,
                         },
                       ],
-                      "id": 308,
-                      "tagName": "label",
+                      "id": 12357,
+                      "tagName": "div",
                       "type": 2,
                     },
                   ],
-                  "id": 303,
-                  "tagName": "div",
+                  "id": 280,
+                  "tagName": "label",
                   "type": 2,
                 },
               ],
@@ -2532,11 +2469,14 @@ exports[`replay/transform transform inputs input - toggle - $value 4`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -2544,54 +2484,51 @@ exports[`replay/transform transform inputs input - toggle - $value 4`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 12357,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                  },
                   "childNodes": [
                     {
                       "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                        "data-rrweb-id": 281,
+                        "style": "position:relative;width:100%;height:100%;",
                       },
                       "childNodes": [
                         {
                           "attributes": {
-                            "style": "position:relative;width:100%;height:100%;",
+                            "data-rrweb-id": 282,
+                            "data-toggle-part": "slider",
+                            "style": "position:absolute;top:33%;left:5%;display:inline-block;width:75%;height:33%;background-color:#1d4aff;opacity: 0.2;border-radius:7.5%;",
                           },
-                          "childNodes": [
-                            {
-                              "attributes": {
-                                "data-toggle-part": "slider",
-                                "style": "position:absolute;top:33%;left:5%;display:inline-block;width:75%;height:33%;background-color:#1d4aff;opacity: 0.2;border-radius:7.5%;",
-                              },
-                              "childNodes": [],
-                              "id": 311,
-                              "tagName": "div",
-                              "type": 2,
-                            },
-                            {
-                              "attributes": {
-                                "data-toggle-part": "handle",
-                                "style": "position:absolute;top:1.5%;right:5%;display:flex;align-items:center;justify-content:center;width:40%;height:75%;cursor:inherit;background-color:#1d4aff;border:2px solid #1d4aff;border-radius:50%;",
-                              },
-                              "childNodes": [],
-                              "id": 312,
-                              "tagName": "div",
-                              "type": 2,
-                            },
-                          ],
-                          "id": 310,
+                          "childNodes": [],
+                          "id": 282,
+                          "tagName": "div",
+                          "type": 2,
+                        },
+                        {
+                          "attributes": {
+                            "data-rrweb-id": 283,
+                            "data-toggle-part": "handle",
+                            "style": "position:absolute;top:1.5%;right:5%;display:flex;align-items:center;justify-content:center;width:40%;height:75%;cursor:inherit;background-color:#1d4aff;border:2px solid #1d4aff;border-radius:50%;",
+                          },
+                          "childNodes": [],
+                          "id": 283,
                           "tagName": "div",
                           "type": 2,
                         },
                       ],
-                      "id": 12357,
+                      "id": 281,
                       "tagName": "div",
                       "type": 2,
                     },
                   ],
-                  "id": 309,
+                  "id": 12357,
                   "tagName": "div",
                   "type": 2,
                 },
@@ -2633,11 +2570,14 @@ exports[`replay/transform transform inputs input - url - https://example.io 1`] 
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -2645,26 +2585,20 @@ exports[`replay/transform transform inputs input - url - https://example.io 1`] 
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                        "type": "url",
-                        "value": "https://example.io",
-                      },
-                      "childNodes": [],
-                      "id": 12352,
-                      "tagName": "input",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 278,
-                  "tagName": "div",
+                  "attributes": {
+                    "data-rrweb-id": 12352,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                    "type": "url",
+                    "value": "https://example.io",
+                  },
+                  "childNodes": [],
+                  "id": 12352,
+                  "tagName": "input",
                   "type": 2,
                 },
               ],
@@ -2695,31 +2629,36 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {
+            "data-rrweb-id": 12365,
             "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
           },
           "childNodes": [
             {
               "attributes": {
+                "data-rrweb-id": 210,
                 "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
               },
               "childNodes": [
                 {
                   "attributes": {
+                    "data-rrweb-id": 162,
                     "fill": "currentColor",
                     "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
                     "viewBox": "0 0 24 24",
                   },
                   "childNodes": [
                     {
-                      "attributes": {},
+                      "attributes": {
+                        "data-rrweb-id": 163,
+                      },
                       "childNodes": [
                         {
-                          "id": 174,
+                          "id": 165,
                           "textContent": "filled star",
                           "type": 3,
                         },
                       ],
-                      "id": 173,
+                      "id": 163,
                       "isSVG": true,
                       "tagName": "title",
                       "type": 2,
@@ -2727,221 +2666,245 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
                     {
                       "attributes": {
                         "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                        "data-rrweb-id": 164,
                       },
                       "childNodes": [],
+                      "id": 164,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 162,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 166,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 167,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 169,
+                          "textContent": "filled star",
+                          "type": 3,
+                        },
+                      ],
+                      "id": 167,
+                      "isSVG": true,
+                      "tagName": "title",
+                      "type": 2,
+                    },
+                    {
+                      "attributes": {
+                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                        "data-rrweb-id": 168,
+                      },
+                      "childNodes": [],
+                      "id": 168,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 166,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 170,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 171,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 173,
+                          "textContent": "filled star",
+                          "type": 3,
+                        },
+                      ],
+                      "id": 171,
+                      "isSVG": true,
+                      "tagName": "title",
+                      "type": 2,
+                    },
+                    {
+                      "attributes": {
+                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                        "data-rrweb-id": 172,
+                      },
+                      "childNodes": [],
+                      "id": 172,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 170,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 174,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 175,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 177,
+                          "textContent": "filled star",
+                          "type": 3,
+                        },
+                      ],
                       "id": 175,
                       "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 172,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 178,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 177,
-                      "isSVG": true,
                       "tagName": "title",
                       "type": 2,
                     },
                     {
                       "attributes": {
                         "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                        "data-rrweb-id": 176,
                       },
                       "childNodes": [],
+                      "id": 176,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 174,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 178,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 179,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 181,
+                          "textContent": "filled star",
+                          "type": 3,
+                        },
+                      ],
                       "id": 179,
                       "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 176,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 182,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 181,
-                      "isSVG": true,
                       "tagName": "title",
                       "type": 2,
                     },
                     {
                       "attributes": {
                         "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                        "data-rrweb-id": 180,
                       },
                       "childNodes": [],
+                      "id": 180,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 178,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 182,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 183,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 185,
+                          "textContent": "filled star",
+                          "type": 3,
+                        },
+                      ],
                       "id": 183,
                       "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 180,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 186,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 185,
-                      "isSVG": true,
                       "tagName": "title",
                       "type": 2,
                     },
                     {
                       "attributes": {
                         "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                        "data-rrweb-id": 184,
                       },
                       "childNodes": [],
-                      "id": 187,
+                      "id": 184,
                       "isSVG": true,
                       "tagName": "path",
                       "type": 2,
                     },
                   ],
-                  "id": 184,
+                  "id": 182,
                   "isSVG": true,
                   "tagName": "svg",
                   "type": 2,
                 },
                 {
                   "attributes": {
+                    "data-rrweb-id": 186,
                     "fill": "currentColor",
                     "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
                     "viewBox": "0 0 24 24",
                   },
                   "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 190,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 189,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
                     {
                       "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                        "data-rrweb-id": 187,
                       },
-                      "childNodes": [],
-                      "id": 191,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 188,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
                       "childNodes": [
                         {
-                          "id": 194,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 193,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                      },
-                      "childNodes": [],
-                      "id": 195,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 192,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 198,
+                          "id": 189,
                           "textContent": "half-filled star",
                           "type": 3,
                         },
                       ],
-                      "id": 197,
+                      "id": 187,
                       "isSVG": true,
                       "tagName": "title",
                       "type": 2,
@@ -2949,206 +2912,227 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
                     {
                       "attributes": {
                         "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                        "data-rrweb-id": 188,
                       },
                       "childNodes": [],
+                      "id": 188,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 186,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 190,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 191,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 193,
+                          "textContent": "empty star",
+                          "type": 3,
+                        },
+                      ],
+                      "id": 191,
+                      "isSVG": true,
+                      "tagName": "title",
+                      "type": 2,
+                    },
+                    {
+                      "attributes": {
+                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                        "data-rrweb-id": 192,
+                      },
+                      "childNodes": [],
+                      "id": 192,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 190,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 194,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 195,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 197,
+                          "textContent": "empty star",
+                          "type": 3,
+                        },
+                      ],
+                      "id": 195,
+                      "isSVG": true,
+                      "tagName": "title",
+                      "type": 2,
+                    },
+                    {
+                      "attributes": {
+                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                        "data-rrweb-id": 196,
+                      },
+                      "childNodes": [],
+                      "id": 196,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 194,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 198,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 199,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 201,
+                          "textContent": "empty star",
+                          "type": 3,
+                        },
+                      ],
                       "id": 199,
                       "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 196,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 202,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 201,
-                      "isSVG": true,
                       "tagName": "title",
                       "type": 2,
                     },
                     {
                       "attributes": {
                         "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                        "data-rrweb-id": 200,
                       },
                       "childNodes": [],
+                      "id": 200,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 198,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 202,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 203,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 205,
+                          "textContent": "empty star",
+                          "type": 3,
+                        },
+                      ],
                       "id": 203,
                       "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 200,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 206,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 205,
-                      "isSVG": true,
                       "tagName": "title",
                       "type": 2,
                     },
                     {
                       "attributes": {
                         "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                        "data-rrweb-id": 204,
                       },
                       "childNodes": [],
+                      "id": 204,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 202,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 206,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 207,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 209,
+                          "textContent": "empty star",
+                          "type": 3,
+                        },
+                      ],
                       "id": 207,
                       "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 204,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 210,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 209,
-                      "isSVG": true,
                       "tagName": "title",
                       "type": 2,
                     },
                     {
                       "attributes": {
                         "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                        "data-rrweb-id": 208,
                       },
                       "childNodes": [],
-                      "id": 211,
+                      "id": 208,
                       "isSVG": true,
                       "tagName": "path",
                       "type": 2,
                     },
                   ],
-                  "id": 208,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 214,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 213,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 215,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 212,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 218,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 217,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 219,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 216,
+                  "id": 206,
                   "isSVG": true,
                   "tagName": "svg",
                   "type": 2,
                 },
               ],
-              "id": 220,
+              "id": 210,
               "tagName": "div",
               "type": 2,
             },
@@ -3194,31 +3178,36 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {
+            "data-rrweb-id": 12365,
             "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
           },
           "childNodes": [
             {
               "attributes": {
+                "data-rrweb-id": 259,
                 "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
               },
               "childNodes": [
                 {
                   "attributes": {
+                    "data-rrweb-id": 211,
                     "fill": "currentColor",
                     "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
                     "viewBox": "0 0 24 24",
                   },
                   "childNodes": [
                     {
-                      "attributes": {},
+                      "attributes": {
+                        "data-rrweb-id": 212,
+                      },
                       "childNodes": [
                         {
-                          "id": 223,
+                          "id": 214,
                           "textContent": "filled star",
                           "type": 3,
                         },
                       ],
-                      "id": 222,
+                      "id": 212,
                       "isSVG": true,
                       "tagName": "title",
                       "type": 2,
@@ -3226,221 +3215,245 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
                     {
                       "attributes": {
                         "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                        "data-rrweb-id": 213,
                       },
                       "childNodes": [],
+                      "id": 213,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 211,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 215,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 216,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 218,
+                          "textContent": "filled star",
+                          "type": 3,
+                        },
+                      ],
+                      "id": 216,
+                      "isSVG": true,
+                      "tagName": "title",
+                      "type": 2,
+                    },
+                    {
+                      "attributes": {
+                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                        "data-rrweb-id": 217,
+                      },
+                      "childNodes": [],
+                      "id": 217,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 215,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 219,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 220,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 222,
+                          "textContent": "filled star",
+                          "type": 3,
+                        },
+                      ],
+                      "id": 220,
+                      "isSVG": true,
+                      "tagName": "title",
+                      "type": 2,
+                    },
+                    {
+                      "attributes": {
+                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                        "data-rrweb-id": 221,
+                      },
+                      "childNodes": [],
+                      "id": 221,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 219,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 223,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 224,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 226,
+                          "textContent": "filled star",
+                          "type": 3,
+                        },
+                      ],
                       "id": 224,
                       "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 221,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 227,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 226,
-                      "isSVG": true,
                       "tagName": "title",
                       "type": 2,
                     },
                     {
                       "attributes": {
                         "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                        "data-rrweb-id": 225,
                       },
                       "childNodes": [],
+                      "id": 225,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 223,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 227,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 228,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 230,
+                          "textContent": "filled star",
+                          "type": 3,
+                        },
+                      ],
                       "id": 228,
                       "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 225,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 231,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 230,
-                      "isSVG": true,
                       "tagName": "title",
                       "type": 2,
                     },
                     {
                       "attributes": {
                         "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                        "data-rrweb-id": 229,
                       },
                       "childNodes": [],
+                      "id": 229,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 227,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 231,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 232,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 234,
+                          "textContent": "filled star",
+                          "type": 3,
+                        },
+                      ],
                       "id": 232,
                       "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 229,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 235,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 234,
-                      "isSVG": true,
                       "tagName": "title",
                       "type": 2,
                     },
                     {
                       "attributes": {
                         "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                        "data-rrweb-id": 233,
                       },
                       "childNodes": [],
-                      "id": 236,
+                      "id": 233,
                       "isSVG": true,
                       "tagName": "path",
                       "type": 2,
                     },
                   ],
-                  "id": 233,
+                  "id": 231,
                   "isSVG": true,
                   "tagName": "svg",
                   "type": 2,
                 },
                 {
                   "attributes": {
+                    "data-rrweb-id": 235,
                     "fill": "currentColor",
                     "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
                     "viewBox": "0 0 24 24",
                   },
                   "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 239,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 238,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
                     {
                       "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                        "data-rrweb-id": 236,
                       },
-                      "childNodes": [],
-                      "id": 240,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 237,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
                       "childNodes": [
                         {
-                          "id": 243,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 242,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                      },
-                      "childNodes": [],
-                      "id": 244,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 241,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 247,
+                          "id": 238,
                           "textContent": "half-filled star",
                           "type": 3,
                         },
                       ],
-                      "id": 246,
+                      "id": 236,
                       "isSVG": true,
                       "tagName": "title",
                       "type": 2,
@@ -3448,206 +3461,227 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
                     {
                       "attributes": {
                         "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                        "data-rrweb-id": 237,
                       },
                       "childNodes": [],
+                      "id": 237,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 235,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 239,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 240,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 242,
+                          "textContent": "empty star",
+                          "type": 3,
+                        },
+                      ],
+                      "id": 240,
+                      "isSVG": true,
+                      "tagName": "title",
+                      "type": 2,
+                    },
+                    {
+                      "attributes": {
+                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                        "data-rrweb-id": 241,
+                      },
+                      "childNodes": [],
+                      "id": 241,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 239,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 243,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 244,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 246,
+                          "textContent": "empty star",
+                          "type": 3,
+                        },
+                      ],
+                      "id": 244,
+                      "isSVG": true,
+                      "tagName": "title",
+                      "type": 2,
+                    },
+                    {
+                      "attributes": {
+                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                        "data-rrweb-id": 245,
+                      },
+                      "childNodes": [],
+                      "id": 245,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 243,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 247,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 248,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 250,
+                          "textContent": "empty star",
+                          "type": 3,
+                        },
+                      ],
                       "id": 248,
                       "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 245,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 251,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 250,
-                      "isSVG": true,
                       "tagName": "title",
                       "type": 2,
                     },
                     {
                       "attributes": {
                         "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                        "data-rrweb-id": 249,
                       },
                       "childNodes": [],
+                      "id": 249,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 247,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 251,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 252,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 254,
+                          "textContent": "empty star",
+                          "type": 3,
+                        },
+                      ],
                       "id": 252,
                       "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 249,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 255,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 254,
-                      "isSVG": true,
                       "tagName": "title",
                       "type": 2,
                     },
                     {
                       "attributes": {
                         "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                        "data-rrweb-id": 253,
                       },
                       "childNodes": [],
+                      "id": 253,
+                      "isSVG": true,
+                      "tagName": "path",
+                      "type": 2,
+                    },
+                  ],
+                  "id": 251,
+                  "isSVG": true,
+                  "tagName": "svg",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 255,
+                    "fill": "currentColor",
+                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                    "viewBox": "0 0 24 24",
+                  },
+                  "childNodes": [
+                    {
+                      "attributes": {
+                        "data-rrweb-id": 256,
+                      },
+                      "childNodes": [
+                        {
+                          "id": 258,
+                          "textContent": "empty star",
+                          "type": 3,
+                        },
+                      ],
                       "id": 256,
                       "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 253,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 259,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 258,
-                      "isSVG": true,
                       "tagName": "title",
                       "type": 2,
                     },
                     {
                       "attributes": {
                         "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                        "data-rrweb-id": 257,
                       },
                       "childNodes": [],
-                      "id": 260,
+                      "id": 257,
                       "isSVG": true,
                       "tagName": "path",
                       "type": 2,
                     },
                   ],
-                  "id": 257,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 263,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 262,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 264,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 261,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 267,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 266,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 268,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 265,
+                  "id": 255,
                   "isSVG": true,
                   "tagName": "svg",
                   "type": 2,
                 },
               ],
-              "id": 269,
+              "id": 259,
               "tagName": "div",
               "type": 2,
             },
@@ -3682,11 +3716,12 @@ exports[`replay/transform transform inputs open keyboard custom event 1`] = `
         "nextId": null,
         "node": {
           "attributes": {
+            "data-rrweb-id": 6,
             "style": "color: #35373e;background-color: #f3f4ef;width: 100vw;height: 150px;bottom: 0;position: fixed;align-items: center;justify-content: center;display: flex;",
           },
           "childNodes": [
             {
-              "id": 170,
+              "id": 160,
               "textContent": "keyboard",
               "type": 3,
             },
@@ -3700,7 +3735,7 @@ exports[`replay/transform transform inputs open keyboard custom event 1`] = `
       {
         "nextId": null,
         "node": {
-          "id": 171,
+          "id": 161,
           "textContent": "keyboard",
           "type": 3,
         },
@@ -3735,11 +3770,14 @@ exports[`replay/transform transform inputs placeholder - $inputType - $value 1`]
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -3747,29 +3785,23 @@ exports[`replay/transform transform inputs placeholder - $inputType - $value 1`]
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 12365,
+                    "style": "color: #35373e;background-color: #f3f4ef;width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;align-items: center;justify-content: center;display: flex;",
+                  },
                   "childNodes": [
                     {
-                      "attributes": {
-                        "style": "color: #35373e;background-color: #f3f4ef;width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;align-items: center;justify-content: center;display: flex;",
-                      },
-                      "childNodes": [
-                        {
-                          "id": 331,
-                          "textContent": "hello",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 12365,
-                      "tagName": "div",
-                      "type": 2,
+                      "id": 292,
+                      "textContent": "hello",
+                      "type": 3,
                     },
                   ],
-                  "id": 330,
+                  "id": 12365,
                   "tagName": "div",
                   "type": 2,
                 },
@@ -3811,11 +3843,14 @@ exports[`replay/transform transform inputs progress rating 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -3823,478 +3858,521 @@ exports[`replay/transform transform inputs progress rating 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 12365,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                  },
                   "childNodes": [
                     {
                       "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                        "data-rrweb-id": 159,
+                        "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
                       },
                       "childNodes": [
                         {
                           "attributes": {
-                            "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
+                            "data-rrweb-id": 111,
+                            "fill": "currentColor",
+                            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                            "viewBox": "0 0 24 24",
                           },
                           "childNodes": [
                             {
                               "attributes": {
-                                "fill": "currentColor",
-                                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                                "viewBox": "0 0 24 24",
+                                "data-rrweb-id": 112,
                               },
                               "childNodes": [
                                 {
-                                  "attributes": {},
-                                  "childNodes": [
-                                    {
-                                      "id": 123,
-                                      "textContent": "filled star",
-                                      "type": 3,
-                                    },
-                                  ],
-                                  "id": 122,
-                                  "isSVG": true,
-                                  "tagName": "title",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                                  },
-                                  "childNodes": [],
-                                  "id": 124,
-                                  "isSVG": true,
-                                  "tagName": "path",
-                                  "type": 2,
+                                  "id": 114,
+                                  "textContent": "filled star",
+                                  "type": 3,
                                 },
                               ],
-                              "id": 121,
+                              "id": 112,
                               "isSVG": true,
-                              "tagName": "svg",
+                              "tagName": "title",
                               "type": 2,
                             },
                             {
                               "attributes": {
-                                "fill": "currentColor",
-                                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                                "viewBox": "0 0 24 24",
+                                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                                "data-rrweb-id": 113,
                               },
-                              "childNodes": [
-                                {
-                                  "attributes": {},
-                                  "childNodes": [
-                                    {
-                                      "id": 127,
-                                      "textContent": "filled star",
-                                      "type": 3,
-                                    },
-                                  ],
-                                  "id": 126,
-                                  "isSVG": true,
-                                  "tagName": "title",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                                  },
-                                  "childNodes": [],
-                                  "id": 128,
-                                  "isSVG": true,
-                                  "tagName": "path",
-                                  "type": 2,
-                                },
-                              ],
-                              "id": 125,
+                              "childNodes": [],
+                              "id": 113,
                               "isSVG": true,
-                              "tagName": "svg",
-                              "type": 2,
-                            },
-                            {
-                              "attributes": {
-                                "fill": "currentColor",
-                                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                                "viewBox": "0 0 24 24",
-                              },
-                              "childNodes": [
-                                {
-                                  "attributes": {},
-                                  "childNodes": [
-                                    {
-                                      "id": 131,
-                                      "textContent": "filled star",
-                                      "type": 3,
-                                    },
-                                  ],
-                                  "id": 130,
-                                  "isSVG": true,
-                                  "tagName": "title",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                                  },
-                                  "childNodes": [],
-                                  "id": 132,
-                                  "isSVG": true,
-                                  "tagName": "path",
-                                  "type": 2,
-                                },
-                              ],
-                              "id": 129,
-                              "isSVG": true,
-                              "tagName": "svg",
-                              "type": 2,
-                            },
-                            {
-                              "attributes": {
-                                "fill": "currentColor",
-                                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                                "viewBox": "0 0 24 24",
-                              },
-                              "childNodes": [
-                                {
-                                  "attributes": {},
-                                  "childNodes": [
-                                    {
-                                      "id": 135,
-                                      "textContent": "filled star",
-                                      "type": 3,
-                                    },
-                                  ],
-                                  "id": 134,
-                                  "isSVG": true,
-                                  "tagName": "title",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                                  },
-                                  "childNodes": [],
-                                  "id": 136,
-                                  "isSVG": true,
-                                  "tagName": "path",
-                                  "type": 2,
-                                },
-                              ],
-                              "id": 133,
-                              "isSVG": true,
-                              "tagName": "svg",
-                              "type": 2,
-                            },
-                            {
-                              "attributes": {
-                                "fill": "currentColor",
-                                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                                "viewBox": "0 0 24 24",
-                              },
-                              "childNodes": [
-                                {
-                                  "attributes": {},
-                                  "childNodes": [
-                                    {
-                                      "id": 139,
-                                      "textContent": "filled star",
-                                      "type": 3,
-                                    },
-                                  ],
-                                  "id": 138,
-                                  "isSVG": true,
-                                  "tagName": "title",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                                  },
-                                  "childNodes": [],
-                                  "id": 140,
-                                  "isSVG": true,
-                                  "tagName": "path",
-                                  "type": 2,
-                                },
-                              ],
-                              "id": 137,
-                              "isSVG": true,
-                              "tagName": "svg",
-                              "type": 2,
-                            },
-                            {
-                              "attributes": {
-                                "fill": "currentColor",
-                                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                                "viewBox": "0 0 24 24",
-                              },
-                              "childNodes": [
-                                {
-                                  "attributes": {},
-                                  "childNodes": [
-                                    {
-                                      "id": 143,
-                                      "textContent": "filled star",
-                                      "type": 3,
-                                    },
-                                  ],
-                                  "id": 142,
-                                  "isSVG": true,
-                                  "tagName": "title",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                                  },
-                                  "childNodes": [],
-                                  "id": 144,
-                                  "isSVG": true,
-                                  "tagName": "path",
-                                  "type": 2,
-                                },
-                              ],
-                              "id": 141,
-                              "isSVG": true,
-                              "tagName": "svg",
-                              "type": 2,
-                            },
-                            {
-                              "attributes": {
-                                "fill": "currentColor",
-                                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                                "viewBox": "0 0 24 24",
-                              },
-                              "childNodes": [
-                                {
-                                  "attributes": {},
-                                  "childNodes": [
-                                    {
-                                      "id": 147,
-                                      "textContent": "half-filled star",
-                                      "type": 3,
-                                    },
-                                  ],
-                                  "id": 146,
-                                  "isSVG": true,
-                                  "tagName": "title",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                                  },
-                                  "childNodes": [],
-                                  "id": 148,
-                                  "isSVG": true,
-                                  "tagName": "path",
-                                  "type": 2,
-                                },
-                              ],
-                              "id": 145,
-                              "isSVG": true,
-                              "tagName": "svg",
-                              "type": 2,
-                            },
-                            {
-                              "attributes": {
-                                "fill": "currentColor",
-                                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                                "viewBox": "0 0 24 24",
-                              },
-                              "childNodes": [
-                                {
-                                  "attributes": {},
-                                  "childNodes": [
-                                    {
-                                      "id": 151,
-                                      "textContent": "empty star",
-                                      "type": 3,
-                                    },
-                                  ],
-                                  "id": 150,
-                                  "isSVG": true,
-                                  "tagName": "title",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                                  },
-                                  "childNodes": [],
-                                  "id": 152,
-                                  "isSVG": true,
-                                  "tagName": "path",
-                                  "type": 2,
-                                },
-                              ],
-                              "id": 149,
-                              "isSVG": true,
-                              "tagName": "svg",
-                              "type": 2,
-                            },
-                            {
-                              "attributes": {
-                                "fill": "currentColor",
-                                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                                "viewBox": "0 0 24 24",
-                              },
-                              "childNodes": [
-                                {
-                                  "attributes": {},
-                                  "childNodes": [
-                                    {
-                                      "id": 155,
-                                      "textContent": "empty star",
-                                      "type": 3,
-                                    },
-                                  ],
-                                  "id": 154,
-                                  "isSVG": true,
-                                  "tagName": "title",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                                  },
-                                  "childNodes": [],
-                                  "id": 156,
-                                  "isSVG": true,
-                                  "tagName": "path",
-                                  "type": 2,
-                                },
-                              ],
-                              "id": 153,
-                              "isSVG": true,
-                              "tagName": "svg",
-                              "type": 2,
-                            },
-                            {
-                              "attributes": {
-                                "fill": "currentColor",
-                                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                                "viewBox": "0 0 24 24",
-                              },
-                              "childNodes": [
-                                {
-                                  "attributes": {},
-                                  "childNodes": [
-                                    {
-                                      "id": 159,
-                                      "textContent": "empty star",
-                                      "type": 3,
-                                    },
-                                  ],
-                                  "id": 158,
-                                  "isSVG": true,
-                                  "tagName": "title",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                                  },
-                                  "childNodes": [],
-                                  "id": 160,
-                                  "isSVG": true,
-                                  "tagName": "path",
-                                  "type": 2,
-                                },
-                              ],
-                              "id": 157,
-                              "isSVG": true,
-                              "tagName": "svg",
-                              "type": 2,
-                            },
-                            {
-                              "attributes": {
-                                "fill": "currentColor",
-                                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                                "viewBox": "0 0 24 24",
-                              },
-                              "childNodes": [
-                                {
-                                  "attributes": {},
-                                  "childNodes": [
-                                    {
-                                      "id": 163,
-                                      "textContent": "empty star",
-                                      "type": 3,
-                                    },
-                                  ],
-                                  "id": 162,
-                                  "isSVG": true,
-                                  "tagName": "title",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                                  },
-                                  "childNodes": [],
-                                  "id": 164,
-                                  "isSVG": true,
-                                  "tagName": "path",
-                                  "type": 2,
-                                },
-                              ],
-                              "id": 161,
-                              "isSVG": true,
-                              "tagName": "svg",
-                              "type": 2,
-                            },
-                            {
-                              "attributes": {
-                                "fill": "currentColor",
-                                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                                "viewBox": "0 0 24 24",
-                              },
-                              "childNodes": [
-                                {
-                                  "attributes": {},
-                                  "childNodes": [
-                                    {
-                                      "id": 167,
-                                      "textContent": "empty star",
-                                      "type": 3,
-                                    },
-                                  ],
-                                  "id": 166,
-                                  "isSVG": true,
-                                  "tagName": "title",
-                                  "type": 2,
-                                },
-                                {
-                                  "attributes": {
-                                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                                  },
-                                  "childNodes": [],
-                                  "id": 168,
-                                  "isSVG": true,
-                                  "tagName": "path",
-                                  "type": 2,
-                                },
-                              ],
-                              "id": 165,
-                              "isSVG": true,
-                              "tagName": "svg",
+                              "tagName": "path",
                               "type": 2,
                             },
                           ],
-                          "id": 169,
-                          "tagName": "div",
+                          "id": 111,
+                          "isSVG": true,
+                          "tagName": "svg",
+                          "type": 2,
+                        },
+                        {
+                          "attributes": {
+                            "data-rrweb-id": 115,
+                            "fill": "currentColor",
+                            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                            "viewBox": "0 0 24 24",
+                          },
+                          "childNodes": [
+                            {
+                              "attributes": {
+                                "data-rrweb-id": 116,
+                              },
+                              "childNodes": [
+                                {
+                                  "id": 118,
+                                  "textContent": "filled star",
+                                  "type": 3,
+                                },
+                              ],
+                              "id": 116,
+                              "isSVG": true,
+                              "tagName": "title",
+                              "type": 2,
+                            },
+                            {
+                              "attributes": {
+                                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                                "data-rrweb-id": 117,
+                              },
+                              "childNodes": [],
+                              "id": 117,
+                              "isSVG": true,
+                              "tagName": "path",
+                              "type": 2,
+                            },
+                          ],
+                          "id": 115,
+                          "isSVG": true,
+                          "tagName": "svg",
+                          "type": 2,
+                        },
+                        {
+                          "attributes": {
+                            "data-rrweb-id": 119,
+                            "fill": "currentColor",
+                            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                            "viewBox": "0 0 24 24",
+                          },
+                          "childNodes": [
+                            {
+                              "attributes": {
+                                "data-rrweb-id": 120,
+                              },
+                              "childNodes": [
+                                {
+                                  "id": 122,
+                                  "textContent": "filled star",
+                                  "type": 3,
+                                },
+                              ],
+                              "id": 120,
+                              "isSVG": true,
+                              "tagName": "title",
+                              "type": 2,
+                            },
+                            {
+                              "attributes": {
+                                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                                "data-rrweb-id": 121,
+                              },
+                              "childNodes": [],
+                              "id": 121,
+                              "isSVG": true,
+                              "tagName": "path",
+                              "type": 2,
+                            },
+                          ],
+                          "id": 119,
+                          "isSVG": true,
+                          "tagName": "svg",
+                          "type": 2,
+                        },
+                        {
+                          "attributes": {
+                            "data-rrweb-id": 123,
+                            "fill": "currentColor",
+                            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                            "viewBox": "0 0 24 24",
+                          },
+                          "childNodes": [
+                            {
+                              "attributes": {
+                                "data-rrweb-id": 124,
+                              },
+                              "childNodes": [
+                                {
+                                  "id": 126,
+                                  "textContent": "filled star",
+                                  "type": 3,
+                                },
+                              ],
+                              "id": 124,
+                              "isSVG": true,
+                              "tagName": "title",
+                              "type": 2,
+                            },
+                            {
+                              "attributes": {
+                                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                                "data-rrweb-id": 125,
+                              },
+                              "childNodes": [],
+                              "id": 125,
+                              "isSVG": true,
+                              "tagName": "path",
+                              "type": 2,
+                            },
+                          ],
+                          "id": 123,
+                          "isSVG": true,
+                          "tagName": "svg",
+                          "type": 2,
+                        },
+                        {
+                          "attributes": {
+                            "data-rrweb-id": 127,
+                            "fill": "currentColor",
+                            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                            "viewBox": "0 0 24 24",
+                          },
+                          "childNodes": [
+                            {
+                              "attributes": {
+                                "data-rrweb-id": 128,
+                              },
+                              "childNodes": [
+                                {
+                                  "id": 130,
+                                  "textContent": "filled star",
+                                  "type": 3,
+                                },
+                              ],
+                              "id": 128,
+                              "isSVG": true,
+                              "tagName": "title",
+                              "type": 2,
+                            },
+                            {
+                              "attributes": {
+                                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                                "data-rrweb-id": 129,
+                              },
+                              "childNodes": [],
+                              "id": 129,
+                              "isSVG": true,
+                              "tagName": "path",
+                              "type": 2,
+                            },
+                          ],
+                          "id": 127,
+                          "isSVG": true,
+                          "tagName": "svg",
+                          "type": 2,
+                        },
+                        {
+                          "attributes": {
+                            "data-rrweb-id": 131,
+                            "fill": "currentColor",
+                            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                            "viewBox": "0 0 24 24",
+                          },
+                          "childNodes": [
+                            {
+                              "attributes": {
+                                "data-rrweb-id": 132,
+                              },
+                              "childNodes": [
+                                {
+                                  "id": 134,
+                                  "textContent": "filled star",
+                                  "type": 3,
+                                },
+                              ],
+                              "id": 132,
+                              "isSVG": true,
+                              "tagName": "title",
+                              "type": 2,
+                            },
+                            {
+                              "attributes": {
+                                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                                "data-rrweb-id": 133,
+                              },
+                              "childNodes": [],
+                              "id": 133,
+                              "isSVG": true,
+                              "tagName": "path",
+                              "type": 2,
+                            },
+                          ],
+                          "id": 131,
+                          "isSVG": true,
+                          "tagName": "svg",
+                          "type": 2,
+                        },
+                        {
+                          "attributes": {
+                            "data-rrweb-id": 135,
+                            "fill": "currentColor",
+                            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                            "viewBox": "0 0 24 24",
+                          },
+                          "childNodes": [
+                            {
+                              "attributes": {
+                                "data-rrweb-id": 136,
+                              },
+                              "childNodes": [
+                                {
+                                  "id": 138,
+                                  "textContent": "half-filled star",
+                                  "type": 3,
+                                },
+                              ],
+                              "id": 136,
+                              "isSVG": true,
+                              "tagName": "title",
+                              "type": 2,
+                            },
+                            {
+                              "attributes": {
+                                "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                                "data-rrweb-id": 137,
+                              },
+                              "childNodes": [],
+                              "id": 137,
+                              "isSVG": true,
+                              "tagName": "path",
+                              "type": 2,
+                            },
+                          ],
+                          "id": 135,
+                          "isSVG": true,
+                          "tagName": "svg",
+                          "type": 2,
+                        },
+                        {
+                          "attributes": {
+                            "data-rrweb-id": 139,
+                            "fill": "currentColor",
+                            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                            "viewBox": "0 0 24 24",
+                          },
+                          "childNodes": [
+                            {
+                              "attributes": {
+                                "data-rrweb-id": 140,
+                              },
+                              "childNodes": [
+                                {
+                                  "id": 142,
+                                  "textContent": "empty star",
+                                  "type": 3,
+                                },
+                              ],
+                              "id": 140,
+                              "isSVG": true,
+                              "tagName": "title",
+                              "type": 2,
+                            },
+                            {
+                              "attributes": {
+                                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                                "data-rrweb-id": 141,
+                              },
+                              "childNodes": [],
+                              "id": 141,
+                              "isSVG": true,
+                              "tagName": "path",
+                              "type": 2,
+                            },
+                          ],
+                          "id": 139,
+                          "isSVG": true,
+                          "tagName": "svg",
+                          "type": 2,
+                        },
+                        {
+                          "attributes": {
+                            "data-rrweb-id": 143,
+                            "fill": "currentColor",
+                            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                            "viewBox": "0 0 24 24",
+                          },
+                          "childNodes": [
+                            {
+                              "attributes": {
+                                "data-rrweb-id": 144,
+                              },
+                              "childNodes": [
+                                {
+                                  "id": 146,
+                                  "textContent": "empty star",
+                                  "type": 3,
+                                },
+                              ],
+                              "id": 144,
+                              "isSVG": true,
+                              "tagName": "title",
+                              "type": 2,
+                            },
+                            {
+                              "attributes": {
+                                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                                "data-rrweb-id": 145,
+                              },
+                              "childNodes": [],
+                              "id": 145,
+                              "isSVG": true,
+                              "tagName": "path",
+                              "type": 2,
+                            },
+                          ],
+                          "id": 143,
+                          "isSVG": true,
+                          "tagName": "svg",
+                          "type": 2,
+                        },
+                        {
+                          "attributes": {
+                            "data-rrweb-id": 147,
+                            "fill": "currentColor",
+                            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                            "viewBox": "0 0 24 24",
+                          },
+                          "childNodes": [
+                            {
+                              "attributes": {
+                                "data-rrweb-id": 148,
+                              },
+                              "childNodes": [
+                                {
+                                  "id": 150,
+                                  "textContent": "empty star",
+                                  "type": 3,
+                                },
+                              ],
+                              "id": 148,
+                              "isSVG": true,
+                              "tagName": "title",
+                              "type": 2,
+                            },
+                            {
+                              "attributes": {
+                                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                                "data-rrweb-id": 149,
+                              },
+                              "childNodes": [],
+                              "id": 149,
+                              "isSVG": true,
+                              "tagName": "path",
+                              "type": 2,
+                            },
+                          ],
+                          "id": 147,
+                          "isSVG": true,
+                          "tagName": "svg",
+                          "type": 2,
+                        },
+                        {
+                          "attributes": {
+                            "data-rrweb-id": 151,
+                            "fill": "currentColor",
+                            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                            "viewBox": "0 0 24 24",
+                          },
+                          "childNodes": [
+                            {
+                              "attributes": {
+                                "data-rrweb-id": 152,
+                              },
+                              "childNodes": [
+                                {
+                                  "id": 154,
+                                  "textContent": "empty star",
+                                  "type": 3,
+                                },
+                              ],
+                              "id": 152,
+                              "isSVG": true,
+                              "tagName": "title",
+                              "type": 2,
+                            },
+                            {
+                              "attributes": {
+                                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                                "data-rrweb-id": 153,
+                              },
+                              "childNodes": [],
+                              "id": 153,
+                              "isSVG": true,
+                              "tagName": "path",
+                              "type": 2,
+                            },
+                          ],
+                          "id": 151,
+                          "isSVG": true,
+                          "tagName": "svg",
+                          "type": 2,
+                        },
+                        {
+                          "attributes": {
+                            "data-rrweb-id": 155,
+                            "fill": "currentColor",
+                            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                            "viewBox": "0 0 24 24",
+                          },
+                          "childNodes": [
+                            {
+                              "attributes": {
+                                "data-rrweb-id": 156,
+                              },
+                              "childNodes": [
+                                {
+                                  "id": 158,
+                                  "textContent": "empty star",
+                                  "type": 3,
+                                },
+                              ],
+                              "id": 156,
+                              "isSVG": true,
+                              "tagName": "title",
+                              "type": 2,
+                            },
+                            {
+                              "attributes": {
+                                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                                "data-rrweb-id": 157,
+                              },
+                              "childNodes": [],
+                              "id": 157,
+                              "isSVG": true,
+                              "tagName": "path",
+                              "type": 2,
+                            },
+                          ],
+                          "id": 155,
+                          "isSVG": true,
+                          "tagName": "svg",
                           "type": 2,
                         },
                       ],
-                      "id": 12365,
+                      "id": 159,
                       "tagName": "div",
                       "type": 2,
                     },
                   ],
-                  "id": 120,
+                  "id": 12365,
                   "tagName": "div",
                   "type": 2,
                 },
@@ -4336,11 +4414,14 @@ exports[`replay/transform transform inputs radio group - $inputType - $value 1`]
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -4348,17 +4429,10 @@ exports[`replay/transform transform inputs radio group - $inputType - $value 1`]
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [],
-                  "id": 280,
-                  "tagName": "div",
-                  "type": 2,
-                },
-              ],
+              "childNodes": [],
               "id": 5,
               "tagName": "body",
               "type": 2,
@@ -4396,11 +4470,14 @@ exports[`replay/transform transform inputs radio_group - $inputType - $value 1`]
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -4408,23 +4485,17 @@ exports[`replay/transform transform inputs radio_group - $inputType - $value 1`]
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                      },
-                      "childNodes": [],
-                      "id": 123123,
-                      "tagName": "div",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 279,
+                  "attributes": {
+                    "data-rrweb-id": 123123,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                  },
+                  "childNodes": [],
+                  "id": 123123,
                   "tagName": "div",
                   "type": 2,
                 },
@@ -4466,11 +4537,14 @@ exports[`replay/transform transform inputs radio_group 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -4478,23 +4552,17 @@ exports[`replay/transform transform inputs radio_group 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
-                      },
-                      "childNodes": [],
-                      "id": 54321,
-                      "tagName": "div",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 270,
+                  "attributes": {
+                    "data-rrweb-id": 54321,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                  },
+                  "childNodes": [],
+                  "id": 54321,
                   "tagName": "div",
                   "type": 2,
                 },
@@ -4536,11 +4604,14 @@ exports[`replay/transform transform inputs web_view - $inputType - $value 1`] = 
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -4548,29 +4619,23 @@ exports[`replay/transform transform inputs web_view - $inputType - $value 1`] = 
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 12365,
+                    "style": "color: #35373e;background-color: #f3f4ef;width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;align-items: center;justify-content: center;display: flex;",
+                  },
                   "childNodes": [
                     {
-                      "attributes": {
-                        "style": "color: #35373e;background-color: #f3f4ef;width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;align-items: center;justify-content: center;display: flex;",
-                      },
-                      "childNodes": [
-                        {
-                          "id": 333,
-                          "textContent": "web_view",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 12365,
-                      "tagName": "div",
-                      "type": 2,
+                      "id": 293,
+                      "textContent": "web_view",
+                      "type": 3,
                     },
                   ],
-                  "id": 332,
+                  "id": 12365,
                   "tagName": "div",
                   "type": 2,
                 },
@@ -4612,11 +4677,14 @@ exports[`replay/transform transform inputs web_view with URL 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -4624,29 +4692,23 @@ exports[`replay/transform transform inputs web_view with URL 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 12365,
+                    "style": "color: #35373e;background-color: #f3f4ef;width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;align-items: center;justify-content: center;display: flex;",
+                  },
                   "childNodes": [
                     {
-                      "attributes": {
-                        "style": "color: #35373e;background-color: #f3f4ef;width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;align-items: center;justify-content: center;display: flex;",
-                      },
-                      "childNodes": [
-                        {
-                          "id": 119,
-                          "textContent": "https://example.com",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 12365,
-                      "tagName": "div",
-                      "type": 2,
+                      "id": 110,
+                      "textContent": "https://example.com",
+                      "type": 3,
                     },
                   ],
-                  "id": 118,
+                  "id": 12365,
                   "tagName": "div",
                   "type": 2,
                 },
@@ -4688,11 +4750,14 @@ exports[`replay/transform transform inputs wrapping with labels 1`] = `
         },
         {
           "attributes": {
+            "data-rrweb-id": 3,
             "style": "height: 100vh; width: 100vw;",
           },
           "childNodes": [
             {
-              "attributes": {},
+              "attributes": {
+                "data-rrweb-id": 4,
+              },
               "childNodes": [],
               "id": 4,
               "tagName": "head",
@@ -4700,40 +4765,35 @@ exports[`replay/transform transform inputs wrapping with labels 1`] = `
             },
             {
               "attributes": {
+                "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
               "childNodes": [
                 {
-                  "attributes": {},
+                  "attributes": {
+                    "data-rrweb-id": 109,
+                    "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                  },
                   "childNodes": [
                     {
                       "attributes": {
-                        "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
+                        "data-rrweb-id": 12359,
+                        "style": null,
+                        "type": "checkbox",
                       },
-                      "childNodes": [
-                        {
-                          "attributes": {
-                            "style": null,
-                            "type": "checkbox",
-                          },
-                          "childNodes": [],
-                          "id": 12359,
-                          "tagName": "input",
-                          "type": 2,
-                        },
-                        {
-                          "id": 116,
-                          "textContent": "i will wrap the checkbox",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 117,
-                      "tagName": "label",
+                      "childNodes": [],
+                      "id": 12359,
+                      "tagName": "input",
                       "type": 2,
                     },
+                    {
+                      "id": 108,
+                      "textContent": "i will wrap the checkbox",
+                      "type": 3,
+                    },
                   ],
-                  "id": 115,
-                  "tagName": "div",
+                  "id": 109,
+                  "tagName": "label",
                   "type": 2,
                 },
               ],
@@ -4775,11 +4835,14 @@ exports[`replay/transform transform omitting x and y is equivalent to setting th
           },
           {
             "attributes": {
+              "data-rrweb-id": 3,
               "style": "height: 100vh; width: 100vw;",
             },
             "childNodes": [
               {
-                "attributes": {},
+                "attributes": {
+                  "data-rrweb-id": 4,
+                },
                 "childNodes": [],
                 "id": 4,
                 "tagName": "head",
@@ -4787,29 +4850,23 @@ exports[`replay/transform transform omitting x and y is equivalent to setting th
               },
               {
                 "attributes": {
+                  "data-rrweb-id": 5,
                   "style": "height: 100vh; width: 100vw;",
                 },
                 "childNodes": [
                   {
-                    "attributes": {},
+                    "attributes": {
+                      "data-rrweb-id": 12345,
+                      "style": "color: #35373e;background-color: #f3f4ef;width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;align-items: center;justify-content: center;display: flex;",
+                    },
                     "childNodes": [
                       {
-                        "attributes": {
-                          "style": "color: #35373e;background-color: #f3f4ef;width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;align-items: center;justify-content: center;display: flex;",
-                        },
-                        "childNodes": [
-                          {
-                            "id": 112,
-                            "textContent": "image",
-                            "type": 3,
-                          },
-                        ],
-                        "id": 12345,
-                        "tagName": "div",
-                        "type": 2,
+                        "id": 106,
+                        "textContent": "image",
+                        "type": 3,
                       },
                     ],
-                    "id": 111,
+                    "id": 12345,
                     "tagName": "div",
                     "type": 2,
                   },

--- a/ee/frontend/mobile-replay/transformers.ts
+++ b/ee/frontend/mobile-replay/transformers.ts
@@ -189,6 +189,7 @@ function makeDivElement(wireframe: wireframeDiv, children: serializedNodeWithId[
         tagName: 'div',
         attributes: {
             style: makeStylesString(wireframe) + 'overflow:hidden;white-space:nowrap;',
+            'data-rrweb-id': _id,
         },
         id: _id,
         childNodes: children,
@@ -203,18 +204,21 @@ function makeTextElement(wireframe: wireframeText, children: serializedNodeWithI
 
     // because we might have to style the text, we always wrap it in a div
     // and apply styles to that
+    const id = idSequence.next().value
     return {
         type: NodeType.Element,
         tagName: 'div',
         attributes: {
             style: makeStylesString(wireframe) + 'overflow:hidden;white-space:nowrap;',
+            'data-rrweb-id': wireframe.id,
         },
-        id: idSequence.next().value,
+        id: wireframe.id,
         childNodes: [
             {
                 type: NodeType.Text,
                 textContent: wireframe.text,
-                id: wireframe.id,
+                // since the text node is wrapped, we assign it a synthetic id
+                id: id,
             },
             ...children,
         ],
@@ -247,11 +251,13 @@ function makePlaceholderElement(
                 color: wireframe.style?.color || FOREGROUND,
                 ...styleOverride,
             }),
+            'data-rrweb-id': wireframe.id,
         },
         id: wireframe.id,
         childNodes: [
             {
                 type: NodeType.Text,
+                // since the text node is wrapped, we assign it a synthetic id
                 id: idSequence.next().value,
                 textContent: txt,
             },
@@ -276,6 +282,7 @@ function makeImageElement(wireframe: wireframeImage, children: serializedNodeWit
             width: wireframe.width,
             height: wireframe.height,
             style: makeStylesString(wireframe),
+            'data-rrweb-id': wireframe.id,
         },
         id: wireframe.id,
         childNodes: children,
@@ -287,6 +294,7 @@ function inputAttributes<T extends wireframeInputComponent>(wireframe: T): attri
         style: makeStylesString(wireframe),
         type: wireframe.inputType,
         ...(wireframe.disabled ? { disabled: wireframe.disabled } : {}),
+        'data-rrweb-id': wireframe.id,
     }
 
     switch (wireframe.inputType) {
@@ -357,13 +365,15 @@ function makeButtonElement(wireframe: wireframeButton, children: serializedNodeW
 }
 
 function makeSelectOptionElement(option: string, selected: boolean): serializedNodeWithId {
+    const optionId = idSequence.next().value
     return {
         type: NodeType.Element,
         tagName: 'option',
         attributes: {
             ...(selected ? { selected: selected } : {}),
+            'data-rrweb-id': optionId,
         },
-        id: idSequence.next().value,
+        id: optionId,
         childNodes: [
             {
                 type: NodeType.Text,
@@ -395,6 +405,7 @@ function groupRadioButtons(children: serializedNodeWithId[], radioGroupName: str
                 attributes: {
                     ...child.attributes,
                     name: radioGroupName,
+                    'data-rrweb-id': child.id,
                 },
             }
         }
@@ -412,6 +423,7 @@ function makeRadioGroupElement(
         tagName: 'div',
         attributes: {
             style: makeStylesString(wireframe),
+            'data-rrweb-id': wireframe.id,
         },
         id: wireframe.id,
         childNodes: groupRadioButtons(children, radioGroupName),
@@ -419,6 +431,9 @@ function makeRadioGroupElement(
 }
 
 function makeStar(title: string, path: string): serializedNodeWithId {
+    const svgId = idSequence.next().value
+    const titleId = idSequence.next().value
+    const pathId = idSequence.next().value
     return {
         type: NodeType.Element,
         tagName: 'svg',
@@ -427,15 +442,18 @@ function makeStar(title: string, path: string): serializedNodeWithId {
             style: 'height: 100%;overflow-clip-margin: content-box;overflow:hidden',
             viewBox: '0 0 24 24',
             fill: 'currentColor',
+            'data-rrweb-id': svgId,
         },
-        id: idSequence.next().value,
+        id: svgId,
         childNodes: [
             {
                 type: NodeType.Element,
                 tagName: 'title',
                 isSVG: true,
-                attributes: {},
-                id: idSequence.next().value,
+                attributes: {
+                    'data-rrweb-id': titleId,
+                },
+                id: titleId,
                 childNodes: [
                     {
                         type: NodeType.Text,
@@ -450,8 +468,9 @@ function makeStar(title: string, path: string): serializedNodeWithId {
                 isSVG: true,
                 attributes: {
                     d: path,
+                    'data-rrweb-id': pathId,
                 },
-                id: idSequence.next().value,
+                id: pathId,
                 childNodes: [],
             },
         ],
@@ -501,14 +520,16 @@ function makeRatingBar(wireframe: wireframeProgress, children: serializedNodeWit
         .fill(undefined)
         .map(() => emptyStar())
 
+    const ratingBarId = idSequence.next().value
     const ratingBar = {
         type: NodeType.Element,
         tagName: 'div',
-        id: idSequence.next().value,
+        id: ratingBarId,
         attributes: {
             style:
                 makeColorStyles(wireframe) +
                 'position: relative; display: flex; flex-direction: row; padding: 2px 4px;',
+            'data-rrweb-id': ratingBarId,
         },
         childNodes: [...filledStars, ...halfStars, ...emptyStars],
     } as serializedNodeWithId
@@ -518,6 +539,7 @@ function makeRatingBar(wireframe: wireframeProgress, children: serializedNodeWit
         tagName: 'div',
         attributes: {
             style: makeStylesString(wireframe),
+            'data-rrweb-id': wireframe.id,
         },
         id: wireframe.id,
         childNodes: [ratingBar, ...children],
@@ -565,11 +587,13 @@ function makeProgressElement(
                   },
               ]
 
+        const wrappingDivId = idSequence.next().value
         return {
             type: NodeType.Element,
             tagName: 'div',
             attributes: {
                 style: makeMinimalStyles(wireframe),
+                'data-rrweb-id': wireframe.id,
             },
             id: wireframe.id,
             childNodes: [
@@ -581,8 +605,9 @@ function makeProgressElement(
                         style: _isPositiveInteger(value)
                             ? makeDeterminateProgressStyles(wireframe, styleOverride)
                             : makeIndeterminateProgressStyles(wireframe, styleOverride),
+                        'data-rrweb-id': wrappingDivId,
                     },
-                    id: idSequence.next().value,
+                    id: wrappingDivId,
                     childNodes: stylingChildren,
                 },
                 ...children,
@@ -604,6 +629,8 @@ function makeProgressElement(
 function makeToggleParts(wireframe: wireframeToggle): serializedNodeWithId[] {
     const togglePosition = wireframe.checked ? 'right' : 'left'
     const defaultColor = wireframe.checked ? '#1d4aff' : BACKGROUND
+    const sliderPartId = idSequence.next().value
+    const handlePartId = idSequence.next().value
     return [
         {
             type: NodeType.Element,
@@ -613,8 +640,9 @@ function makeToggleParts(wireframe: wireframeToggle): serializedNodeWithId[] {
                 style: `position:absolute;top:33%;left:5%;display:inline-block;width:75%;height:33%;background-color:${
                     wireframe.style?.color || defaultColor
                 };opacity: 0.2;border-radius:7.5%;`,
+                'data-rrweb-id': sliderPartId,
             },
-            id: idSequence.next().value,
+            id: sliderPartId,
             childNodes: [],
         },
         {
@@ -627,8 +655,9 @@ function makeToggleParts(wireframe: wireframeToggle): serializedNodeWithId[] {
                 };border:2px solid ${
                     wireframe.style?.borderColor || wireframe.style?.color || defaultColor
                 };border-radius:50%;`,
+                'data-rrweb-id': handlePartId,
             },
-            id: idSequence.next().value,
+            id: handlePartId,
             childNodes: [],
         },
     ]
@@ -636,12 +665,14 @@ function makeToggleParts(wireframe: wireframeToggle): serializedNodeWithId[] {
 
 function makeToggleElement(wireframe: wireframeToggle): (elementNode & { id: number }) | null {
     const isLabelled = 'label' in wireframe
+    const wrappingDivId = idSequence.next().value
     return {
         type: NodeType.Element,
         tagName: 'div',
         attributes: {
             // if labelled take up available space, otherwise use provided positioning
             style: isLabelled ? `height:100%;flex:1` : makePositionStyles(wireframe),
+            'data-rrweb-id': wireframe.id,
         },
         id: wireframe.id,
         childNodes: [
@@ -651,8 +682,9 @@ function makeToggleElement(wireframe: wireframeToggle): (elementNode & { id: num
                 attributes: {
                     // relative position, fills parent
                     style: 'position:relative;width:100%;height:100%;',
+                    'data-rrweb-id': wrappingDivId,
                 },
-                id: idSequence.next().value,
+                id: wrappingDivId,
                 childNodes: makeToggleParts(wireframe),
             },
         ],
@@ -671,13 +703,15 @@ function makeLabelledInput(
 
     const orderedChildren = wireframe.inputType === 'toggle' ? [theLabel, theInputElement] : [theInputElement, theLabel]
 
+    const labelId = idSequence.next().value
     return {
         type: NodeType.Element,
         tagName: 'label',
         attributes: {
             style: makeStylesString(wireframe),
+            'data-rrweb-id': labelId,
         },
-        id: idSequence.next().value,
+        id: labelId,
         childNodes: orderedChildren,
     }
 }
@@ -740,6 +774,7 @@ function makeRectangleElement(
         tagName: 'div',
         attributes: {
             style: makeStylesString(wireframe),
+            'data-rrweb-id': wireframe.id,
         },
         id: wireframe.id,
         childNodes: children,
@@ -926,30 +961,22 @@ export const makeFullEvent = (
                     {
                         type: NodeType.Element,
                         tagName: 'html',
-                        attributes: { style: makeHTMLStyles() },
+                        attributes: { style: makeHTMLStyles(), 'data-rrweb-id': HTML_ELEMENT_ID },
                         id: HTML_ELEMENT_ID,
                         childNodes: [
                             {
                                 type: NodeType.Element,
                                 tagName: 'head',
-                                attributes: {},
+                                attributes: { 'data-rrweb-id': HEAD_ID },
                                 id: HEAD_ID,
                                 childNodes: [],
                             },
                             {
                                 type: NodeType.Element,
                                 tagName: 'body',
-                                attributes: { style: makeBodyStyles() },
+                                attributes: { style: makeBodyStyles(), 'data-rrweb-id': BODY_ID },
                                 id: BODY_ID,
-                                childNodes: [
-                                    {
-                                        type: NodeType.Element,
-                                        tagName: 'div',
-                                        attributes: {},
-                                        id: idSequence.next().value,
-                                        childNodes: convertWireframesFor(mobileEvent.data.wireframes),
-                                    },
-                                ],
+                                childNodes: convertWireframesFor(mobileEvent.data.wireframes) || [],
                             },
                         ],
                     },


### PR DESCRIPTION
Debugging mobile replay is really tricky and I'm frequently stepping through breakpoints in rrweb just so I can understand relation of elements

Let's lift some information into the replayer DOM so this is less tricky

Now the elements in the recreated DOM will have a data attribute listing the ID rrweb has for it. Since mutations rely on the id to parent id relation this should help debug those

<img width="414" alt="Screenshot 2024-01-04 at 12 32 42" src="https://github.com/PostHog/posthog/assets/984817/17fb017c-bb76-43ad-be38-ad7d8694611e">
