### PR TITLE
fix(trends): Fixed trends breaking from rogue operator

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
@@ -578,6 +578,53 @@ describe('filtersToQueryNode', () => {
             }
             expect(result).toEqual(query)
         })
+
+        it('converts properties with the correct cohort structure', () => {
+            const properties: any = {
+                type: FilterLogicalOperator.And,
+                values: [
+                    {
+                        type: FilterLogicalOperator.And,
+                        values: [
+                            {
+                                key: 'id',
+                                type: PropertyFilterType.Cohort,
+                                value: 6,
+                                operator: null,
+                            },
+                        ],
+                    },
+                ],
+            }
+
+            const filters: Partial<FilterType> = {
+                insight: InsightType.TRENDS,
+                properties,
+            }
+
+            const result = filtersToQueryNode(filters)
+
+            const query: InsightQueryNode = {
+                kind: NodeKind.TrendsQuery,
+                properties: {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        {
+                            type: FilterLogicalOperator.And,
+                            values: [
+                                {
+                                    key: 'id',
+                                    type: PropertyFilterType.Cohort,
+                                    value: 6,
+                                },
+                            ],
+                        },
+                    ],
+                },
+                series: [],
+            }
+            expect(result).toEqual(query)
+        })
     })
 
     describe('example insights', () => {

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -126,6 +126,14 @@ const cleanProperties = (parentProperties: FilterType['properties']): InsightsQu
             }
         }
 
+        // Some saved insights have `"operator": null` defined in the properties, this
+        // breaks HogQL trends and Pydantic validation
+        if (filter.type === PropertyFilterType.Cohort) {
+            if ('operator' in filter) {
+                delete filter.operator
+            }
+        }
+
         return filter
     }
 


### PR DESCRIPTION
## Problem
- We were getting pydantic validation errors when submitting a series with a cohort filter with a `null` operator value. `CohortPropertyFilter` shouldn't have _any_ `operator` field
- These were being removed in non-HogQL land by a server-side serializer, setting defaults etc
- Originally reported here: https://posthog.slack.com/archives/C0368RPHLQH/p1705059928350199

## Changes
- Remove the `operator` key from the query object if it exists when sending the query to the server

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
- Added a unit test