### PR TITLE
feat: Try switching from wsgi to asgi

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -59,7 +59,6 @@ jobs:
         timeout-minutes: 5
         outputs:
             chunks: ${{ steps.chunk.outputs.chunks }}
-
         steps:
             - name: Check out
               uses: actions/checkout@v3

--- a/posthog/asgi.py
+++ b/posthog/asgi.py
@@ -1,0 +1,7 @@
+import os
+
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
+
+application = get_asgi_application()

--- a/unit.json
+++ b/unit.json
@@ -38,7 +38,8 @@
             "processes": 4,
             "working_directory": "/code",
             "path": ".",
-            "module": "posthog.wsgi",
+            "module": "posthog.asgi",
+            "protocol": "asgi",
             "user": "nobody",
             "limits": {
                 "requests": 50000


### PR DESCRIPTION

## Problem

By default I don't believe this will change anything (everything runs sync by default), but it will allow us to wrap e.g. clickhouse calls in sync_to_async wrappers to stop them blocking for ages

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
wip
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
