### PR TITLE
fix(funnels): actors modal longer query limit

### DIFF
--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -551,7 +551,8 @@
     AND arrayFlatten(array(prop)) = arrayFlatten(array('finance'))
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFunnelGroupBreakdown.test_funnel_breakdown_group.4
@@ -686,7 +687,8 @@
     AND arrayFlatten(array(prop)) = arrayFlatten(array('finance'))
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFunnelGroupBreakdown.test_funnel_breakdown_group.6
@@ -821,7 +823,8 @@
     AND arrayFlatten(array(prop)) = arrayFlatten(array('technology'))
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFunnelGroupBreakdown.test_funnel_breakdown_group.8
@@ -956,7 +959,8 @@
     AND arrayFlatten(array(prop)) = arrayFlatten(array('technology'))
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestStrictFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events
@@ -1489,7 +1493,8 @@
     AND arrayFlatten(array(prop)) = arrayFlatten(array('finance'))
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestStrictFunnelGroupBreakdown.test_funnel_breakdown_group.4
@@ -1602,7 +1607,8 @@
     AND arrayFlatten(array(prop)) = arrayFlatten(array('finance'))
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestStrictFunnelGroupBreakdown.test_funnel_breakdown_group.6
@@ -1715,7 +1721,8 @@
     AND arrayFlatten(array(prop)) = arrayFlatten(array('technology'))
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestStrictFunnelGroupBreakdown.test_funnel_breakdown_group.8
@@ -1828,7 +1835,8 @@
     AND arrayFlatten(array(prop)) = arrayFlatten(array('technology'))
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestUnorderedFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events
@@ -2526,7 +2534,8 @@
     AND arrayFlatten(array(prop)) = arrayFlatten(array('technology'))
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestUnorderedFunnelGroupBreakdown.test_funnel_breakdown_group.14
@@ -2804,7 +2813,8 @@
     AND arrayFlatten(array(prop)) = arrayFlatten(array('technology'))
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestUnorderedFunnelGroupBreakdown.test_funnel_breakdown_group.2
@@ -3082,7 +3092,8 @@
     AND arrayFlatten(array(prop)) = arrayFlatten(array('finance'))
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestUnorderedFunnelGroupBreakdown.test_funnel_breakdown_group.6
@@ -3360,6 +3371,7 @@
     AND arrayFlatten(array(prop)) = arrayFlatten(array('finance'))
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -62,7 +62,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -155,7 +156,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT concat(prop.1, '::', prop.2) as name,
          countDistinctIf(actor_id, steps = target_step) AS success_count,
@@ -255,7 +257,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -339,7 +342,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -423,7 +427,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -507,7 +512,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -579,7 +585,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT concat(prop.1, '::', prop.2) as name,
          countDistinctIf(actor_id, steps = target_step) AS success_count,
@@ -679,7 +686,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -763,7 +771,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -847,7 +856,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -931,7 +941,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -995,7 +1006,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -1080,7 +1092,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -1165,7 +1178,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -1243,7 +1257,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -1318,7 +1333,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -1393,7 +1409,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -1468,7 +1485,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -1551,7 +1569,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -1637,7 +1656,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -1720,7 +1740,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -1803,7 +1824,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -1889,7 +1911,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -1972,7 +1995,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -2055,7 +2079,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -2138,7 +2163,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -2229,7 +2255,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -2323,7 +2350,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -2414,7 +2442,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2020-01-14 23:59:59', 'UTC') AS date_to,
        toDateTime('2020-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -2489,7 +2518,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT concat(prop.1, '::', prop.2) as name,
          countDistinctIf(actor_id, steps = target_step) AS success_count,
@@ -2577,7 +2607,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -2649,7 +2680,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -2721,7 +2753,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -2793,7 +2826,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -2857,7 +2891,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT concat(prop.1, '::', prop.2) as name,
          countDistinctIf(actor_id, steps = target_step) AS success_count,
@@ -2937,7 +2972,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT concat(prop.1, '::', prop.2) as name,
          countDistinctIf(actor_id, steps = target_step) AS success_count,
@@ -3025,7 +3061,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -3097,7 +3134,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -3169,7 +3207,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -3241,7 +3280,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -3305,7 +3345,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT concat(prop.1, '::', prop.2) as name,
          countDistinctIf(actor_id, steps = target_step) AS success_count,
@@ -3387,7 +3428,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT concat(prop.1, '::', prop.2) as name,
          countDistinctIf(actor_id, steps = target_step) AS success_count,
@@ -3477,7 +3519,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -3551,7 +3594,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -3625,7 +3669,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -3699,7 +3744,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -3765,7 +3811,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT concat(prop.1, '::', prop.2) as name,
          countDistinctIf(actor_id, steps = target_step) AS success_count,
@@ -3847,7 +3894,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT concat(prop.1, '::', prop.2) as name,
          countDistinctIf(actor_id, steps = target_step) AS success_count,
@@ -3937,7 +3985,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -4011,7 +4060,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -4085,7 +4135,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -4159,7 +4210,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -4225,7 +4277,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT concat(prop.1, '::', prop.2) as name,
          countDistinctIf(actor_id, steps = target_step) AS success_count,
@@ -4313,7 +4366,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT concat(prop.1, '::', prop.2) as name,
          countDistinctIf(actor_id, steps = target_step) AS success_count,
@@ -4409,7 +4463,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -4489,7 +4544,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -4569,7 +4625,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -4649,7 +4706,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id
   FROM funnel_actors
@@ -4721,7 +4779,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT concat(prop.1, '::', prop.2) as name,
          countDistinctIf(actor_id, steps = target_step) AS success_count,

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -98,7 +98,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2021-01-08 23:59:59', 'UTC') AS date_to,
        toDateTime('2021-01-01 00:00:00', 'UTC') AS date_from,
        2 AS target_step,
@@ -306,7 +307,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2, 3]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        toDateTime('2021-01-08 23:59:59', 'UTC') AS date_to,
        toDateTime('2021-01-01 00:00:00', 'UTC') AS date_from,
        3 AS target_step,
