### PR TITLE
feat(persons): revert to urls with distinct id

### DIFF
--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -233,9 +233,9 @@ export function renderColumn(
 
         if (isActorsQuery(query.source) && value) {
             displayProps.person = value
-            displayProps.href = value.id
-                ? urls.personByUUID(value.id)
-                : urls.personByDistinctId(value.distinct_ids?.[0] ?? '-')
+            displayProps.href = value.distinct_ids?.[0]
+                ? urls.personByDistinctId(value.distinct_ids[0])
+                : urls.personByUUID(value.id)
         }
 
         return <PersonDisplay {...displayProps} />


### PR DESCRIPTION
## Problem

The ClickHouse persons page (with a second Postgres query to get person id-s) had swapped out the URLs to the persons themselves to use the person UUID instead of distinct_id.

This made the experience worse, as we were doing one-off lookups from ClickHouse.

## Changes

Revert to how it currently is. One-off lookups happen with Postgres. 

This feels like the last thing before releasing the new ClickHouse-based persons query to everyone. We've been using it for a while now within the company without issues.

## How did you test this code?

Compared loading times of both pages in production. Essentially with the `persons-hogql-query` flag on and off, I clicked on various persons in the list. With the `/person/:distinct_id` route the person opened in a second. With the `/persons/:uuid` route, in 5. 