### PR TITLE
feat: wait less for realtime snapshots

### DIFF
--- a/posthog/session_recordings/realtime_snapshots.py
+++ b/posthog/session_recordings/realtime_snapshots.py
@@ -26,14 +26,32 @@ REALTIME_SUBSCRIPTIONS_LOADED_COUNTER = Counter(
 
 SUBSCRIPTION_CHANNEL = "@posthog/replay/realtime-subscriptions"
 
-ATTEMPT_MAX = 5
-# we multiply by the attempt count to increase the timeout
-# so this gives us a sequence of 0.1, 0.2, 0.3, 0.4, 0.5
+ATTEMPT_MAX = 6
 ATTEMPT_TIMEOUT_SECONDS = 0.1
 
 
 def get_key(team_id: str, suffix: str) -> str:
     return f"@posthog/replay/snapshots/team-{team_id}/{suffix}"
+
+
+def publish_subscription(team_id: str, session_id: str) -> None:
+    # We always publish as it could be that a rebalance has occurred
+    # and the consumer doesn't know it should be sending data to redis
+    try:
+        redis = get_client(settings.SESSION_RECORDING_REDIS_URL)
+        redis.publish(
+            SUBSCRIPTION_CHANNEL,
+            json.dumps({"team_id": team_id, "session_id": session_id}),
+        )
+    except Exception as e:
+        capture_exception(
+            e,
+            extras={
+                "operation": "publish_realtime_subscription",
+            },
+            tags={"team_id": team_id, "session_id": session_id},
+        )
+        raise e
 
 
 def get_realtime_snapshots(team_id: str, session_id: str, attempt_count=0) -> Optional[List[Dict]]:
@@ -44,10 +62,7 @@ def get_realtime_snapshots(team_id: str, session_id: str, attempt_count=0) -> Op
 
         # We always publish as it could be that a rebalance has occurred
         # and the consumer doesn't know it should be sending data to redis
-        redis.publish(
-            SUBSCRIPTION_CHANNEL,
-            json.dumps({"team_id": team_id, "session_id": session_id}),
-        )
+        publish_subscription(team_id, session_id)
 
         if not encoded_snapshots and attempt_count < ATTEMPT_MAX:
             logger.info(
@@ -57,15 +72,15 @@ def get_realtime_snapshots(team_id: str, session_id: str, attempt_count=0) -> Op
                 attempt_count=attempt_count,
             )
             # If we don't have it we could be in the process of getting it and syncing it
-            redis.publish(
-                SUBSCRIPTION_CHANNEL,
-                json.dumps({"team_id": team_id, "session_id": session_id}),
-            )
+            publish_subscription(team_id, session_id)
+
             PUBLISHED_REALTIME_SUBSCRIPTIONS_COUNTER.labels(
                 team_id=team_id, session_id=session_id, attempt_count=attempt_count
             ).inc()
 
-            sleep(ATTEMPT_TIMEOUT_SECONDS * attempt_count)
+            # this means we'll sleep 0.1, 0.1, 0,1, 0.2, 0.2, 0.2
+            # for a total of 0.9 seconds
+            sleep(ATTEMPT_TIMEOUT_SECONDS if attempt_count < 4 else ATTEMPT_TIMEOUT_SECONDS * 2)
             return get_realtime_snapshots(team_id, session_id, attempt_count + 1)
 
         if encoded_snapshots:

--- a/posthog/session_recordings/realtime_snapshots.py
+++ b/posthog/session_recordings/realtime_snapshots.py
@@ -74,9 +74,7 @@ def get_realtime_snapshots(team_id: str, session_id: str, attempt_count=0) -> Op
             # If we don't have it we could be in the process of getting it and syncing it
             publish_subscription(team_id, session_id)
 
-            PUBLISHED_REALTIME_SUBSCRIPTIONS_COUNTER.labels(
-                team_id=team_id, session_id=session_id, attempt_count=attempt_count
-            ).inc()
+            PUBLISHED_REALTIME_SUBSCRIPTIONS_COUNTER.labels(attempt_count=attempt_count).inc()
 
             # this means we'll sleep 0.1, 0.1, 0,1, 0.2, 0.2, 0.2
             # for a total of 0.9 seconds

--- a/posthog/session_recordings/realtime_snapshots.py
+++ b/posthog/session_recordings/realtime_snapshots.py
@@ -35,8 +35,11 @@ def get_key(team_id: str, suffix: str) -> str:
 
 
 def publish_subscription(team_id: str, session_id: str) -> None:
-    # We always publish as it could be that a rebalance has occurred
-    # and the consumer doesn't know it should be sending data to redis
+    """
+    Publishing a subscription notifies each instance of Mr Blobby of the request for realtime playback
+    Only zero or one instances will be handling the session, if they are, they will start publishing
+    the snapshot data to Redis so that it can be played before the data has been sent to blob storage
+    """
     try:
         redis = get_client(settings.SESSION_RECORDING_REDIS_URL)
         redis.publish(

--- a/posthog/session_recordings/realtime_snapshots.py
+++ b/posthog/session_recordings/realtime_snapshots.py
@@ -71,8 +71,6 @@ def get_realtime_snapshots(team_id: str, session_id: str, attempt_count=0) -> Op
                 session_id=session_id,
                 attempt_count=attempt_count,
             )
-            # If we don't have it we could be in the process of getting it and syncing it
-            publish_subscription(team_id, session_id)
 
             PUBLISHED_REALTIME_SUBSCRIPTIONS_COUNTER.labels(attempt_count=attempt_count).inc()
 

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -45,7 +45,7 @@ from posthog.rate_limit import (
     ClickHouseSustainedRateThrottle,
 )
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
-from posthog.session_recordings.realtime_snapshots import get_realtime_snapshots
+from posthog.session_recordings.realtime_snapshots import get_realtime_snapshots, publish_subscription
 from posthog.session_recordings.snapshots.convert_legacy_snapshots import (
     convert_original_version_lts_recording,
 )
@@ -379,6 +379,11 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
                         "end_timestamp": None,
                     }
                 )
