### PR TITLE
chore: Add a log line after creating big query table

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -210,6 +210,8 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs):
                 bq_client,
             )
 
+            logger.debug("Working with table schema %s", table_schema)
+
             with BatchExportTemporaryFile() as jsonl_file:
                 rows_exported = get_rows_exported_metric()
                 bytes_exported = get_bytes_exported_metric()


### PR DESCRIPTION
## Problem

Trying to debug an issue with bigquery tables not being created with JSON types. Both unit tests and manual tests are working fine, so the next step is seeing if we get some visibility on the cases that fail.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add a debug log line after creating a bigquery table.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
