### PR TITLE
fix: speculative change to stop empty error ending up in Sentry

### DIFF
--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -1,6 +1,7 @@
 import './SharingModal.scss'
 
 import { LemonButton, LemonSwitch } from '@posthog/lemon-ui'
+import { captureException } from '@sentry/react'
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
@@ -19,7 +20,6 @@ import { DashboardCollaboration } from 'scenes/dashboard/DashboardCollaborators'
 import { InsightModel, InsightShortId, InsightType } from '~/types'
 
 import { sharingLogic } from './sharingLogic'
-import { captureException } from '@sentry/react'
 
 export const SHARING_MODAL_WIDTH = 600
 

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -19,6 +19,7 @@ import { DashboardCollaboration } from 'scenes/dashboard/DashboardCollaborators'
 import { InsightModel, InsightShortId, InsightType } from '~/types'
 
 import { sharingLogic } from './sharingLogic'
+import {captureException} from "@sentry/react";
 
 export const SHARING_MODAL_WIDTH = 600
 
@@ -114,7 +115,14 @@ export function SharingModalContent({
                                     <LemonButton
                                         data-attr="sharing-link-button"
                                         size="small"
-                                        onClick={() => void copyToClipboard(shareLink, 'link')}
+                                        onClick={() => {
+                                            // TRICKY: there's a chance this was sending useless errors to Sentry
+                                            // even when it succeeded, so we're explicitly ignoring the promise success
+                                            // and naming the error when reported to Sentry
+                                            copyToClipboard(shareLink, 'link')
+                                                .then(() => {}) // purposefully no-op
+                                                .catch((e) => captureException(new Error('unexpected sharing modal clipboard error: ' + e.message)));
+                                        }}
                                         icon={<IconLink />}
                                     >
                                         Copy public link

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -19,7 +19,7 @@ import { DashboardCollaboration } from 'scenes/dashboard/DashboardCollaborators'
 import { InsightModel, InsightShortId, InsightType } from '~/types'
 
 import { sharingLogic } from './sharingLogic'
-import {captureException} from "@sentry/react";
+import { captureException } from '@sentry/react'
 
 export const SHARING_MODAL_WIDTH = 600
 
@@ -121,7 +121,13 @@ export function SharingModalContent({
                                             // and naming the error when reported to Sentry
                                             copyToClipboard(shareLink, 'link')
                                                 .then(() => {}) // purposefully no-op
-                                                .catch((e) => captureException(new Error('unexpected sharing modal clipboard error: ' + e.message)));
+                                                .catch((e) =>
+                                                    captureException(
+                                                        new Error(
+                                                            'unexpected sharing modal clipboard error: ' + e.message
+                                                        )
+                                                    )
+                                                )
                                         }}
                                         icon={<IconLink />}
                                     >


### PR DESCRIPTION
We get thousands of errors in Sentry that have no stack trace and just say "true"

Session replay shows they're associated with copying recording urls to the clipboard

Let's try this to see if it stops or clarifies the error

tested locally that we can still copy the URL to clipboard