### PR TITLE
feat(web-analytics): Add web analytics sampling behind a feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -150,6 +150,7 @@ export const FEATURE_FLAGS = {
     HEDGEHOG_MODE_DEBUG: 'hedgehog-mode-debug', // owner: @benjackwhite
     GENERIC_SIGNUP_BENEFITS: 'generic-signup-benefits', // experiment, owner: @raquelmsmith
     WEB_ANALYTICS: 'web-analytics', // owner @robbie-c #team-web-analytics
+    WEB_ANALYTICS_SAMPLING: 'web-analytics-sampling', // owner @robbie-c #team-web-analytics
     HIGH_FREQUENCY_BATCH_EXPORTS: 'high-frequency-batch-exports', // owner: @tomasfarias
     // owner: team monitoring, only to be enabled for PostHog team testing
     EXCEPTION_AUTOCAPTURE: 'exception-autocapture',

--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -1,6 +1,7 @@
 import { useValues } from 'kea'
 import { getColorVar } from 'lib/colors'
 import { IconTrendingDown, IconTrendingFlat, IconTrendingUp } from 'lib/lemon-ui/icons'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { humanFriendlyDuration, humanFriendlyLargeNumber, isNotNil } from 'lib/utils'
@@ -29,12 +30,21 @@ export function WebOverview(props: { query: WebOverviewQuery; cachedResults?: An
         return null
     }
 
-    const results = (response as WebOverviewQueryResponse | undefined)?.results
+    const webOverviewQueryResponse = response as WebOverviewQueryResponse | undefined
 
     return (
-        <EvenlyDistributedRows className="w-full gap-x-2 gap-y-8" minWidthRems={8}>
-            {results?.map((item) => <WebOverviewItemCell key={item.key} item={item} />) || []}
-        </EvenlyDistributedRows>
+        <>
+            <EvenlyDistributedRows className="w-full gap-x-2 gap-y-8" minWidthRems={8}>
+                {webOverviewQueryResponse?.results?.map((item) => <WebOverviewItemCell key={item.key} item={item} />) ||
+                    []}
+            </EvenlyDistributedRows>
+            {webOverviewQueryResponse?.samplingRate ? (
+                <LemonBanner type="info" className="my-4">
+                    These results using a sampling factor of {webOverviewQueryResponse.samplingRate.numerator}/
+                    {webOverviewQueryResponse.samplingRate.denominator}. Sampling is currently in beta.
+                </LemonBanner>
+            ) : null}
+        </>
     )
 }
 

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2876,6 +2876,9 @@
                             },
                             "type": "array"
                         },
