### PR TITLE
fix(pipeline): Load transformations/destinations progressively

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -429,7 +429,7 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                         },
                         {
                             identifier: Scene.Pipeline,
-                            label: 'Data pipeline new',
+                            label: 'Data pipeline 3000',
                             icon: <IconDecisionTree />,
                             to: urls.pipeline(),
                             featureFlag: FEATURE_FLAGS.PIPELINE_UI,

--- a/frontend/src/layout/navigation/TopBar/SitePopover.scss
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.scss
@@ -6,6 +6,7 @@
 }
 
 .SitePopover__side-link {
+    flex-grow: 1;
     margin-left: 0.5rem;
     font-size: 0.8125rem;
     font-weight: 600;

--- a/frontend/src/scenes/pipeline/Destinations.tsx
+++ b/frontend/src/scenes/pipeline/Destinations.tsx
@@ -18,7 +18,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { urls } from 'scenes/urls'
 
-import { PipelineAppTabs, PipelineTabs, PluginConfigTypeNew, ProductKey } from '~/types'
+import { PipelineAppTabs, PipelineTabs, PluginConfigWithPluginInfoNew, ProductKey } from '~/types'
 
 import { pipelineDestinationsLogic } from './destinationsLogic'
 import { NewButton } from './NewButton'
@@ -64,7 +64,7 @@ function BatchExportsTable(): JSX.Element {
 }
 
 function AppsTable(): JSX.Element {
-    const { loading, enabledPluginConfigs, disabledPluginConfigs, plugins, canConfigurePlugins } =
+    const { loading, displayablePluginConfigs, enabledPluginConfigs, disabledPluginConfigs, canConfigurePlugins } =
         useValues(pipelineDestinationsLogic)
     const { toggleEnabled, loadPluginConfigs } = useActions(pipelineDestinationsLogic)
 
@@ -76,7 +76,7 @@ function AppsTable(): JSX.Element {
         <>
             <h2>Webhooks</h2>
             <LemonTable
-                dataSource={[...enabledPluginConfigs, ...disabledPluginConfigs]}
+                dataSource={displayablePluginConfigs}
                 size="xs"
                 loading={loading}
                 columns={[
@@ -103,7 +103,7 @@ function AppsTable(): JSX.Element {
                     {
                         title: 'App',
                         render: function RenderAppInfo(_, pluginConfig) {
-                            return <RenderApp plugin={plugins[pluginConfig.plugin]} />
+                            return <RenderApp plugin={pluginConfig.plugin_info} />
                         },
                     },
                     {
@@ -136,7 +136,7 @@ function AppsTable(): JSX.Element {
                             )
                         },
                     },
-                    updatedAtColumn() as LemonTableColumn<PluginConfigTypeNew, any>,
+                    updatedAtColumn() as LemonTableColumn<PluginConfigWithPluginInfoNew, any>,
                     {
                         title: 'Status',
                         render: function RenderStatus(_, pluginConfig) {
@@ -200,16 +200,15 @@ function AppsTable(): JSX.Element {
                                             >
                                                 View app logs
                                             </LemonButton>
-                                            {plugins[pluginConfig.plugin].url && (
-                                                <LemonButton
-                                                    to={plugins[pluginConfig.plugin].url}
-                                                    targetBlank={true}
-                                                    id={`app-${pluginConfig.id}-source-code`}
-                                                    fullWidth
-                                                >
-                                                    View app source code
-                                                </LemonButton>
-                                            )}
+                                            <LemonButton
+                                                to={pluginConfig.plugin_info?.url}
+                                                targetBlank={true}
+                                                loading={!pluginConfig.plugin_info?.url}
+                                                id={`app-${pluginConfig.id}-source-code`}
+                                                fullWidth
+                                            >
+                                                View app source code
+                                            </LemonButton>
                                             <LemonDivider />
                                             <LemonButton
                                                 status="danger"

--- a/frontend/src/scenes/pipeline/Pipeline.tsx
+++ b/frontend/src/scenes/pipeline/Pipeline.tsx
@@ -34,6 +34,7 @@ export function Pipeline(): JSX.Element {
                 activeKey={currentTab}
                 onChange={(tab) => router.actions.push(urls.pipeline(tab as PipelineTabs))}
                 tabs={Object.values(PipelineTabs).map((tab) => ({
+                    // TODO: Hide admin management based on `canGloballyManagePlugins` permission
                     label: humanFriendlyTabName(tab),
                     key: tab,
                     content: tab_to_content[tab],

--- a/frontend/src/scenes/pipeline/Transformations.tsx
+++ b/frontend/src/scenes/pipeline/Transformations.tsx
@@ -24,7 +24,7 @@ import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { PluginImage } from 'scenes/plugins/plugin/PluginImage'
 import { urls } from 'scenes/urls'
 
-import { PipelineAppTabs, PipelineTabs, PluginConfigTypeNew, ProductKey } from '~/types'
+import { PipelineAppTabs, PipelineTabs, PluginConfigTypeNew, PluginConfigWithPluginInfoNew, ProductKey } from '~/types'
 
 import { NewButton } from './NewButton'
 import { pipelineTransformationsLogic } from './transformationsLogic'
@@ -39,7 +39,7 @@ export function Transformations(): JSX.Element {
         loading,
         sortedEnabledPluginConfigs,
         disabledPluginConfigs,
-        plugins,
+        displayablePluginConfigs,
         canConfigurePlugins,
         shouldShowProductIntroduction,
     } = useValues(pipelineTransformationsLogic)
@@ -83,7 +83,7 @@ export function Transformations(): JSX.Element {
                         </>
                     )}
                     <LemonTable
-                        dataSource={[...sortedEnabledPluginConfigs, ...disabledPluginConfigs]}
+                        dataSource={displayablePluginConfigs}
                         size="xs"
                         loading={loading}
                         columns={[
@@ -97,7 +97,7 @@ export function Transformations(): JSX.Element {
                                     }
                                     // We can't use pluginConfig.order directly as it's not nicely set for everything,
                                     // e.g. geoIP, disabled plugins, especially if we disable them via django admin
-                                    return sortedEnabledPluginConfigs.findIndex((pc) => pc === pluginConfig) + 1
+                                    return sortedEnabledPluginConfigs.findIndex((pc) => pc.id === pluginConfig.id) + 1
                                 },
                             },
                             {
@@ -128,10 +128,10 @@ export function Transformations(): JSX.Element {
                             {
                                 title: 'App',
                                 render: function RenderAppInfo(_, pluginConfig) {
-                                    return <RenderApp plugin={plugins[pluginConfig.plugin]} />
+                                    return <RenderApp plugin={pluginConfig.plugin_info} />
                                 },
                             },
-                            updatedAtColumn() as LemonTableColumn<PluginConfigTypeNew, any>,
+                            updatedAtColumn() as LemonTableColumn<PluginConfigWithPluginInfoNew, any>,
                             {
                                 title: 'Status',
                                 render: function RenderStatus(_, pluginConfig) {
@@ -212,16 +212,15 @@ export function Transformations(): JSX.Element {
                                                     >
                                                         View app logs
                                                     </LemonButton>
-                                                    {plugins[pluginConfig.plugin].url && (
-                                                        <LemonButton
-                                                            to={plugins[pluginConfig.plugin].url}
-                                                            targetBlank={true}
-                                                            id={`app-${pluginConfig.id}-source-code`}
-                                                            fullWidth
-                                                        >
-                                                            View app source code
-                                                        </LemonButton>
-                                                    )}
+                                                    <LemonButton
+                                                        to={pluginConfig.plugin_info?.url}
+                                                        targetBlank={true}
+                                                        loading={!pluginConfig.plugin_info?.url}
+                                                        id={`app-${pluginConfig.id}-source-code`}
+                                                        fullWidth
+                                                    >
+                                                        View app source code
+                                                    </LemonButton>
                                                     <LemonDivider />
                                                     <LemonButton
                                                         status="danger"

--- a/frontend/src/scenes/pipeline/destinationsLogic.tsx
+++ b/frontend/src/scenes/pipeline/destinationsLogic.tsx
@@ -5,7 +5,7 @@ import { canConfigurePlugins } from 'scenes/plugins/access'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 
-import { PluginConfigTypeNew, PluginType, ProductKey } from '~/types'
+import { PluginConfigTypeNew, PluginConfigWithPluginInfoNew, PluginType, ProductKey } from '~/types'
 
 import type { pipelineDestinationsLogicType } from './destinationsLogicType'
 import { capturePluginEvent } from './utils'
@@ -84,6 +84,17 @@ export const pipelineDestinationsLogic = kea<pipelineDestinationsLogicType>([
         disabledPluginConfigs: [
             (s) => [s.pluginConfigs],
             (pluginConfigs) => Object.values(pluginConfigs).filter((pc) => !pc.enabled),
+        ],
+        displayablePluginConfigs: [
+            (s) => [s.pluginConfigs, s.plugins],
+            (pluginConfigs, plugins) => {
+                const enabledFirst = Object.values(pluginConfigs).sort((a, b) => Number(b.enabled) - Number(a.enabled))
+                const withPluginInfo = enabledFirst.map<PluginConfigWithPluginInfoNew>((pluginConfig) => ({
+                    ...pluginConfig,
+                    plugin_info: plugins[pluginConfig.plugin] || null,
+                }))
+                return withPluginInfo
+            },
         ],
         // This is currently an organization level setting but might in the future be user level
         // it's better to add the permission checks everywhere now

--- a/frontend/src/scenes/pipeline/pipelineLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineLogic.tsx
@@ -29,7 +29,7 @@ export const humanFriendlyTabName = (tab: PipelineTabs): string => {
         case PipelineTabs.Destinations:
             return 'Destinations'
         case PipelineTabs.AppsManagement:
-            return 'Apps Management'
+            return 'Apps management'
     }
 }
 

--- a/frontend/src/scenes/pipeline/transformationsLogic.tsx
+++ b/frontend/src/scenes/pipeline/transformationsLogic.tsx
@@ -5,7 +5,7 @@ import { canConfigurePlugins } from 'scenes/plugins/access'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 
-import { PluginConfigTypeNew, PluginType, ProductKey } from '~/types'
+import { PluginConfigTypeNew, PluginConfigWithPluginInfoNew, PluginType, ProductKey } from '~/types'
 
 import type { pipelineTransformationsLogicType } from './transformationsLogicType'
 import { capturePluginEvent } from './utils'
@@ -139,6 +139,17 @@ export const pipelineTransformationsLogic = kea<pipelineTransformationsLogicType
             (s) => [s.pluginConfigs],
             (pluginConfigs) => Object.values(pluginConfigs).filter((pc) => !pc.enabled),
         ],
+        displayablePluginConfigs: [
+            (s) => [s.sortedEnabledPluginConfigs, s.disabledPluginConfigs, s.plugins],
+            (sortedEnabledPluginConfigs, disabledPluginConfigs, plugins) => {
+                const combined = sortedEnabledPluginConfigs.concat(disabledPluginConfigs)
+                const withPluginInfo = combined.map<PluginConfigWithPluginInfoNew>((pluginConfig) => ({
+                    ...pluginConfig,
+                    plugin_info: plugins[pluginConfig.plugin] || null,
+                }))
+                return withPluginInfo
+            },
+        ],
         // This is currently an organization level setting but might in the future be user level
         // it's better to add the permission checks everywhere now
         canConfigurePlugins: [(s) => [s.user], (user) => canConfigurePlugins(user?.organization)],
@@ -164,7 +175,8 @@ export const pipelineTransformationsLogic = kea<pipelineTransformationsLogicType
         },
     })),
     afterMount(({ actions }) => {
-        actions.loadPlugins()
+        // actions.loadPlugins()
+        setTimeout(() => actions.loadPlugins(), 2000)
         actions.loadPluginConfigs()
     }),
 ])

--- a/frontend/src/scenes/pipeline/transformationsLogic.tsx
+++ b/frontend/src/scenes/pipeline/transformationsLogic.tsx
@@ -175,8 +175,7 @@ export const pipelineTransformationsLogic = kea<pipelineTransformationsLogicType
         },
     })),
     afterMount(({ actions }) => {
-        // actions.loadPlugins()
-        setTimeout(() => actions.loadPlugins(), 2000)
+        actions.loadPlugins()
         actions.loadPluginConfigs()
     }),
 ])

--- a/frontend/src/scenes/pipeline/utils.tsx
+++ b/frontend/src/scenes/pipeline/utils.tsx
@@ -1,3 +1,4 @@
+import { LemonSkeleton } from '@posthog/lemon-ui'
 import api from 'lib/api'
 import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
@@ -33,11 +34,16 @@ export async function loadPaginatedResults(
 }
 
 type RenderAppProps = {
-    plugin: PluginType
+    /** If the plugin is null, a skeleton will be rendered. */
+    plugin: PluginType | null
     imageSize?: PluginImageSize
 }
 
 export function RenderApp({ plugin, imageSize }: RenderAppProps): JSX.Element {
+    if (!plugin) {
+        return <LemonSkeleton className="w-15 h-15" />
+    }
+
     return (
         <div className="flex items-center gap-4">
             <Tooltip

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1565,6 +1565,7 @@ export interface JobSpec {
     payload?: Record<string, JobPayloadFieldOptions>
 }
 
+/** @deprecated in favor of PluginConfigTypeNew */
 export interface PluginConfigType {
     id?: number
     plugin: number
@@ -1578,7 +1579,13 @@ export interface PluginConfigType {
     created_at?: string
 }
 
-// TODO: Rename to PluginConfigType once the are removed from the frontend
+/** @deprecated in favor of PluginConfigWithPluginInfoNew */
+export interface PluginConfigWithPluginInfo extends PluginConfigType {
+    id: number
+    plugin_info: PluginType
+}
+
+// TODO: Rename to PluginConfigType once the legacy PluginConfigType are removed from the frontend
 export interface PluginConfigTypeNew {
     id: number
     plugin: number
@@ -1591,9 +1598,9 @@ export interface PluginConfigTypeNew {
     delivery_rate_24h?: number | null
 }
 
-export interface PluginConfigWithPluginInfo extends PluginConfigType {
-    id: number
-    plugin_info: PluginType
+// TODO: Rename to PluginConfigWithPluginInfo once the are removed from the frontend
+export interface PluginConfigWithPluginInfoNew extends PluginConfigTypeNew {
+    plugin_info: PluginType | null
 }
 
 export interface PluginErrorType {

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -554,7 +554,7 @@ class PluginConfigSerializer(serializers.ModelSerializer):
         model = PluginConfig
         fields = [
             "id",
-            "plugin",  # TODO: Rename to plugin_id
+            "plugin",  # TODO: Rename to plugin_id for consistency with team_id
             "enabled",
             "order",
             "config",

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -554,7 +554,7 @@ class PluginConfigSerializer(serializers.ModelSerializer):
         model = PluginConfig
         fields = [
             "id",
-            "plugin",
+            "plugin",  # TODO: Rename to plugin_id
             "enabled",
             "order",
             "config",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -54,7 +54,10 @@ const config = {
             spacing: {
                 // Some additional larger widths for compatibility with our pre-Tailwind system
                 // Don't add new ones here, in new code just use the `w-[32rem]` style for arbitrary values
+                13: '3.25rem',
+                15: '3.75rem',
                 18: '4.5rem',
+                // All whole number values up to 18 ensured above
                 30: '7.5rem',
                 50: '12.5rem',
                 60: '15rem',
@@ -66,6 +69,7 @@ const config = {
                 180: '45rem',
                 192: '48rem',
                 200: '50rem',
+                // All whole number values divisible by 20 up to 200 ensured above
                 248: '62rem',
                 300: '75rem',
             },


### PR DESCRIPTION
## Problem

Fixes this:
<img width="895" alt="Screenshot 2024-01-08 at 16 14 29" src="https://github.com/PostHog/posthog/assets/4550621/77b17584-0014-493f-8ba5-5cc276d2c234">

## Changes

Transformations and destinations are now loaded progressively – if plugin configs are loaded before plugins, we show skeletons for the data we're temporarily missing.
