### PR TITLE
fix(data-warehouse): dont allow task to set everything to complete

### DIFF
--- a/posthog/tasks/warehouse.py
+++ b/posthog/tasks/warehouse.py
@@ -55,7 +55,7 @@ def check_synced_row_limits_of_team(team_id: int) -> None:
             job.pipeline.status = ExternalDataSource.Status.PAUSED
             job.pipeline.save()
     else:
-        all_sources = ExternalDataSource.objects.filter(team_id=team_id)
+        all_sources = ExternalDataSource.objects.filter(team_id=team_id, status=ExternalDataSource.Status.PAUSED)
         for source in all_sources:
             try:
                 unpause_external_data_schedule(source)


### PR DESCRIPTION
## Problem

- limit check keeps settings status to completed even after failure

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- only change the status of paused sources not all

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
