### PR TITLE
fix: unparseable lines reporting

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -78,7 +78,9 @@ export const parseEncodedSnapshots = async (
                 }
             })
         } catch (e) {
-            unparseableLines.push(l)
+            if (typeof l === 'string') {
+                unparseableLines.push(l)
+            }
             return []
         }
     })

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -85,7 +85,7 @@ export const parseEncodedSnapshots = async (
 
     if (unparseableLines.length) {
         const extra = {
-            sessionId,
+            playbackSessionId: sessionId,
             totalLineCount: lineCount,
             unparseableLinesCount: unparseableLines.length,
             exampleLines: unparseableLines.slice(0, 3),

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -53,7 +53,9 @@ export const parseEncodedSnapshots = async (
     if (!postHogEEModule && withMobileTransformer) {
         postHogEEModule = await posthogEE()
     }
-    return items.flatMap((l) => {
+    const lineCount = items.length
+    const unparseableLines: string[] = []
+    const parsedLines = items.flatMap((l) => {
         if (!l) {
             // blob files have an empty line at the end
             return []
@@ -76,14 +78,26 @@ export const parseEncodedSnapshots = async (
                 }
             })
         } catch (e) {
-            posthog.capture('session recording had unparseable line', {
-                sessionId,
-                line: l,
-            })
-            captureException(e)
+            unparseableLines.push(l)
             return []
         }
     })
+
+    if (unparseableLines.length) {
+        const extra = {
+            sessionId,
+            totalLineCount: lineCount,
+            unparseableLinesCount: unparseableLines.length,
+            exampleLines: unparseableLines.slice(0, 3),
+        }
+        posthog.capture('session recording had unparseable lines', extra)
+        captureException(new Error('session recording had unparseable lines'), {
+            tags: { feature: 'session-recording-snapshot-processing' },
+            extra,
+        })
+    }
+
+    return parsedLines
 }
 
 const getHrefFromSnapshot = (snapshot: RecordingSnapshot): string | undefined => {


### PR DESCRIPTION
Had a report of playback freezing https://posthoghelp.zendesk.com/agent/tickets/9164 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/14945)

Of note is many pending calls to sentry 

My theory (and I can't get the recording locally to check) is that there are many unparseable lines in the recording, we're doing lots of reporting of that error, and that's slowing us down.

Even so, we don't need 10 messages when there are 10 unparseable lines...

Let's rule it out and noise it down a little by reporting whether there were unparseable lines once