### PR TITLE
fix: Fix sending feature preview feedback

### DIFF
--- a/frontend/src/layout/FeaturePreviews/featurePreviewsLogic.test.ts
+++ b/frontend/src/layout/FeaturePreviews/featurePreviewsLogic.test.ts
@@ -1,0 +1,31 @@
+import { expectLogic } from 'kea-test-utils'
+import { MOCK_DEFAULT_USER } from 'lib/api.mock'
+import { userLogic } from 'scenes/userLogic'
+
+import { initKeaTests } from '~/test/init'
+
+import { featurePreviewsLogic } from './featurePreviewsLogic'
+
+describe('featurePreviewsLogic', () => {
+    let logic: ReturnType<typeof featurePreviewsLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = featurePreviewsLogic()
+        logic.mount()
+        userLogic.actions.loadUserSuccess(MOCK_DEFAULT_USER)
+    })
+
+    test('submitting feedback', async () => {
+        logic.actions.beginEarlyAccessFeatureFeedback('test')
+        const promise = logic.asyncActions.submitEarlyAccessFeatureFeedback('test')
+        await expectLogic(logic)
+            .toMatchValues({ activeFeedbackFlagKeyLoading: true })
+            .toDispatchActions(['submitEarlyAccessFeatureFeedback'])
+            .toNotHaveDispatchedActions(['submitEarlyAccessFeatureFeedbackSuccess'])
+        await promise
+        await expectLogic(logic)
+            .toMatchValues({ activeFeedbackFlagKeyLoading: false })
+            .toDispatchActions(['submitEarlyAccessFeatureFeedbackSuccess'])
+    })
+})

--- a/frontend/src/layout/FeaturePreviews/featurePreviewsLogic.tsx
+++ b/frontend/src/layout/FeaturePreviews/featurePreviewsLogic.tsx
@@ -18,10 +18,10 @@ export interface EnrichedEarlyAccessFeature extends Omit<EarlyAccessFeature, 'fl
 }
 
 export const featurePreviewsLogic = kea<featurePreviewsLogicType>([
-    path(['layout', 'navigation', 'TopBar', 'FeaturePreviewsModal']),
+    path(['layout', 'FeaturePreviews', 'featurePreviewsLogic']),
     connect({
         values: [featureFlagLogic, ['featureFlags'], userLogic, ['user']],
-        asyncActions: [supportLogic, ['submitZendeskTicket']],
+        actions: [supportLogic, ['submitZendeskTicket']],
     }),
     actions({
         showFeaturePreviewsModal: true,


### PR DESCRIPTION
## Problem

This "Submit feedback" button has been quietly erroring:

<img width="456" alt="Screenshot 2024-01-04 at 20 19 59" src="https://github.com/PostHog/posthog/assets/4550621/8d0c818a-ee9c-40dc-9735-90fbeb2179b6">

The error being:
```
"[KEA] Can not access "asyncActions" on logic "lib.components.support.supportLogic" because it is not mounted!
This can happen in several situations:
- You may need to add the "connect(otherLogic)" logic builder, or "useMountedLogic(otherLogic)" hook to make sure the logic is mounted.
- If "otherLogic" is undefined, your bundler may import and execute code in an unfavourable order. Switch to a function: "connect(() => otherLogic)" 
- It may be that the logic has already unmounted. Do you have a listener that is missing a breakpoint?"
```

Consequently, we weren't receiving the feedback.

## Changes

The bug was extremely simple: turns out `asyncActions` is not a valid `connect()`-ible, only `actions` is. And `actions` actually does work if all we need is `asyncActions`. Hence the fix was just turning `asyncActions: [...]` into `actions: [...]`.

## How did you test this code?

Added a logic test.