### PR TITLE
fix(bi): Fix multiple query requests

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -1,7 +1,7 @@
 import './DataTable.scss'
 
 import clsx from 'clsx'
-import { BindLogic, useMountedLogic, useValues } from 'kea'
+import { BindLogic, useValues } from 'kea'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -100,7 +100,7 @@ export function DataTable({
         key: dataNodeLogicKey ?? dataKey,
         cachedResults: cachedResults,
     }
-    const builtDataNodeLogic = useMountedLogic(dataNodeLogic) ?? dataNodeLogic(dataNodeLogicProps)
+    const builtDataNodeLogic = dataNodeLogic(dataNodeLogicProps)
 
     const {
         response,

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
@@ -26,6 +26,8 @@ export interface DataTableLogicProps {
     dataKey: string
     query: DataTableNode
     context?: QueryContext
+    // Override the data logic node key if needed
+    dataNodeLogicKey?: string
 }
 
 export interface DataTableRow {
@@ -58,7 +60,7 @@ export const dataTableLogic = kea<dataTableLogicType>([
         values: [
             featureFlagLogic,
             ['featureFlags'],
-            dataNodeLogic({ key: props.dataKey, query: props.query.source }),
+            dataNodeLogic({ key: props.dataNodeLogicKey ?? props.dataKey, query: props.query.source }),
             ['response', 'responseLoading', 'responseError'],
         ],
     })),

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -84,6 +84,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
         component = (
             <DataTable
                 uniqueKey={props.uniqueKey}
+                dataNodeLogicKey={props.uniqueKey?.toString()}
                 query={{ kind: NodeKind.DataTableNode, source: query.source }}
                 cachedResults={props.cachedResults}
                 context={{

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -40,17 +40,20 @@ export interface DataVisualizationLogicProps {
 export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
     key((props) => props.key),
     path(['queries', 'nodes', 'DataVisualization', 'dataVisualizationLogic']),
-    connect({
+    connect((props: DataVisualizationLogicProps) => ({
         values: [
             teamLogic,
             ['currentTeamId'],
             insightSceneLogic,
             ['insightMode'],
-            dataNodeLogic,
+            dataNodeLogic({ cachedResults: props.cachedResults, key: props.key, query: props.query.source }),
             ['response', 'responseLoading'],
         ],
-        actions: [dataNodeLogic, ['loadDataSuccess']],
-    }),
+        actions: [
+            dataNodeLogic({ cachedResults: props.cachedResults, key: props.key, query: props.query.source }),
+            ['loadDataSuccess'],
+        ],
+    })),
     props({ query: {} } as DataVisualizationLogicProps),
     actions({
         setVisualizationType: (visualizationType: ChartDisplayType) => ({ visualizationType }),


### PR DESCRIPTION
## Problem
- We're requesting the query data twice from the frontend 

## Changes
- Updated `DataTable` to also accept a custom key for `dataNodeLogic` so that the pre-mounted logic gets reused as opposed to a new one being mounted

## How did you test this code?
- Tested the SQL tab with both the BI flag turned on and turned off