+                # the UI will use this to try to load realtime snapshots
+                # so, we can publish the request for Mr. Blobby to start syncing to Redis now
+                # it takes a short while for the subscription to be sync'd into redis
+                # let's use the network round trip time to get started
+                publish_subscription(team_id=str(self.team.pk), session_id=str(recording.session_id))
 
             response_data["sources"] = sources
 


### PR DESCRIPTION
We're waiting up to 5 seconds for real-time snapshots... 

And we're getting frequent reports of "buffering taking a long time"

So, do we need to wait 5 seconds?

----

We have a counter for the number of times we make a request and its attempt count, and the number of times we succeed and its attempt count.

Looking at successes over the last 7 days 97% of the time we succeed in the first two attempts i.e. at 0 or 0.5 seconds delay

Two-thirds of those first or second-attempt successes were on the second attempt (i.e. after 0.5 seconds)

----

succeeding on attempt_count = 0 must mean that we had previously published the request for real-time snapshots and then reloaded the same recording, so that redis already has a record for that recording 

---

so this PR does three things

* Check Redis for data more frequently for a shorter period
    * sessions that are not available will wait 1.5s instead of 5s
    * sessions that would have replied within 0.5s will potentially reply after 0.1, 0.2, or 0.3 seconds
* the getter method would publish the subscription, and if the data was not available, log a message, and immediately republish the subscription, that's not necessary so it doesn't do that any more
* When the snapshot API tells a caller to check for real-time snapshots, it also publishes the subscription request so that the network round trip time can be used to start syncing the data instead of waiting for the request we know is coming. this should mean more sessions reply "immediately" instead of after 0.x seconds of sleep
