### PR TITLE
fix: mobile mutations

### DIFF
--- a/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
+++ b/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
@@ -2632,516 +2632,1252 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "data-rrweb-id": 12365,
             "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
           },
-          "childNodes": [
-            {
-              "attributes": {
-                "data-rrweb-id": 210,
-                "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
-              },
-              "childNodes": [
-                {
-                  "attributes": {
-                    "data-rrweb-id": 162,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 163,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 165,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 163,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                        "data-rrweb-id": 164,
-                      },
-                      "childNodes": [],
-                      "id": 164,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 162,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 166,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 167,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 169,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 167,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                        "data-rrweb-id": 168,
-                      },
-                      "childNodes": [],
-                      "id": 168,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 166,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 170,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 171,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 173,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 171,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                        "data-rrweb-id": 172,
-                      },
-                      "childNodes": [],
-                      "id": 172,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 170,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 174,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 175,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 177,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 175,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                        "data-rrweb-id": 176,
-                      },
-                      "childNodes": [],
-                      "id": 176,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 174,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 178,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 179,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 181,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 179,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                        "data-rrweb-id": 180,
-                      },
-                      "childNodes": [],
-                      "id": 180,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 178,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 182,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 183,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 185,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 183,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                        "data-rrweb-id": 184,
-                      },
-                      "childNodes": [],
-                      "id": 184,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 182,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 186,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 187,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 189,
-                          "textContent": "half-filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 187,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                        "data-rrweb-id": 188,
-                      },
-                      "childNodes": [],
-                      "id": 188,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 186,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 190,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 191,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 193,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 191,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                        "data-rrweb-id": 192,
-                      },
-                      "childNodes": [],
-                      "id": 192,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 190,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 194,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 195,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 197,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 195,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                        "data-rrweb-id": 196,
-                      },
-                      "childNodes": [],
-                      "id": 196,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 194,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 198,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 199,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 201,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 199,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                        "data-rrweb-id": 200,
-                      },
-                      "childNodes": [],
-                      "id": 200,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 198,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 202,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 203,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 205,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 203,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                        "data-rrweb-id": 204,
-                      },
-                      "childNodes": [],
-                      "id": 204,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 202,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 206,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 207,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 209,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 207,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                        "data-rrweb-id": 208,
-                      },
-                      "childNodes": [],
-                      "id": 208,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 206,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-              ],
-              "id": 210,
-              "tagName": "div",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 12365,
           "tagName": "div",
           "type": 2,
         },
         "parentId": 54321,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 210,
+            "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
+          },
+          "childNodes": [],
+          "id": 210,
+          "tagName": "div",
+          "type": 2,
+        },
+        "parentId": 12365,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 210,
+            "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
+          },
+          "childNodes": [],
+          "id": 210,
+          "tagName": "div",
+          "type": 2,
+        },
+        "parentId": 12365,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 162,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 162,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 162,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 162,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 163,
+          },
+          "childNodes": [],
+          "id": 163,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 162,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 163,
+          },
+          "childNodes": [],
+          "id": 163,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 162,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 165,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 163,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 164,
+          },
+          "childNodes": [],
+          "id": 164,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 162,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 164,
+          },
+          "childNodes": [],
+          "id": 164,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 162,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 166,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 166,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 166,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 166,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 167,
+          },
+          "childNodes": [],
+          "id": 167,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 166,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 167,
+          },
+          "childNodes": [],
+          "id": 167,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 166,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 169,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 167,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 168,
+          },
+          "childNodes": [],
+          "id": 168,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 166,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 168,
+          },
+          "childNodes": [],
+          "id": 168,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 166,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 170,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 170,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 170,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 170,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 171,
+          },
+          "childNodes": [],
+          "id": 171,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 170,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 171,
+          },
+          "childNodes": [],
+          "id": 171,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 170,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 173,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 171,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 172,
+          },
+          "childNodes": [],
+          "id": 172,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 170,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 172,
+          },
+          "childNodes": [],
+          "id": 172,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 170,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 174,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 174,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 174,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 174,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 175,
+          },
+          "childNodes": [],
+          "id": 175,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 174,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 175,
+          },
+          "childNodes": [],
+          "id": 175,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 174,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 177,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 175,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 176,
+          },
+          "childNodes": [],
+          "id": 176,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 174,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 176,
+          },
+          "childNodes": [],
+          "id": 176,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 174,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 178,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 178,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 178,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 178,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 179,
+          },
+          "childNodes": [],
+          "id": 179,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 178,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 179,
+          },
+          "childNodes": [],
+          "id": 179,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 178,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 181,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 179,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 180,
+          },
+          "childNodes": [],
+          "id": 180,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 178,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 180,
+          },
+          "childNodes": [],
+          "id": 180,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 178,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 182,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 182,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 182,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 182,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 183,
+          },
+          "childNodes": [],
+          "id": 183,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 182,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 183,
+          },
+          "childNodes": [],
+          "id": 183,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 182,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 185,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 183,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 184,
+          },
+          "childNodes": [],
+          "id": 184,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 182,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 184,
+          },
+          "childNodes": [],
+          "id": 184,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 182,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 186,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 186,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 186,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 186,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 187,
+          },
+          "childNodes": [],
+          "id": 187,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 186,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 187,
+          },
+          "childNodes": [],
+          "id": 187,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 186,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 189,
+          "textContent": "half-filled star",
+          "type": 3,
+        },
+        "parentId": 187,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 188,
+          },
+          "childNodes": [],
+          "id": 188,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 186,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 188,
+          },
+          "childNodes": [],
+          "id": 188,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 186,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 190,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 190,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 190,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 190,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 191,
+          },
+          "childNodes": [],
+          "id": 191,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 190,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 191,
+          },
+          "childNodes": [],
+          "id": 191,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 190,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 193,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 191,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 192,
+          },
+          "childNodes": [],
+          "id": 192,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 190,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 192,
+          },
+          "childNodes": [],
+          "id": 192,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 190,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 194,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 194,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 194,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 194,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 195,
+          },
+          "childNodes": [],
+          "id": 195,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 194,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 195,
+          },
+          "childNodes": [],
+          "id": 195,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 194,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 197,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 195,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 196,
+          },
+          "childNodes": [],
+          "id": 196,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 194,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 196,
+          },
+          "childNodes": [],
+          "id": 196,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 194,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 198,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 198,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 198,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 198,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 199,
+          },
+          "childNodes": [],
+          "id": 199,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 198,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 199,
+          },
+          "childNodes": [],
+          "id": 199,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 198,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 201,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 199,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 200,
+          },
+          "childNodes": [],
+          "id": 200,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 198,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 200,
+          },
+          "childNodes": [],
+          "id": 200,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 198,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 202,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 202,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 202,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 202,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 203,
+          },
+          "childNodes": [],
+          "id": 203,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 202,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 203,
+          },
+          "childNodes": [],
+          "id": 203,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 202,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 205,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 203,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 204,
+          },
+          "childNodes": [],
+          "id": 204,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 202,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 204,
+          },
+          "childNodes": [],
+          "id": 204,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 202,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 206,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 206,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 206,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 206,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 210,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 207,
+          },
+          "childNodes": [],
+          "id": 207,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 206,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 207,
+          },
+          "childNodes": [],
+          "id": 207,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 206,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 209,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 207,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 208,
+          },
+          "childNodes": [],
+          "id": 208,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 206,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 208,
+          },
+          "childNodes": [],
+          "id": 208,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 206,
       },
     ],
     "attributes": [],
