### PR TITLE
fix: add patches to exclusions in dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,3 +38,4 @@
 !plugin-transpiler/*.*
 !test-runner-jest.config.js
 !test-runner-jest-environment.js
+!patches


### PR DESCRIPTION
fixes #19895 

adding patches directory didn't break out build but if just running `docker build -t image .` then you couldn't build because the docker ignore file excluded the new patches directory 🤷 