### PR TITLE
chore(queries): capture parse errors

### DIFF
--- a/posthog/api/mixins.py
+++ b/posthog/api/mixins.py
@@ -3,6 +3,7 @@ from typing import TypeVar, Type
 from pydantic import BaseModel, ValidationError
 
 from rest_framework.exceptions import ParseError
+from sentry_sdk import capture_exception
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -12,4 +13,5 @@ class PydanticModelMixin:
         try:
             return model.model_validate(data)
         except ValidationError as exc:
+            capture_exception(exc)
             raise ParseError("JSON parse error - %s" % str(exc))


### PR DESCRIPTION
## Problem

Some queries aren't running due to parse errors, but we have no introspection into these.

## Changes

This PR captures parse errors in Sentry.

## How did you test this code?

n/a