### PR TITLE
fix: swallow replayer errors

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerFrame.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrame.tsx
@@ -9,7 +9,7 @@ import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/se
 export const PlayerFrame = (): JSX.Element => {
     const replayDimensionRef = useRef<viewportResizeDimension>()
     const { player, sessionRecordingId } = useValues(sessionRecordingPlayerLogic)
-    const { setScale, setRootFrame } = useActions(sessionRecordingPlayerLogic)
+    const { setScale, setRootFrame, playerErrorSeen } = useActions(sessionRecordingPlayerLogic)
 
     const frameRef = useRef<HTMLDivElement | null>(null)
     // Need useEffect to populate replayer on component paint
@@ -28,10 +28,25 @@ export const PlayerFrame = (): JSX.Element => {
             return
         }
 
+        const handleReplayerErrors = (event: ErrorEvent): void => {
+            // sometimes replayer throws errors but playback can continue
+            // we don't want to show an error message in that case
+            // so let's swallow but report replayer errors
+            if (event.error && event.error.stack?.includes('Replayer.')) {
+                event.preventDefault()
+                event.stopPropagation()
+                playerErrorSeen(event)
+            }
+        }
+
         player.replayer.on('resize', updatePlayerDimensions as Handler)
         window.addEventListener('resize', windowResize)
+        window.addEventListener('error', handleReplayerErrors)
 
-        return () => window.removeEventListener('resize', windowResize)
+        return () => {
+            window.removeEventListener('resize', windowResize)
+            window.removeEventListener('error', handleReplayerErrors)
+        }
     }, [player?.replayer])
 
     // Recalculate the player size when the player changes dimensions

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -475,8 +475,8 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 return
             }
             captureException(errorEvent.error, {
-                extra: { fingerprint },
-                tags: { recordingId: values.sessionRecordingId },
+                extra: { fingerprint, recordingId: values.sessionRecordingId },
+                tags: { feature: 'replayer error swallowed' },
             })
             if (posthog.config.debug) {
                 posthog.capture('replayer error swallowed', { fingerprint })

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1,4 +1,5 @@
 import { lemonToast } from '@posthog/lemon-ui'
+import { captureException } from '@sentry/react'
 import {
     actions,
     afterMount,
@@ -178,8 +179,20 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         setIsFullScreen: (isFullScreen: boolean) => ({ isFullScreen }),
         skipPlayerForward: (rrWebPlayerTime: number, skip: number) => ({ rrWebPlayerTime, skip }),
         incrementClickCount: true,
+        playerErrorSeen: (errorEvent: ErrorEvent) => ({ errorEvent }),
+        fingerprintReported: (fingerprint: string) => ({ fingerprint }),
     }),
     reducers(() => ({
+        reportedReplayerErrors: [
+            new Set<string>(),
+            {
+                fingerprintReported: (state, { fingerprint }) => {
+                    const clonedSet = new Set(state)
+                    clonedSet.add(fingerprint)
+                    return clonedSet
+                },
+            },
+        ],
         clickCount: [
             0,
             {
@@ -454,6 +467,22 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         ],
     }),
     listeners(({ props, values, actions, cache }) => ({
+        playerErrorSeen: ({ errorEvent }) => {
+            const fingerprint = encodeURIComponent(
+                errorEvent.message + errorEvent.filename + errorEvent.lineno + errorEvent.colno
+            )
+            if (values.reportedReplayerErrors.has(fingerprint)) {
+                return
+            }
+            captureException(errorEvent.error, {
+                extra: { fingerprint },
+                tags: { recordingId: values.sessionRecordingId },
+            })
+            if (posthog.config.debug) {
+                posthog.capture('replayer error swallowed', { fingerprint })
+            }
+            actions.fingerprintReported(fingerprint)
+        },
         skipPlayerForward: ({ rrWebPlayerTime, skip }) => {
             // if the player has got stuck on the same timestamp for several animation frames
             // then we skip ahead a little to get past the blockage


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/9145 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/11761)

In this recording the replayer was erroring because there's a bad typecast in its code 

If you swallow the error the playback continues and appears correct to me.

This change attempts to detect and swallow replayer errors. It generates a fingerprint for the error and (only) the first time that error is seen in that playback it reports the error to Sentry. If posthog is in debug mode it also captures the error to posthog

