### PR TITLE
fix: recording viewed event accuracy

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -295,13 +295,14 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                 duration: Math.round(performance.now() - cache.snapshotsStartTime),
             }
 
-            actions.reportViewed()
             actions.reportUsageIfFullyLoaded()
 
             const nextSourceToLoad = sources?.find((s) => !s.loaded)
 
             if (nextSourceToLoad) {
                 actions.loadRecordingSnapshots(nextSourceToLoad)
+            } else {
+                actions.reportViewed()
             }
         },
         loadEventsSuccess: () => {


### PR DESCRIPTION
## Problem

It looks like the `recording viewed` event is firing every time a source successfully loads

## Changes

Only fire the `recording viewed` event for the first source

|Before|After|
|----|----|
| <img width="918" alt="Screenshot 2024-01-23 at 14 22 00" src="https://github.com/PostHog/posthog/assets/6685876/3c0d8ca3-cc2c-4610-87fd-3a1d56139050"> | <img width="937" alt="Screenshot 2024-01-23 at 14 21 26" src="https://github.com/PostHog/posthog/assets/6685876/9364c18e-320e-4d8f-943d-afcabdb83ff1"> |

## How did you test this code?

Wth logging