+                        "samplingRate": {
+                            "$ref": "#/definitions/SamplingRate"
+                        },
                         "timings": {
                             "items": {
                                 "$ref": "#/definitions/QueryTiming"
@@ -2908,6 +2911,9 @@
                         "results": {
                             "items": {},
                             "type": "array"
+                        },
+                        "samplingRate": {
+                            "$ref": "#/definitions/SamplingRate"
                         },
                         "timings": {
                             "items": {
@@ -2945,6 +2951,9 @@
                         "results": {
                             "items": {},
                             "type": "array"
+                        },
+                        "samplingRate": {
+                            "$ref": "#/definitions/SamplingRate"
                         },
                         "timings": {
                             "items": {
@@ -3457,6 +3466,19 @@
                 }
             },
             "required": ["count"],
+            "type": "object"
+        },
+        "SamplingRate": {
+            "additionalProperties": false,
+            "properties": {
+                "denominator": {
+                    "type": "number"
+                },
+                "numerator": {
+                    "type": "number"
+                }
+            },
+            "required": ["numerator"],
             "type": "object"
         },
         "SavedInsightNode": {
@@ -4189,6 +4211,18 @@
                 },
                 "properties": {
                     "$ref": "#/definitions/WebAnalyticsPropertyFilters"
+                },
+                "sampling": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "forceSamplingRate": {
+                            "$ref": "#/definitions/SamplingRate"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "required": ["properties"],
@@ -4235,6 +4269,18 @@
                 },
                 "response": {
                     "$ref": "#/definitions/WebOverviewQueryResponse"
+                },
+                "sampling": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "forceSamplingRate": {
+                            "$ref": "#/definitions/SamplingRate"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "required": ["kind", "properties"],
@@ -4260,6 +4306,9 @@
                         "$ref": "#/definitions/WebOverviewItem"
                     },
                     "type": "array"
+                },
+                "samplingRate": {
+                    "$ref": "#/definitions/SamplingRate"
                 },
                 "timings": {
                     "items": {
@@ -4312,6 +4361,18 @@
                 },
                 "response": {
                     "$ref": "#/definitions/WebStatsTableQueryResponse"
+                },
+                "sampling": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "forceSamplingRate": {
+                            "$ref": "#/definitions/SamplingRate"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "required": ["breakdownBy", "kind", "properties"],
@@ -4339,6 +4400,9 @@
                 "results": {
                     "items": {},
                     "type": "array"
+                },
+                "samplingRate": {
+                    "$ref": "#/definitions/SamplingRate"
                 },
                 "timings": {
                     "items": {
@@ -4369,6 +4433,18 @@
                 },
                 "response": {
                     "$ref": "#/definitions/WebTopClicksQueryResponse"
+                },
+                "sampling": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "forceSamplingRate": {
+                            "$ref": "#/definitions/SamplingRate"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "required": ["kind", "properties"],
@@ -4396,6 +4472,9 @@
                 "results": {
                     "items": {},
                     "type": "array"
+                },
+                "samplingRate": {
+                    "$ref": "#/definitions/SamplingRate"
                 },
                 "timings": {
                     "items": {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -816,6 +816,10 @@ export type WebAnalyticsPropertyFilters = WebAnalyticsPropertyFilter[]
 export interface WebAnalyticsQueryBase {
     dateRange?: DateRange
     properties: WebAnalyticsPropertyFilters
+    sampling?: {
+        enabled?: boolean
+        forceSamplingRate?: SamplingRate
+    }
 }
 
 export interface WebOverviewQuery extends WebAnalyticsQueryBase {
@@ -832,8 +836,14 @@ export interface WebOverviewItem {
     isIncreaseBad?: boolean
 }
 
+export interface SamplingRate {
+    numerator: number
+    denominator?: number
+}
+
 export interface WebOverviewQueryResponse extends QueryResponse {
     results: WebOverviewItem[]
+    samplingRate?: SamplingRate
 }
 
 export interface WebTopClicksQuery extends WebAnalyticsQueryBase {
@@ -844,6 +854,7 @@ export interface WebTopClicksQueryResponse extends QueryResponse {
     results: unknown[]
     types?: unknown[]
     columns?: unknown[]
+    samplingRate?: SamplingRate
 }
 
 export enum WebStatsBreakdown {
@@ -875,6 +886,7 @@ export interface WebStatsTableQueryResponse extends QueryResponse {
     types?: unknown[]
     columns?: unknown[]
     hogql?: string
+    samplingRate?: SamplingRate
 }
 
 export type InsightQueryNode =

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -3,8 +3,9 @@ import { loaders } from 'kea-loaders'
 import { actionToUrl, urlToAction } from 'kea-router'
 import { windowValues } from 'kea-window-values'
 import api from 'lib/api'
-import { RETENTION_FIRST_TIME, STALE_EVENT_SECONDS } from 'lib/constants'
+import { FEATURE_FLAGS, RETENTION_FIRST_TIME, STALE_EVENT_SECONDS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getDefaultInterval, isNotNil, updateDatesWithInterval } from 'lib/utils'
 
 import {
@@ -114,7 +115,9 @@ const initialInterval = getDefaultInterval(initialDateFrom, initialDateTo)
 
 export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
     path(['scenes', 'webAnalytics', 'webAnalyticsSceneLogic']),
-    connect({}),
+    connect(() => ({
+        values: [featureFlagLogic, ['featureFlags']],
+    })),
     actions({
         setWebAnalyticsFilters: (webAnalyticsFilters: WebAnalyticsPropertyFilters) => ({ webAnalyticsFilters }),
         togglePropertyFilter: (
@@ -325,6 +328,11 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 }
                 const compare = !!dateRange.date_from
 
+                const sampling = {
+                    enabled: !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_SAMPLING],
+                    forceSamplingRate: { numerator: 1, denominator: 10 },
+                }
+
                 const tiles: (WebDashboardTile | null)[] = [
                     {
                         layout: {
@@ -335,6 +343,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             kind: NodeKind.WebOverviewQuery,
                             properties: webAnalyticsFilters,
                             dateRange,
+                            sampling,
                         },
                     },
                     {
@@ -459,6 +468,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         breakdownBy: WebStatsBreakdown.Page,
                                         dateRange,
                                         includeScrollDepth: statusCheck?.isSendingPageLeavesScroll,
+                                        sampling,
                                     },
                                     embedded: false,
                                 },
@@ -476,6 +486,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         breakdownBy: WebStatsBreakdown.InitialPage,
                                         dateRange,
                                         includeScrollDepth: statusCheck?.isSendingPageLeavesScroll,
+                                        sampling,
                                     },
                                     embedded: false,
                                 },
@@ -502,6 +513,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         properties: webAnalyticsFilters,
                                         breakdownBy: WebStatsBreakdown.InitialReferringDomain,
                                         dateRange,
+                                        sampling,
                                     },
                                 },
                             },
@@ -517,6 +529,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         properties: webAnalyticsFilters,
                                         breakdownBy: WebStatsBreakdown.InitialChannelType,
                                         dateRange,
+                                        sampling,
                                     },
                                 },
                             },
@@ -532,6 +545,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         properties: webAnalyticsFilters,
                                         breakdownBy: WebStatsBreakdown.InitialUTMSource,
                                         dateRange,
+                                        sampling,
                                     },
                                 },
                             },
@@ -547,6 +561,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         properties: webAnalyticsFilters,
                                         breakdownBy: WebStatsBreakdown.InitialUTMMedium,
                                         dateRange,
+                                        sampling,
                                     },
                                 },
                             },
