### PR TITLE
chore(pipeline): Add redirect for base `/pipeline` route

### DIFF
--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -445,6 +445,7 @@ export const redirects: Record<
     '/project/settings': urls.settings('project'),
     '/organization/settings': urls.settings('organization'),
     '/me/settings': urls.settings('user'),
+    '/pipeline': urls.pipeline(),
 }
 
 export const routes: Record<string, Scene> = {

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -100,7 +100,7 @@ export const urls = {
     personByUUID: (uuid: string, encode: boolean = true): string =>
         encode ? `/persons/${encodeURIComponent(uuid)}` : `/persons/${uuid}`,
     persons: (): string => '/persons',
-    // TODO: Why are Destinations the default tab, and not the first one i.e. Filters?
+    // TODO: Default to the landing page, once it's ready
     pipeline: (tab?: PipelineTabs): string => `/pipeline/${tab ? tab : PipelineTabs.Destinations}`,
     pipelineApp: (id: string | number, tab?: PipelineAppTabs): string =>
         `/pipeline/${id}/${tab ? tab : PipelineAppTabs.Configuration}`,

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -100,6 +100,7 @@ export const urls = {
     personByUUID: (uuid: string, encode: boolean = true): string =>
         encode ? `/persons/${encodeURIComponent(uuid)}` : `/persons/${uuid}`,
     persons: (): string => '/persons',
+    // TODO: Why are Destinations the default tab, and not the first one i.e. Filters?
     pipeline: (tab?: PipelineTabs): string => `/pipeline/${tab ? tab : PipelineTabs.Destinations}`,
     pipelineApp: (id: string | number, tab?: PipelineAppTabs): string =>
         `/pipeline/${id}/${tab ? tab : PipelineAppTabs.Configuration}`,


### PR DESCRIPTION
## Problem

You could go to `us.posthog.com/pipeline/filters`, but just `/pipeline` was confusingly a 404.

## Changes

The base path now points to the default tab.
