### PR TITLE
fix: Fix display of commit in console surprise

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -9,7 +9,7 @@
             const tags = [
                 '{% if debug %}DEBUG mode{% elif region %}Region: {{ region }}{% else %}Hobby deployment{% endif %}',
                 '{% if debug %}Branch: {{ git_branch|default:"unknown" }}{% else %}Commit: {{ git_rev|default:"unknown" }}{% endif %}',
-                'Come join us! https://posthog.com/careers',
+                'Join us! https://posthog.com/careers',
             ]
             console.info(
                 `%c %cPostHog %c— %cIn data we trust\n%c${tags.join('%c %c')}`,
@@ -18,7 +18,7 @@
                 '',
                 'font-style: italic;',
                 'padding: 0.2em 0.4em; border-radius: 0.5em; background: #1d4aff; color: white;',
-                '',
+                'padding-bottom: 0.4em;',
                 'padding: 0.2em 0.4em; border-radius: 0.5em; background: #f54e00; color: white;',
                 '',
                 'padding: 0.2em 0.4em; border-radius: 0.5em; background: #f9bd2b; color: black;'

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -291,9 +291,9 @@ def render_template(
     if sentry_environment := os.environ.get("SENTRY_ENVIRONMENT"):
         context["sentry_environment"] = sentry_environment
 
+    context["git_rev"] = get_git_commit()  # Include commit in prod for the `console.info()` message
     if settings.DEBUG and not settings.TEST:
         context["debug"] = True
-        context["git_rev"] = get_git_commit()
         context["git_branch"] = get_git_branch()
 
     if settings.E2E_TESTING:


### PR DESCRIPTION
## Changes

Fixes this:
<img width="120" alt="Screenshot 2024-01-25 at 14 10 38" src="https://github.com/PostHog/posthog/assets/4550621/f1e3aee3-8c76-4c17-8fe1-6537a733d367">
