### PR TITLE
fix(web-analytics): Fix sampling banner

### DIFF
--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -32,16 +32,19 @@ export function WebOverview(props: { query: WebOverviewQuery; cachedResults?: An
 
     const webOverviewQueryResponse = response as WebOverviewQueryResponse | undefined
 
+    const samplingRate = webOverviewQueryResponse?.samplingRate
+
     return (
         <>
             <EvenlyDistributedRows className="w-full gap-x-2 gap-y-8" minWidthRems={8}>
                 {webOverviewQueryResponse?.results?.map((item) => <WebOverviewItemCell key={item.key} item={item} />) ||
                     []}
             </EvenlyDistributedRows>
-            {webOverviewQueryResponse?.samplingRate ? (
+            {samplingRate && !(samplingRate.numerator === 1 && (samplingRate.denominator ?? 1) === 1) ? (
                 <LemonBanner type="info" className="my-4">
-                    These results using a sampling factor of {webOverviewQueryResponse.samplingRate.numerator}/
-                    {webOverviewQueryResponse.samplingRate.denominator}. Sampling is currently in beta.
+                    These results using a sampling factor of {samplingRate.numerator}
+                    {samplingRate.denominator ?? 1 !== 1 ? `/${samplingRate.denominator}` : ''}. Sampling is currently
+                    in beta.
                 </LemonBanner>
             ) : null}
         </>


### PR DESCRIPTION
## Problem

The sampling banner can show `1/` if there's no sampling.

## Changes

Only show the banner if there's meaningful sampling happening

## How did you test this code?

<img width="1408" alt="Screenshot 2024-01-19 at 18 10 12" src="https://github.com/PostHog/posthog/assets/2056078/7415b8c7-a7bf-4250-866b-08d02a5542c5">

<img width="1154" alt="Screenshot 2024-01-19 at 18 03 37" src="https://github.com/PostHog/posthog/assets/2056078/4aea1bee-0868-4aa5-8acf-396b59515a5f">
