### PR TITLE
fix(debug): Limit debug notice width and align row styles

### DIFF
--- a/frontend/src/lib/components/DebugNotice.tsx
+++ b/frontend/src/lib/components/DebugNotice.tsx
@@ -57,21 +57,33 @@ export function DebugNotice(): JSX.Element | null {
     }
     return (
         <div
-            className="border rounded-md bg-bg-3000 overflow-hidden mb-1.5 w-full font-mono"
+            className="border rounded-md bg-bg-3000 overflow-hidden mb-1.5 w-full font-mono max-w-60"
             // eslint-disable-next-line react/forbid-dom-props
             style={{ fontSize: 13 }} // utility classes don't have a 13px variant
         >
-            <div className="p-2 border-l-4 border-brand-blue text-primary-3000 truncate flex justify-between">
+            <div className="flex items-center gap-2 px-2 h-8 border-l-4 border-brand-blue justify-between">
                 <b>DEBUG mode</b>
-                <LemonButton icon={<IconClose />} size="small" noPadding onClick={() => setNoticeHidden(true)} />
+                <LemonButton
+                    icon={<IconClose />}
+                    tooltip="Dismiss"
+                    size="small"
+                    noPadding
+                    onClick={() => setNoticeHidden(true)}
+                />
             </div>
-            <div className="flex items-center gap-2 px-2 h-8 border-l-4 border-brand-red truncate" title="Branch">
+            <div
+                className="flex items-center gap-2 px-2 h-8 border-l-4 border-brand-red"
+                title={`Branch: ${debugInfo.branch}`}
+            >
                 <IconBranch className="text-lg" />
-                <b>{debugInfo.branch}</b>
+                <b className="min-w-0 flex-1 truncate">{debugInfo.branch}</b>
             </div>
-            <div className="flex items-center gap-2 px-2 h-8 border-l-4 border-brand-yellow truncate" title="Revision">
+            <div
+                className="flex items-center gap-2 px-2 h-8 border-l-4 border-brand-yellow"
+                title={`Revision: ${debugInfo.revision}`}
+            >
                 <IconCode className="text-lg" />
-                <b>{debugInfo.revision}</b>
+                <b className="min-w-0 flex-1 truncate">{debugInfo.revision}</b>
             </div>
         </div>
     )


### PR DESCRIPTION
## Problem

Noticed that some classes got switched back in the final https://github.com/PostHog/posthog/pull/19538 rebase, which I think wasn't intended. Especially since the first row losing `h-8`, which makes it a different height from the others:

<img width="397" alt="Screenshot 2024-01-09 at 15 52 11" src="https://github.com/PostHog/posthog/assets/4550621/1a74e3e8-272a-4c23-84db-1fe8052048dc">
 
I also realized that there's no max width and `truncate` didn't actually work, so long branches looked awkward.

## Changes

Should behave better now:

<img width="397" alt="Screenshot 2024-01-09 at 15 53 34" src="https://github.com/PostHog/posthog/assets/4550621/499ba9d2-3b8c-419e-af7a-806f1e751dc0">