### PR TITLE
chore: Add eslint no-useless-rename rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -245,6 +245,7 @@ module.exports = {
         'no-constant-condition': 'off',
         'no-prototype-builtins': 'off',
         'no-irregular-whitespace': 'off',
+        'no-useless-rename': 'error',
         'import/no-restricted-paths': [
             'error',
             {

--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -9,7 +9,7 @@ import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 
-import { authorizedUrlListLogic, AuthorizedUrlListType as AuthorizedUrlListType } from './authorizedUrlListLogic'
+import { authorizedUrlListLogic, AuthorizedUrlListType } from './authorizedUrlListLogic'
 
 function EmptyState({
     numberOfResults,

--- a/frontend/src/lib/lemon-ui/Spinner/Spinner.stories.tsx
+++ b/frontend/src/lib/lemon-ui/Spinner/Spinner.stories.tsx
@@ -1,7 +1,7 @@
 import { LemonButton } from '@posthog/lemon-ui'
 import { Meta } from '@storybook/react'
 
-import { Spinner as Spinner, SpinnerOverlay } from './Spinner'
+import { Spinner, SpinnerOverlay } from './Spinner'
 
 const meta: Meta<typeof Spinner> = {
     title: 'Lemon UI/Spinner',

--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -68,7 +68,7 @@ export function PersonsModal({
     })
 
     const {
-        query: query,
+        query,
         actors,
         actorsResponseLoading,
         actorsResponse,


### PR DESCRIPTION
## Problem

Useless renames were allowed:

```
const {
    query: query,
    ...
}
```

## Changes

- turn on rule and auto fix

## How did you test this code?

- n/a
