### PR TITLE
chore: enable gossip for flower and to squelch errors

### DIFF
--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -12,14 +12,13 @@ help () {
   echo "  --concurrency=<N>     start N workers (overrides env var WEB_CONCURRENCY)"
   echo
   echo "Advanced Celery options (disabled by default):"
-  echo "  --with-gossip         start Celery gossip (useful for Prometheus)"
   echo "  --with-heartbeat      start Celery internal heartbeat (normally not useful)"
   echo "  --with-mingle         start Celery mingle (normally not useful)"
   exit 0
 }
 
 with_scheduler=false
-with_gossip=false
+with_gossip=true
 with_heartbeat=false
 with_mingle=false
 
@@ -35,10 +34,6 @@ while test $# -gt 0; do
     --with-beat) # Deprecated since the name is too similar to "heartbeat"
       echo "⚠️ Using docker-worker-celery with --with-beat. This argument is deprecated. Use --with-scheduler instead!"
       with_scheduler=true
-      shift
-      ;;
-    --with-gossip)
-      with_gossip=true
       shift
       ;;
     --with-heartbeat)


### PR DESCRIPTION
## Problem

The celery logs were filled with this error:
```
{"event": "pidbox command error: AttributeError(\"'NoneType' object has no attribute 'groups'\")", "timestamp": "2024-01-17T23:03:36.230750Z", "logger": "kombu.pidbox", "level": "error", "pid": 9, "tid": 28147 │
│ 3362922816, "exception": "Traceback (most recent call last):\n  File \"/python-runtime/kombu/pidbox.py\", line 102, in dispatch\n    reply = handle(method, arguments)\n  File \"/python-runtime/kombu/pidbox.py\", line 124, in handle_cast\n    return  │
│ self.handle(method, arguments)\n  File \"/python-runtime/kombu/pidbox.py\", line 118, in handle\n    return self.handlers[method](self.state, **arguments)\n  File \"/python-runtime/celery/worker/control.py\", line 340, in enable_events\n    if dispa │
│ tcher.groups and 'task' not in dispatcher.groups:\nAttributeError: 'NoneType' object has no attribute 'groups'"}
```

After doing a bit of research it turns out this is related to gossip and flower collecting stats on the workers. I turned this on in K8s and the errors went a way and Flower was happy.

Note: This does increase utilization on redis some, but it should be fine at our levels (only 24 workers max right now)

Note2: We are currently running with gossip enabled manually on prod, probably should be everywhere unless there is a reason not to. It is the default for our version of celery.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
