### PR TITLE
fix(web-analytics): Fix scroll depth by setting custom scroll selector

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -37,7 +37,7 @@ export function loadPostHogJS(): void {
                         posthog.opt_in_capturing()
                     }
                 },
-                __preview_measure_pageview_stats: true,
+                scroll_root_selector: ['main', 'html'],
             })
         )
 

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
         "pmtiles": "^2.11.0",
         "postcss": "^8.4.31",
         "postcss-preset-env": "^9.3.0",
-        "posthog-js": "1.99.0",
+        "posthog-js": "1.100.0",
         "posthog-js-lite": "2.5.0",
         "prettier": "^2.8.8",
         "prop-types": "^15.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,8 +240,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0(postcss@8.4.31)
   posthog-js:
-    specifier: 1.99.0
-    version: 1.99.0
+    specifier: 1.100.0
+    version: 1.100.0
   posthog-js-lite:
     specifier: 2.5.0
     version: 2.5.0
@@ -17233,8 +17233,8 @@ packages:
     resolution: {integrity: sha512-Urvlp0Vu9h3td0BVFWt0QXFJDoOZcaAD83XM9d91NKMKTVPZtfU0ysoxstIf5mw/ce9ZfuMgpWPaagrZI4rmSg==}
     dev: false
 
-  /posthog-js@1.99.0:
-    resolution: {integrity: sha512-tFbxQm+mf97GV36eWbehPH7aM6P2yl+TKfmT7sDFG6dneuqp37XgYKADXbIQ7Nlynm2BOlawjkkZYzC2Dt5fcg==}
+  /posthog-js@1.100.0:
+    resolution: {integrity: sha512-r2XZEiHQ9mBK7D1G9k57I8uYZ2kZTAJ0OCX6K/OOdCWN8jKPhw3h5F9No5weilP6eVAn+hrsy7NvPV7SCX7gMg==}
     dependencies:
       fflate: 0.4.8
     dev: false


### PR DESCRIPTION
## Problem

Scroll depth is not reported correctly for the posthog app

## Changes

Fix scroll depth by setting custom scroll selector. Relates to https://github.com/PostHog/posthog-js/pull/961

## How did you test this code?

It's been tested in the posthog-js repo
