### PR TITLE
chore(hogql): Port more tests for retention group queries

### DIFF
--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -74,11 +74,27 @@ class RetentionQueryRunner(QueryRunner):
         else:
             event_date_expr = start_of_interval_sql
 
+        event_filters = [
+            entity_to_expr(entity=self.get_applicable_entity(event_query_type)),
+        ]
+
         target_field = "person_id"
         if self.group_type_index is not None:
             group_index = int(self.group_type_index)
             if 0 <= group_index <= 4:
                 target_field = f"$group_{group_index}"
+
+                event_filters.append(
+                    ast.Not(
+                        expr=ast.Call(
+                            name="has",
+                            args=[
+                                ast.Array(exprs=[ast.Constant(value="")]),
+                                ast.Field(chain=["events", f"$group_{self.group_type_index}"]),
+                            ],
+                        ),
+                    ),
+                )
 
         fields = [
             ast.Alias(alias="event_date", expr=event_date_expr),
@@ -106,10 +122,6 @@ class RetentionQueryRunner(QueryRunner):
             fields.append(
                 ast.Alias(alias="breakdown_values", expr=ast.Array(exprs=[datediff_call])),
             )
-
-        event_filters = [
-            entity_to_expr(entity=self.get_applicable_entity(event_query_type)),
-        ]
 
         if self.query.properties is not None and self.query.properties != []:
             event_filters.append(property_to_expr(self.query.properties, self.team))

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_retention_query_runner.ambr
@@ -1,3 +1,311 @@
+# name: TestClickhouseRetentionGroupAggregation.test_groups_aggregating
+  '
+  SELECT actor_activity.breakdown_values AS breakdown_values,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT DISTINCT breakdown_values AS breakdown_values,
+                     intervals_from_base AS intervals_from_base,
+                     actor_id AS actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               dateDiff('week', target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM
+          (SELECT DISTINCT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                           events.`$group_0` AS target,
+                           [dateDiff('week', toStartOfWeek(toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC'), 0), toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0))] AS breakdown_values
+           FROM events
+           WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))) AS target_event
+        JOIN
+          (SELECT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                  events.`$group_0` AS target
+           FROM events
+           WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))
+           GROUP BY target,
+                    event_date) AS returning_event ON equals(returning_event.target, target_event.target)
+        WHERE ifNull(greater(returning_event.event_date, target_event.event_date), 0)
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM
+          (SELECT DISTINCT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                           events.`$group_0` AS target,
+                           [dateDiff('week', toStartOfWeek(toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC'), 0), toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0))] AS breakdown_values
+           FROM events
+           WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))) AS target_event)
+     WHERE and(or(1, isNull(breakdown_values)), or(1, isNull(intervals_from_base)))) AS actor_activity
+  GROUP BY breakdown_values,
+           intervals_from_base
+  ORDER BY breakdown_values ASC,
+           intervals_from_base ASC
+  LIMIT 10000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1
+  '
+---
+# name: TestClickhouseRetentionGroupAggregation.test_groups_aggregating.1
+  '
+  SELECT groups.key AS key,
+         source.appearances AS appearances
+  FROM
+    (SELECT groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 2)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  INNER JOIN
+    (SELECT actor_activity.actor_id AS actor_id,
+            groupArray(actor_activity.intervals_from_base) AS appearance_intervals,
+            arraySort(appearance_intervals) AS appearances,
+            arrayExists(x -> ifNull(equals(x, 0), 0), appearance_intervals) AS appearance_0,
+            arrayExists(x -> ifNull(equals(x, 1), 0), appearance_intervals) AS appearance_1,
+            arrayExists(x -> ifNull(equals(x, 2), 0), appearance_intervals) AS appearance_2,
+            arrayExists(x -> ifNull(equals(x, 3), 0), appearance_intervals) AS appearance_3,
+            arrayExists(x -> ifNull(equals(x, 4), 0), appearance_intervals) AS appearance_4,
+            arrayExists(x -> ifNull(equals(x, 5), 0), appearance_intervals) AS appearance_5,
+            arrayExists(x -> ifNull(equals(x, 6), 0), appearance_intervals) AS appearance_6
+     FROM
+       (SELECT DISTINCT breakdown_values AS breakdown_values,
+                        intervals_from_base AS intervals_from_base,
+                        actor_id AS actor_id
+        FROM
+          (SELECT target_event.breakdown_values AS breakdown_values,
+                  dateDiff('week', target_event.event_date, returning_event.event_date) AS intervals_from_base,
+                  returning_event.target AS actor_id
+           FROM
+             (SELECT DISTINCT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                              events.`$group_0` AS target,
+                              [dateDiff('week', toStartOfWeek(toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC'), 0), toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0))] AS breakdown_values
+              FROM events
+              WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))) AS target_event
+           JOIN
+             (SELECT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                     events.`$group_0` AS target
+              FROM events
+              WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))
+              GROUP BY target,
+                       event_date) AS returning_event ON equals(returning_event.target, target_event.target)
+           WHERE ifNull(greater(returning_event.event_date, target_event.event_date), 0)
+           UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                            0 AS intervals_from_base,
+                            target_event.target AS actor_id
+           FROM
+             (SELECT DISTINCT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                              events.`$group_0` AS target,
+                              [dateDiff('week', toStartOfWeek(toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC'), 0), toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0))] AS breakdown_values
+              FROM events
+              WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))) AS target_event)
+        WHERE and(or(0, ifNull(equals(breakdown_values, [0]), 0)), or(1, isNull(intervals_from_base)))) AS actor_activity
+     GROUP BY actor_activity.actor_id) AS source ON equals(groups.key, source.actor_id)
+  ORDER BY length(source.appearances) DESC, source.actor_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1
+  '
+---
+# name: TestClickhouseRetentionGroupAggregation.test_groups_aggregating.2
+  '
+  SELECT actor_activity.breakdown_values AS breakdown_values,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT DISTINCT breakdown_values AS breakdown_values,
+                     intervals_from_base AS intervals_from_base,
+                     actor_id AS actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               dateDiff('week', target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM
+          (SELECT DISTINCT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                           events.`$group_1` AS target,
+                           [dateDiff('week', toStartOfWeek(toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC'), 0), toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0))] AS breakdown_values
+           FROM events
+           WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_1`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))) AS target_event
+        JOIN
+          (SELECT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                  events.`$group_1` AS target
+           FROM events
+           WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_1`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))
+           GROUP BY target,
+                    event_date) AS returning_event ON equals(returning_event.target, target_event.target)
+        WHERE ifNull(greater(returning_event.event_date, target_event.event_date), 0)
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM
+          (SELECT DISTINCT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                           events.`$group_1` AS target,
+                           [dateDiff('week', toStartOfWeek(toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC'), 0), toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0))] AS breakdown_values
+           FROM events
+           WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_1`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))) AS target_event)
+     WHERE and(or(1, isNull(breakdown_values)), or(1, isNull(intervals_from_base)))) AS actor_activity
+  GROUP BY breakdown_values,
+           intervals_from_base
+  ORDER BY breakdown_values ASC,
+           intervals_from_base ASC
+  LIMIT 10000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1
+  '
+---
+# name: TestClickhouseRetentionGroupAggregation.test_groups_aggregating_person_on_events
+  '
+  SELECT actor_activity.breakdown_values AS breakdown_values,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT DISTINCT breakdown_values AS breakdown_values,
+                     intervals_from_base AS intervals_from_base,
+                     actor_id AS actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               dateDiff('week', target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM
+          (SELECT DISTINCT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                           events.`$group_0` AS target,
+                           [dateDiff('week', toStartOfWeek(toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC'), 0), toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0))] AS breakdown_values
+           FROM events
+           WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))) AS target_event
+        JOIN
+          (SELECT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                  events.`$group_0` AS target
+           FROM events
+           WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))
+           GROUP BY target,
+                    event_date) AS returning_event ON equals(returning_event.target, target_event.target)
+        WHERE ifNull(greater(returning_event.event_date, target_event.event_date), 0)
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM
+          (SELECT DISTINCT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                           events.`$group_0` AS target,
+                           [dateDiff('week', toStartOfWeek(toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC'), 0), toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0))] AS breakdown_values
+           FROM events
+           WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))) AS target_event)
+     WHERE and(or(1, isNull(breakdown_values)), or(1, isNull(intervals_from_base)))) AS actor_activity
+  GROUP BY breakdown_values,
+           intervals_from_base
+  ORDER BY breakdown_values ASC,
+           intervals_from_base ASC
+  LIMIT 10000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1
+  '
+---
+# name: TestClickhouseRetentionGroupAggregation.test_groups_aggregating_person_on_events.1
+  '
+  SELECT groups.key AS key,
+         source.appearances AS appearances
+  FROM
+    (SELECT groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 2)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  INNER JOIN
+    (SELECT actor_activity.actor_id AS actor_id,
+            groupArray(actor_activity.intervals_from_base) AS appearance_intervals,
+            arraySort(appearance_intervals) AS appearances,
+            arrayExists(x -> ifNull(equals(x, 0), 0), appearance_intervals) AS appearance_0,
+            arrayExists(x -> ifNull(equals(x, 1), 0), appearance_intervals) AS appearance_1,
+            arrayExists(x -> ifNull(equals(x, 2), 0), appearance_intervals) AS appearance_2,
+            arrayExists(x -> ifNull(equals(x, 3), 0), appearance_intervals) AS appearance_3,
+            arrayExists(x -> ifNull(equals(x, 4), 0), appearance_intervals) AS appearance_4,
+            arrayExists(x -> ifNull(equals(x, 5), 0), appearance_intervals) AS appearance_5,
+            arrayExists(x -> ifNull(equals(x, 6), 0), appearance_intervals) AS appearance_6
+     FROM
+       (SELECT DISTINCT breakdown_values AS breakdown_values,
+                        intervals_from_base AS intervals_from_base,
+                        actor_id AS actor_id
+        FROM
+          (SELECT target_event.breakdown_values AS breakdown_values,
+                  dateDiff('week', target_event.event_date, returning_event.event_date) AS intervals_from_base,
+                  returning_event.target AS actor_id
+           FROM
+             (SELECT DISTINCT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                              events.`$group_0` AS target,
+                              [dateDiff('week', toStartOfWeek(toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC'), 0), toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0))] AS breakdown_values
+              FROM events
+              WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))) AS target_event
+           JOIN
+             (SELECT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                     events.`$group_0` AS target
+              FROM events
+              WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))
+              GROUP BY target,
+                       event_date) AS returning_event ON equals(returning_event.target, target_event.target)
+           WHERE ifNull(greater(returning_event.event_date, target_event.event_date), 0)
+           UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                            0 AS intervals_from_base,
+                            target_event.target AS actor_id
+           FROM
+             (SELECT DISTINCT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                              events.`$group_0` AS target,
+                              [dateDiff('week', toStartOfWeek(toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC'), 0), toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0))] AS breakdown_values
+              FROM events
+              WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_0`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))) AS target_event)
+        WHERE and(or(0, ifNull(equals(breakdown_values, [0]), 0)), or(1, isNull(intervals_from_base)))) AS actor_activity
+     GROUP BY actor_activity.actor_id) AS source ON equals(groups.key, source.actor_id)
+  ORDER BY length(source.appearances) DESC, source.actor_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1
+  '
+---
+# name: TestClickhouseRetentionGroupAggregation.test_groups_aggregating_person_on_events.2
+  '
+  SELECT actor_activity.breakdown_values AS breakdown_values,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT DISTINCT breakdown_values AS breakdown_values,
+                     intervals_from_base AS intervals_from_base,
+                     actor_id AS actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               dateDiff('week', target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM
+          (SELECT DISTINCT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                           events.`$group_1` AS target,
+                           [dateDiff('week', toStartOfWeek(toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC'), 0), toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0))] AS breakdown_values
+           FROM events
+           WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_1`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))) AS target_event
+        JOIN
+          (SELECT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                  events.`$group_1` AS target
+           FROM events
+           WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_1`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))
+           GROUP BY target,
+                    event_date) AS returning_event ON equals(returning_event.target, target_event.target)
+        WHERE ifNull(greater(returning_event.event_date, target_event.event_date), 0)
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM
+          (SELECT DISTINCT toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0) AS event_date,
+                           events.`$group_1` AS target,
+                           [dateDiff('week', toStartOfWeek(toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC'), 0), toStartOfWeek(toTimeZone(events.timestamp, 'UTC'), 0))] AS breakdown_values
+           FROM events
+           WHERE and(equals(events.team_id, 2), equals(events.event, '$pageview'), not(has([''], events.`$group_1`)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-06-07 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-07-27 00:00:00.000000', 6, 'UTC'))))) AS target_event)
+     WHERE and(or(1, isNull(breakdown_values)), or(1, isNull(intervals_from_base)))) AS actor_activity
+  GROUP BY breakdown_values,
+           intervals_from_base
+  ORDER BY breakdown_values ASC,
+           intervals_from_base ASC
+  LIMIT 10000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1
+  '
+---
 # name: TestRetention.test_day_interval_sampled
   '
   SELECT actor_activity.breakdown_values AS breakdown_values,

--- a/posthog/hogql_queries/insights/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_retention_query_runner.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime
 
 from zoneinfo import ZoneInfo
+
 from django.test import override_settings
 from rest_framework import status
 
@@ -13,6 +14,9 @@ from posthog.constants import (
 from posthog.hogql_queries.insights.retention_query_runner import RetentionQueryRunner
 from posthog.hogql_queries.actors_query_runner import ActorsQueryRunner
 from posthog.models import Action, ActionStep
+from posthog.models.group.util import create_group
+from posthog.models.group_type_mapping import GroupTypeMapping
+from posthog.models.person import Person
 from posthog.test.base import (
     APIBaseTest,
     ClickhouseTestMixin,
@@ -1637,5 +1641,243 @@ class TestRetention(ClickhouseTestMixin, APIBaseTest):
                 [0, 0, 0],
                 [0, 0],
                 [0],
+            ],
+        )
+
+
+class TestClickhouseRetentionGroupAggregation(ClickhouseTestMixin, APIBaseTest):
+    def run_query(self, query):
+        if not query.get("retentionFilter"):
+            query["retentionFilter"] = {}
+        runner = RetentionQueryRunner(team=self.team, query=query)
+        return runner.calculate().model_dump()["results"]
+
+    def run_actors_query(self, interval, query, select=None, actor="person"):
+        query["kind"] = "RetentionQuery"
+        if not query.get("retentionFilter"):
+            query["retentionFilter"] = {}
+        runner = ActorsQueryRunner(
+            team=self.team,
+            query={
+                "select": [actor, "appearances", *(select or [])],
+                "orderBy": ["length(appearances) DESC", "actor_id"],
+                "source": {
+                    "kind": "InsightActorsQuery",
+                    "interval": interval,
+                    "source": query,
+                },
+            },
+        )
+        return runner.calculate().model_dump()["results"]
+
+    def _create_groups_and_events(self):
+        GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
+        GroupTypeMapping.objects.create(team=self.team, group_type="company", group_type_index=1)
+
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org:5",
+            properties={"industry": "finance"},
+        )
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org:6",
+            properties={"industry": "technology"},
+        )
+
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=1,
+            group_key="company:1",
+            properties={},
+        )
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=1,
+            group_key="company:2",
+            properties={},
+        )
+
+        Person.objects.create(team=self.team, distinct_ids=["person1", "alias1"])
+        Person.objects.create(team=self.team, distinct_ids=["person2"])
+        Person.objects.create(team=self.team, distinct_ids=["person3"])
+
+        _create_events(
+            self.team,
+            [
+                ("person1", _date(0), {"$group_0": "org:5", "$group_1": "company:1"}),
+                ("person2", _date(0), {"$group_0": "org:6"}),
+                ("person3", _date(0)),
+                ("person1", _date(1), {"$group_0": "org:5"}),
+                ("person2", _date(1), {"$group_0": "org:6"}),
+                ("person1", _date(7), {"$group_0": "org:5"}),
+                ("person2", _date(7), {"$group_0": "org:6"}),
+                ("person1", _date(14), {"$group_0": "org:5"}),
+                (
+                    "person1",
+                    _date(month=1, day=-6),
+                    {"$group_0": "org:5", "$group_1": "company:1"},
+                ),
+                ("person2", _date(month=1, day=-6), {"$group_0": "org:6"}),
+                ("person2", _date(month=1, day=1), {"$group_0": "org:6"}),
+                ("person1", _date(month=1, day=1), {"$group_0": "org:5"}),
+                (
+                    "person2",
+                    _date(month=1, day=15),
+                    {"$group_0": "org:6", "$group_1": "company:1"},
+                ),
+            ],
+        )
+
+    @snapshot_clickhouse_queries
+    def test_groups_aggregating(self):
+        self._create_groups_and_events()
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_to": _date(10, month=1, hour=0)},
+                "aggregation_group_type_index": 0,
+                "retentionFilter": {
+                    "period": "Week",
+                    "total_intervals": 7,
+                },
+            }
+        )
+        self.assertEqual(
+            pluck(result, "values", "count"),
+            [
+                [2, 2, 1, 2, 2, 0, 1],
+                [2, 1, 2, 2, 0, 1],
+                [1, 1, 1, 0, 0],
+                [2, 2, 0, 1],
+                [2, 0, 1],
+                [0, 0],
+                [1],
+            ],
+        )
+
+        actor_result = self.run_actors_query(
+            interval=0,
+            query={
+                "dateRange": {"date_to": _date(10, month=1, hour=0)},
+                "aggregation_group_type_index": 0,
+                "retentionFilter": {
+                    "period": "Week",
+                    "total_intervals": 7,
+                },
+            },
+            actor="group",
+        )
+        self.assertCountEqual([actor[0]["id"] for actor in actor_result], ["org:5", "org:6"])
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_to": _date(10, month=1, hour=0)},
+                "aggregation_group_type_index": 1,
+                "retentionFilter": {
+                    "period": "Week",
+                    "total_intervals": 7,
+                },
+            }
+        )
+        self.assertEqual(
+            pluck(result, "values", "count"),
+            [
+                [1, 0, 0, 1, 0, 0, 1],
+                [0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [1, 0, 0, 1],
+                [0, 0, 0],
+                [0, 0],
+                [1],
+            ],
+        )
+
+    def test_groups_in_period(self):
+        self._create_groups_and_events()
+
+        actor_result = self.run_actors_query(
+            interval=0,
+            query={
+                "dateRange": {"date_to": _date(10, month=1, hour=0)},
+                "aggregation_group_type_index": 0,
+                "retentionFilter": {
+                    "period": "Week",
+                    "total_intervals": 7,
+                },
+            },
+            actor="group",
+        )
+
+        self.assertEqual(actor_result[0][0]["id"], "org:5")
+        self.assertEqual(actor_result[0][1], [0, 1, 2, 3, 4])
+
+        self.assertEqual(actor_result[1][0]["id"], "org:6")
+        self.assertEqual(actor_result[1][1], [0, 1, 3, 4, 6])
+
+    @snapshot_clickhouse_queries
+    def test_groups_aggregating_person_on_events(self):
+        self._create_groups_and_events()
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_to": _date(10, month=1, hour=0)},
+                "aggregation_group_type_index": 0,
+                "retentionFilter": {
+                    "period": "Week",
+                    "total_intervals": 7,
+                },
+            }
+        )
+        self.assertEqual(
+            pluck(result, "values", "count"),
+            [
+                [2, 2, 1, 2, 2, 0, 1],
+                [2, 1, 2, 2, 0, 1],
+                [1, 1, 1, 0, 0],
+                [2, 2, 0, 1],
+                [2, 0, 1],
+                [0, 0],
+                [1],
+            ],
+        )
+
+        actor_result = self.run_actors_query(
+            interval=0,
+            query={
+                "dateRange": {"date_to": _date(10, month=1, hour=0)},
+                "aggregation_group_type_index": 0,
+                "retentionFilter": {
+                    "period": "Week",
+                    "total_intervals": 7,
+                },
+            },
+            actor="group",
+        )
+
+        self.assertCountEqual([actor[0]["id"] for actor in actor_result], ["org:5", "org:6"])
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_to": _date(10, month=1, hour=0)},
+                "aggregation_group_type_index": 1,
+                "retentionFilter": {
+                    "period": "Week",
+                    "total_intervals": 7,
+                },
+            }
+        )
+        self.assertEqual(
+            pluck(result, "values", "count"),
+            [
+                [1, 0, 0, 1, 0, 0, 1],
+                [0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [1, 0, 0, 1],
+                [0, 0, 0],
+                [0, 0],
+                [1],
             ],
         )


### PR DESCRIPTION
## Problem

There are more tests, particularly around group aggregation, that are not ported to the new query runner yet.

## Changes

- copied and adjusted tests from https://github.com/PostHog/posthog/blob/master/ee/clickhouse/queries/test/test_retention.py
- found a bug and fixed it 👏🏻 
  - we did not filter the events for empty groups, causing different results than what the tests checked

## How did you test this code?

- tests
