### PR TITLE
fix(hogql): Fix hogql compare capture query type mismatch

### DIFF
--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -275,7 +275,6 @@ export async function query<N extends DataNode = DataNode>(
 
                     posthog.capture('hogql_compare', {
                         query: queryNode,
-                        query_type: isTrendsQuery(queryNode) ? 'trends' : 'lifecycle',
                         equal: mismatchCount === 0,
                         mismatch_count: mismatchCount,
                     })


### PR DESCRIPTION
## Problem

Retention queries also get captured, but the `query_type` is wrong.

## Changes

- remove `query_type` as we can use `query__kind` – would that be okay?   
    
    <img width="697" alt="image" src="https://github.com/PostHog/posthog/assets/59713/f24dfe48-1517-44f4-a370-f4687013b5fb">


## How did you test this code?

- just locally
