### PR TITLE
feat: add notice about new data pipelines addon

### DIFF
--- a/frontend/src/lib/components/BillingAlertsV2.tsx
+++ b/frontend/src/lib/components/BillingAlertsV2.tsx
@@ -48,7 +48,10 @@ export function BillingAlertsV2(): JSX.Element | null {
             <LemonBanner
                 type={billingAlert.status}
                 action={showButton ? buttonProps : undefined}
-                onClose={billingAlert.status !== 'error' ? () => setAlertHidden(true) : undefined}
+                onClose={() => {
+                    billingAlert.status !== 'error' ? () => setAlertHidden(true) : undefined
+                    billingAlert.onClose?.()
+                }}
                 dismissKey={billingAlert.dismissKey}
             >
                 <b>{billingAlert.title}</b>

--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -79,12 +79,25 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
             action: {
                 onClick: () => {
                     posthog.capture('data pipelines notice clicked')
+                    // if they don't dismiss it now, we won't show it next time they come back
+                    posthog.capture('data pipelines notice dismissed', {
+                        $set: {
+                            dismissedDataPipelinesNotice: true,
+                        },
+                    })
                 },
                 children: 'Learn more',
                 to: 'https://posthog.com',
                 targetBlank: true,
             },
             dismissKey: 'data-pipelines-notice',
+            onClose: () => {
+                posthog.capture('data pipelines notice dismissed', {
+                    $set: {
+                        dismissedDataPipelinesNotice: true,
+                    },
+                })
+            },
         })
     }
     return (

--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -7,6 +7,7 @@ import {
     IconCheckCircleOutline,
     IconCheckmark,
     IconChevronRight,
+    IconClose,
     IconExpandMore,
     IconInfo,
     IconPlus,
@@ -14,6 +15,7 @@ import {
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { capitalizeFirstLetter, compactNumber } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { getProductIcon } from 'scenes/products/Products'
@@ -50,6 +52,7 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
     const { toggleIsPricingModalOpen, reportSurveyShown, setSurveyResponse } = useActions(
         billingProductLogic({ product: addon })
     )
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const productType = { plural: `${addon.unit}s`, singular: addon.unit }
     const tierDisplayOptions: LemonSelectOptions<string> = [
@@ -61,90 +64,119 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
     }
 
     return (
-        <div className="bg-side rounded p-6 flex flex-col">
-            <div className="flex justify-between gap-x-4">
-                <div className="flex gap-x-4">
-                    <div className="w-8">{getProductIcon(addon.icon_key, 'text-2xl')}</div>
-                    <div>
-                        <div className="flex gap-x-2 items-center mt-0 mb-2 ">
-                            <h4 className="leading-5 mb-1 font-bold">{addon.name}</h4>
-                            {addon.subscribed && (
-                                <div>
-                                    <LemonTag type="completion" icon={<IconCheckmark />}>
-                                        Subscribed
-                                    </LemonTag>
-                                </div>
-                            )}
+        <Tooltip
+            visible={addon.type === 'data_pipelines' && addon.subscribed && !!featureFlags['data-pipelines-notice']}
+            placement="bottomLeft"
+            delayMs={0}
+            title={
+                <div
+                    className="flex items-center gap-1"
+                    onClick={
+                        // onAcknowledged
+                        undefined
+                    }
+                >
+                    <div className="flex-1">
+                        <h3 className="text-white">Welcome to data pipelines!</h3>
+                        <p className="mb-0">
+                            We've split features (and cost) for product analytics to better reflect users' needs. Your
+                            overall price hasn't changed.{' '}
+                            <Link to={'https://posthog.com'} target="_blank" targetBlankIcon>
+                                Learn more
+                            </Link>
+                            .
+                        </p>
+                    </div>
+
+                    <LemonButton size="small" onClick={undefined} icon={<IconClose />} />
+                </div>
+            }
+        >
+            <div className="bg-side rounded p-6 flex flex-col">
+                <div className="flex justify-between gap-x-4">
+                    <div className="flex gap-x-4">
+                        <div className="w-8">{getProductIcon(addon.icon_key, 'text-2xl')}</div>
+                        <div>
+                            <div className="flex gap-x-2 items-center mt-0 mb-2 ">
+                                <h4 className="leading-5 mb-1 font-bold">{addon.name}</h4>
+                                {addon.subscribed && (
+                                    <div>
+                                        <LemonTag type="completion" icon={<IconCheckmark />}>
+                                            Subscribed
+                                        </LemonTag>
+                                    </div>
+                                )}
+                            </div>
+                            <p className="ml-0 mb-0">{addon.description}</p>
                         </div>
-                        <p className="ml-0 mb-0">{addon.description}</p>
+                    </div>
+                    <div className="ml-4 mr-4 mt-2 self-center flex gap-x-2 whitespace-nowrap">
+                        {addon.docs_url && (
+                            <Tooltip title="Read the docs">
+                                <LemonButton icon={<IconArticle />} size="small" to={addon.docs_url} />
+                            </Tooltip>
+                        )}
+                        {addon.subscribed ? (
+                            <>
+                                <More
+                                    overlay={
+                                        <>
+                                            <LemonButton
+                                                fullWidth
+                                                onClick={() => {
+                                                    setSurveyResponse(addon.type, '$survey_response_1')
+                                                    reportSurveyShown(UNSUBSCRIBE_SURVEY_ID, addon.type)
+                                                }}
+                                            >
+                                                Remove addon
+                                            </LemonButton>
+                                        </>
+                                    }
+                                />
+                            </>
+                        ) : addon.included_with_main_product ? (
+                            <LemonTag type="completion" icon={<IconCheckmark />}>
+                                Included with plan
+                            </LemonTag>
+                        ) : (
+                            <>
+                                <LemonButton
+                                    type="secondary"
+                                    disableClientSideRouting
+                                    onClick={() => {
+                                        toggleIsPricingModalOpen()
+                                    }}
+                                >
+                                    View pricing
+                                </LemonButton>
+                                <LemonButton
+                                    type="primary"
+                                    icon={<IconPlus />}
+                                    size="small"
+                                    to={`/api/billing-v2/activation?products=${addon.type}:${
+                                        currentAndUpgradePlans?.upgradePlan?.plan_key
+                                    }${redirectPath && `&redirect_path=${redirectPath}`}`}
+                                    disableClientSideRouting
+                                >
+                                    Add
+                                </LemonButton>
+                            </>
+                        )}
                     </div>
                 </div>
-                <div className="ml-4 mr-4 mt-2 self-center flex gap-x-2 whitespace-nowrap">
-                    {addon.docs_url && (
-                        <Tooltip title="Read the docs">
-                            <LemonButton icon={<IconArticle />} size="small" to={addon.docs_url} />
-                        </Tooltip>
-                    )}
-                    {addon.subscribed ? (
-                        <>
-                            <More
-                                overlay={
-                                    <>
-                                        <LemonButton
-                                            fullWidth
-                                            onClick={() => {
-                                                setSurveyResponse(addon.type, '$survey_response_1')
-                                                reportSurveyShown(UNSUBSCRIBE_SURVEY_ID, addon.type)
-                                            }}
-                                        >
-                                            Remove addon
-                                        </LemonButton>
-                                    </>
-                                }
-                            />
-                        </>
-                    ) : addon.included_with_main_product ? (
-                        <LemonTag type="completion" icon={<IconCheckmark />}>
-                            Included with plan
-                        </LemonTag>
-                    ) : (
-                        <>
-                            <LemonButton
-                                type="secondary"
-                                disableClientSideRouting
-                                onClick={() => {
-                                    toggleIsPricingModalOpen()
-                                }}
-                            >
-                                View pricing
-                            </LemonButton>
-                            <LemonButton
-                                type="primary"
-                                icon={<IconPlus />}
-                                size="small"
-                                to={`/api/billing-v2/activation?products=${addon.type}:${
-                                    currentAndUpgradePlans?.upgradePlan?.plan_key
-                                }${redirectPath && `&redirect_path=${redirectPath}`}`}
-                                disableClientSideRouting
-                            >
-                                Add
-                            </LemonButton>
-                        </>
-                    )}
-                </div>
+                <ProductPricingModal
+                    modalOpen={isPricingModalOpen}
+                    onClose={toggleIsPricingModalOpen}
+                    product={addon}
+                    planKey={
+                        addon.subscribed
+                            ? currentAndUpgradePlans?.currentPlan?.plan_key
+                            : currentAndUpgradePlans?.upgradePlan?.plan_key
+                    }
+                />
+                {surveyID && <UnsubscribeSurveyModal product={addon} />}
             </div>
-            <ProductPricingModal
-                modalOpen={isPricingModalOpen}
-                onClose={toggleIsPricingModalOpen}
-                product={addon}
-                planKey={
-                    addon.subscribed
-                        ? currentAndUpgradePlans?.currentPlan?.plan_key
-                        : currentAndUpgradePlans?.upgradePlan?.plan_key
-                }
-            />
-            {surveyID && <UnsubscribeSurveyModal product={addon} />}
-        </div>
+        </Tooltip>
     )
 }
 

--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -74,7 +74,7 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
         setProductSpecificAlert({
             status: 'info',
             title: 'Welcome to the data pipelines addon!',
-            message: `We've moved data export features (and cost) to the data pipelines addon to better reflect user needs. Your overall
+            message: `We've moved data export features (and cost) here to better reflect user needs. Your overall
                     price hasn't changed.`,
             action: {
                 onClick: () => {

--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -73,8 +73,8 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
     if (showPipelineAddonNotice) {
         setProductSpecificAlert({
             status: 'info',
-            title: 'Welcome to data pipelines!',
-            message: `We've split features (and cost) for product analytics to better reflect users' needs. Your overall
+            title: 'Welcome to the data pipelines addon!',
+            message: `We've moved data export features (and cost) to the data pipelines addon to better reflect user needs. Your overall
                     price hasn't changed.`,
             action: {
                 onClick: () => {

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -29,6 +29,7 @@ export interface BillingAlertConfig {
     dismissKey?: string
     action?: LemonBannerAction
     pathName?: string
+    onClose?: () => void
 }
 
 const parseBillingResponse = (data: Partial<BillingV2Type>): BillingV2Type => {


### PR DESCRIPTION
## Problem

When we split the pipelines addon out, people might be confused when they see a new addon they are subscribed to in the billing page. We should tell them about it, but in quiet sort of way since nothing is really changing for them.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds a notice to the billing page if they are an OG pipelines customer (ie. they were sub'd to product analytics and we split them out - they didn't subscribe to the pipelines addon specifically on their own) and sub'd to it and in a [feature flag](https://us.posthog.com/feature_flags/26391) that says they haven't dismissed it yet.

TODO: Put the real link to the changelog in there before merging.

![image](https://github.com/PostHog/posthog/assets/18598166/34cd4318-ac2e-48e9-a3d7-9ac6ed9f891a)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀  It's a temporary thing, not going to add a test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
