### PR TITLE
feat(ingestion): report empty batches in consumed_batch_size histogram

### DIFF
--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -197,12 +197,14 @@ export const startBatchConsumer = async ({
 
                 if (!messages) {
                     status.debug('🔁', 'main_loop_empty_batch', { cause: 'undefined' })
+                    consumerBatchSize.labels({ topic, groupId }).observe(0)
                     continue
                 }
 
                 status.debug('🔁', 'main_loop_consumed', { messagesLength: messages.length })
                 if (!messages.length) {
                     status.debug('🔁', 'main_loop_empty_batch', { cause: 'empty' })
+                    consumerBatchSize.labels({ topic, groupId }).observe(0)
                     continue
                 }
 


### PR DESCRIPTION
## Problem

Overflow is slowed down by its rdk consumer, and looping on empty batches. Let's measure this

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
