### PR TITLE
feat(hogql): Added stickiness filters to the live compare

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_trends.py
+++ b/ee/clickhouse/views/test/test_clickhouse_trends.py
@@ -109,7 +109,7 @@ def test_includes_only_intervals_within_range(client: Client):
                 ],
             ),
         )
-        assert trends == {
+        assert trends == trends | {
             "is_cached": False,
             "last_refresh": "2021-09-20T16:00:00Z",
             "next": None,
@@ -182,7 +182,7 @@ def test_can_specify_number_of_smoothing_intervals(client: Client):
             ),
         )
 
-        assert interval_3_trend == {
+        assert interval_3_trend == interval_3_trend | {
             "is_cached": False,
             "last_refresh": "2021-09-20T16:00:00Z",
             "next": None,
@@ -224,7 +224,7 @@ def test_can_specify_number_of_smoothing_intervals(client: Client):
             ),
         )
 
-        assert interval_2_trend == {
+        assert interval_2_trend == interval_2_trend | {
             "is_cached": False,
             "last_refresh": "2021-09-20T16:00:00Z",
             "next": None,
@@ -266,7 +266,7 @@ def test_can_specify_number_of_smoothing_intervals(client: Client):
             ),
         )
 
-        assert interval_1_trend == {
+        assert interval_1_trend == interval_1_trend | {
             "is_cached": False,
             "last_refresh": "2021-09-20T16:00:00Z",
             "next": None,
@@ -350,7 +350,7 @@ def test_smoothing_intervals_copes_with_null_values(client: Client):
             ),
         )
 
-        assert interval_3_trend == {
+        assert interval_3_trend == interval_3_trend | {
             "is_cached": False,
             "last_refresh": "2021-09-20T16:00:00Z",
             "next": None,
@@ -392,7 +392,7 @@ def test_smoothing_intervals_copes_with_null_values(client: Client):
             ),
         )
 
