### PR TITLE
feat(hogql): add funnel event query

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -36,7 +36,7 @@ class FunnelEventQuery:
             sample=self._sample_expr(),
         )
 
-        where_exprs = [self._date_range_expr(), self._entity_expr(skip_entity_filter), self._properties_expr()]
+        where_exprs = [self._date_range_expr(), self._entity_expr(skip_entity_filter)] + self._properties_expr()
         where = ast.And(exprs=[expr for expr in where_exprs if expr is not None])
 
         stmt = ast.SelectQuery(

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -74,11 +74,9 @@ class FunnelEventQuery(FunnelQueryContext):
             aggregation_target = f'{self.EVENT_TABLE_ALIAS}."$group_{self.query.aggregation_group_type_index}"'
 
         # Aggregating by HogQL
-        elif (
-            self.funnelsFilter.funnel_aggregate_by_hogql and self.funnelsFilter.funnel_aggregate_by_hogql != "person_id"
-        ):
+        elif self.funnelsFilter.funnelAggregateByHogQL and self.funnelsFilter.funnelAggregateByHogQL != "person_id":
             aggregation_target = translate_hogql(
-                self.funnelsFilter.funnel_aggregate_by_hogql,
+                self.funnelsFilter.funnelAggregateByHogQL,
                 events_table_alias=self.EVENT_TABLE_ALIAS,
                 context=self.hogql_context,
             )

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -1,0 +1,134 @@
+from typing import List, Optional
+from posthog.hogql import ast
+from posthog.hogql.constants import LimitContext
+from posthog.hogql.hogql import translate_hogql
+from posthog.hogql.timings import HogQLTimings
+from posthog.hogql_queries.insights.funnels.funnel_query_context import FunnelQueryContext
+from posthog.models.team.team import Team
+from posthog.schema import FunnelsQuery, HogQLQueryModifiers
+
+
+class FunnelEventQuery(FunnelQueryContext):
+    EVENT_TABLE_ALIAS = "e"
+
+    def __init__(
+        self,
+        query: FunnelsQuery,
+        team: Team,
+        timings: Optional[HogQLTimings] = None,
+        modifiers: Optional[HogQLQueryModifiers] = None,
+        limit_context: Optional[LimitContext] = None,
+    ):
+        super().__init__(query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context)
+
+    def to_query(
+        self,
+        # entities=None,
+        # entity_name="events",
+        # skip_entity_filter=False,
+    ) -> ast.SelectQuery:
+        select: List[ast.Expr] = [
+            ast.Alias(alias="timestamp", expr=ast.Field(chain=[self.EVENT_TABLE_ALIAS, "timestamp"])),
+            ast.Alias(alias="aggregation_target", expr=ast.Field(chain=[self.aggregation_target_column()])),
+        ]
+
+        select_from = ast.JoinExpr(
+            table=ast.Field(chain=["events"]),
+            alias=self.EVENT_TABLE_ALIAS,
+            sample=self.sample_expr(),
+        )
+
+        where_exprs = [self.date_range_expr()]
+
+        # prop_query = self._get_prop_groups(
+        #     self._filter.property_groups,
+        #     person_properties_mode=get_person_properties_mode(self._team),
+        #     person_id_joined_alias=self._person_id_alias,
+        # )
+
+        # if not skip_entity_filter:
+        #     entity_query = self._get_entity_query(entities, entity_name)
+
+        # person_query = self._get_person_query()
+
+        # query = f"""
+        #     {self._get_person_ids_query()}
+        #     {person_query}
+        #     WHERE
+        #     {entity_query}
+        #     {prop_query}
+        # """
+        where = ast.And(exprs=where_exprs)
+
+        # return query, self.params
+        stmt = ast.SelectQuery(
+            select=select,
+            select_from=select_from,
+            where=where,
+        )
+        return stmt
+
+    def aggregation_target_column(self) -> str:
+        # Aggregating by group
+        if self.query.aggregation_group_type_index is not None:
+            aggregation_target = f'{self.EVENT_TABLE_ALIAS}."$group_{self.query.aggregation_group_type_index}"'
+
+        # Aggregating by HogQL
+        elif (
+            self.funnelsFilter.funnel_aggregate_by_hogql and self.funnelsFilter.funnel_aggregate_by_hogql != "person_id"
+        ):
+            aggregation_target = translate_hogql(
+                self.funnelsFilter.funnel_aggregate_by_hogql,
+                events_table_alias=self.EVENT_TABLE_ALIAS,
+                context=self.hogql_context,
+            )
+
+        # TODO: is this still relevant?
+        # # Aggregating by Distinct ID
+        # elif self._aggregate_users_by_distinct_id:
+        #     aggregation_target = f"{self.EVENT_TABLE_ALIAS}.distinct_id"
+
+        # Aggregating by Person ID
+        else:
+            aggregation_target = "person_id"
+
+        return aggregation_target
+
+    def sample_expr(self) -> ast.SampleExpr | None:
+        if self.query.samplingFactor is None:
+            return None
+        else:
+            return ast.SampleExpr(sample_value=ast.RatioExpr(left=ast.Constant(value=self.query.samplingFactor)))
+
+    def date_range_expr(self) -> ast.Expr:
+        return ast.And(
+            exprs=[
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=ast.Field(chain=[self.EVENT_TABLE_ALIAS, "timestamp"]),
+                    right=ast.Constant(value=self.query_date_range.date_from()),
+                ),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.LtEq,
+                    left=ast.Field(chain=[self.EVENT_TABLE_ALIAS, "timestamp"]),
+                    right=ast.Constant(value=self.query_date_range.date_to()),
+                ),
+            ]
+        )
+
+    # def _get_entity_query(self, entities=None, entity_name="events") -> Tuple[str, Dict[str, Any]]:
+    #     events: Set[Union[int, str, None]] = set()
+    #     entities_to_use = entities or self._filter.entities
+
+    #     for entity in entities_to_use:
+    #         if entity.type == TREND_FILTER_TYPE_ACTIONS:
+    #             action = entity.get_action()
+    #             events.update(action.get_step_events())
+    #         else:
+    #             events.add(entity.id)
+
+    #     # If selecting for "All events", disable entity pre-filtering
+    #     if None in events:
+    #         return "AND 1 = 1", {}
+
+    #     return f"AND event IN %({entity_name})s", {entity_name: sorted(list(events))}

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -41,21 +41,6 @@ class FunnelEventQuery(FunnelQueryContext):
         )
 
         where_exprs = [self._date_range_expr(), self._entity_expr(skip_entity_filter), self._properties_expr()]
