### PR TITLE
fix(notebooks): apply insight query migration to inlined notebook insights

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -12,6 +12,7 @@ import {
 
 import {
     ActionsNode,
+    BreakdownFilter,
     EventsNode,
     FunnelsFilter,
     InsightNodeKind,
@@ -257,19 +258,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
             filters.breakdown_type = 'event'
         }
 
-        query.breakdownFilter = objectCleanWithEmpty({
-            breakdown_type: filters.breakdown_type,
-            breakdown: filters.breakdown,
-            breakdown_normalize_url: filters.breakdown_normalize_url,
-            breakdowns: filters.breakdowns,
-            breakdown_group_type_index: filters.breakdown_group_type_index,
-            ...(isTrendsFilter(filters)
-                ? {
-                      breakdown_histogram_bin_count: filters.breakdown_histogram_bin_count,
-                      breakdown_hide_other_aggregation: filters.breakdown_hide_other_aggregation,
-                  }
-                : {}),
-        })
+        query.breakdownFilter = breakdownFilterToQuery(query, isTrendsFilter(filters))
     }
 
     // group aggregation
@@ -389,4 +378,20 @@ export const retentionFilterToQuery = (filters: Partial<RetentionFilterType>): R
         period: filters.period,
     })
     // TODO: query.aggregation_group_type_index
