### PR TITLE
fix(lemon-ui): Fix labels on basic sparklines

### DIFF
--- a/frontend/src/lib/lemon-ui/Sparkline.tsx
+++ b/frontend/src/lib/lemon-ui/Sparkline.tsx
@@ -43,7 +43,7 @@ export function Sparkline({ labels, data }: SparklineProps): JSX.Element {
                 type: 'bar',
                 data: {
                     labels: labels || adjustedData[0].values.map((_, i) => `Entry ${i}`),
-                                        datasets: adjustedData.map((timeseries) => ({
+                    datasets: adjustedData.map((timeseries) => ({
                         data: timeseries.values,
                         minBarLength: 0,
                         backgroundColor: getColorVar(timeseries.color),

--- a/frontend/src/lib/lemon-ui/Sparkline.tsx
+++ b/frontend/src/lib/lemon-ui/Sparkline.tsx
@@ -42,8 +42,8 @@ export function Sparkline({ labels, data }: SparklineProps): JSX.Element {
             chart = new Chart(canvasRef.current?.getContext('2d') as ChartItem, {
                 type: 'bar',
                 data: {
-                    labels: labels || Object.values(adjustedData).map(() => ''),
-                    datasets: adjustedData.map((timeseries) => ({
+                    labels: labels || adjustedData[0].values.map((_, i) => `Entry ${i}`),
+                                        datasets: adjustedData.map((timeseries) => ({
                         data: timeseries.values,
                         minBarLength: 0,
                         backgroundColor: getColorVar(timeseries.color),

--- a/package.json
+++ b/package.json
@@ -312,11 +312,11 @@
             "stylelint --fix",
             "prettier --write"
         ],
-        "frontend/src/**.{js,jsx,mjs,ts,tsx}": [
+        "frontend/src/**/*.{js,jsx,mjs,ts,tsx}": [
             "eslint -c .eslintrc.js --fix",
             "prettier --write"
         ],
-        "plugin-server/**.{js,jsx,mjs,ts,tsx}": [
+        "plugin-server/**/*.{js,jsx,mjs,ts,tsx}": [
             "pnpm --dir plugin-server exec eslint --fix",
             "pnpm --dir plugin-server exec prettier --write"
         ],


### PR DESCRIPTION
## Problem

Resolves ZEN-9432, which is a bug introduced in #19718.

## Changes

### Before

<img width="956" alt="Screenshot 2024-01-17 at 17 19 15" src="https://github.com/PostHog/posthog/assets/4550621/60d5c7a2-8976-49b2-8e05-c3f243f2f47a">

### After

<img width="962" alt="Screenshot 2024-01-17 at 17 18 47" src="https://github.com/PostHog/posthog/assets/4550621/fca10e47-5772-4652-85c7-ddb44412bb3c">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*
