### PR TITLE
fix: Over fetching groups types

### DIFF
--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -102,7 +102,7 @@ export const groupsModel = kea<groupsModelType>([
     subscriptions(({ values }) => ({
         groupsEnabled: (enabled) => {
             // Load the groups types in the case of groups becoming an available feature after this logic is mounted
-            if (!values.groupTypesLoading && enabled && !values.groupTypesRaw) {
+            if (!values.groupTypesLoading && enabled) {
                 groupsModel.actions.loadAllGroupTypes()
             }
         },

--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -25,7 +25,6 @@ export const groupsModel = kea<groupsModelType>([
             null as Array<GroupType> | null,
             {
                 loadAllGroupTypes: async () => {
-                    console.log('loadAllGroupTypes called!')
                     return await api.get(`api/projects/${values.currentTeamId}/groups_types`)
                 },
                 updateGroupTypesMetadata: async (payload: Array<GroupType>) => {

--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -22,7 +22,7 @@ export const groupsModel = kea<groupsModelType>([
     }),
     loaders(({ values }) => ({
         groupTypesRaw: [
-            null as Array<GroupType> | null,
+            [] as Array<GroupType>,
             {
                 loadAllGroupTypes: async () => {
                     return await api.get(`api/projects/${values.currentTeamId}/groups_types`)
@@ -44,7 +44,7 @@ export const groupsModel = kea<groupsModelType>([
             (s) => [s.groupTypesRaw],
             (groupTypesRaw) =>
                 new Map<GroupTypeIndex, GroupType>(
-                    groupTypesRaw?.map((groupType) => [groupType.group_type_index, groupType]) ?? []
+                    groupTypesRaw.map((groupType) => [groupType.group_type_index, groupType])
                 ),
         ],
         groupTypesLoading: [(s) => [s.groupTypesRawLoading], (groupTypesRawLoading) => groupTypesRawLoading],

--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -3,7 +3,7 @@ import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
 import api from 'lib/api'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { GroupsAccessStatus, groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
+import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { GroupType, GroupTypeIndex } from '~/types'


### PR DESCRIPTION
## Problem

We were doing 2 api calls when we don't need to.

## Changes

* Removes the afterMount as it is taken care of by the subscription call.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
