### PR TITLE
fix(retention): limit series query cache

### DIFF
--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -246,7 +246,15 @@ describe('insightNavLogic', () => {
                 })
             })
 
-            it('stores series from retention entities', async () => {
+            it('retention 0', async () => {
+                // await expectLogic(logic, () => {
+                //     builtInsightDataLogic.actions.setQuery(trendsQuery)
+                // }).toMatchValues({
+                //     queryPropertyCache: expect.objectContaining({
+                //         commonFilter: { show_values_on_series: true },
+                //     }),
+                // })
+
                 await expectLogic(logic, () => {
                     builtInsightDataLogic.actions.setQuery(retentionQuery)
                 }).toMatchValues({
@@ -258,16 +266,33 @@ describe('insightNavLogic', () => {
                                 math: 'total',
                                 name: 'target',
                             },
-                            {
-                                event: 'returning',
-                                kind: 'EventsNode',
-                                math: 'total',
-                                name: 'returning',
-                            },
                         ],
                     }),
                 })
             })
+
+            // it('stores series from retention entities', async () => {
+            //     await expectLogic(logic, () => {
+            //         builtInsightDataLogic.actions.setQuery(retentionQuery)
+            //     }).toMatchValues({
+            //         queryPropertyCache: expect.objectContaining({
+            //             series: [
+            //                 {
+            //                     event: 'target',
+            //                     kind: 'EventsNode',
+            //                     math: 'total',
+            //                     name: 'target',
+            //                 },
+            //                 {
+            //                     event: 'returning',
+            //                     kind: 'EventsNode',
+            //                     math: 'total',
+            //                     name: 'returning',
+            //                 },
+            //             ],
+            //         }),
+            //     })
+            // })
 
             it('updates query when navigating', async () => {
                 await expectLogic(logic, () => {

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -331,7 +331,6 @@ const mergeCachedProperties = (query: InsightQueryNode, cache: QueryPropertyCach
         mergedQuery[filterKey] = {
             ...query[filterKey],
             ...cache[filterKey],
-            ...(isRetentionQuery(mergedQuery) ? mergedQuery.retentionFilter : {}),
             // TODO: fix an issue where switching between trends and funnels with the option enabled would
             // result in an error before uncommenting
             // ...(getCompare(node) ? { compare: getCompare(node) } : {}),

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -270,7 +270,10 @@ const cachePropertiesFromQuery = (query: InsightQueryNode, cache: QueryPropertyC
             ],
         })
         if (series.length > 0) {
-            newCache.series = [...series, ...(cache?.series ? cache.series.slice(series.length) : [])]
+            newCache.series = [
+                ...series.slice(0, cache?.series?.length || 1), // cache only the first series entry if there aren't already two
+                ...(cache?.series ? cache.series.slice(series.length) : []),
+            ]
         }
     }
 
@@ -328,6 +331,7 @@ const mergeCachedProperties = (query: InsightQueryNode, cache: QueryPropertyCach
         mergedQuery[filterKey] = {
             ...query[filterKey],
             ...cache[filterKey],
+            ...(isRetentionQuery(mergedQuery) ? mergedQuery.retentionFilter : {}),
             // TODO: fix an issue where switching between trends and funnels with the option enabled would
             // result in an error before uncommenting
             // ...(getCompare(node) ? { compare: getCompare(node) } : {}),


### PR DESCRIPTION
## Problem

See https://posthoghelp.zendesk.com/agent/tickets/9449 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/12085)

## Changes

This PR limits the amount of entries in the query cache for `series` to the current amount of entries when getting them from a retention filter.

There is another issue where the retention entities won't be set from cached series. I'll implement a fix after https://github.com/PostHog/posthog/pull/19800 is in.

## How did you test this code?

Navigated between insight types