### PR TITLE
fix: use includes, not startsWith for url match

### DIFF
--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -157,7 +157,7 @@ export const onboardingLogic = kea<onboardingLogicType>([
     }),
     listeners(({ actions, values }) => ({
         loadBillingSuccess: () => {
-            if (window.location.pathname.startsWith('/onboarding')) {
+            if (window.location.pathname.includes('/onboarding')) {
                 actions.setProduct(values.billing?.products.find((p) => p.type === values.productKey) || null)
             }
         },


### PR DESCRIPTION
## Problem

Now that urls have the project ID in them, this check for if a URL path starts with /onboarding no longer works.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

use `includes`, not `startsWith`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

It works, before it didn't

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