+}
+
+export const breakdownFilterToQuery = (filters: Record<string, any>, isTrends: boolean): BreakdownFilter => {
+    return objectCleanWithEmpty({
+        breakdown_type: filters.breakdown_type,
+        breakdown: filters.breakdown,
+        breakdown_normalize_url: filters.breakdown_normalize_url,
+        breakdowns: filters.breakdowns,
+        breakdown_group_type_index: filters.breakdown_group_type_index,
+        ...(isTrends
+            ? {
+                  breakdown_histogram_bin_count: filters.breakdown_histogram_bin_count,
+                  breakdown_hide_other_aggregation: filters.breakdown_hide_other_aggregation,
+              }
+            : {}),
+    })
 }

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -13,6 +13,7 @@ import {
 import {
     ActionsNode,
     EventsNode,
+    FunnelsFilter,
     InsightNodeKind,
     InsightQueryNode,
     InsightsQueryBase,
@@ -33,6 +34,7 @@ import {
     AnyPropertyFilter,
     FilterLogicalOperator,
     FilterType,
+    FunnelsFilterType,
     InsightType,
     PropertyFilterType,
     PropertyGroupFilterValue,
@@ -292,29 +294,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
 
     // funnels filter
     if (isFunnelsFilter(filters) && isFunnelsQuery(query)) {
-        query.funnelsFilter = objectCleanWithEmpty({
-            funnelVizType: filters.funnel_viz_type,
-            funnelFromStep: filters.funnel_from_step,
-            funnelToStep: filters.funnel_to_step,
-            funnelStepReference: filters.funnel_step_reference,
-            breakdownAttributionType: filters.breakdown_attribution_type,
-            breakdownAttributionValue: filters.breakdown_attribution_value,
-            binCount: filters.bin_count,
-            funnelWindowIntervalUnit: filters.funnel_window_interval_unit,
-            funnelWindowInterval: filters.funnel_window_interval,
-            funnelOrderType: filters.funnel_order_type,
-            exclusions:
-                filters.exclusions !== undefined
-                    ? filters.exclusions.map(({ funnel_from_step, funnel_to_step, ...rest }) => ({
-                          funnelFromStep: funnel_from_step,
-                          funnelToStep: funnel_to_step,
-                          ...rest,
-                      }))
-                    : undefined,
-            layout: filters.layout,
-            hidden_legend_breakdowns: cleanHiddenLegendSeries(filters.hidden_legend_keys),
-            funnelAggregateByHogQL: filters.funnel_aggregate_by_hogql,
-        })
+        query.funnelsFilter = funnelsFilterToQuery(filters)
     }
 
     // retention filter
@@ -371,4 +351,30 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
 
     // remove undefined and empty array/objects and return
     return objectCleanWithEmpty(query as Record<string, any>, ['series']) as InsightQueryNode
+}
+
+export const funnelsFilterToQuery = (filters: Partial<FunnelsFilterType>): FunnelsFilter => {
+    return objectCleanWithEmpty({
+        funnelVizType: filters.funnel_viz_type,
+        funnelFromStep: filters.funnel_from_step,
+        funnelToStep: filters.funnel_to_step,
+        funnelStepReference: filters.funnel_step_reference,
+        breakdownAttributionType: filters.breakdown_attribution_type,
+        breakdownAttributionValue: filters.breakdown_attribution_value,
+        binCount: filters.bin_count,
+        funnelWindowIntervalUnit: filters.funnel_window_interval_unit,
+        funnelWindowInterval: filters.funnel_window_interval,
+        funnelOrderType: filters.funnel_order_type,
+        exclusions:
+            filters.exclusions !== undefined
+                ? filters.exclusions.map(({ funnel_from_step, funnel_to_step, ...rest }) => ({
+                      funnelFromStep: funnel_from_step,
+                      funnelToStep: funnel_to_step,
+                      ...rest,
+                  }))
+                : undefined,
+        layout: filters.layout,
+        hidden_legend_breakdowns: cleanHiddenLegendSeries(filters.hidden_legend_keys),
+        funnelAggregateByHogQL: filters.funnel_aggregate_by_hogql,
+    })
 }

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -19,6 +19,7 @@ import {
     InsightsQueryBase,
     NodeKind,
     RetentionFilter,
+    TrendsFilter,
 } from '~/queries/schema'
 import {
     isFunnelsQuery,
@@ -42,6 +43,7 @@ import {
     PropertyOperator,
     RetentionEntity,
     RetentionFilterType,
+    TrendsFilterType,
 } from '~/types'
 
 const reverseInsightMap: Record<Exclude<InsightType, InsightType.JSON | InsightType.SQL>, InsightNodeKind> = {
@@ -277,21 +279,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
 
     // trends filter
     if (isTrendsFilter(filters) && isTrendsQuery(query)) {
-        query.trendsFilter = objectCleanWithEmpty({
-            smoothingIntervals: filters.smoothing_intervals,
-            showLegend: filters.show_legend,
-            hidden_legend_indexes: cleanHiddenLegendIndexes(filters.hidden_legend_keys),
-            compare: filters.compare,
-            aggregationAxisFormat: filters.aggregation_axis_format,
-            aggregationAxisPrefix: filters.aggregation_axis_prefix,
-            aggregationAxisPostfix: filters.aggregation_axis_postfix,
-            decimalPlaces: filters.decimal_places,
-            formula: filters.formula,
-            display: filters.display,
-            showValuesOnSeries: filters.show_values_on_series,
-            showPercentStackView: filters.show_percent_stack_view,
-            showLabelsOnSeries: filters.show_labels_on_series,
-        })
+        query.trendsFilter = trendsFilterToQuery(query)
     }
 
     // funnels filter
@@ -345,6 +333,24 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
 
     // remove undefined and empty array/objects and return
     return objectCleanWithEmpty(query as Record<string, any>, ['series']) as InsightQueryNode
+}
+
+export const trendsFilterToQuery = (filters: Partial<TrendsFilterType>): TrendsFilter => {
+    return objectCleanWithEmpty({
+        smoothingIntervals: filters.smoothing_intervals,
+        showLegend: filters.show_legend,
+        hidden_legend_indexes: cleanHiddenLegendIndexes(filters.hidden_legend_keys),
+        compare: filters.compare,
+        aggregationAxisFormat: filters.aggregation_axis_format,
+        aggregationAxisPrefix: filters.aggregation_axis_prefix,
+        aggregationAxisPostfix: filters.aggregation_axis_postfix,
+        decimalPlaces: filters.decimal_places,
+        formula: filters.formula,
+        display: filters.display,
+        showValuesOnSeries: filters.show_values_on_series,
+        showPercentStackView: filters.show_percent_stack_view,
+        showLabelsOnSeries: filters.show_labels_on_series,
+    })
 }
 
 export const funnelsFilterToQuery = (filters: Partial<FunnelsFilterType>): FunnelsFilter => {

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -19,6 +19,7 @@ import {
     InsightQueryNode,
     InsightsQueryBase,
     NodeKind,
+    PathsFilter,
     RetentionFilter,
     TrendsFilter,
 } from '~/queries/schema'
@@ -39,6 +40,7 @@ import {
     FilterType,
     FunnelsFilterType,
     InsightType,
+    PathsFilterType,
     PropertyFilterType,
     PropertyGroupFilterValue,
     PropertyOperator,
@@ -283,22 +285,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
 
     // paths filter
     if (isPathsFilter(filters) && isPathsQuery(query)) {
-        query.pathsFilter = objectCleanWithEmpty({
-            pathsHogQLExpression: filters.paths_hogql_expression,
-            includeEventTypes: filters.include_event_types,
-            startPoint: filters.start_point,
-            endPoint: filters.end_point,
-            pathGroupings: filters.path_groupings,
-            funnelPaths: filters.funnel_paths,
-            funnelFilter: filters.funnel_filter,
-            excludeEvents: filters.exclude_events,
-            stepLimit: filters.step_limit,
-            pathReplacements: filters.path_replacements,
-            localPathCleaningFilters: filters.local_path_cleaning_filters,
-            edgeLimit: filters.edge_limit,
-            minEdgeWeight: filters.min_edge_weight,
-            maxEdgeWeight: filters.max_edge_weight,
-        })
+        query.pathsFilter = pathsFilterToQuery(filters)
     }
 
     // stickiness filter
@@ -378,6 +365,25 @@ export const retentionFilterToQuery = (filters: Partial<RetentionFilterType>): R
         period: filters.period,
     })
     // TODO: query.aggregation_group_type_index
+}
+
+export const pathsFilterToQuery = (filters: Partial<PathsFilterType>): PathsFilter => {
+    return objectCleanWithEmpty({
+        pathsHogQLExpression: filters.paths_hogql_expression,
+        includeEventTypes: filters.include_event_types,
+        startPoint: filters.start_point,
+        endPoint: filters.end_point,
+        pathGroupings: filters.path_groupings,
+        funnelPaths: filters.funnel_paths,
+        funnelFilter: filters.funnel_filter,
+        excludeEvents: filters.exclude_events,
+        stepLimit: filters.step_limit,
+        pathReplacements: filters.path_replacements,
+        localPathCleaningFilters: filters.local_path_cleaning_filters,
+        edgeLimit: filters.edge_limit,
+        minEdgeWeight: filters.min_edge_weight,
+        maxEdgeWeight: filters.max_edge_weight,
+    })
 }
 
 export const breakdownFilterToQuery = (filters: Record<string, any>, isTrends: boolean): BreakdownFilter => {

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -270,7 +270,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
 
     // trends filter
     if (isTrendsFilter(filters) && isTrendsQuery(query)) {
-        query.trendsFilter = trendsFilterToQuery(query)
+        query.trendsFilter = trendsFilterToQuery(filters)
     }
 
     // funnels filter

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -260,7 +260,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
             filters.breakdown_type = 'event'
         }
 
-        query.breakdownFilter = breakdownFilterToQuery(query, isTrendsFilter(filters))
+        query.breakdownFilter = breakdownFilterToQuery(filters, isTrendsFilter(filters))
     }
 
     // group aggregation

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -18,6 +18,7 @@ import {
     InsightQueryNode,
     InsightsQueryBase,
     NodeKind,
+    RetentionFilter,
 } from '~/queries/schema'
 import {
     isFunnelsQuery,
@@ -40,6 +41,7 @@ import {
     PropertyGroupFilterValue,
     PropertyOperator,
     RetentionEntity,
+    RetentionFilterType,
 } from '~/types'
 
 const reverseInsightMap: Record<Exclude<InsightType, InsightType.JSON | InsightType.SQL>, InsightNodeKind> = {
@@ -299,15 +301,7 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
 
     // retention filter
     if (isRetentionFilter(filters) && isRetentionQuery(query)) {
-        query.retentionFilter = objectCleanWithEmpty({
-            retentionType: filters.retention_type,
-            retentionReference: filters.retention_reference,
-            totalIntervals: filters.total_intervals,
-            returningEntity: sanitizeRetentionEntity(filters.returning_entity),
-            targetEntity: sanitizeRetentionEntity(filters.target_entity),
-            period: filters.period,
-        })
-        // TODO: query.aggregation_group_type_index
+        query.retentionFilter = retentionFilterToQuery(filters)
     }
 
     // paths filter
@@ -377,4 +371,16 @@ export const funnelsFilterToQuery = (filters: Partial<FunnelsFilterType>): Funne
         hidden_legend_breakdowns: cleanHiddenLegendSeries(filters.hidden_legend_keys),
         funnelAggregateByHogQL: filters.funnel_aggregate_by_hogql,
     })
+}
+
+export const retentionFilterToQuery = (filters: Partial<RetentionFilterType>): RetentionFilter => {
+    return objectCleanWithEmpty({
+        retentionType: filters.retention_type,
+        retentionReference: filters.retention_reference,
+        totalIntervals: filters.total_intervals,
+        returningEntity: sanitizeRetentionEntity(filters.returning_entity),
+        targetEntity: sanitizeRetentionEntity(filters.target_entity),
+        period: filters.period,
+    })
+    // TODO: query.aggregation_group_type_index
 }

