### PR TITLE
feat: Person deletion via events

### DIFF
--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -332,6 +332,10 @@ export const KEY_MAPPING: KeyMappingInterface = {
             label: 'Identify',
             description: 'A user has been identified with properties',
         },
+        $delete_person: {
+            label: 'Person Deletion',
+            description: 'A user has been deleted',
+        },
         $create_alias: {
             label: 'Alias',
             description: 'An alias ID has been added to a user',

--- a/plugin-server/src/worker/ingestion/event-pipeline/createEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/createEventStep.ts
@@ -4,7 +4,7 @@ import { EventPipelineRunner } from './runner'
 export async function createEventStep(
     runner: EventPipelineRunner,
     event: PreIngestionEvent,
-    person: Person
+    person: Person | null
 ): Promise<[RawClickHouseEvent, Promise<void>]> {
     return await runner.hub.eventsProcessor.createEvent(event, person)
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -1,7 +1,10 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
+import { ProducerRecord } from 'kafkajs'
 import { DateTime } from 'luxon'
 import { Person } from 'types'
 
+import { PostgresUse } from '../../../utils/db/postgres'
+import { timeoutGuard } from '../../../utils/db/utils'
 import { normalizeEvent } from '../../../utils/event'
 import { status } from '../../../utils/status'
 import { DeferredPersonOverrideWriter, PersonOverrideWriter, PersonState } from '../person-state'
@@ -11,7 +14,7 @@ import { EventPipelineRunner } from './runner'
 export async function processPersonsStep(
     runner: EventPipelineRunner,
     pluginEvent: PluginEvent
-): Promise<[PluginEvent, Person]> {
+): Promise<[PluginEvent, Person | null]> {
     let event: PluginEvent
     let timestamp: DateTime
     try {
@@ -20,6 +23,64 @@ export async function processPersonsStep(
     } catch (error) {
         status.warn('⚠️', 'Failed normalizing event', { team_id: pluginEvent.team_id, uuid: pluginEvent.uuid, error })
         throw error
+    }
+
+    if (pluginEvent.event === '$delete_person') {
+        const timeout = timeoutGuard('Still running "$delete_person". Timeout warning after 30 sec!')
+        try {
+            const person = await runner.hub.db.fetchPerson(pluginEvent.team_id, pluginEvent.distinct_id)
+            if (!person) {
+                return [event, null]
+            }
+
+            const kafkaMessages: ProducerRecord[] = await runner.hub.db.postgres.transaction(
+                PostgresUse.COMMON_WRITE,
+                'mergePeople',
+                async (tx) => {
+                    const personDeleteMessages = await runner.hub.db.deletePerson(person, tx)
+                    const personDistinctIdDeleteMessages = await runner.hub.db.deleteDistinctIds(person, tx)
+                    console.log(pluginEvent.properties)
+                    if (pluginEvent.properties!['delete_events']) {
+                        const creatorId = pluginEvent.properties!['created_by_id']
+                        await runner.hub.db.asyncEventsDeletion(person, creatorId, tx)
+                    }
+                    return [...personDeleteMessages, ...personDistinctIdDeleteMessages]
+                }
+            )
+            await runner.hub.db.kafkaProducer.queueMessages(kafkaMessages)
+            // TODO: add tests
+
+            // def test_delete_person(self):
+            //     person = Person.objects.create(
+            //         team=self.team, version=15
+            //     )  # version be > 0 to check that we don't just assume 0 in deletes
+            //     delete_person(person, sync=True)
+            //     ch_persons = sync_execute(
+            //         "SELECT toString(id), version, is_deleted, properties FROM person FINAL WHERE team_id = %(team_id)s and id = %(uuid)s",
+            //         {"team_id": self.team.pk, "uuid": person.uuid},
+            //     )
+            //     self.assertEqual(ch_persons, [(str(person.uuid), 115, 1, "{}")])
+
+            // def test_delete_ch_distinct_ids(self):
+            //     person = Person.objects.create(team=self.team)
+            //     PersonDistinctId.objects.create(team=self.team, person=person, distinct_id="distinct_id1", version=15)
+
+            //     ch_distinct_ids = sync_execute(
+            //         "SELECT is_deleted FROM person_distinct_id2 FINAL WHERE team_id = %(team_id)s and distinct_id = %(distinct_id)s",
+            //         {"team_id": self.team.pk, "distinct_id": "distinct_id1"},
+            //     )
+            //     self.assertEqual(ch_distinct_ids, [(0,)])
+
+            //     delete_person(person, sync=True)
+            //     ch_distinct_ids = sync_execute(
+            //         "SELECT toString(person_id), version, is_deleted FROM person_distinct_id2 FINAL WHERE team_id = %(team_id)s and distinct_id = %(distinct_id)s",
+            //         {"team_id": self.team.pk, "distinct_id": "distinct_id1"},
+            //     )
+            //     self.assertEqual(ch_distinct_ids, [(str(person.uuid), 115, 1)])
+        } finally {
+            clearTimeout(timeout)
+        }
+        return [event, null]
     }
 
     let overridesWriter: PersonOverrideWriter | DeferredPersonOverrideWriter | undefined = undefined

--- a/posthog/models/test/test_person_model.py
+++ b/posthog/models/test/test_person_model.py
@@ -1,9 +1,7 @@
 from uuid import uuid4
 
-from posthog.client import sync_execute
-from posthog.models import Person, PersonDistinctId
+from posthog.models import Person
 from posthog.models.event.util import create_event
-from posthog.models.person.util import delete_person
 from posthog.test.base import BaseTest
 
 
@@ -19,31 +17,3 @@ class TestPerson(BaseTest):
         person_anonymous = Person.objects.create(team=self.team)
         self.assertEqual(person_identified.is_identified, True)
         self.assertEqual(person_anonymous.is_identified, False)
-
-    def test_delete_person(self):
-        person = Person.objects.create(
-            team=self.team, version=15
-        )  # version be > 0 to check that we don't just assume 0 in deletes
-        delete_person(person, sync=True)
-        ch_persons = sync_execute(
-            "SELECT toString(id), version, is_deleted, properties FROM person FINAL WHERE team_id = %(team_id)s and id = %(uuid)s",
-            {"team_id": self.team.pk, "uuid": person.uuid},
-        )
-        self.assertEqual(ch_persons, [(str(person.uuid), 115, 1, "{}")])
-
-    def test_delete_ch_distinct_ids(self):
-        person = Person.objects.create(team=self.team)
-        PersonDistinctId.objects.create(team=self.team, person=person, distinct_id="distinct_id1", version=15)
-
-        ch_distinct_ids = sync_execute(
-            "SELECT is_deleted FROM person_distinct_id2 FINAL WHERE team_id = %(team_id)s and distinct_id = %(distinct_id)s",
-            {"team_id": self.team.pk, "distinct_id": "distinct_id1"},
-        )
-        self.assertEqual(ch_distinct_ids, [(0,)])
-
-        delete_person(person, sync=True)
-        ch_distinct_ids = sync_execute(
-            "SELECT toString(person_id), version, is_deleted FROM person_distinct_id2 FINAL WHERE team_id = %(team_id)s and distinct_id = %(distinct_id)s",
-            {"team_id": self.team.pk, "distinct_id": "distinct_id1"},
-        )
-        self.assertEqual(ch_distinct_ids, [(str(person.uuid), 115, 1)])


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Everything tied to persons should go through events, so we can replicate and everything will work as expected.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

tested locally and saw the deletion event and an entry in the async deletions table
