### PR TITLE
fix(web-analytics): Add more debugging when test filters do not pass validation

### DIFF
--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -87,7 +87,7 @@ class TestProperty(BaseTest):
             self._property_to_expr({"type": "group", "key": "a", "value": "b"})
         self.assertEqual(
             str(e.exception),
-            "Missing required key group_type_index for property type group",
+            "Missing required key group_type_index for property type group with name a",
         )
 
     def test_property_to_expr_event(self):

--- a/posthog/models/property/property.py
+++ b/posthog/models/property/property.py
@@ -255,7 +255,7 @@ class Property:
 
         for key in VALIDATE_PROP_TYPES[self.type]:
             if getattr(self, key, None) is None:
-                raise ValueError(f"Missing required key {key} for property type {self.type}")
+                raise ValueError(f"Missing required key {key} for property type {self.type} with name {self.key}")
 
         if self.type == "behavioral":
             for key in VALIDATE_BEHAVIORAL_PROP_TYPES[cast(BehavioralPropertyType, self.value)]:


### PR DESCRIPTION
## Problem

I'm trying to understand https://posthog.sentry.io/issues/4915238481/?environment=prod-eu&project=1899813&project=6423401&query=&referrer=issue-stream&statsPeriod=14d&stream_index=1, because as far as I can tell the error `Missing required key group_type_index for property type group` should not apply to any of the properties, so I want to see the name.

## Changes

Add the property name to the error message

## How did you test this code?

n/a