@@ -562,6 +577,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         properties: webAnalyticsFilters,
                                         breakdownBy: WebStatsBreakdown.InitialUTMCampaign,
                                         dateRange,
+                                        sampling,
                                     },
                                 },
                             },
@@ -577,6 +593,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         properties: webAnalyticsFilters,
                                         breakdownBy: WebStatsBreakdown.InitialUTMContent,
                                         dateRange,
+                                        sampling,
                                     },
                                 },
                             },
@@ -592,6 +609,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         properties: webAnalyticsFilters,
                                         breakdownBy: WebStatsBreakdown.InitialUTMTerm,
                                         dateRange,
+                                        sampling,
                                     },
                                 },
                             },
@@ -651,6 +669,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         properties: webAnalyticsFilters,
                                         breakdownBy: WebStatsBreakdown.Browser,
                                         dateRange,
+                                        sampling,
                                     },
                                     embedded: false,
                                 },
@@ -667,6 +686,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         properties: webAnalyticsFilters,
                                         breakdownBy: WebStatsBreakdown.OS,
                                         dateRange,
+                                        sampling,
                                     },
                                     embedded: false,
                                 },
@@ -724,6 +744,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                               properties: webAnalyticsFilters,
                                               breakdownBy: WebStatsBreakdown.Country,
                                               dateRange,
+                                              sampling,
                                           },
                                       },
                                   },
@@ -739,6 +760,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                               properties: webAnalyticsFilters,
                                               breakdownBy: WebStatsBreakdown.Region,
                                               dateRange,
+                                              sampling,
                                           },
                                       },
                                   },
