### PR TITLE
feat(hogql): Add actors query to live compare

### DIFF
--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -139,7 +139,8 @@ export async function query<N extends DataNode = DataNode>(
     queryNode: N,
     methodOptions?: ApiMethodOptions,
     refresh?: boolean,
-    queryId?: string
+    queryId?: string,
+    legacyUrl?: string
 ): Promise<NonNullable<N['response']>> {
     if (isTimeToSeeDataSessionsNode(queryNode)) {
         return query(queryNode.source)
@@ -170,6 +171,11 @@ export async function query<N extends DataNode = DataNode>(
     const hogQLInsightsLiveCompareEnabled = Boolean(
         featureFlagLogic.findMounted()?.values.featureFlags?.[FEATURE_FLAGS.HOGQL_INSIGHT_LIVE_COMPARE]
     )
+
+    async function fetchLegacyUrl(): Promise<Record<string, any>> {
+        const response = await api.getResponse(legacyUrl!)
+        return response.json()
+    }
 
     async function fetchLegacyInsights(): Promise<Record<string, any>> {
         if (!isInsightQueryNode(queryNode)) {
@@ -206,20 +212,22 @@ export async function query<N extends DataNode = DataNode>(
                 },
                 methodOptions
             )
-        } else if (isInsightQueryNode(queryNode)) {
+        } else if (isInsightQueryNode(queryNode) || isActorsQuery(queryNode)) {
             if (
                 (hogQLInsightsLifecycleFlagEnabled && isLifecycleQuery(queryNode)) ||
-                (hogQLInsightsPathsFlagEnabled && isPathsQuery(queryNode)) ||
+                (hogQLInsightsPathsFlagEnabled &&
+                    (isPathsQuery(queryNode) || (isActorsQuery(queryNode) && !!legacyUrl))) ||
                 (hogQLInsightsRetentionFlagEnabled && isRetentionQuery(queryNode)) ||
                 (hogQLInsightsTrendsFlagEnabled && isTrendsQuery(queryNode)) ||
                 (hogQLInsightsStickinessFlagEnabled && isStickinessQuery(queryNode)) ||
                 (hogQLInsightsFunnelsFlagEnabled && isFunnelsQuery(queryNode))
             ) {
                 if (hogQLInsightsLiveCompareEnabled) {
+                    const legacyFunction = legacyUrl ? fetchLegacyUrl : fetchLegacyInsights
                     let legacyResponse: any
                     ;[response, legacyResponse] = await Promise.all([
                         api.query(queryNode, methodOptions, queryId, refresh),
-                        fetchLegacyInsights(),
+                        legacyFunction(),
                     ])
 
                     let res1 = response?.result || response?.results
@@ -243,6 +251,9 @@ export async function query<N extends DataNode = DataNode>(
                             action: undefined,
                             persons: undefined,
                         }))
+                    } else if (res2.length > 0 && res2[0].people) {
+                        res2 = res2[0]?.people.map((n: any) => n.id)
+                        res1 = res1.map((n: any) => n[0].id)
                     }
 
                     const getTimingDiff = (): undefined | { diff: number; legacy: number; hogql: number } => {
@@ -265,6 +276,9 @@ export async function query<N extends DataNode = DataNode>(
                         }
                     }
 
+                    const almostEqual = (n1: number, n2: number, epsilon: number = 1.0): boolean =>
+                        Math.abs(n1 - n2) < epsilon
+
                     const timingDiff = getTimingDiff()
 
                     const results = flattenObject(res1)
@@ -276,17 +290,21 @@ export async function query<N extends DataNode = DataNode>(
                     let matchCount = 0
                     let mismatchCount = 0
                     for (const key of sortedKeys) {
-                        if (results[key] === legacyResults[key]) {
+                        let isMatch = false
+                        if (
+                            results[key] === legacyResults[key] ||
+                            (key.includes('average_conversion_time') && almostEqual(results[key], legacyResults[key]))
+                        ) {
+                            isMatch = true
+                        }
+
+                        if (isMatch) {
                             matchCount++
                         } else {
                             mismatchCount++
                         }
-                        tableData.push([
-                            results[key] === legacyResults[key] ? '✅' : '🚨',
-                            key,
-                            results[key],
-                            legacyResults[key],
-                        ])
+
+                        tableData.push([isMatch ? '✅' : '🚨', key, results[key], legacyResults[key]])
                     }
 
                     if (timingDiff) {
@@ -310,12 +328,10 @@ export async function query<N extends DataNode = DataNode>(
                         legacyResponse,
                         timingDiff,
                     })
+                    const resultsLabel = mismatchCount === 0 ? '👏' : '⚠️'
+                    const alertLabel = mismatchCount > 0 ? `🚨${mismatchCount}` : ''
                     // eslint-disable-next-line no-console
-                    console.groupCollapsed(
-                        `Results: ${mismatchCount === 0 ? '✅✅✅' : '✅'} ${matchCount}${
-                            mismatchCount > 0 ? ` 🚨🚨🚨${mismatchCount}` : ''
-                        }`
-                    )
+                    console.groupCollapsed(`Results: ${resultsLabel} ✅${matchCount} ${alertLabel} ${queryNode.kind}`)
                     // eslint-disable-next-line no-console
                     console.table(tableData)
                     // eslint-disable-next-line no-console

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -212,7 +212,7 @@ export async function query<N extends DataNode = DataNode>(
                 },
                 methodOptions
             )
-        } else if (isInsightQueryNode(queryNode) || isActorsQuery(queryNode)) {
+        } else if (isInsightQueryNode(queryNode) || (isActorsQuery(queryNode) && !!legacyUrl)) {
             if (
                 (hogQLInsightsLifecycleFlagEnabled && isLifecycleQuery(queryNode)) ||
                 (hogQLInsightsPathsFlagEnabled &&

--- a/frontend/src/scenes/paths/pathsDataLogic.ts
+++ b/frontend/src/scenes/paths/pathsDataLogic.ts
@@ -142,6 +142,7 @@ export const pathsDataLogic = kea<pathsDataLogicType>([
                     },
                 }
                 openPersonsModal({
+                    url: personsUrl,
                     query: pathsActorsQuery,
                     title: pathsTitle({
                         label: path_dropoff_key || path_start_key || path_end_key || 'Pageview',

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -97,7 +97,8 @@ export const personsModalLogic = kea<personsModalLogicType>([
                         if (values.searchTerm) {
                             url += `&search=${values.searchTerm}`
                         }
-
+                    }
+                    if (url && !query) {
                         const res = await api.get(url)
                         breakpoint()
 
@@ -105,12 +106,19 @@ export const personsModalLogic = kea<personsModalLogicType>([
                             actions.resetActors()
                         }
                         return res
-                    } else if (query) {
-                        const response = await performQuery({
-                            ...values.actorsQuery,
-                            limit: RESULTS_PER_PAGE + 1,
-                            offset: offset || 0,
-                        } as ActorsQuery)
+                    }
+                    if (query) {
+                        const response = await performQuery(
+                            {
+                                ...values.actorsQuery,
+                                limit: RESULTS_PER_PAGE + 1,
+                                offset: offset || 0,
+                            } as ActorsQuery,
+                            undefined,
+                            undefined,
+                            undefined,
+                            url ?? undefined
+                        )
                         breakpoint()
 
                         const assembledSelectFields = values.selectFields


### PR DESCRIPTION
## Problem

Path actors not in actors to live compare

## Changes

- add paths actors by passing legacy URL to fetch and compare results from
- others:
  - just compare conversion times to be almost equal
   - improve the emojis and log query kind as well

<img width="287" alt="image" src="https://github.com/PostHog/posthog/assets/59713/ad20ea30-14cc-4127-91dc-20e6749a9e64">


## How did you test this code?

- check in frontend
