### PR TITLE
fix(3000): Use title font in LemonRow

### DIFF
--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -273,7 +273,7 @@ export function SitePopoverOverlay(): JSX.Element {
                 </SitePopoverSection>
             )}
             {(!(preflight?.cloud || preflight?.demo) || user?.is_staff) && (
-                <SitePopoverSection title="PostHog instance" className="font-title-3000">
+                <SitePopoverSection title="PostHog instance">
                     <SystemStatus />
                     <AsyncMigrations />
                     <InstanceSettings />

--- a/frontend/src/lib/lemon-ui/LemonRow/LemonRow.scss
+++ b/frontend/src/lib/lemon-ui/LemonRow/LemonRow.scss
@@ -6,6 +6,7 @@
     justify-content: center;
     min-height: 2.5rem;
     padding: 0.25rem 1rem;
+    font-family: var(--font-title);
     font-size: 0.875rem;
     line-height: 1.25rem;
     text-align: left;

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -1136,13 +1136,6 @@ $decorations: underline, overline, line-through, no-underline;
     font-family: var(--font-title);
 }
 
-/** title font, but only when posthog-3000 is active */
-.font-title-3000 {
-    .posthog-3000 & {
-        font-family: var(--font-title);
-    }
-}
-
 .font-mono {
     font-family: var(--font-mono);
 }


### PR DESCRIPTION
## Changes

Since `LemonButton` uses Matter, `LemonRow` should too (even if `LemonRow` is slightly esoteric). We currently have a hotfix in place for the inconsistency in `SitePopover` – `.font-title-3000` – but it shouldn't be needed.

One thing before we merge this though is weight 400 of Matter. It's currently not available, which is why the non-interactive rows look just like buttons. Not a bad experience per se, but not smooth either.