### PR TITLE
fix(notebooks): handle legacy stickiness and lifecycle filters

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -18,9 +18,11 @@ import {
     InsightNodeKind,
     InsightQueryNode,
     InsightsQueryBase,
+    LifecycleFilter,
     NodeKind,
     PathsFilter,
     RetentionFilter,
+    StickinessFilter,
     TrendsFilter,
 } from '~/queries/schema'
 import {
@@ -290,21 +292,12 @@ export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNo
 
     // stickiness filter
     if (isStickinessFilter(filters) && isStickinessQuery(query)) {
-        query.stickinessFilter = objectCleanWithEmpty({
-            display: filters.display,
-            compare: filters.compare,
-            showLegend: filters.show_legend,
-            hidden_legend_indexes: cleanHiddenLegendIndexes(filters.hidden_legend_keys),
-            showValuesOnSeries: filters.show_values_on_series,
-        })
+        query.stickinessFilter = stickinessFilterToQuery(filters)
     }
 
     // lifecycle filter
     if (isLifecycleFilter(filters) && isLifecycleQuery(query)) {
-        query.lifecycleFilter = objectCleanWithEmpty({
-            toggledLifecycles: filters.toggledLifecycles,
-            showValuesOnSeries: filters.show_values_on_series,
-        })
+        query.lifecycleFilter = lifecycleFilterToQuery(filters)
     }
 
     // remove undefined and empty array/objects and return
@@ -383,6 +376,23 @@ export const pathsFilterToQuery = (filters: Partial<PathsFilterType>): PathsFilt
         edgeLimit: filters.edge_limit,
         minEdgeWeight: filters.min_edge_weight,
         maxEdgeWeight: filters.max_edge_weight,
+    })
+}
+
+export const stickinessFilterToQuery = (filters: Record<string, any>): StickinessFilter => {
+    return objectCleanWithEmpty({
+        display: filters.display,
+        compare: filters.compare,
+        showLegend: filters.show_legend,
+        hidden_legend_indexes: cleanHiddenLegendIndexes(filters.hidden_legend_keys),
+        showValuesOnSeries: filters.show_values_on_series,
+    })
+}
+
+export const lifecycleFilterToQuery = (filters: Record<string, any>): LifecycleFilter => {
+    return objectCleanWithEmpty({
+        toggledLifecycles: filters.toggledLifecycles,
+        showValuesOnSeries: filters.show_values_on_series,
     })
 }
 

--- a/frontend/src/queries/nodes/InsightQuery/utils/legacy.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/legacy.ts
@@ -72,3 +72,21 @@ export const isLegacyPathsFilter = (filters: Record<string, any> | undefined): b
     ]
     return legacyKeys.some((key) => key in filters)
 }
+
+export const isLegacyStickinessFilter = (filters: Record<string, any> | undefined): boolean => {
+    if (filters == null) {
+        return false
+    }
+
+    const legacyKeys = ['show_legend', 'hidden_legend_keys', 'show_values_on_series']
+    return legacyKeys.some((key) => key in filters)
+}
+
+export const isLegacyLifecycleFilter = (filters: Record<string, any> | undefined): boolean => {
+    if (filters == null) {
+        return false
+    }
+
+    const legacyKeys = ['show_values_on_series']
+    return legacyKeys.some((key) => key in filters)
+}

--- a/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
+++ b/frontend/src/scenes/notebooks/Notebook/migrations/migrate.ts
@@ -3,14 +3,18 @@ import { JSONContent } from '@tiptap/core'
 import {
     breakdownFilterToQuery,
     funnelsFilterToQuery,
+    lifecycleFilterToQuery,
     pathsFilterToQuery,
     retentionFilterToQuery,
+    stickinessFilterToQuery,
     trendsFilterToQuery,
 } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import {
     isLegacyFunnelsFilter,
+    isLegacyLifecycleFilter,
     isLegacyPathsFilter,
     isLegacyRetentionFilter,
+    isLegacyStickinessFilter,
     isLegacyTrendsFilter,
 } from '~/queries/nodes/InsightQuery/utils/legacy'
 import { InsightVizNode, NodeKind } from '~/queries/schema'
@@ -109,6 +113,14 @@ function convertInsightQueriesToNewSchema(content: JSONContent[]): JSONContent[]
 
         if (query.kind === NodeKind.PathsQuery && isLegacyPathsFilter(query.pathsFilter as any)) {
             query.pathsFilter = pathsFilterToQuery(query.pathsFilter as any)
+        }
+
+        if (query.kind === NodeKind.StickinessQuery && isLegacyStickinessFilter(query.stickinessFilter as any)) {
+            query.stickinessFilter = stickinessFilterToQuery(query.stickinessFilter as any)
+        }
+
+        if (query.kind === NodeKind.LifecycleQuery && isLegacyLifecycleFilter(query.lifecycleFilter as any)) {
+            query.lifecycleFilter = lifecycleFilterToQuery(query.lifecycleFilter as any)
         }
 
         /*


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/pull/19991.

Faulty lifecycle filters in insights have been popping up https://posthog.sentry.io/issues/4918406256/events/5d39359b27e740f681b054a6b2d68d39/.

## Changes

This PR handles legacy stickiness and lifecycle filters in the migration.

## How did you test this code?

Implemented in the same way as other filters