--- a/frontend/src/queries/nodes/InsightQuery/utils/legacy.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/legacy.ts
@@ -48,3 +48,27 @@ export const isLegacyRetentionFilter = (filters: Record<string, any> | undefined
     const legacyKeys = ['retention_type', 'retention_reference', 'total_intervals', 'returning_entity', 'target_entity']
     return legacyKeys.some((key) => key in filters)
 }
+
+export const isLegacyPathsFilter = (filters: Record<string, any> | undefined): boolean => {
+    if (filters == null) {
+        return false
+    }
+
+    const legacyKeys = [
+        'paths_hogql_expression',
+        'include_event_types',
+        'start_point',
+        'end_point',
+        'path_groupings',
+        'funnel_paths',
+        'funnel_filter',
+        'exclude_events',
+        'step_limit',
+        'path_replacements',
+        'local_path_cleaning_filters',
+        'edge_limit',
+        'min_edge_weight',
+        'max_edge_weight',
+    ]
+    return legacyKeys.some((key) => key in filters)
+}

--- a/frontend/src/queries/nodes/InsightQuery/utils/legacy.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/legacy.ts
@@ -19,3 +19,12 @@ export const isLegacyFunnelsFilter = (filters: Record<string, any> | undefined):
     ]
     return legacyKeys.some((key) => key in filters)
 }
+
+export const isLegacyRetentionFilter = (filters: Record<string, any> | undefined): boolean => {
+    if (filters == null) {
+        return false
+    }
+
+    const legacyKeys = ['retention_type', 'retention_reference', 'total_intervals', 'returning_entity', 'target_entity']
+    return legacyKeys.some((key) => key in filters)
+}

--- a/frontend/src/queries/nodes/InsightQuery/utils/legacy.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/legacy.ts
@@ -1,0 +1,21 @@
+export const isLegacyFunnelsFilter = (filters: Record<string, any> | undefined): boolean => {
+    if (filters == null) {
+        return false
+    }
+
+    const legacyKeys = [
+        'funnel_viz_type',
+        'funnel_from_step',
+        'funnel_to_step',
+        'funnel_step_reference',
+        'breakdown_attribution_type',
+        'breakdown_attribution_value',
+        'bin_count',
+        'funnel_window_interval_unit',
+        'funnel_window_interval',
+        'funnel_order_type',
+        'hidden_legend_keys',
+        'funnel_aggregate_by_hogql',
+    ]
+    return legacyKeys.some((key) => key in filters)
+}

