### PR TITLE
fix: Add expires to report export child tasks

### DIFF
--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -56,7 +56,8 @@ def generate_assets(
         # Wait for all assets to be exported
         tasks = [exporter.export_asset.si(asset.id) for asset in assets]
         # run them one after the other, so we don't exhaust celery workers
-        parallel_job = chain(*tasks).apply_async()
+        exports_expire_seconds = (settings.PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES * 60) + 10
+        parallel_job = chain(*tasks).apply_async(expires=exports_expire_seconds, retry=False)
 
         wait_for_parallel_celery_group(
             parallel_job,

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1292,6 +1292,7 @@ async def wait_for_parallel_celery_group(task: Any, expires: Optional[datetime.d
 
             logger.error(
                 "Timed out waiting for celery task to finish",
+                task_id=task.id,
                 ready=task.ready(),
                 successful=task.successful(),
                 failed=task.failed(),


### PR DESCRIPTION
## Problem

We create child tasks for report generation and then wait a maximum time. The child tasks however, might be picked up late and get worked on while the parent task already timed out checking for them.

## Changes

- put an expiration time (with 10s buffer)

## How did you test this code?

- not yet... is this covered by tests somehow?