### PR TITLE
feat(web-analytics): Add custom_name to web analytics graphs

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -370,6 +370,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                                 kind: NodeKind.EventsNode,
                                                 math: BaseMathType.UniqueUsers,
                                                 name: '$pageview',
+                                                custom_name: 'Unique visitors',
                                             },
                                         ],
                                         trendsFilter: {
@@ -400,6 +401,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                                 kind: NodeKind.EventsNode,
                                                 math: BaseMathType.TotalCount,
                                                 name: '$pageview',
+                                                custom_name: 'Page views',
                                             },
                                         ],
                                         trendsFilter: {
@@ -430,6 +432,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                                 kind: NodeKind.EventsNode,
                                                 math: BaseMathType.UniqueSessions,
                                                 name: '$pageview',
+                                                custom_name: 'Sessions',
                                             },
                                         ],
                                         trendsFilter: {


### PR DESCRIPTION
## Problem
Labels are confusing. [Internal thread.](https://posthog.slack.com/archives/C05LJK1N3CP/p1705677339524589)
![image](https://github.com/PostHog/posthog/assets/2056078/fd848490-10df-4fd1-9b25-9d47138e9ee6)

## Changes

Set a `custom_name` for the series which matches the title of that tile.

<img width="916" alt="Screenshot 2024-01-19 at 17 50 34" src="https://github.com/PostHog/posthog/assets/2056078/d6a9d775-2b59-4c7a-90ca-a8c4f932dc49">

## How did you test this code?

Ran it manually, attached a screenshot.
