### PR TITLE
fix: Only show session recording cost controls to people who have it enabled

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -1,3 +1,5 @@
+import { AvailableFeature } from '~/types'
+
 import { Invites } from './organization/Invites'
 import { Members } from './organization/Members'
 import { OrganizationDangerZone } from './organization/OrganizationDangerZone'
@@ -158,6 +160,11 @@ export const SettingsMap: SettingSection[] = [
                 id: 'replay-ingestion',
                 title: 'Ingestion controls',
                 component: <ReplayCostControl />,
+                features: [
+                    AvailableFeature.SESSION_REPLAY_SAMPLING,
+                    AvailableFeature.FEATURE_FLAG_BASED_RECORDING,
+                    AvailableFeature.RECORDING_DURATION_MINIMUM,
+                ],
             },
         ],
     },

--- a/frontend/src/scenes/settings/project/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/project/SessionRecordingSettings.tsx
@@ -1,14 +1,12 @@
-import { LemonBanner, LemonButton, LemonSelect, LemonSwitch, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonSelect, LemonSwitch, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
 import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { FlagSelector } from 'lib/components/FlagSelector'
-import { supportLogic } from 'lib/components/Support/supportLogic'
 import { FEATURE_FLAGS, SESSION_REPLAY_MINIMUM_DURATION_OPTIONS } from 'lib/constants'
 import { IconCancel } from 'lib/lemon-ui/icons'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel/LemonLabel'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -182,27 +180,12 @@ export function ReplayCostControl(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
     const { hasAvailableFeature } = useValues(userLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
-    const { openSupportForm } = useActions(supportLogic)
     const samplingControlFeatureEnabled = hasAvailableFeature(AvailableFeature.SESSION_REPLAY_SAMPLING)
     const recordingDurationMinimumFeatureEnabled = hasAvailableFeature(AvailableFeature.RECORDING_DURATION_MINIMUM)
     const featureFlagRecordingFeatureEnabled = hasAvailableFeature(AvailableFeature.FEATURE_FLAG_BASED_RECORDING)
-    const costControlFeaturesEnabled =
-        featureFlags[FEATURE_FLAGS.SESSION_RECORDING_SAMPLING] ||
-        samplingControlFeatureEnabled ||
-        recordingDurationMinimumFeatureEnabled ||
-        featureFlagRecordingFeatureEnabled
 
     return (
         <>
-            {!costControlFeaturesEnabled && (
-                <LemonBanner className="mb-2" type="warning">
-                    <Link onClick={() => openSupportForm({ kind: 'support', target_area: 'session_replay' })}>
-                        Contact support
-                    </Link>{' '}
-                    to enable these features.
-                </LemonBanner>
-            )}
             <p>
                 PostHog offers several tools to let you control the number of recordings you collect and which users you
                 collect recordings for.{' '}
@@ -214,161 +197,163 @@ export function ReplayCostControl(): JSX.Element {
                 </Link>
             </p>
 
-            <>
-                <div className="flex flex-row justify-between">
-                    <LemonLabel className="text-base">Sampling</LemonLabel>
-                    <LemonSelect
-                        disabledReason={!costControlFeaturesEnabled && 'Please contact support to enable this feature.'}
-                        onChange={(v) => {
-                            updateCurrentTeam({ session_recording_sample_rate: v })
-                        }}
-                        dropdownMatchSelectWidth={false}
-                        options={[
-                            {
-                                label: '100% (no sampling)',
-                                value: '1.00',
-                            },
-                            {
-                                label: '95%',
-                                value: '0.95',
-                            },
-                            {
-                                label: '90%',
-                                value: '0.90',
-                            },
-                            {
-                                label: '85%',
-                                value: '0.85',
-                            },
-                            {
-                                label: '80%',
-                                value: '0.80',
-                            },
-                            {
-                                label: '75%',
-                                value: '0.75',
-                            },
-                            {
-                                label: '70%',
-                                value: '0.70',
-                            },
-                            {
-                                label: '65%',
-                                value: '0.65',
-                            },
-                            {
-                                label: '60%',
-                                value: '0.60',
-                            },
-                            {
-                                label: '55%',
-                                value: '0.55',
-                            },
-                            {
-                                label: '50%',
-                                value: '0.50',
-                            },
-                            {
-                                label: '45%',
-                                value: '0.45',
-                            },
-                            {
-                                label: '40%',
-                                value: '0.40',
-                            },
-                            {
-                                label: '35%',
-                                value: '0.35',
-                            },
-                            {
-                                label: '30%',
-                                value: '0.30',
-                            },
-                            {
-                                label: '25%',
-                                value: '0.25',
-                            },
-                            {
-                                label: '20%',
-                                value: '0.20',
-                            },
-                            {
-                                label: '15%',
-                                value: '0.15',
-                            },
-                            {
-                                label: '10%',
-                                value: '0.10',
-                            },
-                            {
-                                label: '5%',
-                                value: '0.05',
-                            },
-                            {
-                                label: '0% (replay disabled)',
-                                value: '0.00',
-                            },
-                        ]}
-                        value={
-                            typeof currentTeam?.session_recording_sample_rate === 'string'
-                                ? currentTeam?.session_recording_sample_rate
-                                : '1.00'
-                        }
-                    />
-                </div>
-                <p>
-                    Use this setting to restrict the percentage of sessions that will be recorded. This is useful if you
-                    want to reduce the amount of data you collect. 100% means all sessions will be collected. 50% means
-                    roughly half of sessions will be collected.
-                </p>
-            </>
-            <>
-                <div className="flex flex-row justify-between">
-                    <LemonLabel className="text-base">Minimum session duration (seconds)</LemonLabel>
-                    <LemonSelect
-                        disabledReason={!costControlFeaturesEnabled && 'Please contact support to enable this feature.'}
-                        dropdownMatchSelectWidth={false}
-                        onChange={(v) => {
-                            updateCurrentTeam({ session_recording_minimum_duration_milliseconds: v })
-                        }}
-                        options={SESSION_REPLAY_MINIMUM_DURATION_OPTIONS}
-                        value={currentTeam?.session_recording_minimum_duration_milliseconds}
-                    />
-                </div>
-                <p>
-                    Setting a minimum session duration will ensure that only sessions that last longer than that value
-                    are collected. This helps you avoid collecting sessions that are too short to be useful.
-                </p>
-            </>
-            <>
-                <div className="flex flex-col space-y-2">
-                    <LemonLabel className="text-base">Enable recordings using feature flag</LemonLabel>
-                    <div className="flex flex-row justify-start">
-                        <FlagSelector
-                            value={currentTeam?.session_recording_linked_flag?.id ?? undefined}
-                            onChange={(id, key) => {
-                                updateCurrentTeam({ session_recording_linked_flag: { id, key } })
+            {samplingControlFeatureEnabled && (
+                <>
+                    <div className="flex flex-row justify-between">
+                        <LemonLabel className="text-base">Sampling</LemonLabel>
+                        <LemonSelect
+                            onChange={(v) => {
+                                updateCurrentTeam({ session_recording_sample_rate: v })
                             }}
-                            readOnly={!costControlFeaturesEnabled}
-                            disabledReason="Please contact support to enable this feature."
+                            dropdownMatchSelectWidth={false}
+                            options={[
+                                {
+                                    label: '100% (no sampling)',
+                                    value: '1.00',
+                                },
+                                {
+                                    label: '95%',
+                                    value: '0.95',
+                                },
+                                {
+                                    label: '90%',
+                                    value: '0.90',
+                                },
+                                {
+                                    label: '85%',
+                                    value: '0.85',
+                                },
+                                {
+                                    label: '80%',
+                                    value: '0.80',
+                                },
+                                {
+                                    label: '75%',
+                                    value: '0.75',
+                                },
+                                {
+                                    label: '70%',
+                                    value: '0.70',
+                                },
+                                {
+                                    label: '65%',
+                                    value: '0.65',
+                                },
+                                {
+                                    label: '60%',
+                                    value: '0.60',
+                                },
+                                {
+                                    label: '55%',
+                                    value: '0.55',
+                                },
+                                {
+                                    label: '50%',
+                                    value: '0.50',
+                                },
+                                {
+                                    label: '45%',
+                                    value: '0.45',
+                                },
+                                {
+                                    label: '40%',
+                                    value: '0.40',
+                                },
+                                {
+                                    label: '35%',
+                                    value: '0.35',
+                                },
+                                {
+                                    label: '30%',
+                                    value: '0.30',
+                                },
+                                {
+                                    label: '25%',
+                                    value: '0.25',
+                                },
+                                {
+                                    label: '20%',
+                                    value: '0.20',
+                                },
+                                {
+                                    label: '15%',
+                                    value: '0.15',
+                                },
+                                {
+                                    label: '10%',
+                                    value: '0.10',
+                                },
+                                {
+                                    label: '5%',
+                                    value: '0.05',
+                                },
+                                {
+                                    label: '0% (replay disabled)',
+                                    value: '0.00',
+                                },
+                            ]}
+                            value={
+                                typeof currentTeam?.session_recording_sample_rate === 'string'
+                                    ? currentTeam?.session_recording_sample_rate
+                                    : '1.00'
+                            }
                         />
-                        {currentTeam?.session_recording_linked_flag && (
-                            <LemonButton
-                                className="ml-2"
-                                icon={<IconCancel />}
-                                size="small"
-                                type="secondary"
-                                onClick={() => updateCurrentTeam({ session_recording_linked_flag: null })}
-                                title="Clear selected flag"
-                            />
-                        )}
                     </div>
-                </div>
-                <p>
-                    Linking a flag means that recordings will only be collected for users who have the flag enabled.
-                    Only supports release toggles (boolean flags).
-                </p>
-            </>
+                    <p>
+                        Use this setting to restrict the percentage of sessions that will be recorded. This is useful if
+                        you want to reduce the amount of data you collect. 100% means all sessions will be collected.
+                        50% means roughly half of sessions will be collected.
+                    </p>
+                </>
+            )}
+            {recordingDurationMinimumFeatureEnabled && (
+                <>
+                    <div className="flex flex-row justify-between">
+                        <LemonLabel className="text-base">Minimum session duration (seconds)</LemonLabel>
+                        <LemonSelect
+                            dropdownMatchSelectWidth={false}
+                            onChange={(v) => {
+                                updateCurrentTeam({ session_recording_minimum_duration_milliseconds: v })
+                            }}
+                            options={SESSION_REPLAY_MINIMUM_DURATION_OPTIONS}
+                            value={currentTeam?.session_recording_minimum_duration_milliseconds}
+                        />
+                    </div>
+                    <p>
+                        Setting a minimum session duration will ensure that only sessions that last longer than that
+                        value are collected. This helps you avoid collecting sessions that are too short to be useful.
+                    </p>
+                </>
+            )}
+            {featureFlagRecordingFeatureEnabled && (
+                <>
+                    <div className="flex flex-col space-y-2">
+                        <LemonLabel className="text-base">Enable recordings using feature flag</LemonLabel>
+                        <div className="flex flex-row justify-start">
+                            <FlagSelector
+                                value={currentTeam?.session_recording_linked_flag?.id ?? undefined}
+                                onChange={(id, key) => {
+                                    updateCurrentTeam({ session_recording_linked_flag: { id, key } })
+                                }}
+                            />
+                            {currentTeam?.session_recording_linked_flag && (
+                                <LemonButton
+                                    className="ml-2"
+                                    icon={<IconCancel />}
+                                    size="small"
+                                    type="secondary"
+                                    onClick={() => updateCurrentTeam({ session_recording_linked_flag: null })}
+                                    title="Clear selected flag"
+                                />
+                            )}
+                        </div>
+                    </div>
+                    <p>
+                        Linking a flag means that recordings will only be collected for users who have the flag enabled.
+                        Only supports release toggles (boolean flags).
+                    </p>
+                </>
+            )}
         </>
     )
 }


### PR DESCRIPTION
## Problem

We had previously allowed users who were on the old session replay plan to see a disabled version of the ingestion controls. We have since been inundated with support requests to migrate users to the new plan so they can use the ingestion controls. In order to control the volumes in the support queue, we are reverting the initial change so that users will only see the controls if they are on the new plans. Users may still find out about the ingestion controls through the website documentation, but the volumes from this pathway should be much less than through the in-app pathway. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
