### PR TITLE
feat: add a URL to link to new dashboard modal

### DIFF
--- a/frontend/src/scenes/dashboard/newDashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/newDashboardLogic.ts
@@ -1,6 +1,6 @@
 import { actions, connect, isBreakpoint, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
-import { router } from 'kea-router'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 import api from 'lib/api'
 import { DashboardRestrictionLevel } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
@@ -196,4 +196,23 @@ export const newDashboardLogic = kea<newDashboardLogicType>([
             actions.setActiveDashboardTemplate(template)
         },
     })),
+    urlToAction(({ actions }) => ({
+        '/dashboard': (_, _searchParams, hashParams) => {
+            if ('newDashboard' in hashParams) {
+                actions.showNewDashboardModal()
+            }
+        },
+    })),
+    actionToUrl({
+        hideNewDashboardModal: () => {
+            const hashParams = router.values.hashParams
+            delete hashParams['newDashboard']
+            return [router.values.location.pathname, router.values.searchParams, hashParams]
+        },
+        showNewDashboardModal: () => {
+            const hashParams = router.values.hashParams
+            hashParams['newDashboard'] = 'modal'
+            return [router.values.location.pathname, router.values.searchParams, hashParams]
+        },
+    }),
 ])


### PR DESCRIPTION
* adds a hash param to URL when the new dashboard modal opens
* clears it when it closes
* loads the new dashboard modal if someonevisits {posthog-url}/dashboard#newDashboard

![2024-01-12 15 50 51](https://github.com/PostHog/posthog/assets/984817/4e936b71-6332-46bf-b8c3-7f35f8432d88)
