### PR TITLE
feat: link to recordings from early access page

### DIFF
--- a/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
+++ b/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
@@ -299,6 +299,32 @@ interface PersonListProps {
     earlyAccessFeature: EarlyAccessFeatureType
 }
 
+function featureFlagEnrolmentFilter(earlyAccessFeature: EarlyAccessFeatureType, optedIn: boolean): Partial<FilterType> {
+    return {
+        events: [
+            {
+                type: 'events',
+                order: 0,
+                name: '$feature_enrollment_update',
+                properties: [
+                    {
+                        key: '$feature_enrollment',
+                        value: [optedIn ? 'true' : 'false'],
+                        operator: 'exact',
+                        type: 'event',
+                    },
+                    {
+                        key: '$feature_flag',
+                        value: [earlyAccessFeature.feature_flag.key],
+                        operator: 'exact',
+                        type: 'event',
+                    },
+                ],
+            },
+        ],
+    }
+}
+
 export function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element {
     const { implementOptInInstructionsModal, activeTab } = useValues(earlyAccessFeatureLogic)
     const { toggleImplementOptInInstructionsModal, setActiveTab } = useActions(earlyAccessFeatureLogic)
@@ -319,29 +345,7 @@ export function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element
                         content: (
                             <>
                                 <PersonsTableByFilter
-                                    recordingsFilters={{
-                                        events: [
-                                            {
-                                                type: 'events',
-                                                order: 0,
-                                                name: '$feature_enrollment_update',
-                                                properties: [
-                                                    {
-                                                        key: '$feature_enrollment',
-                                                        value: ['true'],
-                                                        operator: 'exact',
-                                                        type: 'event',
-                                                    },
-                                                    {
-                                                        key: '$feature_flag',
-                                                        value: [earlyAccessFeature.feature_flag.key],
-                                                        operator: 'exact',
-                                                        type: 'event',
-                                                    },
-                                                ],
-                                            },
-                                        ],
-                                    }}
+                                    recordingsFilters={featureFlagEnrolmentFilter(earlyAccessFeature, true)}
                                     properties={[
                                         {
                                             key: key,
@@ -367,29 +371,7 @@ export function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element
                         label: 'Opted-Out Users',
                         content: (
                             <PersonsTableByFilter
-                                recordingsFilters={{
-                                    events: [
-                                        {
-                                            type: 'events',
-                                            order: 0,
-                                            name: '$feature_enrollment_update',
-                                            properties: [
-                                                {
-                                                    key: '$feature_enrollment',
-                                                    value: ['false'],
-                                                    operator: 'exact',
-                                                    type: 'event',
-                                                },
-                                                {
-                                                    key: '$feature_flag',
-                                                    value: [earlyAccessFeature.feature_flag.key],
-                                                    operator: 'exact',
-                                                    type: 'event',
-                                                },
-                                            ],
-                                        },
-                                    ],
-                                }}
+                                recordingsFilters={featureFlagEnrolmentFilter(earlyAccessFeature, false)}
                                 properties={[
                                     {
                                         key: key,

--- a/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
+++ b/frontend/src/scenes/early-access-features/EarlyAccessFeature.tsx
@@ -23,9 +23,11 @@ import {
     EarlyAccessFeatureStage,
     EarlyAccessFeatureTabs,
     EarlyAccessFeatureType,
+    FilterType,
     PersonPropertyFilter,
     PropertyFilterType,
     PropertyOperator,
+    ReplayTabs,
 } from '~/types'
 
 import { earlyAccessFeatureLogic } from './earlyAccessFeatureLogic'
@@ -315,24 +317,49 @@ export function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element
                         key: EarlyAccessFeatureTabs.OptedIn,
                         label: 'Opted-In Users',
                         content: (
-                            <PersonsTableByFilter
-                                properties={[
-                                    {
-                                        key: key,
-                                        type: PropertyFilterType.Person,
-                                        operator: PropertyOperator.Exact,
-                                        value: ['true'],
-                                    },
-                                ]}
-                                emptyState={
-                                    <div>
-                                        No manual opt-ins. Manually opted-in people will appear here. Start by{' '}
-                                        <Link onClick={toggleImplementOptInInstructionsModal}>
-                                            implementing public opt-in
-                                        </Link>
-                                    </div>
-                                }
-                            />
+                            <>
+                                <PersonsTableByFilter
+                                    recordingsFilters={{
+                                        events: [
+                                            {
+                                                type: 'events',
+                                                order: 0,
+                                                name: '$feature_enrollment_update',
+                                                properties: [
+                                                    {
+                                                        key: '$feature_enrollment',
+                                                        value: ['true'],
+                                                        operator: 'exact',
+                                                        type: 'event',
+                                                    },
+                                                    {
+                                                        key: '$feature_flag',
+                                                        value: [earlyAccessFeature.feature_flag.key],
+                                                        operator: 'exact',
+                                                        type: 'event',
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    }}
+                                    properties={[
+                                        {
+                                            key: key,
+                                            type: PropertyFilterType.Person,
+                                            operator: PropertyOperator.Exact,
+                                            value: ['true'],
+                                        },
+                                    ]}
+                                    emptyState={
+                                        <div>
+                                            No manual opt-ins. Manually opted-in people will appear here. Start by{' '}
+                                            <Link onClick={toggleImplementOptInInstructionsModal}>
+                                                implementing public opt-in
+                                            </Link>
+                                        </div>
+                                    }
+                                />
+                            </>
                         ),
                     },
                     {
@@ -340,6 +367,29 @@ export function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element
                         label: 'Opted-Out Users',
                         content: (
                             <PersonsTableByFilter
+                                recordingsFilters={{
+                                    events: [
+                                        {
+                                            type: 'events',
+                                            order: 0,
+                                            name: '$feature_enrollment_update',
+                                            properties: [
+                                                {
+                                                    key: '$feature_enrollment',
+                                                    value: ['false'],
+                                                    operator: 'exact',
+                                                    type: 'event',
+                                                },
+                                                {
+                                                    key: '$feature_flag',
+                                                    value: [earlyAccessFeature.feature_flag.key],
+                                                    operator: 'exact',
+                                                    type: 'event',
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                }}
                                 properties={[
                                     {
                                         key: key,
@@ -374,27 +424,32 @@ export function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element
 interface PersonsTableByFilterProps {
     properties: PersonPropertyFilter[]
     emptyState?: JSX.Element
+    recordingsFilters: Partial<FilterType>
 }
 
-export function PersonsTableByFilter({ properties, emptyState }: PersonsTableByFilterProps): JSX.Element {
+export function PersonsTableByFilter(props: PersonsTableByFilterProps): JSX.Element {
     const personsLogicProps: PersonsLogicProps = {
         cohort: undefined,
         syncWithUrl: false,
-        fixedProperties: properties,
+        fixedProperties: props.properties,
     }
 
     return (
         <BindLogic logic={personsLogic} props={personsLogicProps}>
-            <PersonsTableByFilterComponent emptyState={emptyState} />
+            <PersonsTableByFilterComponent {...props} />
         </BindLogic>
     )
 }
 
 interface PersonsTableByFilterComponentProps {
     emptyState?: JSX.Element
+    recordingsFilters: Partial<FilterType>
 }
 
-function PersonsTableByFilterComponent({ emptyState }: PersonsTableByFilterComponentProps): JSX.Element {
+function PersonsTableByFilterComponent({
+    emptyState,
+    recordingsFilters,
+}: PersonsTableByFilterComponentProps): JSX.Element {
     const { toggleImplementOptInInstructionsModal } = useActions(earlyAccessFeatureLogic)
 
     const { persons, personsLoading, listFilters } = useValues(personsLogic)
@@ -417,13 +472,27 @@ function PersonsTableByFilterComponent({ emptyState }: PersonsTableByFilterCompo
                     taxonomicGroupTypes={[TaxonomicFilterGroupType.PersonProperties]}
                     showConditionBadge
                 />
-                <LemonButton
-                    key="help-button"
-                    onClick={toggleImplementOptInInstructionsModal}
-                    sideIcon={<IconHelpOutline />}
-                >
-                    Implement public opt-in
-                </LemonButton>
+                <div className="flex flex-row gap-2">
+                    <LemonButton
+                        key="help-button"
+                        onClick={toggleImplementOptInInstructionsModal}
+                        sideIcon={<IconHelpOutline />}
+                    >
+                        Implement public opt-in
+                    </LemonButton>
+                    <LemonButton
+                        key="view-opt-in-session-recordings"
+                        onClick={() => {
+                            router.actions.push(urls.replay(ReplayTabs.Recent, recordingsFilters))
+                        }}
+                        type="secondary"
+                        disabledReason={
+                            personsLoading ? 'Loading…' : persons.results.length === 0 ? 'No users to view' : undefined
+                        }
+                    >
+                        View recordings
+                    </LemonButton>
+                </div>
             </div>
             <PersonsTable
                 people={persons.results}


### PR DESCRIPTION
I set up something in early access... 

One of the first things I wanted to do was see what the users did when they signed up...

(feel free to decide not to add this to the UI if you think I'm odd)

### when there are none

![Screenshot 2024-01-15 at 11 35 08](https://github.com/PostHog/posthog/assets/984817/3a58ba80-c71e-492a-880c-a19d6abf6f28)

### when there are some

![Screenshot 2024-01-15 at 11 35 00](https://github.com/PostHog/posthog/assets/984817/5ab7e95f-a878-40f2-bbb9-150cb5051aa5)

