### PR TITLE
wip: fix redux devtools

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -49,7 +49,17 @@ export const loggerPlugin: () => KeaPlugin = () => ({
     events: {
         beforeReduxStore(options) {
             options.middleware.push((store) => (next) => (action) => {
+                try {
+                    JSON.stringify(action)
+                } catch (e) {
+                    console.error('!!!!!!!! Could not stringify action', action)
+                }
                 const response = next(action)
+                try {
+                    JSON.stringify(store.getState())
+                } catch (e) {
+                    console.error('!!!!!!!! Could not stringify store')
+                }
                 /* eslint-disable no-console */
                 console.groupCollapsed('KEA LOGGER', action)
                 console.log(store.getState())
@@ -104,9 +114,9 @@ export function initKea({ routerHistory, routerLocation, beforePlugins }: InitKe
         waitForPlugin,
     ]
 
-    if (window.JS_KEA_VERBOSE_LOGGING) {
-        plugins.push(loggerPlugin)
-    }
+    // if (window.JS_KEA_VERBOSE_LOGGING) {
+    plugins.push(loggerPlugin)
+    // }
 
     resetContext({
         plugins: plugins,

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/activityForSceneLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/activityForSceneLogic.ts
@@ -3,7 +3,7 @@ import { router } from 'kea-router'
 import { objectsEqual } from 'kea-test-utils'
 import { ActivityLogItem } from 'lib/components/ActivityLog/humanizeActivity'
 import { sceneLogic } from 'scenes/sceneLogic'
-import { SceneConfig } from 'scenes/sceneTypes'
+import { SceneConfig, SceneParams } from 'scenes/sceneTypes'
 
 import { ActivityScope, UserBasicType } from '~/types'
 
@@ -40,9 +40,11 @@ export const activityForSceneLogic = kea<activityForSceneLogicType>([
                     const sceneConfig = s.sceneConfig(state, props)
                     if (activeSceneLogic && 'activityFilters' in activeSceneLogic.selectors) {
                         const activeLoadedScene = sceneLogic.selectors.activeLoadedScene(state, props)
+                        const activeSceneExport = sceneLogic.selectors.activeSceneExport(state, props)
                         return activeSceneLogic.selectors.activityFilters(
                             state,
-                            activeLoadedScene?.paramsToProps?.(activeLoadedScene?.sceneParams) || props
+                            activeSceneExport?.paramsToProps?.(activeLoadedScene?.sceneParams ?? ({} as SceneParams)) ||
+                                props
                         )
                     } else {
                         return activityFiltersForScene(sceneConfig)

--- a/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
+++ b/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
@@ -6,6 +6,7 @@ import { identifierToHuman, objectsEqual, stripHTTP } from 'lib/utils'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
+import { SceneParams } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 
@@ -45,10 +46,10 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>([
         finishRenaming: true,
     }),
     reducers({
-        actionsContainer: [
-            null as HTMLElement | null,
+        hasActionsContainer: [
+            false,
             {
-                setActionsContainer: (_, { element }) => element,
+                setActionsContainer: () => true,
             },
         ],
         renameState: [
@@ -72,9 +73,11 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>([
                     const activeScene = s.activeScene(state, props)
                     if (activeSceneLogic && 'breadcrumbs' in activeSceneLogic.selectors) {
                         const activeLoadedScene = sceneLogic.selectors.activeLoadedScene(state, props)
+                        const activeSceneExport = sceneLogic.selectors.activeSceneExport(state, props)
                         return activeSceneLogic.selectors.breadcrumbs(
                             state,
-                            activeLoadedScene?.paramsToProps?.(activeLoadedScene?.sceneParams) || props
+                            activeSceneExport?.paramsToProps?.(activeLoadedScene?.sceneParams ?? ({} as SceneParams)) ||
+                                props
                         )
                     } else if (activeScene) {
                         const sceneConfig = s.sceneConfig(state, props)
@@ -201,4 +204,9 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>([
             }
         },
     }),
+    listeners(({ cache }) => ({
+        setActionsContainer: ({ actionsContainer }) => {
+            cache.actionsContainer = actionsContainer
+        },
+    })),
 ])

--- a/frontend/src/lib/components/PageHeader.tsx
+++ b/frontend/src/lib/components/PageHeader.tsx
@@ -15,7 +15,10 @@ interface PageHeaderProps {
 }
 
 export function PageHeader({ caption, buttons, tabbedPage }: PageHeaderProps): JSX.Element | null {
-    const { actionsContainer } = useValues(breadcrumbsLogic)
+    const { hasActionsContainer } = useValues(breadcrumbsLogic)
+    const actionsContainer = hasActionsContainer
+        ? breadcrumbsLogic.findMounted()?.cache?.actionsContainer ?? null
+        : null
 
     return (
         <>

--- a/frontend/src/scenes/actions/ActionStep.tsx
+++ b/frontend/src/scenes/actions/ActionStep.tsx
@@ -309,12 +309,12 @@ function TypeSwitcher({
                         label: 'Autocapture',
                     },
                     {
-                        value: 'event',
-                        label: 'Custom event',
+                        value: '$pageview',
+                        label: 'Pageview',
                     },
                     {
-                        value: '$pageview',
-                        label: 'Page view',
+                        value: 'event',
+                        label: 'All events',
                     },
                 ]}
                 fullWidth

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -1,10 +1,12 @@
-import { preloadedScenes } from 'scenes/scenes'
+import { preloadedSceneExports } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
 
 export const appScenes: Record<Scene, () => any> = {
-    [Scene.Error404]: () => ({ default: preloadedScenes[Scene.Error404].component }),
-    [Scene.ErrorNetwork]: () => ({ default: preloadedScenes[Scene.ErrorNetwork].component }),
-    [Scene.ErrorProjectUnavailable]: () => ({ default: preloadedScenes[Scene.ErrorProjectUnavailable].component }),
+    [Scene.Error404]: () => ({ default: preloadedSceneExports[Scene.Error404].component }),
+    [Scene.ErrorNetwork]: () => ({ default: preloadedSceneExports[Scene.ErrorNetwork].component }),
+    [Scene.ErrorProjectUnavailable]: () => ({
+        default: preloadedSceneExports[Scene.ErrorProjectUnavailable].component,
+    }),
     [Scene.Dashboards]: () => import('./dashboard/dashboards/Dashboards'),
     [Scene.Dashboard]: () => import('./dashboard/Dashboard'),
     [Scene.Insight]: () => import('./insights/InsightScene'),

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -89,13 +89,13 @@ export interface SceneExport {
     logic?: LogicWrapper
     /** convert URL parameters from scenes.ts into logic props */
     paramsToProps?: (params: SceneParams) => SceneProps
-    /** when was the scene last touched, unix timestamp for sortability */
-    lastTouch?: number
 }
 
-export interface LoadedScene extends SceneExport {
+export interface LoadedScene {
     id: string
     sceneParams: SceneParams
+    /** when was the scene last touched, unix timestamp for sortability */
+    lastTouch?: number
 }
 
 export interface SceneParams {

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -2,7 +2,7 @@ import { combineUrl } from 'kea-router'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { getDefaultEventsSceneQuery } from 'scenes/events/defaults'
-import { LoadedScene, Params, Scene, SceneConfig } from 'scenes/sceneTypes'
+import { LoadedScene, Params, Scene, SceneConfig, SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { Error404 as Error404Component } from '~/layout/Error404'
@@ -16,18 +16,26 @@ export const emptySceneParams = { params: {}, searchParams: {}, hashParams: {} }
 export const preloadedScenes: Record<string, LoadedScene> = {
     [Scene.Error404]: {
         id: Scene.Error404,
-        component: Error404Component,
         sceneParams: emptySceneParams,
     },
     [Scene.ErrorNetwork]: {
         id: Scene.ErrorNetwork,
-        component: ErrorNetworkComponent,
         sceneParams: emptySceneParams,
     },
     [Scene.ErrorProjectUnavailable]: {
         id: Scene.ErrorProjectUnavailable,
-        component: ErrorProjectUnavailableComponent,
         sceneParams: emptySceneParams,
+    },
+}
+export const preloadedSceneExports: Record<string, SceneExport> = {
+    [Scene.Error404]: {
+        component: Error404Component,
+    },
+    [Scene.ErrorNetwork]: {
+        component: ErrorNetworkComponent,
+    },
+    [Scene.ErrorProjectUnavailable]: {
+        component: ErrorProjectUnavailableComponent,
     },
 }
 


### PR DESCRIPTION
## Problem

The Redux Devtools crash on us. That's because we send to our store non-JSONable data. 

## Changes

Tries to get that data out.

Still WIP and not sure if worth it till the end.

## How did you test this code?

I added code that checks if the store is serializable after every action, and fixed cases where it wasn't. We were:
- Storing a `HTMLElement` in `breadCrumbsLogic`
- Storing the scene's `logic` and component in `sceneLogic`

We still are:
- Storing all sorts of `ref`-s in `insightLogic`, notebook logics, etc
- Storing HTML elements in `toolbarLogic`.