### PR TITLE
fix(flags): Allow fractions for flag rollout

### DIFF
--- a/cypress/e2e/surveys.cy.ts
+++ b/cypress/e2e/surveys.cy.ts
@@ -96,7 +96,7 @@ describe('Surveys', () => {
         cy.get('[data-attr=prop-val] .ant-select-selector').click({ force: true })
         cy.get('[data-attr=prop-val-0]').click({ force: true })
 
-        cy.get('[data-attr="rollout-percentage"]').type('{backspace}')
+        cy.get('[data-attr="rollout-percentage"]').type('{backspace}100')
 
         // save
         cy.get('[data-attr="save-survey"]').click()

--- a/cypress/e2e/surveys.cy.ts
+++ b/cypress/e2e/surveys.cy.ts
@@ -96,7 +96,7 @@ describe('Surveys', () => {
         cy.get('[data-attr=prop-val] .ant-select-selector').click({ force: true })
         cy.get('[data-attr=prop-val-0]').click({ force: true })
 
-        cy.get('[data-attr="rollout-percentage"]').type('{backspace}100')
+        cy.get('[data-attr="rollout-percentage"]').type('100')
 
         // save
         cy.get('[data-attr="save-survey"]').click()

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -975,8 +975,11 @@ function FeatureFlagRollout({ readOnly }: { readOnly?: boolean }): JSX.Element {
                                                         max={100}
                                                         value={value}
                                                         onChange={(changedValue) => {
-                                                            if (changedValue !== null && changedValue !== undefined) {
-                                                                const valueInt = parseInt(changedValue.toString())
+                                                            if (changedValue !== null) {
+                                                                const valueInt =
+                                                                    changedValue !== undefined
+                                                                        ? parseInt(changedValue.toString())
+                                                                        : 0
                                                                 if (!isNaN(valueInt)) {
                                                                     onChange(valueInt)
                                                                 }

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -253,13 +253,14 @@ export function FeatureFlagReleaseConditions({
                                 <LemonInput
                                     data-attr="rollout-percentage"
                                     type="number"
-                                    className="mx-2"
+                                    className="mx-2 max-w-30"
                                     onChange={(value): void => {
-                                        updateConditionSet(index, value || 100)
+                                        updateConditionSet(index, value === undefined ? 0 : value)
                                     }}
                                     value={group.rollout_percentage != null ? group.rollout_percentage : 100}
                                     min={0}
                                     max={100}
+                                    step="any"
                                     suffix={<span>%</span>}
                                 />{' '}
                                 of <b>{aggregationTargetName}</b> in this set.{' '}

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -1026,21 +1026,6 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                 return effectiveRolloutPercentage * (affectedUsers[index] / effectiveTotalUsers)
             },
         ],
-        approximateTotalBlastRadius: [
-            (s) => [s.computeBlastRadiusPercentage, s.featureFlag],
-            (computeBlastRadiusPercentage, featureFlag) => {
-                if (!featureFlag || !featureFlag.filters.groups) {
-                    return 0
-                }
-
-                let total = 0
-                featureFlag.filters.groups.forEach((group, index) => {
-                    total += computeBlastRadiusPercentage(group.rollout_percentage, index)
-                })
-
-                return Math.min(total, 100)
-            },
-        ],
         filteredDashboards: [
             (s) => [s.dashboards, s.featureFlag],
             (dashboards, featureFlag) => {


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/19888

Moving off of antd borked two things:

1. Fractions were disallowed
2. Impossible to set 0 to a release condition

This PR fixes both things
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Run locally, ensure you can input fractions, and set to 0.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
