### PR TITLE
feat(3000): bring back pinned dashboards in navigation

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -15,13 +15,14 @@ import {
     IconTestTube,
     IconToggle,
 } from '@posthog/icons'
-import { LemonButton, lemonToast, Spinner } from '@posthog/lemon-ui'
+import { lemonToast, Spinner } from '@posthog/lemon-ui'
 import { captureException } from '@sentry/react'
 import { actions, connect, events, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { router } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { IconPlusMini } from 'lib/lemon-ui/icons'
+import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { isNotNil } from 'lib/utils'
 import React from 'react'
@@ -339,28 +340,22 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                                 identifier: 'pinned-dashboards-dropdown',
                                 dropdown: {
                                     overlay: (
-                                        <div className="w-50">
-                                            <p className="text-xs text-text-secondary-3000 uppercase font-bold px-2 mt-2 mb-1">
-                                                Pinned dashboards
-                                            </p>
-                                            {dashboardsLoading ? (
-                                                <div className="px-2 py-1 text-text-secondary-3000">
-                                                    <Spinner /> Loading…
-                                                </div>
-                                            ) : (
-                                                <>
-                                                    {pinnedDashboards.map((dashboard) => (
-                                                        <LemonButton
-                                                            key={dashboard.id}
-                                                            to={urls.dashboard(dashboard.id)}
-                                                            fullWidth
-                                                        >
-                                                            {dashboard.name}
-                                                        </LemonButton>
-                                                    ))}
-                                                </>
-                                            )}
-                                        </div>
+                                        <LemonMenuOverlay
+                                            items={[
+                                                {
+                                                    title: 'Pinned dashboards',
+                                                    items: pinnedDashboards.map((dashboard) => ({
+                                                        label: dashboard.name,
+                                                        to: urls.dashboard(dashboard.id),
+                                                    })),
+                                                    footer: dashboardsLoading && (
+                                                        <div className="px-2 py-1 text-text-secondary-3000">
+                                                            <Spinner /> Loading…
+                                                        </div>
+                                                    ),
+                                                },
+                                            ]}
+                                        />
                                     ),
                                     placement: 'bottom-end',
                                 },

--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -335,30 +335,30 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                             icon: <IconDashboard />,
                             logic: isUsingSidebar ? dashboardsSidebarLogic : undefined,
                             to: isUsingSidebar ? undefined : urls.dashboards(),
-                            sideAction: dashboardsLoading
-                                ? {
-                                      identifier: 'pinned-dashboards-dropdown',
-                                      icon: <Spinner textColored className="text-sm" />,
-                                  }
-                                : {
-                                      identifier: 'pinned-dashboards-dropdown',
-                                      dropdown: {
-                                          overlay: (
-                                              <div className="w-50">
-                                                  {pinnedDashboards.map((dashboard) => (
-                                                      <LemonButton
-                                                          key={dashboard.id}
-                                                          to={urls.dashboard(dashboard.id)}
-                                                          fullWidth
-                                                      >
-                                                          {dashboard.name}
-                                                      </LemonButton>
-                                                  ))}
-                                              </div>
-                                          ),
-                                          placement: 'bottom-end',
-                                      },
-                                  },
+                            sideAction: {
+                                identifier: 'pinned-dashboards-dropdown',
+                                dropdown: {
+                                    overlay:
+                                        dashboardsLoading || true ? (
+                                            <div className="w-50 px-2 py-1">
+                                                <Spinner textColored /> Loading…
+                                            </div>
+                                        ) : (
+                                            <div className="w-50">
+                                                {pinnedDashboards.map((dashboard) => (
+                                                    <LemonButton
+                                                        key={dashboard.id}
+                                                        to={urls.dashboard(dashboard.id)}
+                                                        fullWidth
+                                                    >
+                                                        {dashboard.name}
+                                                    </LemonButton>
+                                                ))}
+                                            </div>
+                                        ),
+                                    placement: 'bottom-end',
+                                },
+                            },
                         },
                         {
                             identifier: Scene.Notebooks,

--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -338,24 +338,30 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                             sideAction: {
                                 identifier: 'pinned-dashboards-dropdown',
                                 dropdown: {
-                                    overlay:
-                                        dashboardsLoading || true ? (
-                                            <div className="w-50 px-2 py-1">
-                                                <Spinner textColored /> Loading…
-                                            </div>
-                                        ) : (
-                                            <div className="w-50">
-                                                {pinnedDashboards.map((dashboard) => (
-                                                    <LemonButton
-                                                        key={dashboard.id}
-                                                        to={urls.dashboard(dashboard.id)}
-                                                        fullWidth
-                                                    >
-                                                        {dashboard.name}
-                                                    </LemonButton>
-                                                ))}
-                                            </div>
-                                        ),
+                                    overlay: (
+                                        <div className="w-50">
+                                            <p className="text-xs text-text-secondary-3000 uppercase font-bold px-2 mt-2 mb-1">
+                                                Pinned dashboards
+                                            </p>
+                                            {dashboardsLoading ? (
+                                                <div className="px-2 py-1 text-text-secondary-3000">
+                                                    <Spinner /> Loading…
+                                                </div>
+                                            ) : (
+                                                <>
+                                                    {pinnedDashboards.map((dashboard) => (
+                                                        <LemonButton
+                                                            key={dashboard.id}
+                                                            to={urls.dashboard(dashboard.id)}
+                                                            fullWidth
+                                                        >
+                                                            {dashboard.name}
+                                                        </LemonButton>
+                                                    ))}
+                                                </>
+                                            )}
+                                        </div>
+                                    ),
                                     placement: 'bottom-end',
                                 },
                             },

--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -15,7 +15,7 @@ import {
     IconTestTube,
     IconToggle,
 } from '@posthog/icons'
-import { lemonToast } from '@posthog/lemon-ui'
+import { LemonButton, lemonToast, Spinner } from '@posthog/lemon-ui'
 import { captureException } from '@sentry/react'
 import { actions, connect, events, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { router } from 'kea-router'
@@ -28,6 +28,8 @@ import React from 'react'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
+
+import { dashboardsModel } from '~/models/dashboardsModel'
 
 import { navigationLogic } from '../navigation/navigationLogic'
 import type { navigation3000LogicType } from './navigationLogicType'
@@ -312,8 +314,12 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
             (isNavCollapsedDesktop, mobileLayout): boolean => !mobileLayout && isNavCollapsedDesktop,
         ],
         navbarItems: [
-            () => [featureFlagLogic.selectors.featureFlags],
-            (featureFlags): NavbarItem[][] => {
+            () => [
+                featureFlagLogic.selectors.featureFlags,
+                dashboardsModel.selectors.dashboardsLoading,
+                dashboardsModel.selectors.pinnedDashboards,
+            ],
+            (featureFlags, dashboardsLoading, pinnedDashboards): NavbarItem[][] => {
                 const isUsingSidebar = featureFlags[FEATURE_FLAGS.POSTHOG_3000_NAV]
                 return [
                     [
@@ -329,6 +335,30 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                             icon: <IconDashboard />,
                             logic: isUsingSidebar ? dashboardsSidebarLogic : undefined,
                             to: isUsingSidebar ? undefined : urls.dashboards(),
+                            sideAction: dashboardsLoading
+                                ? {
+                                      identifier: 'pinned-dashboards-dropdown',
+                                      icon: <Spinner textColored className="text-sm" />,
+                                  }
+                                : {
+                                      identifier: 'pinned-dashboards-dropdown',
+                                      dropdown: {
+                                          overlay: (
+                                              <div className="w-50">
+                                                  {pinnedDashboards.map((dashboard) => (
+                                                      <LemonButton
+                                                          key={dashboard.id}
+                                                          to={urls.dashboard(dashboard.id)}
+                                                          fullWidth
+                                                      >
+                                                          {dashboard.name}
+                                                      </LemonButton>
+                                                  ))}
+                                              </div>
+                                          ),
+                                          placement: 'bottom-end',
+                                      },
+                                  },
                         },
                         {
                             identifier: Scene.Notebooks,

--- a/frontend/src/layout/navigation-3000/types.ts
+++ b/frontend/src/layout/navigation-3000/types.ts
@@ -30,7 +30,7 @@ interface NavbarItemBase {
     icon: JSX.Element
     featureFlag?: (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
     tag?: 'alpha' | 'beta' | 'new'
-    sideAction?: Pick<SideAction, 'icon' | 'to' | 'onClick' | 'tooltip'> & { identifier: string }
+    sideAction?: Pick<SideAction, 'icon' | 'to' | 'onClick' | 'tooltip' | 'dropdown'> & { identifier: string }
 }
 export interface SceneNavbarItem extends NavbarItemBase {
     to: string


### PR DESCRIPTION
## Problem

Users have been asking us to bring back pinned dashboards in the nav https://posthog.slack.com/archives/C04L2CV12V9/p1704902127455749

## Changes

This PR does that.

![2024-01-12 17 40 03](https://github.com/PostHog/posthog/assets/1851359/34077c5e-f9cb-4b58-be84-2b1147187cbb)

## How did you test this code?

:eyes: