### PR TITLE
refactor(pipeline-3000): Align API paths with rest of backend

### DIFF
--- a/frontend/src/scenes/pipeline/Pipeline.stories.tsx
+++ b/frontend/src/scenes/pipeline/Pipeline.stories.tsx
@@ -20,7 +20,7 @@ export default {
             get: {
                 'api/organizations/@current/pipeline_transformations/': {},
                 'api/organizations/@current/plugins/': {},
-                'api/projects/:team_id/pipeline_transformations_configs/': {},
+                'api/projects/:team_id/pipeline_transformation_configs/': {},
             },
         }),
     ],
@@ -61,7 +61,7 @@ export function PipelineTransformationsPage(): JSX.Element {
     useStorybookMocks({
         get: {
             'api/organizations/@current/pipeline_transformations/': require('./__mocks__/plugins.json'),
-            'api/projects/:team_id/pipeline_transformations_configs/': require('./__mocks__/transformationPluginConfigs.json'),
+            'api/projects/:team_id/pipeline_transformation_configs/': require('./__mocks__/transformationPluginConfigs.json'),
         },
     })
     useEffect(() => {
@@ -74,7 +74,7 @@ export function PipelineDestinationsPage(): JSX.Element {
     useStorybookMocks({
         get: {
             'api/organizations/@current/pipeline_destinations/': require('./__mocks__/plugins.json'),
-            'api/projects/:team_id/pipeline_destinations_configs/': require('./__mocks__/transformationPluginConfigs.json'),
+            'api/projects/:team_id/pipeline_destination_configs/': require('./__mocks__/transformationPluginConfigs.json'),
         },
     })
     useEffect(() => {

--- a/frontend/src/scenes/pipeline/destinationsLogic.tsx
+++ b/frontend/src/scenes/pipeline/destinationsLogic.tsx
@@ -82,7 +82,7 @@ export const pipelineDestinationsLogic = kea<pipelineDestinationsLogicType>([
                 loadPluginConfigs: async () => {
                     const pluginConfigs: Record<number, PluginConfigTypeNew> = {}
                     const results = await api.loadPaginatedResults(
-                        `api/projects/${values.currentTeamId}/pipeline_destinations_configs`
+                        `api/projects/${values.currentTeamId}/pipeline_destination_configs`
                     )
 
                     for (const pluginConfig of results) {

--- a/frontend/src/scenes/pipeline/transformationsLogic.tsx
+++ b/frontend/src/scenes/pipeline/transformationsLogic.tsx
@@ -53,7 +53,7 @@ export const pipelineTransformationsLogic = kea<pipelineTransformationsLogicType
             {
                 loadPluginConfigs: async () => {
                     const res: PluginConfigTypeNew[] = await api.loadPaginatedResults(
-                        `api/projects/${values.currentTeamId}/pipeline_transformations_configs`
+                        `api/projects/${values.currentTeamId}/pipeline_transformation_configs`
                     )
 
                     return Object.fromEntries(res.map((pluginConfig) => [pluginConfig.id, pluginConfig]))

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -77,16 +77,16 @@ project_plugins_configs_router.register(
     "project_plugins_config_logs",
     ["team_id", "plugin_config_id"],
 )
-pipeline_transformations_configs_router = projects_router.register(
-    r"pipeline_transformations_configs",
+pipeline_transformation_configs_router = projects_router.register(
+    r"pipeline_transformation_configs",
     plugin.PipelineTransformationsConfigsViewSet,
-    "pipeline_transformations_configs",
+    "project_pipeline_transformation_configs",
     ["team_id"],
 )
-pipeline_destinations_configs_router = projects_router.register(
-    r"pipeline_destinations_configs",
+pipeline_destination_configs_router = projects_router.register(
+    r"pipeline_destination_configs",
     plugin.PipelineDestinationsConfigsViewSet,
-    "pipeline_destinations_configs",
+    "project_pipeline_destination_configs",
     ["team_id"],
 )
 


### PR DESCRIPTION
## Problem

We have `.../plugins/` and  `.../plugin_configs/` in the API. In the second example, "plugin" is singular, because it's used as an adjective. The new pipeline APIs had `.../pipeline_transformations/` and `.../pipeline_transformations_configs`, which didn't follow this rule.

## Changes

The rule is now followed: `.../pipeline_transformation_configs/`.

## How did you test this code?

All existing tests should pass.