### PR TITLE
fix(stickiness): fixes stickiness query runner

### DIFF
--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -125,7 +125,7 @@ class StickinessQueryRunner(QueryRunner):
                             SELECT 0 as aggregation_target, (number + 1) as num_intervals
                             FROM numbers(dateDiff({interval}, {date_from} - {interval_subtract}, {date_to}))
                             UNION ALL
-                            {events_query}
+                            SELECT * FROM ({events_query})
                         )
                         GROUP BY num_intervals
                         ORDER BY num_intervals


### PR DESCRIPTION
## Problem
- Turns out we dont support using placeholders for a full `SELECT` statement, unless if its a table expression for a join or a `from` clause, for example

## Changes
- I didn't want to edit the G4 parser file and write some C++ _right now_, so this is a quick fix. But I do intend on adding this properly soon
- Wraps the `SELECT` placeholder in a `SELECT * FROM {placeholder}` instead for now

## How did you test this code?
- Ran the stickiness query in the browser