### PR TITLE
feat(management): add change_team_ownership command

### DIFF
--- a/posthog/management/commands/change_team_ownership.py
+++ b/posthog/management/commands/change_team_ownership.py
@@ -1,0 +1,55 @@
+import logging
+import structlog
+import uuid
+from django.core.management.base import BaseCommand
+
+from posthog.models import Team, Organization
+
+logger = structlog.get_logger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class Command(BaseCommand):
+    help = "Move a team into another organization."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--team-id", default=None, type=int, help="Specify a team to fix data for.")
+        parser.add_argument(
+            "--organization-id", default=None, type=uuid.UUID, help="Specify the destination organization by UUID."
+        )
+        parser.add_argument("--live-run", action="store_true", help="Run changes, default is dry-run")
+
+    def handle(self, *args, **options):
+        run(options)
+
+
+def run(options):
+    live_run = options["live_run"]
+
+    if options["team_id"] is None:
+        logger.error("You must specify --team-id to run this script")
+        exit(1)
+
+    if options["organization_id"] is None:
+        logger.error("You must specify --organization-id to run this script")
+        exit(1)
+
+    team_id = options["team_id"]
+    organization_id = options["organization_id"]
+
+    team = Team.objects.get(pk=team_id)
+    logger.info(f"Team {team_id} is currently in organization {team.organization_id}, named {team.organization.name}")
+
+    org = Organization.objects.get(pk=organization_id)
+    logger.info(f"Target organization {organization_id} is named {org.name}")
+
+    if team.organization_id == organization_id:
+        logger.error(f"Team is already in the specified organization")
+        exit(1)
+
+    if live_run:
+        team.organization_id = organization_id
+        team.save()
+        logger.info("Saved team change")
+    else:
+        logger.info("Skipping the team change, pass --live-run to run it")

--- a/posthog/management/commands/change_team_ownership.py
+++ b/posthog/management/commands/change_team_ownership.py
@@ -1,9 +1,11 @@
 import logging
-import structlog
 import uuid
+
+import structlog
+from django.core.management import CommandError
 from django.core.management.base import BaseCommand
 
-from posthog.models import Team, Organization
+from posthog.models import Organization, Team
 
 logger = structlog.get_logger(__name__)
 logger.setLevel(logging.INFO)
@@ -27,12 +29,10 @@ def run(options):
     live_run = options["live_run"]
 
     if options["team_id"] is None:
-        logger.error("You must specify --team-id to run this script")
-        exit(1)
+        raise CommandError("You must specify --team-id to run this script")
 
     if options["organization_id"] is None:
-        logger.error("You must specify --organization-id to run this script")
-        exit(1)
+        raise CommandError("You must specify --organization-id to run this script")
 
     team_id = options["team_id"]
     organization_id = options["organization_id"]
@@ -44,8 +44,7 @@ def run(options):
     logger.info(f"Target organization {organization_id} is named {org.name}")
 
     if team.organization_id == organization_id:
-        logger.error(f"Team is already in the specified organization")
-        exit(1)
+        raise CommandError("Team is already in the specified organization")
 
     if live_run:
         team.organization_id = organization_id

--- a/posthog/management/commands/test/test_change_team_ownership.py
+++ b/posthog/management/commands/test/test_change_team_ownership.py
@@ -1,0 +1,79 @@
+import pytest
+from django.core.management import CommandError, call_command
+
+from posthog.api.test.test_organization import create_organization
+from posthog.api.test.test_team import create_team
+
+
+@pytest.fixture
+def organization():
+    organization = create_organization("old")
+    yield organization
+    organization.delete()
+
+
+@pytest.fixture
+def new_organization():
+    organization = create_organization("new")
+    yield organization
+    organization.delete()
+
+
+@pytest.fixture
+def team(organization):
+    team = create_team(organization=organization)
+    yield team
+    team.delete()
+
+
+def test_change_team_ownership_required_parameters():
+    with pytest.raises(CommandError):
+        call_command("change_team_ownership", "--team-id=123")
+
+    with pytest.raises(CommandError):
+        call_command("change_team_ownership", "--organization-id=123")
+
+
+@pytest.mark.django_db
+def test_change_team_ownership_dry_run(organization, new_organization, team):
+    """Test organization doesn't change in a dry run"""
+    call_command(
+        "change_team_ownership",
+        f"--team-id={team.id}",
+        f"--organization-id={new_organization.id}",
+    )
+
+    team.refresh_from_db()
+
+    assert team.organization_id == organization.id
+
+
+@pytest.mark.django_db
+def test_change_team_ownership_fails_with_same_organization(organization, team):
+    """Test command fails if trying to change to same organization."""
+    with pytest.raises(CommandError):
+        call_command(
+            "change_team_ownership",
+            f"--team-id={team.id}",
+            f"--organization-id={organization.id}",
+            "--live-run",
+        )
+
+    team.refresh_from_db()
+
+    assert team.organization_id == organization.id
+
+
+@pytest.mark.django_db
+def test_change_team_ownership(new_organization, team):
+    """Test the command works."""
+    call_command(
+        "change_team_ownership",
+        f"--team-id={team.id}",
+        f"--organization-id={new_organization.id}",
+        "--live-run",
+    )
+
+    team.refresh_from_db()
+
+    assert team.organization_id == new_organization.id

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -634,7 +634,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_1')
+                                                      'user_one_2')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -634,7 +634,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_2')
+                                                      'user_one_1')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '
 ---


### PR DESCRIPTION
## Problem

Customer wants to consolidate several orgs into one. Changing the team -> organization ownership reference should be safe, but let's add a management command instead of manually hacking the DB.

## Changes

- add a `change_team_ownership` management command

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
