### PR TITLE
fix: always show plugins if enabled

### DIFF
--- a/frontend/src/scenes/billing/ExportsUnsubscribeTable/exportsUnsubscribeTableLogic.tsx
+++ b/frontend/src/scenes/billing/ExportsUnsubscribeTable/exportsUnsubscribeTableLogic.tsx
@@ -45,7 +45,7 @@ export const exportsUnsubscribeTableLogic = kea<exportsUnsubscribeTableLogicType
                     if (!values.canConfigurePlugins) {
                         return values.pluginConfigsToDisable
                     }
-                    const response = await api.update(`api/plugin_config/${id}`, { enabled: false })
+                    const response = await api.update(`api/plugin_config/${id}`, { enabled: false, deleted: true })
                     return { ...values.pluginConfigsToDisable, [id]: response }
                 },
             },

--- a/frontend/src/scenes/plugins/tabs/apps/AppView.tsx
+++ b/frontend/src/scenes/plugins/tabs/apps/AppView.tsx
@@ -23,15 +23,19 @@ export function AppView({
     const { showAppMetricsForPlugin, sortableEnabledPlugins } = useValues(pluginsLogic)
     const { editPlugin, toggleEnabled, openReorderModal } = useActions(pluginsLogic)
     const { hasAvailableFeature } = useValues(userLogic)
-    if (!hasAvailableFeature(AvailableFeature.DATA_PIPELINES)) {
+
+    const pluginConfig = 'pluginConfig' in plugin ? plugin.pluginConfig : null
+    const isConfigured = !!pluginConfig?.id
+
+    // If pluginConfig is enabled always show it regardless of the feature availability
+    // So self-hosted users who were using the plugins in the past can continue to use them
+    if (!hasAvailableFeature(AvailableFeature.DATA_PIPELINES) && !pluginConfig?.enabled) {
         // If the app isn't in the allowed apps list don't show it
         if (!plugin.url || !PLUGINS_ALLOWED_WITHOUT_DATA_PIPELINES.has(plugin.url)) {
             return <></>
         }
     }
 
-    const pluginConfig = 'pluginConfig' in plugin ? plugin.pluginConfig : null
-    const isConfigured = !!pluginConfig?.id
     const orderedIndex = sortableEnabledPlugins.indexOf(plugin as unknown as any) + 1
     const menuItems: LemonMenuItem[] = []
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Currently self-hosted users wouldn't see plugins that they might be enabled as they won't have data pipeline's addon. This makes it so we show all plugins that are enabled always and then depending on addon existence one can see other plugin. Also made the unsubscribe modal mark plugins as deleted to be extra safe about them not being visible.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
