### PR TITLE
fix(hogql): Fix live compare sort by padding int values to 3 digits

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1685,6 +1685,7 @@ export function flattenObject(ob: Record<string, any>): Record<string, any> {
 
                 let j = i
                 if (i.match(/\d+/)) {
+                    // Pad integer values for better sorting
                     j = i.padStart(3, '0')
                 }
 

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1683,7 +1683,12 @@ export function flattenObject(ob: Record<string, any>): Record<string, any> {
                     continue
                 }
 
-                toReturn[i + '.' + x] = flatObject[x]
+                let j = i
+                if (i.match(/\d+/)) {
+                    j = i.padStart(3, '0')
+                }
+
+                toReturn[j + '.' + x] = flatObject[x]
             }
         } else {
             toReturn[i] = ob[i]


### PR DESCRIPTION
## Problem

Sorting could be better

<img width="515" alt="image" src="https://github.com/PostHog/posthog/assets/59713/428c2fe9-cfa9-43ca-8baf-a2a44bda77a1">



## Changes

- pad all int values

## How did you test this code?

- 👀 
