### PR TITLE
feat(ui): add tooltip to autoload switch

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
@@ -18,6 +18,7 @@ export interface LemonSwitchProps {
     disabledReason?: string | null | false
     'data-attr'?: string
     icon?: React.ReactElement | null
+    tooltip?: string | null
     handleContent?: React.ReactElement | null
     'aria-label'?: string
 }
@@ -37,6 +38,7 @@ export function LemonSwitch({
     label,
     labelClassName,
     icon,
+    tooltip,
     'data-attr': dataAttr,
     'aria-label': ariaLabel,
     handleContent,
@@ -53,6 +55,8 @@ export function LemonSwitch({
     if (disabledReason) {
         disabled = true // Support `disabledReason` while maintaining compatibility with `disabled`
         tooltipContent = <span className="italic">{disabledReason}</span>
+    } else if (tooltip) {
+        tooltipContent = <span>{tooltip}</span>
     }
     let buttonComponent = (
         <button

--- a/frontend/src/queries/nodes/DataNode/AutoLoad.tsx
+++ b/frontend/src/queries/nodes/DataNode/AutoLoad.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch/LemonSwitch'
 import { useEffect } from 'react'
 
-import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { AUTOLOAD_INTERVAL, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 
 export function AutoLoad(): JSX.Element {
     const { autoLoadToggled } = useValues(dataNodeLogic)
@@ -25,6 +25,7 @@ export function AutoLoad(): JSX.Element {
                 label="Automatically load new events"
                 checked={autoLoadToggled}
                 onChange={toggleAutoLoad}
+                tooltip={`Load new events every ${AUTOLOAD_INTERVAL / 1000} seconds.`}
             />
         </div>
     )

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -53,7 +53,7 @@ export interface DataNodeLogicProps {
     doNotLoad?: boolean
 }
 
-const AUTOLOAD_INTERVAL = 30000
+export const AUTOLOAD_INTERVAL = 30000
 const LOAD_MORE_ROWS_LIMIT = 10000
 
 const queryEqual = (a: DataNode, b: DataNode): boolean => {


### PR DESCRIPTION
## Problem

It's not clear how often the autoload runs.

## Changes

Adds a tooltip showing the autoload interval.

<img width="394" alt="Screenshot 2024-01-19 at 17 29 16" src="https://github.com/PostHog/posthog/assets/1851359/af6ed842-3507-4ce6-8d27-0323ff01b642">

## How did you test this code?

:eyes: