### PR TITLE
feat: Add deleted to django admin for plugin config

### DIFF
--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -423,6 +423,7 @@ class PluginConfigAdmin(admin.ModelAdmin):
     list_display_links = ("id", "plugin_name")
     list_filter = (
         ("enabled", admin.BooleanFieldListFilter),
+        ("deleted", admin.BooleanFieldListFilter),
         ("updated_at", admin.DateFieldListFilter),
         ("plugin", admin.RelatedOnlyFieldListFilter),
     )


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
we're showing users apps iff they have an existing plugin-config that isn't deleted, seeing the deleted field in the UI would be helpful to know who sees apps.

<img width="574" alt="Screenshot 2024-01-16 at 18 50 59" src="https://github.com/PostHog/posthog/assets/890921/af5ad396-d8dc-4b64-98c9-1c2d84daf091">



## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
