### PR TITLE
feat: Route some trial tasks to different queues

### DIFF
--- a/bin/celery-queues.env
+++ b/bin/celery-queues.env
@@ -1,3 +1,3 @@
 # Default set of queues to be used by Celery.
 # Important: Add new queues to make Celery consume tasks from them.
-CELERY_WORKER_QUEUES=celery,email,insight_export,insight_refresh,gevent
+CELERY_WORKER_QUEUES=celery,email,insight_export,insight_refresh,analytics_queries

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -401,8 +401,8 @@ def redis_heartbeat():
     get_client().set("POSTHOG_HEARTBEAT", int(time.time()))
 
 
-@app.task(ignore_result=True, bind=True)
-def process_query_task(self, team_id, query_id, query_json, limit_context=None, refresh_requested=False):
+@app.task(ignore_result=True, queue="gevent")
+def process_query_task(team_id, query_id, query_json, limit_context=None, refresh_requested=False):
     """
     Kick off query
     Once complete save results to redis
@@ -822,7 +822,7 @@ def clear_clickhouse_deleted_person():
     remove_deleted_person_data()
 
 
-@app.task(ignore_result=True)
+@app.task(ignore_result=True, queue="priority")
 def redis_celery_queue_depth():
     try:
         with pushed_metrics_registry("redis_celery_queue_depth_registry") as registry:

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -401,7 +401,7 @@ def redis_heartbeat():
     get_client().set("POSTHOG_HEARTBEAT", int(time.time()))
 
 
-@app.task(ignore_result=True, queue="gevent")
+@app.task(ignore_result=True, queue="analytics_queries")
 def process_query_task(team_id, query_id, query_json, limit_context=None, refresh_requested=False):
     """
     Kick off query
@@ -822,7 +822,7 @@ def clear_clickhouse_deleted_person():
     remove_deleted_person_data()
 
 
-@app.task(ignore_result=True, queue="priority")
+@app.task(ignore_result=True, queue="email")
 def redis_celery_queue_depth():
     try:
         with pushed_metrics_registry("redis_celery_queue_depth_registry") as registry:


### PR DESCRIPTION
## Problem

We want to utilize our additional Celery consumers by routing tasks to different queues.

These queues have to match up with the queues and consumers we have configured for all deploys as well as the queues that local Celery looks at.

## Changes

- adjust some innocent tasks to go to different queues

## How did you test this code?

- 🤔 