### PR TITLE
fix: Temporarily disable deliver subscription report task

### DIFF
--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from typing import Optional
 
+from django.conf import settings
 import structlog
 from prometheus_client import Counter
 from sentry_sdk import capture_exception, capture_message
@@ -146,8 +147,9 @@ def schedule_all_subscriptions() -> None:
 
 @app.task()
 def deliver_subscription_report(subscription_id: int) -> None:
-    return
-    # return _deliver_subscription_report(subscription_id)
+    if not settings.TEST:
+        return
+    return _deliver_subscription_report(subscription_id)
 
 
 @app.task()

--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -146,7 +146,8 @@ def schedule_all_subscriptions() -> None:
 
 @app.task()
 def deliver_subscription_report(subscription_id: int) -> None:
-    return _deliver_subscription_report(subscription_id)
+    return
+    # return _deliver_subscription_report(subscription_id)
 
 
 @app.task()


### PR DESCRIPTION

## Problem
This task is backlogged, and as it creates more tasks itself it's created a never ending list of asset export tasks

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
