### PR TITLE
feat(hogql): Use query paginator on HogQLQuery if no limit given

### DIFF
--- a/frontend/src/queries/nodes/DataNode/LoadNext.tsx
+++ b/frontend/src/queries/nodes/DataNode/LoadNext.tsx
@@ -3,13 +3,13 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { DataNode } from '~/queries/schema'
-import { isActorsQuery, isPersonsNode } from '~/queries/utils'
+import { isActorsQuery, isHogQLQuery, isPersonsNode } from '~/queries/utils'
 
 interface LoadNextProps {
     query: DataNode
 }
 export function LoadNext({ query }: LoadNextProps): JSX.Element {
-    const { canLoadNextData, nextDataLoading, numberOfRows } = useValues(dataNodeLogic)
+    const { canLoadNextData, nextDataLoading, numberOfRows, hasMoreData } = useValues(dataNodeLogic)
     const { loadNextData } = useActions(dataNodeLogic)
 
     return (
@@ -25,6 +25,7 @@ export function LoadNext({ query }: LoadNextProps): JSX.Element {
                     ? 'event'
                     : 'events'}
                 {canLoadNextData ? '. Click to load more.' : '. Reached the end of results.'}
+                {isHogQLQuery(query) && !canLoadNextData && hasMoreData && ' Try adding or adjusting a LIMIT clause.'}
             </LemonButton>
         </div>
     )

--- a/frontend/src/queries/nodes/DataNode/LoadNext.tsx
+++ b/frontend/src/queries/nodes/DataNode/LoadNext.tsx
@@ -9,23 +9,31 @@ interface LoadNextProps {
     query: DataNode
 }
 export function LoadNext({ query }: LoadNextProps): JSX.Element {
-    const { canLoadNextData, nextDataLoading, numberOfRows, hasMoreData } = useValues(dataNodeLogic)
+    const { canLoadNextData, nextDataLoading, numberOfRows, hasMoreData, dataLimit } = useValues(dataNodeLogic)
     const { loadNextData } = useActions(dataNodeLogic)
 
     return (
         <div className="m-2 flex items-center">
             <LemonButton onClick={loadNextData} loading={nextDataLoading} fullWidth center disabled={!canLoadNextData}>
-                Showing {canLoadNextData || numberOfRows === 1 ? '' : 'all '}
-                {numberOfRows === 1 ? 'one' : numberOfRows}{' '}
-                {isPersonsNode(query) || isActorsQuery(query)
-                    ? numberOfRows === 1
-                        ? 'person'
-                        : 'people'
-                    : numberOfRows === 1
-                    ? 'event'
-                    : 'events'}
-                {canLoadNextData ? '. Click to load more.' : '. Reached the end of results.'}
-                {isHogQLQuery(query) && !canLoadNextData && hasMoreData && ' Try adding or adjusting a LIMIT clause.'}
+                {isHogQLQuery(query) && !canLoadNextData && hasMoreData && dataLimit ? (
+                    <>
+                        <br />
+                        Default limit of {dataLimit} rows reached. Try adding a LIMIT clause to adjust.
+                    </>
+                ) : (
+                    <>
+                        Showing {canLoadNextData || numberOfRows === 1 ? '' : 'all '}
+                        {numberOfRows === 1 ? 'one' : numberOfRows}{' '}
+                        {isPersonsNode(query) || isActorsQuery(query)
+                            ? numberOfRows === 1
+                                ? 'person'
+                                : 'people'
+                            : numberOfRows === 1
+                            ? 'event'
+                            : 'events'}
+                        {canLoadNextData ? '. Click to load more.' : '. Reached the end of results.'}
+                    </>
+                )}
             </LemonButton>
         </div>
     )

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -429,13 +429,20 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
         hasMoreData: [
             (s) => [s.response],
             (response): boolean => {
-                if (!response) {
+                if (!response?.hasMore) {
                     return false
                 }
-                if ('hasMore' in response) {
-                    return response.hasMore
+                return response.hasMore
+            },
+        ],
+        dataLimit: [
+            // get limit from response
+            (s) => [s.response],
+            (response): number | null => {
+                if (!response?.limit) {
+                    return null
                 }
-                return false
+                return response.limit
             },
         ],
         backToSourceQuery: [

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -426,6 +426,18 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
             (s) => [s.nextQuery, s.isShowingCachedResults],
             (nextQuery, isShowingCachedResults) => (isShowingCachedResults ? false : !!nextQuery),
         ],
+        hasMoreData: [
+            (s) => [s.response],
+            (response): boolean => {
+                if (!response) {
+                    return false
+                }
+                if ('hasMore' in response) {
+                    return response.hasMore
+                }
+                return false
+            },
+        ],
         backToSourceQuery: [
             (s) => [s.query],
             (query): InsightVizNode | null => {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1750,13 +1750,22 @@
                     },
                     "type": "array"
                 },
+                "hasMore": {
+                    "type": "boolean"
+                },
                 "hogql": {
                     "description": "Generated HogQL query",
                     "type": "string"
                 },
+                "limit": {
+                    "type": "integer"
+                },
                 "modifiers": {
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
+                },
+                "offset": {
+                    "type": "integer"
                 },
                 "query": {
                     "description": "Input query string",
@@ -2786,13 +2795,22 @@
                             },
                             "type": "array"
                         },
+                        "hasMore": {
+                            "type": "boolean"
+                        },
                         "hogql": {
                             "description": "Generated HogQL query",
                             "type": "string"
                         },
+                        "limit": {
+                            "type": "integer"
+                        },
                         "modifiers": {
                             "$ref": "#/definitions/HogQLQueryModifiers",
                             "description": "Modifiers used when performing the query"
+                        },
+                        "offset": {
+                            "type": "integer"
                         },
                         "query": {
                             "description": "Input query string",

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -186,6 +186,11 @@ export interface HogQLQueryResponse {
     explain?: string[]
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiers
+    hasMore?: boolean
+    /** @asType integer */
+    limit?: number
+    /** @asType integer */
+    offset?: number
 }
 
 /** Filters object that will be converted to a HogQL {filters} placeholder */

--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -149,9 +149,10 @@
   FROM events
   WHERE equals(events.team_id, 2)
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1
   '''
 # ---
 # name: TestQuery.test_full_hogql_query_materialized
@@ -163,9 +164,10 @@
   FROM events
   WHERE equals(events.team_id, 2)
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1
   '''
 # ---
 # name: TestQuery.test_full_hogql_query_view
@@ -177,9 +179,10 @@
   FROM events
   WHERE equals(events.team_id, 2)
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1
   '''
 # ---
 # name: TestQuery.test_full_hogql_query_view.1
@@ -195,9 +198,10 @@
      FROM events
      WHERE equals(events.team_id, 2)
      ORDER BY toTimeZone(events.timestamp, 'UTC') ASC) AS event_view
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1
   '''
 # ---
 # name: TestQuery.test_hogql_property_filter

--- a/posthog/clickhouse/client/test/__snapshots__/test_execute_async.ambr
+++ b/posthog/clickhouse/client/test/__snapshots__/test_execute_async.ambr
@@ -2,8 +2,9 @@
 # name: ClickhouseClientTestCase.test_async_query_client
   '''
   SELECT plus(1, 1)
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=600,
-                     allow_experimental_object_type=1
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=600,
+                    allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/hogql_query_runner.py
+++ b/posthog/hogql_queries/hogql_query_runner.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Callable, cast
 
 from posthog.clickhouse.client.connection import Workload
 from posthog.hogql import ast
@@ -46,7 +47,10 @@ class HogQLQueryRunner(QueryRunner):
         paginator = None
         if not query.limit:
             paginator = HogQLHasMorePaginator.from_limit_context(limit_context=self.limit_context)
-        func = execute_hogql_query if paginator is None else paginator.execute_hogql_query
+        func = cast(
+            Callable[..., HogQLQueryResponse],
+            execute_hogql_query if paginator is None else paginator.execute_hogql_query,
+        )
         response = func(
             query_type="HogQLQuery",
             query=query,

--- a/posthog/hogql_queries/hogql_query_runner.py
+++ b/posthog/hogql_queries/hogql_query_runner.py
@@ -22,9 +22,6 @@ class HogQLQueryRunner(QueryRunner):
     query: HogQLQuery
     query_type = HogQLQuery
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def to_query(self) -> ast.SelectQuery:
         if self.timings is None:
             self.timings = HogQLTimings()

--- a/posthog/hogql_queries/insights/paginators.py
+++ b/posthog/hogql_queries/insights/paginators.py
@@ -17,7 +17,7 @@ class HogQLHasMorePaginator:
     Takes care of setting the limit and offset on the query.
     """
 
-    def __init__(self, *, limit: Optional[int], offset: Optional[int]):
+    def __init__(self, *, limit: Optional[int] = None, offset: Optional[int] = None):
         self.response: Optional[HogQLQueryResponse] = None
         self.results: list[Any] = []
         self.limit = limit if limit and limit > 0 else DEFAULT_RETURNED_ROWS
@@ -25,7 +25,7 @@ class HogQLHasMorePaginator:
 
     @classmethod
     def from_limit_context(
-        cls, *, limit_context: LimitContext, limit: Optional[int], offset: Optional[int]
+        cls, *, limit_context: LimitContext, limit: Optional[int] = None, offset: Optional[int] = None
     ) -> "HogQLHasMorePaginator":
         max_rows = get_max_limit_for_context(limit_context)
         default_rows = get_default_limit_for_context(limit_context)

--- a/posthog/hogql_queries/test/test_hogql_query_runner.py
+++ b/posthog/hogql_queries/test/test_hogql_query_runner.py
@@ -63,6 +63,7 @@ class TestHogQLQueryRunner(ClickhouseTestMixin, APIBaseTest):
     def test_default_hogql_query_with_limit(self):
         runner = self._create_runner(HogQLQuery(query="select event from events limit 5"))
         response = runner.calculate()
+        assert response.results is not None
         self.assertEqual(len(response.results), 5)
         self.assertNotIn("hasMore", response)
 

--- a/posthog/hogql_queries/test/test_hogql_query_runner.py
+++ b/posthog/hogql_queries/test/test_hogql_query_runner.py
@@ -57,6 +57,15 @@ class TestHogQLQueryRunner(ClickhouseTestMixin, APIBaseTest):
         response = runner.calculate()
         self.assertEqual(response.results[0][0], 10)
 
+        self.assertEqual(response.hasMore, False)
+        self.assertIsNotNone(response.limit)
+
+    def test_default_hogql_query_with_limit(self):
+        runner = self._create_runner(HogQLQuery(query="select event from events limit 5"))
+        response = runner.calculate()
+        self.assertEqual(len(response.results), 5)
+        self.assertNotIn("hasMore", response)
+
     def test_hogql_query_filters(self):
         runner = self._create_runner(
             HogQLQuery(

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1017,10 +1017,13 @@ class HogQLQueryResponse(BaseModel):
         default=None, description="Query error. Returned only if 'explain' is true. Throws an error otherwise."
     )
     explain: Optional[List[str]] = Field(default=None, description="Query explanation output")
+    hasMore: Optional[bool] = None
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query")
+    limit: Optional[int] = None
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    offset: Optional[int] = None
     query: Optional[str] = Field(default=None, description="Input query string")
     results: Optional[List] = Field(default=None, description="Query results")
     timings: Optional[List[QueryTiming]] = Field(
@@ -1148,10 +1151,13 @@ class QueryResponseAlternative6(BaseModel):
         default=None, description="Query error. Returned only if 'explain' is true. Throws an error otherwise."
     )
     explain: Optional[List[str]] = Field(default=None, description="Query explanation output")
+    hasMore: Optional[bool] = None
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query")
+    limit: Optional[int] = None
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    offset: Optional[int] = None
     query: Optional[str] = Field(default=None, description="Input query string")
     results: Optional[List] = Field(default=None, description="Query results")
     timings: Optional[List[QueryTiming]] = Field(


### PR DESCRIPTION
## Problem

Raw HogQLQueries get an implicit default limit when nothing is written by the user.
This is not obvious and not mentioned, so you are left with 100 rows and that's it.

Fixes #19903

## Changes

- if no limit in the SQL is given, use the `HasMorePaginator` to find out if there are more results above the limit at all
- adjust the messaging in this case (and only this)
- future: we can think of adding "load more" here as well... but then we need to dabble into the limits and maybe this also runs counter to the manual SQL nature of the whole thing?

<img width="1093" alt="image" src="https://github.com/PostHog/posthog/assets/59713/bb0c9ce0-7aba-4e31-86f0-44392e6386d8">


## How did you test this code?

- 👀 
