### PR TITLE
feat(properties): error if type mismatch

### DIFF
--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
@@ -1,10 +1,11 @@
 import './PropertiesTable.scss'
 
 import { IconPencil } from '@posthog/icons'
-import { LemonCheckbox, LemonInput, Link } from '@posthog/lemon-ui'
+import { LemonCheckbox, LemonInput, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 import { Dropdown, Input, Menu, Popconfirm } from 'antd'
 import clsx from 'clsx'
 import { useValues } from 'kea'
+import { combineUrl } from 'kea-router'
 import { IconDeleteForever } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonTable, LemonTableColumns, LemonTableProps } from 'lib/lemon-ui/LemonTable'
@@ -12,9 +13,10 @@ import { KEY_MAPPING, keyMappingKeys } from 'lib/taxonomy'
 import { isURL } from 'lib/utils'
 import { useMemo, useState } from 'react'
 import { NewProperty } from 'scenes/persons/NewProperty'
+import { urls } from 'scenes/urls'
 
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { PropertyDefinitionType } from '~/types'
+import { PropertyDefinitionType, PropertyType } from '~/types'
 
 import { CopyToClipboardInline } from '../CopyToClipboard'
 import { PropertyKeyInfo } from '../PropertyKeyInfo'
@@ -136,6 +138,16 @@ function ValueDisplay({
                         valueComponent
                     )}
                     <div className="property-value-type">{propertyType || valueType}</div>
+                    {(propertyType === PropertyType.String && valueType === 'number') ||
+                    (propertyType === PropertyType.Numeric && valueType === 'string') ? (
+                        <Tooltip
+                            title={`The event property's type is set to "${propertyType}", while the received value is of type "${valueType}". Click to correct.`}
+                        >
+                            <Link to={combineUrl(urls.propertyDefinitions(), { property: rootKey }).url}>
+                                <LemonTag type="danger">Type mismatch</LemonTag>
+                            </Link>
+                        </Tooltip>
+                    ) : null}
                 </>
             ) : (
                 <EditTextValueComponent value={value} onChange={handleValueChange} />

--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
@@ -141,7 +141,7 @@ function ValueDisplay({
                     {(propertyType === PropertyType.String && valueType === 'number') ||
                     (propertyType === PropertyType.Numeric && valueType === 'string') ? (
                         <Tooltip
-                            title={`The event property's type is set to "${propertyType}", while the received value is of type "${valueType}". Click to correct.`}
+                            title={`This property's type is set to "${propertyType}", yet the displayed value is of type "${valueType}". Click to correct.`}
                         >
                             <Link to={combineUrl(urls.propertyDefinitions(), { property: rootKey }).url}>
                                 <LemonTag type="danger">Type mismatch</LemonTag>

--- a/frontend/src/scenes/data-management/DataManagementScene.tsx
+++ b/frontend/src/scenes/data-management/DataManagementScene.tsx
@@ -1,5 +1,5 @@
 import { actions, connect, kea, path, reducers, selectors, useActions, useValues } from 'kea'
-import { actionToUrl, urlToAction } from 'kea-router'
+import { actionToUrl, combineUrl, router, urlToAction } from 'kea-router'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { PageHeader } from 'lib/components/PageHeader'
 import { TitleWithIcon } from 'lib/components/TitleWithIcon'
@@ -163,7 +163,15 @@ const dataManagementSceneLogic = kea<dataManagementSceneLogicType>([
         ],
     }),
     actionToUrl(() => ({
-        setTab: ({ tab }) => tabs[tab as DataManagementTab]?.url || tabs.events.url,
+        setTab: ({ tab }) => {
+            const tabUrl = tabs[tab as DataManagementTab]?.url || tabs.events.url
+            if (combineUrl(tabUrl).pathname === router.values.location.pathname) {
+                // don't clear the parameters if we're already on the right page
+                // otherwise we can't use a url with parameters as a landing page
+                return
+            }
+            return tabUrl
+        },
     })),
     urlToAction(({ actions, values }) => {
         return Object.fromEntries(


### PR DESCRIPTION
## Problem

We've gotten a lot of errors when a property's type flips between a number and a string.

## Changes

Shows an error if the property's type is different from it's saved type.

<img width="834" alt="image" src="https://github.com/PostHog/posthog/assets/53387/bb7717b6-9c3f-45fb-ae1d-15d87e609c86">

It's not the easiest flow when you click it, but it should be _good enough_ ™ to avoid a few extra support cases.

![2024-01-10 21 22 20](https://github.com/PostHog/posthog/assets/53387/e15e00dc-f880-43ce-bc2b-eb2dbbcba8a3)


## How did you test this code?

Locally, see above. I set the browser language property to a number.
