### PR TITLE
fix: Pass use_json_type input to insert bq activity

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -308,6 +308,7 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
             data_interval_end=data_interval_end.isoformat(),
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
+            use_json_type=inputs.use_json_type,
         )
 
         await execute_batch_export_insert_activity(


### PR DESCRIPTION
## Problem

We are not passing the `use_json_type` to the insert activity function. Strange that tests didn't catch this one :thinking: 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Pass `use_json_type`.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unit tests still passing.
```
posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py ..............                              [100%]

--------------------------------------------------- snapshot report summary ---------------------------------------------------

=============================================== 14 passed in 132.36s (0:02:12) ================================================
```
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
