### PR TITLE
feat(trends): Adds the printed hogql string to the trends query response object

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -41,7 +41,7 @@ from posthog.models.property import PropertyName, TableColumn
 from posthog.models.team.team import WeekStartDay
 from posthog.models.team import Team
 from posthog.models.utils import UUIDT
-from posthog.schema import InCohortVia, MaterializationMode
+from posthog.schema import HogQLQueryModifiers, InCohortVia, MaterializationMode
 from posthog.utils import PersonOnEventsMode
 
 
@@ -58,13 +58,13 @@ def team_id_guard_for_table(table_type: Union[ast.TableType, ast.TableAliasType]
     )
 
 
-def to_printed_hogql(query: ast.Expr, team: Team) -> str:
+def to_printed_hogql(query: ast.Expr, team: Team, modifiers: Optional[HogQLQueryModifiers] = None) -> str:
     """Prints the HogQL query without mutating the node"""
     return print_ast(
         clone_expr(query),
         dialect="hogql",
         context=HogQLContext(
-            team_id=team.pk, enable_select_queries=True, modifiers=create_default_modifiers_for_team(team)
+            team_id=team.pk, enable_select_queries=True, modifiers=create_default_modifiers_for_team(team, modifiers)
         ),
         pretty=True,
     )

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -145,7 +145,7 @@ class TrendsQueryRunner(QueryRunner):
                     resonse_hogql_query.select_queries.extend(query.select_queries)
 
         with self.timings.measure("printing_hogql_for_response"):
-            response_hogql = to_printed_hogql(resonse_hogql_query, self.team)
+            response_hogql = to_printed_hogql(resonse_hogql_query, self.team, self.modifiers)
 
         res_matrix: List[List[Any] | Any | None] = [None] * len(queries)
         timings_matrix: List[List[QueryTiming] | None] = [None] * len(queries)

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -16,6 +16,7 @@ from posthog.caching.utils import is_stale
 
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
+from posthog.hogql.printer import to_printed_hogql
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.timings import HogQLTimings
 from posthog.hogql_queries.insights.trends.breakdown_values import (
@@ -90,7 +91,7 @@ class TrendsQueryRunner(QueryRunner):
 
     def to_query(self) -> List[ast.SelectQuery | ast.SelectUnionQuery]:  # type: ignore
         queries = []
-        with self.timings.measure("trends_query"):
+        with self.timings.measure("trends_to_query"):
             for series in self.series:
                 if not series.is_previous_period_series:
                     query_date_range = self.query_date_range
@@ -111,7 +112,7 @@ class TrendsQueryRunner(QueryRunner):
 
     def to_actors_query(self) -> ast.SelectQuery | ast.SelectUnionQuery:
         queries = []
-        with self.timings.measure("trends_persons_query"):
+        with self.timings.measure("trends_to_actors_query"):
             for series in self.series:
                 if not series.is_previous_period_series:
                     query_date_range = self.query_date_range
@@ -132,6 +133,19 @@ class TrendsQueryRunner(QueryRunner):
 
     def calculate(self):
         queries = self.to_query()
+
+        if len(queries) == 1:
+            resonse_hogql_query = queries[0]
+        else:
+            resonse_hogql_query = ast.SelectUnionQuery(select_queries=[])
+            for query in queries:
+                if isinstance(query, ast.SelectQuery):
+                    resonse_hogql_query.select_queries.append(query)
+                else:
+                    resonse_hogql_query.select_queries.extend(query.select_queries)
+
+        with self.timings.measure("printing_hogql_for_response"):
+            response_hogql = to_printed_hogql(resonse_hogql_query, self.team)
 
         res_matrix: List[List[Any] | Any | None] = [None] * len(queries)
         timings_matrix: List[List[QueryTiming] | None] = [None] * len(queries)
@@ -202,9 +216,10 @@ class TrendsQueryRunner(QueryRunner):
             and self.query.trendsFilter.formula is not None
             and self.query.trendsFilter.formula != ""
         ):
-            res = self.apply_formula(self.query.trendsFilter.formula, res)
+            with self.timings.measure("apply_formula"):
+                res = self.apply_formula(self.query.trendsFilter.formula, res)
 
-        return TrendsQueryResponse(results=res, timings=timings)
+        return TrendsQueryResponse(results=res, timings=timings, hogql=response_hogql)
 
     def build_series_response(self, response: HogQLQueryResponse, series: SeriesWithExtras, series_count: int):
         if response.results is None:


### PR DESCRIPTION
## Problem
- We dont return the printed hogql in the trends response object (like we do for the lifecycle response)

## Changes
- Returns the printed hogql in the response
- Adds a few more timings to the trends code
- Renames a couple of the timing keys

## How did you test this code?
- In the browser