### PR TITLE
feat(hogql): add list expr

### DIFF
--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -454,6 +454,11 @@ class Array(Expr):
 
 
 @dataclass(kw_only=True)
+class ListExpr(Expr):
+    exprs: List[Expr]
+
+
+@dataclass(kw_only=True)
 class TupleAccess(Expr):
     tuple: Expr
     index: int

--- a/posthog/hogql/placeholders.py
+++ b/posthog/hogql/placeholders.py
@@ -37,7 +37,5 @@ class ReplacePlaceholders(CloningVisitor):
             new_node.start = node.start
             new_node.end = node.end
             return new_node
-        raise HogQLException(
-            f"Placeholder {{{node.field}}} is not available in this context. You can use the following: "
-            + ", ".join((f"{placeholder}" for placeholder in self.placeholders))
-        )
+        else:
+            return None

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -498,6 +498,9 @@ class _Printer(Visitor):
     def visit_array(self, node: ast.Array):
         return f"[{', '.join([self.visit(expr) for expr in node.exprs])}]"
 
+    def visit_list_expr(self, node: ast.ListExpr):
+        return f"{', '.join([self.visit(expr) for expr in node.exprs])}"
+
     def visit_lambda(self, node: ast.Lambda):
         identifiers = [self._print_identifier(arg) for arg in node.args]
         if len(identifiers) == 0:

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -80,6 +80,10 @@ class TraversingVisitor(Visitor):
         for expr in node.exprs:
             self.visit(expr)
 
+    def visit_list_expr(self, node: ast.ListExpr):
+        for expr in node.exprs:
+            self.visit(expr)
+
     def visit_constant(self, node: ast.Constant):
         self.visit(node.type)
 

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -382,6 +382,14 @@ class CloningVisitor(Visitor):
             exprs=[self.visit(expr) for expr in node.exprs],
         )
 
+    def visit_list_expr(self, node: ast.ListExpr):
+        return ast.ListExpr(
+            start=None if self.clear_locations else node.start,
+            end=None if self.clear_locations else node.end,
+            type=None if self.clear_types else node.type,
+            exprs=[self.visit(expr) for expr in node.exprs],
+        )
+
     def visit_constant(self, node: ast.Constant):
         return ast.Constant(
             start=None if self.clear_locations else node.start,


### PR DESCRIPTION
## Problem

SQL syntax is more expressive than HogQL AST nodes for complex structures. Unfortunately `parse_select` and `parse_expr` (1) don't support list placeholders, (2) don't support optional siblings and (3) don't support nullable placeholders.

Examples:
1. `parse_select('SELECT {columns} FROM events', placeholders={"columns": [ast.Constant(value=1), ast.Constant(value=2)]})` (doesn't support list-type columns)
2. `parse_expr("max(steps) over (PARTITION BY aggregation_target {placeholder}) as max_steps", placeholders={"placeholder": ast.Field(chain=['some_col'])})` (doesn't support the placeholder sibling)
3. `parse_select('SELECT event FROM events WHERE {where}', placeholders={"where": None})`(doesn't support nullable placeholder)

## Changes

This PR introduces a `ast.ListExpr` node that can only be added manually to the parse tree and gets expanded to a list. It would be great to add sibling support to the parser for this as well.

### Alternatives

1. Construct the AST manually (without using `parse_select` or `parse_expr`).
2. Use f-strings that are then parsed. This would mean that we'd need to handle things like column names as strings instead of `ast.Field`s as long as possible.
3. Parse the SQL and then modify the AST.
4. `QueryAlternator.append_select`

## How did you test this code?

*Going to add test cases after feedback.*