### PR TITLE
chore(query-nodes): camel case paths filter

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/defaults.ts
+++ b/frontend/src/queries/nodes/InsightQuery/defaults.ts
@@ -60,7 +60,7 @@ const retentionQueryDefault: RetentionQuery = {
 const pathsQueryDefault: PathsQuery = {
     kind: NodeKind.PathsQuery,
     pathsFilter: {
-        include_event_types: [PathType.PageView],
+        includeEventTypes: [PathType.PageView],
     },
 }
 

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
@@ -439,7 +439,6 @@ describe('filtersToQueryNode', () => {
         it('converts all properties', () => {
             const filters: Partial<PathsFilterType> = {
                 insight: InsightType.PATHS,
-                path_type: PathType.Screen,
                 include_event_types: [PathType.Screen, PathType.PageView],
                 start_point: 'a',
                 end_point: 'b',
@@ -463,20 +462,19 @@ describe('filtersToQueryNode', () => {
             const query: PathsQuery = {
                 kind: NodeKind.PathsQuery,
                 pathsFilter: {
-                    path_type: PathType.Screen,
-                    include_event_types: [PathType.Screen, PathType.PageView],
-                    start_point: 'a',
-                    end_point: 'b',
-                    path_groupings: ['c', 'd'],
-                    funnel_paths: FunnelPathType.between,
-                    funnel_filter: { a: 1 },
-                    exclude_events: ['e', 'f'],
-                    step_limit: 1,
-                    path_replacements: true,
-                    local_path_cleaning_filters: [{ alias: 'home' }],
-                    edge_limit: 1,
-                    min_edge_weight: 1,
-                    max_edge_weight: 1,
+                    includeEventTypes: [PathType.Screen, PathType.PageView],
+                    startPoint: 'a',
+                    endPoint: 'b',
+                    pathGroupings: ['c', 'd'],
+                    funnelPaths: FunnelPathType.between,
+                    funnelFilter: { a: 1 },
+                    excludeEvents: ['e', 'f'],
+                    stepLimit: 1,
+                    pathReplacements: true,
+                    localPathCleaningFilters: [{ alias: 'home' }],
+                    edgeLimit: 1,
+                    minEdgeWeight: 1,
+                    maxEdgeWeight: 1,
                 },
             }
             expect(result).toEqual(query)
@@ -1332,11 +1330,11 @@ describe('filtersToQueryNode', () => {
                     date_to: null,
                 },
                 pathsFilter: {
-                    start_point: 'https://hedgebox.net/',
-                    step_limit: 5,
-                    include_event_types: [PathType.PageView],
-                    path_groupings: ['/files/*'],
-                    edge_limit: 50,
+                    startPoint: 'https://hedgebox.net/',
+                    stepLimit: 5,
+                    includeEventTypes: [PathType.PageView],
+                    pathGroupings: ['/files/*'],
+                    edgeLimit: 50,
                 },
                 properties: {
                     type: FilterLogicalOperator.And,

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -310,7 +310,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
     // paths filter
     if (isPathsFilter(filters) && isPathsQuery(query)) {
         query.pathsFilter = objectCleanWithEmpty({
-            pathsHogql_expression: filters.paths_hogql_expression,
+            pathsHogQLExpression: filters.paths_hogql_expression,
             includeEventTypes: filters.include_event_types,
             startPoint: filters.start_point,
             endPoint: filters.end_point,

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -310,21 +310,20 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
     // paths filter
     if (isPathsFilter(filters) && isPathsQuery(query)) {
         query.pathsFilter = objectCleanWithEmpty({
-            path_type: filters.path_type,
-            paths_hogql_expression: filters.paths_hogql_expression,
-            include_event_types: filters.include_event_types,
-            start_point: filters.start_point,
-            end_point: filters.end_point,
-            path_groupings: filters.path_groupings,
-            funnel_paths: filters.funnel_paths,
-            funnel_filter: filters.funnel_filter,
-            exclude_events: filters.exclude_events,
-            step_limit: filters.step_limit,
-            path_replacements: filters.path_replacements,
-            local_path_cleaning_filters: filters.local_path_cleaning_filters,
-            edge_limit: filters.edge_limit,
-            min_edge_weight: filters.min_edge_weight,
-            max_edge_weight: filters.max_edge_weight,
+            pathsHogql_expression: filters.paths_hogql_expression,
+            includeEventTypes: filters.include_event_types,
+            startPoint: filters.start_point,
+            endPoint: filters.end_point,
+            pathGroupings: filters.path_groupings,
+            funnelPaths: filters.funnel_paths,
+            funnelFilter: filters.funnel_filter,
+            excludeEvents: filters.exclude_events,
+            stepLimit: filters.step_limit,
+            pathReplacements: filters.path_replacements,
+            localPathCleaningFilters: filters.local_path_cleaning_filters,
+            edgeLimit: filters.edge_limit,
+            minEdgeWeight: filters.min_edge_weight,
+            maxEdgeWeight: filters.max_edge_weight,
         })
     }
 

--- a/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
@@ -7,7 +7,10 @@ import {
     EventsNode,
     InsightNodeKind,
     InsightQueryNode,
+    LifecycleFilterLegacy,
     NodeKind,
+    PathsFilterLegacy,
+    StickinessFilterLegacy,
     TrendsFilterLegacy,
 } from '~/queries/schema'
 import {
@@ -146,39 +149,78 @@ export const queryNodeToFilter = (query: InsightQueryNode): Partial<FilterType> 
         filters.toggledLifecycles = query.lifecycleFilter?.toggledLifecycles
     }
 
-    // get node specific filter properties e.g. trendsFilter, funnelsFilter, ...
-    const insightFilter = JSON.parse(JSON.stringify(query[filterMap[query.kind]] || {}))
-    const legacyProps: TrendsFilterLegacy = {}
-    if (isTrendsQuery(query)) {
-        legacyProps.smoothing_intervals = insightFilter.smoothingIntervals
-        legacyProps.decimal_places = insightFilter.decimalPlaces
-        legacyProps.aggregation_axis_format = insightFilter.aggregationAxisFormat
-        legacyProps.aggregation_axis_postfix = insightFilter.aggregationAxisPostfix
-        legacyProps.aggregation_axis_prefix = insightFilter.aggregationAxisPrefix
-        legacyProps.show_labels_on_series = insightFilter.showLabelsOnSeries
-        legacyProps.show_percent_stack_view = insightFilter.showPercentStackView
-        legacyProps.show_legend = insightFilter.showLegend
-        legacyProps.show_values_on_series = insightFilter.showValuesOnSeries
-        delete insightFilter.smoothingIntervals
-        delete insightFilter.decimalPlaces
-        delete insightFilter.aggregationAxisFormat
-        delete insightFilter.aggregationAxisPostfix
-        delete insightFilter.aggregationAxisPrefix
-        delete insightFilter.showLabelsOnSeries
-        delete insightFilter.showPercentStackView
-        delete insightFilter.showLegend
-        delete insightFilter.showValuesOnSeries
-    } else if (isStickinessQuery(query)) {
-        legacyProps.show_legend = insightFilter.showLegend
-        legacyProps.show_values_on_series = insightFilter.showValuesOnSeries
-        delete insightFilter.showLegend
-        delete insightFilter.showValuesOnSeries
-    } else if (isLifecycleQuery(query)) {
-        legacyProps.show_values_on_series = insightFilter.showValuesOnSeries
-        delete insightFilter.showValuesOnSeries
+    // we don't want to mutate the original query
+    const queryCopy = JSON.parse(JSON.stringify(query))
+
+    // replace camel cased props with the snake cased variant
+    const camelCasedTrendsProps: TrendsFilterLegacy = {}
+    const camelCasedPathsProps: PathsFilterLegacy = {}
+    const camelCasedStickinessProps: StickinessFilterLegacy = {}
+    const camelCasedLifecycleProps: LifecycleFilterLegacy = {}
+    if (isTrendsQuery(queryCopy)) {
+        camelCasedTrendsProps.smoothing_intervals = queryCopy.trendsFilter?.smoothingIntervals
+        camelCasedTrendsProps.decimal_places = queryCopy.trendsFilter?.decimalPlaces
+        camelCasedTrendsProps.aggregation_axis_format = queryCopy.trendsFilter?.aggregationAxisFormat
+        camelCasedTrendsProps.aggregation_axis_postfix = queryCopy.trendsFilter?.aggregationAxisPostfix
+        camelCasedTrendsProps.aggregation_axis_prefix = queryCopy.trendsFilter?.aggregationAxisPrefix
+        camelCasedTrendsProps.show_labels_on_series = queryCopy.trendsFilter?.showLabelsOnSeries
+        camelCasedTrendsProps.show_percent_stack_view = queryCopy.trendsFilter?.showPercentStackView
+        camelCasedTrendsProps.show_legend = queryCopy.trendsFilter?.showLegend
+        camelCasedTrendsProps.show_values_on_series = queryCopy.trendsFilter?.showValuesOnSeries
+        delete queryCopy.trendsFilter?.smoothingIntervals
+        delete queryCopy.trendsFilter?.decimalPlaces
+        delete queryCopy.trendsFilter?.aggregationAxisFormat
+        delete queryCopy.trendsFilter?.aggregationAxisPostfix
+        delete queryCopy.trendsFilter?.aggregationAxisPrefix
+        delete queryCopy.trendsFilter?.showLabelsOnSeries
+        delete queryCopy.trendsFilter?.showPercentStackView
+        delete queryCopy.trendsFilter?.showLegend
+        delete queryCopy.trendsFilter?.showValuesOnSeries
+    } else if (isPathsQuery(queryCopy)) {
+        camelCasedPathsProps.edge_limit = queryCopy.pathsFilter?.edgeLimit
+        camelCasedPathsProps.paths_hogql_expression = queryCopy.pathsFilter?.pathsHogQLExpression
+        camelCasedPathsProps.include_event_types = queryCopy.pathsFilter?.includeEventTypes
+        camelCasedPathsProps.start_point = queryCopy.pathsFilter?.startPoint
+        camelCasedPathsProps.end_point = queryCopy.pathsFilter?.endPoint
+        camelCasedPathsProps.path_groupings = queryCopy.pathsFilter?.pathGroupings
+        camelCasedPathsProps.exclude_events = queryCopy.pathsFilter?.excludeEvents
+        camelCasedPathsProps.step_limit = queryCopy.pathsFilter?.stepLimit
+        camelCasedPathsProps.path_replacements = queryCopy.pathsFilter?.pathReplacements
+        camelCasedPathsProps.local_path_cleaning_filters = queryCopy.pathsFilter?.localPathCleaningFilters
+        camelCasedPathsProps.min_edge_weight = queryCopy.pathsFilter?.minEdgeWeight
+        camelCasedPathsProps.max_edge_weight = queryCopy.pathsFilter?.maxEdgeWeight
+        camelCasedPathsProps.funnel_paths = queryCopy.pathsFilter?.funnelPaths
+        camelCasedPathsProps.funnel_filter = queryCopy.pathsFilter?.funnelFilter
+        delete queryCopy.pathsFilter?.edgeLimit
+        delete queryCopy.pathsFilter?.pathsHogQLExpression
+        delete queryCopy.pathsFilter?.includeEventTypes
+        delete queryCopy.pathsFilter?.startPoint
+        delete queryCopy.pathsFilter?.endPoint
+        delete queryCopy.pathsFilter?.pathGroupings
+        delete queryCopy.pathsFilter?.excludeEvents
+        delete queryCopy.pathsFilter?.stepLimit
+        delete queryCopy.pathsFilter?.pathReplacements
+        delete queryCopy.pathsFilter?.localPathCleaningFilters
+        delete queryCopy.pathsFilter?.minEdgeWeight
+        delete queryCopy.pathsFilter?.maxEdgeWeight
+        delete queryCopy.pathsFilter?.funnelPaths
+        delete queryCopy.pathsFilter?.funnelFilter
+    } else if (isStickinessQuery(queryCopy)) {
+        camelCasedStickinessProps.show_legend = queryCopy.stickinessFilter?.showLegend
+        camelCasedStickinessProps.show_values_on_series = queryCopy.stickinessFilter?.showValuesOnSeries
+        delete queryCopy.stickinessFilter?.showLegend
+        delete queryCopy.stickinessFilter?.showValuesOnSeries
+    } else if (isLifecycleQuery(queryCopy)) {
+        camelCasedLifecycleProps.show_values_on_series = queryCopy.lifecycleFilter?.showValuesOnSeries
+        delete queryCopy.lifecycleFilter?.showValuesOnSeries
     }
-    Object.assign(filters, insightFilter)
-    Object.assign(filters, legacyProps)
+    Object.assign(filters, camelCasedTrendsProps)
+    Object.assign(filters, camelCasedPathsProps)
+    Object.assign(filters, camelCasedStickinessProps)
+    Object.assign(filters, camelCasedLifecycleProps)
+
+    // add the remaining node specific filter properties
+    Object.assign(filters, queryCopy[filterMap[query.kind]])
 
     return filters
 }

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -76,7 +76,7 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
         isTrendsFunnel
     const hasPathsAdvanced = availableFeatures.includes(AvailableFeature.PATHS_ADVANCED)
     const hasAttribution = isStepsFunnel
-    const hasPathsHogQL = isPaths && pathsFilter?.include_event_types?.includes(PathType.HogQL)
+    const hasPathsHogQL = isPaths && pathsFilter?.includeEventTypes?.includes(PathType.HogQL)
 
     const editorFilters: InsightEditorFilterGroup[] = [
         {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2239,7 +2239,7 @@
                 "pathReplacements": {
                     "type": "boolean"
                 },
-                "pathsHogqlExpression": {
+                "pathsHogQLExpression": {
                     "type": "string"
                 },
                 "startPoint": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2193,6 +2193,66 @@
         },
         "PathsFilter": {
             "additionalProperties": false,
+            "properties": {
+                "edge_limit": {
+                    "type": "number"
+                },
+                "end_point": {
+                    "type": "string"
+                },
+                "exclude_events": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "funnel_filter": {
+                    "type": "object"
+                },
+                "funnel_paths": {
+                    "$ref": "#/definitions/FunnelPathType"
+                },
+                "include_event_types": {
+                    "items": {
+                        "$ref": "#/definitions/PathType"
+                    },
+                    "type": "array"
+                },
+                "local_path_cleaning_filters": {
+                    "items": {
+                        "$ref": "#/definitions/PathCleaningFilter"
+                    },
+                    "type": "array"
+                },
+                "max_edge_weight": {
+                    "type": "number"
+                },
+                "min_edge_weight": {
+                    "type": "number"
+                },
+                "path_groupings": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "path_replacements": {
+                    "type": "boolean"
+                },
+                "paths_hogql_expression": {
+                    "type": "string"
+                },
+                "start_point": {
+                    "type": "string"
+                },
+                "step_limit": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "PathsFilterLegacy": {
+            "additionalProperties": false,
             "description": "`PathsFilterType` minus everything inherited from `FilterType` and persons modal related params",
             "properties": {
                 "edge_limit": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2194,58 +2194,58 @@
         "PathsFilter": {
             "additionalProperties": false,
             "properties": {
-                "edge_limit": {
+                "edgeLimit": {
                     "type": "number"
                 },
-                "end_point": {
+                "endPoint": {
                     "type": "string"
                 },
-                "exclude_events": {
+                "excludeEvents": {
                     "items": {
                         "type": "string"
                     },
                     "type": "array"
                 },
-                "funnel_filter": {
+                "funnelFilter": {
                     "type": "object"
                 },
-                "funnel_paths": {
+                "funnelPaths": {
                     "$ref": "#/definitions/FunnelPathType"
                 },
-                "include_event_types": {
+                "includeEventTypes": {
                     "items": {
                         "$ref": "#/definitions/PathType"
                     },
                     "type": "array"
                 },
-                "local_path_cleaning_filters": {
+                "localPathCleaningFilters": {
                     "items": {
                         "$ref": "#/definitions/PathCleaningFilter"
                     },
                     "type": "array"
                 },
-                "max_edge_weight": {
+                "maxEdgeWeight": {
                     "type": "number"
                 },
-                "min_edge_weight": {
+                "minEdgeWeight": {
                     "type": "number"
                 },
-                "path_groupings": {
+                "pathGroupings": {
                     "items": {
                         "type": "string"
                     },
                     "type": "array"
                 },
-                "path_replacements": {
+                "pathReplacements": {
                     "type": "boolean"
                 },
-                "paths_hogql_expression": {
+                "pathsHogqlExpression": {
                     "type": "string"
                 },
-                "start_point": {
+                "startPoint": {
                     "type": "string"
                 },
-                "step_limit": {
+                "stepLimit": {
                     "type": "number"
                 }
             },

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -605,20 +605,20 @@ export type PathsFilterLegacy = Omit<
 >
 
 export type PathsFilter = {
-    edge_limit?: PathsFilterLegacy['edge_limit']
-    paths_hogql_expression?: PathsFilterLegacy['paths_hogql_expression']
-    include_event_types?: PathsFilterLegacy['include_event_types']
-    start_point?: PathsFilterLegacy['start_point']
-    end_point?: PathsFilterLegacy['end_point']
-    path_groupings?: PathsFilterLegacy['path_groupings']
-    exclude_events?: PathsFilterLegacy['exclude_events']
-    step_limit?: PathsFilterLegacy['step_limit']
-    path_replacements?: PathsFilterLegacy['path_replacements']
-    local_path_cleaning_filters?: PathsFilterLegacy['local_path_cleaning_filters']
-    min_edge_weight?: PathsFilterLegacy['min_edge_weight']
-    max_edge_weight?: PathsFilterLegacy['max_edge_weight']
-    funnel_paths?: PathsFilterLegacy['funnel_paths']
-    funnel_filter?: PathsFilterLegacy['funnel_filter']
+    edgeLimit?: PathsFilterLegacy['edge_limit']
+    pathsHogqlExpression?: PathsFilterLegacy['paths_hogql_expression']
+    includeEventTypes?: PathsFilterLegacy['include_event_types']
+    startPoint?: PathsFilterLegacy['start_point']
+    endPoint?: PathsFilterLegacy['end_point']
+    pathGroupings?: PathsFilterLegacy['path_groupings']
+    excludeEvents?: PathsFilterLegacy['exclude_events']
+    stepLimit?: PathsFilterLegacy['step_limit']
+    pathReplacements?: PathsFilterLegacy['path_replacements']
+    localPathCleaningFilters?: PathsFilterLegacy['local_path_cleaning_filters']
+    minEdgeWeight?: PathsFilterLegacy['min_edge_weight']
+    maxEdgeWeight?: PathsFilterLegacy['max_edge_weight']
+    funnelPaths?: PathsFilterLegacy['funnel_paths']
+    funnelFilter?: PathsFilterLegacy['funnel_filter']
 }
 
 export interface PathsQuery extends InsightsQueryBase {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -606,7 +606,7 @@ export type PathsFilterLegacy = Omit<
 
 export type PathsFilter = {
     edgeLimit?: PathsFilterLegacy['edge_limit']
-    pathsHogqlExpression?: PathsFilterLegacy['paths_hogql_expression']
+    pathsHogQLExpression?: PathsFilterLegacy['paths_hogql_expression']
     includeEventTypes?: PathsFilterLegacy['include_event_types']
     startPoint?: PathsFilterLegacy['start_point']
     endPoint?: PathsFilterLegacy['end_point']

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -599,10 +599,28 @@ export interface RetentionQuery extends InsightsQueryBase {
 }
 
 /** `PathsFilterType` minus everything inherited from `FilterType` and persons modal related params */
-export type PathsFilter = Omit<
+export type PathsFilterLegacy = Omit<
     PathsFilterType,
     keyof FilterType | 'path_start_key' | 'path_end_key' | 'path_dropoff_key'
 >
+
+export type PathsFilter = {
+    edge_limit?: PathsFilterLegacy['edge_limit']
+    paths_hogql_expression?: PathsFilterLegacy['paths_hogql_expression']
+    include_event_types?: PathsFilterLegacy['include_event_types']
+    start_point?: PathsFilterLegacy['start_point']
+    end_point?: PathsFilterLegacy['end_point']
+    path_groupings?: PathsFilterLegacy['path_groupings']
+    exclude_events?: PathsFilterLegacy['exclude_events']
+    step_limit?: PathsFilterLegacy['step_limit']
+    path_replacements?: PathsFilterLegacy['path_replacements']
+    local_path_cleaning_filters?: PathsFilterLegacy['local_path_cleaning_filters']
+    min_edge_weight?: PathsFilterLegacy['min_edge_weight']
+    max_edge_weight?: PathsFilterLegacy['max_edge_weight']
+    funnel_paths?: PathsFilterLegacy['funnel_paths']
+    funnel_filter?: PathsFilterLegacy['funnel_filter']
+}
+
 export interface PathsQuery extends InsightsQueryBase {
     kind: NodeKind.PathsQuery
     /** Properties specific to the paths insight */

--- a/frontend/src/scenes/insights/EditorFilters/PathsAdvanced.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/PathsAdvanced.tsx
@@ -16,19 +16,19 @@ export function PathsAdvanced({ insightProps, ...rest }: EditorFilterProps): JSX
     const { pathsFilter } = useValues(pathsDataLogic(insightProps))
     const { updateInsightFilter } = useActions(pathsDataLogic(insightProps))
 
-    const { edge_limit, min_edge_weight, max_edge_weight } = pathsFilter || {}
+    const { edgeLimit, minEdgeWeight, maxEdgeWeight } = pathsFilter || {}
 
     const [localEdgeParameters, setLocalEdgeParameters] = useState<PathEdgeParameters>({
-        edge_limit: edge_limit,
-        min_edge_weight: min_edge_weight,
-        max_edge_weight: max_edge_weight,
+        edgeLimit,
+        minEdgeWeight,
+        maxEdgeWeight,
     })
 
     const updateEdgeParameters = (): void => {
         if (
-            localEdgeParameters.edge_limit !== edge_limit ||
-            localEdgeParameters.min_edge_weight !== min_edge_weight ||
-            localEdgeParameters.max_edge_weight !== max_edge_weight
+            localEdgeParameters.edgeLimit !== edgeLimit ||
+            localEdgeParameters.minEdgeWeight !== minEdgeWeight ||
+            localEdgeParameters.maxEdgeWeight !== maxEdgeWeight
         ) {
             updateInsightFilter({ ...localEdgeParameters })
         }
@@ -49,7 +49,7 @@ export function PathsAdvanced({ insightProps, ...rest }: EditorFilterProps): JSX
                     onChange={(value): void =>
                         setLocalEdgeParameters((state) => ({
                             ...state,
-                            edge_limit: Number(value),
+                            edgeLimit: Number(value),
                         }))
                     }
                     onBlur={updateEdgeParameters}
@@ -70,7 +70,7 @@ export function PathsAdvanced({ insightProps, ...rest }: EditorFilterProps): JSX
                         onChange={(value): void =>
                             setLocalEdgeParameters((state) => ({
                                 ...state,
-                                min_edge_weight: Number(value),
+                                minEdgeWeight: Number(value),
                             }))
                         }
                         onBlur={updateEdgeParameters}
@@ -82,7 +82,7 @@ export function PathsAdvanced({ insightProps, ...rest }: EditorFilterProps): JSX
                         onChange={(value): void =>
                             setLocalEdgeParameters((state) => ({
                                 ...state,
-                                max_edge_weight: Number(value),
+                                maxEdgeWeight: Number(value),
                             }))
                         }
                         min={0}

--- a/frontend/src/scenes/insights/EditorFilters/PathsEventTypes.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/PathsEventTypes.tsx
@@ -4,7 +4,8 @@ import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { pathsDataLogic } from 'scenes/paths/pathsDataLogic'
 
-import { EditorFilterProps, PathsFilterType, PathType } from '~/types'
+import { PathsFilter } from '~/queries/schema'
+import { EditorFilterProps, PathType } from '~/types'
 
 import { humanizePathsEventTypes } from '../utils'
 
@@ -12,9 +13,9 @@ export function PathsEventsTypes({ insightProps }: EditorFilterProps): JSX.Eleme
     const { pathsFilter } = useValues(pathsDataLogic(insightProps))
     const { updateInsightFilter } = useActions(pathsDataLogic(insightProps))
 
-    const includeEventTypes = pathsFilter?.include_event_types
-    const setIncludeEventTypes = (includeEventTypes: PathsFilterType['include_event_types']): void => {
-        updateInsightFilter({ include_event_types: includeEventTypes })
+    const includeEventTypes = pathsFilter?.includeEventTypes
+    const setIncludeEventTypes = (includeEventTypes: PathsFilter['includeEventTypes']): void => {
+        updateInsightFilter({ includeEventTypes: includeEventTypes })
     }
 
     const options = [

--- a/frontend/src/scenes/insights/EditorFilters/PathsExclusions.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/PathsExclusions.tsx
@@ -9,14 +9,14 @@ export function PathsExclusions({ insightProps }: EditorFilterProps): JSX.Elemen
     const { pathsFilter, taxonomicGroupTypes } = useValues(pathsDataLogic(insightProps))
     const { updateInsightFilter } = useActions(pathsDataLogic(insightProps))
 
-    const { exclude_events, path_groupings } = pathsFilter || {}
+    const { excludeEvents, pathGroupings } = pathsFilter || {}
     return (
         <PathItemFilters
             taxonomicGroupTypes={taxonomicGroupTypes}
-            pageKey={`${keyForInsightLogicProps('new')(insightProps)}-exclude_events`}
+            pageKey={`${keyForInsightLogicProps('new')(insightProps)}-excludeEvents`}
             propertyFilters={
-                exclude_events &&
-                exclude_events.map(
+                excludeEvents &&
+                excludeEvents.map(
                     (name): EventPropertyFilter => ({
                         key: name,
                         value: name,
@@ -26,9 +26,9 @@ export function PathsExclusions({ insightProps }: EditorFilterProps): JSX.Elemen
                 )
             }
             onChange={(values) => {
-                updateInsightFilter({ exclude_events: values.map((v) => v.value as string) })
+                updateInsightFilter({ excludeEvents: values.map((v) => v.value as string) })
             }}
-            wildcardOptions={path_groupings?.map((name) => ({ name }))}
+            wildcardOptions={pathGroupings?.map((name) => ({ name }))}
         />
     )
 }

--- a/frontend/src/scenes/insights/EditorFilters/PathsHogQL.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/PathsHogQL.tsx
@@ -13,13 +13,13 @@ export function PathsHogQL({ insightProps }: EditorFilterProps): JSX.Element {
     return (
         <TaxonomicPopover
             groupType={TaxonomicFilterGroupType.HogQLExpression}
-            value={pathsFilter?.pathsHogqlExpression || 'event'}
+            value={pathsFilter?.pathsHogQLExpression || 'event'}
             data-attr="paths-hogql-expression"
             fullWidth
             onChange={(v, g) => {
                 const hogQl = taxonomicEventFilterToHogQL(g, v)
                 if (hogQl) {
-                    updateInsightFilter({ pathsHogqlExpression: hogQl })
+                    updateInsightFilter({ pathsHogQLExpression: hogQl })
                 }
             }}
             groupTypes={[TaxonomicFilterGroupType.HogQLExpression]}

--- a/frontend/src/scenes/insights/EditorFilters/PathsHogQL.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/PathsHogQL.tsx
@@ -13,13 +13,13 @@ export function PathsHogQL({ insightProps }: EditorFilterProps): JSX.Element {
     return (
         <TaxonomicPopover
             groupType={TaxonomicFilterGroupType.HogQLExpression}
-            value={pathsFilter?.paths_hogql_expression || 'event'}
+            value={pathsFilter?.pathsHogqlExpression || 'event'}
             data-attr="paths-hogql-expression"
             fullWidth
             onChange={(v, g) => {
                 const hogQl = taxonomicEventFilterToHogQL(g, v)
                 if (hogQl) {
-                    updateInsightFilter({ paths_hogql_expression: hogQl })
+                    updateInsightFilter({ pathsHogqlExpression: hogQl })
                 }
             }}
             groupTypes={[TaxonomicFilterGroupType.HogQLExpression]}

--- a/frontend/src/scenes/insights/EditorFilters/PathsTarget.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/PathsTarget.tsx
@@ -23,18 +23,18 @@ function PathsTarget({ position, insightProps }: PathTargetProps): JSX.Element {
     const { pathsFilter, taxonomicGroupTypes } = useValues(pathsDataLogic(insightProps))
     const { updateInsightFilter } = useActions(pathsDataLogic(insightProps))
 
-    const { funnel_paths, funnel_filter, start_point, end_point, path_groupings } = pathsFilter || {}
+    const { funnelPaths, funnelFilter, startPoint, endPoint, pathGroupings } = pathsFilter || {}
 
-    const overrideStartInput = funnel_paths && [FunnelPathType.between, FunnelPathType.after].includes(funnel_paths)
-    const overrideEndInput = funnel_paths && [FunnelPathType.between, FunnelPathType.before].includes(funnel_paths)
+    const overrideStartInput = funnelPaths && [FunnelPathType.between, FunnelPathType.after].includes(funnelPaths)
+    const overrideEndInput = funnelPaths && [FunnelPathType.between, FunnelPathType.before].includes(funnelPaths)
     const overrideInputs = overrideStartInput || overrideEndInput
 
-    const key = position === 'start' ? 'start_point' : 'end_point'
+    const key = position === 'start' ? 'startPoint' : 'endPoint'
     const onChange = (item: string): void => {
         updateInsightFilter({ [key]: item })
     }
     const onReset = (): void => {
-        updateInsightFilter({ [key]: undefined, funnel_filter: undefined, funnel_paths: undefined })
+        updateInsightFilter({ [key]: undefined, funnelFilter: undefined, funnelPaths: undefined })
     }
 
     function _getStepNameAtIndex(filters: Record<string, any>, index: number): string {
@@ -65,18 +65,18 @@ function PathsTarget({ position, insightProps }: PathTargetProps): JSX.Element {
     }
 
     function getStartPointLabel(): JSX.Element {
-        if (funnel_paths) {
-            if (funnel_paths === FunnelPathType.after) {
-                return _getStepLabel(funnel_filter, funnel_filter?.funnel_step)
-            } else if (funnel_paths === FunnelPathType.between) {
+        if (funnelPaths) {
+            if (funnelPaths === FunnelPathType.after) {
+                return _getStepLabel(funnelFilter, funnelFilter?.funnel_step)
+            } else if (funnelPaths === FunnelPathType.between) {
                 // funnel_step targets the later of the 2 events when specifying between so the start point index is shifted back 1
-                return _getStepLabel(funnel_filter, funnel_filter?.funnel_step, -1)
+                return _getStepLabel(funnelFilter, funnelFilter?.funnel_step, -1)
             } else {
                 return <span />
             }
         } else {
-            return start_point ? (
-                <span className="label">{start_point}</span>
+            return startPoint ? (
+                <span className="label">{startPoint}</span>
             ) : (
                 <span className="label text-muted">Add start point</span>
             )
@@ -84,15 +84,15 @@ function PathsTarget({ position, insightProps }: PathTargetProps): JSX.Element {
     }
 
     function getEndPointLabel(): JSX.Element {
-        if (funnel_paths) {
-            if (funnel_paths === FunnelPathType.before || funnel_paths === FunnelPathType.between) {
-                return _getStepLabel(funnel_filter, funnel_filter?.funnel_step)
+        if (funnelPaths) {
+            if (funnelPaths === FunnelPathType.before || funnelPaths === FunnelPathType.between) {
+                return _getStepLabel(funnelFilter, funnelFilter?.funnel_step)
             } else {
                 return <span />
             }
         } else {
-            return end_point ? (
-                <span className="label">{end_point}</span>
+            return endPoint ? (
+                <span className="label">{endPoint}</span>
             ) : (
                 <span className="label text-muted">Add end point</span>
             )
@@ -103,18 +103,18 @@ function PathsTarget({ position, insightProps }: PathTargetProps): JSX.Element {
         start: {
             index: 0,
             getLabel: getStartPointLabel,
-            pathItem: start_point,
-            closeButtonEnabled: start_point || overrideStartInput,
+            pathItem: startPoint,
+            closeButtonEnabled: startPoint || overrideStartInput,
             disabled: overrideEndInput && !overrideStartInput,
-            funnelFilterLink: funnel_filter && overrideStartInput,
+            funnelFilterLink: funnelFilter && overrideStartInput,
         },
         end: {
             index: 1,
             getLabel: getEndPointLabel,
-            pathItem: end_point,
-            closeButtonEnabled: end_point || overrideEndInput,
+            pathItem: endPoint,
+            closeButtonEnabled: endPoint || overrideEndInput,
             disabled: overrideStartInput && !overrideEndInput,
-            funnelFilterLink: funnel_filter && overrideEndInput,
+            funnelFilterLink: funnelFilter && overrideEndInput,
         },
     }[position]
 
@@ -125,7 +125,7 @@ function PathsTarget({ position, insightProps }: PathTargetProps): JSX.Element {
             onChange={onChange}
             taxonomicGroupTypes={taxonomicGroupTypes}
             disabled={overrideInputs}
-            wildcardOptions={path_groupings?.map((name) => ({ name }))}
+            wildcardOptions={pathGroupings?.map((name) => ({ name }))}
         >
             <LemonButton
                 data-attr={'new-prop-filter-' + positionOptions.index}
@@ -138,7 +138,7 @@ function PathsTarget({ position, insightProps }: PathTargetProps): JSX.Element {
                     positionOptions.funnelFilterLink
                         ? () => {
                               router.actions.push(
-                                  combineUrl('/insights', encodeParams(funnel_filter as Record<string, any>, '?')).url
+                                  combineUrl('/insights', encodeParams(funnelFilter as Record<string, any>, '?')).url
                               )
                           }
                         : () => {}

--- a/frontend/src/scenes/insights/EditorFilters/PathsWildcardGroups.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/PathsWildcardGroups.tsx
@@ -10,8 +10,8 @@ export function PathsWildcardGroups({ insightProps }: EditorFilterProps): JSX.El
 
     return (
         <LemonSelectMultiple
-            onChange={(path_groupings: string[]) => updateInsightFilter({ path_groupings })}
-            value={pathsFilter?.path_groupings || []}
+            onChange={(pathGroupings: string[]) => updateInsightFilter({ pathGroupings })}
+            value={pathsFilter?.pathGroupings || []}
             filterOption={false}
             mode="multiple-custom"
         />

--- a/frontend/src/scenes/insights/filters/PathCleaningFilter.tsx
+++ b/frontend/src/scenes/insights/filters/PathCleaningFilter.tsx
@@ -11,7 +11,7 @@ export function PathCleaningFilter({ insightProps }: EditorFilterProps): JSX.Ele
     const { pathsFilter } = useValues(pathsDataLogic(insightProps))
     const { updateInsightFilter } = useActions(pathsDataLogic(insightProps))
 
-    const { local_path_cleaning_filters, path_replacements } = pathsFilter || {}
+    const { localPathCleaningFilters, pathReplacements } = pathsFilter || {}
 
     const { currentTeam } = useValues(teamLogic)
     const hasFilters = (currentTeam?.path_cleaning_filters || []).length > 0
@@ -19,8 +19,8 @@ export function PathCleaningFilter({ insightProps }: EditorFilterProps): JSX.Ele
     return (
         <>
             <PathCleanFilters
-                filters={local_path_cleaning_filters}
-                setFilters={(filters) => updateInsightFilter({ local_path_cleaning_filters: filters })}
+                filters={localPathCleaningFilters}
+                setFilters={(filters) => updateInsightFilter({ localPathCleaningFilters: filters })}
             />
             <Tooltip
                 title={
@@ -33,10 +33,10 @@ export function PathCleaningFilter({ insightProps }: EditorFilterProps): JSX.Ele
                 <div className="inline-block mt-4">
                     <LemonSwitch
                         disabled={!hasFilters}
-                        checked={hasFilters ? path_replacements || false : false}
+                        checked={hasFilters ? pathReplacements || false : false}
                         onChange={(checked: boolean) => {
                             localStorage.setItem('default_path_clean_filters', checked.toString())
-                            updateInsightFilter({ path_replacements: checked })
+                            updateInsightFilter({ pathReplacements: checked })
                         }}
                         label="Apply global path URL cleaning"
                         bordered

--- a/frontend/src/scenes/insights/filters/PathCleaningFilter.tsx
+++ b/frontend/src/scenes/insights/filters/PathCleaningFilter.tsx
@@ -35,7 +35,6 @@ export function PathCleaningFilter({ insightProps }: EditorFilterProps): JSX.Ele
                         disabled={!hasFilters}
                         checked={hasFilters ? pathReplacements || false : false}
                         onChange={(checked: boolean) => {
-                            localStorage.setItem('default_path_clean_filters', checked.toString())
                             updateInsightFilter({ pathReplacements: checked })
                         }}
                         label="Apply global path URL cleaning"

--- a/frontend/src/scenes/insights/summarizeInsight.test.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.test.ts
@@ -787,7 +787,7 @@ describe('summarizing insights', () => {
             const query: PathsQuery = {
                 kind: NodeKind.PathsQuery,
                 pathsFilter: {
-                    include_event_types: [PathType.PageView, PathType.Screen, PathType.CustomEvent],
+                    includeEventTypes: [PathType.PageView, PathType.Screen, PathType.CustomEvent],
                 },
             }
 
@@ -800,11 +800,11 @@ describe('summarizing insights', () => {
             expect(result).toEqual('User paths based on all events')
         })
 
-        it('summarizes a Paths insight based on all events (empty include_event_types case)', () => {
+        it('summarizes a Paths insight based on all events (empty includeEventTypes case)', () => {
             const query: PathsQuery = {
                 kind: NodeKind.PathsQuery,
                 pathsFilter: {
-                    include_event_types: [],
+                    includeEventTypes: [],
                 },
             }
 
@@ -821,9 +821,9 @@ describe('summarizing insights', () => {
             const query: PathsQuery = {
                 kind: NodeKind.PathsQuery,
                 pathsFilter: {
-                    include_event_types: [PathType.PageView],
-                    start_point: '/landing-page',
-                    end_point: '/basket',
+                    includeEventTypes: [PathType.PageView],
+                    startPoint: '/landing-page',
+                    endPoint: '/basket',
                 },
             }
 

--- a/frontend/src/scenes/insights/summarizeInsight.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.ts
@@ -264,14 +264,14 @@ export function summarizeInsightQuery(query: InsightQueryNode, context: SummaryC
         )
     } else if (isPathsQuery(query)) {
         // Sync format with PathsSummary in InsightDetails
-        let summary = `User paths based on ${humanizePathsEventTypes(query.pathsFilter?.include_event_types).join(
+        let summary = `User paths based on ${humanizePathsEventTypes(query.pathsFilter?.includeEventTypes).join(
             ' and '
         )}`
-        if (query.pathsFilter?.start_point) {
-            summary += ` starting at ${query.pathsFilter?.start_point}`
+        if (query.pathsFilter?.startPoint) {
+            summary += ` starting at ${query.pathsFilter?.startPoint}`
         }
-        if (query.pathsFilter?.end_point) {
-            summary += `${query.pathsFilter?.start_point ? ' and' : ''} ending at ${query.pathsFilter?.end_point}`
+        if (query.pathsFilter?.endPoint) {
+            summary += `${query.pathsFilter?.startPoint ? ' and' : ''} ending at ${query.pathsFilter?.endPoint}`
         }
         return summary
     } else if (isStickinessQuery(query)) {

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -11,7 +11,7 @@ import { urls } from 'scenes/urls'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { FormatPropertyValueForDisplayFunction } from '~/models/propertyDefinitionsModel'
 import { examples } from '~/queries/examples'
-import { ActionsNode, BreakdownFilter, EventsNode } from '~/queries/schema'
+import { ActionsNode, BreakdownFilter, EventsNode, PathsFilter } from '~/queries/schema'
 import { isEventsNode } from '~/queries/utils'
 import {
     ActionFilter,
@@ -26,7 +26,6 @@ import {
     InsightModel,
     InsightShortId,
     InsightType,
-    PathsFilterType,
     PathType,
     TrendsFilterType,
 } from '~/types'
@@ -162,25 +161,25 @@ export async function getInsightId(shortId: InsightShortId): Promise<number | un
               .results[0]?.id
 }
 
-export function humanizePathsEventTypes(include_event_types: PathsFilterType['include_event_types']): string[] {
+export function humanizePathsEventTypes(includeEventTypes: PathsFilter['includeEventTypes']): string[] {
     let humanEventTypes: string[] = []
-    if (include_event_types) {
-        if (include_event_types.includes(PathType.PageView)) {
+    if (includeEventTypes) {
+        if (includeEventTypes.includes(PathType.PageView)) {
             humanEventTypes.push('page views')
         }
-        if (include_event_types.includes(PathType.Screen)) {
+        if (includeEventTypes.includes(PathType.Screen)) {
             humanEventTypes.push('screen views')
         }
-        if (include_event_types.includes(PathType.CustomEvent)) {
+        if (includeEventTypes.includes(PathType.CustomEvent)) {
             humanEventTypes.push('custom events')
         }
         if (
-            (humanEventTypes.length === 0 && !include_event_types.includes(PathType.HogQL)) ||
+            (humanEventTypes.length === 0 && !includeEventTypes.includes(PathType.HogQL)) ||
             humanEventTypes.length === 3
         ) {
             humanEventTypes = ['all events']
         }
-        if (include_event_types.includes(PathType.HogQL)) {
+        if (includeEventTypes.includes(PathType.HogQL)) {
             humanEventTypes.push('HogQL expression')
         }
     }

--- a/frontend/src/scenes/insights/views/Paths/PathStepPicker.tsx
+++ b/frontend/src/scenes/insights/views/Paths/PathStepPicker.tsx
@@ -17,7 +17,7 @@ export function PathStepPicker(): JSX.Element {
     const { pathsFilter } = useValues(pathsDataLogic(insightProps))
     const { updateInsightFilter } = useActions(pathsDataLogic(insightProps))
 
-    const { step_limit } = pathsFilter || {}
+    const { stepLimit } = pathsFilter || {}
 
     const { user } = useValues(userLogic)
 
@@ -32,8 +32,8 @@ export function PathStepPicker(): JSX.Element {
     return (
         <LemonSelect
             size="small"
-            value={step_limit || DEFAULT_STEP_LIMIT}
-            onChange={(count) => updateInsightFilter({ step_limit: count })}
+            value={stepLimit || DEFAULT_STEP_LIMIT}
+            onChange={(count) => updateInsightFilter({ stepLimit: count })}
             options={options}
         />
     )

--- a/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
@@ -186,7 +186,7 @@ const SLASH_COMMANDS: SlashCommandsItem[] = [
                 buildInsightVizQueryContent({
                     kind: NodeKind.PathsQuery,
                     pathsFilter: {
-                        include_event_types: [PathType.PageView],
+                        includeEventTypes: [PathType.PageView],
                     },
                 })
             ),

--- a/frontend/src/scenes/paths/PathNodeCardButton.tsx
+++ b/frontend/src/scenes/paths/PathNodeCardButton.tsx
@@ -5,7 +5,8 @@ import { IconEllipsis } from 'lib/lemon-ui/icons'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { userLogic } from 'scenes/userLogic'
 
-import { AvailableFeature, PathsFilterType } from '~/types'
+import { PathsFilter } from '~/queries/schema'
+import { AvailableFeature } from '~/types'
 
 import { pathsDataLogicType } from './pathsDataLogicType'
 import { pageUrl, PathNodeData } from './pathUtils'
@@ -16,8 +17,8 @@ type PathNodeCardButton = {
     node: PathNodeData
     viewPathToFunnel: pathsDataLogicType['actions']['viewPathToFunnel']
     openPersonsModal: pathsDataLogicType['actions']['openPersonsModal']
-    filter: PathsFilterType
-    setFilter: (filter: PathsFilterType) => void
+    filter: PathsFilter
+    setFilter: (filter: PathsFilter) => void
 }
 
 export function PathNodeCardButton({
@@ -32,10 +33,10 @@ export function PathNodeCardButton({
     const { user } = useValues(userLogic)
     const hasAdvancedPaths = user?.organization?.available_features?.includes(AvailableFeature.PATHS_ADVANCED)
 
-    const setAsPathStart = (): void => setFilter({ start_point: pageUrl(node) })
-    const setAsPathEnd = (): void => setFilter({ end_point: pageUrl(node) })
+    const setAsPathStart = (): void => setFilter({ startPoint: pageUrl(node) })
+    const setAsPathEnd = (): void => setFilter({ endPoint: pageUrl(node) })
     const excludePathItem = (): void => {
-        setFilter({ exclude_events: [...(filter.exclude_events || []), pageUrl(node, false)] })
+        setFilter({ excludeEvents: [...(filter.excludeEvents || []), pageUrl(node, false)] })
     }
     const viewFunnel = (): void => {
         viewPathToFunnel(node)

--- a/frontend/src/scenes/paths/pathUtils.ts
+++ b/frontend/src/scenes/paths/pathUtils.ts
@@ -1,6 +1,7 @@
 import { RGBColor } from 'd3'
 
-import { FunnelPathType, PathsFilterType } from '~/types'
+import { PathsFilter } from '~/queries/schema'
+import { FunnelPathType } from '~/types'
 
 export interface PathTargetLink {
     average_conversion_time: number
@@ -110,19 +111,16 @@ export function pageUrl(d: PathNodeData, display?: boolean): string {
         : name
 }
 
-export const isSelectedPathStartOrEnd = (
-    pathsFilter: Partial<PathsFilterType>,
-    pathItemCard: PathNodeData
-): boolean => {
+export const isSelectedPathStartOrEnd = (pathsFilter: PathsFilter, pathItemCard: PathNodeData): boolean => {
     const cardName = pageUrl(pathItemCard)
     const isPathStart = pathItemCard.targetLinks.length === 0
     const isPathEnd = pathItemCard.sourceLinks.length === 0
-    const { start_point, end_point, funnel_paths, funnel_filter } = pathsFilter
+    const { startPoint, endPoint, funnelPaths, funnelFilter } = pathsFilter
     return (
-        (start_point === cardName && isPathStart) ||
-        (end_point === cardName && isPathEnd) ||
-        (funnel_paths === FunnelPathType.between &&
-            ((cardName === funnel_filter?.events[funnel_filter.funnel_step - 1].name && isPathEnd) ||
-                (cardName === funnel_filter?.events[funnel_filter.funnel_step - 2].name && isPathStart)))
+        (startPoint === cardName && isPathStart) ||
+        (endPoint === cardName && isPathEnd) ||
+        (funnelPaths === FunnelPathType.between &&
+            ((cardName === funnelFilter?.events[funnelFilter.funnel_step - 1].name && isPathEnd) ||
+                (cardName === funnelFilter?.events[funnelFilter.funnel_step - 2].name && isPathStart)))
     )
 }

--- a/frontend/src/scenes/paths/pathsDataLogic.test.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.test.ts
@@ -31,7 +31,7 @@ describe('pathsDataLogic', () => {
     it('selects taxonomicGroupTypes from pathsFilter', async () => {
         await expectLogic(logic, () => {
             logic.actions.updateInsightFilter({
-                include_event_types: [PathType.PageView, PathType.Screen, PathType.CustomEvent],
+                includeEventTypes: [PathType.PageView, PathType.Screen, PathType.CustomEvent],
             })
         }).toMatchValues(logic, {
             taxonomicGroupTypes: [

--- a/frontend/src/scenes/paths/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.ts
@@ -90,14 +90,14 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
             (s) => [s.pathsFilter],
             (pathsFilter) => {
                 const taxonomicGroupTypes: TaxonomicFilterGroupType[] = []
-                if (pathsFilter?.include_event_types) {
-                    if (pathsFilter?.include_event_types.includes(PathType.PageView)) {
+                if (pathsFilter?.includeEventTypes) {
+                    if (pathsFilter?.includeEventTypes.includes(PathType.PageView)) {
                         taxonomicGroupTypes.push(TaxonomicFilterGroupType.PageviewUrls)
                     }
-                    if (pathsFilter?.include_event_types.includes(PathType.Screen)) {
+                    if (pathsFilter?.includeEventTypes.includes(PathType.Screen)) {
                         taxonomicGroupTypes.push(TaxonomicFilterGroupType.Screens)
                     }
-                    if (pathsFilter?.include_event_types.includes(PathType.CustomEvent)) {
+                    if (pathsFilter?.includeEventTypes.includes(PathType.CustomEvent)) {
                         taxonomicGroupTypes.push(TaxonomicFilterGroupType.CustomEvents)
                     }
                 }

--- a/frontend/src/scenes/paths/renderPaths.ts
+++ b/frontend/src/scenes/paths/renderPaths.ts
@@ -4,7 +4,7 @@ import { D3Selector } from 'lib/hooks/useD3'
 import { stripHTTP } from 'lib/utils'
 import { Dispatch, RefObject, SetStateAction } from 'react'
 
-import { PathsFilterType } from '~/types'
+import { PathsFilter } from '~/queries/schema'
 
 import { FALLBACK_CANVAS_WIDTH, HIDE_PATH_CARD_HEIGHT } from './Paths'
 import { PathNode } from './pathsDataLogic'
@@ -33,7 +33,7 @@ const createSankey = (width: number, height: number): Sankey.SankeyLayout<any, a
 const appendPathNodes = (
     svg: any,
     nodes: PathNodeData[],
-    pathsFilter: Partial<PathsFilterType>,
+    pathsFilter: PathsFilter,
     setNodeCards: Dispatch<SetStateAction<PathNodeData[]>>
 ): void => {
     svg.append('g')
@@ -200,7 +200,7 @@ export function renderPaths(
     canvasWidth: number,
     canvasHeight: number,
     paths: { links: PathNode[]; nodes: any[] },
-    pathsFilter: Partial<PathsFilterType>,
+    pathsFilter: PathsFilter,
     setNodeCards: Dispatch<SetStateAction<PathNodeData[]>>
 ): void {
     if (!paths || paths.nodes.length === 0) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2846,9 +2846,9 @@ export interface AppContext {
 export type StoredMetricMathOperations = 'max' | 'min' | 'sum'
 
 export interface PathEdgeParameters {
-    edge_limit?: number | undefined
-    min_edge_weight?: number | undefined
-    max_edge_weight?: number | undefined
+    edgeLimit?: number | undefined
+    minEdgeWeight?: number | undefined
+    maxEdgeWeight?: number | undefined
 }
 
 export enum SignificanceCode {

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -6628,17 +6628,6 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.251
   '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '''
-# ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.252
-  '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
@@ -6661,7 +6650,7 @@
   LIMIT 21 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.253
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.252
   '''
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -6782,7 +6771,7 @@
   LIMIT 21 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.254
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.253
   '''
   SELECT "posthog_taggeditem"."id",
          "posthog_taggeditem"."tag_id",
@@ -6804,7 +6793,7 @@
                                                 5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.255
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.254
   '''
   SELECT "posthog_sharingconfiguration"."id",
          "posthog_sharingconfiguration"."team_id",
@@ -6822,7 +6811,7 @@
                                                           5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.256
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.255
   '''
   SELECT "posthog_dashboardtile"."id",
          "posthog_dashboardtile"."dashboard_id",
@@ -6994,7 +6983,7 @@
   ORDER BY "posthog_dashboarditem"."order" ASC /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.257
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.256
   '''
   SELECT "posthog_insightcachingstate"."id",
          "posthog_insightcachingstate"."team_id",
@@ -7015,7 +7004,7 @@
                                                               5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.258
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.257
   '''
   SELECT ("posthog_dashboardtile"."insight_id") AS "_prefetch_related_val_insight_id",
          "posthog_dashboard"."id",
@@ -7121,7 +7110,7 @@
                                                       5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.259
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.258
   '''
   SELECT "posthog_dashboardtile"."id",
          "posthog_dashboardtile"."dashboard_id",
@@ -7144,6 +7133,32 @@
                                                       3,
                                                       4,
                                                       5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '''
+# ---
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.259
+  '''
+  SELECT "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."restriction_level",
+         "posthog_dashboard"."deprecated_tags",
+         "posthog_dashboard"."tags",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared"
+  FROM "posthog_dashboard"
+  WHERE "posthog_dashboard"."id" IN (1,
+                                     2,
+                                     3,
+                                     4,
+                                     5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.26
@@ -7198,32 +7213,6 @@
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.260
-  '''
-  SELECT "posthog_dashboard"."id",
-         "posthog_dashboard"."name",
-         "posthog_dashboard"."description",
-         "posthog_dashboard"."team_id",
-         "posthog_dashboard"."pinned",
-         "posthog_dashboard"."created_at",
-         "posthog_dashboard"."created_by_id",
-         "posthog_dashboard"."deleted",
-         "posthog_dashboard"."last_accessed_at",
-         "posthog_dashboard"."filters",
-         "posthog_dashboard"."creation_mode",
-         "posthog_dashboard"."restriction_level",
-         "posthog_dashboard"."deprecated_tags",
-         "posthog_dashboard"."tags",
-         "posthog_dashboard"."share_token",
-         "posthog_dashboard"."is_shared"
-  FROM "posthog_dashboard"
-  WHERE "posthog_dashboard"."id" IN (1,
-                                     2,
-                                     3,
-                                     4,
-                                     5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '''
-# ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.261
   '''
   SELECT "posthog_dashboardtile"."id",
          "posthog_dashboardtile"."dashboard_id",
@@ -7393,7 +7382,7 @@
   ORDER BY "posthog_dashboarditem"."order" ASC /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.262
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.261
   '''
   SELECT "posthog_insightcachingstate"."id",
          "posthog_insightcachingstate"."team_id",
@@ -7414,7 +7403,7 @@
                                                               5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.263
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.262
   '''
   SELECT ("posthog_dashboardtile"."insight_id") AS "_prefetch_related_val_insight_id",
          "posthog_dashboard"."id",
@@ -7520,7 +7509,7 @@
                                                       5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.264
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.263
   '''
   SELECT "posthog_dashboardtile"."id",
          "posthog_dashboardtile"."dashboard_id",
@@ -7545,7 +7534,7 @@
                                                       5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.265
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.264
   '''
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -7571,7 +7560,7 @@
                                      5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.266
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.265
   '''
   SELECT "posthog_taggeditem"."id",
          "posthog_taggeditem"."tag_id",
@@ -7593,7 +7582,7 @@
                                               5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.267
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.266
   '''
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -7604,7 +7593,7 @@
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.268
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.267
   '''
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -7615,13 +7604,24 @@
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.269
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.268
   '''
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
   WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '''
+# ---
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.269
+  '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7662,7 +7662,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7673,7 +7673,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7684,7 +7684,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7695,7 +7695,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7706,7 +7706,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7717,7 +7717,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7728,7 +7728,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7739,23 +7739,12 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '''
-# ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.278
-  '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
   WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.279
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.278
   '''
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -7780,6 +7769,17 @@
                                           3,
                                           4,
                                           5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '''
+# ---
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.279
+  '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.28
@@ -7812,7 +7812,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7823,7 +7823,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7834,7 +7834,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7845,7 +7845,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7856,7 +7856,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7867,7 +7867,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7878,7 +7878,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7889,7 +7889,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7900,7 +7900,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7911,7 +7911,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7946,7 +7946,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7957,7 +7957,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7968,7 +7968,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7979,7 +7979,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7990,7 +7990,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8001,7 +8001,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8012,7 +8012,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8023,7 +8023,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8034,7 +8034,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8045,7 +8045,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8118,7 +8118,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8129,7 +8129,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8140,7 +8140,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8151,7 +8151,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8162,7 +8162,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8173,7 +8173,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8184,7 +8184,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8195,7 +8195,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8206,7 +8206,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8217,7 +8217,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8263,7 +8263,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8274,7 +8274,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8285,7 +8285,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8296,7 +8296,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8307,7 +8307,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -6628,6 +6628,17 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.251
   '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '''
+# ---
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.252
+  '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
@@ -6650,7 +6661,7 @@
   LIMIT 21 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.252
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.253
   '''
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -6771,7 +6782,7 @@
   LIMIT 21 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.253
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.254
   '''
   SELECT "posthog_taggeditem"."id",
          "posthog_taggeditem"."tag_id",
@@ -6793,7 +6804,7 @@
                                                 5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.254
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.255
   '''
   SELECT "posthog_sharingconfiguration"."id",
          "posthog_sharingconfiguration"."team_id",
@@ -6811,7 +6822,7 @@
                                                           5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.255
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.256
   '''
   SELECT "posthog_dashboardtile"."id",
          "posthog_dashboardtile"."dashboard_id",
@@ -6983,7 +6994,7 @@
   ORDER BY "posthog_dashboarditem"."order" ASC /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.256
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.257
   '''
   SELECT "posthog_insightcachingstate"."id",
          "posthog_insightcachingstate"."team_id",
@@ -7004,7 +7015,7 @@
                                                               5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.257
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.258
   '''
   SELECT ("posthog_dashboardtile"."insight_id") AS "_prefetch_related_val_insight_id",
          "posthog_dashboard"."id",
@@ -7110,7 +7121,7 @@
                                                       5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.258
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.259
   '''
   SELECT "posthog_dashboardtile"."id",
          "posthog_dashboardtile"."dashboard_id",
@@ -7133,32 +7144,6 @@
                                                       3,
                                                       4,
                                                       5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '''
-# ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.259
-  '''
-  SELECT "posthog_dashboard"."id",
-         "posthog_dashboard"."name",
-         "posthog_dashboard"."description",
-         "posthog_dashboard"."team_id",
-         "posthog_dashboard"."pinned",
-         "posthog_dashboard"."created_at",
-         "posthog_dashboard"."created_by_id",
-         "posthog_dashboard"."deleted",
-         "posthog_dashboard"."last_accessed_at",
-         "posthog_dashboard"."filters",
-         "posthog_dashboard"."creation_mode",
-         "posthog_dashboard"."restriction_level",
-         "posthog_dashboard"."deprecated_tags",
-         "posthog_dashboard"."tags",
-         "posthog_dashboard"."share_token",
-         "posthog_dashboard"."is_shared"
-  FROM "posthog_dashboard"
-  WHERE "posthog_dashboard"."id" IN (1,
-                                     2,
-                                     3,
-                                     4,
-                                     5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.26
@@ -7213,6 +7198,32 @@
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.260
+  '''
+  SELECT "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."restriction_level",
+         "posthog_dashboard"."deprecated_tags",
+         "posthog_dashboard"."tags",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared"
+  FROM "posthog_dashboard"
+  WHERE "posthog_dashboard"."id" IN (1,
+                                     2,
+                                     3,
+                                     4,
+                                     5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '''
+# ---
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.261
   '''
   SELECT "posthog_dashboardtile"."id",
          "posthog_dashboardtile"."dashboard_id",
@@ -7382,7 +7393,7 @@
   ORDER BY "posthog_dashboarditem"."order" ASC /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.261
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.262
   '''
   SELECT "posthog_insightcachingstate"."id",
          "posthog_insightcachingstate"."team_id",
@@ -7403,7 +7414,7 @@
                                                               5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.262
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.263
   '''
   SELECT ("posthog_dashboardtile"."insight_id") AS "_prefetch_related_val_insight_id",
          "posthog_dashboard"."id",
@@ -7509,7 +7520,7 @@
                                                       5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.263
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.264
   '''
   SELECT "posthog_dashboardtile"."id",
          "posthog_dashboardtile"."dashboard_id",
@@ -7534,7 +7545,7 @@
                                                       5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.264
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.265
   '''
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -7560,7 +7571,7 @@
                                      5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.265
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.266
   '''
   SELECT "posthog_taggeditem"."id",
          "posthog_taggeditem"."tag_id",
@@ -7582,24 +7593,13 @@
                                               5 /* ... */) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.266
-  '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '''
-# ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.267
   '''
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7610,7 +7610,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7621,7 +7621,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7662,7 +7662,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7673,7 +7673,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7684,7 +7684,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7695,7 +7695,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7706,7 +7706,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7717,7 +7717,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7728,7 +7728,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7739,12 +7739,23 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.278
+  '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '''
+# ---
+# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.279
   '''
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -7769,17 +7780,6 @@
                                           3,
                                           4,
                                           5 /* ... */)) /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '''
-# ---
-# name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.279
-  '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.28
@@ -7812,7 +7812,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7823,7 +7823,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7834,7 +7834,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7845,7 +7845,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7856,7 +7856,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7867,7 +7867,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7878,7 +7878,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7889,7 +7889,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7900,7 +7900,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7911,7 +7911,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7946,7 +7946,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7957,7 +7957,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7968,7 +7968,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7979,7 +7979,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -7990,7 +7990,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8001,7 +8001,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8012,7 +8012,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8023,7 +8023,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8034,7 +8034,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8045,7 +8045,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8118,7 +8118,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8129,7 +8129,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8140,7 +8140,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8151,7 +8151,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8162,7 +8162,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8173,7 +8173,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8184,7 +8184,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8195,7 +8195,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8206,7 +8206,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8217,7 +8217,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8263,7 +8263,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8274,7 +8274,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8285,7 +8285,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8296,7 +8296,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
@@ -8307,7 +8307,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1 /*controller='project_dashboards-detail',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -373,21 +373,20 @@ def _insight_filter(filter: Dict):
     elif _insight_type(filter) == "PATHS":
         insight_filter = {
             "pathsFilter": PathsFilter(
-                # path_type=filter.get('path_type'), # legacy
-                paths_hogql_expression=filter.get("paths_hogql_expression"),
-                include_event_types=filter.get("include_event_types"),
-                start_point=filter.get("start_point"),
-                end_point=filter.get("end_point"),
-                path_groupings=filter.get("path_groupings"),
-                exclude_events=filter.get("exclude_events"),
-                step_limit=filter.get("step_limit"),
-                path_replacements=filter.get("path_replacements"),
-                local_path_cleaning_filters=filter.get("local_path_cleaning_filters"),
-                edge_limit=filter.get("edge_limit"),
-                min_edge_weight=filter.get("min_edge_weight"),
-                max_edge_weight=filter.get("max_edge_weight"),
-                funnel_paths=filter.get("funnel_paths"),
-                funnel_filter=filter.get("funnel_filter"),
+                pathsHogqlExpression=filter.get("paths_hogql_expression"),
+                includeEventTypes=filter.get("include_event_types"),
+                startPoint=filter.get("start_point"),
+                endPoint=filter.get("end_point"),
+                pathGroupings=filter.get("path_groupings"),
+                excludeEvents=filter.get("exclude_events"),
+                stepLimit=filter.get("step_limit"),
+                pathReplacements=filter.get("path_replacements"),
+                localPathCleaningFilters=filter.get("local_path_cleaning_filters"),
+                edgeLimit=filter.get("edge_limit"),
+                minEdgeWeight=filter.get("min_edge_weight"),
+                maxEdgeWeight=filter.get("max_edge_weight"),
+                funnelPaths=filter.get("funnel_paths"),
+                funnelFilter=filter.get("funnel_filter"),
             )
         }
     elif _insight_type(filter) == "LIFECYCLE":

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -373,7 +373,7 @@ def _insight_filter(filter: Dict):
     elif _insight_type(filter) == "PATHS":
         insight_filter = {
             "pathsFilter": PathsFilter(
-                pathsHogqlExpression=filter.get("paths_hogql_expression"),
+                pathsHogQLExpression=filter.get("paths_hogql_expression"),
                 includeEventTypes=filter.get("include_event_types"),
                 startPoint=filter.get("start_point"),
                 endPoint=filter.get("end_point"),

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -1458,22 +1458,22 @@ class TestFilterToQuery(BaseTest):
         self.assertEqual(
             query.pathsFilter,
             PathsFilter(
-                include_event_types=[PathType.field_pageview, PathType.hogql],
-                paths_hogql_expression="event",
-                start_point="http://localhost:8000/events",
-                end_point="http://localhost:8000/home",
-                edge_limit=50,
-                min_edge_weight=10,
-                max_edge_weight=20,
-                local_path_cleaning_filters=[
+                includeEventTypes=[PathType.field_pageview, PathType.hogql],
+                pathsHogqlExpression="event",
+                startPoint="http://localhost:8000/events",
+                endPoint="http://localhost:8000/home",
+                edgeLimit=50,
+                minEdgeWeight=10,
+                maxEdgeWeight=20,
+                localPathCleaningFilters=[
                     PathCleaningFilter(alias="merchant", regex="\\/merchant\\/\\d+\\/dashboard$")
                 ],
-                path_replacements=True,
-                exclude_events=["http://localhost:8000/events"],
-                step_limit=5,
-                path_groupings=["/merchant/*/payment"],
-                funnel_paths=FunnelPathType.funnel_path_between_steps,
-                funnel_filter={
+                pathReplacements=True,
+                excludeEvents=["http://localhost:8000/events"],
+                stepLimit=5,
+                pathGroupings=["/merchant/*/payment"],
+                funnelPaths=FunnelPathType.funnel_path_between_steps,
+                funnelFilter={
                     "insight": "FUNNELS",
                     "events": [
                         {

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -1459,7 +1459,7 @@ class TestFilterToQuery(BaseTest):
             query.pathsFilter,
             PathsFilter(
                 includeEventTypes=[PathType.field_pageview, PathType.hogql],
-                pathsHogqlExpression="event",
+                pathsHogQLExpression="event",
                 startPoint="http://localhost:8000/events",
                 endPoint="http://localhost:8000/home",
                 edgeLimit=50,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -403,6 +403,26 @@ class PathsFilter(BaseModel):
     min_edge_weight: Optional[float] = None
     path_groupings: Optional[List[str]] = None
     path_replacements: Optional[bool] = None
+    paths_hogql_expression: Optional[str] = None
+    start_point: Optional[str] = None
+    step_limit: Optional[float] = None
+
+
+class PathsFilterLegacy(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    edge_limit: Optional[float] = None
+    end_point: Optional[str] = None
+    exclude_events: Optional[List[str]] = None
+    funnel_filter: Optional[Dict[str, Any]] = None
+    funnel_paths: Optional[FunnelPathType] = None
+    include_event_types: Optional[List[PathType]] = None
+    local_path_cleaning_filters: Optional[List[PathCleaningFilter]] = None
+    max_edge_weight: Optional[float] = None
+    min_edge_weight: Optional[float] = None
+    path_groupings: Optional[List[str]] = None
+    path_replacements: Optional[bool] = None
     path_type: Optional[PathType] = None
     paths_hogql_expression: Optional[str] = None
     start_point: Optional[str] = None

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -403,7 +403,7 @@ class PathsFilter(BaseModel):
     minEdgeWeight: Optional[float] = None
     pathGroupings: Optional[List[str]] = None
     pathReplacements: Optional[bool] = None
-    pathsHogqlExpression: Optional[str] = None
+    pathsHogQLExpression: Optional[str] = None
     startPoint: Optional[str] = None
     stepLimit: Optional[float] = None
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -392,20 +392,20 @@ class PathsFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    edge_limit: Optional[float] = None
-    end_point: Optional[str] = None
-    exclude_events: Optional[List[str]] = None
-    funnel_filter: Optional[Dict[str, Any]] = None
-    funnel_paths: Optional[FunnelPathType] = None
-    include_event_types: Optional[List[PathType]] = None
-    local_path_cleaning_filters: Optional[List[PathCleaningFilter]] = None
-    max_edge_weight: Optional[float] = None
-    min_edge_weight: Optional[float] = None
-    path_groupings: Optional[List[str]] = None
-    path_replacements: Optional[bool] = None
-    paths_hogql_expression: Optional[str] = None
-    start_point: Optional[str] = None
-    step_limit: Optional[float] = None
+    edgeLimit: Optional[float] = None
+    endPoint: Optional[str] = None
+    excludeEvents: Optional[List[str]] = None
+    funnelFilter: Optional[Dict[str, Any]] = None
+    funnelPaths: Optional[FunnelPathType] = None
+    includeEventTypes: Optional[List[PathType]] = None
+    localPathCleaningFilters: Optional[List[PathCleaningFilter]] = None
+    maxEdgeWeight: Optional[float] = None
+    minEdgeWeight: Optional[float] = None
+    pathGroupings: Optional[List[str]] = None
+    pathReplacements: Optional[bool] = None
+    pathsHogqlExpression: Optional[str] = None
+    startPoint: Optional[str] = None
+    stepLimit: Optional[float] = None
 
 
 class PathsFilterLegacy(BaseModel):

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -636,7 +636,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_0')
+                                                      'user_one_2')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '''
 # ---

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -636,7 +636,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_2')
+                                                      'user_one_0')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '''
 # ---


### PR DESCRIPTION
## Problem

We want to clean up our query schema. See also https://github.com/PostHog/posthog/issues/19541.

## Changes

This PR camel cases all pathFilter properties.

- [x] edge_limit
- [x] paths_hogql_expression
- [x] include_event_types
- [x] start_point
- [x] end_point
- [x] path_groupings
- [x] exclude_events
- [x] step_limit
- [x] path_replacements
- [x] local_path_cleaning_filters
- [x] min_edge_weight
- [x] max_edge_weight
- [x] funnel_paths
- [x] funnel_filter - the filters themselves aren't touched in any way. probably best to do so when we implement the hogql version of the query

## How did you test this code?

Verified setting, saving and loading an insight with this filter works