### PR TITLE
test: Add unit tests for command 

### DIFF
--- a/posthog/management/commands/change_team_ownership.py
+++ b/posthog/management/commands/change_team_ownership.py
@@ -1,9 +1,11 @@
 import logging
-import structlog
 import uuid
+
+import structlog
+from django.core.management import CommandError
 from django.core.management.base import BaseCommand
 
-from posthog.models import Team, Organization
+from posthog.models import Organization, Team
 
 logger = structlog.get_logger(__name__)
 logger.setLevel(logging.INFO)
@@ -27,12 +29,10 @@ def run(options):
     live_run = options["live_run"]
 
     if options["team_id"] is None:
-        logger.error("You must specify --team-id to run this script")
-        exit(1)
+        raise CommandError("You must specify --team-id to run this script")
 
     if options["organization_id"] is None:
-        logger.error("You must specify --organization-id to run this script")
-        exit(1)
+        raise CommandError("You must specify --organization-id to run this script")
 
     team_id = options["team_id"]
     organization_id = options["organization_id"]
@@ -44,8 +44,7 @@ def run(options):
     logger.info(f"Target organization {organization_id} is named {org.name}")
 
     if team.organization_id == organization_id:
-        logger.error(f"Team is already in the specified organization")
-        exit(1)
+        raise CommandError("Team is already in the specified organization")
 
     if live_run:
         team.organization_id = organization_id

--- a/posthog/management/commands/test/test_change_team_ownership.py
+++ b/posthog/management/commands/test/test_change_team_ownership.py
@@ -1,0 +1,79 @@
+import pytest
+from django.core.management import CommandError, call_command
+
+from posthog.api.test.test_organization import create_organization
+from posthog.api.test.test_team import create_team
+
+
+@pytest.fixture
+def organization():
+    organization = create_organization("old")
+    yield organization
+    organization.delete()
+
+
+@pytest.fixture
+def new_organization():
+    organization = create_organization("new")
+    yield organization
+    organization.delete()
+
+
+@pytest.fixture
+def team(organization):
+    team = create_team(organization=organization)
+    yield team
+    team.delete()
+
+
+def test_change_team_ownership_required_parameters():
+    with pytest.raises(CommandError):
+        call_command("change_team_ownership", "--team-id=123")
+
+    with pytest.raises(CommandError):
+        call_command("change_team_ownership", "--organization-id=123")
+
+
+@pytest.mark.django_db
+def test_change_team_ownership_dry_run(organization, new_organization, team):
+    """Test organization doesn't change in a dry run"""
+    call_command(
+        "change_team_ownership",
+        f"--team-id={team.id}",
+        f"--organization-id={new_organization.id}",
+    )
+
+    team.refresh_from_db()
+
+    assert team.organization_id == organization.id
+
+
+@pytest.mark.django_db
+def test_change_team_ownership_fails_with_same_organization(organization, team):
+    """Test command fails if trying to change to same organization."""
+    with pytest.raises(CommandError):
+        call_command(
+            "change_team_ownership",
+            f"--team-id={team.id}",
+            f"--organization-id={organization.id}",
+            "--live-run",
+        )
+
+    team.refresh_from_db()
+
+    assert team.organization_id == organization.id
+
+
+@pytest.mark.django_db
+def test_change_team_ownership(new_organization, team):
+    """Test the command works."""
+    call_command(
+        "change_team_ownership",
+        f"--team-id={team.id}",
+        f"--organization-id={new_organization.id}",
+        "--live-run",
+    )
+
+    team.refresh_from_db()
+
+    assert team.organization_id == new_organization.id


### PR DESCRIPTION
## Changes

Added some unit tests to ensure change_team_ownership command works.
Used CommandError to log to stderr and exit, as that's the recommended/best way to exit a django command.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*