@@ -754,6 +776,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                               properties: webAnalyticsFilters,
                                               breakdownBy: WebStatsBreakdown.City,
                                               dateRange,
+                                              sampling,
                                           },
                                       },
                                   },

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -33,6 +33,7 @@ from posthog.schema import (
     HogQLQueryModifiers,
     RetentionQuery,
     PathsQuery,
+    SamplingRate,
 )
 from posthog.utils import generate_cache_key, get_safe_cache
 
@@ -63,6 +64,7 @@ class QueryResponse(BaseModel, Generic[DataT]):
     hasMore: Optional[bool] = None
     limit: Optional[int] = None
     offset: Optional[int] = None
+    samplingRate: Optional[SamplingRate] = None
 
 
 class CachedQueryResponse(QueryResponse):

--- a/posthog/hogql_queries/web_analytics/ctes.py
+++ b/posthog/hogql_queries/web_analytics/ctes.py
@@ -13,6 +13,7 @@ SELECT
     avg(toFloat(JSONExtractRaw(events.properties, '$prev_pageview_max_scroll_percentage'))) as average_scroll_percentage
 FROM
     events
+SAMPLE {sample_rate}
 WHERE
     (event = '$pageview' OR event = '$pageleave') AND events.properties.`$prev_pageview_pathname` IS NOT NULL
     AND ({pathname_scroll_where})
@@ -26,6 +27,7 @@ SELECT
     uniq(events.person_id) as unique_visitors
 FROM
     events
+SAMPLE {sample_rate}
 WHERE
     (event = '$pageview')
     AND ({counts_where})
