### PR TITLE
feat: android mobile replay recruit banner

### DIFF
--- a/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
+++ b/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
@@ -3,6 +3,7 @@ import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 
 import { HogQLQuery, NodeKind } from '~/queries/schema'
+import { hogql } from '~/queries/utils'
 
 import type { versionCheckerLogicType } from './versionCheckerLogicType'
 
@@ -42,7 +43,7 @@ export const versionCheckerLogic = kea<versionCheckerLogicType>([
                 loadUsedVersions: async () => {
                     const query: HogQLQuery = {
                         kind: NodeKind.HogQLQuery,
-                        query: `SELECT properties.$lib_version AS lib_version, max(timestamp) AS latest_timestamp, count(lib_version) as count
+                        query: hogql`SELECT properties.$lib_version AS lib_version, max(timestamp) AS latest_timestamp, count(lib_version) as count
                                 FROM events
                                 WHERE timestamp >= now() - INTERVAL 1 DAY 
                                 AND timestamp <= now()

--- a/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
+++ b/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, kea, listeners, path, reducers, sharedListeners } from 'kea'
+import { actions, afterMount, kea, key, listeners, path, props, reducers, sharedListeners } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 
@@ -11,6 +11,7 @@ const CHECK_INTERVAL_MS = 1000 * 60 * 60 // 6 hour
 export type SDKVersion = {
     version: string
     timestamp?: string
+    count?: number
 }
 
 export type SDKVersionWarning = {
@@ -20,12 +21,19 @@ export type SDKVersionWarning = {
     level: 'warning' | 'info' | 'error'
 }
 
+export interface VersionCheckerLogicProps {
+    numberOfDays?: number
+    lib?: string
+}
+
 export const versionCheckerLogic = kea<versionCheckerLogicType>([
     path(['components', 'VersionChecker', 'versionCheckerLogic']),
+    props({ numberOfDays: 1, lib: 'web' } as VersionCheckerLogicProps),
+    key((props) => `${props.lib}-${props.numberOfDays}`),
     actions({
         setVersionWarning: (versionWarning: SDKVersionWarning | null) => ({ versionWarning }),
     }),
-    loaders({
+    loaders(({ props }) => ({
         availableVersions: [
             null as SDKVersion[] | null,
             {
@@ -44,9 +52,9 @@ export const versionCheckerLogic = kea<versionCheckerLogicType>([
                         kind: NodeKind.HogQLQuery,
                         query: `SELECT properties.$lib_version AS lib_version, max(timestamp) AS latest_timestamp, count(lib_version) as count
                                 FROM events
-                                WHERE timestamp >= now() - INTERVAL 1 DAY 
+                                WHERE timestamp >= now() - INTERVAL ${props.numberOfDays || 1} DAY 
                                 AND timestamp <= now()
-                                AND properties.$lib = 'web'
+                                AND properties.$lib = '${props.lib || 'web'}'
                                 GROUP BY lib_version
                                 ORDER BY latest_timestamp DESC
                                 limit 10`,
@@ -58,12 +66,13 @@ export const versionCheckerLogic = kea<versionCheckerLogicType>([
                         res.results?.map((x) => ({
                             version: x[0],
                             timestamp: x[1],
+                            count: x[2],
                         })) ?? null
                     )
                 },
             },
         ],
-    }),
+    })),
 
     reducers({
         lastCheckTimestamp: [

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -192,6 +192,7 @@ export const FEATURE_FLAGS = {
     SESSION_REPLAY_EXPORT_MOBILE_DATA: 'session-replay-export-mobile-data', // owner: #team-replay
     DISCUSSIONS: 'discussions', // owner: #team-replay
     REDIRECT_INGESTION_PRODUCT_ANALYTICS_ONBOARDING: 'redirect-ingestion-product-analytics-onboarding', // owner: @biancayang
+    RECRUIT_ANDROID_MOBILE_BETA_TESTERS: 'recruit-android-mobile-beta-testers', // owner: #team-replay
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/events/Events.tsx
+++ b/frontend/src/scenes/events/Events.tsx
@@ -1,6 +1,7 @@
 import { PageHeader } from 'lib/components/PageHeader'
 import { EventsScene } from 'scenes/events/EventsScene'
 import { SceneExport } from 'scenes/sceneTypes'
+import { AndroidRecordingsPromptBanner } from 'scenes/session-recordings/mobile-replay/AndroidRecordingPromptBanner'
 
 import { eventsSceneLogic } from './eventsSceneLogic'
 
@@ -14,6 +15,7 @@ export function Events(): JSX.Element {
         <>
             <PageHeader title={'Event explorer'} />
             <div className="non-3000 pt-4 border-t" />
+            <AndroidRecordingsPromptBanner context={'events'} />
             <EventsScene />
         </>
     )

--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -16,6 +16,7 @@ import { Dashboard } from 'scenes/dashboard/Dashboard'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { projectHomepageLogic } from 'scenes/project-homepage/projectHomepageLogic'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
+import { AndroidRecordingsPromptBanner } from 'scenes/session-recordings/mobile-replay/AndroidRecordingPromptBanner'
 import { inviteLogic } from 'scenes/settings/organization/inviteLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -57,6 +58,7 @@ export function ProjectHomepage(): JSX.Element {
     return (
         <div className="ProjectHomepage">
             <PageHeader title={currentTeam?.name || ''} delimited buttons={headerButtons} />
+            <AndroidRecordingsPromptBanner context={'home'} />
             <div className="ProjectHomepage__lists">
                 <RecentInsights />
                 <RecentPersons />

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -13,6 +13,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { SceneExport } from 'scenes/sceneTypes'
+import { AndroidRecordingsPromptBanner } from 'scenes/session-recordings/mobile-replay/AndroidRecordingPromptBanner'
 import { sessionRecordingsPlaylistLogic } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -136,6 +137,7 @@ export function SessionsRecordings(): JSX.Element {
             />
             <div className="space-y-2">
                 <VersionCheckerBanner />
+                <AndroidRecordingsPromptBanner />
 
                 {recordingsDisabled ? (
                     <LemonBanner

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -137,7 +137,7 @@ export function SessionsRecordings(): JSX.Element {
             />
             <div className="space-y-2">
                 <VersionCheckerBanner />
-                <AndroidRecordingsPromptBanner />
+                <AndroidRecordingsPromptBanner context={'replay'} />
 
                 {recordingsDisabled ? (
                     <LemonBanner

--- a/frontend/src/scenes/session-recordings/mobile-replay/AndroidRecordingPromptBanner.tsx
+++ b/frontend/src/scenes/session-recordings/mobile-replay/AndroidRecordingPromptBanner.tsx
@@ -34,7 +34,7 @@ export function AndroidRecordingsPromptBanner(): JSX.Element | null {
                     <Link onClick={() => openSupportForm({ kind: 'support', target_area: 'session_replay' })}>
                         Contact support
                     </Link>{' '}
-                    to join the test.
+                    to join the test and earn PostHog merch.
                 </div>
             </LemonBanner>
         </FlaggedFeature>

--- a/frontend/src/scenes/session-recordings/mobile-replay/AndroidRecordingPromptBanner.tsx
+++ b/frontend/src/scenes/session-recordings/mobile-replay/AndroidRecordingPromptBanner.tsx
@@ -4,12 +4,13 @@ import { supportLogic } from 'lib/components/Support/supportLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { Link } from 'lib/lemon-ui/Link'
-import { androidRecordingPromptBannerLogic } from 'scenes/session-recordings/mobile-replay/androidRecordingPromptBannerLogic'
+import {
+    androidRecordingPromptBannerLogic,
+    AndroidRecordingPromptBannerLogicProps,
+} from 'scenes/session-recordings/mobile-replay/androidRecordingPromptBannerLogic'
 
-export function AndroidRecordingsPromptBanner(): JSX.Element | null {
-    const { shouldPromptUser } = useValues(
-        androidRecordingPromptBannerLogic({ numberOfDays: 30, lib: 'posthog-android' })
-    )
+export function AndroidRecordingsPromptBanner(props: AndroidRecordingPromptBannerLogicProps): JSX.Element | null {
+    const { shouldPromptUser } = useValues(androidRecordingPromptBannerLogic(props))
     const { openSupportForm } = useActions(supportLogic)
 
     if (!shouldPromptUser) {

--- a/frontend/src/scenes/session-recordings/mobile-replay/AndroidRecordingPromptBanner.tsx
+++ b/frontend/src/scenes/session-recordings/mobile-replay/AndroidRecordingPromptBanner.tsx
@@ -1,0 +1,42 @@
+import { useActions, useValues } from 'kea'
+import { FlaggedFeature } from 'lib/components/FlaggedFeature'
+import { supportLogic } from 'lib/components/Support/supportLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { Link } from 'lib/lemon-ui/Link'
+import { androidRecordingPromptBannerLogic } from 'scenes/session-recordings/mobile-replay/androidRecordingPromptBannerLogic'
+
+export function AndroidRecordingsPromptBanner(): JSX.Element | null {
+    const { shouldPromptUser } = useValues(
+        androidRecordingPromptBannerLogic({ numberOfDays: 30, lib: 'posthog-android' })
+    )
+    const { openSupportForm } = useActions(supportLogic)
+
+    if (!shouldPromptUser) {
+        return null
+    }
+
+    return (
+        <FlaggedFeature flag={FEATURE_FLAGS.RECRUIT_ANDROID_MOBILE_BETA_TESTERS} match={true}>
+            <LemonBanner
+                type={'info'}
+                dismissKey={`android-recording-beta-prompt`}
+                action={{
+                    children: 'Learn more',
+                    to: 'https://github.com/PostHog/posthog-android/blob/chore/session-replay/USAGE.md#android-session-recording',
+                    targetBlank: true,
+                }}
+                className="mb-4"
+            >
+                <h1 className={'mb-0'}>Android Session Replay.</h1>
+                <div>
+                    We're recruiting beta testers for Android Session Replay.{' '}
+                    <Link onClick={() => openSupportForm({ kind: 'support', target_area: 'session_replay' })}>
+                        Contact support
+                    </Link>{' '}
+                    to join the test.
+                </div>
+            </LemonBanner>
+        </FlaggedFeature>
+    )
+}

--- a/frontend/src/scenes/session-recordings/mobile-replay/AndroidRecordingPromptBanner.tsx
+++ b/frontend/src/scenes/session-recordings/mobile-replay/AndroidRecordingPromptBanner.tsx
@@ -24,7 +24,7 @@ export function AndroidRecordingsPromptBanner(props: AndroidRecordingPromptBanne
                 dismissKey={`android-recording-beta-prompt`}
                 action={{
                     children: 'Learn more',
-                    to: 'https://github.com/PostHog/posthog-android/blob/chore/session-replay/USAGE.md#android-session-recording',
+                    to: 'https://github.com/PostHog/posthog-android/blob/main/USAGE.md#android-session-recording',
                     targetBlank: true,
                 }}
                 className="mb-4"

--- a/frontend/src/scenes/session-recordings/mobile-replay/androidRecordingPromptBannerLogic.ts
+++ b/frontend/src/scenes/session-recordings/mobile-replay/androidRecordingPromptBannerLogic.ts
@@ -1,0 +1,28 @@
+import { connect, kea, path, props, selectors } from 'kea'
+import { versionCheckerLogic, VersionCheckerLogicProps } from 'lib/components/VersionChecker/versionCheckerLogic'
+import posthog from 'posthog-js'
+
+import type { androidRecordingPromptBannerLogicType } from './androidRecordingPromptBannerLogicType'
+
+export const androidRecordingPromptBannerLogic = kea<androidRecordingPromptBannerLogicType>([
+    path(['scenes', 'session-recordings', 'SessionRecordings']),
+
+    props({} as VersionCheckerLogicProps),
+
+    connect((props: VersionCheckerLogicProps) => ({
+        values: [versionCheckerLogic(props), ['usedVersions']],
+    })),
+
+    selectors({
+        shouldPromptUser: [
+            (s) => [s.usedVersions],
+            (usedVersions) => {
+                const isUsingAndroid = (usedVersions?.length || 0) > 0
+                if (isUsingAndroid) {
+                    posthog.capture('replay visitor has android events', { androidVersions: usedVersions })
+                }
+                return isUsingAndroid
+            },
+        ],
+    }),
+])

--- a/frontend/src/scenes/session-recordings/mobile-replay/androidRecordingPromptBannerLogic.ts
+++ b/frontend/src/scenes/session-recordings/mobile-replay/androidRecordingPromptBannerLogic.ts
@@ -1,28 +1,84 @@
-import { connect, kea, path, props, selectors } from 'kea'
-import { versionCheckerLogic, VersionCheckerLogicProps } from 'lib/components/VersionChecker/versionCheckerLogic'
+import { afterMount, kea, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import api from 'lib/api'
+import { SDKVersion } from 'lib/components/VersionChecker/versionCheckerLogic'
 import posthog from 'posthog-js'
+
+import { HogQLQuery, NodeKind } from '~/queries/schema'
 
 import type { androidRecordingPromptBannerLogicType } from './androidRecordingPromptBannerLogicType'
 
+const CHECK_INTERVAL_MS = 1000 * 60 * 60 // 6 hour
+
+export interface AndroidRecordingPromptBannerLogicProps {
+    context: 'home' | 'events' | 'replay'
+}
+
+export type AndroidEventCount = {
+    version: string
+    count?: number
+}
+
 export const androidRecordingPromptBannerLogic = kea<androidRecordingPromptBannerLogicType>([
     path(['scenes', 'session-recordings', 'SessionRecordings']),
+    props({} as AndroidRecordingPromptBannerLogicProps),
+    loaders({
+        androidVersions: [
+            null as SDKVersion[] | null,
+            {
+                loadAndroidLibVersions: async () => {
+                    const query: HogQLQuery = {
+                        kind: NodeKind.HogQLQuery,
+                        query: `SELECT properties.$lib_version AS lib_version,
+                                       max(timestamp) AS latest_timestamp,
+                                       count(lib_version) as count
+                                FROM events
+                                WHERE timestamp >= now() - INTERVAL 30 DAY
+                                  AND timestamp <= now()
+                                  AND properties.$lib in ('posthog-android')
+                                GROUP BY lib_version
+                                ORDER BY latest_timestamp DESC
+                                    limit 10`,
+                    }
 
-    props({} as VersionCheckerLogicProps),
+                    const res = await api.query(query)
 
-    connect((props: VersionCheckerLogicProps) => ({
-        values: [versionCheckerLogic(props), ['usedVersions']],
-    })),
+                    return (
+                        res.results?.map((x) => ({
+                            version: x[0],
+                            count: x[2],
+                        })) ?? null
+                    )
+                },
+            },
+        ],
+    }),
+    reducers({
+        lastCheckTimestamp: [
+            0,
+            { persist: true },
+            {
+                loadAndroidLibVersionsSuccess: () => Date.now(),
+            },
+        ],
+    }),
 
-    selectors({
+    selectors(({ props }) => ({
         shouldPromptUser: [
-            (s) => [s.usedVersions],
-            (usedVersions) => {
-                const isUsingAndroid = (usedVersions?.length || 0) > 0
+            (s) => [s.androidVersions],
+            (androidVersions) => {
+                const isUsingAndroid = (androidVersions?.length || 0) > 0
                 if (isUsingAndroid) {
-                    posthog.capture('replay visitor has android events', { androidVersions: usedVersions })
+                    posthog.capture(`${props.context} visitor has android events`, { androidVersions })
                 }
                 return isUsingAndroid
             },
         ],
+    })),
+
+    afterMount(({ actions, values }) => {
+        if (values.lastCheckTimestamp < Date.now() - CHECK_INTERVAL_MS) {
+            actions.loadAndroidLibVersions()
+        }
     }),
 ])

--- a/frontend/src/scenes/session-recordings/mobile-replay/androidRecordingPromptBannerLogic.ts
+++ b/frontend/src/scenes/session-recordings/mobile-replay/androidRecordingPromptBannerLogic.ts
@@ -5,6 +5,7 @@ import api from 'lib/api'
 import posthog from 'posthog-js'
 
 import { HogQLQuery, NodeKind } from '~/queries/schema'
+import { hogql } from '~/queries/utils'
 
 import type { androidRecordingPromptBannerLogicType } from './androidRecordingPromptBannerLogicType'
 
@@ -33,13 +34,13 @@ export const androidRecordingPromptBannerLogic = kea<androidRecordingPromptBanne
 
                     const query: HogQLQuery = {
                         kind: NodeKind.HogQLQuery,
-                        query: `SELECT properties.$lib_version AS lib_version,
+                        query: hogql`SELECT properties.$lib_version AS lib_version,
                                        max(timestamp)          AS latest_timestamp,
                                        count(lib_version) as count
                                 FROM events
                                 WHERE timestamp >= now() - INTERVAL 30 DAY
                                   AND timestamp <= now()
-                                  AND properties.$lib in ('posthog-android')
+                                  AND properties.$lib = 'posthog-android'
                                 GROUP BY lib_version
                                 ORDER BY latest_timestamp DESC
                                     limit 10`,

--- a/posthog/api/test/__snapshots__/test_annotation.ambr
+++ b/posthog/api/test/__snapshots__/test_annotation.ambr
@@ -81,127 +81,6 @@
 ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.10
   '
-  SELECT "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."pending_email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."is_email_verified",
-         "posthog_user"."has_seen_product_intro_for",
-         "posthog_user"."email_opt_in",
-         "posthog_user"."theme_mode",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."events_column_config"
-  FROM "posthog_user"
-  WHERE "posthog_user"."id" = 2
-  LIMIT 21 /**/
-  '
----
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.11
-  '
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."extra_settings",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 2
-  LIMIT 21 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
-  '
----
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.12
-  '
-  SELECT "posthog_organizationmembership"."id",
-         "posthog_organizationmembership"."organization_id",
-         "posthog_organizationmembership"."user_id",
-         "posthog_organizationmembership"."level",
-         "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist",
-         "posthog_organization"."available_features"
-  FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
-  '
----
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
-  '
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_annotation"
-  WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-           AND "posthog_annotation"."scope" = 'organization')
-          OR "posthog_annotation"."team_id" = 2)
-         AND NOT "posthog_annotation"."deleted") /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
-  '
----
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
-  '
   SELECT "posthog_annotation"."id",
          "posthog_annotation"."content",
          "posthog_annotation"."created_at",
@@ -276,6 +155,127 @@
          AND NOT "posthog_annotation"."deleted")
   ORDER BY "posthog_annotation"."date_marker" DESC
   LIMIT 1000 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  '
+---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.11
+  '
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 2
+  LIMIT 21 /**/
+  '
+---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.12
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."extra_settings",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  '
+---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
+  '
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."available_features"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  '
+---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
+  '
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_annotation"
+  WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+           AND "posthog_annotation"."scope" = 'organization')
+          OR "posthog_annotation"."team_id" = 2)
+         AND NOT "posthog_annotation"."deleted") /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
   '
 ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.15
@@ -520,89 +520,22 @@
 ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.8
   '
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  '
+---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.9
+  '
   SELECT COUNT(*) AS "__count"
   FROM "posthog_annotation"
   WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
            AND "posthog_annotation"."scope" = 'organization')
           OR "posthog_annotation"."team_id" = 2)
          AND NOT "posthog_annotation"."deleted") /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
-  '
----
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.9
-  '
-  SELECT "posthog_annotation"."id",
-         "posthog_annotation"."content",
-         "posthog_annotation"."created_at",
-         "posthog_annotation"."updated_at",
-         "posthog_annotation"."dashboard_item_id",
-         "posthog_annotation"."team_id",
-         "posthog_annotation"."organization_id",
-         "posthog_annotation"."created_by_id",
-         "posthog_annotation"."scope",
-         "posthog_annotation"."creation_type",
-         "posthog_annotation"."date_marker",
-         "posthog_annotation"."deleted",
-         "posthog_annotation"."apply_all",
-         "posthog_dashboarditem"."id",
-         "posthog_dashboarditem"."name",
-         "posthog_dashboarditem"."derived_name",
-         "posthog_dashboarditem"."description",
-         "posthog_dashboarditem"."team_id",
-         "posthog_dashboarditem"."filters",
-         "posthog_dashboarditem"."filters_hash",
-         "posthog_dashboarditem"."query",
-         "posthog_dashboarditem"."order",
-         "posthog_dashboarditem"."deleted",
-         "posthog_dashboarditem"."saved",
-         "posthog_dashboarditem"."created_at",
-         "posthog_dashboarditem"."last_refresh",
-         "posthog_dashboarditem"."refreshing",
-         "posthog_dashboarditem"."created_by_id",
-         "posthog_dashboarditem"."is_sample",
-         "posthog_dashboarditem"."short_id",
-         "posthog_dashboarditem"."favorited",
-         "posthog_dashboarditem"."refresh_attempt",
-         "posthog_dashboarditem"."last_modified_at",
-         "posthog_dashboarditem"."last_modified_by_id",
-         "posthog_dashboarditem"."dashboard_id",
-         "posthog_dashboarditem"."layouts",
-         "posthog_dashboarditem"."color",
-         "posthog_dashboarditem"."dive_dashboard_id",
-         "posthog_dashboarditem"."updated_at",
-         "posthog_dashboarditem"."deprecated_tags",
-         "posthog_dashboarditem"."tags",
-         "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."pending_email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."is_email_verified",
-         "posthog_user"."requested_password_reset_at",
-         "posthog_user"."has_seen_product_intro_for",
-         "posthog_user"."email_opt_in",
-         "posthog_user"."theme_mode",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."events_column_config"
-  FROM "posthog_annotation"
-  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
-  LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
-  WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-           AND "posthog_annotation"."scope" = 'organization')
-          OR "posthog_annotation"."team_id" = 2)
-         AND NOT "posthog_annotation"."deleted")
-  ORDER BY "posthog_annotation"."date_marker" DESC
-  LIMIT 1000 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
   '
 ---

--- a/posthog/api/test/__snapshots__/test_annotation.ambr
+++ b/posthog/api/test/__snapshots__/test_annotation.ambr
@@ -81,6 +81,127 @@
 ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.10
   '
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 2
+  LIMIT 21 /**/
+  '
+---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.11
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."extra_settings",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  '
+---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.12
+  '
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."available_features"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  '
+---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
+  '
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_annotation"
+  WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+           AND "posthog_annotation"."scope" = 'organization')
+          OR "posthog_annotation"."team_id" = 2)
+         AND NOT "posthog_annotation"."deleted") /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  '
+---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
+  '
   SELECT "posthog_annotation"."id",
          "posthog_annotation"."content",
          "posthog_annotation"."created_at",
@@ -155,127 +276,6 @@
          AND NOT "posthog_annotation"."deleted")
   ORDER BY "posthog_annotation"."date_marker" DESC
   LIMIT 1000 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
-  '
----
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.11
-  '
-  SELECT "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."pending_email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."is_email_verified",
-         "posthog_user"."has_seen_product_intro_for",
-         "posthog_user"."email_opt_in",
-         "posthog_user"."theme_mode",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."events_column_config"
-  FROM "posthog_user"
-  WHERE "posthog_user"."id" = 2
-  LIMIT 21 /**/
-  '
----
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.12
-  '
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."extra_settings",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 2
-  LIMIT 21 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
-  '
----
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
-  '
-  SELECT "posthog_organizationmembership"."id",
-         "posthog_organizationmembership"."organization_id",
-         "posthog_organizationmembership"."user_id",
-         "posthog_organizationmembership"."level",
-         "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist",
-         "posthog_organization"."available_features"
-  FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE "posthog_organizationmembership"."user_id" = 2 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
-  '
----
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
-  '
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_annotation"
-  WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-           AND "posthog_annotation"."scope" = 'organization')
-          OR "posthog_annotation"."team_id" = 2)
-         AND NOT "posthog_annotation"."deleted") /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
   '
 ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.15
@@ -520,22 +520,89 @@
 ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.8
   '
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
-  '
----
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.9
-  '
   SELECT COUNT(*) AS "__count"
   FROM "posthog_annotation"
   WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
            AND "posthog_annotation"."scope" = 'organization')
           OR "posthog_annotation"."team_id" = 2)
          AND NOT "posthog_annotation"."deleted") /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
+  '
+---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.9
+  '
+  SELECT "posthog_annotation"."id",
+         "posthog_annotation"."content",
+         "posthog_annotation"."created_at",
+         "posthog_annotation"."updated_at",
+         "posthog_annotation"."dashboard_item_id",
+         "posthog_annotation"."team_id",
+         "posthog_annotation"."organization_id",
+         "posthog_annotation"."created_by_id",
+         "posthog_annotation"."scope",
+         "posthog_annotation"."creation_type",
+         "posthog_annotation"."date_marker",
+         "posthog_annotation"."deleted",
+         "posthog_annotation"."apply_all",
+         "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."derived_name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."query",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt",
+         "posthog_dashboarditem"."last_modified_at",
+         "posthog_dashboarditem"."last_modified_by_id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."updated_at",
+         "posthog_dashboarditem"."deprecated_tags",
+         "posthog_dashboarditem"."tags",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."requested_password_reset_at",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_annotation"
+  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
+  WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+           AND "posthog_annotation"."scope" = 'organization')
+          OR "posthog_annotation"."team_id" = 2)
+         AND NOT "posthog_annotation"."deleted")
+  ORDER BY "posthog_annotation"."date_marker" DESC
+  LIMIT 1000 /*controller='project_annotations-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/annotations/%3F%24'*/
   '
 ---


### PR DESCRIPTION
we want to recruit testers for android mobile replay

we already have people using the android SDKs, so let's prompt them when they visit posthog

similar to the version checker, runs on home, events, and replay pages

if local storage has a record of android events ever on that account then we don't check again (because we're not going to have this banner around for too long)

otherwise checks for android events on mount... 

if they have android events and flag is inactive then records an event that they visited the page having received any events from posthog-android in the last 30 days

<img width="475" alt="Screenshot 2024-01-08 at 10 01 14" src="https://github.com/PostHog/posthog/assets/984817/c6a4519d-3a8f-4665-937c-9f5f8fb5d24e">

2) with the flag active it shows a banner trying to recruit the user to beta test mobile replay

<img width="895" alt="Screenshot 2024-01-07 at 22 27 45" src="https://github.com/PostHog/posthog/assets/984817/c39cdd9c-58ce-4c80-82b8-b858d2dd9262">
