### PR TITLE
fix(trends): horizontal bar other/null values

### DIFF
--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -3,7 +3,7 @@ import { getSeriesColor } from 'lib/colors'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { useEffect, useState } from 'react'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { formatBreakdownLabel } from 'scenes/insights/utils'
+import { formatBreakdownLabel, isNullBreakdown, isOtherBreakdown } from 'scenes/insights/utils'
 
 import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
@@ -35,7 +35,9 @@ export function ActionsHorizontalBar({ showPersonsModal = true }: ChartParams): 
 
         setData([
             {
-                labels: _data.map((item) => item.label),
+                labels: _data.map((item) =>
+                    isOtherBreakdown(item.label) ? 'Other' : isNullBreakdown(item.label) ? 'None' : item.label
+                ),
                 data: _data.map((item) => item.aggregated_value),
                 actions: _data.map((item) => item.action),
                 personsValues: _data.map((item) => item.persons),


### PR DESCRIPTION
## Problem

The Horizontal Bar chart was still showing `$$_posthog_breakdown_other_$$`

<img width="1021" alt="image" src="https://github.com/PostHog/posthog/assets/53387/28aa67cf-6524-41e5-9e76-989435f0bf0d">

## Changes

Replaces that with "Other". Also shows "None" for nulls.

<img width="1030" alt="Screenshot 2024-01-15 at 16 33 07" src="https://github.com/PostHog/posthog/assets/53387/5e73aff8-93cc-4a08-a788-eddd86b5a39c">


## How did you test this code?

Visually in the UI