### PR TITLE
fix(web-analytics): validate web analytics filters from url

### DIFF
--- a/frontend/src/queries/schema-guards.ts
+++ b/frontend/src/queries/schema-guards.ts
@@ -3,7 +3,9 @@ import Ajv from 'ajv'
 import { WebAnalyticsPropertyFilters } from '~/queries/schema'
 
 import schema from './schema.json'
-const ajv = new Ajv()
+const ajv = new Ajv({
+    allowUnionTypes: true,
+})
 ajv.addSchema(schema)
 
 export const isWebAnalyticsPropertyFilters = (data: unknown): data is WebAnalyticsPropertyFilters => {

--- a/frontend/src/queries/schema-guards.ts
+++ b/frontend/src/queries/schema-guards.ts
@@ -1,0 +1,15 @@
+import Ajv from 'ajv'
+
+import { WebAnalyticsPropertyFilters } from '~/queries/schema'
+
+import schema from './schema.json'
+const ajv = new Ajv()
+ajv.addSchema(schema)
+
+export const isWebAnalyticsPropertyFilters = (data: unknown): data is WebAnalyticsPropertyFilters => {
+    const validator = ajv.getSchema('#/definitions/WebAnalyticsPropertyFilters')
+    if (!validator) {
+        throw new Error('Could not find validator for WebAnalyticsPropertyFilters')
+    }
+    return validator(data) as boolean
+}

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -29,6 +29,7 @@ import {
 } from '~/types'
 
 import type { webAnalyticsLogicType } from './webAnalyticsLogicType'
+import { isWebAnalyticsPropertyFilters } from '~/queries/schema-guards'
 
 export interface WebTileLayout {
     /** The class has to be spelled out without interpolation, as otherwise Tailwind can't pick it up. */
@@ -997,8 +998,10 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             _,
             { filters, date_from, date_to, interval, device_tab, source_tab, graphs_tab, path_tab, geography_tab }
         ) => {
+            const parsedFilters = isWebAnalyticsPropertyFilters(filters) ? filters : initialWebAnalyticsFilter
+
             actions.setStateFromUrl({
-                filters: filters || initialWebAnalyticsFilter,
+                filters: parsedFilters,
                 dateFrom: date_from || null,
                 dateTo: date_to || null,
                 interval: interval || null,

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -15,6 +15,7 @@ import {
     WebAnalyticsPropertyFilters,
     WebStatsBreakdown,
 } from '~/queries/schema'
+import { isWebAnalyticsPropertyFilters } from '~/queries/schema-guards'
 import {
     BaseMathType,
     ChartDisplayType,
@@ -29,7 +30,6 @@ import {
 } from '~/types'
 
 import type { webAnalyticsLogicType } from './webAnalyticsLogicType'
-import { isWebAnalyticsPropertyFilters } from '~/queries/schema-guards'
 
 export interface WebTileLayout {
     /** The class has to be spelled out without interpolation, as otherwise Tailwind can't pick it up. */


### PR DESCRIPTION
## Problem
This session recording https://us.posthog.com/project/2/replay/018d3e90-c24c-7c78-86ea-7a6017708838?t=10 somehow opens a link https://us.posthog.com/project/39981/web?filters=%7B%22filter_test_accounts%22%3Atrue%7D which is `{filter_test_accounts: true}` for the filters parameter. This isn't valid, as it should be an array.

I haven't figured out why this is happening, but this at least makes the page work

## Changes

Use the json schema to validate this parameter at runtime

## How did you test this code?

Tried http://localhost:8000/project/1/web?filters=%7B%22filter_test_accounts%22%3Atrue%7D locally, and made sure that adding others filters still works