-
-        # prop_query = self._get_prop_groups(
-        #     self._filter.property_groups,
-        #     person_properties_mode=get_person_properties_mode(self._team),
-        #     person_id_joined_alias=self._person_id_alias,
-        # )
-
-        # person_query = self._get_person_query()
-        # person_ids_query = self._get_person_ids_query()
-
-        # query = f"""
-        #     {person_ids_query}
-        #     {person_query}
-        #     WHERE
-        # """
         where = ast.And(exprs=[expr for expr in where_exprs if expr is not None])
 
         stmt = ast.SelectQuery(

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -1,14 +1,11 @@
-from typing import List, Optional, Set, Union
+from typing import List, Set, Union
 from posthog.hogql import ast
-from posthog.hogql.constants import LimitContext
 from posthog.hogql.hogql import translate_hogql
-from posthog.hogql.timings import HogQLTimings
 from posthog.hogql_queries.insights.funnels.funnel_query_context import FunnelQueryContext
 from posthog.hogql_queries.utils.date_range import DateRange
 from posthog.hogql_queries.utils.properties import Properties
 from posthog.models.action.action import Action
-from posthog.models.team.team import Team
-from posthog.schema import ActionsNode, EventsNode, FunnelsQuery, HogQLQueryModifiers
+from posthog.schema import ActionsNode, EventsNode
 from rest_framework.exceptions import ValidationError
 
 
@@ -19,15 +16,9 @@ class FunnelEventQuery:
 
     def __init__(
         self,
-        query: FunnelsQuery,
-        team: Team,
-        timings: Optional[HogQLTimings] = None,
-        modifiers: Optional[HogQLQueryModifiers] = None,
-        limit_context: Optional[LimitContext] = None,
+        context: FunnelQueryContext,
     ):
-        self.context = FunnelQueryContext(
-            query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context
-        )
+        self.context = context
 
     def to_query(
         self,

--- a/posthog/hogql_queries/insights/funnels/funnel_query_context.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_query_context.py
@@ -5,8 +5,6 @@ from posthog.hogql_queries.insights.query_context import QueryContext
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.team.team import Team
 from posthog.schema import FunnelsFilter, FunnelsQuery, HogQLQueryModifiers
-from posthog.hogql_queries.utils.query_date_range import QueryDateRange
-from datetime import datetime
 
 
 class FunnelQueryContext(QueryContext):
@@ -26,10 +24,5 @@ class FunnelQueryContext(QueryContext):
         self.funnelsFilter = self.query.funnelsFilter or FunnelsFilter()
 
     @cached_property
-    def query_date_range(self):
-        return QueryDateRange(
-            date_range=self.query.dateRange,
-            team=self.team,
-            interval=self.query.interval,
-            now=datetime.now(),
-        )
+    def max_steps(self) -> int:
+        return len(self.query.series)

--- a/posthog/hogql_queries/insights/funnels/funnel_query_context.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_query_context.py
@@ -1,0 +1,52 @@
+from typing import Optional
+from posthog.hogql.constants import LimitContext
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.modifiers import create_default_modifiers_for_team
+from posthog.hogql.timings import HogQLTimings
+from posthog.models.filters.mixins.utils import cached_property
+from posthog.models.team.team import Team
+from posthog.schema import FunnelsFilter, FunnelsQuery, HogQLQueryModifiers
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from datetime import datetime
+
+
+class FunnelQueryContext:
+    query: FunnelsQuery
+    team: Team
+    timings: HogQLTimings
+    modifiers: HogQLQueryModifiers
+    limit_context: LimitContext
+    hogql_context: HogQLContext
+
+    funnelsFilter: FunnelsFilter
+
+    def __init__(
+        self,
+        query: FunnelsQuery,
+        team: Team,
+        timings: Optional[HogQLTimings] = None,
+        modifiers: Optional[HogQLQueryModifiers] = None,
+        limit_context: Optional[LimitContext] = None,
+    ):
+        self.query = query
+        self.team = team
+        self.timings = timings or HogQLTimings()
+        self.limit_context = limit_context or LimitContext.QUERY
+        self.modifiers = create_default_modifiers_for_team(team, modifiers)
+        self.hogql_context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            timings=self.timings,
+            modifiers=self.modifiers,
+        )
+
+        self.funnelsFilter = self.query.funnelsFilter or FunnelsFilter()
+
+    @cached_property
+    def query_date_range(self):
+        return QueryDateRange(
+            date_range=self.query.dateRange,
+            team=self.team,
+            interval=self.query.interval,
+            now=datetime.now(),
+        )

--- a/posthog/hogql_queries/insights/funnels/funnel_query_context.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_query_context.py
@@ -1,8 +1,7 @@
 from typing import Optional
 from posthog.hogql.constants import LimitContext
-from posthog.hogql.context import HogQLContext
-from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.timings import HogQLTimings
+from posthog.hogql_queries.insights.query_context import QueryContext
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.team.team import Team
 from posthog.schema import FunnelsFilter, FunnelsQuery, HogQLQueryModifiers
@@ -10,14 +9,8 @@ from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from datetime import datetime
 
 
-class FunnelQueryContext:
+class FunnelQueryContext(QueryContext):
     query: FunnelsQuery
-    team: Team
-    timings: HogQLTimings
-    modifiers: HogQLQueryModifiers
-    limit_context: LimitContext
-    hogql_context: HogQLContext
-
     funnelsFilter: FunnelsFilter
 
     def __init__(
@@ -28,17 +21,7 @@ class FunnelQueryContext:
         modifiers: Optional[HogQLQueryModifiers] = None,
         limit_context: Optional[LimitContext] = None,
     ):
-        self.query = query
-        self.team = team
-        self.timings = timings or HogQLTimings()
-        self.limit_context = limit_context or LimitContext.QUERY
-        self.modifiers = create_default_modifiers_for_team(team, modifiers)
-        self.hogql_context = HogQLContext(
-            team_id=self.team.pk,
-            enable_select_queries=True,
-            timings=self.timings,
-            modifiers=self.modifiers,
-        )
+        super().__init__(query=query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context)
 
         self.funnelsFilter = self.query.funnelsFilter or FunnelsFilter()
 

--- a/posthog/hogql_queries/insights/query_context.py
+++ b/posthog/hogql_queries/insights/query_context.py
@@ -1,0 +1,41 @@
+from abc import ABC
+from typing import Optional
+from posthog.hogql.constants import LimitContext
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.modifiers import create_default_modifiers_for_team
+from posthog.hogql.timings import HogQLTimings
+from posthog.models.team.team import Team
+from posthog.schema import (
+    HogQLQueryModifiers,
+)
+
+from posthog.types import InsightQueryNode
+
+
+class QueryContext(ABC):
+    query: InsightQueryNode
+    team: Team
+    timings: HogQLTimings
+    modifiers: HogQLQueryModifiers
+    limit_context: LimitContext
+    hogql_context: HogQLContext
+
+    def __init__(
+        self,
+        query: InsightQueryNode,
+        team: Team,
+        timings: Optional[HogQLTimings] = None,
+        modifiers: Optional[HogQLQueryModifiers] = None,
+        limit_context: Optional[LimitContext] = None,
+    ):
+        self.query = query
+        self.team = team
+        self.timings = timings or HogQLTimings()
+        self.limit_context = limit_context or LimitContext.QUERY
+        self.modifiers = create_default_modifiers_for_team(team, modifiers)
+        self.hogql_context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            timings=self.timings,
+            modifiers=self.modifiers,
+        )

