### PR TITLE
fix(frontend): Fix clipped date picker

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.scss
@@ -1,6 +1,5 @@
-.filter-row-popover {
-    // so the datepicker is visible
-    overflow: visible;
+.filter-row-popover .Popover__box {
+    overflow: visible; // Only required because the Ant popover is rendered _within_ the filter popover
 }
 
 .property-filter-row {


### PR DESCRIPTION
## Changes

Resolves #19867. Unfortunately Ant's picker uses a different popover mechanism from our stuff (renders within the parent popover's hierarchy, instead of parallel to it), so we were clipping it. We had an old override for this, but #19813 broke it.