### PR TITLE
fix: Remove webhook body stringify

### DIFF
--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -106,7 +106,7 @@ async function runSingleTeamPluginComposeWebhook(
 
             const request = await trackedFetch(webhook.url, {
                 method: webhook.method || 'POST',
-                body: JSON.stringify(webhook.body, undefined, 4),
+                body: webhook.body,
                 headers: webhook.headers || { 'Content-Type': 'application/json' },
                 timeout: hub.EXTERNAL_REQUEST_TIMEOUT_MS,
             })


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Some endpoints might not want the data to be JSON.stringified, but some other format, so this belongs to the app code and we should trust the app to send us an already JSON.stringified body if needed

Currently there are 3 apps using composeWebhook - all of them do `JSON.stringify` already

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
