### PR TITLE
fix(elements): remove slash colon

### DIFF
--- a/posthog/models/event/event.py
+++ b/posthog/models/event/event.py
@@ -83,7 +83,7 @@ class Selector:
     def __init__(self, selector: str, escape_slashes=True):
         self.parts = []
         # Sometimes people manually add *, just remove them as they don't do anything
-        selector = selector.replace("> * > ", "").replace("> *", "").strip()
+        selector = selector.replace("> * > ", "").replace("> *", "").replace("\\:", ":").strip()
         tags = list(self._split(selector))
         tags.reverse()
         # Detecting selector parts

--- a/posthog/models/test/test_event_model.py
+++ b/posthog/models/test/test_event_model.py
@@ -718,3 +718,8 @@ class TestSelectors(BaseTest):
         self.assertEqual(selector1.parts[1].data, {"tag_name": "div"})
         self.assertEqual(selector1.parts[1].direct_descendant, False)
         self.assertEqual(selector1.parts[1].unique_order, 1)
+
+    def test_slash_colon(self):
+        # Make sure we strip these for full text search to work in the database
+        selector1 = Selector("div#root\\:id")
+        self.assertEqual(selector1.parts[0].data, {"tag_name": "div", "attr_id": "root:id"})


### PR DESCRIPTION
## Problem

CSS selectors with legit colons in the ID don't work when querying for events. E.g. `#root\:id`

## Changes

Now they do.

## How did you test this code?

Added a test. Tested with a real event on a real ID with a colon in the browser locally.