### PR TITLE
fix: local file playback working in posthog 3000

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
@@ -40,13 +40,6 @@ export const LemonFileInput = ({
     const [drag, setDrag] = useState(false)
     const dropRef = createRef<HTMLDivElement>()
 
-    callToAction = callToAction || (
-        <>
-            <IconUploadFile className={'text-2xl'} /> Click or drag and drop to upload
-            {accept ? ` ${acceptToDisplayName(accept)}` : ''}
-        </>
-    )
-
     useEffect(() => {
         if (value && value !== files) {
             setFiles(value)
@@ -144,7 +137,12 @@ export const LemonFileInput = ({
                         accept={accept}
                         onChange={onInputChange}
                     />
-                    {callToAction}
+                    {callToAction || (
+                        <>
+                            <IconUploadFile className={'text-2xl'} /> Click or drag and drop to upload
+                            {accept ? ` ${acceptToDisplayName(accept)}` : ''}
+                        </>
+                    )}
                 </label>
                 {files.length > 0 && (
                     <div className={'flex flex-row gap-2'}>

--- a/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
@@ -9,7 +9,9 @@ import { ChangeEvent, createRef, RefObject, useEffect, useState } from 'react'
 export interface LemonFileInputProps extends Pick<HTMLInputElement, 'multiple' | 'accept'> {
     value?: File[]
     onChange?: (newValue: File[]) => void
-    // are the files currently being uploaded?
+    /**
+     * are the files currently being uploaded?
+     */
     loading?: boolean
     /** if this is not provided then this component is the drop target
      * and is styled when a file is dragged over it
@@ -18,7 +20,9 @@ export interface LemonFileInputProps extends Pick<HTMLInputElement, 'multiple' |
      * styling is applied to the alternativeDropTargetRef
      * **/
     alternativeDropTargetRef?: RefObject<HTMLElement>
-    // the text to display to the user, a sensible default is used if not provided
+    /**
+     * the text to display to the user, a sensible default is used if not provided
+     */
     callToAction?: string | JSX.Element
 }
 

--- a/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
@@ -18,6 +18,8 @@ export interface LemonFileInputProps extends Pick<HTMLInputElement, 'multiple' |
      * styling is applied to the alternativeDropTargetRef
      * **/
     alternativeDropTargetRef?: RefObject<HTMLElement>
+    // the text to display to the user, a sensible default is used if not provided
+    callToAction?: string | JSX.Element
 }
 
 export const LemonFileInput = ({
@@ -28,6 +30,7 @@ export const LemonFileInput = ({
     // e.g. '.json' or 'image/*'
     accept,
     alternativeDropTargetRef,
+    callToAction,
 }: LemonFileInputProps): JSX.Element => {
     const [files, setFiles] = useState(value || value || ([] as File[]))
 
@@ -36,6 +39,13 @@ export const LemonFileInput = ({
     let dragCounter = 0
     const [drag, setDrag] = useState(false)
     const dropRef = createRef<HTMLDivElement>()
+
+    callToAction = callToAction || (
+        <>
+            <IconUploadFile className={'text-2xl'} /> Click or drag and drop to upload
+            {accept ? ` ${acceptToDisplayName(accept)}` : ''}
+        </>
+    )
 
     useEffect(() => {
         if (value && value !== files) {
@@ -134,8 +144,7 @@ export const LemonFileInput = ({
                         accept={accept}
                         onChange={onInputChange}
                     />
-                    <IconUploadFile className={'text-2xl'} /> Click or drag and drop to upload
-                    {accept ? ` ${acceptToDisplayName(accept)}` : ''}
+                    {callToAction}
                 </label>
                 {files.length > 0 && (
                     <div className={'flex flex-row gap-2'}>

--- a/frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.tsx
@@ -10,7 +10,7 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import posthog from 'posthog-js'
-import React, { createRef, useRef, useState } from 'react'
+import React, { useRef, useState } from 'react'
 import TextareaAutosize from 'react-textarea-autosize'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
@@ -80,7 +80,7 @@ export const LemonTextAreaMarkdown = React.forwardRef<HTMLTextAreaElement, Lemon
         const { objectStorageAvailable } = useValues(preflightLogic)
 
         const [isPreviewShown, setIsPreviewShown] = useState(false)
-        const dropRef = createRef<HTMLDivElement>()
+        const dropRef = useRef<HTMLDivElement>(null)
 
         const { setFilesToUpload, filesToUpload, uploading } = useUploadFiles({
             onUpload: (url, fileName) => {

--- a/frontend/src/scenes/session-recordings/file-playback/SessionRecordingFilePlayback.tsx
+++ b/frontend/src/scenes/session-recordings/file-playback/SessionRecordingFilePlayback.tsx
@@ -1,9 +1,10 @@
-import Dragger from 'antd/lib/upload/Dragger'
 import { useActions, useValues } from 'kea'
 import { PayGatePage } from 'lib/components/PayGatePage/PayGatePage'
 import { IconUploadFile } from 'lib/lemon-ui/icons'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { LemonFileInput } from 'lib/lemon-ui/LemonFileInput'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
+import { createRef } from 'react'
 import { userLogic } from 'scenes/userLogic'
 
 import { AvailableFeature } from '~/types'
@@ -16,6 +17,8 @@ export function SessionRecordingFilePlayback(): JSX.Element {
     const { sessionRecording, sessionRecordingLoading, playerKey } = useValues(sessionRecordingFilePlaybackLogic)
     const { hasAvailableFeature } = useValues(userLogic)
     const filePlaybackEnabled = hasAvailableFeature(AvailableFeature.RECORDINGS_FILE_EXPORT)
+
+    const dropRef = createRef<HTMLDivElement>()
 
     if (!filePlaybackEnabled) {
         return (
@@ -51,26 +54,25 @@ export function SessionRecordingFilePlayback(): JSX.Element {
                     <SessionRecordingPlayer sessionRecordingId="" playerKey={playerKey} />
                 </div>
             ) : (
-                <Dragger
-                    name="file"
-                    multiple={false}
-                    accept=".json"
-                    showUploadList={false}
-                    beforeUpload={(file) => {
-                        loadFromFile(file)
-                        return false
-                    }}
+                <div
+                    ref={dropRef}
+                    className="w-full border rounded p-20 text-muted-alt flex flex-col items-center justify-center"
                 >
-                    <div className="p-20 flex flex-col items-center justify-center space-y-2 text-muted-alt">
-                        <p className="flex items-center gap-2 font-semibold">
-                            <IconUploadFile className="text-xl" />
-                            Load recording
-                        </p>
-                        <p className="text-muted-alt ">
-                            Drag and drop your exported recording here or click to open the file browser.
-                        </p>
-                    </div>
-                </Dragger>
+                    <LemonFileInput
+                        accept={'application/json'}
+                        multiple={false}
+                        onChange={(files) => loadFromFile(files[0])}
+                        alternativeDropTargetRef={dropRef}
+                        callToAction={
+                            <div className={'flex flex-col items-center justify-center space-y-2'}>
+                                <p className="flex items-center gap-2 font-semibold">
+                                    <IconUploadFile className={'text-2xl'} /> Load recording
+                                </p>
+                                <div>Drag and drop your exported recording here or click to open the file browser.</div>
+                            </div>
+                        }
+                    />
+                </div>
             )}
         </div>
     )

--- a/frontend/src/scenes/session-recordings/file-playback/SessionRecordingFilePlayback.tsx
+++ b/frontend/src/scenes/session-recordings/file-playback/SessionRecordingFilePlayback.tsx
@@ -4,7 +4,7 @@ import { IconUploadFile } from 'lib/lemon-ui/icons'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonFileInput } from 'lib/lemon-ui/LemonFileInput'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
-import { createRef } from 'react'
+import { useRef } from 'react'
 import { userLogic } from 'scenes/userLogic'
 
 import { AvailableFeature } from '~/types'
@@ -18,7 +18,7 @@ export function SessionRecordingFilePlayback(): JSX.Element {
     const { hasAvailableFeature } = useValues(userLogic)
     const filePlaybackEnabled = hasAvailableFeature(AvailableFeature.RECORDINGS_FILE_EXPORT)
 
-    const dropRef = createRef<HTMLDivElement>()
+    const dropRef = useRef<HTMLDivElement>(null)
 
     if (!filePlaybackEnabled) {
         return (
@@ -65,9 +65,9 @@ export function SessionRecordingFilePlayback(): JSX.Element {
                         alternativeDropTargetRef={dropRef}
                         callToAction={
                             <div className={'flex flex-col items-center justify-center space-y-2'}>
-                                <p className="flex items-center gap-2 font-semibold">
+                                <span className="flex items-center gap-2 font-semibold">
                                     <IconUploadFile className={'text-2xl'} /> Load recording
-                                </p>
+                                </span>
                                 <div>Drag and drop your exported recording here or click to open the file browser.</div>
                             </div>
                         }


### PR DESCRIPTION
local file playback view had invisible text in dark mode

well, not any more!

(we already had a lemon file input that handles this so I switched from Ant to that)

![2024-01-04 18 54 16](https://github.com/PostHog/posthog/assets/984817/340fcf4f-3603-4afd-acd9-be5c0eb988dc)
