### PR TITLE
fix: exception autocapture lost its flag

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -81,6 +81,7 @@ export const SettingsMap: SettingSection[] = [
                 id: 'exception-autocapture',
                 title: 'Exception Autocapture',
                 component: <ExceptionAutocaptureSettings />,
+                flag: 'EXCEPTION_AUTOCAPTURE',
             },
             {
                 id: 'autocapture-data-attributes',


### PR DESCRIPTION
exception autocapture has a remote config section in settings. it _was_ behind a flag and only active for ben and paul

i guess in the switch to being a data driven settings section we lost the flag so it is available for all users to turn on for e.g. https://posthoghelp.zendesk.com/agent/tickets/9210 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/11315)

this puts it back behind a flag