### PR TITLE
fix(data-management): fix event definition loading

### DIFF
--- a/frontend/src/scenes/data-management/definition/definitionLogic.ts
+++ b/frontend/src/scenes/data-management/definition/definitionLogic.ts
@@ -115,7 +115,7 @@ export const definitionLogic = kea<definitionLogicType>([
                 hasAvailableFeature(AvailableFeature.INGESTION_TAXONOMY) ||
                 hasAvailableFeature(AvailableFeature.TAGGING),
         ],
-        isEvent: [() => [router.selectors.location], ({ pathname }) => pathname.startsWith(urls.eventDefinitions())],
+        isEvent: [() => [router.selectors.location], ({ pathname }) => pathname.includes(urls.eventDefinitions())],
         isProperty: [(s) => [s.isEvent], (isEvent) => !isEvent],
         singular: [(s) => [s.isEvent], (isEvent): string => (isEvent ? 'event' : 'property')],
         breadcrumbs: [

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -149,11 +149,11 @@ class EventDefinitionViewSet(
         ):
             from ee.models.event_definition import EnterpriseEventDefinition
 
-            enterprise_event = EnterpriseEventDefinition.objects.filter(id=id).first()
+            enterprise_event = EnterpriseEventDefinition.objects.filter(id=id, team_id=self.team_id).first()
             if enterprise_event:
                 return enterprise_event
 
-            non_enterprise_event = EventDefinition.objects.get(id=id)
+            non_enterprise_event = EventDefinition.objects.get(id=id, team_id=self.team_id)
             new_enterprise_event = EnterpriseEventDefinition(
                 eventdefinition_ptr_id=non_enterprise_event.id, description=""
             )
@@ -161,7 +161,7 @@ class EventDefinitionViewSet(
             new_enterprise_event.save()
             return new_enterprise_event
 
-        return EventDefinition.objects.get(id=id)
+        return EventDefinition.objects.get(id=id, team_id=self.team_id)
 
     def get_serializer_class(self) -> Type[serializers.ModelSerializer]:
         serializer_class = self.serializer_class

--- a/posthog/api/property_definition.py
+++ b/posthog/api/property_definition.py
@@ -573,17 +573,17 @@ class PropertyDefinitionViewSet(
             except ImportError:
                 pass
             else:
-                enterprise_property = EnterprisePropertyDefinition.objects.filter(id=id).first()
+                enterprise_property = EnterprisePropertyDefinition.objects.filter(id=id, team_id=self.team_id).first()
                 if enterprise_property:
                     return enterprise_property
-                non_enterprise_property = PropertyDefinition.objects.get(id=id)
+                non_enterprise_property = PropertyDefinition.objects.get(id=id, team_id=self.team_id)
                 new_enterprise_property = EnterprisePropertyDefinition(
                     propertydefinition_ptr_id=non_enterprise_property.id, description=""
                 )
                 new_enterprise_property.__dict__.update(non_enterprise_property.__dict__)
                 new_enterprise_property.save()
                 return new_enterprise_property
-        return PropertyDefinition.objects.get(id=id)
+        return PropertyDefinition.objects.get(id=id, team_id=self.team_id)
 
     @extend_schema(parameters=[PropertyDefinitionQuerySerializer])
     def list(self, request, *args, **kwargs):


### PR DESCRIPTION
## Problem

Event definition edit pages weren't loading.

## Changes

Fixes the logic that checked the URL to determine if it's an event or person property.

## How did you test this code?

Locally in the browser. The page that didn't load now loaded.