### PR TITLE
chore(data-warehouse): remove flag for external link

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -156,7 +156,6 @@ export const FEATURE_FLAGS = {
     EXCEPTION_AUTOCAPTURE: 'exception-autocapture',
     DATA_WAREHOUSE: 'data-warehouse', // owner: @EDsCODE
     DATA_WAREHOUSE_VIEWS: 'data-warehouse-views', // owner: @EDsCODE
-    DATA_WAREHOUSE_EXTERNAL_LINK: 'data-warehouse-external-link', // owner: @EDsCODE
     FF_DASHBOARD_TEMPLATES: 'ff-dashboard-templates', // owner: @EDsCODE
     SHOW_PRODUCT_INTRO_EXISTING_PRODUCTS: 'show-product-intro-existing-products', // owner: @raquelmsmith
     ARTIFICIAL_HOG: 'artificial-hog', // owner: @Twixes

--- a/frontend/src/scenes/data-warehouse/external/DataWarehouseExternalScene.tsx
+++ b/frontend/src/scenes/data-warehouse/external/DataWarehouseExternalScene.tsx
@@ -3,9 +3,7 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { PageHeader } from 'lib/components/PageHeader'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { IconSettings } from 'lib/lemon-ui/icons'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -25,7 +23,6 @@ export function DataWarehouseExternalScene(): JSX.Element {
     const { shouldShowEmptyState, shouldShowProductIntroduction, isSourceModalOpen } =
         useValues(dataWarehouseSceneLogic)
     const { toggleSourceModal } = useActions(dataWarehouseSceneLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     return (
         <div>
@@ -39,25 +36,19 @@ export function DataWarehouseExternalScene(): JSX.Element {
                     </div>
                 }
                 buttons={
-                    featureFlags[FEATURE_FLAGS.DATA_WAREHOUSE_EXTERNAL_LINK] ? (
-                        <LemonButton
-                            type="primary"
-                            sideAction={{
-                                icon: <IconSettings />,
-                                onClick: () => router.actions.push(urls.dataWarehouseSettings()),
-                                'data-attr': 'saved-insights-new-insight-dropdown',
-                            }}
-                            data-attr="new-data-warehouse-easy-link"
-                            key={'new-data-warehouse-easy-link'}
-                            onClick={() => toggleSourceModal()}
-                        >
-                            Link Source
-                        </LemonButton>
-                    ) : !(shouldShowProductIntroduction || shouldShowEmptyState) ? (
-                        <LemonButton type="primary" to={urls.dataWarehouseTable()} data-attr="new-data-warehouse-table">
-                            New table
-                        </LemonButton>
-                    ) : undefined
+                    <LemonButton
+                        type="primary"
+                        sideAction={{
+                            icon: <IconSettings />,
+                            onClick: () => router.actions.push(urls.dataWarehouseSettings()),
+                            'data-attr': 'saved-insights-new-insight-dropdown',
+                        }}
+                        data-attr="new-data-warehouse-easy-link"
+                        key={'new-data-warehouse-easy-link'}
+                        onClick={() => toggleSourceModal()}
+                    >
+                        Link Source
+                    </LemonButton>
                 }
                 caption={
                     <div>
@@ -78,11 +69,7 @@ export function DataWarehouseExternalScene(): JSX.Element {
                     description={
                         'Bring your production database, revenue data, CRM contacts or any other data into PostHog.'
                     }
-                    action={() =>
-                        featureFlags[FEATURE_FLAGS.DATA_WAREHOUSE_EXTERNAL_LINK]
-                            ? toggleSourceModal()
-                            : router.actions.push(urls.dataWarehouseTable())
-                    }
+                    action={toggleSourceModal}
                     isEmpty={shouldShowEmptyState}
                     docsURL="https://posthog.com/docs/data/data-warehouse"
                     productKey={ProductKey.DATA_WAREHOUSE}

--- a/frontend/src/scenes/data-warehouse/settings/DataWarehouseSettingsScene.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/DataWarehouseSettingsScene.tsx
@@ -2,9 +2,7 @@ import { TZLabel } from '@posthog/apps-common'
 import { LemonButton, LemonDialog, LemonSwitch, LemonTable, LemonTag, Link, Spinner } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { More } from 'lib/lemon-ui/LemonButton/More'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -33,7 +31,6 @@ export function DataWarehouseSettingsScene(): JSX.Element {
     const { deleteSource, reloadSource } = useActions(dataWarehouseSettingsLogic)
     const { toggleSourceModal } = useActions(dataWarehouseSceneLogic)
     const { isSourceModalOpen } = useValues(dataWarehouseSceneLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const renderExpandable = (source: ExternalDataStripeSource): JSX.Element => {
         return (
@@ -59,16 +56,14 @@ export function DataWarehouseSettingsScene(): JSX.Element {
                     </div>
                 }
                 buttons={
-                    featureFlags[FEATURE_FLAGS.DATA_WAREHOUSE_EXTERNAL_LINK] ? (
-                        <LemonButton
-                            type="primary"
-                            data-attr="new-data-warehouse-easy-link"
-                            key={'new-data-warehouse-easy-link'}
-                            onClick={() => toggleSourceModal()}
-                        >
-                            Link Source
-                        </LemonButton>
-                    ) : undefined
+                    <LemonButton
+                        type="primary"
+                        data-attr="new-data-warehouse-easy-link"
+                        key={'new-data-warehouse-easy-link'}
+                        onClick={() => toggleSourceModal()}
+                    >
+                        Link Source
+                    </LemonButton>
                 }
                 caption={
                     <div>


### PR DESCRIPTION
## Problem

- data warehouse features depend on two flags right now

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- remove external link flag so everything depends on data-warehouse flag

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
