### PR TITLE
feat: allow varying open ai model for session summary

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -522,7 +522,7 @@ class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
                 )
             return response
         except Exception as e:
-            error_response = Response({"error": str(e)}, status=500)
+            error_response = Response({"error": "error summarizing session"}, status=500)
             error_response.headers["Cache-Control"] = "no-cache"
             if timings:
                 error_response.headers["Server-Timing"] = ", ".join(

--- a/posthog/session_recordings/session_summary/summarize_session.py
+++ b/posthog/session_recordings/session_summary/summarize_session.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import List, Dict, Any
 
 import openai
+from django.conf import settings
 from prometheus_client import Histogram
 
 from posthog.api.activity_log import ServerTimingsGathered
@@ -330,7 +331,7 @@ def summarize_recording(recording: SessionRecording, user: User, team: Team):
     with timer("openai_completion"):
         result = openai.ChatCompletion.create(
             # model="gpt-4-1106-preview",  # allows 128k tokens
-            model="gpt-4",  # allows 8k tokens
+            model=settings.OPENAI_API_MODEL,  # allows 8k tokens
             temperature=0.7,
             messages=messages,
             user=f"{instance_region}/{user.pk}",  # The user ID is for tracking within OpenAI in case of overuse/abuse

--- a/posthog/settings/session_replay.py
+++ b/posthog/settings/session_replay.py
@@ -5,3 +5,5 @@ from posthog.utils import str_to_bool
 # when allowing use of denormalized properties in some session replay event queries
 # it is likely this can be returned to the default of True in future but would need careful monitoring
 ALLOW_DENORMALIZED_PROPS_IN_LISTING = get_from_env("ALLOW_DENORMALIZED_PROPS_IN_LISTING", False, type_cast=str_to_bool)
+
+OPENAI_API_MODEL = get_from_env("OPENAI_API_MODEL", "gpt-4")


### PR DESCRIPTION
allows varying the open ai api model for session summary from environment variables 

tested by running locally and seeing summary work