### PR TITLE
fix: always show batch exports if enabled

### DIFF
--- a/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
@@ -11,17 +11,10 @@ import { LemonSelectMultiple } from 'lib/lemon-ui/LemonSelectMultiple/LemonSelec
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { userLogic } from 'scenes/userLogic'
-
-import { AvailableFeature } from '~/types'
 
 import { batchExportsEditLogic, BatchExportsEditLogicProps } from './batchExportEditLogic'
 
 export function BatchExportsEditForm(props: BatchExportsEditLogicProps): JSX.Element {
-    const { hasAvailableFeature } = useValues(userLogic)
-    if (!hasAvailableFeature(AvailableFeature.DATA_PIPELINES)) {
-        return <></>
-    }
     const logic = batchExportsEditLogic(props)
     const { isNew, batchExportConfigForm, isBatchExportConfigFormSubmitting, batchExportConfigLoading } =
         useValues(logic)

--- a/frontend/src/scenes/batch_exports/BatchExportEditScene.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportEditScene.tsx
@@ -1,9 +1,6 @@
 import { useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SceneExport } from 'scenes/sceneTypes'
-import { userLogic } from 'scenes/userLogic'
-
-import { AvailableFeature } from '~/types'
 
 import { BatchExportsEditForm } from './BatchExportEditForm'
 import { BatchExportsEditLogicProps } from './batchExportEditLogic'
@@ -18,10 +15,6 @@ export const scene: SceneExport = {
 }
 
 export function BatchExportsEditScene(): JSX.Element {
-    const { hasAvailableFeature } = useValues(userLogic)
-    if (!hasAvailableFeature(AvailableFeature.DATA_PIPELINES)) {
-        return <></>
-    }
     const { id } = useValues(batchExportsEditSceneLogic)
 
     return (

--- a/frontend/src/scenes/batch_exports/BatchExportScene.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportScene.tsx
@@ -46,9 +46,6 @@ export const scene: SceneExport = {
 
 export function RunsTab(): JSX.Element {
     const { hasAvailableFeature } = useValues(userLogic)
-    if (!hasAvailableFeature(AvailableFeature.DATA_PIPELINES)) {
-        return <></>
-    }
     const {
         batchExportRunsResponse,
         batchExportConfig,
@@ -61,6 +58,7 @@ export function RunsTab(): JSX.Element {
 
     const [dateRangeVisible, setDateRangeVisible] = useState(false)
 
+    const hasDataPipelines = hasAvailableFeature(AvailableFeature.DATA_PIPELINES)
     if (!batchExportConfig && !batchExportConfigLoading) {
         return <NotFound object="Batch Export" />
     }
@@ -203,7 +201,7 @@ export function RunsTab(): JSX.Element {
                                     render: function RenderName(_, groupedRun) {
                                         return (
                                             <span className="flex items-center gap-1">
-                                                {!isRunInProgress(groupedRun.runs[0]) && (
+                                                {!isRunInProgress(groupedRun.runs[0]) && hasDataPipelines && (
                                                     <LemonButton
                                                         size="small"
                                                         type="secondary"
@@ -245,9 +243,11 @@ export function RunsTab(): JSX.Element {
                                 <>
                                     No runs yet. Your exporter runs every <b>{batchExportConfig.interval}</b>.
                                     <br />
-                                    <LemonButton type="primary" onClick={openBackfillModal}>
-                                        Create historic export
-                                    </LemonButton>
+                                    {hasDataPipelines && (
+                                        <LemonButton type="primary" onClick={openBackfillModal}>
+                                            Create historic export
+                                        </LemonButton>
+                                    )}
                                 </>
                             }
                         />
@@ -397,6 +397,8 @@ export function BatchExportScene(): JSX.Element {
     const { batchExportConfig, batchExportConfigLoading, activeTab } = useValues(batchExportLogic)
     const { loadBatchExportConfig, loadBatchExportRuns, openBackfillModal, pause, unpause, archive, setActiveTab } =
         useActions(batchExportLogic)
+    const { hasAvailableFeature } = useValues(userLogic)
+    const hasDataPipelines = hasAvailableFeature(AvailableFeature.DATA_PIPELINES)
 
     useEffect(() => {
         loadBatchExportConfig()
@@ -446,10 +448,14 @@ export function BatchExportScene(): JSX.Element {
                             >
                                 <LemonButton icon={<IconEllipsis />} size="small" />
                             </LemonMenu>
-                            <LemonDivider vertical />
-                            <LemonButton type="secondary" onClick={() => openBackfillModal()}>
-                                Create historic export
-                            </LemonButton>
+                            {hasDataPipelines && (
+                                <>
+                                    <LemonDivider vertical />
+                                    <LemonButton type="secondary" onClick={() => openBackfillModal()}>
+                                        Create historic export
+                                    </LemonButton>
+                                </>
+                            )}
 
                             <LemonButton type="primary" to={urls.batchExportEdit(batchExportConfig?.id)}>
                                 Edit

--- a/frontend/src/scenes/batch_exports/BatchExportsListScene.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportsListScene.tsx
@@ -18,18 +18,17 @@ export const scene: SceneExport = {
 
 export function BatchExportsListScene(): JSX.Element {
     const { hasAvailableFeature } = useValues(userLogic)
-    if (!hasAvailableFeature(AvailableFeature.DATA_PIPELINES)) {
-        return <></>
-    }
     return (
         <>
             <PageHeader
                 buttons={
-                    <>
-                        <LemonButton type="primary" to={urls.batchExportNew()}>
-                            Create export workflow
-                        </LemonButton>
-                    </>
+                    hasAvailableFeature(AvailableFeature.DATA_PIPELINES) && (
+                        <>
+                            <LemonButton type="primary" to={urls.batchExportNew()}>
+                                Create export workflow
+                            </LemonButton>
+                        </>
+                    )
                 }
             />
             <p>Batch exports allow you to export your data to a destination of your choice.</p>
@@ -42,11 +41,19 @@ export function BatchExportsListScene(): JSX.Element {
 export function BatchExportsList(): JSX.Element {
     const { batchExportConfigs, batchExportConfigsLoading, pagination } = useValues(batchExportsListLogic)
     const { unpause, pause } = useActions(batchExportsListLogic)
+    const { hasAvailableFeature } = useValues(userLogic)
+    const hasDataPipelines = hasAvailableFeature(AvailableFeature.DATA_PIPELINES)
+
+    const configs = batchExportConfigs?.results ?? []
+
+    if (configs.length === 0 && !hasDataPipelines) {
+        return <></>
+    }
 
     return (
         <>
             <LemonTable
-                dataSource={batchExportConfigs?.results ?? []}
+                dataSource={configs}
                 loading={batchExportConfigsLoading}
                 pagination={pagination}
                 columns={[
@@ -118,14 +125,17 @@ export function BatchExportsList(): JSX.Element {
                                     label: 'Edit',
                                     to: urls.batchExportEdit(batchExport.id),
                                 },
-                                {
+                            ]
+                            if (hasDataPipelines || !batchExport.paused) {
+                                // without addon one cannot resume paused batch exports
+                                menuItems.push({
                                     label: batchExport.paused ? 'Resume' : 'Pause',
                                     status: batchExport.paused ? 'default' : 'danger',
                                     onClick: () => {
                                         batchExport.paused ? unpause(batchExport) : pause(batchExport)
                                     },
-                                },
-                            ]
+                                })
+                            }
                             return (
                                 <LemonMenu items={menuItems} placement="left">
                                     <LemonButton size="small" noPadding icon={<IconEllipsis />} />

--- a/frontend/src/scenes/plugins/tabs/batch-exports/BatchExportsTab.tsx
+++ b/frontend/src/scenes/plugins/tabs/batch-exports/BatchExportsTab.tsx
@@ -5,8 +5,11 @@ import { AvailableFeature } from '~/types'
 
 export function BatchExportsTab(): JSX.Element {
     return (
-        <PayGateMini feature={AvailableFeature.DATA_PIPELINES}>
-            <BatchExportsList />
-        </PayGateMini>
+        <>
+            <PayGateMini feature={AvailableFeature.DATA_PIPELINES}>
+                <></>
+            </PayGateMini>
+            <BatchExportsList /> {/* We always show enabled batch exports */}
+        </>
     )
 }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Currently self-hosted users wouldn't see exports that they might be enabled as they won't have data pipeline's addon. This makes it so we show all exports that are enabled always and then depending on addon existence one can create new ones. 


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<img width="1000" alt="Screenshot 2024-01-18 at 14 15 08" src="https://github.com/PostHog/posthog/assets/890921/7e73e0ce-4f93-4b94-852e-f979d0f72e4b">