--- a/posthog/hogql_queries/insights/query_context.py
+++ b/posthog/hogql_queries/insights/query_context.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from typing import Optional
+from datetime import datetime
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.modifiers import create_default_modifiers_for_team
@@ -19,6 +20,7 @@ class QueryContext(ABC):
     modifiers: HogQLQueryModifiers
     limit_context: LimitContext
     hogql_context: HogQLContext
+    now: datetime
 
     def __init__(
         self,
@@ -27,6 +29,7 @@ class QueryContext(ABC):
         timings: Optional[HogQLTimings] = None,
         modifiers: Optional[HogQLQueryModifiers] = None,
         limit_context: Optional[LimitContext] = None,
+        now: Optional[datetime] = None,
     ):
         self.query = query
         self.team = team
@@ -39,3 +42,4 @@ class QueryContext(ABC):
             timings=self.timings,
             modifiers=self.modifiers,
         )
+        self.now = now or datetime.now()

--- a/posthog/hogql_queries/utils/date_range.py
+++ b/posthog/hogql_queries/utils/date_range.py
@@ -1,0 +1,45 @@
+from typing import Optional
+from posthog.hogql import ast
+from posthog.hogql_queries.insights.query_context import QueryContext
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+
+
+# TODO: Refactor QueryDateRange to conform to this wrapper, if we decide for the context / utils approach
+class DateRange:
+    context: QueryContext
+
+    def __init__(
+        self,
+        context: QueryContext,
+    ) -> None:
+        self.context = context
+
+        return
+
+    def to_expr(self, field: Optional[ast.Field] = None) -> ast.Expr:
+        team, query, now = self.context.team, self.context.query, self.context.now
+
+        if not field:
+            field = ast.Field(chain=["timestamp"])
+
+        date_range = QueryDateRange(
+            date_range=query.dateRange,
+            team=team,
+            interval=query.interval,
+            now=now,
+        )
+
+        return ast.And(
+            exprs=[
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=field,
+                    right=ast.Constant(value=date_range.date_from()),
+                ),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.LtEq,
+                    left=field,
+                    right=ast.Constant(value=date_range.date_to()),
+                ),
+            ]
+        )

