### PR TITLE
fix: account urls are not per project

### DIFF
--- a/frontend/src/lib/utils/router-utils.test.ts
+++ b/frontend/src/lib/utils/router-utils.test.ts
@@ -1,0 +1,12 @@
+import { addProjectIdIfMissing } from 'lib/utils/router-utils'
+
+describe('router-utils', () => {
+    it('does not redirect account URLs to a project URL', () => {
+        const altered = addProjectIdIfMissing('/account/two_factor', 123)
+        expect(altered).toEqual('/account/two_factor')
+    })
+    it('does not allow account urls to have a project url', () => {
+        const altered = addProjectIdIfMissing('/project/123/account/two_factor', 123)
+        expect(altered).toEqual('/account/two_factor')
+    })
+})

--- a/frontend/src/lib/utils/router-utils.ts
+++ b/frontend/src/lib/utils/router-utils.ts
@@ -11,6 +11,7 @@ const pathsWithoutProjectId = [
     'login',
     'signup',
     'create-organization',
+    'account',
 ]
 
 function isPathWithoutProjectId(path: string): boolean {


### PR DESCRIPTION
see this thread in community https://posthog.com/questions/2-factor-settings-and-support-is-buggered

we missed the `/account/` urls as part of https://github.com/PostHog/posthog/pull/13474

adds it to the exclusion list