### PR TITLE
fix: Add timeout to subscription reports

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -60,6 +60,13 @@ services:
         image: maildev/maildev:2.0.5
         restart: on-failure
 
+    flower:
+        image: mher/flower:2.0.0
+        restart: on-failure
+        environment:
+            FLOWER_PORT: 5555
+            CELERY_BROKER_URL: redis://redis:6379
+
     worker: &worker
         command: ./bin/docker-worker-celery --with-scheduler
         restart: on-failure

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,6 +27,13 @@ services:
         ports:
             - '6379:6379'
 
+    flower:
+        extends:
+            file: docker-compose.base.yml
+            service: flower
+        ports:
+            - '5555:5555'
+
     clickhouse:
         extends:
             file: docker-compose.base.yml

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -68,4 +68,7 @@ BILLING_SERVICE_URL = get_from_env("BILLING_SERVICE_URL", "https://billing.posth
 # Whether to enable the admin portal. Default false for self-hosted as if not setup properly can pose security issues.
 ADMIN_PORTAL_ENABLED = get_from_env("ADMIN_PORTAL_ENABLED", DEMO or DEBUG, type_cast=str_to_bool)
 
-ASSET_GENERATION_MAX_TIMEOUT_MINUTES = get_from_env("ASSET_GENERATION_MAX_TIMEOUT_MINUTES", 10.0, type_cast=float)
+ASSET_GENERATION_MAX_TIMEOUT_SECONDS = get_from_env("ASSET_GENERATION_MAX_TIMEOUT_SECONDS", 60.0, type_cast=float)
+PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES = get_from_env(
+    "PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES", 10.0, type_cast=float
+)

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -68,4 +68,4 @@ BILLING_SERVICE_URL = get_from_env("BILLING_SERVICE_URL", "https://billing.posth
 # Whether to enable the admin portal. Default false for self-hosted as if not setup properly can pose security issues.
 ADMIN_PORTAL_ENABLED = get_from_env("ADMIN_PORTAL_ENABLED", DEMO or DEBUG, type_cast=str_to_bool)
 
-ASSET_GENERATION_MAX_TIMEOUT_MINUTES = get_from_env("ASSET_GENERATION_MAX_TIMEOUT_MINUTES", 10, type_cast=int)
+ASSET_GENERATION_MAX_TIMEOUT_MINUTES = get_from_env("ASSET_GENERATION_MAX_TIMEOUT_MINUTES", 10.0, type_cast=float)

--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -144,12 +144,12 @@ def schedule_all_subscriptions() -> None:
         deliver_subscription_report.delay(subscription.id)
 
 
-@app.task()
+@app.task(soft_time_limit=30, time_limit=40)
 def deliver_subscription_report(subscription_id: int) -> None:
     return _deliver_subscription_report(subscription_id)
 
 
-@app.task()
+@app.task(soft_time_limit=30, time_limit=40)
 def handle_subscription_value_change(
     subscription_id: int, previous_value: str, invite_message: Optional[str] = None
 ) -> None:

--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -145,10 +145,10 @@ def schedule_all_subscriptions() -> None:
         deliver_subscription_report.delay(subscription.id)
 
 
-report_timeout = settings.PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES * 1.5
+report_timeout_seconds = settings.PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES * 60 * 1.5
 
 
-@app.task(soft_time_limit=report_timeout, timeout=report_timeout + 10)
+@app.task(soft_time_limit=report_timeout_seconds, timeout=report_timeout_seconds + 10)
 def deliver_subscription_report(subscription_id: int) -> None:
     return _deliver_subscription_report(subscription_id)
 

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -60,7 +60,7 @@ def generate_assets(
 
         wait_for_parallel_celery_group(
             parallel_job,
-            max_timeout=timedelta(minutes=settings.ASSET_GENERATION_MAX_TIMEOUT_MINUTES),
+            max_timeout=timedelta(seconds=settings.PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES),
         )
 
         return insights, assets

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -60,7 +60,7 @@ def generate_assets(
 
         wait_for_parallel_celery_group(
             parallel_job,
-            max_timeout=timedelta(seconds=settings.PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES),
+            max_timeout=timedelta(minutes=settings.PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES),
         )
 
         return insights, assets

--- a/ee/tasks/test/subscriptions/test_subscriptions_utils.py
+++ b/ee/tasks/test/subscriptions/test_subscriptions_utils.py
@@ -34,7 +34,7 @@ class TestSubscriptionsTasksUtils(APIBaseTest):
         self.subscription = create_subscription(team=self.team, insight=self.insight, created_by=self.user)
 
     def test_generate_assets_for_insight(self, mock_export_task: MagicMock, _mock_group: MagicMock) -> None:
-        with self.settings(ASSET_GENERATION_MAX_TIMEOUT_MINUTES=1):
+        with self.settings(PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES=1):
             insights, assets = generate_assets(self.subscription)
 
             assert insights == [self.insight]
@@ -44,7 +44,7 @@ class TestSubscriptionsTasksUtils(APIBaseTest):
     def test_generate_assets_for_dashboard(self, mock_export_task: MagicMock, _mock_group: MagicMock) -> None:
         subscription = create_subscription(team=self.team, dashboard=self.dashboard, created_by=self.user)
 
-        with self.settings(ASSET_GENERATION_MAX_TIMEOUT_MINUTES=1):
+        with self.settings(PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES=1):
             insights, assets = generate_assets(subscription)
 
         assert len(insights) == len(self.tiles)
@@ -54,7 +54,7 @@ class TestSubscriptionsTasksUtils(APIBaseTest):
     def test_raises_if_missing_resource(self, _mock_export_task: MagicMock, _mock_group: MagicMock) -> None:
         subscription = create_subscription(team=self.team, created_by=self.user)
 
-        with self.settings(ASSET_GENERATION_MAX_TIMEOUT_MINUTES=1), pytest.raises(Exception) as e:
+        with self.settings(PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES=1), pytest.raises(Exception) as e:
             generate_assets(subscription)
 
         assert str(e.value) == "There are no insights to be sent for this Subscription"
@@ -68,7 +68,7 @@ class TestSubscriptionsTasksUtils(APIBaseTest):
             current_tile.insight.save()
         subscription = create_subscription(team=self.team, dashboard=self.dashboard, created_by=self.user)
 
-        with self.settings(ASSET_GENERATION_MAX_TIMEOUT_MINUTES=1):
+        with self.settings(PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES=1):
             insights, assets = generate_assets(subscription)
 
             assert len(insights) == 1
@@ -90,7 +90,7 @@ class TestSubscriptionsTasksUtils(APIBaseTest):
         mock_running_exports.children = [running_export_task]
         mock_running_exports.ready = mock_ready
 
-        with self.settings(ASSET_GENERATION_MAX_TIMEOUT_MINUTES=0.01), pytest.raises(Exception) as e:
+        with self.settings(PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES=0.01), pytest.raises(Exception) as e:
             generate_assets(self.subscription)
 
         assert str(e.value) == "Timed out waiting for celery task to finish"

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -136,24 +136,13 @@
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
-  '''
-# ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
-  '''
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
   '''
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -164,7 +153,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '''
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -175,7 +164,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '''
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -186,7 +175,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -217,7 +206,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -238,6 +227,22 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
+  '''
+# ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
+  '''
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
   '''
 # ---
 # name: TestDecide.test_flag_with_behavioural_cohorts

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -88,6 +88,22 @@
   LIMIT 21 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.10
+  '''
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
+  '''
+# ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.2
   '''
   SELECT "posthog_organizationmembership"."id",
@@ -120,13 +136,24 @@
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.3
   '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
+  '''
+# ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+  '''
   SELECT (1) AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.4
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '''
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -137,7 +164,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '''
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -148,7 +175,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '''
   SELECT "posthog_instancesetting"."id",
          "posthog_instancesetting"."key",
@@ -159,7 +186,7 @@
   LIMIT 1 /*controller='team-detail',route='api/projects/%28%3FP%3Cid%3E%5B%5E/.%5D%2B%29/%3F%24'*/
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -190,7 +217,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -211,22 +238,6 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
-  '''
-# ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.9
-  '''
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginconfig"."web_token",
-         "posthog_pluginsourcefile"."updated_at",
-         "posthog_plugin"."updated_at",
-         "posthog_pluginconfig"."updated_at"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 2)
   '''
 # ---
 # name: TestDecide.test_flag_with_behavioural_cohorts

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -636,7 +636,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_0')
+                                                      'user_one_2')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '''
 # ---

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -636,7 +636,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_2')
+                                                      'user_one_0')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '''
 # ---

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from prometheus_client import Counter, Histogram
 
+from posthog import settings
 from posthog.celery import app
 from posthog.models import ExportedAsset
 
@@ -40,8 +41,7 @@ EXPORT_TIMER = Histogram(
     retry_backoff=True,
     acks_late=True,
     ignore_result=False,
-    soft_time_limit=30,
-    time_limit=60,
+    time_limit=settings.ASSET_GENERATION_MAX_TIMEOUT_SECONDS,
 )
 def export_asset(exported_asset_id: int, limit: Optional[int] = None) -> None:
     from posthog.tasks.exports import csv_exporter, image_exporter

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -40,6 +40,8 @@ EXPORT_TIMER = Histogram(
     retry_backoff=True,
     acks_late=True,
     ignore_result=False,
+    soft_time_limit=30,
+    time_limit=60,
 )
 def export_asset(exported_asset_id: int, limit: Optional[int] = None) -> None:
     from posthog.tasks.exports import csv_exporter, image_exporter


### PR DESCRIPTION
## Problem

The subscription reports are blocking other things. One thing we need to do is fix it but for now just add a timeout

## Changes

* Also adds flower locally

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