@@ -47,6 +49,7 @@ SESSION_CTE = """
         (num_autocaptures == 0 AND num_pageviews <= 1 AND duration_s < 10) AS is_bounce
     FROM
         events
+    SAMPLE {sample_rate}
     WHERE
         session_id IS NOT NULL
         AND (events.event == '$pageview' OR events.event == '$autocapture' OR events.event == '$pageleave')

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -148,7 +148,10 @@ LIMIT 10
             else:
                 return col_val
 
-        results = [[to_data(c, i) for (i, c) in enumerate(r)] for r in response.results]
+        if response.results:
+            results = [[to_data(c, i) for (i, c) in enumerate(r)] if r else None for r in response.results]
+        else:
+            results = None
 
         return WebStatsTableQueryResponse(
             columns=response.columns,

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -135,6 +135,7 @@ LIMIT 10
             timings=self.timings,
             modifiers=self.modifiers,
         )
+        assert response.results is not None
 
         def to_data(col_val, col_idx):
             if col_idx == 0:  # breakdown_value

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -148,10 +148,7 @@ LIMIT 10
             else:
                 return col_val
 
-        if response.results:
-            results = [[to_data(c, i) for (i, c) in enumerate(r)] if r else None for r in response.results]
-        else:
-            results = None
+        results = [[to_data(c, i) for (i, c) in enumerate(r)] for r in response.results]
 
         return WebStatsTableQueryResponse(
             columns=response.columns,
@@ -329,6 +326,7 @@ LIMIT 10
                 placeholders={
                     "counts_where": self.events_where(),
                     "where_breakdown": self.where_breakdown(),
+                    "sample_rate": self._sample_ratio,
                 },
             )
 

--- a/posthog/hogql_queries/web_analytics/test/test_web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_analytics_query_runner.py
@@ -1,0 +1,101 @@
+from typing import Union, List
+
+from freezegun import freeze_time
+
+from posthog.hogql_queries.web_analytics.stats_table import WebStatsTableQueryRunner
+from posthog.hogql_queries.web_analytics.web_overview import WebOverviewQueryRunner
+from posthog.schema import (
+    DateRange,
+    WebStatsTableQuery,
+    WebStatsBreakdown,
+    WebOverviewQuery,
+    EventPropertyFilter,
+    PersonPropertyFilter,
+    PropertyOperator,
+)
+from posthog.test.base import (
+    APIBaseTest,
+    ClickhouseTestMixin,
+    _create_event,
+    _create_person,
+)
+
+
+class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
+    def _create_events(self, data, event="$pageview"):
+        person_result = []
+        for id, timestamps in data:
+            with freeze_time(timestamps[0][0]):
+                person_result.append(
+                    _create_person(
+                        team_id=self.team.pk,
+                        distinct_ids=[id],
+                        properties={
+                            "name": id,
+                            **({"email": "test@posthog.com"} if id == "test" else {}),
+                        },
+                    )
+                )
+            for timestamp, session_id, pathname in timestamps:
+                _create_event(
+                    team=self.team,
+                    event=event,
+                    distinct_id=id,
+                    timestamp=timestamp,
+                    properties={"$session_id": session_id, "$pathname": pathname},
+                )
+        return person_result
+
+    def _create_web_stats_table_query(self, date_from, date_to, properties, breakdown_by=WebStatsBreakdown.Page):
+        query = WebStatsTableQuery(
+            dateRange=DateRange(date_from=date_from, date_to=date_to), properties=properties, breakdownBy=breakdown_by
+        )
+        return WebStatsTableQueryRunner(team=self.team, query=query)
+
+    def _create__web_overview_query(self, date_from, date_to, properties):
+        query = WebOverviewQuery(
+            dateRange=DateRange(date_from=date_from, date_to=date_to),
+            properties=properties,
+        )
+        return WebOverviewQueryRunner(team=self.team, query=query)
+
+    def test_sample_rate_cache_key_is_same_across_subclasses(self):
+        properties: List[Union[EventPropertyFilter, PersonPropertyFilter]] = [
+            EventPropertyFilter(key="$current_url", value="/a", operator=PropertyOperator.is_not),
+            PersonPropertyFilter(key="$initial_utm_source", value="google", operator=PropertyOperator.is_not),
+        ]
+        date_from = "2023-12-08"
+        date_to = "2023-12-15"
+
+        stats_key = self._create_web_stats_table_query(date_from, date_to, properties)._sample_rate_cache_key()
+        overview_key = self._create__web_overview_query(date_from, date_to, properties)._sample_rate_cache_key()
+
+        self.assertEqual(stats_key, overview_key)
+
+    def test_sample_rate_cache_key_is_same_with_different_properties(self):
+        properties_a: List[Union[EventPropertyFilter, PersonPropertyFilter]] = [
+            EventPropertyFilter(key="$current_url", value="/a", operator=PropertyOperator.is_not),
+        ]
+        properties_b: List[Union[EventPropertyFilter, PersonPropertyFilter]] = [
+            EventPropertyFilter(key="$current_url", value="/b", operator=PropertyOperator.is_not),
+        ]
+        date_from = "2023-12-08"
+        date_to = "2023-12-15"
+
+        key_a = self._create_web_stats_table_query(date_from, date_to, properties_a)._sample_rate_cache_key()
+        key_b = self._create_web_stats_table_query(date_from, date_to, properties_b)._sample_rate_cache_key()
+
+        self.assertEqual(key_a, key_b)
+
+    def test_sample_rate_cache_key_changes_with_date_range(self):
+        properties: List[Union[EventPropertyFilter, PersonPropertyFilter]] = [
+            EventPropertyFilter(key="$current_url", value="/a", operator=PropertyOperator.is_not),
+        ]
+        date_from_a = "2023-12-08"
+        date_from_b = "2023-12-09"
+        date_to = "2023-12-15"
+
+        key_a = self._create_web_stats_table_query(date_from_a, date_to, properties)._sample_rate_cache_key()
+        key_b = self._create_web_stats_table_query(date_from_b, date_to, properties)._sample_rate_cache_key()
+
+        self.assertNotEquals(key_a, key_b)

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -58,8 +58,8 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(
             [
-                ("/", 2, 2, 0),
-                ("/login", 1, 1, 0),
+                ["/", 2, 2, 0],
+                ["/login", 1, 1, 0],
             ],
             results,
         )
@@ -76,9 +76,9 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(
             [
-                ("/", 2, 2, 0),
-                ("/login", 1, 1, 0),
-                ("/docs", 1, 1, 0),
+                ["/", 2, 2, 0],
+                ["/login", 1, 1, 0],
+                ["/docs", 1, 1, 0],
             ],
             results,
         )

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -221,6 +221,7 @@ WHERE
     def _unsample(self, n: Optional[int | float]):
         if n is None:
             return None
+
         return (
             n * self._sample_rate.denominator / self._sample_rate.numerator
             if self._sample_rate.denominator

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -236,6 +236,6 @@ def _sample_rate_from_count(count: int) -> SamplingRate:
     sample_rate_steps = [1_000, 100, 10]
 
     for step in sample_rate_steps:
-        if count / sample_target > step:
-            return SamplingRate(numerator=1, denominator=sample_target)
+        if count / sample_target >= step:
+            return SamplingRate(numerator=1, denominator=step)
     return SamplingRate(numerator=1)

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -152,7 +152,7 @@ class WebAnalyticsQueryRunner(QueryRunner, ABC):
 
     def _sample_rate_cache_key(self) -> str:
         return generate_cache_key(
-            f"web_analytics_sample_rate_{self.query.dateRange.model_dump_json()}_{self.team.pk}_{self.team.timezone}"
+            f"web_analytics_sample_rate_{self.query.dateRange.model_dump_json() if self.query.dateRange else None}_{self.team.pk}_{self.team.timezone}"
         )
 
     def _get_or_calculate_sample_ratio(self) -> SamplingRate:

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -36,6 +36,7 @@ WITH pages_query AS (
         uniq(if(timestamp >= {start} AND timestamp < {mid}, events.properties.$session_id, NULL)) AS previous_unique_sessions
     FROM
         events
+    SAMPLE {sample_rate}
     WHERE
         event = '$pageview' AND
         timestamp >= {start} AND
@@ -60,6 +61,7 @@ sessions_query AS (
             (num_autocaptures == 0 AND num_pageviews <= 1 AND duration_s < 10) AS is_bounce
         FROM
             events
+        SAMPLE {sample_rate}
         WHERE
             session_id IS NOT NULL
             AND (events.event == '$pageview' OR events.event == '$autocapture' OR events.event == '$pageleave')
@@ -92,6 +94,8 @@ CROSS JOIN sessions_query
                     "event_properties": self.event_properties(),
                     "session_where": self.session_where(include_previous_period=True),
                     "session_having": self.session_having(include_previous_period=True),
+                    "sample_rate": self._sample_ratio,
+                    "sample_expr": ast.SampleExpr(sample_value=self._sample_ratio),
                 },
                 backend="cpp",
             )
@@ -111,12 +115,13 @@ CROSS JOIN sessions_query
 
         return WebOverviewQueryResponse(
             results=[
-                to_data("visitors", "unit", row[0], row[1]),
-                to_data("views", "unit", row[2], row[3]),
-                to_data("sessions", "unit", row[4], row[5]),
+                to_data("visitors", "unit", self._unsample(row[0]), self._unsample(row[1])),
+                to_data("views", "unit", self._unsample(row[2]), self._unsample(row[3])),
+                to_data("sessions", "unit", self._unsample(row[4]), self._unsample(row[5])),
                 to_data("session duration", "duration_s", row[6], row[7]),
                 to_data("bounce rate", "percentage", row[8], row[9], is_increase_bad=True),
             ],
+            samplingRate=self._sample_rate,
         )
 
     @cached_property

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -581,6 +581,14 @@ class RetentionValue(BaseModel):
     count: int
 
 
+class SamplingRate(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    denominator: Optional[float] = None
+    numerator: float
+
+
 class SessionPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -747,6 +755,14 @@ class VizSpecificOptions(BaseModel):
     RETENTION: Optional[RETENTION] = None
 
 
+class Sampling(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    enabled: Optional[bool] = None
+    forceSamplingRate: Optional[SamplingRate] = None
+
+
 class Kind1(str, Enum):
     unit = "unit"
     duration_s = "duration_s"
@@ -774,6 +790,7 @@ class WebOverviewQueryResponse(BaseModel):
     last_refresh: Optional[str] = None
     next_allowed_client_refresh: Optional[str] = None
     results: List[WebOverviewItem]
+    samplingRate: Optional[SamplingRate] = None
     timings: Optional[List[QueryTiming]] = None
 
 
@@ -805,6 +822,7 @@ class WebStatsTableQueryResponse(BaseModel):
     last_refresh: Optional[str] = None
     next_allowed_client_refresh: Optional[str] = None
     results: List
+    samplingRate: Optional[SamplingRate] = None
     timings: Optional[List[QueryTiming]] = None
     types: Optional[List] = None
 
@@ -819,6 +837,7 @@ class WebTopClicksQueryResponse(BaseModel):
     last_refresh: Optional[str] = None
     next_allowed_client_refresh: Optional[str] = None
     results: List
+    samplingRate: Optional[SamplingRate] = None
     timings: Optional[List[QueryTiming]] = None
     types: Optional[List] = None
 
@@ -1150,6 +1169,7 @@ class QueryResponseAlternative8(BaseModel):
     last_refresh: Optional[str] = None
     next_allowed_client_refresh: Optional[str] = None
     results: List[WebOverviewItem]
+    samplingRate: Optional[SamplingRate] = None
     timings: Optional[List[QueryTiming]] = None
 
 
@@ -1163,6 +1183,7 @@ class QueryResponseAlternative9(BaseModel):
     last_refresh: Optional[str] = None
     next_allowed_client_refresh: Optional[str] = None
     results: List
+    samplingRate: Optional[SamplingRate] = None
     timings: Optional[List[QueryTiming]] = None
     types: Optional[List] = None
 
@@ -1302,6 +1323,7 @@ class WebAnalyticsQueryBase(BaseModel):
     )
     dateRange: Optional[DateRange] = None
     properties: List[Union[EventPropertyFilter, PersonPropertyFilter]]
+    sampling: Optional[Sampling] = None
 
 
 class WebOverviewQuery(BaseModel):
@@ -1312,6 +1334,7 @@ class WebOverviewQuery(BaseModel):
     kind: Literal["WebOverviewQuery"] = "WebOverviewQuery"
     properties: List[Union[EventPropertyFilter, PersonPropertyFilter]]
     response: Optional[WebOverviewQueryResponse] = None
+    sampling: Optional[Sampling] = None
 
 
 class WebStatsTableQuery(BaseModel):
@@ -1324,6 +1347,7 @@ class WebStatsTableQuery(BaseModel):
     kind: Literal["WebStatsTableQuery"] = "WebStatsTableQuery"
     properties: List[Union[EventPropertyFilter, PersonPropertyFilter]]
     response: Optional[WebStatsTableQueryResponse] = None
+    sampling: Optional[Sampling] = None
 
 
 class WebTopClicksQuery(BaseModel):
@@ -1334,6 +1358,7 @@ class WebTopClicksQuery(BaseModel):
     kind: Literal["WebTopClicksQuery"] = "WebTopClicksQuery"
     properties: List[Union[EventPropertyFilter, PersonPropertyFilter]]
     response: Optional[WebTopClicksQueryResponse] = None
+    sampling: Optional[Sampling] = None
 
 
 class AnyResponseType(


### PR DESCRIPTION
## Problem

Web analytic performance is too slow, this will speed it up considerably. It's behind a FF because sampling will by inaccurate due to how distinct_id works, I want to see how bad it is.

## Changes

Add sampling to the web analytics queries

## How did you test this code?

Sampling is not unit tested yet, but the existing tests pass when sampled by a factor of 1/1, and a factor of 10 worked when running locally. Testing this on our instance is the next step but needs this to be merged first, and it's behind a FF.
