### PR TITLE
ci: Don't treat unordered lists as empty PR description content

### DIFF
--- a/.github/workflows/lint-new-pr.yml
+++ b/.github/workflows/lint-new-pr.yml
@@ -16,7 +16,7 @@ jobs:
               run: |
                   FILTERED_BODY=$( \
                       sed -r -e \
-                      '/^(\.\.\.)|(\*)|(#+ )|(- )|(<!--)|(👉)/d' \
+                      '/^(\.\.\.)|(\*)|(#+ )|(<!--)|(👉)/d' \
                       <<< $RAW_BODY \
                   )
                   echo "::debug::Filtered PR body to $FILTERED_BODY"


### PR DESCRIPTION
## Problem

Empty PR detection complained a bit too much, like [here](https://github.com/PostHog/posthog/pull/19864). [See internal thread.](https://posthog.slack.com/archives/C02E3BKC78F/p1705668981772279)

## Changes

Fixes the case where unordered lists were treated as empty PR description content, causing descriptions composed only out of lists to be marked as empty.
