### PR TITLE
feat: Always show discussion tab

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/activityForSceneLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/activityForSceneLogic.ts
@@ -22,7 +22,12 @@ export const activityFiltersForScene = (sceneConfig: SceneConfig | null): Activi
         const pathParts = removeProjectIdIfPresent(router.values.currentLocation.pathname).split('/')
         const item_id = pathParts[2]
 
-        return { scope: sceneConfig.activityScope, item_id }
+        // Loose check for the item_id being a number, a short_id (8 chars) or a uuid
+        if (item_id && (item_id.length === 8 || item_id.length === 36 || !isNaN(parseInt(item_id)))) {
+            return { scope: sceneConfig.activityScope, item_id }
+        }
+
+        return { scope: sceneConfig.activityScope }
     }
     return null
 }

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/activityForSceneLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/activityForSceneLogic.ts
@@ -2,6 +2,7 @@ import { connect, kea, path, selectors } from 'kea'
 import { router } from 'kea-router'
 import { objectsEqual } from 'kea-test-utils'
 import { ActivityLogItem } from 'lib/components/ActivityLog/humanizeActivity'
+import { removeProjectIdIfPresent } from 'lib/utils/router-utils'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { SceneConfig } from 'scenes/sceneTypes'
 
@@ -18,7 +19,7 @@ export type ActivityFilters = {
 export const activityFiltersForScene = (sceneConfig: SceneConfig | null): ActivityFilters | null => {
     if (sceneConfig?.activityScope) {
         // NOTE: - HACKY, we are just parsing the item_id from the url optimistically...
-        const pathParts = router.values.currentLocation.pathname.split('/')
+        const pathParts = removeProjectIdIfPresent(router.values.currentLocation.pathname).split('/')
         const item_id = pathParts[2]
 
         return { scope: sceneConfig.activityScope, item_id }

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -9,7 +9,6 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SidePanelTab } from '~/types'
 
 import { sidePanelActivityLogic } from './panels/activity/sidePanelActivityLogic'
-import { sidePanelDiscussionLogic } from './panels/discussion/sidePanelDiscussionLogic'
 import { sidePanelStatusLogic } from './panels/sidePanelStatusLogic'
 import type { sidePanelLogicType } from './sidePanelLogicType'
 import { sidePanelStateLogic } from './sidePanelStateLogic'
@@ -37,8 +36,6 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
             // We need to mount this to ensure that marking as read works when the panel closes
             sidePanelActivityLogic,
             ['unreadCount'],
-            sidePanelDiscussionLogic,
-            ['commentCount', 'commentCountLoading'],
             sidePanelStatusLogic,
             ['status'],
         ],
@@ -90,11 +87,11 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                     tabs.push(SidePanelTab.Support)
                 }
                 tabs.push(SidePanelTab.Activity)
-                if (isReady && !hasCompletedAllTasks) {
-                    tabs.push(SidePanelTab.Activation)
-                }
                 if (featureflags[FEATURE_FLAGS.DISCUSSIONS]) {
                     tabs.push(SidePanelTab.Discussion)
+                }
+                if (isReady && !hasCompletedAllTasks) {
+                    tabs.push(SidePanelTab.Activation)
                 }
                 tabs.push(SidePanelTab.FeaturePreviews)
                 tabs.push(SidePanelTab.Settings)
@@ -109,15 +106,11 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
         ],
 
         visibleTabs: [
-            (s) => [s.enabledTabs, s.selectedTab, s.sidePanelOpen, s.commentCount, s.unreadCount, s.status],
-            (enabledTabs, selectedTab, sidePanelOpen, commentCount, unreadCount, status): SidePanelTab[] => {
+            (s) => [s.enabledTabs, s.selectedTab, s.sidePanelOpen, s.unreadCount, s.status],
+            (enabledTabs, selectedTab, sidePanelOpen, unreadCount, status): SidePanelTab[] => {
                 return enabledTabs.filter((tab) => {
                     if (tab === selectedTab && sidePanelOpen) {
                         return true
-                    }
-
-                    if (tab === SidePanelTab.Discussion) {
-                        return commentCount > 0
                     }
 
                     if (tab === SidePanelTab.Activity && unreadCount) {


### PR DESCRIPTION
## Problem

@raquelmsmith was right (she normally is!)

We want to get some feedback so lets make it prominent, at the very least whilst we are testing it.

## Changes

* Always show the panel if in the flag
* Looks pretty good tbh - we could also make the visible ones customizable in the future 🤔 
* Also fixes the url check for the activity log

<img width="509" alt="Screenshot 2024-01-18 at 18 07 55" src="https://github.com/PostHog/posthog/assets/2536520/95419561-99e4-4766-9fea-6071b52155ae">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
