### PR TITLE
feat: capture on user the first product they selected to onboard into

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -489,7 +489,13 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportSurveyTemplateClicked: (template: SurveyTemplateType) => ({ template }),
         reportProductUnsubscribed: (product: string) => ({ product }),
         // onboarding
-        reportOnboardingProductSelected: (productKey: string) => ({ productKey }),
+        reportOnboardingProductSelected: (
+            productKey: string,
+            includeFirstOnboardingProductOnUserProperties: boolean
+        ) => ({
+            productKey,
+            includeFirstOnboardingProductOnUserProperties,
+        }),
         reportOnboardingCompleted: (productKey: string) => ({ productKey }),
         reportSubscribedDuringOnboarding: (productKey: string) => ({ productKey }),
         // command bar
@@ -1192,10 +1198,14 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             })
         },
         // onboarding
-        reportOnboardingProductSelected: ({ productKey }) => {
+        reportOnboardingProductSelected: ({ productKey, includeFirstOnboardingProductOnUserProperties }) => {
             posthog.capture('onboarding product selected', {
                 product_key: productKey,
-                $set_once: { first_onboarding_product_selected: productKey },
+                $set_once: {
+                    first_onboarding_product_selected: includeFirstOnboardingProductOnUserProperties
+                        ? productKey
+                        : undefined,
+                },
             })
         },
         reportOnboardingCompleted: ({ productKey }) => {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -1195,6 +1195,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportOnboardingProductSelected: ({ productKey }) => {
             posthog.capture('onboarding product selected', {
                 product_key: productKey,
+                $set_once: { first_onboarding_product_selected: productKey },
             })
         },
         reportOnboardingCompleted: ({ productKey }) => {

--- a/frontend/src/scenes/products/productsLogic.tsx
+++ b/frontend/src/scenes/products/productsLogic.tsx
@@ -2,6 +2,7 @@ import { actions, connect, kea, listeners, path } from 'kea'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { onboardingLogic } from 'scenes/onboarding/onboardingLogic'
 import { teamLogic } from 'scenes/teamLogic'
+import { userLogic } from 'scenes/userLogic'
 
 import { ProductKey } from '~/types'
 
@@ -11,13 +12,20 @@ export const productsLogic = kea<productsLogicType>([
     path(() => ['scenes', 'products', 'productsLogic']),
     connect({
         actions: [teamLogic, ['updateCurrentTeam'], onboardingLogic, ['setProduct']],
+        values: [userLogic, ['user']],
     }),
     actions(() => ({
         onSelectProduct: (product: ProductKey) => ({ product }),
     })),
-    listeners(({ actions }) => ({
+    listeners(({ actions, values }) => ({
         onSelectProduct: ({ product }) => {
-            eventUsageLogic.actions.reportOnboardingProductSelected(product)
+            const includeFirstOnboardingProductOnUserProperties = values.user?.date_joined
+                ? new Date(values.user?.date_joined) > new Date('2024-01-10T00:00:00Z')
+                : false
+            eventUsageLogic.actions.reportOnboardingProductSelected(
+                product,
+                includeFirstOnboardingProductOnUserProperties
+            )
 
             switch (product) {
                 case ProductKey.PRODUCT_ANALYTICS:


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C043VJ93L3B/p1704725633700459

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Sets on the user the first product they decided to onboard into. Will only get set for people who join after 2024-01-10

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