--- a/posthog/hogql_queries/utils/date_range.py
+++ b/posthog/hogql_queries/utils/date_range.py
@@ -1,16 +1,16 @@
 from typing import Optional
 from posthog.hogql import ast
-from posthog.hogql_queries.insights.query_context import QueryContext
+from posthog.hogql_queries.insights.funnels.funnel_query_context import FunnelQueryContext
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 
 
 # TODO: Refactor QueryDateRange to conform to this wrapper, if we decide for the context / utils approach
 class DateRange:
-    context: QueryContext
+    context: FunnelQueryContext
 
     def __init__(
         self,
-        context: QueryContext,
+        context: FunnelQueryContext,
     ) -> None:
         self.context = context
 

--- a/posthog/hogql_queries/utils/properties.py
+++ b/posthog/hogql_queries/utils/properties.py
@@ -1,0 +1,68 @@
+from typing import List
+from posthog.hogql import ast
+from posthog.hogql.property import property_to_expr
+from posthog.models.team.team import Team
+from posthog.schema import (
+    CohortPropertyFilter,
+    ElementPropertyFilter,
+    EmptyPropertyFilter,
+    EventPropertyFilter,
+    FeaturePropertyFilter,
+    GroupPropertyFilter,
+    HogQLPropertyFilter,
+    PersonPropertyFilter,
+    PropertyGroupFilter,
+    RecordingDurationFilter,
+    SessionPropertyFilter,
+)
+
+PropertiesType = (
+    List[
+        EventPropertyFilter
+        | PersonPropertyFilter
+        | ElementPropertyFilter
+        | SessionPropertyFilter
+        | CohortPropertyFilter
+        | RecordingDurationFilter
+        | GroupPropertyFilter
+        | FeaturePropertyFilter
+        | HogQLPropertyFilter
+        | EmptyPropertyFilter
+    ]
+    | PropertyGroupFilter
+    | None
+)
+
+
+class Properties:
+    team: Team
+    properties: PropertiesType
+    filterTestAccounts: bool | None
+
+    def __init__(
+        self,
+        team: Team,
+        properties: PropertiesType,
+        filterTestAccounts: bool | None,
+    ) -> None:
+        self.team = team
+        self.properties = properties
+        self.filterTestAccounts = filterTestAccounts
+
+    def to_exprs(self) -> List[ast.Expr]:
+        exprs: List[ast.Expr] = []
+
+        # Filter Test Accounts
+        if (
+            self.filterTestAccounts
+            and isinstance(self.team.test_account_filters, list)
+            and len(self.team.test_account_filters) > 0
+        ):
+            for property in self.team.test_account_filters:
+                exprs.append(property_to_expr(property, self.team))
+
+        # Properties
+        if self.properties is not None and self.properties != []:
+            exprs.append(property_to_expr(self.properties, self.team))
+
+        return exprs


### PR DESCRIPTION
## Problem

This PR converts the [FunnelEventQuery.get_query()](https://github.com/PostHog/posthog/blob/master/posthog/queries/funnels/funnel_event_query.py) method to HogQL (see https://github.com/PostHog/posthog/issues/19925 for where that query fits in the overall picture).

There are two things where I'd like your thoughts on:
1. It would be great to have a standard way of sharing common query -> expression methods. See https://github.com/PostHog/posthog/pull/19911#discussion_r1464710170
2. Part of the interface is an abstract `QueryContext` that has a concrete implementation for each insight e.g. `FunnelQueryContext` and is supposed to capture all context for the queries including calculated properties like `max_steps` in this PR. Does it make sense to add this additional layer of abstraction or should all this go into the `HogQLContext` and it's `values`?

## Changes

See above.

## How did you test this code?

There are no tests for this query and I haven't added any. It might be good to add unit tests, but I'd like to get a full funnels insight working before that (so that the overall picture makes sense).