@@ -3181,516 +3917,1252 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "data-rrweb-id": 12365,
             "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
           },
-          "childNodes": [
-            {
-              "attributes": {
-                "data-rrweb-id": 259,
-                "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
-              },
-              "childNodes": [
-                {
-                  "attributes": {
-                    "data-rrweb-id": 211,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 212,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 214,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 212,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                        "data-rrweb-id": 213,
-                      },
-                      "childNodes": [],
-                      "id": 213,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 211,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 215,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 216,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 218,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 216,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                        "data-rrweb-id": 217,
-                      },
-                      "childNodes": [],
-                      "id": 217,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 215,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 219,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 220,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 222,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 220,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                        "data-rrweb-id": 221,
-                      },
-                      "childNodes": [],
-                      "id": 221,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 219,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 223,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 224,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 226,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 224,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                        "data-rrweb-id": 225,
-                      },
-                      "childNodes": [],
-                      "id": 225,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 223,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 227,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 228,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 230,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 228,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                        "data-rrweb-id": 229,
-                      },
-                      "childNodes": [],
-                      "id": 229,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 227,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 231,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 232,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 234,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 232,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                        "data-rrweb-id": 233,
-                      },
-                      "childNodes": [],
-                      "id": 233,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 231,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 235,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 236,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 238,
-                          "textContent": "half-filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 236,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                        "data-rrweb-id": 237,
-                      },
-                      "childNodes": [],
-                      "id": 237,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 235,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 239,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 240,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 242,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 240,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                        "data-rrweb-id": 241,
-                      },
-                      "childNodes": [],
-                      "id": 241,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 239,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 243,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 244,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 246,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 244,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                        "data-rrweb-id": 245,
-                      },
-                      "childNodes": [],
-                      "id": 245,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 243,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 247,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 248,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 250,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 248,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                        "data-rrweb-id": 249,
-                      },
-                      "childNodes": [],
-                      "id": 249,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 247,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 251,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 252,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 254,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 252,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                        "data-rrweb-id": 253,
-                      },
-                      "childNodes": [],
-                      "id": 253,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 251,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "data-rrweb-id": 255,
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {
-                        "data-rrweb-id": 256,
-                      },
-                      "childNodes": [
-                        {
-                          "id": 258,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 256,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                        "data-rrweb-id": 257,
-                      },
-                      "childNodes": [],
-                      "id": 257,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 255,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-              ],
-              "id": 259,
-              "tagName": "div",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 12365,
           "tagName": "div",
           "type": 2,
         },
         "parentId": 54321,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 259,
+            "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
+          },
+          "childNodes": [],
+          "id": 259,
+          "tagName": "div",
+          "type": 2,
+        },
+        "parentId": 12365,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 259,
+            "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
+          },
+          "childNodes": [],
+          "id": 259,
+          "tagName": "div",
+          "type": 2,
+        },
+        "parentId": 12365,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 211,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 211,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 211,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 211,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 212,
+          },
+          "childNodes": [],
+          "id": 212,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 211,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 212,
+          },
+          "childNodes": [],
+          "id": 212,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 211,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 214,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 212,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 213,
+          },
+          "childNodes": [],
+          "id": 213,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 211,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 213,
+          },
+          "childNodes": [],
+          "id": 213,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 211,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 215,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 215,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 215,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 215,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 216,
+          },
+          "childNodes": [],
+          "id": 216,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 215,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 216,
+          },
+          "childNodes": [],
+          "id": 216,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 215,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 218,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 216,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 217,
+          },
+          "childNodes": [],
+          "id": 217,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 215,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 217,
+          },
+          "childNodes": [],
+          "id": 217,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 215,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 219,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 219,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 219,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 219,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 220,
+          },
+          "childNodes": [],
+          "id": 220,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 219,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 220,
+          },
+          "childNodes": [],
+          "id": 220,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 219,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 222,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 221,
+          },
+          "childNodes": [],
+          "id": 221,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 219,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 221,
+          },
+          "childNodes": [],
+          "id": 221,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 219,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 223,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 223,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 223,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 223,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 224,
+          },
+          "childNodes": [],
+          "id": 224,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 223,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 224,
+          },
+          "childNodes": [],
+          "id": 224,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 223,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 226,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 224,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 225,
+          },
+          "childNodes": [],
+          "id": 225,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 223,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 225,
+          },
+          "childNodes": [],
+          "id": 225,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 223,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 227,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 227,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 227,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 227,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 228,
+          },
+          "childNodes": [],
+          "id": 228,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 227,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 228,
+          },
+          "childNodes": [],
+          "id": 228,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 227,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 230,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 228,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 229,
+          },
+          "childNodes": [],
+          "id": 229,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 227,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 229,
+          },
+          "childNodes": [],
+          "id": 229,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 227,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 231,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 231,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 231,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 231,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 232,
+          },
+          "childNodes": [],
+          "id": 232,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 231,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 232,
+          },
+          "childNodes": [],
+          "id": 232,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 231,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 234,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 232,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 233,
+          },
+          "childNodes": [],
+          "id": 233,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 231,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+            "data-rrweb-id": 233,
+          },
+          "childNodes": [],
+          "id": 233,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 231,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 235,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 235,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 235,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 235,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 236,
+          },
+          "childNodes": [],
+          "id": 236,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 235,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 236,
+          },
+          "childNodes": [],
+          "id": 236,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 235,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 238,
+          "textContent": "half-filled star",
+          "type": 3,
+        },
+        "parentId": 236,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 237,
+          },
+          "childNodes": [],
+          "id": 237,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 235,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 237,
+          },
+          "childNodes": [],
+          "id": 237,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 235,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 239,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 239,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 239,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 239,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 240,
+          },
+          "childNodes": [],
+          "id": 240,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 239,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 240,
+          },
+          "childNodes": [],
+          "id": 240,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 239,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 242,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 240,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 241,
+          },
+          "childNodes": [],
+          "id": 241,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 239,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 241,
+          },
+          "childNodes": [],
+          "id": 241,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 239,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 243,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 243,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 243,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 243,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 244,
+          },
+          "childNodes": [],
+          "id": 244,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 243,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 244,
+          },
+          "childNodes": [],
+          "id": 244,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 243,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 246,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 244,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 245,
+          },
+          "childNodes": [],
+          "id": 245,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 243,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 245,
+          },
+          "childNodes": [],
+          "id": 245,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 243,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 247,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 247,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 247,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 247,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 248,
+          },
+          "childNodes": [],
+          "id": 248,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 247,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 248,
+          },
+          "childNodes": [],
+          "id": 248,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 247,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 250,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 248,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 249,
+          },
+          "childNodes": [],
+          "id": 249,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 247,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 249,
+          },
+          "childNodes": [],
+          "id": 249,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 247,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 251,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 251,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 251,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 251,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 252,
+          },
+          "childNodes": [],
+          "id": 252,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 251,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 252,
+          },
+          "childNodes": [],
+          "id": 252,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 251,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 254,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 252,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 253,
+          },
+          "childNodes": [],
+          "id": 253,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 251,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 253,
+          },
+          "childNodes": [],
+          "id": 253,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 251,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 255,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 255,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 255,
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [],
+          "id": 255,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 259,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 256,
+          },
+          "childNodes": [],
+          "id": 256,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 255,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "data-rrweb-id": 256,
+          },
+          "childNodes": [],
+          "id": 256,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 255,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 258,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 256,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 257,
+          },
+          "childNodes": [],
+          "id": 257,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 255,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+            "data-rrweb-id": 257,
+          },
+          "childNodes": [],
+          "id": 257,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 255,
       },
     ],
     "attributes": [],

