### PR TITLE
chore(hogql): Fix some hogql_parser docs typos

### DIFF
--- a/hogql_parser/CONTRIBUTING.md
+++ b/hogql_parser/CONTRIBUTING.md
@@ -38,11 +38,11 @@ The three pages below are must-reads though. They're key to writing production-r
 ## Conventions
 
 1. Use `snake_case`. ANTLR is `camelCase`-heavy because of its Java heritage, but both the C++ stdlib and CPython are snaky.
-2. Use the `auto` type for ANTLR and ANTLR-derived types, since they can be pretty verbose. Otherwise specify the type explictly.
+2. Use the `auto` type for ANTLR and ANTLR-derived types, since they can be pretty verbose. Otherwise, specify the type explicitly.
 3. Stay out of Python land as long as possible. E.g. avoid using `PyObject*`s` for bools or strings.
    Do use Python for parsing numbers though - that way we don't need to consider integer overflow.
 4. If any child rule results in an AST node, so must the parent rule - once in Python land, always in Python land.
-   E.g. it doesn't make sense to create a `vector<PyObject*>`, that should just be a `PyObject*` of Python type `list`.
+   E.g. it doesn't  make sense to create a `vector<PyObject*>`, that should just be a `PyObject*` of Python type `list`.
 
 ## How to develop locally on macOS
 

--- a/hogql_parser/pyproject.toml
+++ b/hogql_parser/pyproject.toml
@@ -9,7 +9,7 @@ build = [ # Build CPython wheels on Linux and macOS, for x86 as well as ARM
     "cp3*-manylinux_x86_64",
     "cp3*-manylinux_aarch64",
 ]
-build-frontend = "build" # This is successor to building with pip
+build-frontend = "build" # This is the successor to building with pip
 
 [tool.cibuildwheel.macos]
 archs = [ # We could also build a universal wheel, but separate ones are lighter individually
@@ -28,9 +28,9 @@ before-all = [
     "dnf install -y boost-devel unzip cmake curl uuid pkg-config",
     "curl https://www.antlr.org/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip",
     # Check that the downloaded archive is the expected runtime - a security measure
-    "anltr_known_md5sum=\"c875c148991aacd043f733827644a76f\"",
+    "antlr_known_md5sum=\"c875c148991aacd043f733827644a76f\"",
     "antlr_found_ms5sum=\"$(md5sum antlr4-source.zip | cut -d' ' -f1)\"",
-    'if [[ "$anltr_known_md5sum" != "$antlr_found_ms5sum" ]]; then exit 64; fi',
+    'if [[ "$antlr_known_md5sum" != "$antlr_found_ms5sum" ]]; then exit 64; fi',
     "unzip antlr4-source.zip -d antlr4-source && cd antlr4-source",
     "cmake .",
     "DESTDIR=out make install",


### PR DESCRIPTION
## Changes

This is actually from December when I was looking at something in `hogql_parser`, found some typos. This fixes the typos.