--- a/frontend/src/queries/nodes/InsightQuery/utils/legacy.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/legacy.ts
@@ -1,3 +1,23 @@
+export const isLegacyTrendsFilter = (filters: Record<string, any> | undefined): boolean => {
+    if (filters == null) {
+        return false
+    }
+
+    const legacyKeys = [
+        'smoothing_intervals',
+        'show_legend',
+        'hidden_legend_keys',
+        'aggregation_axis_format',
+        'aggregation_axis_prefix',
+        'aggregation_axis_postfix',
+        'decimal_places',
+        'show_values_on_series',
+        'show_percent_stack_view',
+        'show_labels_on_series',
+    ]
+    return legacyKeys.some((key) => key in filters)
+}
+
 export const isLegacyFunnelsFilter = (filters: Record<string, any> | undefined): boolean => {
     if (filters == null) {
         return false

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
@@ -539,6 +539,269 @@ describe('migrate()', () => {
                 },
             ],
         ],
+        [
+            'migrates series TODO',
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'TrendsQuery',
+                                series: [
+                                    {
+                                        id: '2674',
+                                        kind: 'ActionsNode',
+                                        math: 'unique_group',
+                                        name: 'User Signed Up (Comprehensive)',
+                                        properties: [
+                                            {
+                                                key: 'is_organization_first_user',
+                                                type: 'event',
+                                                value: ['true'],
+                                                operator: 'exact',
+                                            },
+                                        ],
+                                        custom_name: 'All Org Signups',
+                                        math_group_type_index: 0,
+                                    },
+                                    {
+                                        id: '2674',
+                                        kind: 'ActionsNode',
+                                        math: 'unique_group',
+                                        name: 'User Signed Up (Comprehensive)',
+                                        properties: [
+                                            {
+                                                key: 'id',
+                                                type: 'cohort',
+                                                value: 15394,
+                                                operator: null,
+                                            },
+                                            {
+                                                key: 'is_organization_first_user',
+                                                type: 'event',
+                                                value: ['true'],
+                                                operator: 'exact',
+                                            },
+                                        ],
+                                        custom_name: 'High ICP Organizations',
+                                        math_group_type_index: 0,
+                                    },
+                                    {
+                                        id: '8231',
+                                        kind: 'ActionsNode',
+                                        math: 'unique_group',
+                                        name: 'User Signed Up (Cloud)',
+                                        properties: [
+                                            {
+                                                key: 'is_organization_first_user',
+                                                type: 'event',
+                                                value: ['true'],
+                                                operator: 'exact',
+                                            },
+                                        ],
+                                        custom_name: 'Cloud Signups',
+                                        math_group_type_index: 0,
+                                    },
+                                    {
+                                        id: '9847',
+                                        kind: 'ActionsNode',
+                                        math: 'unique_group',
+                                        name: 'User signed up (self-hosted Clickhouse)',
+                                        properties: [
+                                            {
+                                                key: 'is_organization_first_user',
+                                                type: 'event',
+                                                value: ['true'],
+                                                operator: 'exact',
+                                            },
+                                        ],
+                                        custom_name: 'Open Source Signups',
+                                        math_group_type_index: 0,
+                                    },
+                                ],
+                                interval: 'week',
+                                dateRange: { date_to: null, date_from: '-90d' },
+                                properties: {
+                                    type: 'AND',
+                                    values: [
+                                        {
+                                            type: 'AND',
+                                            values: [
+                                                {
+                                                    key: 'email',
+                                                    type: 'event',
+                                                    value: 'posthog.com',
+                                                    operator: 'not_icontains',
+                                                },
+                                                {
+                                                    key: 'organization_name',
+                                                    type: 'group',
+                                                    value: ['teste'],
+                                                    operator: 'is_not',
+                                                    group_type_index: 0,
+                                                },
+                                                {
+                                                    key: 'organization_name',
+                                                    type: 'group',
+                                                    value: ['HOgflix movie'],
+                                                    operator: 'is_not',
+                                                    group_type_index: 0,
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                                trendsFilter: {
+                                    compare: false,
+                                    display: 'ActionsLineGraph',
+                                    show_legend: false,
+                                    smoothing_intervals: 1,
+                                    show_values_on_series: true,
+                                },
+                                filterTestAccounts: false,
+                            },
+                        },
+                        title: 'Weekly Org Signups',
+                        __init: null,
+                        height: null,
+                        nodeId: '564e15f2-78a0-4ff9-837d-c871aa71c2ef',
+                        children: null,
+                    },
+                },
+            ],
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'TrendsQuery',
+                                series: [
+                                    {
+                                        id: '2674',
+                                        kind: 'ActionsNode',
+                                        math: 'unique_group',
+                                        name: 'User Signed Up (Comprehensive)',
+                                        properties: [
+                                            {
+                                                key: 'is_organization_first_user',
+                                                type: 'event',
+                                                value: ['true'],
+                                                operator: 'exact',
+                                            },
+                                        ],
+                                        custom_name: 'All Org Signups',
+                                        math_group_type_index: 0,
+                                    },
+                                    {
+                                        id: '2674',
+                                        kind: 'ActionsNode',
+                                        math: 'unique_group',
+                                        name: 'User Signed Up (Comprehensive)',
+                                        properties: [
+                                            {
+                                                key: 'id',
+                                                type: 'cohort',
+                                                value: 15394,
+                                                operator: null,
+                                            },
+                                            {
+                                                key: 'is_organization_first_user',
+                                                type: 'event',
+                                                value: ['true'],
+                                                operator: 'exact',
+                                            },
+                                        ],
+                                        custom_name: 'High ICP Organizations',
+                                        math_group_type_index: 0,
+                                    },
+                                    {
+                                        id: '8231',
+                                        kind: 'ActionsNode',
+                                        math: 'unique_group',
+                                        name: 'User Signed Up (Cloud)',
+                                        properties: [
+                                            {
+                                                key: 'is_organization_first_user',
+                                                type: 'event',
+                                                value: ['true'],
+                                                operator: 'exact',
+                                            },
+                                        ],
+                                        custom_name: 'Cloud Signups',
+                                        math_group_type_index: 0,
+                                    },
+                                    {
+                                        id: '9847',
+                                        kind: 'ActionsNode',
+                                        math: 'unique_group',
+                                        name: 'User signed up (self-hosted Clickhouse)',
+                                        properties: [
+                                            {
+                                                key: 'is_organization_first_user',
+                                                type: 'event',
+                                                value: ['true'],
+                                                operator: 'exact',
+                                            },
+                                        ],
+                                        custom_name: 'Open Source Signups',
+                                        math_group_type_index: 0,
+                                    },
+                                ],
+                                interval: 'week',
+                                dateRange: { date_to: null, date_from: '-90d' },
+                                properties: {
+                                    type: 'AND',
+                                    values: [
+                                        {
+                                            type: 'AND',
+                                            values: [
+                                                {
+                                                    key: 'email',
+                                                    type: 'event',
+                                                    value: 'posthog.com',
+                                                    operator: 'not_icontains',
+                                                },
+                                                {
+                                                    key: 'organization_name',
+                                                    type: 'group',
+                                                    value: ['teste'],
+                                                    operator: 'is_not',
+                                                    group_type_index: 0,
+                                                },
+                                                {
+                                                    key: 'organization_name',
+                                                    type: 'group',
+                                                    value: ['HOgflix movie'],
+                                                    operator: 'is_not',
+                                                    group_type_index: 0,
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                                trendsFilter: {
+                                    compare: false,
+                                    display: 'ActionsLineGraph',
+                                    showLegend: false,
+                                    smoothingIntervals: 1,
+                                    showValuesOnSeries: true,
+                                },
+                                filterTestAccounts: false,
+                            },
+                        },
+                        title: 'Weekly Org Signups',
+                        __init: null,
+                        height: null,
+                        nodeId: '564e15f2-78a0-4ff9-837d-c871aa71c2ef',
+                        children: null,
+                    },
+                },
+            ],
+        ],
     ]
 
     contentToExpected.forEach(([name, prevContent, nextContent]) => {

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
@@ -272,6 +272,97 @@ describe('migrate()', () => {
                 },
             ],
         ],
+        [
+            'migrates trends queries (mixed with breakdown)',
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'TrendsQuery',
+                                series: [
+                                    {
+                                        kind: 'EventsNode',
+                                        math: 'dau',
+                                        name: '$pageview',
+                                        event: '$pageview',
+                                        properties: [
+                                            {
+                                                key: '$current_url',
+                                                type: 'event',
+                                                value: 'https://(app|eu).posthog.com',
+                                                operator: 'regex',
+                                            },
+                                        ],
+                                    },
+                                ],
+                                interval: 'day',
+                                breakdown: {
+                                    breakdown: '$feature/posthog-3000',
+                                    breakdown_type: 'event',
+                                },
+                                trendsFilter: {
+                                    display: 'ActionsLineGraph',
+                                    show_legend: true,
+                                },
+                                filterTestAccounts: false,
+                            },
+                        },
+                        title: 'Rollout of users on 3000',
+                        __init: null,
+                        height: null,
+                        nodeId: '4c2a07ee-fc9f-45c5-b36c-5e14a10f8e89',
+                        children: null,
+                    },
+                },
+            ],
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'TrendsQuery',
+                                series: [
+                                    {
+                                        kind: 'EventsNode',
+                                        math: 'dau',
+                                        name: '$pageview',
+                                        event: '$pageview',
+                                        properties: [
+                                            {
+                                                key: '$current_url',
+                                                type: 'event',
+                                                value: 'https://(app|eu).posthog.com',
+                                                operator: 'regex',
+                                            },
+                                        ],
+                                    },
+                                ],
+                                interval: 'day',
+                                breakdown: {
+                                    breakdown: '$feature/posthog-3000',
+                                    breakdown_type: 'event',
+                                },
+                                trendsFilter: {
+                                    display: 'ActionsLineGraph',
+                                    showLegend: true,
+                                },
+                                filterTestAccounts: false,
+                            },
+                        },
+                        title: 'Rollout of users on 3000',
+                        __init: null,
+                        height: null,
+                        nodeId: '4c2a07ee-fc9f-45c5-b36c-5e14a10f8e89',
+                        children: null,
+                    },
+                },
+            ],
+        ],
     ]
 
     contentToExpected.forEach(([name, prevContent, nextContent]) => {

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
@@ -482,6 +482,63 @@ describe('migrate()', () => {
                 },
             ],
         ],
+        [
+            'migrates paths filter',
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'PathsQuery',
+                                interval: 'day',
+                                dateRange: { date_to: null, date_from: '-30d' },
+                                pathsFilter: {
+                                    edge_limit: 20,
+                                    step_limit: 9,
+                                    start_point: 'https://posthog.com/blog/best-mixpanel-alternatives',
+                                    include_event_types: ['$pageview'],
+                                },
+                                filterTestAccounts: true,
+                            },
+                        },
+                        title: null,
+                        __init: null,
+                        height: null,
+                        nodeId: 'e2f225af-7e5f-40c0-afbd-832cbb866079',
+                        children: null,
+                    },
+                },
+            ],
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'PathsQuery',
+                                interval: 'day',
+                                dateRange: { date_to: null, date_from: '-30d' },
+                                pathsFilter: {
+                                    edgeLimit: 20,
+                                    stepLimit: 9,
+                                    startPoint: 'https://posthog.com/blog/best-mixpanel-alternatives',
+                                    includeEventTypes: ['$pageview'],
+                                },
+                                filterTestAccounts: true,
+                            },
+                        },
+                        title: null,
+                        __init: null,
+                        height: null,
+                        nodeId: 'e2f225af-7e5f-40c0-afbd-832cbb866079',
+                        children: null,
+                    },
+                },
+            ],
+        ],
     ]
 
     contentToExpected.forEach(([name, prevContent, nextContent]) => {

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
@@ -57,7 +57,7 @@ describe('migrate()', () => {
                                     },
                                 ],
                                 interval: 'week',
-                                breakdown: { breakdown_type: 'event', breakdown: '$referring_domain' },
+                                breakdownFilter: { breakdown_type: 'event', breakdown: '$referring_domain' },
                                 trendsFilter: { compare: false, display: 'ActionsBar' },
                             },
                         },
