### PR TITLE
feat(insights): sanitize retention query

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -115,6 +115,9 @@ export const sanitizeRetentionEntity = (entity: RetentionEntity | undefined): Re
             delete record[key]
         }
     }
+    if ('id' in record) {
+        record.id = Number(record.id)
+    }
     return record
 }
 

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -37,6 +37,7 @@ import {
     PropertyFilterType,
     PropertyGroupFilterValue,
     PropertyOperator,
+    RetentionEntity,
 } from '~/types'
 
 const reverseInsightMap: Record<Exclude<InsightType, InsightType.JSON | InsightType.SQL>, InsightNodeKind> = {
@@ -103,6 +104,18 @@ export const cleanHiddenLegendSeries = (
               .filter(([k, v]) => !/^\d+$/.test(k) && v === true)
               .map(([k]) => k)
         : undefined
+}
+export const sanitizeRetentionEntity = (entity: RetentionEntity | undefined): RetentionEntity | undefined => {
+    if (!entity) {
+        return undefined
+    }
+    const record = { ...entity }
+    for (const key of Object.keys(record)) {
+        if (!['id', 'kind', 'name', 'type', 'order', 'uuid', 'custom_name'].includes(key)) {
+            delete record[key]
+        }
+    }
+    return record
 }
 
 const cleanProperties = (parentProperties: FilterType['properties']): InsightsQueryBase['properties'] => {
@@ -307,8 +320,8 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
             retentionType: filters.retention_type,
             retentionReference: filters.retention_reference,
             totalIntervals: filters.total_intervals,
-            returningEntity: filters.returning_entity,
-            targetEntity: filters.target_entity,
+            returningEntity: sanitizeRetentionEntity(filters.returning_entity),
+            targetEntity: sanitizeRetentionEntity(filters.target_entity),
             period: filters.period,
         })
         // TODO: query.aggregation_group_type_index

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -115,7 +115,7 @@ export const sanitizeRetentionEntity = (entity: RetentionEntity | undefined): Re
             delete record[key]
         }
     }
-    if ('id' in record) {
+    if ('id' in record && record.type === 'actions') {
         record.id = Number(record.id)
     }
     return record


### PR DESCRIPTION
## Problem

```
JSON parse error - 6 validation errors for QueryRequest
query.RetentionQuery.retentionFilter.returningEntity.math
Extra inputs are not permitted
```

## Changes

Sanitizes the retention entity fields.

## How did you test this code?

Nothing broke locally