### PR TITLE
chore(data-warehouse): fixed height for empty message

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/DataWarehouseExternalScene.tsx
+++ b/frontend/src/scenes/data-warehouse/external/DataWarehouseExternalScene.tsx
@@ -213,7 +213,7 @@ export function DataWarehouseExternalScene(): JSX.Element {
                         </div>
                     </div>
                 ) : (
-                    <div className="px-4 py-3 col-span-2 flex justify-center items-center">
+                    <div className="px-4 py-3 h-100 col-span-2 flex justify-center items-center">
                         <EmptyMessage
                             title="No table selected"
                             description="Please select a table from the list on the left"


### PR DESCRIPTION
## Problem

- empty message height not set

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- set empty message height

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