@@ -343,7 +343,7 @@ describe('migrate()', () => {
                                     },
                                 ],
                                 interval: 'day',
-                                breakdown: {
+                                breakdownFilter: {
                                     breakdown: '$feature/posthog-3000',
                                     breakdown_type: 'event',
                                 },
@@ -358,6 +358,125 @@ describe('migrate()', () => {
                         __init: null,
                         height: null,
                         nodeId: '4c2a07ee-fc9f-45c5-b36c-5e14a10f8e89',
+                        children: null,
+                    },
+                },
+            ],
+        ],
+        [
+            'migrates breakdown',
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'TrendsQuery',
+                                series: [
+                                    {
+                                        kind: 'EventsNode',
+                                        math: 'dau',
+                                        name: '$pageview',
+                                        event: '$pageview',
+                                        properties: [
+                                            {
+                                                key: '$referring_domain',
+                                                type: 'event',
+                                                value: 'google|duckduckgo|brave|bing',
+                                                operator: 'regex',
+                                            },
+                                            {
+                                                key: 'utm_source',
+                                                type: 'event',
+                                                value: 'is_not_set',
+                                                operator: 'is_not_set',
+                                            },
+                                            {
+                                                key: '$host',
+                                                type: 'event',
+                                                value: ['posthog.com'],
+                                                operator: 'exact',
+                                            },
+                                        ],
+                                    },
+                                ],
+                                interval: 'week',
+                                breakdown: {
+                                    breakdown: '$referring_domain',
+                                    breakdown_type: 'event',
+                                },
+                                dateRange: { date_to: null, date_from: '-90d' },
+                                properties: {
+                                    type: 'AND',
+                                    values: [{ type: 'AND', values: [] }],
+                                },
+                                trendsFilter: { compare: false, display: 'ActionsBar' },
+                                filterTestAccounts: true,
+                            },
+                        },
+                        title: 'SEO trend last 90 days',
+                        __init: null,
+                        height: null,
+                        nodeId: '245516ed-8bb2-41c3-83c6-fc10bb0c5149',
+                        children: null,
+                    },
+                },
+            ],
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'TrendsQuery',
+                                series: [
+                                    {
+                                        kind: 'EventsNode',
+                                        math: 'dau',
+                                        name: '$pageview',
+                                        event: '$pageview',
+                                        properties: [
+                                            {
+                                                key: '$referring_domain',
+                                                type: 'event',
+                                                value: 'google|duckduckgo|brave|bing',
+                                                operator: 'regex',
+                                            },
+                                            {
+                                                key: 'utm_source',
+                                                type: 'event',
+                                                value: 'is_not_set',
+                                                operator: 'is_not_set',
+                                            },
+                                            {
+                                                key: '$host',
+                                                type: 'event',
+                                                value: ['posthog.com'],
+                                                operator: 'exact',
+                                            },
+                                        ],
+                                    },
+                                ],
+                                interval: 'week',
+                                breakdownFilter: {
+                                    breakdown: '$referring_domain',
+                                    breakdown_type: 'event',
+                                },
+                                dateRange: { date_to: null, date_from: '-90d' },
+                                properties: {
+                                    type: 'AND',
+                                    values: [{ type: 'AND', values: [] }],
+                                },
+                                trendsFilter: { compare: false, display: 'ActionsBar' },
+                                filterTestAccounts: true,
+                            },
+                        },
+                        title: 'SEO trend last 90 days',
+                        __init: null,
+                        height: null,
+                        nodeId: '245516ed-8bb2-41c3-83c6-fc10bb0c5149',
                         children: null,
                     },
                 },

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
@@ -183,6 +183,95 @@ describe('migrate()', () => {
                 },
             ],
         ],
