### PR TITLE
fix(web-analytics): Remove bounce rate from most stats tables

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -4473,6 +4473,9 @@
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
                 },
+                "includeBounceRate": {
+                    "type": "boolean"
+                },
                 "includeScrollDepth": {
                     "type": "boolean"
                 },

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -908,6 +908,7 @@ export interface WebStatsTableQuery extends WebAnalyticsQueryBase {
     breakdownBy: WebStatsBreakdown
     response?: WebStatsTableQueryResponse
     includeScrollDepth?: boolean
+    includeBounceRate?: boolean // automatically sets includeScrollDepth to true
 }
 export interface WebStatsTableQueryResponse extends QueryResponse {
     results: unknown[]

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -907,8 +907,8 @@ export interface WebStatsTableQuery extends WebAnalyticsQueryBase {
     kind: NodeKind.WebStatsTableQuery
     breakdownBy: WebStatsBreakdown
     response?: WebStatsTableQueryResponse
-    includeScrollDepth?: boolean
-    includeBounceRate?: boolean // automatically sets includeScrollDepth to true
+    includeScrollDepth?: boolean // automatically sets includeBounceRate to true
+    includeBounceRate?: boolean
 }
 export interface WebStatsTableQueryResponse extends QueryResponse {
     results: unknown[]

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -471,6 +471,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                         breakdownBy: WebStatsBreakdown.Page,
                                         dateRange,
                                         includeScrollDepth: statusCheck?.isSendingPageLeavesScroll,
+                                        includeBounceRate: true,
                                         sampling,
                                     },
                                     embedded: false,

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -460,7 +460,6 @@ posthog/hogql_queries/insights/lifecycle_query_runner.py:0: note: Consider using
 posthog/hogql_queries/insights/lifecycle_query_runner.py:0: error: Argument 1 to "sorted" has incompatible type "list[Any] | None"; expected "Iterable[Any]"  [arg-type]
 posthog/hogql_queries/insights/lifecycle_query_runner.py:0: error: Item "SelectUnionQuery" of "SelectQuery | SelectUnionQuery" has no attribute "select_from"  [union-attr]
 posthog/hogql_queries/insights/lifecycle_query_runner.py:0: error: Item "None" of "JoinExpr | Any | None" has no attribute "sample"  [union-attr]
-posthog/hogql_queries/web_analytics/web_overview.py:0: error: Value of type "list[Any] | None" is not indexable  [index]
 posthog/hogql_queries/legacy_compatibility/process_insight.py:0: error: Incompatible types in assignment (expression has type "PathFilter", variable has type "RetentionFilter")  [assignment]
 posthog/hogql_queries/legacy_compatibility/process_insight.py:0: error: Incompatible types in assignment (expression has type "StickinessFilter", variable has type "RetentionFilter")  [assignment]
 posthog/hogql_queries/legacy_compatibility/process_insight.py:0: error: Incompatible types in assignment (expression has type "Filter", variable has type "RetentionFilter")  [assignment]

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -58,8 +58,8 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(
             [
-                ["/", 2, 2, 0],
-                ["/login", 1, 1, 0],
+                ["/", 2, 2],
+                ["/login", 1, 1],
             ],
             results,
         )
@@ -76,9 +76,9 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(
             [
-                ["/", 2, 2, 0],
-                ["/login", 1, 1, 0],
-                ["/docs", 1, 1, 0],
+                ["/", 2, 2],
+                ["/login", 1, 1],
+                ["/docs", 1, 1],
             ],
             results,
         )

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -110,6 +110,7 @@ CROSS JOIN sessions_query
             timings=self.timings,
             modifiers=self.modifiers,
         )
+        assert response.results
 
         row = response.results[0]
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1393,6 +1393,7 @@ class WebStatsTableQuery(BaseModel):
     )
     breakdownBy: WebStatsBreakdown
     dateRange: Optional[DateRange] = None
+    includeBounceRate: Optional[bool] = None
     includeScrollDepth: Optional[bool] = None
     kind: Literal["WebStatsTableQuery"] = "WebStatsTableQuery"
     properties: List[Union[EventPropertyFilter, PersonPropertyFilter]]


### PR DESCRIPTION
## Problem

This is mostly a short-term performance band-aid, and it wasn't adding much to begin with.

## Changes

Don't calculate the bounce rate in the stats tables. IMO it's not super critical for people to know the breakdown on the bounce rate, although it's be good to bring this back when we do the larger performance improvements.

Before:
<img width="702" alt="Screenshot 2024-01-23 at 22 26 38" src="https://github.com/PostHog/posthog/assets/2056078/aae13c4a-c29a-4cbb-ac55-f44449413faa">

After:
<img width="705" alt="Screenshot 2024-01-23 at 22 25 44" src="https://github.com/PostHog/posthog/assets/2056078/e409de41-cd73-433c-aa17-ef69f029a867">

(long term I'd like to add a % of total visitors)

## How did you test this code?

Updated the existing tests, ran it manually