### PR TITLE
fix: correct flag allows override access to ingestion controls

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -160,6 +160,7 @@ export const SettingsMap: SettingSection[] = [
                 id: 'replay-ingestion',
                 title: 'Ingestion controls',
                 component: <ReplayCostControl />,
+                flag: 'SESSION_RECORDING_SAMPLING',
                 features: [
                     AvailableFeature.SESSION_REPLAY_SAMPLING,
                     AvailableFeature.FEATURE_FLAG_BASED_RECORDING,

--- a/frontend/src/scenes/settings/project/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/project/SessionRecordingSettings.tsx
@@ -181,19 +181,22 @@ export function ReplayCostControl(): JSX.Element | null {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
     const { hasAvailableFeature } = useValues(userLogic)
-    const  { featureFlags } = useValues(featureFlagLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     // some organisations have access to this by virtue of being in a flag
     // other orgs have access by virtue of being on the correct plan
     // having the flag enabled overrides the plan feature check
     const flagIsEnabled = featureFlags[FEATURE_FLAGS.SESSION_RECORDING_SAMPLING]
     const samplingControlFeatureEnabled = flagIsEnabled || hasAvailableFeature(AvailableFeature.SESSION_REPLAY_SAMPLING)
-    const recordingDurationMinimumFeatureEnabled = flagIsEnabled || hasAvailableFeature(AvailableFeature.RECORDING_DURATION_MINIMUM)
-    const featureFlagRecordingFeatureEnabled = flagIsEnabled || hasAvailableFeature(AvailableFeature.FEATURE_FLAG_BASED_RECORDING)
+    const recordingDurationMinimumFeatureEnabled =
+        flagIsEnabled || hasAvailableFeature(AvailableFeature.RECORDING_DURATION_MINIMUM)
+    const featureFlagRecordingFeatureEnabled =
+        flagIsEnabled || hasAvailableFeature(AvailableFeature.FEATURE_FLAG_BASED_RECORDING)
 
-    const canAccessAnyControl = samplingControlFeatureEnabled || recordingDurationMinimumFeatureEnabled || featureFlagRecordingFeatureEnabled
+    const canAccessAnyControl =
+        samplingControlFeatureEnabled || recordingDurationMinimumFeatureEnabled || featureFlagRecordingFeatureEnabled
 
-    return canAccessAnyControl?(
+    return canAccessAnyControl ? (
         <>
             <p>
                 PostHog offers several tools to let you control the number of recordings you collect and which users you


### PR DESCRIPTION
follow-up to https://github.com/PostHog/posthog/pull/19772

We want to show the ingestion controls config if you are added to the correct flag _or_ you are on a plan that already has access to it

We were showing it only when your plan had access... 

This change means that

* if the flag is active you have access to all the settings
* otherwise we check the available features and show the section if any are present, and each control if the appropriate plan feature is present

----

tested locally by switching the flag on and off and seeing the settings section appear and disappear