### PR TITLE
fix: Hide apps with deleted configs

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -340,7 +340,7 @@ class PluginViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
                 | Q(is_global=True)
                 | Q(
                     id__in=PluginConfig.objects.filter(  # If a config exists the org can see the plugin
-                        team__organization_id=self.organization_id
+                        team__organization_id=self.organization_id, deleted=False
                     ).values_list("plugin_id", flat=True)
                 )
             )

--- a/posthog/api/test/__snapshots__/test_plugin.ambr
+++ b/posthog/api/test/__snapshots__/test_plugin.ambr
@@ -64,7 +64,8 @@
            (SELECT U0."plugin_id"
             FROM "posthog_pluginconfig" U0
             INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
+            WHERE (NOT U0."deleted"
+                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid))) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
   '''
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.11
@@ -119,7 +120,8 @@
            (SELECT U0."plugin_id"
             FROM "posthog_pluginconfig" U0
             INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid))
+            WHERE (NOT U0."deleted"
+                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
   LIMIT 100 /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
   '''
 # ---
@@ -221,7 +223,8 @@
            (SELECT U0."plugin_id"
             FROM "posthog_pluginconfig" U0
             INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
+            WHERE (NOT U0."deleted"
+                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid))) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
   '''
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.17
@@ -276,7 +279,8 @@
            (SELECT U0."plugin_id"
             FROM "posthog_pluginconfig" U0
             INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid))
+            WHERE (NOT U0."deleted"
+                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
   LIMIT 100 /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
   '''
 # ---
@@ -402,7 +406,8 @@
            (SELECT U0."plugin_id"
             FROM "posthog_pluginconfig" U0
             INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
+            WHERE (NOT U0."deleted"
+                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid))) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
   '''
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.23
@@ -457,7 +462,8 @@
            (SELECT U0."plugin_id"
             FROM "posthog_pluginconfig" U0
             INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid))
+            WHERE (NOT U0."deleted"
+                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
   LIMIT 100 /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
   '''
 # ---
@@ -491,7 +497,8 @@
            (SELECT U0."plugin_id"
             FROM "posthog_pluginconfig" U0
             INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
+            WHERE (NOT U0."deleted"
+                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid))) /*controller='organization_plugins-list',route='api/organizations/%28%3FP%3Cparent_lookup_organization_id%3E%5B%5E/.%5D%2B%29/plugins/%3F%24'*/
   '''
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.6


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We're using config existence as a way to whitelist custom/private apps for users.
But sometimes apps deletion can be tricky if there's lots of plugin storage objects tied to it for example, for these cases it would be useful to use the deleted=true

related: https://posthog.slack.com/archives/C0374DA782U/p1705420134876189?thread_ts=1705406689.326249&cid=C0374DA782U

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
