### PR TITLE
fix(event-explorer): do not sort by persons

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -226,7 +226,7 @@ export function DataTable({
                             }}
                         />
                         <LemonDivider />
-                        {canSort && key !== 'person.$delete' ? (
+                        {canSort && key !== 'person.$delete' && key !== 'person' ? (
                             <>
                                 <LemonButton
                                     fullWidth


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/9451 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/12087)

Sorting by persons in the event explorer gives an error.


## Changes

That's because we swap the person field for a "distinct_id", and then make a second query to get the actual person data. We do it because it's about 10x faster. Sadly this makes the column unsortable. I could swap "person" out with "person.properties.email" (or whatever the first display name is) when sorting, but given the various aggregations you can perform on the table, it's not trivial to make sure nothing errors.

Thus, I have just removed the sorting options for now if the column is "person".

![2024-01-18 15 35 38](https://github.com/PostHog/posthog/assets/53387/c6865849-b672-40a1-bfc0-ddd98118facc)


## How did you test this code?

Locally in the browser. See screenshots.