### PR TITLE
fix(poe): link to the new doc

### DIFF
--- a/frontend/src/scenes/settings/project/SettingPersonsOnEvents.tsx
+++ b/frontend/src/scenes/settings/project/SettingPersonsOnEvents.tsx
@@ -9,16 +9,17 @@ export function SettingPersonsOnEvents(): JSX.Element {
     return (
         <>
             <p>
-                We have updated our data model to also store person properties directly on events, making queries
+                We have updated our data model to store person properties directly on events, making queries
                 significantly faster. This means that person properties will no longer be "timeless", but rather
                 point-in-time i.e. on filters we'll consider a person's properties at the time of the event, rather than
                 at present time. This may cause data to change on some of your insights, but will be the default way we
                 handle person properties going forward. For now, you can control whether you want this on or not, and
                 should feel free to let us know of any concerns you might have. If you do enable this, you should see
                 speed improvements of around 3-5x on average on most of your insights.
-                <Link to="https://github.com/PostHog/posthog/blob/75a2111f2c4f9183dd45f85c7b103c7b0524eabf/plugin-server/src/worker/ingestion/PoE.md">
-                    More info.
-                </Link>
+            </p>
+            <p>
+                Please note, <strong>you might need to change the way you send us events</strong> after enabling this
+                feature. <Link to="https://github.com/PostHog/meta/issues/173">Read more here.</Link>
             </p>
 
             <LemonSwitch


### PR DESCRIPTION
## Problem

The link under "project settings" was leading to the [old doc](https://github.com/PostHog/posthog/blob/75a2111f2c4f9183dd45f85c7b103c7b0524eabf/plugin-server/src/worker/ingestion/PoE.md), which confused people more than it helped. 

## Changes

Adds a **bold** message to read the new doc when enabling this. I didn't change the copy much:

<img width="1157" alt="image" src="https://github.com/PostHog/posthog/assets/53387/af690d32-1808-44c2-b401-cc4149c894a2">


## How did you test this code?

In the UI