### PR TITLE
fix: pipeline apps management page hide out of sync while loading

### DIFF
--- a/frontend/src/scenes/pipeline/AppsManagement.tsx
+++ b/frontend/src/scenes/pipeline/AppsManagement.tsx
@@ -34,6 +34,7 @@ export function AppsManagement(): JSX.Element {
         shouldNotBeGlobalPlugins,
         globalPlugins,
         localPlugins,
+        pluginsLoading,
     } = useValues(appsManagementLogic)
     const { isDev, isCloudOrDev } = useValues(preflightLogic)
 
@@ -43,7 +44,10 @@ export function AppsManagement(): JSX.Element {
 
     return (
         <div className="pipeline-apps-management-scene">
+            {/* When plugins are still loading we don't know yet if any apps are out of sync
+            with the global state, so skip this section for smooter user experience */}
             {isCloudOrDev &&
+                !pluginsLoading &&
                 (missingGlobalPlugins.length > 0 ||
                     shouldBeGlobalPlugins.length > 0 ||
                     shouldNotBeGlobalPlugins.length > 0) && <OutOfSyncApps />}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
I've noticed how it's annoying that on intial load I see all the plugins being missing, but the problem simply is that we haven't loaded the plugins yet - hide the whole section while we don't have enough info about it.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
