### PR TITLE
fix(scripts): remove duplicate visual regression test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
         "test": "pnpm test:unit && pnpm test:visual-regression",
         "test:unit": "jest --testPathPattern=frontend/",
         "jest": "jest",
-        "test:visual-regression": "pnpm test:visual-regression:docker",
         "test:visual-regression": "rm -rf frontend/__snapshots__/__failures__/ && docker compose -f docker-compose.playwright.yml run --rm -it --build playwright pnpm test:visual-regression:docker",
         "test:visual-regression:docker": "NODE_OPTIONS=--max-old-space-size=6144 test-storybook -u --no-index-json --browsers chromium webkit --url http://host.docker.internal:6006",
         "test:visual-regression:local": "NODE_OPTIONS=--max-old-space-size=6144 test-storybook -u --no-index-json --browsers chromium webkit --url http://localhost:6006",


### PR DESCRIPTION
## Problem

I oversaw to remove the duplicate script in https://github.com/PostHog/posthog/pull/19527

## Changes

This PR removes it.

## How did you test this code?

CI run.