### PR TITLE
fix: denormalized props plz

### DIFF
--- a/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
@@ -3,6 +3,7 @@ import re
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Literal, NamedTuple, Tuple, Union
 
+from django.conf import settings
 from sentry_sdk import capture_exception
 
 from posthog.client import sync_execute
@@ -429,7 +430,7 @@ class SessionIdEventsQuery(EventQuery):
             # when allowing use of denormalized properties in this query
             # it is likely this can be returned to the default of True in future
             # but would need careful monitoring
-            allow_denormalized_props=False,
+            allow_denormalized_props=settings.ALLOW_DENORMALIZED_PROPS_IN_LISTING,
         )
 
         (

--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -3765,6 +3765,182 @@
   OFFSET 0
   '''
 # ---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_event_property_test_account_filter_allowing_denormalized_props
+  '''
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          AND timestamp >= '2021-01-13 12:00:00'
+          AND timestamp <= '2021-01-22 08:00:00'
+          WHERE notEmpty(`$session_id`)
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '''
+# ---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_event_property_test_account_filter_allowing_denormalized_props.1
+  '''
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          AND timestamp >= '2021-01-13 12:00:00'
+          AND timestamp <= '2021-01-22 08:00:00'
+          WHERE notEmpty(`$session_id`)
+            AND (has(['false'], replaceRegexpAll(JSONExtractRaw(e.properties, 'is_internal_user'), '^"|"$', '')))
+          GROUP BY `$session_id`
+          HAVING 1=1) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '''
+# ---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_event_property_test_account_filter_allowing_denormalized_props_materialized
+  '''
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          AND timestamp >= '2021-01-13 12:00:00'
+          AND timestamp <= '2021-01-22 08:00:00'
+          WHERE notEmpty(`$session_id`)
+            AND (event = '$pageview')
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['$pageview'])) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '''
+# ---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_event_property_test_account_filter_allowing_denormalized_props_materialized.1
+  '''
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-31 20:00:00'
+    AND s.min_first_timestamp >= '2021-01-14 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-21 20:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2020-12-31 20:00:00'
+          AND e.timestamp <= now()
+          AND timestamp >= '2021-01-13 12:00:00'
+          AND timestamp <= '2021-01-22 08:00:00'
+          WHERE notEmpty(`$session_id`)
+            AND (has(['false'], "mat_is_internal_user"))
+          GROUP BY `$session_id`
+          HAVING 1=1) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '''
+# ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_event_property_test_account_filter_materialized
   '''
   

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -40,6 +40,7 @@ from posthog.settings.object_storage import *
 from posthog.settings.temporal import *
 from posthog.settings.web import *
 from posthog.settings.data_warehouse import *
+from posthog.settings.session_replay import *
 
 from posthog.settings.utils import get_from_env, str_to_bool
 

--- a/posthog/settings/session_replay.py
+++ b/posthog/settings/session_replay.py
@@ -1,0 +1,7 @@
+from posthog.settings import get_from_env
+from posthog.utils import str_to_bool
+
+# TRICKY: we saw unusual memory usage behavior in EU clickhouse cluster
+# when allowing use of denormalized properties in some session replay event queries
+# it is likely this can be returned to the default of True in future but would need careful monitoring
+ALLOW_DENORMALIZED_PROPS_IN_LISTING = get_from_env("ALLOW_DENORMALIZED_PROPS_IN_LISTING", False, type_cast=str_to_bool)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1033,7 +1033,7 @@ def _request_has_key_set(key: str, request: Request) -> bool:
 
 
 def str_to_bool(value: Any) -> bool:
-    """Return whether the provided string (or any value really) represents true. Otherwise false.
+    """Return whether the provided string (or any value really) represents true. Otherwise, false.
     Just like plugin server stringToBoolean.
     """
     if not value:


### PR DESCRIPTION
follow up to #19491

we had customer report of slowness when filtering over the last week or two which would tie up with not querying materialized columns when they were previously being used...

let's make it configurable and then we can turn it on in the US and test if it helps