+        [
+            'migrates retention filter',
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'RetentionQuery',
+                                retentionFilter: {
+                                    period: 'Week',
+                                    targetEntity: {
+                                        id: 'recording analyzed',
+                                        name: 'recording analyzed',
+                                        type: 'events',
+                                        uuid: 'ae1136ce-cee1-4225-b27a-fbff3a99d4a9',
+                                        order: 0,
+                                    },
+                                    retentionType: 'retention_first_time',
+                                    target_entity: {
+                                        id: 'recording analyzed',
+                                        name: 'recording analyzed',
+                                        type: 'events',
+                                        uuid: 'af560c55-fa85-4c38-b056-94b6e253530a',
+                                        order: 0,
+                                    },
+                                    retention_type: 'retention_first_time',
+                                    total_intervals: 7,
+                                    returning_entity: {
+                                        id: 'recording analyzed',
+                                        name: 'recording analyzed',
+                                        type: 'events',
+                                        uuid: '286575a9-1485-47d0-9bf6-9d439bc051b3',
+                                        order: 0,
+                                    },
+                                    retention_reference: 'total',
+                                },
+                                aggregation_group_type_index: 0,
+                            },
+                        },
+                        title: "Retention 'recording analyzed' for unique organizations, last 6 weeks",
+                        __init: null,
+                        height: null,
+                        nodeId: 'a562d7e0-068f-40c3-ac1b-ca91f1d5effe',
+                        children: null,
+                    },
+                },
+            ],
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'RetentionQuery',
+                                retentionFilter: {
+                                    period: 'Week',
+                                    targetEntity: {
+                                        id: 'recording analyzed',
+                                        name: 'recording analyzed',
+                                        type: 'events',
+                                        uuid: 'af560c55-fa85-4c38-b056-94b6e253530a',
+                                        order: 0,
+                                    },
+                                    retentionType: 'retention_first_time',
+                                    totalIntervals: 7,
+                                    returningEntity: {
+                                        id: 'recording analyzed',
+                                        name: 'recording analyzed',
+                                        type: 'events',
+                                        uuid: '286575a9-1485-47d0-9bf6-9d439bc051b3',
+                                        order: 0,
+                                    },
+                                    retentionReference: 'total',
+                                },
+                                aggregation_group_type_index: 0,
+                            },
+                        },
+                        title: "Retention 'recording analyzed' for unique organizations, last 6 weeks",
+                        __init: null,
+                        height: null,
+                        nodeId: 'a562d7e0-068f-40c3-ac1b-ca91f1d5effe',
+                        children: null,
+                    },
+                },
+            ],
+        ],
     ]
 
     contentToExpected.forEach(([name, prevContent, nextContent]) => {

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.test.ts
@@ -1,0 +1,202 @@
+import { NotebookType } from '~/types'
+
+import mockNotebook from '../__mocks__/notebook-12345.json'
+import { JSONContent } from '../utils'
+import { migrate } from './migrate'
+
+describe('migrate()', () => {
+    const contentToExpected: [string, JSONContent[], JSONContent[]][] = [
+        ['migrates node without changes', [{ type: 'paragraph' }], [{ type: 'paragraph' }]],
+        [
+            'migrates query node with string content to object content',
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: '{"kind":"InsightVizNode","source":{"kind":"TrendsQuery","properties":{"type":"AND","values":[{"type":"AND","values":[]}]},"filterTestAccounts":true,"dateRange":{"date_to":null,"date_from":"-90d"},"series":[{"kind":"EventsNode","event":"$pageview","name":"$pageview","properties":[{"key":"$referring_domain","type":"event","value":"google|duckduckgo|brave|bing","operator":"regex"},{"key":"utm_source","type":"event","value":"is_not_set","operator":"is_not_set"},{"key":"$host","type":"event","value":["posthog.com"],"operator":"exact"}],"math":"dau"}],"interval":"week","breakdown":{"breakdown_type":"event","breakdown":"$referring_domain"},"trendsFilter":{"compare":false,"display":"ActionsBar"}}}',
+                        title: 'SEO trend last 90 days',
+                        __init: null,
+                        height: null,
+                        nodeId: '245516ed-8bb2-41c3-83c6-fc10bb0c5149',
+                        children: null,
+                    },
+                },
+            ],
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'TrendsQuery',
+                                properties: { type: 'AND', values: [{ type: 'AND', values: [] }] },
+                                filterTestAccounts: true,
+                                dateRange: { date_to: null, date_from: '-90d' },
+                                series: [
+                                    {
+                                        kind: 'EventsNode',
+                                        event: '$pageview',
+                                        name: '$pageview',
+                                        properties: [
+                                            {
+                                                key: '$referring_domain',
+                                                type: 'event',
+                                                value: 'google|duckduckgo|brave|bing',
+                                                operator: 'regex',
+                                            },
+                                            {
+                                                key: 'utm_source',
+                                                type: 'event',
+                                                value: 'is_not_set',
+                                                operator: 'is_not_set',
+                                            },
+                                            { key: '$host', type: 'event', value: ['posthog.com'], operator: 'exact' },
+                                        ],
+                                        math: 'dau',
+                                    },
+                                ],
+                                interval: 'week',
+                                breakdown: { breakdown_type: 'event', breakdown: '$referring_domain' },
+                                trendsFilter: { compare: false, display: 'ActionsBar' },
+                            },
+                        },
+                        title: 'SEO trend last 90 days',
+                        __init: null,
+                        height: null,
+                        nodeId: '245516ed-8bb2-41c3-83c6-fc10bb0c5149',
+                        children: null,
+                    },
+                },
+            ],
+        ],
+        [
+            'migrates funnels filter',
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'FunnelsQuery',
+                                series: [
+                                    {
+                                        kind: 'EventsNode',
+                                        math: 'total',
+                                        name: 'user signed up',
+                                        event: 'user signed up',
+                                        properties: [
+                                            {
+                                                key: 'is_organization_first_user',
+                                                type: 'person',
+                                                value: ['true'],
+                                                operator: 'exact',
+                                            },
+                                            {
+                                                key: 'realm',
+                                                type: 'event',
+                                                value: ['cloud'],
+                                                operator: 'exact',
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        kind: 'EventsNode',
+                                        math: 'total',
+                                        name: 'recording analyzed',
+                                        event: 'recording analyzed',
+                                    },
+                                ],
+                                interval: 'day',
+                                dateRange: { date_to: '', date_from: '-6w' },
+                                funnelsFilter: {
+                                    funnel_viz_type: 'trends',
+                                    funnel_order_type: 'ordered',
+                                    funnel_window_interval: 14,
+                                    funnel_window_interval_unit: 'day',
+                                },
+                                aggregation_group_type_index: 0,
+                            },
+                        },
+                        title: 'Organisation signed up -> recording analyzed, last 6 weeks',
+                        __init: null,
+                        height: 516,
+                        nodeId: 'be5c5e34-f330-4f3f-9a2f-6361c60d0f2e',
+                        children: null,
+                    },
+                },
+            ],
+            [
+                {
+                    type: 'ph-query',
+                    attrs: {
+                        query: {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'FunnelsQuery',
+                                series: [
+                                    {
+                                        kind: 'EventsNode',
+                                        math: 'total',
+                                        name: 'user signed up',
+                                        event: 'user signed up',
+                                        properties: [
+                                            {
+                                                key: 'is_organization_first_user',
+                                                type: 'person',
+                                                value: ['true'],
+                                                operator: 'exact',
+                                            },
+                                            {
+                                                key: 'realm',
+                                                type: 'event',
+                                                value: ['cloud'],
+                                                operator: 'exact',
+                                            },
+                                        ],
+                                    },
+                                    {
+                                        kind: 'EventsNode',
+                                        math: 'total',
+                                        name: 'recording analyzed',
+                                        event: 'recording analyzed',
+                                    },
+                                ],
+                                interval: 'day',
+                                dateRange: { date_to: '', date_from: '-6w' },
+                                funnelsFilter: {
+                                    funnelOrderType: 'ordered',
+                                    funnelVizType: 'trends',
+                                    funnelWindowInterval: 14,
+                                    funnelWindowIntervalUnit: 'day',
+                                },
+                                aggregation_group_type_index: 0,
+                            },
+                        },
+                        title: 'Organisation signed up -> recording analyzed, last 6 weeks',
+                        __init: null,
+                        height: 516,
+                        nodeId: 'be5c5e34-f330-4f3f-9a2f-6361c60d0f2e',
+                        children: null,
+                    },
+                },
+            ],
+        ],
+    ]
+
+    contentToExpected.forEach(([name, prevContent, nextContent]) => {
+        it(name, () => {
+            const prevNotebook: NotebookType = {
+                ...mockNotebook,
+                content: { type: 'doc', content: prevContent },
+            }
+            const nextNotebook: NotebookType = {
+                ...mockNotebook,
+                content: { type: 'doc', content: nextContent },
+            }
+
+            expect(migrate(prevNotebook)).toEqual(nextNotebook)
+        })
+    })
+})

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
@@ -1,6 +1,7 @@
 import { JSONContent } from '@tiptap/core'
 
 import {
+    breakdownFilterToQuery,
     funnelsFilterToQuery,
     retentionFilterToQuery,
     trendsFilterToQuery,
@@ -89,6 +90,9 @@ function convertInsightQueriesToNewSchema(content: JSONContent[]): JSONContent[]
         const insightQuery = node.attrs.query as InsightVizNode
         const query = insightQuery.source
 
+        /*
+         * Insight filters
+         */
         if (query.kind === NodeKind.TrendsQuery && isLegacyTrendsFilter(query.trendsFilter as any)) {
             query.trendsFilter = trendsFilterToQuery(query.trendsFilter as any)
         }
@@ -99,6 +103,14 @@ function convertInsightQueriesToNewSchema(content: JSONContent[]): JSONContent[]
 
         if (query.kind === NodeKind.RetentionQuery && isLegacyRetentionFilter(query.retentionFilter as any)) {
             query.retentionFilter = retentionFilterToQuery(query.retentionFilter as any)
+        }
+
+        /*
+         * Breakdown
+         */
+        if ((query.kind === NodeKind.TrendsQuery || query.kind === NodeKind.FunnelsQuery) && 'breakdown' in query) {
+            query.breakdownFilter = breakdownFilterToQuery(query.breakdown as any, query.kind === NodeKind.TrendsQuery)
+            delete query.breakdown
         }
 
         return {

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
@@ -1,7 +1,15 @@
 import { JSONContent } from '@tiptap/core'
 
-import { funnelsFilterToQuery, retentionFilterToQuery } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
-import { isLegacyFunnelsFilter, isLegacyRetentionFilter } from '~/queries/nodes/InsightQuery/utils/legacy'
+import {
+    funnelsFilterToQuery,
+    retentionFilterToQuery,
+    trendsFilterToQuery,
+} from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
+import {
+    isLegacyFunnelsFilter,
+    isLegacyRetentionFilter,
+    isLegacyTrendsFilter,
+} from '~/queries/nodes/InsightQuery/utils/legacy'
 import { InsightVizNode, NodeKind } from '~/queries/schema'
 import { NotebookNodeType, NotebookType } from '~/types'
 
@@ -78,25 +86,26 @@ function convertInsightQueriesToNewSchema(content: JSONContent[]): JSONContent[]
             return node
         }
 
-        const query = node.attrs.query as InsightVizNode
-        const querySource = query.source
+        const insightQuery = node.attrs.query as InsightVizNode
+        const query = insightQuery.source
 
-        if (querySource.kind === NodeKind.FunnelsQuery && isLegacyFunnelsFilter(querySource.funnelsFilter as any)) {
-            querySource.funnelsFilter = funnelsFilterToQuery(querySource.funnelsFilter as any)
+        if (query.kind === NodeKind.TrendsQuery && isLegacyTrendsFilter(query.trendsFilter as any)) {
+            query.trendsFilter = trendsFilterToQuery(query.trendsFilter as any)
         }
 
-        if (
-            querySource.kind === NodeKind.RetentionQuery &&
-            isLegacyRetentionFilter(querySource.retentionFilter as any)
-        ) {
-            querySource.retentionFilter = retentionFilterToQuery(querySource.retentionFilter as any)
+        if (query.kind === NodeKind.FunnelsQuery && isLegacyFunnelsFilter(query.funnelsFilter as any)) {
+            query.funnelsFilter = funnelsFilterToQuery(query.funnelsFilter as any)
+        }
+
+        if (query.kind === NodeKind.RetentionQuery && isLegacyRetentionFilter(query.retentionFilter as any)) {
+            query.retentionFilter = retentionFilterToQuery(query.retentionFilter as any)
         }
 
         return {
             ...node,
             attrs: {
                 ...node.attrs,
-                query: query,
+                query: insightQuery,
             },
         }
     })

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
@@ -3,11 +3,13 @@ import { JSONContent } from '@tiptap/core'
 import {
     breakdownFilterToQuery,
     funnelsFilterToQuery,
+    pathsFilterToQuery,
     retentionFilterToQuery,
     trendsFilterToQuery,
 } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import {
     isLegacyFunnelsFilter,
+    isLegacyPathsFilter,
     isLegacyRetentionFilter,
     isLegacyTrendsFilter,
 } from '~/queries/nodes/InsightQuery/utils/legacy'
@@ -103,6 +105,10 @@ function convertInsightQueriesToNewSchema(content: JSONContent[]): JSONContent[]
 
         if (query.kind === NodeKind.RetentionQuery && isLegacyRetentionFilter(query.retentionFilter as any)) {
             query.retentionFilter = retentionFilterToQuery(query.retentionFilter as any)
+        }
+
+        if (query.kind === NodeKind.PathsQuery && isLegacyPathsFilter(query.pathsFilter as any)) {
+            query.pathsFilter = pathsFilterToQuery(query.pathsFilter as any)
         }
 
         /*

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
@@ -1,7 +1,7 @@
 import { JSONContent } from '@tiptap/core'
 
-import { funnelsFilterToQuery } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
-import { isLegacyFunnelsFilter } from '~/queries/nodes/InsightQuery/utils/legacy'
+import { funnelsFilterToQuery, retentionFilterToQuery } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
+import { isLegacyFunnelsFilter, isLegacyRetentionFilter } from '~/queries/nodes/InsightQuery/utils/legacy'
 import { InsightVizNode, NodeKind } from '~/queries/schema'
 import { NotebookNodeType, NotebookType } from '~/types'
 
@@ -83,6 +83,13 @@ function convertInsightQueriesToNewSchema(content: JSONContent[]): JSONContent[]
 
         if (querySource.kind === NodeKind.FunnelsQuery && isLegacyFunnelsFilter(querySource.funnelsFilter as any)) {
             querySource.funnelsFilter = funnelsFilterToQuery(querySource.funnelsFilter as any)
+        }
+
+        if (
+            querySource.kind === NodeKind.RetentionQuery &&
+            isLegacyRetentionFilter(querySource.retentionFilter as any)
+        ) {
+            querySource.retentionFilter = retentionFilterToQuery(querySource.retentionFilter as any)
         }
 
         return {


### PR DESCRIPTION
## Problem

Some inline insights in notebooks are broken, since the schema changes haven't been applied there.

## Changes

This PR tries to correct that using actually broken insights in production as a guide.

## How did you test this code?

Added tests