### PR TITLE
fix(insights): deactivate series cache for retention and lifecycle insights

### DIFF
--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -160,24 +160,24 @@ describe('insightNavLogic', () => {
                     },
                 },
             }
-            const retentionQuery: InsightVizNode = {
-                kind: NodeKind.InsightVizNode,
-                source: {
-                    kind: NodeKind.RetentionQuery,
-                    retentionFilter: {
-                        returning_entity: {
-                            id: 'returning',
-                            name: 'returning',
-                            type: 'events',
-                        },
-                        target_entity: {
-                            id: 'target',
-                            name: 'target',
-                            type: 'events',
-                        },
-                    },
-                },
-            }
+            // const retentionQuery: InsightVizNode = {
+            //     kind: NodeKind.InsightVizNode,
+            //     source: {
+            //         kind: NodeKind.RetentionQuery,
+            //         retentionFilter: {
+            //             returning_entity: {
+            //                 id: 'returning',
+            //                 name: 'returning',
+            //                 type: 'events',
+            //             },
+            //             target_entity: {
+            //                 id: 'target',
+            //                 name: 'target',
+            //                 type: 'events',
+            //             },
+            //         },
+            //     },
+            // }
 
             it('is initialized on mount', async () => {
                 await expectLogic(logic).toMatchValues({
@@ -246,28 +246,28 @@ describe('insightNavLogic', () => {
                 })
             })
 
-            it('stores series from retention entities', async () => {
-                await expectLogic(logic, () => {
-                    builtInsightDataLogic.actions.setQuery(retentionQuery)
-                }).toMatchValues({
-                    queryPropertyCache: expect.objectContaining({
-                        series: [
-                            {
-                                event: 'target',
-                                kind: 'EventsNode',
-                                math: 'total',
-                                name: 'target',
-                            },
-                            {
-                                event: 'returning',
-                                kind: 'EventsNode',
-                                math: 'total',
-                                name: 'returning',
-                            },
-                        ],
-                    }),
-                })
-            })
+            // it('stores series from retention entities', async () => {
+            //     await expectLogic(logic, () => {
+            //         builtInsightDataLogic.actions.setQuery(retentionQuery)
+            //     }).toMatchValues({
+            //         queryPropertyCache: expect.objectContaining({
+            //             series: [
+            //                 {
+            //                     event: 'target',
+            //                     kind: 'EventsNode',
+            //                     math: 'total',
+            //                     name: 'target',
+            //                 },
+            //                 {
+            //                     event: 'returning',
+            //                     kind: 'EventsNode',
+            //                     math: 'total',
+            //                     name: 'returning',
+            //                 },
+            //             ],
+            //         }),
+            //     })
+            // })
 
             it('updates query when navigating', async () => {
                 await expectLogic(logic, () => {

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -8,7 +8,6 @@ import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { filterTestAccountsDefaultsLogic } from 'scenes/settings/project/filterTestAccountDefaultsLogic'
 
 import { examples, TotalEventsTable } from '~/queries/examples'
-import { actionsAndEventsToSeries } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import { insightMap } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { getDisplay, getShowPercentStackView, getShowValueOnSeries } from '~/queries/nodes/InsightViz/utils'
 import {
@@ -36,9 +35,10 @@ import {
     isInsightQueryWithBreakdown,
     isInsightQueryWithSeries,
     isInsightVizNode,
+    isLifecycleQuery,
     isRetentionQuery,
 } from '~/queries/utils'
-import { ActionFilter, InsightLogicProps, InsightType } from '~/types'
+import { InsightLogicProps, InsightType } from '~/types'
 
 import type { insightNavLogicType } from './insightNavLogicType'
 
@@ -256,22 +256,26 @@ export const insightNavLogic = kea<insightNavLogicType>([
 const cachePropertiesFromQuery = (query: InsightQueryNode, cache: QueryPropertyCache | null): QueryPropertyCache => {
     const newCache = JSON.parse(JSON.stringify(query)) as QueryPropertyCache
 
-    // set series (first two entries) from retention target and returning entity
-    if (isRetentionQuery(query)) {
-        const { target_entity, returning_entity } = query.retentionFilter || {}
-        const series = actionsAndEventsToSeries({
-            events: [
-                ...(target_entity?.type === 'events' ? [target_entity as ActionFilter] : []),
-                ...(returning_entity?.type === 'events' ? [returning_entity as ActionFilter] : []),
-            ],
-            actions: [
-                ...(target_entity?.type === 'actions' ? [target_entity as ActionFilter] : []),
-                ...(returning_entity?.type === 'actions' ? [returning_entity as ActionFilter] : []),
-            ],
-        })
-        if (series.length > 0) {
-            newCache.series = [...series, ...(cache?.series ? cache.series.slice(series.length) : [])]
-        }
+    // // set series (first two entries) from retention target and returning entity
+    // if (isRetentionQuery(query)) {
+    //     const { target_entity, returning_entity } = query.retentionFilter || {}
+    //     const series = actionsAndEventsToSeries({
+    //         events: [
+    //             ...(target_entity?.type === 'events' ? [target_entity as ActionFilter] : []),
+    //             ...(returning_entity?.type === 'events' ? [returning_entity as ActionFilter] : []),
+    //         ],
+    //         actions: [
+    //             ...(target_entity?.type === 'actions' ? [target_entity as ActionFilter] : []),
+    //             ...(returning_entity?.type === 'actions' ? [returning_entity as ActionFilter] : []),
+    //         ],
+    //     })
+    //     if (series.length > 0) {
+    //         newCache.series = [...series, ...(cache?.series ? cache.series.slice(series.length) : [])]
+    //     }
+    // }
+
+    if (isLifecycleQuery(query)) {
+        newCache.series = cache?.series
     }
 
     // store the insight specific filter in commonFilter
@@ -292,7 +296,11 @@ const mergeCachedProperties = (query: InsightQueryNode, cache: QueryPropertyCach
     // series
     if (isInsightQueryWithSeries(mergedQuery)) {
         if (cache.series) {
-            mergedQuery.series = cache.series
+            if (isLifecycleQuery(mergedQuery)) {
+                mergedQuery.series = cache.series.slice(0, 1)
+            } else {
+                mergedQuery.series = cache.series
+            }
         } else if (cache.retentionFilter?.target_entity || cache.retentionFilter?.returning_entity) {
             mergedQuery.series = [
                 ...(cache.retentionFilter.target_entity


### PR DESCRIPTION
## Problem

See this Slack thread https://posthog.slack.com/archives/C0368RPHLQH/p1705587408655359

## Changes

This PR temporarily deactivates the query cache for series for retention and lifecycle insights. A proper fix needs untangling of the `RetentionEntity` type, which currently has both a `type` and a `kind`. I'd like to do that after https://github.com/PostHog/posthog/pull/19800 is in.

## How did you test this code?

Navigating between insight types