### PR TITLE
fix: paths for some scenes

### DIFF
--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -94,6 +94,7 @@ export const sceneConfigurations: Record<Scene, SceneConfig> = {
         projectBased: true,
         name: 'Data management',
         activityScope: ActivityScope.DATA_MANAGEMENT,
+        defaultDocsPath: '/docs/data',
     },
     [Scene.EventDefinition]: {
         projectBased: true,
@@ -128,7 +129,7 @@ export const sceneConfigurations: Record<Scene, SceneConfig> = {
         projectBased: true,
         name: 'Person',
         activityScope: ActivityScope.PERSON,
-        defaultDocsPath: '/docs/session-replay',
+        defaultDocsPath: '/docs/data/persons',
     },
     [Scene.PersonsManagement]: {
         projectBased: true,
@@ -173,6 +174,7 @@ export const sceneConfigurations: Record<Scene, SceneConfig> = {
     [Scene.FeatureFlags]: {
         projectBased: true,
         name: 'Feature flags',
+        defaultDocsPath: '/docs/feature-flags',
         activityScope: ActivityScope.FEATURE_FLAG,
     },
     [Scene.FeatureFlag]: {
@@ -183,7 +185,7 @@ export const sceneConfigurations: Record<Scene, SceneConfig> = {
     [Scene.Surveys]: {
         projectBased: true,
         name: 'Surveys',
-        defaultDocsPath: '/docs/feature-flags/creating-feature-flags',
+        defaultDocsPath: '/docs/surveys',
         activityScope: ActivityScope.SURVEY,
     },
     [Scene.Survey]: {
@@ -200,7 +202,7 @@ export const sceneConfigurations: Record<Scene, SceneConfig> = {
     [Scene.DataWarehouse]: {
         projectBased: true,
         name: 'Data warehouse',
-        defaultDocsPath: '/docs/feature-flags/creating-feature-flags',
+        defaultDocsPath: '/docs/data-warehouse',
     },
     [Scene.DataWarehouseExternal]: {
         projectBased: true,


### PR DESCRIPTION
## Problem

Docs paths were wrong for some scenes, causing the wrong docs to be shown 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Fixes the paths

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
