### PR TITLE
fix: onboarding invite notice when no invites

### DIFF
--- a/frontend/src/scenes/onboarding/OnboardingInviteTeammates.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingInviteTeammates.tsx
@@ -13,6 +13,7 @@ export const OnboardingInviteTeammates = ({ stepKey }: { stepKey: OnboardingStep
     const { preflight } = useValues(preflightLogic)
     const { product } = useValues(onboardingLogic)
     const { inviteTeamMembers } = useActions(inviteLogic)
+    const { invitesToSend, canSubmit: canSubmitInvites } = useValues(inviteLogic)
 
     const titlePrefix = (): string => {
         switch (product?.type) {
@@ -49,7 +50,12 @@ export const OnboardingInviteTeammates = ({ stepKey }: { stepKey: OnboardingStep
             title={`${titlePrefix()} better with friends.`}
             stepKey={stepKey}
             hedgehog={<PhonePairHogs height={120} width={288} />}
-            continueAction={() => preflight?.email_service_available && inviteTeamMembers()}
+            continueAction={() =>
+                preflight?.email_service_available &&
+                invitesToSend[0]?.target_email &&
+                canSubmitInvites &&
+                inviteTeamMembers()
+            }
         >
             <div className="mb-6">
                 <p>


### PR DESCRIPTION
## Problem

If no teammates were invited in onboarding, then they'd get a notice saying "invited undefined team members"

## Changes

Only invites people if there are people to invite

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

🙈 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
