### PR TITLE
chore: add Elements to taxonomy

### DIFF
--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -692,6 +692,10 @@ export const KEY_MAPPING: KeyMappingInterface = {
             label: 'GeoIP Disabled',
             description: `Whether to skip GeoIP processing for the event.`,
         },
+        $elements: {
+            label: 'Elements',
+            description: `The element tree that was clicked. Only sent with Autocapture events.`,
+        },
         $el_text: {
             label: 'Element Text',
             description: `The text of the element that was clicked. Only sent with Autocapture events.`,


### PR DESCRIPTION
## Problem

JS and RN send the $elements property but it's not part of the taxonomy

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
