### PR TITLE
feat: add and separator to toolbar

### DIFF
--- a/frontend/src/scenes/actions/ActionStep.tsx
+++ b/frontend/src/scenes/actions/ActionStep.tsx
@@ -178,7 +178,7 @@ function Option({
     )
 }
 
-export const AndSeparator = (): JSX.Element => {
+const AndSeparator = (): JSX.Element => {
     return (
         <div className="flex w-full justify-center">
             <OperandTag operand="and" />

--- a/frontend/src/scenes/actions/ActionStep.tsx
+++ b/frontend/src/scenes/actions/ActionStep.tsx
@@ -178,7 +178,7 @@ function Option({
     )
 }
 
-const AndSeparator = (): JSX.Element => {
+export const AndSeparator = (): JSX.Element => {
     return (
         <div className="flex w-full justify-center">
             <OperandTag operand="and" />

--- a/frontend/src/toolbar/actions/ActionsEditingToolbarMenu.tsx
+++ b/frontend/src/toolbar/actions/ActionsEditingToolbarMenu.tsx
@@ -153,7 +153,7 @@ export const ActionsEditingToolbarMenu = (): JSX.Element => {
                                                 label="Text"
                                                 caption="Text content inside your element"
                                             />
-                                            <LemonTag type={'highlight'}>
+                                            <LemonTag type="highlight">
                                                 <span className="uppercase">and</span>
                                             </LemonTag>
                                             <StepField

--- a/frontend/src/toolbar/actions/ActionsEditingToolbarMenu.tsx
+++ b/frontend/src/toolbar/actions/ActionsEditingToolbarMenu.tsx
@@ -144,7 +144,7 @@ export const ActionsEditingToolbarMenu = (): JSX.Element => {
                                                     </>
                                                 }
                                             />
-                                            <LemonTag type={'highlight'}>
+                                            <LemonTag type="highlight">
                                                 <span className="uppercase">and</span>
                                             </LemonTag>
                                             <StepField

--- a/frontend/src/toolbar/actions/ActionsEditingToolbarMenu.tsx
+++ b/frontend/src/toolbar/actions/ActionsEditingToolbarMenu.tsx
@@ -4,6 +4,7 @@ import { Field, Form, Group } from 'kea-forms'
 import { IconClose, IconDelete, IconEdit, IconMagnifier, IconMinusOutlined, IconPlus } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { AndSeparator } from 'scenes/actions/ActionStep'
 
 import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
 import { SelectorEditingModal } from '~/toolbar/actions/SelectorEditingModal'
@@ -144,13 +145,14 @@ export const ActionsEditingToolbarMenu = (): JSX.Element => {
                                                     </>
                                                 }
                                             />
+                                            <AndSeparator />
                                             <StepField
                                                 step={step}
                                                 item="text"
                                                 label="Text"
                                                 caption="Text content inside your element"
                                             />
-
+                                            <AndSeparator />
                                             <StepField
                                                 step={step}
                                                 item="url"

--- a/frontend/src/toolbar/actions/ActionsEditingToolbarMenu.tsx
+++ b/frontend/src/toolbar/actions/ActionsEditingToolbarMenu.tsx
@@ -1,10 +1,9 @@
-import { LemonDivider } from '@posthog/lemon-ui'
+import { LemonDivider, LemonTag } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { Field, Form, Group } from 'kea-forms'
 import { IconClose, IconDelete, IconEdit, IconMagnifier, IconMinusOutlined, IconPlus } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
-import { AndSeparator } from 'scenes/actions/ActionStep'
 
 import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
 import { SelectorEditingModal } from '~/toolbar/actions/SelectorEditingModal'
@@ -145,14 +144,18 @@ export const ActionsEditingToolbarMenu = (): JSX.Element => {
                                                     </>
                                                 }
                                             />
-                                            <AndSeparator />
+                                            <LemonTag type={'highlight'}>
+                                                <span className="uppercase">and</span>
+                                            </LemonTag>
                                             <StepField
                                                 step={step}
                                                 item="text"
                                                 label="Text"
                                                 caption="Text content inside your element"
                                             />
-                                            <AndSeparator />
+                                            <LemonTag type={'highlight'}>
+                                                <span className="uppercase">and</span>
+                                            </LemonTag>
                                             <StepField
                                                 step={step}
                                                 item="url"


### PR DESCRIPTION
When editing an action in posthog we make it clear the conditions are ANDed.

let's make it clear in the toolbar too

<img width="392" alt="Screenshot 2024-01-11 at 22 03 38" src="https://github.com/PostHog/posthog/assets/984817/943d2e80-d4e2-456c-88fa-70676fbe4ece">