--- a/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
+++ b/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
@@ -3159,6 +3159,2782 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         },
         "parentId": 54321,
       },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
+          },
+          "childNodes": [
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 174,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 173,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 175,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 172,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 178,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 177,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 179,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 176,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 182,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 181,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 183,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 180,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 186,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 185,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 187,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 184,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 190,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 189,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 191,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 188,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 194,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 193,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 195,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 192,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 198,
+                      "textContent": "half-filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 197,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 199,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 196,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 202,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 201,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 203,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 200,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 206,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 205,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 207,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 204,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 210,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 209,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 211,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 208,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 214,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 213,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 215,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 212,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 218,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 217,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 219,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 216,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+          ],
+          "id": 220,
+          "tagName": "div",
+          "type": 2,
+        },
+        "parentId": 12365,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
+          },
+          "childNodes": [
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 174,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 173,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 175,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 172,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 178,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 177,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 179,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 176,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 182,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 181,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 183,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 180,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 186,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 185,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 187,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 184,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 190,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 189,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 191,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 188,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 194,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 193,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 195,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 192,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 198,
+                      "textContent": "half-filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 197,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 199,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 196,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 202,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 201,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 203,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 200,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 206,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 205,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 207,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 204,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 210,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 209,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 211,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 208,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 214,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 213,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 215,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 212,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 218,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 217,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 219,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 216,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+          ],
+          "id": 220,
+          "tagName": "div",
+          "type": 2,
+        },
+        "parentId": 12365,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 174,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 173,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 175,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 172,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 174,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 173,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 175,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 172,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 174,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 173,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 172,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 174,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 173,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 172,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 174,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 173,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 175,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 172,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 175,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 172,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 178,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 177,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 179,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 176,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 178,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 177,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 179,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 176,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 178,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 177,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 176,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 178,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 177,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 176,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 178,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 177,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 179,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 176,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 179,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 176,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 182,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 181,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 183,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 180,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 182,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 181,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 183,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 180,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 182,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 181,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 180,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 182,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 181,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 180,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 182,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 181,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 183,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 180,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 183,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 180,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 186,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 185,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 187,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 184,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 186,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 185,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 187,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 184,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 186,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 185,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 184,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 186,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 185,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 184,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 186,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 185,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 187,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 184,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 187,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 184,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 190,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 189,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 191,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 188,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 190,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 189,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 191,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 188,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 190,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 189,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 188,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 190,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 189,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 188,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 190,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 189,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 191,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 188,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 191,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 188,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 194,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 193,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 195,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 192,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 194,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 193,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 195,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 192,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 194,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 193,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 192,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 194,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 193,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 192,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 194,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 193,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 195,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 192,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 195,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 192,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 198,
+                  "textContent": "half-filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 197,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 199,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 196,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 198,
+                  "textContent": "half-filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 197,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 199,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 196,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 198,
+              "textContent": "half-filled star",
+              "type": 3,
+            },
+          ],
+          "id": 197,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 196,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 198,
+              "textContent": "half-filled star",
+              "type": 3,
+            },
+          ],
+          "id": 197,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 196,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 198,
+          "textContent": "half-filled star",
+          "type": 3,
+        },
+        "parentId": 197,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 199,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 196,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 199,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 196,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 202,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 201,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 203,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 200,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 202,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 201,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 203,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 200,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 202,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 201,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 200,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 202,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 201,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 200,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 202,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 201,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 203,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 200,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 203,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 200,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 206,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 205,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 207,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 204,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 206,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 205,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 207,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 204,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 206,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 205,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 204,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 206,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 205,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 204,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 206,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 205,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 207,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 204,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 207,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 204,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 210,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 209,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 211,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 208,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 210,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 209,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 211,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 208,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 210,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 209,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 208,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 210,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 209,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 208,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 210,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 209,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 211,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 208,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 211,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 208,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 214,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 213,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 215,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 212,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 214,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 213,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 215,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 212,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 214,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 213,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 212,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 214,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 213,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 212,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 214,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 213,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 215,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 212,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 215,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 212,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 218,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 217,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 219,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 216,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 218,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 217,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 219,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 216,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 220,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 218,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 217,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 216,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 218,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 217,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 216,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 218,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 217,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 219,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 216,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 219,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 216,
+      },
     ],
     "attributes": [],
     "removes": [],
@@ -3657,6 +6433,2782 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
           "type": 2,
         },
         "parentId": 54321,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