-        assert interval_1_trend == {
+        assert interval_1_trend == interval_1_trend | {
             "is_cached": False,
             "last_refresh": "2021-09-20T16:00:00Z",
             "next": None,

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -216,7 +216,7 @@ export async function query<N extends DataNode = DataNode>(
                 (hogQLInsightsFunnelsFlagEnabled && isFunnelsQuery(queryNode))
             ) {
                 if (hogQLInsightsLiveCompareEnabled) {
-                    let legacyResponse
+                    let legacyResponse: any
                     ;[response, legacyResponse] = await Promise.all([
                         api.query(queryNode, methodOptions, queryId, refresh),
                         fetchLegacyInsights(),
@@ -230,7 +230,7 @@ export async function query<N extends DataNode = DataNode>(
                         const order = { new: 1, returning: 2, resurrecting: 3, dormant: 4 }
                         res1.sort((a: any, b: any) => order[a.status] - order[b.status])
                         res2.sort((a: any, b: any) => order[a.status] - order[b.status])
-                    } else if (isTrendsQuery(queryNode)) {
+                    } else if (isTrendsQuery(queryNode) || isStickinessQuery(queryNode)) {
                         res1 = res1?.map((n: any) => ({
                             ...n,
                             filter: undefined,
@@ -245,12 +245,34 @@ export async function query<N extends DataNode = DataNode>(
                         }))
                     }
 
+                    const getTimingDiff = (): undefined | { diff: number; legacy: number; hogql: number } => {
+                        const hogQLTimings = response?.timings
+                        const legacyTimings = legacyResponse?.timings
+
+                        if (!hogQLTimings || !legacyTimings) {
+                            return undefined
+                        }
+
+                        const hogqlTotalTime =
+                            hogQLTimings.find((n: { k: string; t: number }) => n['k'] === '.')?.t ?? 0
+                        const legacyTotalTime =
+                            legacyTimings.find((n: { k: string; t: number }) => n['k'] === '.')?.t ?? 0
+
+                        return {
+                            diff: hogqlTotalTime - legacyTotalTime,
+                            legacy: legacyTotalTime,
+                            hogql: hogqlTotalTime,
+                        }
+                    }
+
+                    const timingDiff = getTimingDiff()
+
                     const results = flattenObject(res1)
                     const legacyResults = flattenObject(res2)
                     const sortedKeys = Array.from(new Set([...Object.keys(results), ...Object.keys(legacyResults)]))
                         .filter((key) => !key.includes('.persons_urls.') && !key.includes('.people_url'))
                         .sort()
-                    const tableData = [['', 'key', 'HOGQL', 'LEGACY']]
+                    const tableData: any[] = [['', 'key', 'HOGQL', 'LEGACY']]
                     let matchCount = 0
                     let mismatchCount = 0
                     for (const key of sortedKeys) {
@@ -266,6 +288,16 @@ export async function query<N extends DataNode = DataNode>(
                             legacyResults[key],
                         ])
                     }
+
+                    if (timingDiff) {
+                        tableData.push([
+                            timingDiff.diff <= 0 ? '🚀' : '🐌',
+                            'timingDiff',
+                            timingDiff.hogql,
+                            timingDiff.legacy,
+                        ])
+                    }
+
                     const symbols = mismatchCount === 0 ? '🍀🍀🍀' : '🏎️🏎️🏎'
                     // eslint-disable-next-line no-console
                     console.log(`${symbols} Insight Race ${symbols}`, {
@@ -276,6 +308,7 @@ export async function query<N extends DataNode = DataNode>(
                         equal: mismatchCount === 0,
                         response,
                         legacyResponse,
+                        timingDiff,
                     })
                     // eslint-disable-next-line no-console
                     console.groupCollapsed(
@@ -292,6 +325,13 @@ export async function query<N extends DataNode = DataNode>(
                         query: queryNode,
                         equal: mismatchCount === 0,
                         mismatch_count: mismatchCount,
+                        ...(timingDiff
+                            ? {
+                                  timing_diff: timingDiff.diff,
+                                  timing_hogqL: timingDiff.hogql,
+                                  timing_legacy: timingDiff.legacy,
+                              }
+                            : {}),
                     })
                 } else {
                     response = await api.query(queryNode, methodOptions, queryId, refresh)

--- a/posthog/api/test/test_insight_funnels.py
+++ b/posthog/api/test/test_insight_funnels.py
@@ -598,7 +598,8 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
         response_data.pop("last_refresh")
         self.assertEqual(
             response_data,
-            {
+            response_data
+            | {
                 "is_cached": False,
                 "timezone": "UTC",
                 "result": {
@@ -656,7 +657,8 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
         response_data.pop("last_refresh")
         self.assertEqual(
             response_data,
-            {
+            response_data
+            | {
                 "is_cached": False,
                 "timezone": "UTC",
                 "result": {
@@ -714,7 +716,8 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
         response_data.pop("last_refresh")
         self.assertEqual(
             response_data,
-            {
+            response_data
+            | {
                 "is_cached": False,
                 "timezone": "UTC",
                 "result": {

--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -136,7 +136,7 @@ class StickinessQueryRunner(QueryRunner):
 
             interval_addition = ast.Call(
                 name=f"toInterval{date_range.interval_name.capitalize()}",
-                args=[ast.Constant(value=2)],
+                args=[ast.Constant(value=1)],
             )
 
             select_query = parse_select(
@@ -313,7 +313,7 @@ class StickinessQueryRunner(QueryRunner):
 
     def intervals_num(self):
         delta = self.query_date_range.date_to() - self.query_date_range.date_from()
-        return delta.days + 2
+        return delta.days + 1
 
     def setup_series(self) -> List[SeriesWithExtras]:
         series_with_extras = [

--- a/posthog/hogql_queries/insights/test/test_stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_stickiness_query_runner.py
@@ -237,7 +237,7 @@ class TestStickinessQueryRunner(APIBaseTest):
 
         result = response.results[0]
 
-        assert result["days"] == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        assert result["days"] == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     def test_count(self):
         self._create_test_events()
@@ -267,7 +267,6 @@ class TestStickinessQueryRunner(APIBaseTest):
             "8 days",
             "9 days",
             "10 days",
-            "11 days",
         ]
 
     def test_interval_hour(self):
@@ -277,13 +276,13 @@ class TestStickinessQueryRunner(APIBaseTest):
 
         result = response.results[0]
 
-        hours_labels = [f"{hour + 1} hour{'' if hour == 0 else 's'}" for hour in range(26)]
-        hours_data = [0] * 26
+        hours_labels = [f"{hour + 1} hour{'' if hour == 0 else 's'}" for hour in range(25)]
+        hours_data = [0] * 25
         hours_data[0] = 2
 
         assert result["label"] == "$pageview"
         assert result["labels"] == hours_labels
-        assert result["days"] == [hour + 1 for hour in range(26)]
+        assert result["days"] == [hour + 1 for hour in range(25)]
         assert result["data"] == hours_data
 
     def test_interval_day(self):
@@ -305,9 +304,8 @@ class TestStickinessQueryRunner(APIBaseTest):
             "8 days",
             "9 days",
             "10 days",
-            "11 days",
         ]
-        assert result["days"] == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        assert result["days"] == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         assert result["data"] == [
             0,
             0,
@@ -319,7 +317,6 @@ class TestStickinessQueryRunner(APIBaseTest):
             0,
             1,
             0,
-            0,
         ]
 
     def test_interval_week(self):
@@ -330,9 +327,9 @@ class TestStickinessQueryRunner(APIBaseTest):
         result = response.results[0]
 
         assert result["label"] == "$pageview"
-        assert result["labels"] == ["1 week", "2 weeks", "3 weeks", "4 weeks"]
-        assert result["days"] == [1, 2, 3, 4]
-        assert result["data"] == [0, 0, 2, 0]
+        assert result["labels"] == ["1 week", "2 weeks", "3 weeks"]
+        assert result["days"] == [1, 2, 3]
+        assert result["data"] == [0, 0, 2]
 
     def test_interval_month(self):
         self._create_test_events()
@@ -342,9 +339,9 @@ class TestStickinessQueryRunner(APIBaseTest):
         result = response.results[0]
 
         assert result["label"] == "$pageview"
-        assert result["labels"] == ["1 month", "2 months"]
-        assert result["days"] == [1, 2]
-        assert result["data"] == [2, 0]
+        assert result["labels"] == ["1 month"]
+        assert result["days"] == [1]
+        assert result["data"] == [2]
 
     def test_property_filtering(self):
         self._create_test_events()
@@ -366,7 +363,6 @@ class TestStickinessQueryRunner(APIBaseTest):
             0,
             1,
             0,
-            0,
         ]
 
     def test_property_filtering_hogql(self):
@@ -386,7 +382,6 @@ class TestStickinessQueryRunner(APIBaseTest):
             0,
             0,
             1,
-            0,
             0,
         ]
 
@@ -415,7 +410,6 @@ class TestStickinessQueryRunner(APIBaseTest):
             0,
             1,
             0,
-            0,
         ]
 
     def test_any_event(self):
@@ -442,7 +436,6 @@ class TestStickinessQueryRunner(APIBaseTest):
             0,
             0,
             1,
-            0,
             0,
         ]
 
@@ -472,7 +465,6 @@ class TestStickinessQueryRunner(APIBaseTest):
             0,
             0,
             1,
-            0,
             0,
         ]
 
@@ -508,7 +500,6 @@ class TestStickinessQueryRunner(APIBaseTest):
             0,
             1,
             0,
-            0,
         ]
 
     def test_group_aggregations(self):
@@ -534,7 +525,6 @@ class TestStickinessQueryRunner(APIBaseTest):
             0,
             1,
             0,
-            0,
         ]
 
     def test_hogql_aggregations(self):
@@ -558,6 +548,5 @@ class TestStickinessQueryRunner(APIBaseTest):
             0,
             0,
             1,
-            0,
             0,
         ]


### PR DESCRIPTION
## Problem
- We want to be able to compare stickiness queries using the insights compare flag in prod
- We also want to be able to track performance differences between legacy and hogql insights

## Changes
- Adds a filter for stickiness props in for the live compare feature
- Fixes a bug with stickiness queries showing too many extra days/weeks/months on the graph
- Adds timings to all legacy insights - this just wraps the endpoint with a `HogQLTimings` object, and returns the timings in the response
- Reports the legacy and hogql timings (+ the difference) to the console on the live compare flag, and back to PostHog in the compare flag

<img width="610" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/be479aee-9fcf-4d74-9f54-7cf32484b269">

<img width="591" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/fc31055b-03a5-4395-b7b6-d328124de175">


## How did you test this code?
- Browser clicking