### PR TITLE
feat: remember replay filters

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -145,6 +145,8 @@ describe('sessionRecordingsPlaylistLogic', () => {
                     updateSearchParams: true,
                 })
                 logic.mount()
+                // the logic persists its filters
+                logic.actions.resetFilters()
             })
 
             describe('core assumptions', () => {

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -365,6 +365,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
         ],
         customFilters: [
             props.filters ?? null,
+            { persist: true },
             {
                 setFilters: (state, { filters }) => ({
                     ...state,


### PR DESCRIPTION
The feedback that it is frustrating to recreate filters when watching recordings has come up a few times

That clashes with playlists as a feature, but we're not actively working on them, and they clash with notebooks so 🤷 

This stores the filters for the main replay page in browser storage so that your last filters are always your starting point when you come back to replay.

The reset button is visible in simple and advanced filter mode, so if someone wants to start from scratch then they can

(tested by checking that refreshing doesn't clear the filters and the stored filters don't clash with playlists)