+          },
+          "childNodes": [
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 223,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 222,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 224,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 221,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 227,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 226,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 228,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 225,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 231,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 230,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 232,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 229,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 235,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 234,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 236,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 233,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 239,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 238,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 240,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 237,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 243,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 242,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 244,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 241,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 247,
+                      "textContent": "half-filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 246,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 248,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 245,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 251,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 250,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 252,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 249,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 255,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 254,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 256,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 253,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 259,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 258,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 260,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 257,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 263,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 262,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 264,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 261,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 267,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 266,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 268,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 265,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+          ],
+          "id": 269,
+          "tagName": "div",
+          "type": 2,
+        },
+        "parentId": 12365,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
+          },
+          "childNodes": [
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 223,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 222,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 224,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 221,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 227,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 226,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 228,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 225,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 231,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 230,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 232,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 229,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 235,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 234,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 236,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 233,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 239,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 238,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 240,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 237,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 243,
+                      "textContent": "filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 242,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+                  },
+                  "childNodes": [],
+                  "id": 244,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 241,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 247,
+                      "textContent": "half-filled star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 246,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 248,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 245,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 251,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 250,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 252,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 249,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 255,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 254,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 256,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 253,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 259,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 258,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 260,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 257,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 263,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 262,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 264,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 261,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "fill": "currentColor",
+                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+                "viewBox": "0 0 24 24",
+              },
+              "childNodes": [
+                {
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "id": 267,
+                      "textContent": "empty star",
+                      "type": 3,
+                    },
+                  ],
+                  "id": 266,
+                  "isSVG": true,
+                  "tagName": "title",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+                  },
+                  "childNodes": [],
+                  "id": 268,
+                  "isSVG": true,
+                  "tagName": "path",
+                  "type": 2,
+                },
+              ],
+              "id": 265,
+              "isSVG": true,
+              "tagName": "svg",
+              "type": 2,
+            },
+          ],
+          "id": 269,
+          "tagName": "div",
+          "type": 2,
+        },
+        "parentId": 12365,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 223,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 222,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 224,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 221,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 223,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 222,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 224,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 221,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 223,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 222,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 221,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 223,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 222,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 221,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 223,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 222,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 224,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 221,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 224,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 221,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 227,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 226,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 228,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 225,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 227,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 226,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 228,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 225,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 227,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 226,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 225,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 227,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 226,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 225,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 227,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 226,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 228,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 225,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 228,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 225,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 231,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 230,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 232,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 229,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 231,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 230,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 232,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 229,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 231,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 230,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 229,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 231,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 230,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 229,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 231,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 230,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 232,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 229,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 232,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 229,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 235,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 234,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 236,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 233,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 235,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 234,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 236,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 233,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 235,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 234,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 233,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 235,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 234,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 233,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 235,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 234,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 236,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 233,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 236,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 233,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 239,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 238,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 240,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 237,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 239,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 238,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 240,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 237,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 239,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 238,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 237,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 239,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 238,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 237,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 239,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 238,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 240,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 237,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 240,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 237,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 243,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 242,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 244,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 241,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 243,
+                  "textContent": "filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 242,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+              },
+              "childNodes": [],
+              "id": 244,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 241,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 243,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 242,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 241,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 243,
+              "textContent": "filled star",
+              "type": 3,
+            },
+          ],
+          "id": 242,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 241,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 243,
+          "textContent": "filled star",
+          "type": 3,
+        },
+        "parentId": 242,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 244,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 241,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+          },
+          "childNodes": [],
+          "id": 244,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 241,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 247,
+                  "textContent": "half-filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 246,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 248,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 245,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 247,
+                  "textContent": "half-filled star",
+                  "type": 3,
+                },
+              ],
+              "id": 246,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 248,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 245,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 247,
+              "textContent": "half-filled star",
+              "type": 3,
+            },
+          ],
+          "id": 246,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 245,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 247,
+              "textContent": "half-filled star",
+              "type": 3,
+            },
+          ],
+          "id": 246,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 245,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 247,
+          "textContent": "half-filled star",
+          "type": 3,
+        },
+        "parentId": 246,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 248,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 245,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 248,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 245,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 251,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 250,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 252,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 249,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 251,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 250,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 252,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 249,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 251,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 250,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 249,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 251,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 250,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 249,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 251,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 250,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 252,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 249,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 252,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 249,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 255,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 254,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 256,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 253,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 255,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 254,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 256,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 253,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 255,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 254,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 253,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 255,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 254,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 253,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 255,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 254,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 256,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 253,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 256,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 253,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 259,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 258,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 260,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 257,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 259,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 258,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 260,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 257,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 259,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 258,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 257,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 259,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 258,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 257,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 259,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 258,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 260,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 257,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 260,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 257,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 263,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 262,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 264,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 261,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 263,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 262,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 264,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 261,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 263,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 262,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 261,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 263,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 262,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 261,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 263,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 262,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 264,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 261,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 264,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 261,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 267,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 266,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 268,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 265,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "fill": "currentColor",
+            "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
+            "viewBox": "0 0 24 24",
+          },
+          "childNodes": [
+            {
+              "attributes": {},
+              "childNodes": [
+                {
+                  "id": 267,
+                  "textContent": "empty star",
+                  "type": 3,
+                },
+              ],
+              "id": 266,
+              "isSVG": true,
+              "tagName": "title",
+              "type": 2,
+            },
+            {
+              "attributes": {
+                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+              },
+              "childNodes": [],
+              "id": 268,
+              "isSVG": true,
+              "tagName": "path",
+              "type": 2,
+            },
+          ],
+          "id": 265,
+          "isSVG": true,
+          "tagName": "svg",
+          "type": 2,
+        },
+        "parentId": 269,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 267,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 266,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 265,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {},
+          "childNodes": [
+            {
+              "id": 267,
+              "textContent": "empty star",
+              "type": 3,
+            },
+          ],
+          "id": 266,
+          "isSVG": true,
+          "tagName": "title",
+          "type": 2,
+        },
+        "parentId": 265,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "id": 267,
+          "textContent": "empty star",
+          "type": 3,
+        },
+        "parentId": 266,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 268,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 265,
+      },
+      {
+        "nextId": null,
+        "node": {
+          "attributes": {
+            "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
+          },
+          "childNodes": [],
+          "id": 268,
+          "isSVG": true,
+          "tagName": "path",
+          "type": 2,
+        },
+        "parentId": 265,
       },
     ],
     "attributes": [],

--- a/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
+++ b/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
@@ -2697,462 +2697,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
           "attributes": {
             "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
           },
-          "childNodes": [
-            {
-              "attributes": {
-                "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
-              },
-              "childNodes": [
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 174,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 173,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                      },
-                      "childNodes": [],
-                      "id": 175,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 172,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 178,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 177,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                      },
-                      "childNodes": [],
-                      "id": 179,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 176,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 182,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 181,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                      },
-                      "childNodes": [],
-                      "id": 183,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 180,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 186,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 185,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                      },
-                      "childNodes": [],
-                      "id": 187,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 184,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 190,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 189,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                      },
-                      "childNodes": [],
-                      "id": 191,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 188,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 194,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 193,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                      },
-                      "childNodes": [],
-                      "id": 195,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 192,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 198,
-                          "textContent": "half-filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 197,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 199,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 196,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 202,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 201,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 203,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 200,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 206,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 205,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 207,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 204,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 210,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 209,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 211,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 208,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 214,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 213,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 215,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 212,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 218,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 217,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 219,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 216,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-              ],
-              "id": 220,
-              "tagName": "div",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 12365,
           "tagName": "div",
           "type": 2,
@@ -3165,452 +2710,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
           "attributes": {
             "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
           },
