### PR TITLE
fix: SDK API Host is app. instead of us.

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -10,6 +10,7 @@ import { withMockDate } from './decorators/withMockDate'
 import { defaultMocks } from '~/mocks/handlers'
 import { withFeatureFlags } from './decorators/withFeatureFlags'
 import { withTheme } from './decorators/withTheme'
+import { apiHostOrigin } from 'lib/utils/apiHost'
 
 const setupMsw = () => {
     // Make sure the msw worker is started
@@ -35,7 +36,7 @@ setupMsw()
 const setupPosthogJs = () => {
     // Make sure we don't hit production posthog. We want to control requests to,
     // e.g. `/decide/` for feature flags
-    window.JS_POSTHOG_HOST = window.location.origin
+    window.JS_POSTHOG_HOST = apiHostOrigin()
 
     loadPostHogJS()
 }

--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
@@ -18,6 +18,7 @@ import { encodeParams, urlToAction } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 import api from 'lib/api'
 import { isDomain, isURL } from 'lib/utils'
+import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -70,7 +71,7 @@ export function appEditorUrl(appUrl: string, actionId?: number | null, defaultIn
         // the toolbar, which isn't correct when used behind a reverse proxy as
         // we require e.g. SSO login to the app, which will not work when placed
         // behind a proxy unless we register each domain with the OAuth2 client.
-        apiURL: window.location.origin,
+        apiURL: apiHostOrigin(),
         appUrl,
         ...(actionId ? { actionId } : {}),
     }

--- a/frontend/src/lib/components/JSSnippet.tsx
+++ b/frontend/src/lib/components/JSSnippet.tsx
@@ -1,5 +1,6 @@
 import { useValues } from 'kea'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
 export function JSSnippet(): JSX.Element {
@@ -8,9 +9,7 @@ export function JSSnippet(): JSX.Element {
     return (
         <CodeSnippet language={Language.HTML}>{`<script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('${currentTeam?.api_token}',{api_host:'${
-            window.location.origin === 'https://us.posthog.com' ? 'https://app.posthog.com' : window.location.origin
-        }'})
+    posthog.init('${currentTeam?.api_token}',{api_host:'${apiHostOrigin}'})
 </script>`}</CodeSnippet>
     )
 }

--- a/frontend/src/lib/utils/apiHost.ts
+++ b/frontend/src/lib/utils/apiHost.ts
@@ -1,0 +1,8 @@
+export function apiHostOrigin(): string {
+    let apiHost = window.location.origin
+    // similar to https://github.com/PostHog/posthog-js/blob/b79315b7a4fa0caded7026bda2fec01defb0ba73/src/posthog-core.ts#L1742
+    if (apiHost === 'https://us.posthog.com') {
+        apiHost = 'https://app.posthog.com'
+    }
+    return apiHost
+}

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -1,5 +1,6 @@
 import { useValues } from 'kea'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { GroupType } from '~/types'
@@ -444,7 +445,7 @@ export function APISnippet({ groupType }: FeatureFlagSnippet): JSX.Element {
     return (
         <>
             <CodeSnippet language={Language.Bash} wrap>
-                {`curl ${window.location.origin}/decide?v=3/ \\
+                {`curl ${apiHostOrigin()}/decide?v=3/ \\
 -X POST -H 'Content-Type: application/json' \\
 -d '{
     "api_key": "${currentTeam ? currentTeam.api_token : '[project_api_key]'}",

--- a/frontend/src/scenes/onboarding/sdks/product-analytics/api.tsx
+++ b/frontend/src/scenes/onboarding/sdks/product-analytics/api.tsx
@@ -1,10 +1,11 @@
 import { useValues } from 'kea'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
 function APISnippet(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
-    const url = window.location.origin
+    const url = apiHostOrigin()
 
     return (
         <CodeSnippet language={Language.HTTP}>

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/flutter.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/flutter.tsx
@@ -1,5 +1,6 @@
 import { useValues } from 'kea'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
 function FlutterInstallSnippet(): JSX.Element {
@@ -8,7 +9,7 @@ function FlutterInstallSnippet(): JSX.Element {
 
 function FlutterAndroidSetupSnippet(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
-    const url = window.location.origin
+    const url = apiHostOrigin()
 
     return (
         <CodeSnippet language={Language.XML}>
@@ -23,7 +24,7 @@ function FlutterAndroidSetupSnippet(): JSX.Element {
 
 function FlutterIOSSetupSnippet(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
-    const url = window.location.origin
+    const url = apiHostOrigin()
 
     return (
         <CodeSnippet language={Language.XML}>

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/ios.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/ios.tsx
@@ -1,5 +1,6 @@
 import { useValues } from 'kea'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
 function IOSInstallCocoaPodsSnippet(): JSX.Element {
@@ -28,7 +29,7 @@ import UIKit
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         let POSTHOG_API_KEY = "${currentTeam?.api_token}"
-        let POSTHOG_HOST = "${window.location.origin}"
+        let POSTHOG_HOST = "${apiHostOrigin()}"
 
         let config = PostHogConfig(apiKey: POSTHOG_API_KEY, host: POSTHOG_HOST)
         PostHogSDK.shared.setup(config)

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/next-js.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/next-js.tsx
@@ -1,6 +1,7 @@
 import { useValues } from 'kea'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { Link } from 'lib/lemon-ui/Link'
+import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { JSInstallSnippet } from './js-web'
@@ -10,10 +11,9 @@ function NextEnvVarsSnippet(): JSX.Element {
 
     return (
         <CodeSnippet language={Language.Bash}>
-            {[
-                `NEXT_PUBLIC_POSTHOG_KEY=${currentTeam?.api_token}`,
-                `NEXT_PUBLIC_POSTHOG_HOST=${window.location.origin}`,
-            ].join('\n')}
+            {[`NEXT_PUBLIC_POSTHOG_KEY=${currentTeam?.api_token}`, `NEXT_PUBLIC_POSTHOG_HOST=${apiHostOrigin()}`].join(
+                '\n'
+            )}
         </CodeSnippet>
     )
 }

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/php.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/php.tsx
@@ -1,5 +1,6 @@
 import { useValues } from 'kea'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
 function PHPConfigSnippet(): JSX.Element {
@@ -24,7 +25,7 @@ function PHPSetupSnippet(): JSX.Element {
     return (
         <CodeSnippet language={Language.PHP}>
             {`PostHog::init('${currentTeam?.api_token}',
-    array('host' => '${window.location.origin}')
+    array('host' => '${apiHostOrigin()}')
 );`}
         </CodeSnippet>
     )

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react-native.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react-native.tsx
@@ -1,11 +1,12 @@
 import { Link } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
 export function SDKInstallRNInstructions(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
-    const url = window.location.origin
+    const url = apiHostOrigin()
 
     return (
         <>

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/ruby.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/ruby.tsx
@@ -1,5 +1,6 @@
 import { useValues } from 'kea'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
 function RubyInstallSnippet(): JSX.Element {
@@ -13,7 +14,7 @@ function RubySetupSnippet(): JSX.Element {
         <CodeSnippet language={Language.Ruby}>
             {`posthog = PostHog::Client.new({
     api_key: "${currentTeam?.api_token}",
-    host: "${window.location.origin}",
+    host: "${apiHostOrigin()}",
     on_error: Proc.new { |status, msg| print msg }
 })`}
         </CodeSnippet>


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0460J93NBU/p1706544626918109

The ApiHost should always be `app.*` instead of `us.*`.
Since the apiHost is inferred from `window.location.origin`, a lot of places including the onboarding sets `us.*` instead.

There are more places where `window.location.origin` is being used but I used the best of my judgment to make the change or not.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
