### PR TITLE
fix(stickiness): work with actions

### DIFF
--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -256,11 +256,11 @@ class StickinessQueryRunner(QueryRunner):
         )
 
         # Series
-        if self.series_event(series) is not None:
+        if isinstance(series, EventsNode):
             filters.append(
                 parse_expr(
                     "event = {event}",
-                    placeholders={"event": ast.Constant(value=self.series_event(series))},
+                    placeholders={"event": ast.Constant(value=series.event)},
                 )
             )
 

--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -256,7 +256,7 @@ class StickinessQueryRunner(QueryRunner):
         )
 
         # Series
-        if isinstance(series, EventsNode):
+        if isinstance(series, EventsNode) and series.event is not None:
             filters.append(
                 parse_expr(
                     "event = {event}",

--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -263,6 +263,13 @@ class StickinessQueryRunner(QueryRunner):
                     placeholders={"event": ast.Constant(value=series.event)},
                 )
             )
+        elif isinstance(series, ActionsNode):
+            try:
+                action = Action.objects.get(pk=int(series.id), team=self.team)
+                filters.append(action_to_expr(action))
+            except Action.DoesNotExist:
+                # If an action doesn't exist, we want to return no events
+                filters.append(parse_expr("1 = 2"))
 
         # Filter Test Accounts
         if (
@@ -280,15 +287,6 @@ class StickinessQueryRunner(QueryRunner):
         # Series Filters
         if series.properties is not None and series.properties != []:
             filters.append(property_to_expr(series.properties, self.team))
-
-        # Actions
-        if isinstance(series, ActionsNode):
-            try:
-                action = Action.objects.get(pk=int(series.id), team=self.team)
-                filters.append(action_to_expr(action))
-            except Action.DoesNotExist:
-                # If an action doesn't exist, we want to return no events
-                filters.append(parse_expr("1 = 2"))
 
         if len(filters) == 0:
             return ast.Constant(value=True)

--- a/posthog/hogql_queries/insights/test/test_stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_stickiness_query_runner.py
@@ -442,7 +442,7 @@ class TestStickinessQueryRunner(APIBaseTest):
     def test_actions(self):
         self._create_test_events()
 
-        action = Action.objects.create(name="$pageview", team=self.team)
+        action = Action.objects.create(name="My Action", team=self.team)
         ActionStep.objects.create(
             action=action,
             event="$pageview",


### PR DESCRIPTION
## Problem

Actions in stickiness weren't correctly implemented. They'd search for the name of an event with the action's name instead.

## Changes

Fixes it.

## How did you test this code?

Action series started showing data in the UI. Updated a test to fail and made it pass.