### PR TITLE
chore(navigation): Put theme "Sync with system" option last

### DIFF
--- a/frontend/src/scenes/settings/user/ThemeSwitcher.tsx
+++ b/frontend/src/scenes/settings/user/ThemeSwitcher.tsx
@@ -13,9 +13,9 @@ export function ThemeSwitcher({
     return (
         <LemonSelect
             options={[
-                { icon: <IconLaptop />, value: 'system', label: `Sync with system` },
                 { icon: <IconDay />, value: 'light', label: 'Light mode' },
                 { icon: <IconNight />, value: 'dark', label: 'Dark mode' },
+                { icon: <IconLaptop />, value: 'system', label: `Sync with system` },
             ]}
             value={themeMode}
             renderButtonContent={(leaf) => {


### PR DESCRIPTION
## Changes

Now that light mode is the default theme and not "Sync with system", the latter should be the last option instead of the first.

![Screenshot 2024-01-05 at 18 51 23](https://github.com/PostHog/posthog/assets/4550621/d4c36af9-8af4-4506-ab8c-d8f1ed4c3e0c)