### PR TITLE
feat: Show the currently used region in the settings page

### DIFF
--- a/frontend/src/scenes/settings/project/ProjectSettings.tsx
+++ b/frontend/src/scenes/settings/project/ProjectSettings.tsx
@@ -150,7 +150,7 @@ export function ProjectVariables(): JSX.Element {
                         Project Region
                     </h3>
                     <p>This is the region where your PostHog data is hosted.</p>
-                    <CodeSnippet thing="project ID">{region === 'EU' ? 'EU Cloud' : 'US Cloud'}</CodeSnippet>
+                    <CodeSnippet thing="project ID">{`${region} Cloud`}</CodeSnippet>
                 </div>
             ) : null}
         </div>

--- a/frontend/src/scenes/settings/project/ProjectSettings.tsx
+++ b/frontend/src/scenes/settings/project/ProjectSettings.tsx
@@ -89,6 +89,8 @@ export function Bookmarklet(): JSX.Element {
 export function ProjectVariables(): JSX.Element {
     const { currentTeam, isTeamTokenResetAvailable } = useValues(teamLogic)
     const { resetToken } = useActions(teamLogic)
+    const { preflight } = useValues(preflightLogic)
+    const region = preflight?.region
 
     return (
         <div className="flex items-start gap-4 flex-wrap">
@@ -142,19 +144,13 @@ export function ProjectVariables(): JSX.Element {
                 </p>
                 <CodeSnippet thing="project ID">{String(currentTeam?.id || '')}</CodeSnippet>
             </div>
-            {['https://eu.posthog.com', 'https://us.posthog.com'].includes(
-                preflightLogic.values.preflight?.site_url ?? ''
-            ) ? (
+            {region ? (
                 <div className="flex-1">
                     <h3 id="project-id" className="min-w-[25rem]">
                         Project Region
                     </h3>
                     <p>This is the region where your PostHog data is hosted.</p>
-                    <CodeSnippet thing="project ID">
-                        {preflightLogic.values.preflight?.site_url === 'https://eu.posthog.com'
-                            ? 'EU Cloud'
-                            : 'US Cloud'}
-                    </CodeSnippet>
+                    <CodeSnippet thing="project ID">{region === 'EU' ? 'EU Cloud' : 'US Cloud'}</CodeSnippet>
                 </div>
             ) : null}
         </div>

--- a/frontend/src/scenes/settings/project/ProjectSettings.tsx
+++ b/frontend/src/scenes/settings/project/ProjectSettings.tsx
@@ -150,7 +150,7 @@ export function ProjectVariables(): JSX.Element {
                         Project Region
                     </h3>
                     <p>This is the region where your PostHog data is hosted.</p>
-                    <CodeSnippet thing="project ID">{`${region} Cloud`}</CodeSnippet>
+                    <CodeSnippet thing="project region">{`${region} Cloud`}</CodeSnippet>
                 </div>
             ) : null}
         </div>

--- a/frontend/src/scenes/settings/project/ProjectSettings.tsx
+++ b/frontend/src/scenes/settings/project/ProjectSettings.tsx
@@ -149,7 +149,7 @@ export function ProjectVariables(): JSX.Element {
                     <h3 id="project-id" className="min-w-[25rem]">
                         Project Region
                     </h3>
-                    <p>This is the region where your PostHog data is currently hosted in.</p>
+                    <p>This is the region where your PostHog data is hosted.</p>
                     <CodeSnippet thing="project ID">
                         {preflightLogic.values.preflight?.site_url === 'https://eu.posthog.com'
                             ? 'EU Cloud'

--- a/frontend/src/scenes/settings/project/ProjectSettings.tsx
+++ b/frontend/src/scenes/settings/project/ProjectSettings.tsx
@@ -146,7 +146,7 @@ export function ProjectVariables(): JSX.Element {
             </div>
             {region ? (
                 <div className="flex-1">
-                    <h3 id="project-id" className="min-w-[25rem]">
+                    <h3 id="project-region" className="min-w-[25rem]">
                         Project Region
                     </h3>
                     <p>This is the region where your PostHog data is hosted.</p>

--- a/frontend/src/scenes/settings/project/ProjectSettings.tsx
+++ b/frontend/src/scenes/settings/project/ProjectSettings.tsx
@@ -9,6 +9,7 @@ import { JSSnippet } from 'lib/components/JSSnippet'
 import { IconRefresh } from 'lib/lemon-ui/icons'
 import { Link } from 'lib/lemon-ui/Link'
 import { useState } from 'react'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { isAuthenticatedTeam, teamLogic } from 'scenes/teamLogic'
 
 import { TimezoneConfig } from './TimezoneConfig'
@@ -141,6 +142,21 @@ export function ProjectVariables(): JSX.Element {
                 </p>
                 <CodeSnippet thing="project ID">{String(currentTeam?.id || '')}</CodeSnippet>
             </div>
+            {['https://eu.posthog.com', 'https://us.posthog.com'].includes(
+                preflightLogic.values.preflight?.site_url ?? ''
+            ) ? (
+                <div className="flex-1">
+                    <h3 id="project-id" className="min-w-[25rem]">
+                        Project Region
+                    </h3>
+                    <p>This is the region where your PostHog data is currently hosted in.</p>
+                    <CodeSnippet thing="project ID">
+                        {preflightLogic.values.preflight?.site_url === 'https://eu.posthog.com'
+                            ? 'EU Cloud'
+                            : 'US Cloud'}
+                    </CodeSnippet>
+                </div>
+            ) : null}
         </div>
     )
 }


### PR DESCRIPTION
## Problem

Got multiple tickets asking about which region they are currently on, this might make it clearer.

## Changes

![2024-01-16 at 15 39 19@2x](https://github.com/PostHog/posthog/assets/13001502/f71e5538-41ae-485a-a546-f2eed8b014ed)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

I manually inserted `https://eu.posthog.com` as the `site_url`
