### PR TITLE
feat(hogql): inline editor metadata source

### DIFF
--- a/frontend/src/lib/components/HogQLEditor/HogQLEditor.tsx
+++ b/frontend/src/lib/components/HogQLEditor/HogQLEditor.tsx
@@ -6,12 +6,15 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea/LemonTextArea'
 import { useRef, useState } from 'react'
 
+import { AnyDataNode } from '~/queries/schema'
+import { isActorsQuery } from '~/queries/utils'
+
 import { hogQLEditorLogic } from './hogQLEditorLogic'
 
 export interface HogQLEditorProps {
     onChange: (value: string) => void
     value: string | undefined
-    hogQLTable?: string
+    metadataSource?: AnyDataNode
     disablePersonProperties?: boolean
     disableAutoFocus?: boolean
     disableCmdEnter?: boolean
@@ -23,7 +26,7 @@ let uniqueNode = 0
 export function HogQLEditor({
     onChange,
     value,
-    hogQLTable,
+    metadataSource,
     disablePersonProperties,
     disableAutoFocus,
     disableCmdEnter,
@@ -32,7 +35,7 @@ export function HogQLEditor({
 }: HogQLEditorProps): JSX.Element {
     const [key] = useState(() => `HogQLEditor.${uniqueNode++}`)
     const textareaRef = useRef<HTMLTextAreaElement | null>(null)
-    const logic = hogQLEditorLogic({ key, value, onChange, hogQLTable, textareaRef })
+    const logic = hogQLEditorLogic({ key, value, onChange, metadataSource, textareaRef })
     const { localValue, error, responseLoading } = useValues(logic)
     const { setLocalValue, submit } = useActions(logic)
 
@@ -57,7 +60,7 @@ export function HogQLEditor({
                 maxRows={6}
                 placeholder={
                     placeholder ??
-                    (hogQLTable === 'persons'
+                    (metadataSource && isActorsQuery(metadataSource)
                         ? "Enter HogQL expression, such as:\n- properties.$geoip_country_name\n- toInt(properties.$browser_version) * 10\n- concat(properties.name, ' <', properties.email, '>')\n- is_identified ? 'user' : 'anon'"
                         : disablePersonProperties
                         ? "Enter HogQL expression, such as:\n- properties.$current_url\n- toInt(properties.`Long Field Name`) * 10\n- concat(event, ' ', distinct_id)\n- if(1 < 2, 'small', 'large')"

--- a/frontend/src/lib/components/HogQLEditor/hogQLEditorLogic.ts
+++ b/frontend/src/lib/components/HogQLEditor/hogQLEditorLogic.ts
@@ -3,14 +3,14 @@ import { loaders } from 'kea-loaders'
 import React from 'react'
 
 import { query } from '~/queries/query'
-import { HogQLMetadata, HogQLMetadataResponse, NodeKind } from '~/queries/schema'
+import { AnyDataNode, HogQLMetadata, HogQLMetadataResponse, NodeKind } from '~/queries/schema'
 
 import type { hogQLEditorLogicType } from './hogQLEditorLogicType'
 
 export interface HogQLEditorLogicProps {
     key: string
     value: string | undefined
-    hogQLTable?: string
+    metadataSource?: AnyDataNode
     onChange: (value: string) => void
     textareaRef?: React.MutableRefObject<HTMLTextAreaElement | null>
 }
@@ -34,7 +34,7 @@ export const hogQLEditorLogic = kea<hogQLEditorLogicType>([
                     const response = await query<HogQLMetadata>({
                         kind: NodeKind.HogQLMetadata,
                         expr: values.localValue,
-                        table: props.hogQLTable || 'events',
+                        exprSource: props.metadataSource || undefined,
                     })
                     breakpoint()
                     if (response && Array.isArray(response.errors) && response.errors.length > 0) {

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -6,6 +6,7 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import React, { useEffect } from 'react'
 import { LogicalRowDivider } from 'scenes/cohorts/CohortFilters/CohortCriteriaRowBuilder'
 
+import { AnyDataNode } from '~/queries/schema'
 import { AnyPropertyFilter, FilterLogicalOperator } from '~/types'
 
 import { FilterRow } from './components/FilterRow'
@@ -19,7 +20,7 @@ interface PropertyFiltersProps {
     showConditionBadge?: boolean
     disablePopover?: boolean
     taxonomicGroupTypes?: TaxonomicFilterGroupType[]
-    hogQLTable?: string
+    metadataSource?: AnyDataNode
     showNestedArrow?: boolean
     eventNames?: string[]
     logicalRowDivider?: boolean
@@ -40,7 +41,7 @@ export function PropertyFilters({
     showConditionBadge = false,
     disablePopover = false, // use bare PropertyFilter without popover
     taxonomicGroupTypes,
-    hogQLTable,
+    metadataSource,
     showNestedArrow = false,
     eventNames = [],
     orFiltering = false,
@@ -93,7 +94,7 @@ export function PropertyFilters({
                                             onComplete={onComplete}
                                             orFiltering={orFiltering}
                                             taxonomicGroupTypes={taxonomicGroupTypes}
-                                            hogQLTable={hogQLTable}
+                                            metadataSource={metadataSource}
                                             eventNames={eventNames}
                                             propertyGroupType={propertyGroupType}
                                             disablePopover={disablePopover || orFiltering}

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -42,7 +42,7 @@ export function TaxonomicPropertyFilter({
     orFiltering,
     addText = 'Add filter',
     hasRowOperator,
-    hogQLTable,
+    metadataSource,
     propertyAllowList,
 }: PropertyFilterInternalProps): JSX.Element {
     const pageKey = useMemo(() => pageKeyInput || `filter-${uniqueMemoizedIndex++}`, [pageKeyInput])
@@ -105,7 +105,7 @@ export function TaxonomicPropertyFilter({
             value={cohortOrOtherValue}
             onChange={taxonomicOnChange}
             taxonomicGroupTypes={groupTypes}
-            hogQLTable={hogQLTable}
+            metadataSource={metadataSource}
             eventNames={eventNames}
             propertyAllowList={propertyAllowList}
         />

--- a/frontend/src/lib/components/PropertyFilters/types.ts
+++ b/frontend/src/lib/components/PropertyFilters/types.ts
@@ -6,6 +6,7 @@ import {
     TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
 
+import { AnyDataNode } from '~/queries/schema'
 import { AnyPropertyFilter, FilterLogicalOperator, PropertyGroupFilter } from '~/types'
 
 export interface PropertyFilterBaseProps {
@@ -43,6 +44,6 @@ export interface PropertyFilterInternalProps {
     orFiltering?: boolean
     addText?: string | null
     hasRowOperator?: boolean
-    hogQLTable?: string
+    metadataSource?: AnyDataNode
     propertyAllowList?: { [key in TaxonomicFilterGroupType]?: string[] }
 }

--- a/frontend/src/lib/components/TaxonomicFilter/InlineHogQLEditor.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InlineHogQLEditor.tsx
@@ -1,19 +1,21 @@
 import { HogQLEditor } from 'lib/components/HogQLEditor/HogQLEditor'
 import { TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
 
+import { AnyDataNode } from '~/queries/schema'
+
 export interface InlineHogQLEditorProps {
     value?: TaxonomicFilterValue
     onChange: (value: TaxonomicFilterValue) => void
-    hogQLTable?: string
+    metadataSource?: AnyDataNode
 }
 
-export function InlineHogQLEditor({ value, onChange, hogQLTable }: InlineHogQLEditorProps): JSX.Element {
+export function InlineHogQLEditor({ value, onChange, metadataSource }: InlineHogQLEditorProps): JSX.Element {
     return (
         <div className="px-2">
             <HogQLEditor
                 onChange={onChange}
                 value={String(value ?? '')}
-                hogQLTable={hogQLTable}
+                metadataSource={metadataSource}
                 submitText={value ? 'Update HogQL expression' : 'Add HogQL expression'}
                 disableAutoFocus // :TRICKY: No autofocus here. It's controlled in the TaxonomicFilter.
             />

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -25,7 +25,7 @@ export function TaxonomicFilter({
     onClose,
     taxonomicGroupTypes,
     optionsFromProp,
-    hogQLTable,
+    metadataSource,
     eventNames,
     height,
     width,
@@ -54,7 +54,7 @@ export function TaxonomicFilter({
         popoverEnabled,
         selectFirstItem,
         excludedProperties,
-        hogQLTable,
+        metadataSource,
         propertyAllowList,
     }
 

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -134,7 +134,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
             (taxonomicFilterLogicKey) => taxonomicFilterLogicKey,
         ],
         eventNames: [() => [(_, props) => props.eventNames], (eventNames) => eventNames ?? []],
-        hogQLTable: [() => [(_, props) => props.hogQLTable], (hogQLTable) => hogQLTable ?? 'events'],
+        metadataSource: [() => [(_, props) => props.metadataSource], (metadataSource) => metadataSource ?? 'events'],
         excludedProperties: [
             () => [(_, props) => props.excludedProperties],
             (excludedProperties) => excludedProperties ?? {},
@@ -149,7 +149,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 s.groupAnalyticsTaxonomicGroups,
                 s.groupAnalyticsTaxonomicGroupNames,
                 s.eventNames,
-                s.hogQLTable,
+                s.metadataSource,
                 s.excludedProperties,
                 s.propertyAllowList,
             ],
@@ -158,7 +158,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 groupAnalyticsTaxonomicGroups,
                 groupAnalyticsTaxonomicGroupNames,
                 eventNames,
-                hogQLTable,
+                metadataSource,
                 excludedProperties,
                 propertyAllowList
             ): TaxonomicFilterGroup[] => {
@@ -447,7 +447,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         type: TaxonomicFilterGroupType.HogQLExpression,
                         render: InlineHogQLEditor,
                         getPopoverHeader: () => 'HogQL',
-                        componentProps: { hogQLTable },
+                        componentProps: { metadataSource },
                     },
                     ...groupAnalyticsTaxonomicGroups,
                     ...groupAnalyticsTaxonomicGroupNames,

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -1,6 +1,7 @@
 import Fuse from 'fuse.js'
 import { LogicWrapper } from 'kea'
 
+import { AnyDataNode } from '~/queries/schema'
 import { ActionType, CohortType, EventDefinition, PersonProperty, PropertyDefinition } from '~/types'
 
 export interface SimpleOption {
@@ -23,7 +24,7 @@ export interface TaxonomicFilterProps {
     /** use to filter results in a group by name, currently only working for EventProperties */
     excludedProperties?: { [key in TaxonomicFilterGroupType]?: TaxonomicFilterValue[] }
     propertyAllowList?: { [key in TaxonomicFilterGroupType]?: string[] } // only return properties in this list, currently only working for EventProperties
-    hogQLTable?: string
+    metadataSource?: AnyDataNode
 }
 
 export interface TaxonomicFilterLogicProps extends TaxonomicFilterProps {

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -5,6 +5,8 @@ import { LemonButton, LemonButtonProps } from 'lib/lemon-ui/LemonButton'
 import { LemonDropdown } from 'lib/lemon-ui/LemonDropdown'
 import { useEffect, useState } from 'react'
 
+import { AnyDataNode } from '~/queries/schema'
+
 export interface TaxonomicPopoverProps<ValueType extends TaxonomicFilterValue = TaxonomicFilterValue>
     extends Omit<LemonButtonProps, 'children' | 'onClick' | 'sideIcon' | 'sideAction'> {
     groupType: TaxonomicFilterGroupType
@@ -20,7 +22,7 @@ export interface TaxonomicPopoverProps<ValueType extends TaxonomicFilterValue = 
     allowClear?: boolean
     style?: React.CSSProperties
     excludedProperties?: { [key in TaxonomicFilterGroupType]?: TaxonomicFilterValue[] }
-    hogQLTable?: string
+    metadataSource?: AnyDataNode
 }
 
 /** Like TaxonomicPopover, but convenient when you know you will only use string values */
@@ -46,7 +48,7 @@ export function TaxonomicPopover<ValueType extends TaxonomicFilterValue = Taxono
     placeholderClass = 'text-muted',
     allowClear = false,
     excludedProperties,
-    hogQLTable,
+    metadataSource,
     ...buttonPropsRest
 }: TaxonomicPopoverProps<ValueType>): JSX.Element {
     const [localValue, setLocalValue] = useState<ValueType>(value || ('' as ValueType))
@@ -83,7 +85,7 @@ export function TaxonomicPopover<ValueType extends TaxonomicFilterValue = Taxono
                     }}
                     taxonomicGroupTypes={groupTypes ?? [groupType]}
                     eventNames={eventNames}
-                    hogQLTable={hogQLTable}
+                    metadataSource={metadataSource}
                     excludedProperties={excludedProperties}
                 />
             }

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -154,7 +154,6 @@ export function DataTable({
         : columnsInQuery
 
     const groupTypes = isActorsQuery(query.source) ? personGroupTypes : eventGroupTypes
-    const hogQLTable = isActorsQuery(query.source) ? 'persons' : 'events'
 
     const lemonColumns: LemonTableColumn<DataTableRow, any>[] = [
         ...columnsInLemonTable.map((key, index) => ({
@@ -192,7 +191,7 @@ export function DataTable({
                             groupType={TaxonomicFilterGroupType.HogQLExpression}
                             value={key}
                             groupTypes={groupTypes}
-                            hogQLTable={hogQLTable}
+                            metadataSource={query.source}
                             renderValue={() => <>Edit column</>}
                             type="tertiary"
                             fullWidth
@@ -266,7 +265,7 @@ export function DataTable({
                             groupType={TaxonomicFilterGroupType.HogQLExpression}
                             value={''}
                             groupTypes={groupTypes}
-                            hogQLTable={hogQLTable}
+                            metadataSource={query.source}
                             placeholder={<span className="not-italic">Add column left</span>}
                             data-attr="datatable-add-column-left"
                             type="tertiary"
@@ -295,7 +294,7 @@ export function DataTable({
                             groupType={TaxonomicFilterGroupType.HogQLExpression}
                             value={''}
                             groupTypes={groupTypes}
-                            hogQLTable={hogQLTable}
+                            metadataSource={query.source}
                             placeholder={<span className="not-italic">Add column right</span>}
                             data-attr="datatable-add-column-right"
                             type="tertiary"

--- a/frontend/src/queries/nodes/PersonsNode/PersonPropertyFilters.tsx
+++ b/frontend/src/queries/nodes/PersonsNode/PersonPropertyFilters.tsx
@@ -2,7 +2,7 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { useState } from 'react'
 
-import { ActorsQuery, PersonsNode } from '~/queries/schema'
+import { ActorsQuery, NodeKind, PersonsNode } from '~/queries/schema'
 import { isActorsQuery } from '~/queries/utils'
 import { PersonPropertyFilter } from '~/types'
 
@@ -33,7 +33,7 @@ export function PersonPropertyFilters({ query, setQuery }: PersonPropertyFilters
                       ]
                     : [TaxonomicFilterGroupType.PersonProperties]
             }
-            hogQLTable="persons"
+            metadataSource={{ kind: NodeKind.ActorsQuery }}
         />
     ) : (
         <div>Error: property groups are not supported.</div>

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1567,6 +1567,10 @@
                     "description": "HogQL expression to validate (use `select` or `expr`, but not both)",
                     "type": "string"
                 },
+                "exprSource": {
+                    "$ref": "#/definitions/AnyDataNode",
+                    "description": "Query within which \"expr\" is validated. Defaults to \"select * from events\""
+                },
                 "filters": {
                     "$ref": "#/definitions/HogQLFilters"
                 },

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -208,6 +208,8 @@ export interface HogQLMetadata extends DataNode {
     select?: string
     /** HogQL expression to validate (use `select` or `expr`, but not both) */
     expr?: string
+    /** Query within which "expr" is validated. Defaults to "select * from events" */
+    exprSource?: AnyDataNode
     /** Table to validate the expression against */
     table?: string
     filters?: HogQLFilters

--- a/posthog/hogql/hogql.py
+++ b/posthog/hogql/hogql.py
@@ -10,6 +10,7 @@ from posthog.hogql.errors import (
 )
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
+from posthog.hogql.visitor import clone_expr
 
 
 # This is called only from "non-hogql-based" insights to translate HogQL expressions into ClickHouse SQL
@@ -18,7 +19,7 @@ def translate_hogql(
     query: str,
     context: HogQLContext,
     dialect: Literal["hogql", "clickhouse"] = "clickhouse",
-    table: str = "events",
+    metadata_source: Optional[ast.SelectQuery] = None,
     *,
     events_table_alias: Optional[str] = None,
     placeholders: Optional[Dict[str, ast.Expr]] = None,
@@ -34,9 +35,15 @@ def translate_hogql(
                 raise ValueError("Cannot translate HogQL for a filter with no team specified")
             context.database = create_hogql_database(context.team_id)
         node = parse_expr(query, placeholders=placeholders)
-        select_query = ast.SelectQuery(select=[node], select_from=ast.JoinExpr(table=ast.Field(chain=[table])))
+        if metadata_source is not None:
+            select_query = cast(ast.SelectQuery, clone_expr(metadata_source, clear_locations=True))
+            select_query.select.append(node)
+        else:
+            select_query = ast.SelectQuery(select=[node], select_from=ast.JoinExpr(table=ast.Field(chain=["events"])))
+
         if events_table_alias is not None:
             select_query.select_from.alias = events_table_alias
+
         prepared_select_query: ast.SelectQuery = cast(
             ast.SelectQuery,
             prepare_ast_for_printing(select_query, context=context, dialect=dialect, stack=[select_query]),

--- a/posthog/hogql/metadata.py
+++ b/posthog/hogql/metadata.py
@@ -6,6 +6,7 @@ from posthog.hogql.hogql import translate_hogql
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import print_ast
 from posthog.hogql.query import create_default_modifiers_for_team
+from posthog.hogql_queries.query_runner import get_query_runner
 from posthog.models import Team
 from posthog.schema import HogQLMetadataResponse, HogQLMetadata, HogQLNotice
 from posthog.hogql import ast
@@ -28,7 +29,11 @@ def get_hogql_metadata(
     try:
         if isinstance(query.expr, str):
             context = HogQLContext(team_id=team.pk, modifiers=create_default_modifiers_for_team(team))
-            translate_hogql(query.expr, context=context, table=query.table or "events")
+            if query.exprSource is not None:
+                source_query = get_query_runner(query.exprSource, team).to_query()
+                translate_hogql(query.expr, context=context, metadata_source=source_query)
+            else:
+                translate_hogql(query.expr, context=context)
         elif isinstance(query.select, str):
             context = HogQLContext(
                 team_id=team.pk,

--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -1,6 +1,6 @@
 from posthog.hogql.metadata import get_hogql_metadata
 from posthog.models import PropertyDefinition, Cohort
-from posthog.schema import HogQLMetadata, HogQLMetadataResponse
+from posthog.schema import HogQLMetadata, HogQLMetadataResponse, HogQLQuery
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 from django.test import override_settings
 
@@ -10,7 +10,12 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
 
     def _expr(self, query: str, table: str = "events") -> HogQLMetadataResponse:
         return get_hogql_metadata(
-            query=HogQLMetadata(kind="HogQLMetadata", expr=query, table=table, response=None),
+            query=HogQLMetadata(
+                kind="HogQLMetadata",
+                expr=query,
+                exprSource=HogQLQuery(kind="HogQLQuery", query=f"select * from {table}"),
+                response=None,
+            ),
             team=self.team,
         )
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1336,22 +1336,6 @@ class HogQLFilters(BaseModel):
     ] = None
 
 
-class HogQLMetadata(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    expr: Optional[str] = Field(
-        default=None, description="HogQL expression to validate (use `select` or `expr`, but not both)"
-    )
-    filters: Optional[HogQLFilters] = None
-    kind: Literal["HogQLMetadata"] = "HogQLMetadata"
-    response: Optional[HogQLMetadataResponse] = Field(default=None, description="Cached query response")
-    select: Optional[str] = Field(
-        default=None, description="Full select query to validate (use `select` or `expr`, but not both)"
-    )
-    table: Optional[str] = Field(default=None, description="Table to validate the expression against")
-
-
 class HogQLQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1991,6 +1975,39 @@ class DataTableNode(BaseModel):
         WebStatsTableQuery,
         WebTopClicksQuery,
     ] = Field(..., description="Source of the events")
+
+
+class HogQLMetadata(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    expr: Optional[str] = Field(
+        default=None, description="HogQL expression to validate (use `select` or `expr`, but not both)"
+    )
+    exprSource: Optional[
+        Union[
+            EventsNode,
+            ActionsNode,
+            PersonsNode,
+            TimeToSeeDataSessionsQuery,
+            EventsQuery,
+            ActorsQuery,
+            InsightActorsQuery,
+            SessionsTimelineQuery,
+            HogQLQuery,
+            HogQLMetadata,
+            WebOverviewQuery,
+            WebStatsTableQuery,
+            WebTopClicksQuery,
+        ]
+    ] = Field(default=None, description='Query within which "expr" is validated. Defaults to "select * from events"')
+    filters: Optional[HogQLFilters] = None
+    kind: Literal["HogQLMetadata"] = "HogQLMetadata"
+    response: Optional[HogQLMetadataResponse] = Field(default=None, description="Cached query response")
+    select: Optional[str] = Field(
+        default=None, description="Full select query to validate (use `select` or `expr`, but not both)"
+    )
+    table: Optional[str] = Field(default=None, description="Table to validate the expression against")
 
 
 class QuerySchema(RootModel):


### PR DESCRIPTION
## Problem

The "inline HogQL editor" (e.g. under "edit column" or "add breakdown") didn't really know what data it was operating on. It only knew of the "events" and "persons" tables.

## Changes

Now it can offer correct suggestions no matter the query:

![2024-01-08 14 56 42](https://github.com/PostHog/posthog/assets/53387/15e7e485-0492-4e82-b3e8-4e9136545b18)

For this I changed the previous `table: string` column in `HogQLMetadata` to `exprSource: AnyDataNode`

## How did you test this code?

Updated the metadata test.