### PR TITLE
fix(insights): correct incompleteness offset timezone handling

### DIFF
--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -153,8 +153,12 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
                 if (results[0]?.days === undefined) {
                     return 0
                 }
-                const startDate = dayjs().startOf(interval ?? 'd')
-                const startIndex = results[0].days.findIndex((day: string) => dayjs(day) >= startDate)
+                const startDate = dayjs()
+                    .tz('utc', true)
+                    .startOf(interval ?? 'd')
+                const startIndex = results[0].days.findIndex((day: string) => {
+                    return dayjs(day).tz('utc', true) >= startDate
+                })
 
                 if (startIndex !== undefined && startIndex !== -1) {
                     return startIndex - results[0].days.length


### PR DESCRIPTION
## Problem

Change the system timezone to something with a large negative offset e.g. "Adamstown - Pitcairn Islands". Observe that in a hourly insight you will see a large amount of incomplete datums. This is not correct and only the last interval is incomplete.

![image](https://github.com/PostHog/posthog/assets/1851359/d5e18e4b-52d6-4a94-8b67-4596a07b82fd)

## Changes

This PR treats the dates as UTC local, fixing the issue.

## How did you test this code?

Tested an example before and after