### PR TITLE
feat: add severity level field to the support modal

### DIFF
--- a/frontend/src/layout/FeaturePreviews/featurePreviewsLogic.tsx
+++ b/frontend/src/layout/FeaturePreviews/featurePreviewsLogic.tsx
@@ -58,6 +58,7 @@ export const featurePreviewsLogic = kea<featurePreviewsLogicType>([
                         kind: 'feedback',
                         // NOTE: We don't know which area the flag should be - for now we just override it to be the key...
                         target_area: values.activeFeedbackFlagKey as any,
+                        severity_level: 'low',
                         message,
                     })
                     return null

--- a/frontend/src/lib/components/Support/SupportForm.tsx
+++ b/frontend/src/lib/components/Support/SupportForm.tsx
@@ -1,5 +1,5 @@
 import { LemonInput, LemonSegmentedButton, LemonSegmentedButtonOption, lemonToast } from '@posthog/lemon-ui'
-import { useActions, useValues } from 'kea'
+import { useActions, useSelector, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { Field } from 'lib/forms/Field'
 import { useUploadFiles } from 'lib/hooks/useUploadFiles'
@@ -7,7 +7,7 @@ import { IconBugReport, IconFeedback, IconHelpOutline } from 'lib/lemon-ui/icons
 import { LemonFileInput } from 'lib/lemon-ui/LemonFileInput/LemonFileInput'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect/LemonSelect'
 import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea/LemonTextArea'
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { userLogic } from 'scenes/userLogic'
 
@@ -43,6 +43,7 @@ export function SupportForm(): JSX.Element | null {
     const { objectStorageAvailable } = useValues(preflightLogic)
     // the support model can be shown when logged out, file upload is not offered to anonymous users
     const { user } = useValues(userLogic)
+    const supportRequestKind = useSelector(supportLogic.selectors.kind)
 
     const dropRef = useRef<HTMLDivElement>(null)
 
@@ -54,6 +55,14 @@ export function SupportForm(): JSX.Element | null {
             lemonToast.error(`Error uploading image: ${detail}`)
         },
     })
+
+    useEffect(() => {
+        if (supportRequestKind === 'bug') {
+            setSendSupportRequestValue('severity_level', 'medium')
+        } else {
+            setSendSupportRequestValue('severity_level', 'low')
+        }
+    }, [supportRequestKind])
 
     return (
         <Form

--- a/frontend/src/lib/components/Support/SupportForm.tsx
+++ b/frontend/src/lib/components/Support/SupportForm.tsx
@@ -102,9 +102,12 @@ export function SupportForm(): JSX.Element | null {
                     }))}
                 />
             </Field>
-            <span className="text-muted cursor-pointer">
+            <span className="text-muted">
                 Check out the{' '}
-                <Link to="https://posthog.com/docs/support-options#severity-levels">severity level definitions</Link>
+                <Link target="_blank" to="https://posthog.com/docs/support-options#severity-levels">
+                    severity level definitions
+                </Link>
+                .
             </span>
             <Field
                 name="message"

--- a/frontend/src/lib/components/Support/SupportForm.tsx
+++ b/frontend/src/lib/components/Support/SupportForm.tsx
@@ -11,7 +11,7 @@ import { useRef } from 'react'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { userLogic } from 'scenes/userLogic'
 
-import { supportLogic, SupportTicketKind, TARGET_AREA_TO_NAME } from './supportLogic'
+import { SEVERITY_LEVEL_TO_NAME, supportLogic, SupportTicketKind, TARGET_AREA_TO_NAME } from './supportLogic'
 
 const SUPPORT_TICKET_OPTIONS: LemonSegmentedButtonOption<SupportTicketKind>[] = [
     {
@@ -75,6 +75,15 @@ export function SupportForm(): JSX.Element | null {
             )}
             <Field name="kind" label="What type of message is this?">
                 <LemonSegmentedButton fullWidth options={SUPPORT_TICKET_OPTIONS} />
+            </Field>
+            <Field name="severity_level" label="What is the severity of this issue?">
+                <LemonSelect
+                    fullWidth
+                    options={Object.entries(SEVERITY_LEVEL_TO_NAME).map(([key, value]) => ({
+                        label: value,
+                        value: key,
+                    }))}
+                />
             </Field>
             <Field name="target_area" label="What area does this best relate to?">
                 <LemonSelect

--- a/frontend/src/lib/components/Support/SupportForm.tsx
+++ b/frontend/src/lib/components/Support/SupportForm.tsx
@@ -1,4 +1,4 @@
-import { LemonInput, LemonSegmentedButton, LemonSegmentedButtonOption, lemonToast } from '@posthog/lemon-ui'
+import { LemonInput, LemonSegmentedButton, LemonSegmentedButtonOption, lemonToast, Link } from '@posthog/lemon-ui'
 import { useActions, useSelector, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { Field } from 'lib/forms/Field'
@@ -94,6 +94,10 @@ export function SupportForm(): JSX.Element | null {
                     }))}
                 />
             </Field>
