### PR TITLE
fix: kafka.errors.MessageSizeTooLargeError

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -45,6 +45,8 @@ services:
             KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
             KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+            KAFKA_CFG_MAX_REQUEST_SIZE: 20971520
+            KAFKA_CFG_MESSAGE_MAX_BYTES: 20971520
             ALLOW_PLAINTEXT_LISTENER: 'true'
 
     object_storage:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -74,6 +74,8 @@ services:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
             SECRET_KEY: $POSTHOG_SECRET
+            # KAFKA_MAX_REQUEST_SIZE default 1MB, change to 2MB
+            SESSION_RECORDING_KAFKA_MAX_REQUEST_SIZE_BYTES: 20971520
     plugins:
         extends:
             file: docker-compose.base.yml
@@ -92,6 +94,7 @@ services:
             - '443:443'
         volumes:
             - ./Caddyfile:/etc/caddy/Caddyfile
+            - caddy-data:/data
         depends_on:
             - web
     object_storage:
@@ -153,3 +156,4 @@ volumes:
     object_storage:
     postgres-data:
     clickhouse-data:
+    caddy-data:


### PR DESCRIPTION
## Problem
fix https://github.com/PostHog/posthog/issues/19633

solution
1. kafka producer config:  max.request.size set to 20971520
2. kafka server config: message.max.bytes set to 20971520
3. posthog kafka client, SESSION_RECORDING_KAFKA_MAX_REQUEST_SIZE_BYTES set to 20971520

related to https://github.com/bitnami/containers/pull/54458


another thing
1. put Caddy's data into caddy-data docker volume, I use Local HTTPS, Caddy will generate [local CA](https://caddyserver.com/docs/running#local-https-with-docker), when recreating the container, avoid reinstalling Caddy's root CA on my host machine


