### PR TITLE
fix(date-range): tooltip

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -922,13 +922,13 @@ export function dateFilterToText(
         if (dateOption && counter) {
             let date = null
             switch (dateOption) {
-                case 'quarters':
+                case 'quarter':
                     date = dayjs().subtract(counter * 3, 'M')
                     break
-                case 'months':
+                case 'month':
                     date = dayjs().subtract(counter, 'M')
                     break
-                case 'weeks':
+                case 'week':
                     date = dayjs().subtract(counter * 7, 'd')
                     break
                 default:

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -917,7 +917,7 @@ export function dateFilterToText(
     }
 
     if (dateFrom) {
-        const dateOption = dateOptionsMap[dateFrom.slice(-1)]
+        const dateOption: (typeof dateOptionsMap)[keyof typeof dateOptionsMap] = dateOptionsMap[dateFrom.slice(-1)]
         const counter = parseInt(dateFrom.slice(1, -1))
         if (dateOption && counter) {
             let date = null


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/9177 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/12856)

The "days till now" selector had an incorrect tooltip value. It would always show the range in days, no matter the selected unit.

## Changes

Fixes it:

<img width="401" alt="image" src="https://github.com/PostHog/posthog/assets/53387/79a76978-213d-4e81-9ba9-3393448c1628">


## How did you test this code?

Clicking in the browser