### PR TITLE
feat: show browser offline status in the inspector list

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
@@ -2,7 +2,7 @@ import { TZLabel } from '@posthog/apps-common'
 import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { IconGauge, IconTerminal, IconUnverifiedEvent } from 'lib/lemon-ui/icons'
+import { IconGauge, IconOffline, IconTerminal, IconUnverifiedEvent } from 'lib/lemon-ui/icons'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { ceilMsToClosestSecond, colonDelimitedDuration } from 'lib/utils'
 import { useEffect } from 'react'
@@ -35,6 +35,10 @@ const typeToIconAndDescription = {
     [SessionRecordingPlayerTab.NETWORK]: {
         Icon: IconGauge,
         tooltip: 'Network event',
+    },
+    ['offline-status']: {
+        Icon: IconOffline,
+        tooltip: 'browser went offline or returned online',
     },
 }
 const PLAYER_INSPECTOR_LIST_ITEM_MARGIN = 4
@@ -157,6 +161,10 @@ export function PlayerInspectorListItem({
                     <ItemConsoleLog item={item} {...itemProps} />
                 ) : item.type === SessionRecordingPlayerTab.EVENTS ? (
                     <ItemEvent item={item} {...itemProps} />
+                ) : item.type === 'offline-status' ? (
+                    <div className="flex items-start p-2 text-xs">
+                        {item.offline ? 'Browser went offline' : 'Browser returned online'}
+                    </div>
                 ) : null}
 
                 {isExpanded ? (

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -1,4 +1,4 @@
-import { eventWithTime } from '@rrweb/types'
+import { customEvent, eventWithTime } from '@rrweb/types'
 import FuseClass from 'fuse.js'
 import { actions, connect, events, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
@@ -69,7 +69,16 @@ export type InspectorListItemPerformance = InspectorListItemBase & {
     data: PerformanceEvent
 }
 
-export type InspectorListItem = InspectorListItemEvent | InspectorListItemConsole | InspectorListItemPerformance
+export type InspectorListOfflineStatusChange = InspectorListItemBase & {
+    type: 'offline-status'
+    offline: boolean
+}
+
+export type InspectorListItem =
+    | InspectorListItemEvent
+    | InspectorListItemConsole
+    | InspectorListItemPerformance
+    | InspectorListOfflineStatusChange
 
 export interface PlayerInspectorLogicProps extends SessionRecordingPlayerLogicProps {
     matchingEventsMatchType?: MatchingEventsMatchType
@@ -191,6 +200,41 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
             },
         ],
 
+        offlineStatusChanges: [
+            (s) => [s.start, s.sessionPlayerData],
+            (start, sessionPlayerData): InspectorListOfflineStatusChange[] => {
+                const logs: InspectorListOfflineStatusChange[] = []
+
+                const startMs = start?.valueOf() ?? 0
+                Object.entries(sessionPlayerData.snapshotsByWindowId).forEach(([windowId, snapshots]) => {
+                    snapshots.forEach((snapshot: eventWithTime) => {
+                        if (
+                            snapshot.type === 5 // RRWeb custom event type
+                        ) {
+                            const customEvent = snapshot as customEvent
+                            const tag = customEvent.data.tag
+
+                            if (['browser offline', 'browser online'].includes(tag)) {
+                                const timestamp = dayjs(snapshot.timestamp)
+                                const timeInRecording = timestamp.valueOf() - startMs
+                                logs.push({
+                                    type: 'offline-status',
+                                    offline: tag === 'browser offline',
+                                    timestamp: timestamp,
+                                    timeInRecording: timeInRecording,
+                                    search: tag,
+                                    windowId: windowId,
+                                    highlightColor: tag === 'browser offline' ? 'warning' : undefined,
+                                } satisfies InspectorListOfflineStatusChange)
+                            }
+                        }
+                    })
+                })
+
+                return logs
+            },
+        ],
+
         consoleLogs: [
             (s) => [s.sessionPlayerData],
             (sessionPlayerData): RecordingConsoleLogV2[] => {
@@ -253,8 +297,22 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
         ],
 
         allItems: [
-            (s) => [s.start, s.allPerformanceEvents, s.consoleLogs, s.sessionEventsData, s.matchingEventUUIDs],
-            (start, performanceEvents, consoleLogs, eventsData, matchingEventUUIDs): InspectorListItem[] => {
+            (s) => [
+                s.start,
+                s.allPerformanceEvents,
+                s.consoleLogs,
+                s.sessionEventsData,
+                s.matchingEventUUIDs,
+                s.offlineStatusChanges,
+            ],
+            (
+                start,
+                performanceEvents,
+                consoleLogs,
+                eventsData,
+                matchingEventUUIDs,
+                offlineStatusChanges
+            ): InspectorListItem[] => {
                 // NOTE: Possible perf improvement here would be to have a selector to parse the items
                 // and then do the filtering of what items are shown, elsewhere
                 // ALSO: We could move the individual filtering logic into the MiniFilters themselves
@@ -262,6 +320,11 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 const items: InspectorListItem[] = []
 
                 const startMs = start?.valueOf() ?? 0
+
+                // no conversion needed for offlineStatusChanges, they're ready to roll
+                for (const event of offlineStatusChanges || []) {
+                    items.push(event)
+                }
 
                 // PERFORMANCE EVENTS
                 const performanceEventsArr = performanceEvents || []
@@ -371,6 +434,10 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
 
                 for (const item of allItems) {
                     let include = false
+
+                    if (item.type === 'offline-status') {
+                        include = true
+                    }
 
                     // EVENTS
                     if (item.type === SessionRecordingPlayerTab.EVENTS) {

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -224,7 +224,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                                     timeInRecording: timeInRecording,
                                     search: tag,
                                     windowId: windowId,
-                                    highlightColor: tag === 'browser offline' ? 'warning' : undefined,
+                                    highlightColor: 'warning',
                                 } satisfies InspectorListOfflineStatusChange)
                             }
                         }


### PR DESCRIPTION
From posthog-js 1.102.0 we're going to be capturing custom events when the browser connection status flips from offline/online (so long as the browser behaves correctly [hey opera mini once again](https://caniuse.com/online-status))

This adds that into the inspector list. The intention is to make it easier to see why requests are failing

<img width="346" alt="Screenshot 2024-01-24 at 15 02 37" src="https://github.com/PostHog/posthog/assets/984817/f45371f4-5b1e-4b3f-9bb7-d720e267eb11">

i'm too lazy to re-screenshot but I removed the red highlighting here
<img width="348" alt="Screenshot 2024-01-24 at 15 02 50" src="https://github.com/PostHog/posthog/assets/984817/4b188fa8-0d4a-43b5-a5bd-39c160e3dcb2">
