### PR TITLE
fix(hogql): nulls and boolean comparisons

### DIFF
--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -187,6 +187,13 @@ class TestProperty(BaseTest):
             ),
             self._parse_expr("properties.unknown_prop = true"),
         )
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "event", "key": "boolean_prop", "value": "false"},
+                team=self.team,
+            ),
+            self._parse_expr("properties.boolean_prop = false"),
+        )
 
     def test_property_to_expr_event_list(self):
         # positive

--- a/posthog/hogql/transforms/property_types.py
+++ b/posthog/hogql/transforms/property_types.py
@@ -4,7 +4,6 @@ from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import DateTimeDatabaseField
 from posthog.hogql.escape_sql import escape_hogql_identifier
-from posthog.hogql.parser import parse_expr
 from posthog.hogql.visitor import CloningVisitor, TraversingVisitor
 from posthog.models.property import PropertyName, TableColumn
 from posthog.utils import PersonOnEventsMode
@@ -155,7 +154,15 @@ class PropertySwapper(CloningVisitor):
         if field_type == "Float":
             return ast.Call(name="toFloat", args=[node])
         if field_type == "Boolean":
-            return parse_expr("{node} = 'true'", {"node": node})
+            return ast.Call(
+                name="transform",
+                args=[
+                    node,
+                    ast.Constant(value=["true", "false"]),
+                    ast.Constant(value=[True, False]),
+                    ast.Constant(value=None),
+                ],
+            )
         return node
 
     def _add_property_notice(

--- a/posthog/hogql/transforms/test/__snapshots__/test_property_types.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_property_types.ambr
@@ -22,7 +22,7 @@
 # name: TestPropertyTypes.test_resolve_property_types_event
   '''
   
-  SELECT multiply(toFloat64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '')), toFloat64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_1)s), ''), 'null'), '^"|"$', ''))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_2)s), ''), 'null'), '^"|"$', ''), %(hogql_val_3)s), 0) AS bool 
+  SELECT multiply(toFloat64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '')), toFloat64OrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_1)s), ''), 'null'), '^"|"$', ''))), transform(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_2)s), ''), 'null'), '^"|"$', ''), %(hogql_val_3)s, %(hogql_val_4)s, NULL) AS bool 
   FROM events 
   WHERE equals(events.team_id, 420) 
   LIMIT 10000


### PR DESCRIPTION
## Problem

A certain combination of filters, booleans and nulls caused HogQL to evaluate things differently.

Essentially, the expression `properties.boolean_prop == false` would evaluate to `true` if the property was either `false` or `null`. 

## Changes

Now boolean string properties are correctly parsed as `true`, `false`, or `null`, depending on their state.

The query:

```sql
select properties.$autocapture_disabled_server_side, 
       properties.$autocapture_disabled_server_side = true, 
       properties.$autocapture_disabled_server_side = false 
from events limit 100
```

Now (some rows are "null"):
<img width="1473" alt="image" src="https://github.com/PostHog/posthog/assets/53387/668ec7d8-d347-49ff-9285-5bb68f8f93ae">

Before (all rows always "false"):
<img width="1477" alt="image" src="https://github.com/PostHog/posthog/assets/53387/dbdc8bf6-587b-4271-bdbb-b3ff4c498b8a">

## How did you test this code?

Tests