### PR TITLE
fix: cannot read body twice

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -61,8 +61,8 @@ jobs:
                         # the dependencies more clear if we separated the backend/frontend
                         # code completely
                         # really we should ignore ee/frontend/** but dorny doesn't support that
+                        # - '!ee/frontend/**'
                         - 'ee/**/*'
-                        - '!ee/frontend/**'
                         - 'posthog/**/*'
                         - 'bin/*.py'
                         - requirements.txt

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -62,6 +62,8 @@ jobs:
                         # code completely
                         # really we should ignore ee/frontend/** but dorny doesn't support that
                         # - '!ee/frontend/**'
+                        # including the negated rule appears to work
+                        # but makes it always match because the checked file always isn't `ee/frontend/**` 🙈
                         - 'ee/**/*'
                         - 'posthog/**/*'
                         - 'bin/*.py'

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1555,10 +1555,10 @@ const api = {
                 .withQueryString(toParams({ source: 'blob', blob_key: blobKey, version: '2' }))
                 .getResponse()
 
+            const contentBuffer = new Uint8Array(await response.arrayBuffer())
             try {
-                // we clone the response here because if we throw _after_ reading the body
-                // then we can't read the body below
-                const textLines = await response.clone().text()
+                const textDecoder = new TextDecoder()
+                const textLines = textDecoder.decode(contentBuffer)
 
                 if (textLines) {
                     return textLines.split('\n')
@@ -1567,7 +1567,6 @@ const api = {
                 // we assume it is gzipped, swallow the error, and carry on below
             }
 
-            const contentBuffer = new Uint8Array(await response.arrayBuffer())
             return strFromU8(decompressSync(contentBuffer)).trim().split('\n')
         },
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1556,13 +1556,15 @@ const api = {
                 .getResponse()
 
             try {
-                const textLines = await response.text()
+                // we clone the response here because if we throw _after_ reading the body
+                // then we can't read the body below
+                const textLines = await response.clone().text()
 
                 if (textLines) {
                     return textLines.split('\n')
                 }
             } catch (e) {
-                // Must be gzipped
+                // we assume it is gzipped, swallow the error, and carry on below
             }
 
             const contentBuffer = new Uint8Array(await response.arrayBuffer())

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
@@ -8,7 +8,6 @@ import {
 } from 'scenes/session-recordings/player/sessionRecordingDataLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
-import { TextDecoder } from 'util'
 
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useAvailableFeatures } from '~/mocks/features'
@@ -19,10 +18,6 @@ import { AvailableFeature } from '~/types'
 import recordingEventsJson from '../__mocks__/recording_events_query'
 import recordingMetaJson from '../__mocks__/recording_meta.json'
 import { snapshotsAsJSONLines, sortedRecordingSnapshots } from '../__mocks__/recording_snapshots'
-
-// Jest/JSDom don't know about TextEncoder but the browsers we support do
-// @ts-expect-error
-global.TextDecoder = TextDecoder
 
 const sortedRecordingSnapshotsJson = sortedRecordingSnapshots()
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
@@ -8,6 +8,7 @@ import {
 } from 'scenes/session-recordings/player/sessionRecordingDataLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
+import { TextDecoder } from 'util'
 
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useAvailableFeatures } from '~/mocks/features'
@@ -18,6 +19,10 @@ import { AvailableFeature } from '~/types'
 import recordingEventsJson from '../__mocks__/recording_events_query'
 import recordingMetaJson from '../__mocks__/recording_meta.json'
 import { snapshotsAsJSONLines, sortedRecordingSnapshots } from '../__mocks__/recording_snapshots'
+
+// Jest/JSDom don't know about TextEncoder but the browsers we support do
+// @ts-expect-error
+global.TextDecoder = TextDecoder
 
 const sortedRecordingSnapshotsJson = sortedRecordingSnapshots()
 
@@ -127,6 +132,7 @@ describe('sessionRecordingDataLogic', () => {
                 })
             resumeKeaLoadersErrors()
         })
+
         it('fetch metadata success and snapshots error', async () => {
             silenceKeaLoadersErrors()
             // Unmount and remount the logic to trigger fetching the data again after the mock change

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -12,10 +12,15 @@ import { sessionRecordingDataLogic } from 'scenes/session-recordings/player/sess
 import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { sessionRecordingsPlaylistLogic } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
 import { urls } from 'scenes/urls'
+import { TextDecoder } from 'util'
 
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
+
+// Jest/JSDom don't know about TextEncoder but the browsers we support do
+// @ts-expect-error
+global.TextDecoder = TextDecoder
 
 describe('sessionRecordingPlayerLogic', () => {
     let logic: ReturnType<typeof sessionRecordingPlayerLogic.build>

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -12,15 +12,10 @@ import { sessionRecordingDataLogic } from 'scenes/session-recordings/player/sess
 import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { sessionRecordingsPlaylistLogic } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
 import { urls } from 'scenes/urls'
-import { TextDecoder } from 'util'
 
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
-
-// Jest/JSDom don't know about TextEncoder but the browsers we support do
-// @ts-expect-error
-global.TextDecoder = TextDecoder
 
 describe('sessionRecordingPlayerLogic', () => {
     let logic: ReturnType<typeof sessionRecordingPlayerLogic.build>

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,12 @@
 import 'whatwg-fetch'
 import 'jest-canvas-mock'
 
+import { TextEncoder, TextDecoder } from 'util'
+// Jest/JSDom don't know about TextEncoder but the browsers we support do
+// https://github.com/jsdom/jsdom/issues/2524
+global.TextDecoder = TextDecoder
+global.TextEncoder = TextEncoder
+
 window.scrollTo = jest.fn()
 window.matchMedia = jest.fn(
     () => ({ matches: false, addListener: jest.fn(), removeListener: jest.fn() } as MediaQueryList)


### PR DESCRIPTION
While investigating why the player error state doesn't consistently show I was running with "catch uncaught exceptions" on in dev tools

That highlighted that we were explicitly reading the body of the response twice, which is verboten

Instead, we can read the body and convert it to a uint8array, and then use that in both places we were previously reading the body