@@ -458,7 +460,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id ,
          any(funnel_actors.matching_events) AS matching_events
@@ -590,7 +593,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id ,
          any(funnel_actors.matching_events) AS matching_events
@@ -722,7 +726,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [1, 2]
-     ORDER BY aggregation_target),
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000),
        2 AS target_step
   SELECT funnel_actors.actor_id AS actor_id ,
          any(funnel_actors.matching_events) AS matching_events

--- a/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
@@ -87,7 +87,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps = 1
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT last_path_key as source_event,
          path_key as target_event,
          COUNT(*) AS event_count,
@@ -254,7 +255,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps = 1
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT DISTINCT person_id AS actor_id
   FROM
     (SELECT person_id,
@@ -416,7 +418,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps = 1
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT DISTINCT person_id AS actor_id
   FROM
     (SELECT person_id,
@@ -578,7 +581,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps = 1
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT DISTINCT person_id AS actor_id
   FROM
     (SELECT person_id,
@@ -740,7 +744,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps = 1
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT DISTINCT person_id AS actor_id
   FROM
     (SELECT person_id,
@@ -902,7 +907,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps = 1
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT last_path_key as source_event,
          path_key as target_event,
          COUNT(*) AS event_count,
@@ -1077,7 +1083,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps = 1
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT DISTINCT person_id AS actor_id
   FROM
     (SELECT person_id,
@@ -1247,7 +1254,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps = 1
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT DISTINCT person_id AS actor_id
   FROM
     (SELECT person_id,
@@ -1417,7 +1425,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps = 1
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT DISTINCT person_id AS actor_id
   FROM
     (SELECT person_id,
@@ -1587,7 +1596,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps = 1
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT DISTINCT person_id AS actor_id
   FROM
     (SELECT person_id,
@@ -1757,7 +1767,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [2, 3]
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT last_path_key as source_event,
          path_key as target_event,
          COUNT(*) AS event_count,
@@ -1924,7 +1935,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [2, 3]
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT last_path_key as source_event,
          path_key as target_event,
          COUNT(*) AS event_count,
@@ -2091,7 +2103,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps = 2
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT last_path_key as source_event,
          path_key as target_event,
          COUNT(*) AS event_count,
@@ -2258,7 +2271,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [2, 3]
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT last_path_key as source_event,
          path_key as target_event,
          COUNT(*) AS event_count,
@@ -2425,7 +2439,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [2, 3]
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT last_path_key as source_event,
          path_key as target_event,
          COUNT(*) AS event_count,
@@ -2594,7 +2609,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [2, 3]
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT DISTINCT person_id AS actor_id
   FROM
     (SELECT person_id,
@@ -2758,7 +2774,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [2, 3]
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT DISTINCT person_id AS actor_id
   FROM
     (SELECT person_id,
@@ -2922,7 +2939,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [2, 3]
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT DISTINCT person_id AS actor_id
   FROM
     (SELECT person_id,
@@ -3086,7 +3104,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [2, 3]
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT DISTINCT person_id AS actor_id
   FROM
     (SELECT person_id,
@@ -3250,7 +3269,8 @@
                  steps
         HAVING steps = max_steps)
      WHERE steps IN [2, 3]
-     ORDER BY aggregation_target)
+     ORDER BY aggregation_target SETTINGS max_ast_elements=1000000,
+                                          max_expanded_ast_elements=1000000)
   SELECT DISTINCT person_id AS actor_id
   FROM
     (SELECT person_id,

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
@@ -98,7 +98,8 @@
   WHERE steps IN [1, 2]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: ClickhouseTestFunnelGroups.test_funnel_group_aggregation_with_groups_entity_filtering
@@ -202,7 +203,8 @@
   WHERE steps IN [1, 2]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: ClickhouseTestFunnelGroups.test_funnel_with_groups_entity_filtering
@@ -319,7 +321,8 @@
   WHERE steps IN [1, 2]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: ClickhouseTestFunnelGroups.test_funnel_with_groups_global_filtering
@@ -450,6 +453,7 @@
   WHERE steps IN [1, 2]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -104,6 +104,7 @@
   WHERE steps IN [1, 2, 3]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_unordered.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_unordered.ambr
@@ -157,6 +157,7 @@
   WHERE steps IN [1, 2]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---

--- a/posthog/queries/funnels/sql.py
+++ b/posthog/queries/funnels/sql.py
@@ -7,4 +7,5 @@ WHERE {persons_steps}
 ORDER BY aggregation_target
 {limit}
 {offset}
+SETTINGS max_ast_elements=1000000, max_expanded_ast_elements=1000000
 """

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -172,7 +172,8 @@
   WHERE steps IN [2, 3]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFOSSFunnel.test_funnel_events_with_person_on_events_v2
@@ -659,7 +660,8 @@
   WHERE steps IN [1, 2, 3]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFOSSFunnel.test_funnel_with_property_groups.2
@@ -766,7 +768,8 @@
   WHERE steps IN [2, 3]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFOSSFunnel.test_funnel_with_property_groups.3
@@ -873,7 +876,8 @@
   WHERE steps IN [3]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFOSSFunnel.test_funnel_with_static_cohort_step_filter

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_persons.ambr
@@ -160,7 +160,8 @@
   WHERE steps IN [1, 2, 3]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFunnelPersons.test_funnel_person_recordings.1
@@ -335,7 +336,8 @@
   WHERE steps IN [2, 3]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFunnelPersons.test_funnel_person_recordings.3
@@ -510,7 +512,8 @@
   WHERE steps = 2
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFunnelPersons.test_funnel_person_recordings.5

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
@@ -121,7 +121,8 @@
   WHERE steps IN [1, 2, 3]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.1
@@ -257,7 +258,8 @@
   WHERE steps IN [2, 3]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.3
@@ -393,7 +395,8 @@
   WHERE steps = 2
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.5

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_trends.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_trends.ambr
@@ -329,6 +329,7 @@
   WHERE steps_completed >= 3
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
@@ -138,7 +138,8 @@
   WHERE steps_completed >= 2
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFunnelTrendsPersons.test_funnel_trend_persons_returns_recordings.1
@@ -292,7 +293,8 @@
     AND steps_completed < 3
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFunnelTrendsPersons.test_funnel_trend_persons_with_drop_off.1
@@ -445,7 +447,8 @@
   WHERE steps_completed >= 3
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFunnelTrendsPersons.test_funnel_trend_persons_with_no_to_step.1

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
@@ -228,7 +228,8 @@
   WHERE steps IN [1, 2, 3]
   ORDER BY aggregation_target
   LIMIT 100
-  OFFSET 0
+  OFFSET 0 SETTINGS max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestFunnelUnorderedStepsPersons.test_unordered_funnel_does_not_return_recordings.1


### PR DESCRIPTION
## Problem

With 16+ steps, the funnel completed/dropdown actors modal doesn't open.

## Changes

Doubles the AST size limit for funnels person queries.

## How did you test this code?

- Tested in production that this setting can be altered by changing it to `2` and seeing an error.
- Tested locally by making a funnel actors query and noting that it contained the following bit:
<img width="746" alt="Screenshot 2024-01-10 at 17 35 41" src="https://github.com/PostHog/posthog/assets/53387/b6916099-834d-4e3c-a098-028edce24ca3">
