### PR TITLE
fix(insights): query source editor works again

### DIFF
--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -1,5 +1,6 @@
 import './Insight.scss'
 
+import equal from 'fast-deep-equal'
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
 import { useEffect } from 'react'
 import { InsightPageHeader } from 'scenes/insights/InsightPageHeader'
@@ -50,9 +51,9 @@ export function Insight({ insightId }: InsightSceneProps): JSX.Element {
 
     const actuallyShowQueryEditor = insightMode === ItemMode.Edit && showQueryEditor
 
-    const setQuery = (query: Node): void => {
-        if (!isInsightVizNode(query)) {
-            setInsightQuery(query)
+    const setQuery = (queryToSet: Node): void => {
+        if (!equal(query, queryToSet)) {
+            setInsightQuery(queryToSet)
         }
     }
 


### PR DESCRIPTION
## Problem

The query editor didn't work for insights anymore... as it seems to have been disabled

## Changes

Now it does. 

![2024-01-26 16 35 14](https://github.com/PostHog/posthog/assets/53387/ebaf350f-4b7e-4fc0-ba39-0f90e75dafa6)


## How did you test this code?

I could save changes made in this editor again.