### PR TITLE
fix: always show inspector if widescreen

### DIFF
--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -151,6 +151,8 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
         )
     }
 
+    const isWidescreen = !isFullScreen && size === 'medium'
+
     return (
         <BindLogic logic={sessionRecordingPlayerLogic} props={logicProps}>
             <div
@@ -158,8 +160,8 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
                 className={clsx('SessionRecordingPlayer', {
                     'SessionRecordingPlayer--fullscreen': isFullScreen,
                     'SessionRecordingPlayer--no-border': noBorder,
-                    'SessionRecordingPlayer--widescreen': !isFullScreen && size === 'medium',
-                    'SessionRecordingPlayer--inspector-focus': inspectorFocus,
+                    'SessionRecordingPlayer--widescreen': isWidescreen,
+                    'SessionRecordingPlayer--inspector-focus': inspectorFocus || isWidescreen,
                     'SessionRecordingPlayer--inspector-hidden': noInspector || size === 'tiny',
                     'SessionRecordingPlayer--buffering': isBuffering,
                 })}


### PR DESCRIPTION
## Problem

![2024-01-18 09 06 19](https://github.com/PostHog/posthog/assets/6685876/9dd5dd18-649e-48e4-9746-b9c172dfd46b)


## Changes

Hide inspector until hover on smaller screens (as before)
<img width="1036" alt="Screenshot 2024-01-18 at 13 24 16" src="https://github.com/PostHog/posthog/assets/6685876/931849c8-f067-4ab3-b004-c897fbadcd41">

Always show inspector when in widescreen (fix)
<img width="1584" alt="Screenshot 2024-01-18 at 13 24 26" src="https://github.com/PostHog/posthog/assets/6685876/23e6fc14-e7f1-435a-b936-90c0316053fa">


## How did you test this code?

Visually