### PR TITLE
fix(surveys): result viz choice overflow bug

### DIFF
--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -297,7 +297,7 @@ export function SingleChoiceQuestionPieChart({
                 <div className="mb-8">
                     <div className="font-semibold text-muted-alt">Single choice</div>
                     <div className="text-xl font-bold mb-2">{question.question}</div>
-                    <div className="h-80 border rounded pt-4 pb-2 flex">
+                    <div className="h-80 overflow-y-auto border rounded pt-4 pb-2 flex">
                         <div className="relative h-full w-80">
                             <BindLogic logic={insightLogic} props={insightProps}>
                                 <PieChart


### PR DESCRIPTION
## Problem

When there are too many choice result options, the container overflows

<img width="670" alt="Screenshot 2024-01-17 at 3 08 28 PM" src="https://github.com/PostHog/posthog/assets/25164963/673b02c5-ff75-42d7-823c-0fb9f364e397">

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
