### PR TITLE
fix: Respect .dockerignore in depot builds

### DIFF
--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -20,6 +20,9 @@ outputs:
 runs:
     using: 'composite'
     steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
         - name: Set up Depot CLI
           uses: depot/setup-action@v1
 
@@ -32,6 +35,7 @@ runs:
           id: build
           uses: depot/build-push-action@v1
           with:
+              context: .
               buildx-fallback: false # buildx is so slow it's better to just fail
               tags: ${{ steps.emit.outputs.tag }}
               platforms: linux/amd64,linux/arm64

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -59,6 +59,7 @@ jobs:
               id: build
               uses: depot/build-push-action@v1
               with:
+                  context: .
                   buildx-fallback: false # the fallback is so slow it's better to just fail
                   push: true
                   tags: ${{ steps.aws-ecr.outputs.registry }}/pr-test:${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION

## Problem
See https://github.com/docker/build-push-action#git-context

Without including "context: ." .dockerignore is not processed

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
