### PR TITLE
feat: convert to insight

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -15,9 +15,6 @@ import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { JSONContent } from '@tiptap/core'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
-import { IconMagnifier } from 'lib/lemon-ui/icons'
-import { router } from 'kea-router'
-import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 
 const DEFAULT_QUERY: QuerySchema = {
     kind: NodeKind.DataTableNode,
@@ -37,7 +34,7 @@ const Component = ({
     const { query, nodeId } = attributes
     const nodeLogic = useMountedLogic(notebookNodeLogic)
     const { expanded } = useValues(nodeLogic)
-    const { setTitlePlaceholder, setActions } = useActions(nodeLogic)
+    const { setTitlePlaceholder } = useActions(nodeLogic)
     const summarizeInsight = useSummarizeInsight()
 
     useEffect(() => {
@@ -67,18 +64,6 @@ const Component = ({
         }
 
         setTitlePlaceholder(title)
-
-        const queryFilters = isInsightVizNode(query) ? queryNodeToFilter(query.source) : null
-
-        if (queryFilters) {
-            setActions([
-                {
-                    text: 'Create new insight',
-                    icon: <IconMagnifier />,
-                    onClick: () => router.actions.push(urls.insightNew(queryFilters)),
-                },
-            ])
-        }
     }, [query])
 
     const modifiedQuery = useMemo(() => {
@@ -241,7 +226,11 @@ export const NotebookNodeQuery = createPostHogWidgetNode<NotebookNodeQueryAttrib
         },
     },
     href: (attrs) =>
-        attrs.query.kind === NodeKind.SavedInsightNode ? urls.insightView(attrs.query.shortId) : undefined,
+        attrs.query.kind === NodeKind.SavedInsightNode
+            ? urls.insightView(attrs.query.shortId)
+            : isInsightVizNode(attrs.query)
+            ? urls.insightNew(undefined, undefined, attrs.query)
+            : undefined,
     Settings,
     pasteOptions: {
         find: urls.insightView('(.+)' as InsightShortId),

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -1,12 +1,12 @@
 import { Query } from '~/queries/Query/Query'
 import { DataTableNode, InsightQueryNode, InsightVizNode, NodeKind, QuerySchema } from '~/queries/schema'
 import { createPostHogWidgetNode } from 'scenes/notebooks/Nodes/NodeWrapper'
-import { AnyPartialFilterType, InsightLogicProps, InsightShortId, NotebookNodeType } from '~/types'
+import { InsightLogicProps, InsightShortId, NotebookNodeType } from '~/types'
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { useEffect, useMemo } from 'react'
 import { notebookNodeLogic } from './notebookNodeLogic'
 import { NotebookNodeProps, NotebookNodeAttributeProperties } from '../Notebook/utils'
-import { containsHogQLQuery, isHogQLQuery, isNodeWithSource } from '~/queries/utils'
+import { containsHogQLQuery, isHogQLQuery, isInsightVizNode, isNodeWithSource } from '~/queries/utils'
 import { LemonButton } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { urls } from 'scenes/urls'
@@ -17,6 +17,7 @@ import { JSONContent } from '@tiptap/core'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 import { IconMagnifier } from 'lib/lemon-ui/icons'
 import { router } from 'kea-router'
+import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 
 const DEFAULT_QUERY: QuerySchema = {
     kind: NodeKind.DataTableNode,
@@ -27,19 +28,6 @@ const DEFAULT_QUERY: QuerySchema = {
         after: '-24h',
         limit: 100,
     },
-}
-
-const generateFiltersFromQuery = (query: QuerySchema): AnyPartialFilterType | null => {
-    switch (query.kind) {
-        case NodeKind.InsightVizNode:
-            return query.source
-        case NodeKind.TrendsQuery:
-            return query
-        case NodeKind.HogQLQuery:
-            return query.filters || null
-        default:
-            return null
-    }
 }
 
 const Component = ({
@@ -80,7 +68,7 @@ const Component = ({
 
         setTitlePlaceholder(title)
 
-        const queryFilters = generateFiltersFromQuery(query)
+        const queryFilters = isInsightVizNode(query) ? queryNodeToFilter(query.source) : null
 
         if (queryFilters) {
             setActions([

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -67,10 +67,14 @@ export const urls = {
     batchExportEdit: (id: string): string => `/batch_exports/${id}/edit`,
     ingestionWarnings: (): string => '/data-management/ingestion-warnings',
     insights: (): string => '/insights',
-    insightNew: (filters?: AnyPartialFilterType, dashboardId?: DashboardType['id'] | null, query?: string): string =>
+    insightNew: (
+        filters?: AnyPartialFilterType,
+        dashboardId?: DashboardType['id'] | null,
+        query?: string | Record<string, any>
+    ): string =>
         combineUrl('/insights/new', dashboardId ? { dashboard: dashboardId } : {}, {
             ...(filters ? { filters } : {}),
-            ...(query ? { q: query } : {}),
+            ...(query ? { q: typeof query === 'string' ? query : JSON.stringify(query) } : {}),
         }).url,
     insightNewHogQL: (query: string): string =>
         urls.insightNew(


### PR DESCRIPTION
## Problem

Editing insights is somewhat limited in notebooks right now. It was suggested we add a way to convert a query into an insight.

## Changes

- Generate filters from the nodes `query` attribute
- Redirect from the notebook to the insight creation with the filters set
- Piggybacked off the existing actions rather than special casing this in the nodes "More" menu
<img width="855" alt="Screenshot 2024-01-22 at 15 53 52" src="https://github.com/PostHog/posthog/assets/6685876/c4c64861-569a-446a-a660-2c282e13e2d6">


## How did you test this code?

Manually