### PR TITLE
fix(batch-exports): Always use SSL for Postgres, but disable cert che…

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -34,17 +34,19 @@ from posthog.temporal.batch_exports.metrics import (
 @contextlib.asynccontextmanager
 async def postgres_connection(inputs) -> typing.AsyncIterator[psycopg.AsyncConnection]:
     """Manage a Postgres connection."""
+    kwargs: dict[str, typing.Any] = {}
+    if inputs.has_self_signed_cert:
+        # Disable certificate verification for self-signed certificates.
+        kwargs["sslrootcert"] = None
+
     connection = await psycopg.AsyncConnection.connect(
         user=inputs.user,
         password=inputs.password,
         dbname=inputs.database,
         host=inputs.host,
         port=inputs.port,
-        # The 'hasSelfSignedCert' parameter in the postgres-plugin was provided mainly
-        # for users of Heroku and RDS. It was used to set 'rejectUnauthorized' to false if a self-signed cert was used.
-        # Mapping this to sslmode is not straight-forward, but going by Heroku's recommendation (see below) we should use 'disable'.
-        # Reference: https://devcenter.heroku.com/articles/connecting-heroku-postgres#connecting-in-node-js
-        sslmode="disable" if inputs.has_self_signed_cert is True else "prefer",
+        sslmode="prefer" if settings.TEST else "require",
+        **kwargs,
     )
 
     try:


### PR DESCRIPTION
…cking for self signed

## Problem

We should (IMO) _always_ use SSL for outgoing connections. Raw connections put us at risk of leaking customer auth/data.

See also: https://posthoghelp.zendesk.com/agent/tickets/9245 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/11401)
See also: https://github.com/PostHog/posthog/issues/19251

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Instead of disabling SSL, disable checking the server cert (when necessary).

It was really annoying to figure out how to do this. I saw an offhand comment about `null` `sslrootcert`. Digging through Postgres, it seems legit (see top, where it's copied into `fnbuf`, and then it's `null`, so it falls into the branch where it doesn't perform verification):

https://github.com/postgres/postgres/blob/5fd61055eacf3d0c45be20b90402a87c9848db43/src/interfaces/libpq/fe-secure-openssl.c#L1048-L1112
and then
https://github.com/postgres/postgres/blob/5fd61055eacf3d0c45be20b90402a87c9848db43/src/interfaces/libpq/fe-secure-openssl.c#L1456-L1461

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
