### PR TITLE
chore(query-nodes): camel case funnels filter

### DIFF
--- a/frontend/src/queries/examples.ts
+++ b/frontend/src/queries/examples.ts
@@ -204,7 +204,7 @@ const InsightFunnelsQuery: FunnelsQuery = {
     },
     series,
     funnelsFilter: {
-        funnel_order_type: StepOrderValue.ORDERED,
+        funnelOrderType: StepOrderValue.ORDERED,
     },
     breakdownFilter: {
         breakdown: '$geoip_country_code',

--- a/frontend/src/queries/nodes/InsightQuery/defaults.ts
+++ b/frontend/src/queries/nodes/InsightQuery/defaults.ts
@@ -34,7 +34,7 @@ export const funnelsQueryDefault: FunnelsQuery = {
         },
     ],
     funnelsFilter: {
-        funnel_viz_type: FunnelVizType.Steps,
+        funnelVizType: FunnelVizType.Steps,
     },
 }
 

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
@@ -381,20 +381,20 @@ describe('filtersToQueryNode', () => {
             const query: FunnelsQuery = {
                 kind: NodeKind.FunnelsQuery,
                 funnelsFilter: {
-                    funnel_viz_type: FunnelVizType.Steps,
-                    funnel_from_step: 1,
-                    funnel_to_step: 2,
-                    funnel_step_reference: FunnelStepReference.total,
-                    breakdown_attribution_type: BreakdownAttributionType.AllSteps,
-                    breakdown_attribution_value: 1,
-                    bin_count: 'auto',
-                    funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Day,
-                    funnel_window_interval: 7,
-                    funnel_order_type: StepOrderValue.ORDERED,
+                    funnelVizType: FunnelVizType.Steps,
+                    funnelFromStep: 1,
+                    funnelToStep: 2,
+                    funnelStepReference: FunnelStepReference.total,
+                    breakdownAttributionType: BreakdownAttributionType.AllSteps,
+                    breakdownAttributionValue: 1,
+                    binCount: 'auto',
+                    funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit.Day,
+                    funnelWindowInterval: 7,
+                    funnelOrderType: StepOrderValue.ORDERED,
                     exclusions: [
                         {
-                            funnel_from_step: 0,
-                            funnel_to_step: 1,
+                            funnelFromStep: 0,
+                            funnelToStep: 1,
                         },
                     ],
                     layout: FunnelLayout.horizontal,
@@ -1101,7 +1101,7 @@ describe('filtersToQueryNode', () => {
                 ],
                 filterTestAccounts: true,
                 funnelsFilter: {
-                    funnel_viz_type: FunnelVizType.Steps,
+                    funnelVizType: FunnelVizType.Steps,
                 },
             }
             expect(result).toEqual(query)
@@ -1171,7 +1171,7 @@ describe('filtersToQueryNode', () => {
                 ],
                 filterTestAccounts: true,
                 funnelsFilter: {
-                    funnel_viz_type: FunnelVizType.Steps,
+                    funnelVizType: FunnelVizType.Steps,
                 },
             }
             expect(result).toEqual(query)

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -277,20 +277,27 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
     // funnels filter
     if (isFunnelsFilter(filters) && isFunnelsQuery(query)) {
         query.funnelsFilter = objectCleanWithEmpty({
-            funnel_viz_type: filters.funnel_viz_type,
-            funnel_from_step: filters.funnel_from_step,
-            funnel_to_step: filters.funnel_to_step,
-            funnel_step_reference: filters.funnel_step_reference,
-            breakdown_attribution_type: filters.breakdown_attribution_type,
-            breakdown_attribution_value: filters.breakdown_attribution_value,
-            bin_count: filters.bin_count,
-            funnel_window_interval_unit: filters.funnel_window_interval_unit,
-            funnel_window_interval: filters.funnel_window_interval,
-            funnel_order_type: filters.funnel_order_type,
-            exclusions: filters.exclusions,
+            funnelVizType: filters.funnel_viz_type,
+            funnelFromStep: filters.funnel_from_step,
+            funnelToStep: filters.funnel_to_step,
+            funnelStepReference: filters.funnel_step_reference,
+            breakdownAttributionType: filters.breakdown_attribution_type,
+            breakdownAttributionValue: filters.breakdown_attribution_value,
+            binCount: filters.bin_count,
+            funnelWindowIntervalUnit: filters.funnel_window_interval_unit,
+            funnelWindowInterval: filters.funnel_window_interval,
+            funnelOrderType: filters.funnel_order_type,
+            exclusions:
+                filters.exclusions !== undefined
+                    ? filters.exclusions.map(({ funnel_from_step, funnel_to_step, ...rest }) => ({
+                          funnelFromStep: funnel_from_step,
+                          funnelToStep: funnel_to_step,
+                          ...rest,
+                      }))
+                    : undefined,
             layout: filters.layout,
             hidden_legend_breakdowns: cleanHiddenLegendSeries(filters.hidden_legend_keys),
-            funnel_aggregate_by_hogql: filters.funnel_aggregate_by_hogql,
+            funnelAggregateByhogql: filters.funnel_aggregate_by_hogql,
         })
     }
 

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -297,7 +297,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
                     : undefined,
             layout: filters.layout,
             hidden_legend_breakdowns: cleanHiddenLegendSeries(filters.hidden_legend_keys),
-            funnelAggregateByhogql: filters.funnel_aggregate_by_hogql,
+            funnelAggregateByHogQL: filters.funnel_aggregate_by_hogql,
         })
     }
 

--- a/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
@@ -191,7 +191,7 @@ export const queryNodeToFilter = (query: InsightQueryNode): Partial<FilterType> 
         camelCasedFunnelsProps.bin_count = queryCopy.funnelsFilter?.binCount
         camelCasedFunnelsProps.breakdown_attribution_type = queryCopy.funnelsFilter?.breakdownAttributionType
         camelCasedFunnelsProps.breakdown_attribution_value = queryCopy.funnelsFilter?.breakdownAttributionValue
-        camelCasedFunnelsProps.funnel_aggregate_by_hogql = queryCopy.funnelsFilter?.funnelAggregateByHogql
+        camelCasedFunnelsProps.funnel_aggregate_by_hogql = queryCopy.funnelsFilter?.funnelAggregateByHogQL
         camelCasedFunnelsProps.funnel_to_step = queryCopy.funnelsFilter?.funnelToStep
         camelCasedFunnelsProps.funnel_from_step = queryCopy.funnelsFilter?.funnelFromStep
         camelCasedFunnelsProps.funnel_order_type = queryCopy.funnelsFilter?.funnelOrderType
@@ -204,7 +204,7 @@ export const queryNodeToFilter = (query: InsightQueryNode): Partial<FilterType> 
         delete queryCopy.funnelsFilter?.binCount
         delete queryCopy.funnelsFilter?.breakdownAttributionType
         delete queryCopy.funnelsFilter?.breakdownAttributionValue
-        delete queryCopy.funnelsFilter?.funnelAggregateByHogql
+        delete queryCopy.funnelsFilter?.funnelAggregateByHogQL
         delete queryCopy.funnelsFilter?.funnelToStep
         delete queryCopy.funnelsFilter?.funnelFromStep
         delete queryCopy.funnelsFilter?.funnelOrderType

--- a/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
@@ -5,6 +5,7 @@ import {
     ActionsNode,
     BreakdownFilter,
     EventsNode,
+    FunnelsFilterLegacy,
     InsightNodeKind,
     InsightQueryNode,
     LifecycleFilterLegacy,
@@ -155,6 +156,7 @@ export const queryNodeToFilter = (query: InsightQueryNode): Partial<FilterType> 
 
     // replace camel cased props with the snake cased variant
     const camelCasedTrendsProps: TrendsFilterLegacy = {}
+    const camelCasedFunnelsProps: FunnelsFilterLegacy = {}
     const camelCasedRetentionProps: RetentionFilterLegacy = {}
     const camelCasedPathsProps: PathsFilterLegacy = {}
     const camelCasedStickinessProps: StickinessFilterLegacy = {}
@@ -178,6 +180,39 @@ export const queryNodeToFilter = (query: InsightQueryNode): Partial<FilterType> 
         delete queryCopy.trendsFilter?.showPercentStackView
         delete queryCopy.trendsFilter?.showLegend
         delete queryCopy.trendsFilter?.showValuesOnSeries
+    } else if (isFunnelsQuery(queryCopy)) {
+        camelCasedFunnelsProps.exclusions = queryCopy.funnelsFilter?.exclusions
+            ? queryCopy.funnelsFilter.exclusions.map(({ funnelFromStep, funnelToStep, ...rest }) => ({
+                  funnel_from_step: funnelFromStep,
+                  funnel_to_step: funnelToStep,
+                  ...rest,
+              }))
+            : undefined
+        camelCasedFunnelsProps.bin_count = queryCopy.funnelsFilter?.binCount
+        camelCasedFunnelsProps.breakdown_attribution_type = queryCopy.funnelsFilter?.breakdownAttributionType
+        camelCasedFunnelsProps.breakdown_attribution_value = queryCopy.funnelsFilter?.breakdownAttributionValue
+        camelCasedFunnelsProps.funnel_aggregate_by_hogql = queryCopy.funnelsFilter?.funnelAggregateByHogql
+        camelCasedFunnelsProps.funnel_to_step = queryCopy.funnelsFilter?.funnelToStep
+        camelCasedFunnelsProps.funnel_from_step = queryCopy.funnelsFilter?.funnelFromStep
+        camelCasedFunnelsProps.funnel_order_type = queryCopy.funnelsFilter?.funnelOrderType
+        camelCasedFunnelsProps.funnel_viz_type = queryCopy.funnelsFilter?.funnelVizType
+        camelCasedFunnelsProps.funnel_window_interval = queryCopy.funnelsFilter?.funnelWindowInterval
+        camelCasedFunnelsProps.funnel_window_interval_unit = queryCopy.funnelsFilter?.funnelWindowIntervalUnit
+        // camelCasedFunnelsProps.hidden_legend_breakdowns = queryCopy.funnelsFilter?.hiddenLegendBreakdowns
+        camelCasedFunnelsProps.funnel_step_reference = queryCopy.funnelsFilter?.funnelStepReference
+        delete queryCopy.funnelsFilter?.exclusions
+        delete queryCopy.funnelsFilter?.binCount
+        delete queryCopy.funnelsFilter?.breakdownAttributionType
+        delete queryCopy.funnelsFilter?.breakdownAttributionValue
+        delete queryCopy.funnelsFilter?.funnelAggregateByHogql
+        delete queryCopy.funnelsFilter?.funnelToStep
+        delete queryCopy.funnelsFilter?.funnelFromStep
+        delete queryCopy.funnelsFilter?.funnelOrderType
+        delete queryCopy.funnelsFilter?.funnelVizType
+        delete queryCopy.funnelsFilter?.funnelWindowInterval
+        delete queryCopy.funnelsFilter?.funnelWindowIntervalUnit
+        // delete queryCopy.funnelsFilter?.hiddenLegendBreakdowns
+        delete queryCopy.funnelsFilter?.funnelStepReference
     } else if (isRetentionQuery(queryCopy)) {
         camelCasedRetentionProps.retention_reference = queryCopy.retentionFilter?.retentionReference
         camelCasedRetentionProps.retention_type = queryCopy.retentionFilter?.retentionType
@@ -228,6 +263,7 @@ export const queryNodeToFilter = (query: InsightQueryNode): Partial<FilterType> 
         delete queryCopy.lifecycleFilter?.showValuesOnSeries
     }
     Object.assign(filters, camelCasedTrendsProps)
+    Object.assign(filters, camelCasedFunnelsProps)
     Object.assign(filters, camelCasedRetentionProps)
     Object.assign(filters, camelCasedPathsProps)
     Object.assign(filters, camelCasedStickinessProps)

--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -151,7 +151,7 @@ export function InsightVizDisplay({
             timedOutQueryId === null &&
             isFunnelWithEnoughSteps &&
             hasFunnelResults &&
-            funnelsFilter?.funnel_viz_type === FunnelVizType.Steps &&
+            funnelsFilter?.funnelVizType === FunnelVizType.Steps &&
             !disableTable
         ) {
             return (

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1410,7 +1410,7 @@
                     },
                     "type": "array"
                 },
-                "funnelAggregateByHogql": {
+                "funnelAggregateByHogQL": {
                     "type": "string"
                 },
                 "funnelFromStep": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1322,6 +1322,36 @@
                 "custom_name": {
                     "type": ["string", "null"]
                 },
+                "funnelFromStep": {
+                    "type": "number"
+                },
+                "funnelToStep": {
+                    "type": "number"
+                },
+                "id": {
+                    "type": ["string", "number", "null"]
+                },
+                "index": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": ["string", "null"]
+                },
+                "order": {
+                    "type": "number"
+                },
+                "type": {
+                    "$ref": "#/definitions/EntityType"
+                }
+            },
+            "type": "object"
+        },
+        "FunnelExclusionLegacy": {
+            "additionalProperties": false,
+            "properties": {
+                "custom_name": {
+                    "type": ["string", "null"]
+                },
                 "funnel_from_step": {
                     "type": "number"
                 },
@@ -1364,6 +1394,60 @@
         },
         "FunnelsFilter": {
             "additionalProperties": false,
+            "properties": {
+                "binCount": {
+                    "$ref": "#/definitions/BinCountValue"
+                },
+                "breakdownAttributionType": {
+                    "$ref": "#/definitions/BreakdownAttributionType"
+                },
+                "breakdownAttributionValue": {
+                    "type": "number"
+                },
+                "exclusions": {
+                    "items": {
+                        "$ref": "#/definitions/FunnelExclusion"
+                    },
+                    "type": "array"
+                },
+                "funnelAggregateByHogql": {
+                    "type": "string"
+                },
+                "funnelFromStep": {
+                    "type": "number"
+                },
+                "funnelOrderType": {
+                    "$ref": "#/definitions/StepOrderValue"
+                },
+                "funnelStepReference": {
+                    "$ref": "#/definitions/FunnelStepReference"
+                },
+                "funnelToStep": {
+                    "type": "number"
+                },
+                "funnelVizType": {
+                    "$ref": "#/definitions/FunnelVizType"
+                },
+                "funnelWindowInterval": {
+                    "type": "number"
+                },
+                "funnelWindowIntervalUnit": {
+                    "$ref": "#/definitions/FunnelConversionWindowTimeUnit"
+                },
+                "hidden_legend_breakdowns": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "layout": {
+                    "$ref": "#/definitions/FunnelLayout"
+                }
+            },
+            "type": "object"
+        },
+        "FunnelsFilterLegacy": {
+            "additionalProperties": false,
             "description": "`FunnelsFilterType` minus everything inherited from `FilterType` and persons modal related params and `hidden_legend_keys` replaced by `hidden_legend_breakdowns`",
             "properties": {
                 "bin_count": {
@@ -1377,7 +1461,7 @@
                 },
                 "exclusions": {
                     "items": {
-                        "$ref": "#/definitions/FunnelExclusion"
+                        "$ref": "#/definitions/FunnelExclusionLegacy"
                     },
                     "type": "array"
                 },

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -9,6 +9,7 @@ import {
     EventPropertyFilter,
     EventType,
     FilterType,
+    FunnelExclusion,
     FunnelsFilterType,
     GroupMathType,
     HogQLMathType,
@@ -549,7 +550,7 @@ export interface TrendsQuery extends InsightsQueryBase {
 
 /** `FunnelsFilterType` minus everything inherited from `FilterType` and persons modal related params
  * and `hidden_legend_keys` replaced by `hidden_legend_breakdowns` */
-export type FunnelsFilter = Omit<
+export type FunnelsFilterLegacy = Omit<
     FunnelsFilterType & { hidden_legend_breakdowns?: string[] },
     | keyof FilterType
     | 'hidden_legend_keys'
@@ -561,6 +562,24 @@ export type FunnelsFilter = Omit<
     | 'funnel_step'
     | 'funnel_custom_steps'
 >
+
+export type FunnelsFilter = {
+    exclusions?: FunnelExclusion[]
+    layout?: FunnelsFilterLegacy['layout']
+    binCount?: FunnelsFilterLegacy['bin_count']
+    breakdownAttributionType?: FunnelsFilterLegacy['breakdown_attribution_type']
+    breakdownAttributionValue?: FunnelsFilterLegacy['breakdown_attribution_value']
+    funnelAggregateByHogql?: FunnelsFilterLegacy['funnel_aggregate_by_hogql']
+    funnelToStep?: FunnelsFilterLegacy['funnel_to_step']
+    funnelFromStep?: FunnelsFilterLegacy['funnel_from_step']
+    funnelOrderType?: FunnelsFilterLegacy['funnel_order_type']
+    funnelVizType?: FunnelsFilterLegacy['funnel_viz_type']
+    funnelWindowInterval?: FunnelsFilterLegacy['funnel_window_interval']
+    funnelWindowIntervalUnit?: FunnelsFilterLegacy['funnel_window_interval_unit']
+    hidden_legend_breakdowns?: FunnelsFilterLegacy['hidden_legend_breakdowns']
+    funnelStepReference?: FunnelsFilterLegacy['funnel_step_reference']
+}
+
 export interface FunnelsQuery extends InsightsQueryBase {
     kind: NodeKind.FunnelsQuery
     /** Granularity of the response. Can be one of `hour`, `day`, `week` or `month` */

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -569,7 +569,7 @@ export type FunnelsFilter = {
     binCount?: FunnelsFilterLegacy['bin_count']
     breakdownAttributionType?: FunnelsFilterLegacy['breakdown_attribution_type']
     breakdownAttributionValue?: FunnelsFilterLegacy['breakdown_attribution_value']
-    funnelAggregateByHogql?: FunnelsFilterLegacy['funnel_aggregate_by_hogql']
+    funnelAggregateByHogQL?: FunnelsFilterLegacy['funnel_aggregate_by_hogql']
     funnelToStep?: FunnelsFilterLegacy['funnel_to_step']
     funnelFromStep?: FunnelsFilterLegacy['funnel_from_step']
     funnelOrderType?: FunnelsFilterLegacy['funnel_order_type']

--- a/frontend/src/scenes/funnels/Funnel.tsx
+++ b/frontend/src/scenes/funnels/Funnel.tsx
@@ -15,12 +15,12 @@ import { FunnelHistogram } from './FunnelHistogram'
 export function Funnel(props: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { funnelsFilter } = useValues(funnelDataLogic(insightProps))
-    const { funnel_viz_type, layout } = funnelsFilter || {}
+    const { funnelVizType, layout } = funnelsFilter || {}
 
     let viz: JSX.Element | null = null
-    if (funnel_viz_type == FunnelVizType.Trends) {
+    if (funnelVizType == FunnelVizType.Trends) {
         viz = <FunnelLineGraph {...props} />
-    } else if (funnel_viz_type == FunnelVizType.TimeToConvert) {
+    } else if (funnelVizType == FunnelVizType.TimeToConvert) {
         viz = <FunnelHistogram />
     } else if ((layout || FunnelLayout.vertical) === FunnelLayout.vertical) {
         viz = <FunnelBarChart {...props} />
@@ -30,8 +30,8 @@ export function Funnel(props: ChartParams): JSX.Element {
 
     return (
         <div
-            className={`FunnelInsight FunnelInsight--type-${funnel_viz_type?.toLowerCase()}${
-                funnel_viz_type === FunnelVizType.Steps ? '-' + (layout ?? FunnelLayout.vertical) : ''
+            className={`FunnelInsight FunnelInsight--type-${funnelVizType?.toLowerCase()}${
+                funnelVizType === FunnelVizType.Steps ? '-' + (layout ?? FunnelLayout.vertical) : ''
             }`}
         >
             {viz}

--- a/frontend/src/scenes/funnels/FunnelBarGraph/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph/FunnelBarGraph.tsx
@@ -36,7 +36,7 @@ export function FunnelBarGraph({
     const { ref: graphRef, width } = useResizeObserver()
 
     const steps = visibleStepsWithConversionMetrics
-    const stepReference = funnelsFilter?.funnel_step_reference || FunnelStepReference.total
+    const stepReference = funnelsFilter?.funnelStepReference || FunnelStepReference.total
 
     const showPersonsModal = canOpenPersonModal && showPersonsModalProp
 
@@ -67,7 +67,7 @@ export function FunnelBarGraph({
                     <section key={step.order} className="funnel-step">
                         <div className="funnel-series-container">
                             <div className={`funnel-series-linebox ${showLineBefore ? 'before' : ''}`} />
-                            {funnelsFilter?.funnel_order_type === StepOrderValue.UNORDERED ? (
+                            {funnelsFilter?.funnelOrderType === StepOrderValue.UNORDERED ? (
                                 <SeriesGlyph variant="funnel-step-glyph">
                                     <IconInfinity style={{ fill: 'var(--primary_alt)', width: 14 }} />
                                 </SeriesGlyph>
@@ -79,13 +79,13 @@ export function FunnelBarGraph({
                         <header>
                             <div className="flex items-center max-w-full grow">
                                 <div className="funnel-step-title">
-                                    {funnelsFilter?.funnel_order_type === StepOrderValue.UNORDERED ? (
+                                    {funnelsFilter?.funnelOrderType === StepOrderValue.UNORDERED ? (
                                         <span>Completed {step.order + 1} steps</span>
                                     ) : (
                                         <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} />
                                     )}
                                 </div>
-                                {funnelsFilter?.funnel_order_type !== StepOrderValue.UNORDERED &&
+                                {funnelsFilter?.funnelOrderType !== StepOrderValue.UNORDERED &&
                                     stepIndex > 0 &&
                                     step.action_id === steps[stepIndex - 1].action_id && <DuplicateStepIndicator />}
                                 <FunnelStepMore stepIndex={stepIndex} />

--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -17,7 +17,7 @@ export function FunnelCanvasLabel(): JSX.Element | null {
     const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
 
     const labels = [
-        ...(funnelsFilter?.funnel_viz_type === FunnelVizType.Steps
+        ...(funnelsFilter?.funnelVizType === FunnelVizType.Steps
             ? [
                   <>
                       <span className="flex items-center text-muted-alt mr-1">
@@ -32,7 +32,7 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                   </>,
               ]
             : []),
-        ...(funnelsFilter?.funnel_viz_type !== FunnelVizType.Trends
+        ...(funnelsFilter?.funnelVizType !== FunnelVizType.Trends
             ? [
                   <>
                       <span className="flex items-center text-muted-alt">
@@ -43,14 +43,14 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                           </Tooltip>
                           <span>Average time to convert</span>
                       </span>
-                      {funnelsFilter?.funnel_viz_type === FunnelVizType.TimeToConvert && <FunnelStepsPicker />}
+                      {funnelsFilter?.funnelVizType === FunnelVizType.TimeToConvert && <FunnelStepsPicker />}
                       <span className="text-muted-alt mr-1">:</span>
-                      {funnelsFilter?.funnel_viz_type === FunnelVizType.TimeToConvert ? (
+                      {funnelsFilter?.funnelVizType === FunnelVizType.TimeToConvert ? (
                           <span className="font-bold">{humanFriendlyDuration(conversionMetrics.averageTime)}</span>
                       ) : (
                           <Link
                               className="font-bold"
-                              onClick={() => updateInsightFilter({ funnel_viz_type: FunnelVizType.TimeToConvert })}
+                              onClick={() => updateInsightFilter({ funnelVizType: FunnelVizType.TimeToConvert })}
                           >
                               {humanFriendlyDuration(conversionMetrics.averageTime)}
                           </Link>
@@ -58,7 +58,7 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                   </>,
               ]
             : []),
-        ...(funnelsFilter?.funnel_viz_type === FunnelVizType.Trends
+        ...(funnelsFilter?.funnelVizType === FunnelVizType.Trends
             ? [
                   <>
                       <span className="text-muted-alt">Conversion rate</span>

--- a/frontend/src/scenes/funnels/funnelDataLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.test.ts
@@ -74,7 +74,7 @@ describe('funnelDataLogic', () => {
                 kind: NodeKind.FunnelsQuery,
                 series: [],
                 funnelsFilter: {
-                    funnel_viz_type: FunnelVizType.Steps,
+                    funnelVizType: FunnelVizType.Steps,
                 },
             }
 
@@ -93,7 +93,7 @@ describe('funnelDataLogic', () => {
                 kind: NodeKind.FunnelsQuery,
                 series: [],
                 funnelsFilter: {
-                    funnel_viz_type: FunnelVizType.TimeToConvert,
+                    funnelVizType: FunnelVizType.TimeToConvert,
                 },
             }
 
@@ -112,7 +112,7 @@ describe('funnelDataLogic', () => {
                 kind: NodeKind.FunnelsQuery,
                 series: [],
                 funnelsFilter: {
-                    funnel_viz_type: FunnelVizType.Trends,
+                    funnelVizType: FunnelVizType.Trends,
                 },
             }
 
@@ -242,7 +242,7 @@ describe('funnelDataLogic', () => {
                     kind: NodeKind.FunnelsQuery,
                     series: [],
                     funnelsFilter: {
-                        funnel_viz_type: FunnelVizType.TimeToConvert,
+                        funnelVizType: FunnelVizType.TimeToConvert,
                     },
                 }
                 const insight: Partial<InsightModel> = {
@@ -759,7 +759,7 @@ describe('funnelDataLogic', () => {
                     kind: NodeKind.FunnelsQuery,
                     series: [],
                     funnelsFilter: {
-                        funnel_viz_type: FunnelVizType.TimeToConvert,
+                        funnelVizType: FunnelVizType.TimeToConvert,
                     },
                 }
                 const insight: Partial<InsightModel> = {
@@ -799,7 +799,7 @@ describe('funnelDataLogic', () => {
                     kind: NodeKind.FunnelsQuery,
                     series: [],
                     funnelsFilter: {
-                        funnel_viz_type: FunnelVizType.TimeToConvert,
+                        funnelVizType: FunnelVizType.TimeToConvert,
                     },
                 }
                 const insight: Partial<InsightModel> = {
@@ -825,7 +825,7 @@ describe('funnelDataLogic', () => {
                     kind: NodeKind.FunnelsQuery,
                     series: [],
                     funnelsFilter: {
-                        funnel_viz_type: FunnelVizType.TimeToConvert,
+                        funnelVizType: FunnelVizType.TimeToConvert,
                     },
                 }
                 const insight: Partial<InsightModel> = {
@@ -848,7 +848,7 @@ describe('funnelDataLogic', () => {
                     kind: NodeKind.FunnelsQuery,
                     series: [],
                     funnelsFilter: {
-                        funnel_viz_type: FunnelVizType.TimeToConvert,
+                        funnelVizType: FunnelVizType.TimeToConvert,
                     },
                 }
                 const insight: Partial<InsightModel> = {
@@ -882,7 +882,7 @@ describe('funnelDataLogic', () => {
                 kind: NodeKind.FunnelsQuery,
                 series: [],
                 funnelsFilter: {
-                    funnel_viz_type: FunnelVizType.Steps,
+                    funnelVizType: FunnelVizType.Steps,
                 },
             }
 
@@ -906,7 +906,7 @@ describe('funnelDataLogic', () => {
                 kind: NodeKind.FunnelsQuery,
                 series: [],
                 funnelsFilter: {
-                    funnel_viz_type: FunnelVizType.TimeToConvert,
+                    funnelVizType: FunnelVizType.TimeToConvert,
                 },
             }
 
@@ -930,7 +930,7 @@ describe('funnelDataLogic', () => {
                 kind: NodeKind.FunnelsQuery,
                 series: [],
                 funnelsFilter: {
-                    funnel_viz_type: FunnelVizType.Trends,
+                    funnelVizType: FunnelVizType.Trends,
                 },
             }
 
@@ -956,7 +956,7 @@ describe('funnelDataLogic', () => {
                 kind: NodeKind.FunnelsQuery,
                 series: [],
                 funnelsFilter: {
-                    funnel_viz_type: FunnelVizType.Steps,
+                    funnelVizType: FunnelVizType.Steps,
                 },
             }
 
@@ -984,7 +984,7 @@ describe('funnelDataLogic', () => {
                 kind: NodeKind.FunnelsQuery,
                 series: [],
                 funnelsFilter: {
-                    funnel_viz_type: FunnelVizType.TimeToConvert,
+                    funnelVizType: FunnelVizType.TimeToConvert,
                 },
             }
             const insight: Partial<InsightModel> = {
@@ -1011,7 +1011,7 @@ describe('funnelDataLogic', () => {
                 kind: NodeKind.FunnelsQuery,
                 series: [],
                 funnelsFilter: {
-                    funnel_viz_type: FunnelVizType.Trends,
+                    funnelVizType: FunnelVizType.Trends,
                 },
             }
 
@@ -1039,8 +1039,8 @@ describe('funnelDataLogic', () => {
         it('with defaults', async () => {
             await expectLogic(logic).toMatchValues({
                 conversionWindow: {
-                    funnel_window_interval: 14,
-                    funnel_window_interval_unit: 'day',
+                    funnelWindowInterval: 14,
+                    funnelWindowIntervalUnit: 'day',
                 },
             })
         })
@@ -1050,8 +1050,8 @@ describe('funnelDataLogic', () => {
                 kind: NodeKind.FunnelsQuery,
                 series: [],
                 funnelsFilter: {
-                    funnel_window_interval: 3,
-                    funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Week,
+                    funnelWindowInterval: 3,
+                    funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit.Week,
                 },
             }
 
@@ -1059,8 +1059,8 @@ describe('funnelDataLogic', () => {
                 logic.actions.updateQuerySource(query)
             }).toMatchValues({
                 conversionWindow: {
-                    funnel_window_interval: 3,
-                    funnel_window_interval_unit: 'week',
+                    funnelWindowInterval: 3,
+                    funnelWindowIntervalUnit: 'week',
                 },
             })
         })
@@ -1096,8 +1096,8 @@ describe('funnelDataLogic', () => {
                 kind: NodeKind.FunnelsQuery,
                 series: [],
                 funnelsFilter: {
-                    funnel_window_interval: 2,
-                    funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Day,
+                    funnelWindowInterval: 2,
+                    funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit.Day,
                 },
             }
 

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -91,19 +91,19 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                     ? null
                     : funnelsFilter === undefined
                     ? true
-                    : funnelsFilter.funnel_viz_type === FunnelVizType.Steps
+                    : funnelsFilter.funnelVizType === FunnelVizType.Steps
             },
         ],
         isTimeToConvertFunnel: [
             (s) => [s.funnelsFilter],
             (funnelsFilter): boolean | null => {
-                return funnelsFilter === null ? null : funnelsFilter?.funnel_viz_type === FunnelVizType.TimeToConvert
+                return funnelsFilter === null ? null : funnelsFilter?.funnelVizType === FunnelVizType.TimeToConvert
             },
         ],
         isTrendsFunnel: [
             (s) => [s.funnelsFilter],
             (funnelsFilter): boolean | null => {
-                return funnelsFilter === null ? null : funnelsFilter?.funnel_viz_type === FunnelVizType.Trends
+                return funnelsFilter === null ? null : funnelsFilter?.funnelVizType === FunnelVizType.Trends
             },
         ],
 
@@ -124,8 +124,8 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                     return { singular: '', plural: '' }
                 }
 
-                return querySource.funnelsFilter?.funnel_aggregate_by_hogql
-                    ? aggregationLabelForHogQL(querySource.funnelsFilter.funnel_aggregate_by_hogql)
+                return querySource.funnelsFilter?.funnelAggregateByHogql
+                    ? aggregationLabelForHogQL(querySource.funnelsFilter.funnelAggregateByHogql)
                     : aggregationLabel(querySource.aggregation_group_type_index)
             },
         ],
@@ -173,7 +173,7 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
         stepsWithConversionMetrics: [
             (s) => [s.steps, s.funnelsFilter],
             (steps, funnelsFilter): FunnelStepWithConversionMetrics[] => {
-                const stepReference = funnelsFilter?.funnel_step_reference || FunnelStepReference.total
+                const stepReference = funnelsFilter?.funnelStepReference || FunnelStepReference.total
                 return stepsWithConversionMetrics(steps, stepReference)
             },
         ],
@@ -219,7 +219,7 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
         timeConversionResults: [
             (s) => [s.results, s.funnelsFilter],
             (results, funnelsFilter): FunnelsTimeConversionBins | null => {
-                return funnelsFilter?.funnel_viz_type === FunnelVizType.TimeToConvert
+                return funnelsFilter?.funnelVizType === FunnelVizType.TimeToConvert
                     ? (results as FunnelsTimeConversionBins)
                     : null
             },
@@ -253,11 +253,11 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
         hasFunnelResults: [
             (s) => [s.funnelsFilter, s.steps, s.histogramGraphData],
             (funnelsFilter, steps, histogramGraphData) => {
-                if (funnelsFilter?.funnel_viz_type === FunnelVizType.Steps || !funnelsFilter?.funnel_viz_type) {
+                if (funnelsFilter?.funnelVizType === FunnelVizType.Steps || !funnelsFilter?.funnelVizType) {
                     return !!(steps && steps[0] && steps[0].count > -1)
-                } else if (funnelsFilter.funnel_viz_type === FunnelVizType.TimeToConvert) {
+                } else if (funnelsFilter.funnelVizType === FunnelVizType.TimeToConvert) {
                     return (histogramGraphData?.length ?? 0) > 0
-                } else if (funnelsFilter.funnel_viz_type === FunnelVizType.Trends) {
+                } else if (funnelsFilter.funnelVizType === FunnelVizType.Trends) {
                     return (steps?.length ?? 0) > 0 && !!steps?.[0]?.labels
                 } else {
                     return false
@@ -267,10 +267,10 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
         numericBinCount: [
             (s) => [s.funnelsFilter, s.timeConversionResults],
             (funnelsFilter, timeConversionResults): number => {
-                if (funnelsFilter?.bin_count === BIN_COUNT_AUTO) {
+                if (funnelsFilter?.binCount === BIN_COUNT_AUTO) {
                     return timeConversionResults?.bins?.length ?? 0
                 }
-                return funnelsFilter?.bin_count ?? 0
+                return funnelsFilter?.binCount ?? 0
             },
         ],
 
@@ -278,7 +278,7 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
             (s) => [s.steps, s.funnelsFilter, s.timeConversionResults],
             (steps, funnelsFilter, timeConversionResults): FunnelTimeConversionMetrics => {
                 // steps should be empty in time conversion view. Return metrics precalculated on backend
-                if (funnelsFilter?.funnel_viz_type === FunnelVizType.TimeToConvert) {
+                if (funnelsFilter?.funnelVizType === FunnelVizType.TimeToConvert) {
                     return {
                         averageTime: timeConversionResults?.average_conversion_time ?? 0,
                         stepRate: 0,
@@ -287,7 +287,7 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                 }
 
                 // Handle metrics for trends
-                if (funnelsFilter?.funnel_viz_type === FunnelVizType.Trends) {
+                if (funnelsFilter?.funnelVizType === FunnelVizType.Trends) {
                     return {
                         averageTime: 0,
                         stepRate: 0,
@@ -321,10 +321,10 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
         conversionWindow: [
             (s) => [s.funnelsFilter],
             (funnelsFilter): FunnelConversionWindow => {
-                const { funnel_window_interval, funnel_window_interval_unit } = funnelsFilter || {}
+                const { funnelWindowInterval, funnelWindowIntervalUnit } = funnelsFilter || {}
                 return {
-                    funnel_window_interval: funnel_window_interval || 14,
-                    funnel_window_interval_unit: funnel_window_interval_unit || FunnelConversionWindowTimeUnit.Day,
+                    funnelWindowInterval: funnelWindowInterval || 14,
+                    funnelWindowIntervalUnit: funnelWindowIntervalUnit || FunnelConversionWindowTimeUnit.Day,
                 }
             },
         ],
@@ -348,18 +348,18 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
         ],
 
         /*
-         * Advanced options: funnel_order_type, funnel_step_reference, exclusions
+         * Advanced options: funnelOrderType, funnelStepReference, exclusions
          */
         advancedOptionsUsedCount: [
             (s) => [s.funnelsFilter],
             (funnelsFilter): number => {
                 let count = 0
-                if (funnelsFilter?.funnel_order_type && funnelsFilter?.funnel_order_type !== StepOrderValue.ORDERED) {
+                if (funnelsFilter?.funnelOrderType && funnelsFilter?.funnelOrderType !== StepOrderValue.ORDERED) {
                     count = count + 1
                 }
                 if (
-                    funnelsFilter?.funnel_step_reference &&
-                    funnelsFilter?.funnel_step_reference !== FunnelStepReference.total
+                    funnelsFilter?.funnelStepReference &&
+                    funnelsFilter?.funnelStepReference !== FunnelStepReference.total
                 ) {
                     count = count + 1
                 }

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -124,8 +124,8 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                     return { singular: '', plural: '' }
                 }
 
-                return querySource.funnelsFilter?.funnelAggregateByHogql
-                    ? aggregationLabelForHogQL(querySource.funnelsFilter.funnelAggregateByHogql)
+                return querySource.funnelsFilter?.funnelAggregateByHogQL
+                    ? aggregationLabelForHogQL(querySource.funnelsFilter.funnelAggregateByHogQL)
                     : aggregationLabel(querySource.aggregation_group_type_index)
             },
         ],

--- a/frontend/src/scenes/funnels/funnelPersonsModalLogic.ts
+++ b/frontend/src/scenes/funnels/funnelPersonsModalLogic.ts
@@ -74,7 +74,7 @@ export const funnelPersonsModalLogic = kea<funnelPersonsModalLogicType>([
         canOpenPersonModal: [
             (s) => [s.funnelsFilter, s.isInDashboardContext],
             (funnelsFilter, isInDashboardContext): boolean => {
-                return !isInDashboardContext && !funnelsFilter?.funnelAggregateByHogql
+                return !isInDashboardContext && !funnelsFilter?.funnelAggregateByHogQL
             },
         ],
     }),

--- a/frontend/src/scenes/funnels/funnelPersonsModalLogic.ts
+++ b/frontend/src/scenes/funnels/funnelPersonsModalLogic.ts
@@ -74,7 +74,7 @@ export const funnelPersonsModalLogic = kea<funnelPersonsModalLogicType>([
         canOpenPersonModal: [
             (s) => [s.funnelsFilter, s.isInDashboardContext],
             (funnelsFilter, isInDashboardContext): boolean => {
-                return !isInDashboardContext && !funnelsFilter?.funnel_aggregate_by_hogql
+                return !isInDashboardContext && !funnelsFilter?.funnelAggregateByHogql
             },
         ],
     }),
@@ -94,7 +94,7 @@ export const funnelPersonsModalLogic = kea<funnelPersonsModalLogicType>([
                     step: typeof stepIndex === 'number' ? stepIndex + 1 : step.order + 1,
                     label: step.name,
                     seriesId: step.order,
-                    order_type: values.funnelsFilter?.funnel_order_type,
+                    order_type: values.funnelsFilter?.funnelOrderType,
                 }),
             })
         },
@@ -112,7 +112,7 @@ export const funnelPersonsModalLogic = kea<funnelPersonsModalLogicType>([
                     breakdown_value: breakdownValues.isEmpty ? undefined : breakdownValues.breakdown_value.join(', '),
                     label: step.name,
                     seriesId: step.order,
-                    order_type: values.funnelsFilter?.funnel_order_type,
+                    order_type: values.funnelsFilter?.funnelOrderType,
                 }),
             })
         },

--- a/frontend/src/scenes/funnels/funnelUtils.test.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.test.ts
@@ -1,7 +1,7 @@
 import { dayjs } from 'lib/dayjs'
 
+import { EventsNode, FunnelsQuery, NodeKind } from '~/queries/schema'
 import {
-    FilterType,
     FunnelConversionWindowTimeUnit,
     FunnelCorrelation,
     FunnelCorrelationResultsType,
@@ -12,7 +12,7 @@ import {
 import {
     EMPTY_BREAKDOWN_VALUES,
     getBreakdownStepValues,
-    getClampedStepRangeFilter,
+    getClampedStepRange,
     getIncompleteConversionWindowStartDate,
     getMeanAndStandardDeviation,
     getVisibilityKey,
@@ -133,100 +133,107 @@ describe('getVisibilityKey()', () => {
 describe('getIncompleteConversionWindowStartDate()', () => {
     const windows = [
         {
-            funnel_window_interval: 10,
-            funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Second,
+            funnelWindowInterval: 10,
+            funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit.Second,
             expected: '2018-04-04T15:59:50.000Z',
         },
         {
-            funnel_window_interval: 60,
-            funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Minute,
+            funnelWindowInterval: 60,
+            funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit.Minute,
             expected: '2018-04-04T15:00:00.000Z',
         },
         {
-            funnel_window_interval: 24,
-            funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Hour,
+            funnelWindowInterval: 24,
+            funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit.Hour,
             expected: '2018-04-03T16:00:00.000Z',
         },
         {
-            funnel_window_interval: 7,
-            funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Day,
+            funnelWindowInterval: 7,
+            funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit.Day,
             expected: '2018-03-28T16:00:00.000Z',
         },
         {
-            funnel_window_interval: 53,
-            funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Week,
+            funnelWindowInterval: 53,
+            funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit.Week,
             expected: '2017-03-29T16:00:00.000Z',
         },
         {
-            funnel_window_interval: 12,
-            funnel_window_interval_unit: FunnelConversionWindowTimeUnit.Month,
+            funnelWindowInterval: 12,
+            funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit.Month,
             expected: '2017-04-04T16:00:00.000Z',
         },
     ]
     const frozenStartDate = dayjs('2018-04-04T16:00:00.000Z')
 
     windows.forEach(({ expected, ...w }) => {
-        it(`get start date of conversion window ${w.funnel_window_interval} ${w.funnel_window_interval_unit}s`, () => {
+        it(`get start date of conversion window ${w.funnelWindowInterval} ${w.funnelWindowIntervalUnit}s`, () => {
             expect(getIncompleteConversionWindowStartDate(w, frozenStartDate).toISOString()).toEqual(expected)
         })
     })
 })
 
-describe('getClampedStepRangeFilter', () => {
+describe('getClampedStepRange', () => {
     it('prefers step range to existing filters', () => {
-        const stepRange = {
-            funnel_from_step: 0,
-            funnel_to_step: 1,
-        } as FunnelExclusion
-        const filters = {
-            funnel_from_step: 1,
-            funnel_to_step: 2,
-            actions: [{}, {}],
-            events: [{}, {}],
-        } as FilterType
-        const clampedStepRange = getClampedStepRangeFilter({
+        const stepRange: FunnelExclusion = {
+            funnelFromStep: 0,
+            funnelToStep: 1,
+        }
+        const query: FunnelsQuery = {
+            kind: NodeKind.FunnelsQuery,
+            funnelsFilter: {
+                funnelFromStep: 1,
+                funnelToStep: 2,
+            },
+            series: [{}, {}] as EventsNode[],
+        }
+        const clampedStepRange = getClampedStepRange({
             stepRange,
-            filters,
+            query,
         })
         expect(clampedStepRange).toEqual({
-            funnel_from_step: 0,
-            funnel_to_step: 1,
+            funnelFromStep: 0,
+            funnelToStep: 1,
         })
     })
 
     it('ensures step range is clamped to step range', () => {
-        const stepRange = {} as FunnelExclusion
-        const filters = {
-            funnel_from_step: -1,
-            funnel_to_step: 12,
-            actions: [{}, {}],
-            events: [{}, {}],
-        } as FilterType
-        const clampedStepRange = getClampedStepRangeFilter({
+        const stepRange: FunnelExclusion = {}
+        const query: FunnelsQuery = {
+            kind: NodeKind.FunnelsQuery,
+            funnelsFilter: {
+                funnelFromStep: -1,
+
+                funnelToStep: 12,
+            },
+            series: [{}, {}, {}] as EventsNode[],
+        }
+        const clampedStepRange = getClampedStepRange({
             stepRange,
-            filters,
+            query,
         })
         expect(clampedStepRange).toEqual({
-            funnel_from_step: 0,
-            funnel_to_step: 3,
+            funnelFromStep: 0,
+            funnelToStep: 2,
         })
     })
 
     it('returns undefined if the incoming filters are undefined', () => {
-        const stepRange = {} as FunnelExclusion
-        const filters = {
-            funnel_from_step: undefined,
-            funnel_to_step: undefined,
-            actions: [{}, {}],
-            events: [{}, {}],
-        } as FilterType
-        const clampedStepRange = getClampedStepRangeFilter({
+        const stepRange: FunnelExclusion = {}
+        const query: FunnelsQuery = {
+            kind: NodeKind.FunnelsQuery,
+            funnelsFilter: {
+                funnelFromStep: undefined,
+                funnelToStep: undefined,
+            },
+            series: [{}, {}] as EventsNode[],
+        }
+        const clampedStepRange = getClampedStepRange({
             stepRange,
-            filters,
+            query,
         })
         expect(clampedStepRange).toEqual({
-            funnel_from_step: undefined,
-            funnel_to_step: undefined,
+            funnelFromStep: undefined,
+            funnelToStep: undefined,
         })
     })
 })

--- a/frontend/src/scenes/funnels/funnelUtils.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.ts
@@ -588,11 +588,11 @@ export const appendToCorrelationConfig = (
     })
 }
 
-export function aggregationLabelForHogQL(funnelAggregateByHogql: string): Noun {
-    if (funnelAggregateByHogql === 'person_id') {
+export function aggregationLabelForHogQL(funnelAggregateByHogQL: string): Noun {
+    if (funnelAggregateByHogQL === 'person_id') {
         return { singular: 'person', plural: 'persons' }
     }
-    if (funnelAggregateByHogql === 'properties.$session_id') {
+    if (funnelAggregateByHogQL === 'properties.$session_id') {
         return { singular: 'session', plural: 'sessions' }
     }
     return { singular: 'result', plural: 'results' }

--- a/frontend/src/scenes/funnels/funnelUtils.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.ts
@@ -19,7 +19,6 @@ import {
     FunnelCorrelationResultsType,
     FunnelExclusion,
     FunnelResultType,
-    FunnelsFilterType,
     FunnelStep,
     FunnelStepReference,
     FunnelStepWithConversionMetrics,
@@ -220,87 +219,33 @@ export const getBreakdownStepValues = (
     return EMPTY_BREAKDOWN_VALUES
 }
 
-export const isStepsEmpty = (filters: FunnelsFilterType): boolean =>
-    [...(filters.actions || []), ...(filters.events || [])].length === 0
-
-export const isStepsUndefined = (filters: FunnelsFilterType): boolean =>
-    typeof filters.events === 'undefined' && (typeof filters.actions === 'undefined' || filters.actions.length === 0)
-
-export const deepCleanFunnelExclusionEvents = (filters: FunnelsFilterType): FunnelExclusion[] | undefined => {
-    if (!filters.exclusions) {
-        return undefined
-    }
-
-    const lastIndex = Math.max((filters.events?.length || 0) + (filters.actions?.length || 0) - 1, 1)
-    const exclusions = filters.exclusions.map((event) => {
-        const funnel_from_step = event.funnel_from_step ? clamp(event.funnel_from_step, 0, lastIndex - 1) : 0
-        return {
-            ...event,
-            ...{ funnel_from_step },
-            ...{
-                funnel_to_step: event.funnel_to_step
-                    ? clamp(event.funnel_to_step, funnel_from_step + 1, lastIndex)
-                    : lastIndex,
-            },
-        }
-    })
-    return exclusions.length > 0 ? exclusions : undefined
-}
-
 const findFirstNumber = (candidates: (number | undefined)[]): number | undefined =>
     candidates.find((s) => typeof s === 'number')
 
-export const getClampedStepRangeFilter = ({
-    stepRange,
-    filters,
-}: {
-    stepRange?: FunnelExclusion
-    filters: FunnelsFilterType
-}): FunnelExclusion => {
-    const maxStepIndex = Math.max((filters.events?.length || 0) + (filters.actions?.length || 0) - 1, 1)
-
-    let funnel_from_step = findFirstNumber([stepRange?.funnel_from_step, filters.funnel_from_step])
-    let funnel_to_step = findFirstNumber([stepRange?.funnel_to_step, filters.funnel_to_step])
-
-    const funnelFromStepIsSet = typeof funnel_from_step === 'number'
-    const funnelToStepIsSet = typeof funnel_to_step === 'number'
-
-    if (funnelFromStepIsSet && funnelToStepIsSet) {
-        funnel_from_step = clamp(funnel_from_step ?? 0, 0, maxStepIndex)
-        funnel_to_step = clamp(funnel_to_step ?? maxStepIndex, funnel_from_step + 1, maxStepIndex)
-    }
-
-    return {
-        ...(stepRange || {}),
-        funnel_from_step,
-        funnel_to_step,
-    }
-}
-
-export const getClampedStepRangeFilterDataExploration = ({
+export const getClampedStepRange = ({
     stepRange,
     query,
 }: {
     stepRange?: FunnelExclusion
     query: FunnelsQuery
 }): FunnelExclusion => {
-    const maxStepIndex = Math.max(query.series.length || 0 - 1, 1)
+    const maxStepIndex = Math.max((query.series.length || 0) - 1, 1)
 
-    let funnel_from_step = findFirstNumber([stepRange?.funnel_from_step, query.funnelsFilter?.funnel_from_step])
-    let funnel_to_step = findFirstNumber([stepRange?.funnel_to_step, query.funnelsFilter?.funnel_to_step])
+    let funnelFromStep = findFirstNumber([stepRange?.funnelFromStep, query.funnelsFilter?.funnelFromStep])
+    let funnelToStep = findFirstNumber([stepRange?.funnelToStep, query.funnelsFilter?.funnelToStep])
 
-    const funnelFromStepIsSet = typeof funnel_from_step === 'number'
-    const funnelToStepIsSet = typeof funnel_to_step === 'number'
+    const funnelFromStepIsSet = typeof funnelFromStep === 'number'
+    const funnelToStepIsSet = typeof funnelToStep === 'number'
 
     if (funnelFromStepIsSet && funnelToStepIsSet) {
-        funnel_from_step = clamp(funnel_from_step ?? 0, 0, maxStepIndex)
-        funnel_to_step = clamp(funnel_to_step ?? maxStepIndex, funnel_from_step + 1, maxStepIndex)
+        funnelFromStep = clamp(funnelFromStep ?? 0, 0, maxStepIndex)
+        funnelToStep = clamp(funnelToStep ?? maxStepIndex, funnelFromStep + 1, maxStepIndex)
     }
 
     return {
         ...(stepRange || {}),
-        funnel_from_step,
-        funnel_to_step,
+        funnelFromStep,
+        funnelToStep,
     }
 }
 
@@ -323,8 +268,8 @@ export function getIncompleteConversionWindowStartDate(
     window: FunnelConversionWindow,
     startDate: dayjs.Dayjs = dayjs()
 ): dayjs.Dayjs {
-    const { funnel_window_interval, funnel_window_interval_unit } = window
-    return startDate.subtract(funnel_window_interval, funnel_window_interval_unit)
+    const { funnelWindowInterval, funnelWindowIntervalUnit } = window
+    return startDate.subtract(funnelWindowInterval, funnelWindowIntervalUnit)
 }
 
 export function generateBaselineConversionUrl(url?: string | null): string {
@@ -643,11 +588,11 @@ export const appendToCorrelationConfig = (
     })
 }
 
-export function aggregationLabelForHogQL(funnel_aggregate_by_hogql: string): Noun {
-    if (funnel_aggregate_by_hogql === 'person_id') {
+export function aggregationLabelForHogQL(funnelAggregateByHogql: string): Noun {
+    if (funnelAggregateByHogql === 'person_id') {
         return { singular: 'person', plural: 'persons' }
     }
-    if (funnel_aggregate_by_hogql === 'properties.$session_id') {
+    if (funnelAggregateByHogql === 'properties.$session_id') {
         return { singular: 'session', plural: 'sessions' }
     }
     return { singular: 'result', plural: 'results' }

--- a/frontend/src/scenes/insights/EditorFilters/AttributionFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/AttributionFilter.tsx
@@ -11,15 +11,15 @@ export function Attribution({ insightProps }: EditorFilterProps): JSX.Element {
     const { insightFilter, steps } = useValues(funnelDataLogic(insightProps))
     const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
 
-    const { breakdown_attribution_type, breakdown_attribution_value, funnel_order_type } = (insightFilter ||
+    const { breakdownAttributionType, breakdownAttributionValue, funnelOrderType } = (insightFilter ||
         {}) as FunnelsFilter
 
     const currentValue: BreakdownAttributionType | `${BreakdownAttributionType.Step}/${number}` =
-        !breakdown_attribution_type
+        !breakdownAttributionType
             ? BreakdownAttributionType.FirstTouch
-            : breakdown_attribution_type === BreakdownAttributionType.Step
-            ? `${breakdown_attribution_type}/${breakdown_attribution_value || 0}`
-            : breakdown_attribution_type
+            : breakdownAttributionType === BreakdownAttributionType.Step
+            ? `${breakdownAttributionType}/${breakdownAttributionValue || 0}`
+            : breakdownAttributionType
 
     return (
         <LemonSelect
@@ -32,7 +32,7 @@ export function Attribution({ insightProps }: EditorFilterProps): JSX.Element {
                 {
                     value: BreakdownAttributionType.Step,
                     label: 'Any step',
-                    hidden: funnel_order_type !== StepOrderValue.UNORDERED,
+                    hidden: funnelOrderType !== StepOrderValue.UNORDERED,
                 },
                 {
                     label: 'Specific step',
@@ -43,17 +43,15 @@ export function Attribution({ insightProps }: EditorFilterProps): JSX.Element {
                             label: `Step ${stepIndex + 1}`,
                             hidden: stepIndex >= steps.length,
                         })),
-                    hidden: funnel_order_type === StepOrderValue.UNORDERED,
+                    hidden: funnelOrderType === StepOrderValue.UNORDERED,
                 },
             ]}
             onChange={(value) => {
                 const [breakdownAttributionType, breakdownAttributionValue] = (value || '').split('/')
                 if (value) {
                     updateInsightFilter({
-                        breakdown_attribution_type: breakdownAttributionType as BreakdownAttributionType,
-                        breakdown_attribution_value: breakdownAttributionValue
-                            ? parseInt(breakdownAttributionValue)
-                            : 0,
+                        breakdownAttributionType: breakdownAttributionType as BreakdownAttributionType,
+                        breakdownAttributionValue: breakdownAttributionValue ? parseInt(breakdownAttributionValue) : 0,
                     })
                 }
             }}

--- a/frontend/src/scenes/insights/EditorFilters/FunnelsAdvanced.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/FunnelsAdvanced.tsx
@@ -41,8 +41,8 @@ export function FunnelsAdvanced({ insightProps }: EditorFilterProps): JSX.Elemen
                         status="danger"
                         onClick={() => {
                             updateInsightFilter({
-                                funnel_order_type: undefined,
-                                funnel_step_reference: undefined,
+                                funnelOrderType: undefined,
+                                funnelStepReference: undefined,
                                 exclusions: undefined,
                             })
                         }}

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -239,8 +239,8 @@ describe('insightNavLogic', () => {
                     queryPropertyCache: expect.objectContaining({
                         commonFilter: {
                             showValuesOnSeries: true,
-                            funnel_order_type: 'strict',
-                            funnel_viz_type: 'steps',
+                            funnelOrderType: 'strict',
+                            funnelVizType: 'steps',
                         },
                     }),
                 })

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -155,8 +155,8 @@ describe('insightNavLogic', () => {
                         },
                     ],
                     funnelsFilter: {
-                        funnel_order_type: StepOrderValue.STRICT,
-                        funnel_viz_type: FunnelVizType.Steps,
+                        funnelOrderType: StepOrderValue.STRICT,
+                        funnelVizType: FunnelVizType.Steps,
                     },
                 },
             }

--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -55,14 +55,14 @@ export function AggregationSelect({
         isLifecycleQuery(querySource) || isStickinessQuery(querySource)
             ? undefined
             : querySource.aggregation_group_type_index,
-        isFunnelsQuery(querySource) ? querySource.funnelsFilter?.funnelAggregateByHogql : undefined
+        isFunnelsQuery(querySource) ? querySource.funnelsFilter?.funnelAggregateByHogQL : undefined
     )
     const onChange = (value: string): void => {
         const { aggregationQuery, groupIndex } = hogQLToFilterValue(value)
         if (isFunnelsQuery(querySource)) {
             updateQuerySource({
                 aggregation_group_type_index: groupIndex,
-                funnelsFilter: { ...querySource.funnelsFilter, funnelAggregateByHogql: aggregationQuery },
+                funnelsFilter: { ...querySource.funnelsFilter, funnelAggregateByHogQL: aggregationQuery },
             } as FunnelsQuery)
         } else {
             updateQuerySource({ aggregation_group_type_index: groupIndex } as FunnelsQuery)

--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -55,14 +55,14 @@ export function AggregationSelect({
         isLifecycleQuery(querySource) || isStickinessQuery(querySource)
             ? undefined
             : querySource.aggregation_group_type_index,
-        isFunnelsQuery(querySource) ? querySource.funnelsFilter?.funnel_aggregate_by_hogql : undefined
+        isFunnelsQuery(querySource) ? querySource.funnelsFilter?.funnelAggregateByHogql : undefined
     )
     const onChange = (value: string): void => {
         const { aggregationQuery, groupIndex } = hogQLToFilterValue(value)
         if (isFunnelsQuery(querySource)) {
             updateQuerySource({
                 aggregation_group_type_index: groupIndex,
-                funnelsFilter: { ...querySource.funnelsFilter, funnel_aggregate_by_hogql: aggregationQuery },
+                funnelsFilter: { ...querySource.funnelsFilter, funnelAggregateByHogql: aggregationQuery },
             } as FunnelsQuery)
         } else {
             updateQuerySource({ aggregation_group_type_index: groupIndex } as FunnelsQuery)

--- a/frontend/src/scenes/insights/filters/FunnelExclusionsFilter/ExclusionRowSuffix.tsx
+++ b/frontend/src/scenes/insights/filters/FunnelExclusionsFilter/ExclusionRowSuffix.tsx
@@ -2,12 +2,12 @@ import { LemonButton, LemonSelect } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { IconDelete } from 'lib/lemon-ui/icons'
-import { getClampedStepRangeFilterDataExploration } from 'scenes/funnels/funnelUtils'
+import { getClampedStepRange } from 'scenes/funnels/funnelUtils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
-import { FunnelsQuery } from '~/queries/schema'
-import { ActionFilter as ActionFilterType, FunnelExclusion, FunnelsFilterType } from '~/types'
+import { FunnelsFilter, FunnelsQuery } from '~/queries/schema'
+import { ActionFilter as ActionFilterType, FunnelExclusion } from '~/types'
 
 type ExclusionRowSuffixComponentBaseProps = {
     filter: ActionFilterType | FunnelExclusion
@@ -29,9 +29,9 @@ export function ExclusionRowSuffix({
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
 
     const setOneEventExclusionFilter = (eventFilter: FunnelExclusion, index: number): void => {
-        const exclusions = ((insightFilter as FunnelsFilterType)?.exclusions || []).map((e, e_i) =>
+        const exclusions = ((insightFilter as FunnelsFilter)?.exclusions || []).map((e, e_i) =>
             e_i === index
-                ? getClampedStepRangeFilterDataExploration({
+                ? getClampedStepRange({
                       stepRange: eventFilter,
                       query: querySource as FunnelsQuery,
                   })
@@ -43,23 +43,23 @@ export function ExclusionRowSuffix({
         })
     }
 
-    const exclusions = (insightFilter as FunnelsFilterType)?.exclusions
+    const exclusions = (insightFilter as FunnelsFilter)?.exclusions
     const numberOfSeries = series?.length || 0
 
     const stepRange = {
-        funnel_from_step: exclusions?.[index]?.funnel_from_step ?? exclusionDefaultStepRange.funnel_from_step,
-        funnel_to_step: exclusions?.[index]?.funnel_to_step ?? exclusionDefaultStepRange.funnel_to_step,
+        funnelFromStep: exclusions?.[index]?.funnelFromStep ?? exclusionDefaultStepRange.funnelFromStep,
+        funnelToStep: exclusions?.[index]?.funnelToStep ?? exclusionDefaultStepRange.funnelToStep,
     }
 
     const onChange = (
-        funnel_from_step: number | undefined = stepRange.funnel_from_step,
-        funnel_to_step: number | undefined = stepRange.funnel_to_step
+        funnelFromStep: number | undefined = stepRange.funnelFromStep,
+        funnelToStep: number | undefined = stepRange.funnelToStep
     ): void => {
         setOneEventExclusionFilter(
             {
                 ...filter,
-                funnel_from_step,
-                funnel_to_step,
+                funnelFromStep,
+                funnelToStep,
             },
             index
         )
@@ -71,7 +71,7 @@ export function ExclusionRowSuffix({
             <LemonSelect
                 className="mx-1"
                 size="small"
-                value={stepRange.funnel_from_step || 0}
+                value={stepRange.funnelFromStep || 0}
                 onChange={onChange}
                 options={Array.from(Array(numberOfSeries).keys())
                     .slice(0, -1)
@@ -82,10 +82,10 @@ export function ExclusionRowSuffix({
             <LemonSelect
                 className="ml-1"
                 size="small"
-                value={stepRange.funnel_to_step || (stepRange.funnel_from_step ?? 0) + 1}
-                onChange={(toStep: number) => onChange(stepRange.funnel_from_step, toStep)}
+                value={stepRange.funnelToStep || (stepRange.funnelFromStep ?? 0) + 1}
+                onChange={(toStep: number) => onChange(stepRange.funnelFromStep, toStep)}
                 options={Array.from(Array(numberOfSeries).keys())
-                    .slice((stepRange.funnel_from_step ?? 0) + 1)
+                    .slice((stepRange.funnelFromStep ?? 0) + 1)
                     .map((stepIndex) => ({ value: stepIndex, label: `Step ${stepIndex + 1}` }))}
                 disabled={!isFunnelWithEnoughSteps}
             />

--- a/frontend/src/scenes/insights/filters/FunnelExclusionsFilter/FunnelExclusionsFilter.tsx
+++ b/frontend/src/scenes/insights/filters/FunnelExclusionsFilter/FunnelExclusionsFilter.tsx
@@ -27,8 +27,8 @@ export function FunnelExclusionsFilter(): JSX.Element {
     const setFilters = (filters: Partial<FilterType>): void => {
         const exclusions = (filters.events as FunnelExclusion[]).map((e) => ({
             ...e,
-            funnel_from_step: e.funnel_from_step || exclusionDefaultStepRange.funnel_from_step,
-            funnel_to_step: e.funnel_to_step || exclusionDefaultStepRange.funnel_to_step,
+            funnelFromStep: e.funnelFromStep || exclusionDefaultStepRange.funnelFromStep,
+            funnelToStep: e.funnelToStep || exclusionDefaultStepRange.funnelToStep,
         }))
         updateInsightFilter({ exclusions })
     }

--- a/frontend/src/scenes/insights/filters/FunnelStepReferencePicker.tsx
+++ b/frontend/src/scenes/insights/filters/FunnelStepReferencePicker.tsx
@@ -11,7 +11,7 @@ export function FunnelStepReferencePicker(): JSX.Element | null {
     const { insightFilter } = useValues(funnelDataLogic(insightProps))
     const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
 
-    const { funnel_step_reference } = (insightFilter || {}) as FunnelsFilter
+    const { funnelStepReference } = (insightFilter || {}) as FunnelsFilter
 
     const options = [
         {
@@ -26,8 +26,8 @@ export function FunnelStepReferencePicker(): JSX.Element | null {
 
     return (
         <LemonSelect
-            value={funnel_step_reference || FunnelStepReference.total}
-            onChange={(stepRef) => stepRef && updateInsightFilter({ funnel_step_reference: stepRef })}
+            value={funnelStepReference || FunnelStepReference.total}
+            onChange={(stepRef) => stepRef && updateInsightFilter({ funnelStepReference: stepRef })}
             dropdownMatchSelectWidth={false}
             data-attr="funnel-step-reference-selector"
             options={options}

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -289,8 +289,8 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         exclusionDefaultStepRange: [
             (s) => [s.querySource],
             (querySource: FunnelsQuery): Omit<FunnelExclusion, 'id' | 'name'> => ({
-                funnel_from_step: 0,
-                funnel_to_step: (querySource.series || []).length > 1 ? querySource.series.length - 1 : 1,
+                funnelFromStep: 0,
+                funnelToStep: (querySource.series || []).length > 1 ? querySource.series.length - 1 : 1,
             }),
         ],
         exclusionFilters: [

--- a/frontend/src/scenes/insights/summarizeInsight.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.ts
@@ -228,17 +228,17 @@ export function summarizeInsightQuery(query: InsightQueryNode, context: SummaryC
     } else if (isFunnelsQuery(query)) {
         let summary
         const linkSymbol =
-            query.funnelsFilter?.funnel_order_type === StepOrderValue.STRICT
+            query.funnelsFilter?.funnelOrderType === StepOrderValue.STRICT
                 ? '⇉'
-                : query.funnelsFilter?.funnel_order_type === StepOrderValue.UNORDERED
+                : query.funnelsFilter?.funnelOrderType === StepOrderValue.UNORDERED
                 ? '&'
                 : '→'
         summary = `${query.series.map((s) => getDisplayNameFromEntityNode(s)).join(` ${linkSymbol} `)} ${
             context.aggregationLabel(query.aggregation_group_type_index, true).singular
         } conversion`
-        if (query.funnelsFilter?.funnel_viz_type === FunnelVizType.TimeToConvert) {
+        if (query.funnelsFilter?.funnelVizType === FunnelVizType.TimeToConvert) {
             summary += ' time'
-        } else if (query.funnelsFilter?.funnel_viz_type === FunnelVizType.Trends) {
+        } else if (query.funnelsFilter?.funnelVizType === FunnelVizType.Trends) {
             summary += ' trend'
         } else {
             // Steps are the default viz type

--- a/frontend/src/scenes/insights/views/Funnels/FunnelBinsPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelBinsPicker.tsx
@@ -48,7 +48,7 @@ export function FunnelBinsPicker({ disabled }: FunnelBinsPickerProps): JSX.Eleme
     const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
 
     const setBinCount = (binCount: BinCountValue): void => {
-        updateInsightFilter({ bin_count: binCount && binCount !== BIN_COUNT_AUTO ? binCount : undefined })
+        updateInsightFilter({ binCount: binCount && binCount !== BIN_COUNT_AUTO ? binCount : undefined })
     }
 
     return (
@@ -57,7 +57,7 @@ export function FunnelBinsPicker({ disabled }: FunnelBinsPickerProps): JSX.Eleme
             dropdownClassName="funnel-bin-filter-dropdown"
             data-attr="funnel-bin-filter"
             defaultValue={BIN_COUNT_AUTO}
-            value={funnelsFilter?.bin_count || BIN_COUNT_AUTO}
+            value={funnelsFilter?.binCount || BIN_COUNT_AUTO}
             onSelect={(count) => setBinCount(count)}
             dropdownRender={(menu) => {
                 return (

--- a/frontend/src/scenes/insights/views/Funnels/FunnelConversionWindowFilter.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelConversionWindowFilter.tsx
@@ -24,26 +24,26 @@ export function FunnelConversionWindowFilter({ insightProps }: Pick<EditorFilter
     const { insightFilter, querySource } = useValues(funnelDataLogic(insightProps))
     const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
 
-    const { funnel_window_interval = 14, funnel_window_interval_unit = FunnelConversionWindowTimeUnit.Day } =
+    const { funnelWindowInterval = 14, funnelWindowIntervalUnit = FunnelConversionWindowTimeUnit.Day } =
         (insightFilter || {}) as FunnelsFilter
 
     const [localConversionWindow, setLocalConversionWindow] = useState<FunnelConversionWindow>({
-        funnel_window_interval,
-        funnel_window_interval_unit,
+        funnelWindowInterval,
+        funnelWindowIntervalUnit,
     })
 
     const options: LemonSelectOption<FunnelConversionWindowTimeUnit>[] = Object.keys(TIME_INTERVAL_BOUNDS).map(
         (unit) => ({
-            label: capitalizeFirstLetter(pluralize(funnel_window_interval ?? 7, unit, `${unit}s`, false)),
+            label: capitalizeFirstLetter(pluralize(funnelWindowInterval ?? 7, unit, `${unit}s`, false)),
             value: unit as FunnelConversionWindowTimeUnit,
         })
     )
-    const intervalBounds = TIME_INTERVAL_BOUNDS[funnel_window_interval_unit ?? FunnelConversionWindowTimeUnit.Day]
+    const intervalBounds = TIME_INTERVAL_BOUNDS[funnelWindowIntervalUnit ?? FunnelConversionWindowTimeUnit.Day]
 
     const setConversionWindow = useDebouncedCallback((): void => {
         if (
-            localConversionWindow.funnel_window_interval !== funnel_window_interval ||
-            localConversionWindow.funnel_window_interval_unit !== funnel_window_interval_unit
+            localConversionWindow.funnelWindowInterval !== funnelWindowInterval ||
+            localConversionWindow.funnelWindowIntervalUnit !== funnelWindowIntervalUnit
         ) {
             updateInsightFilter(localConversionWindow)
         }
@@ -74,12 +74,12 @@ export function FunnelConversionWindowFilter({ insightProps }: Pick<EditorFilter
                     fullWidth={false}
                     min={intervalBounds[0]}
                     max={intervalBounds[1]}
-                    defaultValue={funnel_window_interval}
-                    value={localConversionWindow.funnel_window_interval}
-                    onChange={(funnel_window_interval) => {
+                    defaultValue={funnelWindowInterval}
+                    value={localConversionWindow.funnelWindowInterval}
+                    onChange={(funnelWindowInterval) => {
                         setLocalConversionWindow((state) => ({
                             ...state,
-                            funnel_window_interval: Number(funnel_window_interval),
+                            funnelWindowInterval: Number(funnelWindowInterval),
                         }))
                         setConversionWindow()
                     }}
@@ -88,10 +88,10 @@ export function FunnelConversionWindowFilter({ insightProps }: Pick<EditorFilter
                 />
                 <LemonSelect
                     dropdownMatchSelectWidth={false}
-                    value={localConversionWindow.funnel_window_interval_unit}
-                    onChange={(funnel_window_interval_unit: FunnelConversionWindowTimeUnit | null) => {
-                        if (funnel_window_interval_unit) {
-                            setLocalConversionWindow((state) => ({ ...state, funnel_window_interval_unit }))
+                    value={localConversionWindow.funnelWindowIntervalUnit}
+                    onChange={(funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit | null) => {
+                        if (funnelWindowIntervalUnit) {
+                            setLocalConversionWindow((state) => ({ ...state, funnelWindowIntervalUnit }))
                             setConversionWindow()
                         }
                     }}

--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepOrderPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepOrderPicker.tsx
@@ -32,14 +32,14 @@ export function FunnelStepOrderPicker(): JSX.Element {
     const { insightFilter } = useValues(funnelDataLogic(insightProps))
     const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
 
-    const { funnel_order_type } = (insightFilter || {}) as FunnelsFilter
+    const { funnelOrderType } = (insightFilter || {}) as FunnelsFilter
 
     return (
         <LemonSelect
             id="funnel-step-order-filter"
             data-attr="funnel-step-order-filter"
-            value={funnel_order_type || StepOrderValue.ORDERED}
-            onChange={(stepOrder) => stepOrder && updateInsightFilter({ funnel_order_type: stepOrder })}
+            value={funnelOrderType || StepOrderValue.ORDERED}
+            onChange={(stepOrder) => stepOrder && updateInsightFilter({ funnelOrderType: stepOrder })}
             dropdownMatchSelectWidth={false}
             options={options}
         />

--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsPicker.tsx
@@ -11,15 +11,15 @@ export function FunnelStepsPicker(): JSX.Element | null {
     const { series, isFunnelWithEnoughSteps, funnelsFilter } = useValues(insightVizDataLogic(insightProps))
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
 
-    const onChange = (funnel_from_step?: number, funnel_to_step?: number): void => {
-        updateInsightFilter({ funnel_from_step, funnel_to_step })
+    const onChange = (funnelFromStep?: number, funnelToStep?: number): void => {
+        updateInsightFilter({ funnelFromStep, funnelToStep })
     }
 
     const filterSteps = series || []
     const numberOfSeries = series?.length || 0
     const fromRange = isFunnelWithEnoughSteps ? Array.from(Array(Math.max(numberOfSeries)).keys()).slice(0, -1) : [0]
     const toRange = isFunnelWithEnoughSteps
-        ? Array.from(Array(Math.max(numberOfSeries)).keys()).slice((funnelsFilter?.funnel_from_step ?? 0) + 1)
+        ? Array.from(Array(Math.max(numberOfSeries)).keys()).slice((funnelsFilter?.funnelFromStep ?? 0) + 1)
         : [1]
 
     const optionsForRange = (range: number[]): LemonSelectOptions<number> => {
@@ -51,9 +51,9 @@ export function FunnelStepsPicker(): JSX.Element | null {
                 optionTooltipPlacement="bottomLeft"
                 disabled={!isFunnelWithEnoughSteps}
                 options={optionsForRange(fromRange)}
-                value={funnelsFilter?.funnel_from_step || 0}
+                value={funnelsFilter?.funnelFromStep || 0}
                 onChange={(fromStep: number | null) =>
-                    fromStep != null && onChange(fromStep, funnelsFilter?.funnel_to_step)
+                    fromStep != null && onChange(fromStep, funnelsFilter?.funnelToStep)
                 }
             />
             <span className="text-muted-alt">to</span>
@@ -64,10 +64,8 @@ export function FunnelStepsPicker(): JSX.Element | null {
                 optionTooltipPlacement="bottomLeft"
                 disabled={!isFunnelWithEnoughSteps}
                 options={optionsForRange(toRange)}
-                value={funnelsFilter?.funnel_to_step || Math.max(numberOfSeries - 1, 1)}
-                onChange={(toStep: number | null) =>
-                    toStep != null && onChange(funnelsFilter?.funnel_from_step, toStep)
-                }
+                value={funnelsFilter?.funnelToStep || Math.max(numberOfSeries - 1, 1)}
+                onChange={(toStep: number | null) => toStep != null && onChange(funnelsFilter?.funnelFromStep, toStep)}
             />
         </div>
     )

--- a/frontend/src/scenes/insights/views/Funnels/FunnelVizType.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelVizType.tsx
@@ -35,7 +35,7 @@ export function FunnelVizType({ insightProps }: Pick<EditorFilterProps, 'insight
     const { insightFilter } = useValues(funnelDataLogic(insightProps))
     const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
 
-    const { funnel_viz_type } = (insightFilter || {}) as FunnelsFilter
+    const { funnelVizType } = (insightFilter || {}) as FunnelsFilter
 
     const options = [
         {
@@ -76,10 +76,10 @@ export function FunnelVizType({ insightProps }: Pick<EditorFilterProps, 'insight
     return (
         <LemonSelect
             size="small"
-            value={funnel_viz_type || VizType.Steps}
+            value={funnelVizType || VizType.Steps}
             onChange={(value) => {
-                if (funnel_viz_type !== value) {
-                    updateInsightFilter({ funnel_viz_type: value })
+                if (funnelVizType !== value) {
+                    updateInsightFilter({ funnelVizType: value })
                 }
             }}
             options={options}

--- a/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/SlashCommands.tsx
@@ -144,7 +144,7 @@ const SLASH_COMMANDS: SlashCommandsItem[] = [
                         },
                     ],
                     funnelsFilter: {
-                        funnel_viz_type: FunnelVizType.Steps,
+                        funnelVizType: FunnelVizType.Steps,
                     },
                 })
             ),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -823,9 +823,14 @@ export type EntityFilter = {
     order?: number
 }
 
-export interface FunnelExclusion extends Partial<EntityFilter> {
+export interface FunnelExclusionLegacy extends Partial<EntityFilter> {
     funnel_from_step?: number
     funnel_to_step?: number
+}
+
+export interface FunnelExclusion extends Partial<EntityFilter> {
+    funnelFromStep?: number
+    funnelToStep?: number
 }
 
 export type EntityFilterTypes = EntityFilter | ActionFilter | null
@@ -1845,7 +1850,7 @@ export interface FunnelsFilterType extends FilterType {
     funnel_window_interval_unit?: FunnelConversionWindowTimeUnit // minutes, days, weeks, etc. for conversion window
     funnel_window_interval?: number | undefined // length of conversion window
     funnel_order_type?: StepOrderValue
-    exclusions?: FunnelExclusion[] // used in funnel exclusion filters
+    exclusions?: FunnelExclusionLegacy[] // used in funnel exclusion filters
     funnel_aggregate_by_hogql?: string
 
     // frontend only
@@ -2115,8 +2120,8 @@ export interface FunnelTimeConversionMetrics {
 }
 
 export interface FunnelConversionWindow {
-    funnel_window_interval_unit: FunnelConversionWindowTimeUnit
-    funnel_window_interval: number
+    funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit
+    funnelWindowInterval: number
 }
 
 // https://github.com/PostHog/posthog/blob/master/posthog/models/filters/mixins/funnel.py#L100

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -332,27 +332,27 @@ def _insight_filter(filter: Dict):
     elif _insight_type(filter) == "FUNNELS":
         insight_filter = {
             "funnelsFilter": FunnelsFilter(
-                funnel_viz_type=filter.get("funnel_viz_type"),
-                funnel_order_type=filter.get("funnel_order_type"),
-                funnel_from_step=filter.get("funnel_from_step"),
-                funnel_to_step=filter.get("funnel_to_step"),
-                funnel_window_interval_unit=filter.get("funnel_window_interval_unit"),
-                funnel_window_interval=filter.get("funnel_window_interval"),
-                funnel_step_reference=filter.get("funnel_step_reference"),
-                breakdown_attribution_type=filter.get("breakdown_attribution_type"),
-                breakdown_attribution_value=filter.get("breakdown_attribution_value"),
-                bin_count=filter.get("bin_count"),
+                funnelVizType=filter.get("funnel_viz_type"),
+                funnelOrderType=filter.get("funnel_order_type"),
+                funnelFromStep=filter.get("funnel_from_step"),
+                funnelToStep=filter.get("funnel_to_step"),
+                funnelWindowIntervalUnit=filter.get("funnel_window_interval_unit"),
+                funnelWindowInterval=filter.get("funnel_window_interval"),
+                funnelStepReference=filter.get("funnel_step_reference"),
+                breakdownAttributionType=filter.get("breakdown_attribution_type"),
+                breakdownAttributionValue=filter.get("breakdown_attribution_value"),
+                binCount=filter.get("bin_count"),
                 exclusions=[
                     FunnelExclusion(
                         **to_base_entity_dict(entity),
-                        funnel_from_step=entity.get("funnel_from_step"),
-                        funnel_to_step=entity.get("funnel_to_step"),
+                        funnelFromStep=entity.get("funnel_from_step"),
+                        funnelToStep=entity.get("funnel_to_step"),
                     )
                     for entity in filter.get("exclusions", [])
                 ],
                 layout=filter.get("layout"),
                 # hidden_legend_breakdowns: cleanHiddenLegendSeries(filter.get('hidden_legend_keys')),
-                funnel_aggregate_by_hogql=filter.get("funnel_aggregate_by_hogql"),
+                funnelAggregateByHogql=filter.get("funnel_aggregate_by_hogql"),
             ),
         }
     elif _insight_type(filter) == "RETENTION":

--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -352,7 +352,7 @@ def _insight_filter(filter: Dict):
                 ],
                 layout=filter.get("layout"),
                 # hidden_legend_breakdowns: cleanHiddenLegendSeries(filter.get('hidden_legend_keys')),
-                funnelAggregateByHogql=filter.get("funnel_aggregate_by_hogql"),
+                funnelAggregateByHogQL=filter.get("funnel_aggregate_by_hogql"),
             ),
         }
     elif _insight_type(filter) == "RETENTION":

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -1354,26 +1354,26 @@ class TestFilterToQuery(BaseTest):
         self.assertEqual(
             query.funnelsFilter,
             FunnelsFilter(
-                funnel_viz_type=FunnelVizType.steps,
-                funnel_from_step=1,
-                funnel_to_step=2,
-                funnel_window_interval_unit=FunnelConversionWindowTimeUnit.hour,
-                funnel_window_interval=13,
-                breakdown_attribution_type=BreakdownAttributionType.step,
-                breakdown_attribution_value=2,
-                funnel_order_type=StepOrderValue.strict,
+                funnelVizType=FunnelVizType.steps,
+                funnelFromStep=1,
+                funnelToStep=2,
+                funnelWindowIntervalUnit=FunnelConversionWindowTimeUnit.hour,
+                funnelWindowInterval=13,
+                breakdownAttributionType=BreakdownAttributionType.step,
+                breakdownAttributionValue=2,
+                funnelOrderType=StepOrderValue.strict,
                 exclusions=[
                     FunnelExclusion(
                         id="$pageview",
                         type=EntityType.events,
                         order=0,
                         name="$pageview",
-                        funnel_from_step=1,
-                        funnel_to_step=2,
+                        funnelFromStep=1,
+                        funnelToStep=2,
                     )
                 ],
-                bin_count=15,
-                funnel_aggregate_by_hogql="person_id",
+                binCount=15,
+                funnelAggregateByHogql="person_id",
                 # funnel_step_reference=FunnelStepReference.previous,
             ),
         )

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -1373,7 +1373,7 @@ class TestFilterToQuery(BaseTest):
                     )
                 ],
                 binCount=15,
-                funnelAggregateByHogql="person_id",
+                funnelAggregateByHogQL="person_id",
                 # funnel_step_reference=FunnelStepReference.previous,
             ),
         )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -955,7 +955,7 @@ class FunnelsFilter(BaseModel):
     breakdownAttributionType: Optional[BreakdownAttributionType] = None
     breakdownAttributionValue: Optional[float] = None
     exclusions: Optional[List[FunnelExclusion]] = None
-    funnelAggregateByHogql: Optional[str] = None
+    funnelAggregateByHogQL: Optional[str] = None
     funnelFromStep: Optional[float] = None
     funnelOrderType: Optional[StepOrderValue] = None
     funnelStepReference: Optional[FunnelStepReference] = None

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -215,6 +215,20 @@ class FunnelExclusion(BaseModel):
         extra="forbid",
     )
     custom_name: Optional[str] = None
+    funnelFromStep: Optional[float] = None
+    funnelToStep: Optional[float] = None
+    id: Optional[Union[str, float]] = None
+    index: Optional[float] = None
+    name: Optional[str] = None
+    order: Optional[float] = None
+    type: Optional[EntityType] = None
+
+
+class FunnelExclusionLegacy(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    custom_name: Optional[str] = None
     funnel_from_step: Optional[float] = None
     funnel_to_step: Optional[float] = None
     id: Optional[Union[str, float]] = None
@@ -937,10 +951,30 @@ class FunnelsFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    binCount: Optional[Union[float, str]] = None
+    breakdownAttributionType: Optional[BreakdownAttributionType] = None
+    breakdownAttributionValue: Optional[float] = None
+    exclusions: Optional[List[FunnelExclusion]] = None
+    funnelAggregateByHogql: Optional[str] = None
+    funnelFromStep: Optional[float] = None
+    funnelOrderType: Optional[StepOrderValue] = None
+    funnelStepReference: Optional[FunnelStepReference] = None
+    funnelToStep: Optional[float] = None
+    funnelVizType: Optional[FunnelVizType] = None
+    funnelWindowInterval: Optional[float] = None
+    funnelWindowIntervalUnit: Optional[FunnelConversionWindowTimeUnit] = None
+    hidden_legend_breakdowns: Optional[List[str]] = None
+    layout: Optional[FunnelLayout] = None
+
+
+class FunnelsFilterLegacy(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
     bin_count: Optional[Union[float, str]] = None
     breakdown_attribution_type: Optional[BreakdownAttributionType] = None
     breakdown_attribution_value: Optional[float] = None
-    exclusions: Optional[List[FunnelExclusion]] = None
+    exclusions: Optional[List[FunnelExclusionLegacy]] = None
     funnel_aggregate_by_hogql: Optional[str] = None
     funnel_from_step: Optional[float] = None
     funnel_order_type: Optional[StepOrderValue] = None

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -636,7 +636,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_0')
+                                                      'user_one_2')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '''
 # ---

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -636,7 +636,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_2')
+                                                      'user_one_0')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '''
 # ---


### PR DESCRIPTION
## Problem

We want to clean up our query schema. See also https://github.com/PostHog/posthog/issues/19541.

## Changes

This PR camel cases all funnelFilter properties.

- [x] exclusions
- [x] layout
- [x] binCount
- [x] breakdownAttributionType
- [x] breakdownAttributionValue
- [x] funnelAggregateByHogQL
- [x] funnelToStep
- [x] funnelFromStep
- [x] funnelOrderType
- [x] funnelVizType
- [x] funnelWindowInterval
- [x] funnelWindowIntervalUnit
- [x] hidden_legend_breakdowns - to be unified with other hidden legend items
- [x] funnelStepReference

## How did you test this code?

Verified setting, saving and loading an insight with this filter works
