### PR TITLE
chore(data-warehouse): add regex that only allows valid characters

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/sourceFormLogic.ts
+++ b/frontend/src/scenes/data-warehouse/external/forms/sourceFormLogic.ts
@@ -29,11 +29,22 @@ const getPayloadDefaults = (sourceType: string): Record<string, any> => {
 const getErrorsDefaults = (sourceType: string): ((args: Record<string, any>) => Record<string, any>) => {
     switch (sourceType) {
         case 'Stripe':
-            return ({ payload }) => ({
-                payload: {
-                    account_id: !payload.account_id && 'Please enter an account id.',
-                    client_secret: !payload.client_secret && 'Please enter a client secret.',
-                },
+            return ({ prefix, payload }) => {
+                return {
+                    prefix: /^[a-zA-Z0-9_-]*$/.test(prefix)
+                        ? null
+                        : "Please enter a valid prefix (only letters, numbers, and '_' or '-').",
+                    payload: {
+                        account_id: !payload.account_id && 'Please enter an account id.',
+                        client_secret: !payload.client_secret && 'Please enter a client secret.',
+                    },
+                }
+            }
+        case 'Hubspot':
+            return ({ prefix }) => ({
+                prefix: /^[a-zA-Z0-9_-]*$/.test(prefix)
+                    ? null
+                    : "Please enter a valid prefix (only letters, numbers, and '_' or '-').",
             })
         default:
             return () => ({})
@@ -119,7 +130,10 @@ export const sourceFormLogic = kea<sourceFormLogicType>([
                     schema: '',
                 },
             },
-            errors: ({ payload: { host, port, dbname, user, password, schema } }) => ({
+            errors: ({ prefix, payload: { host, port, dbname, user, password, schema } }) => ({
+                prefix: /^[a-zA-Z0-9_-]*$/.test(prefix)
+                    ? null
+                    : "Please enter a valid prefix (only letters, numbers, and '_' or '-').",
                 payload: {
                     host: !host && 'Please enter a host.',
                     port: !port && 'Please enter a port.',


### PR DESCRIPTION
## Problem

- prefix doesn't have validation so table names could become broken (using [] or .)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- add regex that only allows specific characters

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