-          "childNodes": [
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 174,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 173,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 175,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 172,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 178,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 177,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 179,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 176,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 182,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 181,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 183,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 180,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 186,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 185,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 187,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 184,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 190,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 189,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 191,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 188,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 194,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 193,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 195,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 192,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 198,
-                      "textContent": "half-filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 197,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 199,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 196,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 202,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 201,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 203,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 200,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 206,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 205,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 207,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 204,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 210,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 209,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 211,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 208,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 214,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 213,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 215,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 212,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 218,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 217,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 219,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 216,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 220,
           "tagName": "div",
           "type": 2,
@@ -3623,452 +2723,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
           "attributes": {
             "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
           },
-          "childNodes": [
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 174,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 173,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 175,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 172,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 178,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 177,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 179,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 176,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 182,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 181,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 183,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 180,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 186,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 185,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 187,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 184,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 190,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 189,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 191,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 188,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 194,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 193,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 195,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 192,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 198,
-                      "textContent": "half-filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 197,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 199,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 196,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 202,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 201,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 203,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 200,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 206,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 205,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 207,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 204,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 210,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 209,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 211,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 208,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 214,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 213,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 215,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 212,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 218,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 217,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 219,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 216,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 220,
           "tagName": "div",
           "type": 2,
@@ -4083,32 +2738,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 174,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 173,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 175,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 172,
           "isSVG": true,
           "tagName": "svg",
@@ -4124,32 +2754,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 174,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 173,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 175,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 172,
           "isSVG": true,
           "tagName": "svg",
@@ -4161,13 +2766,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 174,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 173,
           "isSVG": true,
           "tagName": "title",
@@ -4179,13 +2778,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 174,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 173,
           "isSVG": true,
           "tagName": "title",
@@ -4238,32 +2831,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 178,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 177,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 179,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 176,
           "isSVG": true,
           "tagName": "svg",
@@ -4279,32 +2847,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 178,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 177,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 179,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 176,
           "isSVG": true,
           "tagName": "svg",
@@ -4316,13 +2859,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 178,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 177,
           "isSVG": true,
           "tagName": "title",
@@ -4334,13 +2871,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 178,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 177,
           "isSVG": true,
           "tagName": "title",
@@ -4393,32 +2924,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 182,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 181,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 183,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 180,
           "isSVG": true,
           "tagName": "svg",
@@ -4434,32 +2940,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 182,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 181,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 183,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 180,
           "isSVG": true,
           "tagName": "svg",
@@ -4471,13 +2952,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 182,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 181,
           "isSVG": true,
           "tagName": "title",
@@ -4489,13 +2964,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 182,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 181,
           "isSVG": true,
           "tagName": "title",
@@ -4548,32 +3017,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 186,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 185,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 187,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 184,
           "isSVG": true,
           "tagName": "svg",
@@ -4589,32 +3033,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 186,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 185,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 187,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 184,
           "isSVG": true,
           "tagName": "svg",
@@ -4626,13 +3045,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 186,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 185,
           "isSVG": true,
           "tagName": "title",
@@ -4644,13 +3057,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 186,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 185,
           "isSVG": true,
           "tagName": "title",
@@ -4703,32 +3110,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 190,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 189,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 191,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 188,
           "isSVG": true,
           "tagName": "svg",
@@ -4744,32 +3126,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 190,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 189,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 191,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 188,
           "isSVG": true,
           "tagName": "svg",
@@ -4781,13 +3138,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 190,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 189,
           "isSVG": true,
           "tagName": "title",
@@ -4799,13 +3150,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 190,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 189,
           "isSVG": true,
           "tagName": "title",
@@ -4858,32 +3203,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 194,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 193,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 195,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 192,
           "isSVG": true,
           "tagName": "svg",
@@ -4899,32 +3219,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 194,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 193,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 195,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 192,
           "isSVG": true,
           "tagName": "svg",
@@ -4936,13 +3231,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 194,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 193,
           "isSVG": true,
           "tagName": "title",
@@ -4954,13 +3243,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 194,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 193,
           "isSVG": true,
           "tagName": "title",
@@ -5013,32 +3296,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 198,
-                  "textContent": "half-filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 197,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 199,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 196,
           "isSVG": true,
           "tagName": "svg",
@@ -5054,32 +3312,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 198,
-                  "textContent": "half-filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 197,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 199,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 196,
           "isSVG": true,
           "tagName": "svg",
@@ -5091,13 +3324,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 198,
-              "textContent": "half-filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 197,
           "isSVG": true,
           "tagName": "title",
@@ -5109,13 +3336,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 198,
-              "textContent": "half-filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 197,
           "isSVG": true,
           "tagName": "title",
@@ -5168,32 +3389,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 202,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 201,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 203,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 200,
           "isSVG": true,
           "tagName": "svg",
@@ -5209,32 +3405,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 202,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 201,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 203,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 200,
           "isSVG": true,
           "tagName": "svg",
@@ -5246,13 +3417,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 202,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 201,
           "isSVG": true,
           "tagName": "title",
@@ -5264,13 +3429,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 202,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 201,
           "isSVG": true,
           "tagName": "title",
@@ -5323,32 +3482,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 206,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 205,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 207,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 204,
           "isSVG": true,
           "tagName": "svg",
@@ -5364,32 +3498,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 206,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 205,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 207,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 204,
           "isSVG": true,
           "tagName": "svg",
@@ -5401,13 +3510,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 206,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 205,
           "isSVG": true,
           "tagName": "title",
@@ -5419,13 +3522,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 206,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 205,
           "isSVG": true,
           "tagName": "title",
@@ -5478,32 +3575,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 210,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 209,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 211,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 208,
           "isSVG": true,
           "tagName": "svg",
@@ -5519,32 +3591,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 210,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 209,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 211,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 208,
           "isSVG": true,
           "tagName": "svg",
@@ -5556,13 +3603,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 210,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 209,
           "isSVG": true,
           "tagName": "title",
@@ -5574,13 +3615,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 210,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 209,
           "isSVG": true,
           "tagName": "title",
@@ -5633,32 +3668,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 214,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 213,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 215,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 212,
           "isSVG": true,
           "tagName": "svg",
@@ -5674,32 +3684,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 214,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 213,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 215,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 212,
           "isSVG": true,
           "tagName": "svg",
@@ -5711,13 +3696,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 214,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 213,
           "isSVG": true,
           "tagName": "title",
@@ -5729,13 +3708,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 214,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 213,
           "isSVG": true,
           "tagName": "title",
@@ -5788,32 +3761,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 218,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 217,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 219,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 216,
           "isSVG": true,
           "tagName": "svg",
@@ -5829,32 +3777,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 218,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 217,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 219,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 216,
           "isSVG": true,
           "tagName": "svg",
@@ -5866,13 +3789,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 218,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 217,
           "isSVG": true,
           "tagName": "title",
@@ -5884,13 +3801,7 @@ exports[`replay/transform transform inputs isolated add mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 218,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 217,
           "isSVG": true,
           "tagName": "title",
@@ -5972,462 +3883,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
           "attributes": {
             "style": "width: 100px;height: 30px;position: fixed;left: 0px;top: 0px;",
           },
-          "childNodes": [
-            {
-              "attributes": {
-                "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
-              },
-              "childNodes": [
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 223,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 222,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                      },
-                      "childNodes": [],
-                      "id": 224,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 221,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 227,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 226,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                      },
-                      "childNodes": [],
-                      "id": 228,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 225,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 231,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 230,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                      },
-                      "childNodes": [],
-                      "id": 232,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 229,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 235,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 234,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                      },
-                      "childNodes": [],
-                      "id": 236,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 233,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 239,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 238,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                      },
-                      "childNodes": [],
-                      "id": 240,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 237,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 243,
-                          "textContent": "filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 242,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                      },
-                      "childNodes": [],
-                      "id": 244,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 241,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 247,
-                          "textContent": "half-filled star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 246,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 248,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 245,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 251,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 250,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 252,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 249,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 255,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 254,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 256,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 253,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 259,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 258,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 260,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 257,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 263,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 262,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 264,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 261,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "fill": "currentColor",
-                    "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                    "viewBox": "0 0 24 24",
-                  },
-                  "childNodes": [
-                    {
-                      "attributes": {},
-                      "childNodes": [
-                        {
-                          "id": 267,
-                          "textContent": "empty star",
-                          "type": 3,
-                        },
-                      ],
-                      "id": 266,
-                      "isSVG": true,
-                      "tagName": "title",
-                      "type": 2,
-                    },
-                    {
-                      "attributes": {
-                        "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                      },
-                      "childNodes": [],
-                      "id": 268,
-                      "isSVG": true,
-                      "tagName": "path",
-                      "type": 2,
-                    },
-                  ],
-                  "id": 265,
-                  "isSVG": true,
-                  "tagName": "svg",
-                  "type": 2,
-                },
-              ],
-              "id": 269,
-              "tagName": "div",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 12365,
           "tagName": "div",
           "type": 2,
@@ -6440,452 +3896,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
           "attributes": {
             "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
           },
-          "childNodes": [
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 223,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 222,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 224,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 221,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 227,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 226,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 228,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 225,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 231,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 230,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 232,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 229,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 235,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 234,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 236,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 233,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 239,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 238,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 240,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 237,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 243,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 242,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 244,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 241,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 247,
-                      "textContent": "half-filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 246,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 248,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 245,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 251,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 250,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 252,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 249,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 255,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 254,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 256,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 253,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 259,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 258,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 260,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 257,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 263,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 262,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 264,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 261,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 267,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 266,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 268,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 265,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 269,
           "tagName": "div",
           "type": 2,
@@ -6898,452 +3909,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
           "attributes": {
             "style": "position: relative; display: flex; flex-direction: row; padding: 2px 4px;",
           },
-          "childNodes": [
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 223,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 222,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 224,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 221,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 227,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 226,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 228,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 225,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 231,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 230,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 232,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 229,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 235,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 234,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 236,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 233,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 239,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 238,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 240,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 237,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 243,
-                      "textContent": "filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 242,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-                  },
-                  "childNodes": [],
-                  "id": 244,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 241,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 247,
-                      "textContent": "half-filled star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 246,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 248,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 245,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 251,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 250,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 252,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 249,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 255,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 254,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 256,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 253,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 259,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 258,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 260,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 257,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 263,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 262,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 264,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 261,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "fill": "currentColor",
-                "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
-                "viewBox": "0 0 24 24",
-              },
-              "childNodes": [
-                {
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "id": 267,
-                      "textContent": "empty star",
-                      "type": 3,
-                    },
-                  ],
-                  "id": 266,
-                  "isSVG": true,
-                  "tagName": "title",
-                  "type": 2,
-                },
-                {
-                  "attributes": {
-                    "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-                  },
-                  "childNodes": [],
-                  "id": 268,
-                  "isSVG": true,
-                  "tagName": "path",
-                  "type": 2,
-                },
-              ],
-              "id": 265,
-              "isSVG": true,
-              "tagName": "svg",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 269,
           "tagName": "div",
           "type": 2,
@@ -7358,32 +3924,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 223,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 222,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 224,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 221,
           "isSVG": true,
           "tagName": "svg",
@@ -7399,32 +3940,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 223,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 222,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 224,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 221,
           "isSVG": true,
           "tagName": "svg",
@@ -7436,13 +3952,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 223,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 222,
           "isSVG": true,
           "tagName": "title",
@@ -7454,13 +3964,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 223,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 222,
           "isSVG": true,
           "tagName": "title",
@@ -7513,32 +4017,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 227,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 226,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 228,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 225,
           "isSVG": true,
           "tagName": "svg",
@@ -7554,32 +4033,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 227,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 226,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 228,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 225,
           "isSVG": true,
           "tagName": "svg",
@@ -7591,13 +4045,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 227,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 226,
           "isSVG": true,
           "tagName": "title",
@@ -7609,13 +4057,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 227,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 226,
           "isSVG": true,
           "tagName": "title",
@@ -7668,32 +4110,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 231,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 230,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 232,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 229,
           "isSVG": true,
           "tagName": "svg",
@@ -7709,32 +4126,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 231,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 230,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 232,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 229,
           "isSVG": true,
           "tagName": "svg",
@@ -7746,13 +4138,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 231,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 230,
           "isSVG": true,
           "tagName": "title",
@@ -7764,13 +4150,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 231,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 230,
           "isSVG": true,
           "tagName": "title",
@@ -7823,32 +4203,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 235,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 234,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 236,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 233,
           "isSVG": true,
           "tagName": "svg",
@@ -7864,32 +4219,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 235,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 234,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 236,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 233,
           "isSVG": true,
           "tagName": "svg",
@@ -7901,13 +4231,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 235,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 234,
           "isSVG": true,
           "tagName": "title",
@@ -7919,13 +4243,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 235,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 234,
           "isSVG": true,
           "tagName": "title",
@@ -7978,32 +4296,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 239,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 238,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 240,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 237,
           "isSVG": true,
           "tagName": "svg",
@@ -8019,32 +4312,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 239,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 238,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 240,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 237,
           "isSVG": true,
           "tagName": "svg",
@@ -8056,13 +4324,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 239,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 238,
           "isSVG": true,
           "tagName": "title",
@@ -8074,13 +4336,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 239,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 238,
           "isSVG": true,
           "tagName": "title",
@@ -8133,32 +4389,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 243,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 242,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 244,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 241,
           "isSVG": true,
           "tagName": "svg",
@@ -8174,32 +4405,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 243,
-                  "textContent": "filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 242,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
-              },
-              "childNodes": [],
-              "id": 244,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 241,
           "isSVG": true,
           "tagName": "svg",
@@ -8211,13 +4417,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 243,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 242,
           "isSVG": true,
           "tagName": "title",
@@ -8229,13 +4429,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 243,
-              "textContent": "filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 242,
           "isSVG": true,
           "tagName": "title",
@@ -8288,32 +4482,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 247,
-                  "textContent": "half-filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 246,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 248,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 245,
           "isSVG": true,
           "tagName": "svg",
@@ -8329,32 +4498,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 247,
-                  "textContent": "half-filled star",
-                  "type": 3,
-                },
-              ],
-              "id": 246,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.4V6.1L13.71,10.13L18.09,10.5L14.77,13.39L15.76,17.67M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 248,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 245,
           "isSVG": true,
           "tagName": "svg",
@@ -8366,13 +4510,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 247,
-              "textContent": "half-filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 246,
           "isSVG": true,
           "tagName": "title",
@@ -8384,13 +4522,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 247,
-              "textContent": "half-filled star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 246,
           "isSVG": true,
           "tagName": "title",
@@ -8443,32 +4575,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 251,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 250,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 252,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 249,
           "isSVG": true,
           "tagName": "svg",
@@ -8484,32 +4591,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 251,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 250,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 252,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 249,
           "isSVG": true,
           "tagName": "svg",
@@ -8521,13 +4603,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 251,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 250,
           "isSVG": true,
           "tagName": "title",
@@ -8539,13 +4615,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 251,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 250,
           "isSVG": true,
           "tagName": "title",
@@ -8598,32 +4668,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 255,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 254,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 256,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 253,
           "isSVG": true,
           "tagName": "svg",
@@ -8639,32 +4684,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 255,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 254,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 256,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 253,
           "isSVG": true,
           "tagName": "svg",
@@ -8676,13 +4696,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 255,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 254,
           "isSVG": true,
           "tagName": "title",
@@ -8694,13 +4708,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 255,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 254,
           "isSVG": true,
           "tagName": "title",
@@ -8753,32 +4761,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 259,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 258,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 260,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 257,
           "isSVG": true,
           "tagName": "svg",
@@ -8794,32 +4777,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 259,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 258,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 260,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 257,
           "isSVG": true,
           "tagName": "svg",
@@ -8831,13 +4789,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 259,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 258,
           "isSVG": true,
           "tagName": "title",
@@ -8849,13 +4801,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 259,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 258,
           "isSVG": true,
           "tagName": "title",
@@ -8908,32 +4854,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 263,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 262,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 264,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 261,
           "isSVG": true,
           "tagName": "svg",
@@ -8949,32 +4870,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 263,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 262,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 264,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 261,
           "isSVG": true,
           "tagName": "svg",
@@ -8986,13 +4882,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 263,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 262,
           "isSVG": true,
           "tagName": "title",
@@ -9004,13 +4894,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 263,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 262,
           "isSVG": true,
           "tagName": "title",
@@ -9063,32 +4947,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 267,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 266,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 268,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 265,
           "isSVG": true,
           "tagName": "svg",
@@ -9104,32 +4963,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
             "style": "height: 100%;overflow-clip-margin: content-box;overflow:hidden",
             "viewBox": "0 0 24 24",
           },
-          "childNodes": [
-            {
-              "attributes": {},
-              "childNodes": [
-                {
-                  "id": 267,
-                  "textContent": "empty star",
-                  "type": 3,
-                },
-              ],
-              "id": 266,
-              "isSVG": true,
-              "tagName": "title",
-              "type": 2,
-            },
-            {
-              "attributes": {
-                "d": "M12,15.39L8.24,17.66L9.23,13.38L5.91,10.5L10.29,10.13L12,6.09L13.71,10.13L18.09,10.5L14.77,13.38L15.76,17.66M22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.45,13.97L5.82,21L12,17.27L18.18,21L16.54,13.97L22,9.24Z",
-              },
-              "childNodes": [],
-              "id": 268,
-              "isSVG": true,
-              "tagName": "path",
-              "type": 2,
-            },
-          ],
+          "childNodes": [],
           "id": 265,
           "isSVG": true,
           "tagName": "svg",
@@ -9141,13 +4975,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 267,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 266,
           "isSVG": true,
           "tagName": "title",
@@ -9159,13 +4987,7 @@ exports[`replay/transform transform inputs isolated update mutation 1`] = `
         "nextId": null,
         "node": {
           "attributes": {},
-          "childNodes": [
-            {
-              "id": 267,
-              "textContent": "empty star",
-              "type": 3,
-            },
-          ],
+          "childNodes": [],
           "id": 266,
           "isSVG": true,
           "tagName": "title",

--- a/ee/frontend/mobile-replay/mobile.types.ts
+++ b/ee/frontend/mobile-replay/mobile.types.ts
@@ -1,5 +1,5 @@
 // copied from rrweb-snapshot, not included in rrweb types
-import { customEvent, EventType, IncrementalSource } from '@rrweb/types'
+import { customEvent, EventType, IncrementalSource, removedNodeMutation } from '@rrweb/types'
 
 export enum NodeType {
     Document = 0,
@@ -290,17 +290,17 @@ export type MobileNodeMutation = {
     wireframe: wireframe
 }
 
-export type MobileAddedNodeMutationData = {
-    source: IncrementalSource.Mutation
-    adds: MobileNodeMutation[]
-}
-
-export type MobileUpdatedNodeMutationData = {
+export type MobileNodeMutationData = {
     source: IncrementalSource.Mutation
     /**
      * @description An update is implemented as a remove and then an add, so the updates array contains the ID of the removed node and the wireframe for the added node
      */
     updates: MobileNodeMutation[]
+    adds: MobileNodeMutation[]
+    /**
+     * @description A mobile remove is identical to a web remove
+     */
+    removes: removedNodeMutation[]
 }
 
 export type MobileIncrementalSnapshotEvent = {
@@ -308,7 +308,7 @@ export type MobileIncrementalSnapshotEvent = {
     /**
      * @description This sits alongside the RRWeb incremental snapshot event type, mobile replay can send any of the RRWeb incremental snapshot event types, which will be passed unchanged to the player - for example to send touch events. removed node mutations are passed unchanged to the player.
      */
-    data: MobileAddedNodeMutationData | MobileUpdatedNodeMutationData
+    data: MobileNodeMutationData
 }
 
 export type metaEvent = {

--- a/ee/frontend/mobile-replay/mobile.types.ts
+++ b/ee/frontend/mobile-replay/mobile.types.ts
@@ -295,12 +295,12 @@ export type MobileNodeMutationData = {
     /**
      * @description An update is implemented as a remove and then an add, so the updates array contains the ID of the removed node and the wireframe for the added node
      */
-    updates: MobileNodeMutation[]
-    adds: MobileNodeMutation[]
+    updates?: MobileNodeMutation[]
+    adds?: MobileNodeMutation[]
     /**
      * @description A mobile remove is identical to a web remove
      */
-    removes: removedNodeMutation[]
+    removes?: removedNodeMutation[]
 }
 
 export type MobileIncrementalSnapshotEvent = {

--- a/ee/frontend/mobile-replay/schema/mobile/rr-mobile-schema.json
+++ b/ee/frontend/mobile-replay/schema/mobile/rr-mobile-schema.json
@@ -124,14 +124,7 @@
             "additionalProperties": false,
             "properties": {
                 "data": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/MobileAddedNodeMutationData"
-                        },
-                        {
-                            "$ref": "#/definitions/MobileUpdatedNodeMutationData"
-                        }
-                    ],
+                    "$ref": "#/definitions/MobileNodeMutationData",
                     "description": "This sits alongside the RRWeb incremental snapshot event type, mobile replay can send any of the RRWeb incremental snapshot event types, which will be passed unchanged to the player - for example to send touch events. removed node mutations are passed unchanged to the player."
                 },
                 "delay": {
@@ -238,22 +231,6 @@
             "const": 0,
             "type": "number"
         },
-        "MobileAddedNodeMutationData": {
-            "additionalProperties": false,
-            "properties": {
-                "adds": {
-                    "items": {
-                        "$ref": "#/definitions/MobileNodeMutation"
-                    },
-                    "type": "array"
-                },
-                "source": {
-                    "$ref": "#/definitions/IncrementalSource.Mutation"
-                }
-            },
-            "required": ["source", "adds"],
-            "type": "object"
-        },
         "MobileNodeMutation": {
             "additionalProperties": false,
             "properties": {
@@ -265,6 +242,36 @@
                 }
             },
             "required": ["parentId", "wireframe"],
+            "type": "object"
+        },
+        "MobileNodeMutationData": {
+            "additionalProperties": false,
+            "properties": {
+                "adds": {
+                    "items": {
+                        "$ref": "#/definitions/MobileNodeMutation"
+                    },
+                    "type": "array"
+                },
+                "removes": {
+                    "description": "A mobile remove is identical to a web remove",
+                    "items": {
+                        "$ref": "#/definitions/removedNodeMutation"
+                    },
+                    "type": "array"
+                },
+                "source": {
+                    "$ref": "#/definitions/IncrementalSource.Mutation"
+                },
+                "updates": {
+                    "description": "An update is implemented as a remove and then an add, so the updates array contains the ID of the removed node and the wireframe for the added node",
+                    "items": {
+                        "$ref": "#/definitions/MobileNodeMutation"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["source", "updates", "adds", "removes"],
             "type": "object"
         },
         "MobileNodeType": {
@@ -315,21 +322,20 @@
             },
             "type": "object"
         },
-        "MobileUpdatedNodeMutationData": {
+        "removedNodeMutation": {
             "additionalProperties": false,
             "properties": {
-                "source": {
-                    "$ref": "#/definitions/IncrementalSource.Mutation"
+                "id": {
+                    "type": "number"
                 },
-                "updates": {
-                    "description": "An update is implemented as a remove and then an add, so the updates array contains the ID of the removed node and the wireframe for the added node",
-                    "items": {
-                        "$ref": "#/definitions/MobileNodeMutation"
-                    },
-                    "type": "array"
+                "isShadow": {
+                    "type": "boolean"
+                },
+                "parentId": {
+                    "type": "number"
                 }
             },
-            "required": ["source", "updates"],
+            "required": ["parentId", "id"],
             "type": "object"
         },
         "wireframe": {

--- a/ee/frontend/mobile-replay/schema/mobile/rr-mobile-schema.json
+++ b/ee/frontend/mobile-replay/schema/mobile/rr-mobile-schema.json
@@ -271,7 +271,7 @@
                     "type": "array"
                 }
             },
-            "required": ["source", "updates", "adds", "removes"],
+            "required": ["source"],
             "type": "object"
         },
         "MobileNodeType": {

--- a/ee/frontend/mobile-replay/transformers.ts
+++ b/ee/frontend/mobile-replay/transformers.ts
@@ -820,7 +820,10 @@ function makeIncrementalAdd(add: MobileNodeMutation): addedNodeMutation | null {
         : null
 }
 
-function makeIncrementalRemove(update: MobileNodeMutation): removedNodeMutation {
+/**
+ * When processing an update we remove the entire item, and then add it back in.
+ */
+function makeIncrementalRemoveForUpdate(update: MobileNodeMutation): removedNodeMutation {
     return {
         parentId: update.parentId,
         id: update.wireframe.id,
@@ -857,7 +860,7 @@ export const makeIncrementalEvent = (
 
     if (isMobileIncrementalSnapshotEvent(mobileEvent)) {
         const adds: addedNodeMutation[] = []
-        const removes: removedNodeMutation[] = []
+        const removes: removedNodeMutation[] = mobileEvent.data.removes
         if ('adds' in mobileEvent.data && Array.isArray(mobileEvent.data.adds)) {
             mobileEvent.data.adds.forEach((add) => {
                 const converted = makeIncrementalAdd(add)
@@ -869,7 +872,7 @@ export const makeIncrementalEvent = (
         }
         if ('updates' in mobileEvent.data && Array.isArray(mobileEvent.data.updates)) {
             mobileEvent.data.updates.forEach((update) => {
-                const removal = makeIncrementalRemove(update)
+                const removal = makeIncrementalRemoveForUpdate(update)
                 if (removal) {
                     removes.push(removal)
                 }

--- a/ee/frontend/mobile-replay/transformers.ts
+++ b/ee/frontend/mobile-replay/transformers.ts
@@ -14,6 +14,7 @@ import { isObject } from 'lib/utils'
 
 import {
     attributes,
+    documentNode,
     elementNode,
     fullSnapshotEvent as MobileFullSnapshotEvent,
     keyboardEvent,
@@ -809,15 +810,25 @@ function isMobileIncrementalSnapshotEvent(x: unknown): x is MobileIncrementalSna
     return hasMutationSource && (hasAddedWireframe || hasUpdatedWireframe)
 }
 
-function makeIncrementalAdd(add: MobileNodeMutation): addedNodeMutation | null {
+function makeIncrementalAdd(add: MobileNodeMutation): addedNodeMutation[] | null {
     const converted = convertWireframe(add.wireframe)
-    return converted
-        ? {
-              parentId: add.parentId,
-              nextId: null,
-              node: converted,
-          }
-        : null
+    if (!converted) {
+        return null
+    }
+
+    const addition: addedNodeMutation = {
+        parentId: add.parentId,
+        nextId: null,
+        node: converted,
+    }
+    const adds: addedNodeMutation[] = []
+    if (addition) {
+        const flattened = flattenMutationAdds(addition)
+        flattened.forEach((x) => adds.push(x))
+        return adds
+    } else {
+        return null
+    }
 }
 
 /**
@@ -830,13 +841,42 @@ function makeIncrementalRemoveForUpdate(update: MobileNodeMutation): removedNode
     }
 }
 
+function isNode(x: unknown): x is serializedNodeWithId {
+    // KLUDGE: really we should check that x.type is valid, but we're safe enough already
+    return isObject(x) && 'type' in x && 'id' in x
+}
+
+function isNodeWithChildren(x: unknown): x is elementNode | documentNode {
+    return isNode(x) && 'childNodes' in x && Array.isArray(x.childNodes)
+}
+
+function flattenMutationAdds(converted: addedNodeMutation): addedNodeMutation[] {
+    const flattened: addedNodeMutation[] = []
+    flattened.push(converted)
+    const node: unknown = converted.node
+    const newParentId = converted.node.id
+    if (isNodeWithChildren(node)) {
+        node.childNodes.forEach((child) => {
+            flattened.push({
+                parentId: newParentId,
+                nextId: null,
+                node: child,
+            })
+            if (isNodeWithChildren(child)) {
+                flattened.push(...flattenMutationAdds({ parentId: newParentId, nextId: null, node: child }))
+            }
+        })
+    }
+    return flattened
+}
+
 /**
  * We want to ensure that any events don't use id = 0.
  * They must always represent a valid ID from the dom, so we swap in the body id when the id = 0.
  *
  * For "removes", we don't need to do anything, the id of the element to be removed remains valid. We won't try and remove other elements that we added during transformation in order to show that element.
  *
- * "adds" are converted from wireframes to nodes and converted to incrementalSnapshotEvent.adds
+ * "adds" are converted from wireframes to nodes and converted to `incrementalSnapshotEvent.adds`
  *
  * "updates" are converted to a remove and an add.
  *
@@ -860,14 +900,10 @@ export const makeIncrementalEvent = (
 
     if (isMobileIncrementalSnapshotEvent(mobileEvent)) {
         const adds: addedNodeMutation[] = []
-        const removes: removedNodeMutation[] = mobileEvent.data.removes
+        const removes: removedNodeMutation[] = mobileEvent.data.removes || []
         if ('adds' in mobileEvent.data && Array.isArray(mobileEvent.data.adds)) {
             mobileEvent.data.adds.forEach((add) => {
-                const converted = makeIncrementalAdd(add)
-                if (converted) {
-                    // TODO when implementing keyboard placeholder we had to flatten the mutations not nest them
-                    adds.push(converted)
-                }
+                makeIncrementalAdd(add)?.forEach((x) => adds.push(x))
             })
         }
         if ('updates' in mobileEvent.data && Array.isArray(mobileEvent.data.updates)) {
@@ -876,10 +912,7 @@ export const makeIncrementalEvent = (
                 if (removal) {
                     removes.push(removal)
                 }
-                const addition = makeIncrementalAdd(update)
-                if (addition) {
-                    adds.push(addition)
-                }
+                makeIncrementalAdd(update)?.forEach((x) => adds.push(x))
             })
         }
 


### PR DESCRIPTION
the reality was (as expected) different to the theory 🤣 

* makes mutation node arrays optional
* include rrweb's removeNodeMutation directly into mobile incremental snapshots
* incremental adds are always flattened so that maker returns an array
* since the adds are flattened we can delete the child nodes as we flatten them so that rrweb handles less data

![2024-01-04 15 17 31](https://github.com/PostHog/posthog/assets/984817/ba159f4b-871a-4032-859b-211996f5495f)