+            <span className="text-muted cursor-pointer">
+                Checkout the{' '}
+                <Link to="https://posthog.com/docs/support-options#severity-levels">severity level definitions</Link>
+            </span>
             <Field name="target_area" label="What area does this best relate to?">
                 <LemonSelect
                     fullWidth

--- a/frontend/src/lib/components/Support/SupportForm.tsx
+++ b/frontend/src/lib/components/Support/SupportForm.tsx
@@ -95,7 +95,7 @@ export function SupportForm(): JSX.Element | null {
                 />
             </Field>
             <span className="text-muted cursor-pointer">
-                Checkout the{' '}
+                Check out the{' '}
                 <Link to="https://posthog.com/docs/support-options#severity-levels">severity level definitions</Link>
             </span>
             <Field name="target_area" label="What area does this best relate to?">

--- a/frontend/src/lib/components/Support/SupportForm.tsx
+++ b/frontend/src/lib/components/Support/SupportForm.tsx
@@ -1,5 +1,5 @@
 import { LemonInput, LemonSegmentedButton, LemonSegmentedButtonOption, lemonToast, Link } from '@posthog/lemon-ui'
-import { useActions, useSelector, useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { Field } from 'lib/forms/Field'
 import { useUploadFiles } from 'lib/hooks/useUploadFiles'
@@ -43,7 +43,6 @@ export function SupportForm(): JSX.Element | null {
     const { objectStorageAvailable } = useValues(preflightLogic)
     // the support model can be shown when logged out, file upload is not offered to anonymous users
     const { user } = useValues(userLogic)
-    const supportRequestKind = useSelector(supportLogic.selectors.kind)
 
     const dropRef = useRef<HTMLDivElement>(null)
 
@@ -57,12 +56,12 @@ export function SupportForm(): JSX.Element | null {
     })
 
     useEffect(() => {
-        if (supportRequestKind === 'bug') {
+        if (sendSupportRequest.kind === 'bug') {
             setSendSupportRequestValue('severity_level', 'medium')
         } else {
             setSendSupportRequestValue('severity_level', 'low')
         }
-    }, [supportRequestKind])
+    }, [sendSupportRequest.kind])
 
     return (
         <Form

--- a/frontend/src/lib/components/Support/SupportForm.tsx
+++ b/frontend/src/lib/components/Support/SupportForm.tsx
@@ -84,6 +84,15 @@ export function SupportForm(): JSX.Element | null {
             <Field name="kind" label="What type of message is this?">
                 <LemonSegmentedButton fullWidth options={SUPPORT_TICKET_OPTIONS} />
             </Field>
+            <Field name="target_area" label="What area does this best relate to?">
+                <LemonSelect
+                    fullWidth
+                    options={Object.entries(TARGET_AREA_TO_NAME).map(([key, value]) => ({
+                        label: value,
+                        value: key,
+                    }))}
+                />
+            </Field>
             <Field name="severity_level" label="What is the severity of this issue?">
                 <LemonSelect
                     fullWidth
@@ -97,15 +106,6 @@ export function SupportForm(): JSX.Element | null {
                 Check out the{' '}
                 <Link to="https://posthog.com/docs/support-options#severity-levels">severity level definitions</Link>
             </span>
-            <Field name="target_area" label="What area does this best relate to?">
-                <LemonSelect
-                    fullWidth
-                    options={Object.entries(TARGET_AREA_TO_NAME).map(([key, value]) => ({
-                        label: value,
-                        value: key,
-                    }))}
-                />
-            </Field>
             <Field
                 name="message"
                 label={sendSupportRequest.kind ? SUPPORT_TICKET_KIND_TO_PROMPT[sendSupportRequest.kind] : 'Content'}

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -185,7 +185,6 @@ export const supportLogic = kea<supportLogicType>([
                     ? SUPPORT_TICKET_KIND_TO_TITLE[sendSupportRequest.kind]
                     : 'Leave a message with PostHog',
         ],
-        kind: [(s) => [s.sendSupportRequest ?? null], (sendSupportRequest) => sendSupportRequest.kind],
     }),
     listeners(({ actions, props, values }) => ({
         updateUrlParams: async () => {

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -220,7 +220,7 @@ export const supportLogic = kea<supportLogicType>([
 
             actions.updateUrlParams()
         },
-        submitZendeskTicket: async ({ name, email, kind, target_area, message }) => {
+        submitZendeskTicket: async ({ name, email, kind, target_area, severity_level, message }) => {
             const zendesk_ticket_uuid = uuid()
             const subject =
                 SUPPORT_KIND_TO_SUBJECT[kind ?? 'support'] +
@@ -235,6 +235,12 @@ export const supportLogic = kea<supportLogicType>([
                 request: {
                     requester: { name: name, email: email },
                     subject: subject,
+                    custom_fields: [
+                        {
+                            id: 22084126888475,
+                            value: severity_level,
+                        },
+                    ],
                     comment: {
                         body: (
                             message +

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -138,7 +138,6 @@ export const supportLogic = kea<supportLogicType>([
         openSupportForm: (values: Partial<SupportFormFields>) => values,
         submitZendeskTicket: (form: SupportFormFields) => form,
         updateUrlParams: true,
-        updateSeverityBasedOnTicketKind: true,
     })),
     reducers(() => ({
         isSupportFormOpen: [
@@ -186,6 +185,7 @@ export const supportLogic = kea<supportLogicType>([
                     ? SUPPORT_TICKET_KIND_TO_TITLE[sendSupportRequest.kind]
                     : 'Leave a message with PostHog',
         ],
+        kind: [(s) => [s.sendSupportRequest ?? null], (sendSupportRequest) => sendSupportRequest.kind],
     }),
     listeners(({ actions, props, values }) => ({
         updateUrlParams: async () => {
@@ -311,15 +311,6 @@ export const supportLogic = kea<supportLogicType>([
 
         setSendSupportRequestValue: () => {
             actions.updateUrlParams()
-            actions.updateSeverityBasedOnTicketKind()
-        },
-
-        updateSeverityBasedOnTicketKind: async () => {
-            if (values.sendSupportRequest.kind === 'bug') {
-                values.sendSupportRequest.severity_level = 'medium'
-            } else {
-                values.sendSupportRequest.severity_level = 'low'
-            }
         },
     })),
 

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -138,6 +138,7 @@ export const supportLogic = kea<supportLogicType>([
         openSupportForm: (values: Partial<SupportFormFields>) => values,
         submitZendeskTicket: (form: SupportFormFields) => form,
         updateUrlParams: true,
+        updateSeverityBasedOnTicketKind: true,
     })),
     reducers(() => ({
         isSupportFormOpen: [
@@ -304,6 +305,15 @@ export const supportLogic = kea<supportLogicType>([
 
         setSendSupportRequestValue: () => {
             actions.updateUrlParams()
+            actions.updateSeverityBasedOnTicketKind()
+        },
+
+        updateSeverityBasedOnTicketKind: async () => {
+            if (values.sendSupportRequest.kind === 'bug') {
+                values.sendSupportRequest.severity_level = 'medium'
+            } else {
+                values.sendSupportRequest.severity_level = 'low'
+            }
         },
     })),
 

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -71,7 +71,7 @@ export const TARGET_AREA_TO_NAME = {
 }
 
 export const SEVERITY_LEVEL_TO_NAME = {
-    critical: 'Critical - Outage / Data loss / Breach',
+    critical: 'Critical - Outage / data loss / breach',
     high: 'High - Feature unavailable / Significant impact',
     medium: 'Medium - Feature not working as expected',
     low: 'Low - Feature request or Question',

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -70,6 +70,13 @@ export const TARGET_AREA_TO_NAME = {
     'posthog-3000': 'PostHog 3000',
 }
 
+export const SEVERITY_LEVEL_TO_NAME = {
+    critical: 'Critical - Outage / Data loss / Breach',
+    high: 'High - Feature unavailable / Significant impact',
+    medium: 'Medium - Feature not working as expected',
+    low: 'Low - Feature request or Question',
+}
+
 export const SUPPORT_KIND_TO_SUBJECT = {
     bug: 'Bug Report',
     feedback: 'Feedback',
@@ -145,6 +152,7 @@ export const supportLogic = kea<supportLogicType>([
                 name: '',
                 email: '',
                 kind: 'support',
+                severity_level: null,
                 target_area: null,
                 message: '',
             } as SupportFormFields,
@@ -154,6 +162,7 @@ export const supportLogic = kea<supportLogicType>([
                     email: !values.user ? (!email ? 'Please enter your email' : '') : '',
                     message: !message ? 'Please enter a message' : '',
                     kind: !kind ? 'Please choose' : undefined,
+                    severity_level: !target_area ? 'Please choose' : undefined,
                     target_area: !target_area ? 'Please choose' : undefined,
                 }
             },

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -84,6 +84,7 @@ export const SUPPORT_KIND_TO_SUBJECT = {
 }
 
 export type SupportTicketTargetArea = keyof typeof TARGET_AREA_TO_NAME
+export type SupportTicketSeverityLevel = keyof typeof SEVERITY_LEVEL_TO_NAME
 export type SupportTicketKind = keyof typeof SUPPORT_KIND_TO_SUBJECT
 
 export const URL_PATH_TO_TARGET_AREA: Record<string, SupportTicketTargetArea> = {
@@ -121,6 +122,7 @@ export type SupportFormFields = {
     email: string
     kind: SupportTicketKind
     target_area: SupportTicketTargetArea | null
+    severity_level: SupportTicketSeverityLevel | null
     message: string
 }
 
@@ -156,13 +158,13 @@ export const supportLogic = kea<supportLogicType>([
                 target_area: null,
                 message: '',
             } as SupportFormFields,
-            errors: ({ name, email, message, kind, target_area }) => {
+            errors: ({ name, email, message, kind, target_area, severity_level }) => {
                 return {
                     name: !values.user ? (!name ? 'Please enter your name' : '') : '',
                     email: !values.user ? (!email ? 'Please enter your email' : '') : '',
                     message: !message ? 'Please enter a message' : '',
                     kind: !kind ? 'Please choose' : undefined,
-                    severity_level: !target_area ? 'Please choose' : undefined,
+                    severity_level: !severity_level ? 'Please choose' : undefined,
                     target_area: !target_area ? 'Please choose' : undefined,
                 }
             },
@@ -189,13 +191,14 @@ export const supportLogic = kea<supportLogicType>([
             const panelOptions = [
                 values.sendSupportRequest.kind ?? '',
                 values.sendSupportRequest.target_area ?? '',
+                values.sendSupportRequest.severity_level ?? '',
             ].join(':')
 
             if (panelOptions !== ':') {
                 actions.setSidePanelOptions(panelOptions)
             }
         },
-        openSupportForm: async ({ name, email, kind, target_area, message }) => {
+        openSupportForm: async ({ name, email, kind, target_area, severity_level, message }) => {
             const area = target_area ?? getURLPathToTargetArea(window.location.pathname)
             kind = kind ?? 'support'
             actions.resetSendSupportRequest({
@@ -203,6 +206,7 @@ export const supportLogic = kea<supportLogicType>([
                 email: email ?? '',
                 kind,
                 target_area: area,
+                severity_level: severity_level ?? null,
                 message: message ?? '',
             })
 
@@ -312,22 +316,24 @@ export const supportLogic = kea<supportLogicType>([
             const [panel, ...panelOptions] = (hashParams['panel'] ?? '').split(':')
 
             if (panel === SidePanelTab.Support) {
-                const [kind, area] = panelOptions
+                const [kind, area, severity] = panelOptions
 
                 actions.openSupportForm({
                     kind: Object.keys(SUPPORT_KIND_TO_SUBJECT).includes(kind) ? kind : null,
                     target_area: Object.keys(TARGET_AREA_TO_NAME).includes(area) ? area : null,
+                    severity_level: Object.keys(SEVERITY_LEVEL_TO_NAME).includes(severity) ? severity : null,
                 })
                 return
             }
 
             // Legacy supportModal param
             if ('supportModal' in hashParams) {
-                const [kind, area] = (hashParams['supportModal'] || '').split(':')
+                const [kind, area, severity] = (hashParams['supportModal'] || '').split(':')
 
                 actions.openSupportForm({
                     kind: Object.keys(SUPPORT_KIND_TO_SUBJECT).includes(kind) ? kind : null,
                     target_area: Object.keys(TARGET_AREA_TO_NAME).includes(area) ? area : null,
+                    severity_level: Object.keys(SEVERITY_LEVEL_TO_NAME).includes(severity) ? severity : null,
                 })
             }
         },


### PR DESCRIPTION
## Problem

add severity level field to the support modal #19781
![2024-01-17 at 16 38 11@2x](https://github.com/PostHog/posthog/assets/13001502/aa5874a6-a2e8-485d-a38d-9e8c2ffc6cd0)

## How did you test this code?

manually sent a ticket through the app and check if the ticket contains the correct `severity_level`