### PR TITLE
fix: gather server timings for important changes

### DIFF
--- a/posthog/api/activity_log.py
+++ b/posthog/api/activity_log.py
@@ -153,6 +153,7 @@ class ActivityLogViewSet(StructuredViewSetMixin, viewsets.GenericViewSet, mixins
             if last_read_date and params.get("unread") == "true":
                 last_read_filter = f"AND created_at > '{last_read_date.last_viewed_activity_date.isoformat()}'"
 
+        with timer("query_for_candidate_ids"):
             # before we filter to include only the important changes, we need to deduplicate too frequent changes
             candidate_ids = ActivityLog.objects.raw(
                 f"""
@@ -176,6 +177,7 @@ class ActivityLogViewSet(StructuredViewSetMixin, viewsets.GenericViewSet, mixins
                 """
             )
 
+        with timer("construct_query"):
             other_peoples_changes = (
                 self.queryset.exclude(user=user)
                 .filter(team_id=self.team.id)


### PR DESCRIPTION
We don't have much visibility into what is happening in this endpoint which appears to have slowed down...

let's add some timings to see if it helps us zero in on where to look

this will give us something like

<img width="663" alt="Screenshot 2024-01-05 at 15 44 27" src="https://github.com/PostHog/posthog/assets/984817/23e2c53f-66b6-40b8-af69-07b0b9eee5bd">
