### PR TITLE
fix(android replay): fix banner

### DIFF
--- a/frontend/src/scenes/session-recordings/mobile-replay/AndroidRecordingPromptBanner.tsx
+++ b/frontend/src/scenes/session-recordings/mobile-replay/AndroidRecordingPromptBanner.tsx
@@ -29,8 +29,8 @@ export function AndroidRecordingsPromptBanner(props: AndroidRecordingPromptBanne
                 }}
                 className="mb-4"
             >
-                <h1 className="mb-0">Android Session Replay.</h1>
-                <div>
+                <h3 className="mb-0 ml-2">Android Session Replay</h3>
+                <div className="ml-2">
                     We're recruiting beta testers for Android Session Replay.{' '}
                     <Link onClick={() => openSupportForm({ kind: 'support', target_area: 'session_replay' })}>
                         Contact support


### PR DESCRIPTION
I'm proposing a slight change to the Android banner :)

## Changes
- make the header smaller than the page's h1
- remove the full stop in the header
- add a margin after the info icon

Before
<img width="1225" alt="Screenshot 2024-01-15 at 12 07 09" src="https://github.com/PostHog/posthog/assets/22996112/40b0edfa-5e74-40fb-b1b4-bd2ce3d350c6">

After
<img width="1222" alt="Screenshot 2024-01-15 at 12 07 26" src="https://github.com/PostHog/posthog/assets/22996112/7fceb6ed-707b-4794-9a4f-3adfc3db4139">

## How did you test this code?
👀 
