### PR TITLE
fix: Open-source hobby deploy fails, fix PostHog/posthog#16169

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -197,8 +197,6 @@ services:
         <<: *worker
         command: ./bin/temporal-django-worker
         restart: on-failure
-        environment:
-            TEMPORAL_HOST: temporal
         depends_on:
             - db
             - redis

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -145,6 +145,7 @@ services:
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
+            TEMPORAL_HOST: temporal
 
 volumes:
     zookeeper-data:


### PR DESCRIPTION
fix https://github.com/PostHog/posthog/issues/16169



```bash
docker compose config
```

expected
```
...
temporal-django-worker:
    command:
      - /compose/temporal-django-worker
    depends_on:
      clickhouse:
        condition: service_started
        required: true
      db:
        condition: service_started
        required: true
      kafka:
        condition: service_started
        required: true
      object_storage:
        condition: service_started
        required: true
      redis:
        condition: service_started
        required: true
      temporal:
        condition: service_started
        required: true
    environment:
      CLICKHOUSE_DATABASE: posthog
      CLICKHOUSE_HOST: clickhouse
      CLICKHOUSE_SECURE: "false"
      CLICKHOUSE_VERIFY: "false"
      DATABASE_URL: postgres://posthog:posthog@db:5432/posthog
      DEPLOYMENT: hobby
      DISABLE_SECURE_SSL_REDIRECT: "true"
      IS_BEHIND_PROXY: "true"
      KAFKA_HOSTS: kafka
      PGHOST: db
      PGPASSWORD: posthog
      PGUSER: posthog
      REDIS_URL: redis://redis:6379/
      SECRET_KEY: 29cfc82ae530dbcefac584f117ab347ea39acb7614dc82c28523b548
      SENTRY_DSN: ""
      SITE_URL: https://posthog-demo.dev
      TEMPORAL_HOST: temporal
    image: posthog/posthog:latest
...
```