### PR TITLE
chore(pipeline): Add `appType` to `pipelineAppLogic`

### DIFF
--- a/frontend/src/scenes/pipeline/Pipeline.tsx
+++ b/frontend/src/scenes/pipeline/Pipeline.tsx
@@ -16,7 +16,7 @@ import { Transformations } from './Transformations'
 export function Pipeline(): JSX.Element {
     const { currentTab } = useValues(pipelineLogic)
 
-    const tab_to_content: Record<PipelineTabs, JSX.Element> = {
+    const tabToContent: Record<PipelineTabs, JSX.Element> = {
         [PipelineTabs.Filters]: <div>Coming soon</div>,
         [PipelineTabs.Transformations]: <Transformations />,
         [PipelineTabs.Destinations]: <Destinations />,
@@ -37,7 +37,7 @@ export function Pipeline(): JSX.Element {
                     // TODO: Hide admin management based on `canGloballyManagePlugins` permission
                     label: humanFriendlyTabName(tab),
                     key: tab,
-                    content: tab_to_content[tab],
+                    content: tabToContent[tab],
                 }))}
             />
         </div>

--- a/frontend/src/scenes/pipeline/PipelineApp.tsx
+++ b/frontend/src/scenes/pipeline/PipelineApp.tsx
@@ -19,10 +19,13 @@ import { pipelineAppLogic } from './pipelineAppLogic'
 export const scene: SceneExport = {
     component: PipelineApp,
     logic: pipelineAppLogic,
-    paramsToProps: ({ params: { kind, id } }: { params: { kind?: string; id?: string } }) => ({
-        kind: kind,
-        id: id ? parseInt(id) : 'new',
-    }),
+    paramsToProps: ({ params: { kind, id } }: { params: { kind?: string; id?: string } }) => {
+        const numericId = id ? parseInt(id) : undefined
+        return {
+            kind: kind,
+            id: numericId && !isNaN(numericId) ? numericId : id,
+        }
+    },
 }
 
 export function PipelineApp({ kind, id }: { kind?: string; id?: string } = {}): JSX.Element {
@@ -41,7 +44,7 @@ export function PipelineApp({ kind, id }: { kind?: string; id?: string } = {}): 
         return <Spinner />
     }
 
-    const tab_to_content: Record<PipelineAppTabs, JSX.Element> = {
+    const tabToContent: Record<PipelineAppTabs, JSX.Element> = {
         [PipelineAppTabs.Configuration]: <div>Configuration editing</div>,
         [PipelineAppTabs.Metrics]: <AppMetrics pluginConfigId={confId} />,
         [PipelineAppTabs.Logs]: <PluginLogs pluginConfigId={confId} />,
@@ -58,7 +61,7 @@ export function PipelineApp({ kind, id }: { kind?: string; id?: string } = {}): 
                 tabs={Object.values(PipelineAppTabs).map((tab) => ({
                     label: capitalizeFirstLetter(tab),
                     key: tab,
-                    content: tab_to_content[tab],
+                    content: tabToContent[tab],
                 }))}
             />
         </div>

--- a/frontend/src/scenes/pipeline/pipelineAppLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineAppLogic.tsx
@@ -6,6 +6,7 @@ import { urls } from 'scenes/urls'
 
 import { Breadcrumb, PipelineAppTabs, PipelineTabs } from '~/types'
 
+import { DestinationType } from './destinationsLogic'
 import type { pipelineAppLogicType } from './pipelineAppLogicType'
 
 export interface PipelineAppLogicProps {
@@ -47,6 +48,10 @@ export const pipelineAppLogic = kea<pipelineAppLogicType>([
                     name: 'App name',
                 },
             ],
+        ],
+        appType: [
+            (_, p) => [p.id],
+            (id): DestinationType['type'] => (typeof id === 'number' ? 'webhook' : 'batch_export'),
         ],
     }),
     actionToUrl(({ values, props }) => {


### PR DESCRIPTION
## Changes

The base for rendering destination config/info based on it being either a webhook one or batch export one.