### PR TITLE
feat(insights): actor breakdown options in data table

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -24,6 +24,7 @@ import { ColumnConfigurator } from '~/queries/nodes/DataTable/ColumnConfigurator
 import { DataTableExport } from '~/queries/nodes/DataTable/DataTableExport'
 import { dataTableLogic, DataTableLogicProps, DataTableRow } from '~/queries/nodes/DataTable/dataTableLogic'
 import { EventRowActions } from '~/queries/nodes/DataTable/EventRowActions'
+import { InsightActorsQueryOptions } from '~/queries/nodes/DataTable/InsightActorsQueryOptions'
 import { QueryFeature } from '~/queries/nodes/DataTable/queryFeatures'
 import { renderColumn } from '~/queries/nodes/DataTable/renderColumn'
 import { renderColumnMeta } from '~/queries/nodes/DataTable/renderColumnMeta'
@@ -55,6 +56,7 @@ import {
     isEventsQuery,
     isHogQlAggregation,
     isHogQLQuery,
+    isInsightActorsQuery,
     taxonomicEventFilterToHogQL,
     taxonomicPersonFilterToHogQL,
 } from '~/queries/utils'
@@ -384,6 +386,18 @@ export function DataTable({
 
     const firstRowLeft = [
         backToSourceQuery ? <BackToSource key="return-to-source" /> : null,
+        backToSourceQuery && isActorsQuery(query.source) && isInsightActorsQuery(query.source.source) ? (
+            <InsightActorsQueryOptions
+                query={query.source.source}
+                setQuery={(q) =>
+                    setQuerySource({
+                        ...query.source,
+                        source: { ...(query.source as ActorsQuery).source, ...q },
+                    } as ActorsQuery)
+                }
+                key="source-query-options"
+            />
+        ) : null,
         showDateRange && sourceFeatures.has(QueryFeature.dateRangePicker) ? (
             <DateRange key="date-range" query={query.source} setQuery={setQuerySource} />
         ) : null,

--- a/frontend/src/queries/nodes/DataTable/InsightActorsQueryOptions.tsx
+++ b/frontend/src/queries/nodes/DataTable/InsightActorsQueryOptions.tsx
@@ -1,0 +1,44 @@
+import { useMountedLogic, useValues } from 'kea'
+import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { insightActorsQueryOptionsLogic } from '~/queries/nodes/DataTable/insightActorsQueryOptionsLogic'
+import { InsightActorsQuery } from '~/queries/schema'
+
+interface InsightActorsQueryOptionsProps {
+    query: InsightActorsQuery
+    setQuery?: (query: InsightActorsQuery) => void
+}
+export function InsightActorsQueryOptions({ setQuery, query }: InsightActorsQueryOptionsProps): JSX.Element | null {
+    const localDataNodeLogic = useMountedLogic(dataNodeLogic)
+    const { insightActorsQueryOptions } = useValues(
+        insightActorsQueryOptionsLogic({
+            key: localDataNodeLogic.key,
+            query: query,
+        })
+    )
+
+    return query && insightActorsQueryOptions ? (
+        <>
+            {Object.entries(insightActorsQueryOptions)
+                .filter(([, value]) => !!value)
+                .map(([key, options]) => (
+                    <div key={key}>
+                        <LemonSelect
+                            fullWidth
+                            className="min-w-32"
+                            placeholder={key}
+                            value={query?.[key] ?? null}
+                            onChange={(v) =>
+                                setQuery?.({
+                                    ...query,
+                                    [key]: v,
+                                })
+                            }
+                            options={options}
+                        />
+                    </div>
+                ))}
+        </>
+    ) : null
+}

--- a/frontend/src/queries/nodes/DataTable/insightActorsQueryOptionsLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/insightActorsQueryOptionsLogic.ts
@@ -1,0 +1,46 @@
+import { actions, afterMount, kea, path, props, propsChanged } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import { query as performQuery } from '~/queries/query'
+import {
+    InsightActorsQuery,
+    InsightActorsQueryOptions,
+    InsightActorsQueryOptionsResponse,
+    NodeKind,
+} from '~/queries/schema'
+import { isInsightActorsQuery } from '~/queries/utils'
+
+import type { insightActorsQueryOptionsLogicType } from './insightActorsQueryOptionsLogicType'
+
+export const insightActorsQueryOptionsLogic = kea<insightActorsQueryOptionsLogicType>([
+    path(['queries', 'nodes', 'DataTable', 'sourceQueryOptionsLogic']),
+    props({} as { key: string; query: InsightActorsQuery }),
+    actions({
+        load: true,
+    }),
+    loaders(({ values, props }) => ({
+        insightActorsQueryOptions: [
+            null as InsightActorsQueryOptionsResponse | null,
+            {
+                load: async () => {
+                    if (!props.query || !isInsightActorsQuery(props.query)) {
+                        return values.insightActorsQueryOptions || null
+                    }
+                    const optionsQuery: InsightActorsQueryOptions = {
+                        kind: NodeKind.InsightActorsQueryOptions,
+                        source: props.query,
+                    }
+                    return await performQuery(optionsQuery)
+                },
+            },
+        ],
+    })),
+    afterMount(({ actions }) => {
+        actions.load()
+    }),
+    propsChanged(({ actions, props }, oldProps) => {
+        if (JSON.stringify(props.query) !== JSON.stringify(oldProps.query)) {
+            actions.load()
+        }
+    }),
+])


### PR DESCRIPTION
## Problem

Not a problem, but a suggestion for improvement.

## Changes

Takes the actors breakdown select fields from the persons modal, and adds them to the full screen data table:

![2024-01-25 16 30 10](https://github.com/PostHog/posthog/assets/53387/9f4c3048-f1b9-4c0b-a770-badd99b579e1)

## How did you test this code?

UI changes tested visually (see screencast)