### PR TITLE
fix: mobile layout woes

### DIFF
--- a/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
+++ b/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
@@ -76,6 +76,34 @@ exports[`replay/transform transform can convert images 1`] = `
                     "tagName": "img",
                     "type": 2,
                   },
+                  {
+                    "attributes": {
+                      "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                      "data-rrweb-id": 9,
+                    },
+                    "childNodes": [],
+                    "id": 9,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 7,
+                    },
+                    "childNodes": [],
+                    "id": 7,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 11,
+                    },
+                    "childNodes": [],
+                    "id": 11,
+                    "tagName": "div",
+                    "type": 2,
+                  },
                 ],
                 "id": 5,
                 "tagName": "body",
@@ -146,11 +174,40 @@ exports[`replay/transform transform can convert navigation bar 1`] = `
                 "childNodes": [
                   {
                     "attributes": {
-                      "data-rrweb-id": 12345,
-                      "style": "border-width: 4px;border-radius: 10px;border-color: #ee3ee4;border-style: solid;color: #ee3ee4;width: 100px;height: 30px;position: fixed;left: 11px;top: 12px;overflow:hidden;white-space:nowrap;",
+                      "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                      "data-rrweb-id": 9,
                     },
                     "childNodes": [],
-                    "id": 12345,
+                    "id": 9,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 7,
+                    },
+                    "childNodes": [
+                      {
+                        "attributes": {
+                          "data-rrweb-id": 12345,
+                          "style": "border-width: 4px;border-radius: 10px;border-color: #ee3ee4;border-style: solid;color: #ee3ee4;width: 100px;height: 30px;position: fixed;left: 11px;top: 12px;",
+                        },
+                        "childNodes": [],
+                        "id": 12345,
+                        "tagName": "div",
+                        "type": 2,
+                      },
+                    ],
+                    "id": 7,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 11,
+                    },
+                    "childNodes": [],
+                    "id": 11,
                     "tagName": "div",
                     "type": 2,
                   },
@@ -248,6 +305,34 @@ exports[`replay/transform transform can convert rect with text 1`] = `
                     "tagName": "div",
                     "type": 2,
                   },
+                  {
+                    "attributes": {
+                      "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                      "data-rrweb-id": 9,
+                    },
+                    "childNodes": [],
+                    "id": 9,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 7,
+                    },
+                    "childNodes": [],
+                    "id": 7,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 11,
+                    },
+                    "childNodes": [],
+                    "id": 11,
+                    "tagName": "div",
+                    "type": 2,
+                  },
                 ],
                 "id": 5,
                 "tagName": "body",
@@ -318,73 +403,66 @@ exports[`replay/transform transform can convert status bar 1`] = `
                 "childNodes": [
                   {
                     "attributes": {
-                      "data-rrweb-id": 7,
-                      "style": "background-color: #000000;border-width: 4px;border-radius: 10px;border-color: #ee3ee4;border-style: solid;color: #ee3ee4;height: 30px;position: fixed;left: 0px;top: 0px;z-index: 9999999;display:flex;flex-direction:row;align-items:center;",
+                      "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                      "data-rrweb-id": 9,
                     },
-                    "childNodes": [
-                      {
-                        "attributes": {
-                          "data-rrweb-id": 102,
-                          "style": "width: 5px;",
-                        },
-                        "childNodes": [],
-                        "id": 102,
-                        "tagName": "div",
-                        "type": 2,
-                      },
-                      {
-                        "attributes": {
-                          "data-rrweb-id": 100,
-                        },
-                        "childNodes": [
-                          {
-                            "id": 101,
-                            "textContent": "12:00 AM",
-                            "type": 3,
-                          },
-                        ],
-                        "id": 100,
-                        "tagName": "div",
-                        "type": 2,
-                      },
-                    ],
-                    "id": 7,
+                    "childNodes": [],
+                    "id": 9,
                     "tagName": "div",
                     "type": 2,
                   },
                   {
                     "attributes": {
                       "data-rrweb-id": 7,
-                      "style": "width: 100px;height: 0px;position: fixed;left: 13px;top: 17px;z-index: 9999999;display:flex;flex-direction:row;align-items:center;",
+                    },
+                    "childNodes": [],
+                    "id": 7,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 11,
                     },
                     "childNodes": [
                       {
                         "attributes": {
-                          "data-rrweb-id": 105,
-                          "style": "width: 5px;",
-                        },
-                        "childNodes": [],
-                        "id": 105,
-                        "tagName": "div",
-                        "type": 2,
-                      },
-                      {
-                        "attributes": {
-                          "data-rrweb-id": 103,
+                          "data-rrweb-id": 12,
+                          "style": "width: 100px;height: 0px;position: fixed;left: 13px;top: 17px;display:flex;flex-direction:row;align-items:center;",
                         },
                         "childNodes": [
                           {
-                            "id": 104,
-                            "textContent": "12:00 AM",
-                            "type": 3,
+                            "attributes": {
+                              "data-rrweb-id": 102,
+                              "style": "width: 5px;",
+                            },
+                            "childNodes": [],
+                            "id": 102,
+                            "tagName": "div",
+                            "type": 2,
+                          },
+                          {
+                            "attributes": {
+                              "data-rrweb-id": 100,
+                            },
+                            "childNodes": [
+                              {
+                                "id": 101,
+                                "textContent": "12:00 AM",
+                                "type": 3,
+                              },
+                            ],
+                            "id": 100,
+                            "tagName": "div",
+                            "type": 2,
                           },
                         ],
-                        "id": 103,
+                        "id": 12,
                         "tagName": "div",
                         "type": 2,
                       },
                     ],
-                    "id": 7,
+                    "id": 11,
                     "tagName": "div",
                     "type": 2,
                   },
@@ -455,7 +533,36 @@ exports[`replay/transform transform can ignore unknown wireframe types 1`] = `
                   "data-rrweb-id": 5,
                   "style": "height: 100vh; width: 100vw;",
                 },
-                "childNodes": [],
+                "childNodes": [
+                  {
+                    "attributes": {
+                      "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                      "data-rrweb-id": 9,
+                    },
+                    "childNodes": [],
+                    "id": 9,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 7,
+                    },
+                    "childNodes": [],
+                    "id": 7,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 11,
+                    },
+                    "childNodes": [],
+                    "id": 11,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                ],
                 "id": 5,
                 "tagName": "body",
                 "type": 2,
@@ -548,6 +655,34 @@ exports[`replay/transform transform can process unknown types without error 1`] 
                       },
                     ],
                     "id": 12345,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                      "data-rrweb-id": 9,
+                    },
+                    "childNodes": [],
+                    "id": 9,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 7,
+                    },
+                    "childNodes": [],
+                    "id": 7,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 11,
+                    },
+                    "childNodes": [],
+                    "id": 11,
                     "tagName": "div",
                     "type": 2,
                   },
@@ -656,6 +791,34 @@ exports[`replay/transform transform can set background image to base64 png 1`] =
                     },
                     "childNodes": [],
                     "id": 12346,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                      "data-rrweb-id": 9,
+                    },
+                    "childNodes": [],
+                    "id": 9,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 7,
+                    },
+                    "childNodes": [],
+                    "id": 7,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 11,
+                    },
+                    "childNodes": [],
+                    "id": 11,
                     "tagName": "div",
                     "type": 2,
                   },
@@ -820,6 +983,34 @@ exports[`replay/transform transform child wireframes are processed 1`] = `
                     "tagName": "div",
                     "type": 2,
                   },
+                  {
+                    "attributes": {
+                      "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                      "data-rrweb-id": 9,
+                    },
+                    "childNodes": [],
+                    "id": 9,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 7,
+                    },
+                    "childNodes": [],
+                    "id": 7,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 11,
+                    },
+                    "childNodes": [],
+                    "id": 11,
+                    "tagName": "div",
+                    "type": 2,
+                  },
                 ],
                 "id": 5,
                 "tagName": "body",
@@ -850,34 +1041,7 @@ exports[`replay/transform transform incremental mutations de-duplicate the tree 
         "node": {
           "attributes": {
             "data-rrweb-id": 142908405,
-            "style": "background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABDgAAAC5CAYAAADNs4/hAAAAAXNSR0IArs4c6QAAAARzQklUCAgI
-CHwIZIgAAAWeSURBVHic7dyxqh1lGIbR77cIBuzTWKUShDSChVh7ITaWFoH0Emsr78D7sBVCBFOZ
-QMo0XoAEEshvZeeZ8cR9PDywVjsfm7d+mNkzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-AAAAAAAAAAAAAADA7Vn/5mjv/fHMfDszX83MgxtdBAAAADDzbGZ+npkf1lqvzo5PA8fe++uZ+XFm
-7v73bQAAAADX8npmvllr/XR0dBg49t73Z+b3mblzwWEAAAAA1/FmZj5da7286uCDkx94POIGAAAA
-cLvuzMx3RwdngeOzy20BAAAAeG+HjeLKT1T23h/OzJ9zHkEAAAAAbtq7mflorfX6nx6e/QfHvpFJ
-AAAAANe01rqyY3g7AwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgT
-OAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACA
-PIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAA
-AMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgA
-AACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyB
-AwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADI
-EzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAA
-gDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMA
-AADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4
-AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8
-gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAA
-yBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAA
-AIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIED
-AAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgT
-OAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACA
-PIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAA
-AMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgA
-AACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIOwscL/6XFQAAAADHDhvFWeD47YJD
-AAAAAN7XYaNYRw/33p/PzC/jUxYAAADg9rydmS/WWk+vOjgMF2utJzPz+NKrAAAAAK7h0VHcmDl5
-g+Nve+8vZ+b7mflkZu5dYBgAAADAkT9m5vnMPFxr/XrbYwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-AAAAAAAAAAAAAAAAAAAAAAAAgCN/AW0xMqHnNQceAAAAAElFTkSuQmCC
-');background-size: auto;background-repeat: no-repeat;width: 411px;height: 70px;position: fixed;left: 0px;top: 536px;overflow:hidden;white-space:nowrap;",
+            "style": "background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABDgAAAC5CAYAAADNs4/hAAAAAXNSR0IArs4c6QAAAARzQklUCAgICHwIZIgAAAWeSURBVHic7dyxqh1lGIbR77cIBuzTWKUShDSChVh7ITaWFoH0Emsr78D7sBVCBFOZQMo0XoAEEshvZeeZ8cR9PDywVjsfm7d+mNkzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADA7Vn/5mjv/fHMfDszX83MgxtdBAAAADDzbGZ+npkf1lqvzo5PA8fe++uZ+XFm7v73bQAAAADX8npmvllr/XR0dBg49t73Z+b3mblzwWEAAAAA1/FmZj5da7286uCDkx94POIGAAAAcLvuzMx3RwdngeOzy20BAAAAeG+HjeLKT1T23h/OzJ9zHkEAAAAAbtq7mflorfX6nx6e/QfHvpFJAAAAANe01rqyY3g7AwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIEzgAAACAPIEDAAAAyBM4AAAAgDyBAwAAAMgTOAAAAIA8gQMAAADIOwscL/6XFQAAAADHDhvFWeD47YJDAAAAAN7XYaNYRw/33p/PzC/jUxYAAADg9rydmS/WWk+vOjgMF2utJzPz+NKrAAAAAK7h0VHcmDl5g+Nve+8vZ+b7mflkZu5dYBgAAADAkT9m5vnMPFxr/XrbYwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgCN/AW0xMqHnNQceAAAAAElFTkSuQmCC');background-size: auto;background-repeat: no-repeat;width: 411px;height: 70px;position: fixed;left: 0px;top: 536px;overflow:hidden;white-space:nowrap;",
           },
           "childNodes": [],
           "id": 142908405,
@@ -1347,6 +1511,34 @@ exports[`replay/transform transform inputs buttons with nested elements 1`] = `
                   "tagName": "button",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -1374,7 +1566,7 @@ exports[`replay/transform transform inputs closed keyboard custom event 1`] = `
     "attributes": [],
     "removes": [
       {
-        "id": 6,
+        "id": 10,
         "parentId": 5,
       },
     ],
@@ -1422,7 +1614,36 @@ exports[`replay/transform transform inputs input - $inputType - hello 1`] = `
                 "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
-              "childNodes": [],
+              "childNodes": [
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
+              ],
               "id": 5,
               "tagName": "body",
               "type": 2,
@@ -1494,6 +1715,34 @@ exports[`replay/transform transform inputs input - button - click me 1`] = `
                   ],
                   "id": 12358,
                   "tagName": "button",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
                   "type": 2,
                 },
               ],
@@ -1581,6 +1830,34 @@ exports[`replay/transform transform inputs input - checkbox - $value 1`] = `
                   "tagName": "label",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -1663,6 +1940,34 @@ exports[`replay/transform transform inputs input - checkbox - $value 2`] = `
                   ],
                   "id": 101,
                   "tagName": "label",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
                   "type": 2,
                 },
               ],
@@ -1751,6 +2056,34 @@ exports[`replay/transform transform inputs input - checkbox - $value 3`] = `
                   "tagName": "label",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -1818,6 +2151,34 @@ exports[`replay/transform transform inputs input - checkbox - $value 4`] = `
                   "childNodes": [],
                   "id": 12357,
                   "tagName": "input",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
                   "type": 2,
                 },
               ],
@@ -1889,6 +2250,34 @@ exports[`replay/transform transform inputs input - email - $value 1`] = `
                   "tagName": "input",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -1958,6 +2347,34 @@ exports[`replay/transform transform inputs input - number - $value 1`] = `
                   "tagName": "input",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -2025,6 +2442,34 @@ exports[`replay/transform transform inputs input - password - $value 1`] = `
                   "childNodes": [],
                   "id": 12348,
                   "tagName": "input",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
                   "type": 2,
                 },
               ],
@@ -2121,6 +2566,34 @@ exports[`replay/transform transform inputs input - progress - $value 1`] = `
                   "tagName": "div",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -2189,6 +2662,34 @@ exports[`replay/transform transform inputs input - progress - $value 2`] = `
                   "childNodes": [],
                   "id": 12365,
                   "tagName": "progress",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
                   "type": 2,
                 },
               ],
@@ -2261,6 +2762,34 @@ exports[`replay/transform transform inputs input - progress - 0.75 1`] = `
                   "tagName": "progress",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -2331,6 +2860,34 @@ exports[`replay/transform transform inputs input - progress - 0.75 2`] = `
                   "tagName": "progress",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -2398,6 +2955,34 @@ exports[`replay/transform transform inputs input - search - $value 1`] = `
                   "childNodes": [],
                   "id": 12351,
                   "tagName": "input",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
                   "type": 2,
                 },
               ],
@@ -2501,6 +3086,34 @@ exports[`replay/transform transform inputs input - select - hello 1`] = `
                   "tagName": "select",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -2569,6 +3182,34 @@ exports[`replay/transform transform inputs input - tel - $value 1`] = `
                   "childNodes": [],
                   "id": 12352,
                   "tagName": "input",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
                   "type": 2,
                 },
               ],
@@ -2640,6 +3281,34 @@ exports[`replay/transform transform inputs input - text - $value 1`] = `
                   "tagName": "input",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -2707,6 +3376,34 @@ exports[`replay/transform transform inputs input - text - hello 1`] = `
                   "childNodes": [],
                   "id": 12346,
                   "tagName": "input",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
                   "type": 2,
                 },
               ],
@@ -2778,6 +3475,34 @@ exports[`replay/transform transform inputs input - textArea - $value 1`] = `
                   "tagName": "input",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -2845,6 +3570,34 @@ exports[`replay/transform transform inputs input - textArea - hello 1`] = `
                   "childNodes": [],
                   "id": 12363,
                   "tagName": "input",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
                   "type": 2,
                 },
               ],
@@ -2964,6 +3717,34 @@ exports[`replay/transform transform inputs input - toggle - $value 1`] = `
                   "tagName": "label",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -3079,6 +3860,34 @@ exports[`replay/transform transform inputs input - toggle - $value 2`] = `
                   ],
                   "id": 104,
                   "tagName": "label",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
                   "type": 2,
                 },
               ],
@@ -3198,6 +4007,34 @@ exports[`replay/transform transform inputs input - toggle - $value 3`] = `
                   "tagName": "label",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -3299,6 +4136,34 @@ exports[`replay/transform transform inputs input - toggle - $value 4`] = `
                   "tagName": "div",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -3366,6 +4231,34 @@ exports[`replay/transform transform inputs input - url - https://example.io 1`] 
                   "childNodes": [],
                   "id": 12352,
                   "tagName": "input",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
                   "type": 2,
                 },
               ],
@@ -5955,8 +6848,8 @@ exports[`replay/transform transform inputs open keyboard custom event 1`] = `
         "nextId": null,
         "node": {
           "attributes": {
-            "data-rrweb-id": 6,
-            "style": "background-color: #f3f4ef;color: #35373e;width: 100vw;height: 150px;bottom: 0;position: fixed;z-index: 9999998;align-items: center;justify-content: center;display: flex;",
+            "data-rrweb-id": 10,
+            "style": "background-color: #f3f4ef;color: #35373e;width: 100vw;height: 150px;bottom: 0;position: fixed;align-items: center;justify-content: center;display: flex;",
           },
           "childNodes": [
             {
@@ -5965,11 +6858,11 @@ exports[`replay/transform transform inputs open keyboard custom event 1`] = `
               "type": 3,
             },
           ],
-          "id": 6,
+          "id": 10,
           "tagName": "div",
           "type": 2,
         },
-        "parentId": 5,
+        "parentId": 9,
       },
       {
         "nextId": null,
@@ -5978,7 +6871,7 @@ exports[`replay/transform transform inputs open keyboard custom event 1`] = `
           "textContent": "keyboard",
           "type": 3,
         },
-        "parentId": 6,
+        "parentId": 10,
       },
     ],
     "attributes": [],
@@ -6041,6 +6934,34 @@ exports[`replay/transform transform inputs placeholder - $inputType - $value 1`]
                     },
                   ],
                   "id": 12365,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
                   "tagName": "div",
                   "type": 2,
                 },
@@ -6615,6 +7536,34 @@ exports[`replay/transform transform inputs progress rating 1`] = `
                   "tagName": "div",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -6671,7 +7620,36 @@ exports[`replay/transform transform inputs radio group - $inputType - $value 1`]
                 "data-rrweb-id": 5,
                 "style": "height: 100vh; width: 100vw;",
               },
-              "childNodes": [],
+              "childNodes": [
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
+              ],
               "id": 5,
               "tagName": "body",
               "type": 2,
@@ -6735,6 +7713,34 @@ exports[`replay/transform transform inputs radio_group - $inputType - $value 1`]
                   },
                   "childNodes": [],
                   "id": 123123,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
                   "tagName": "div",
                   "type": 2,
                 },
@@ -6802,6 +7808,34 @@ exports[`replay/transform transform inputs radio_group 1`] = `
                   },
                   "childNodes": [],
                   "id": 54321,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
                   "tagName": "div",
                   "type": 2,
                 },
@@ -6878,6 +7912,34 @@ exports[`replay/transform transform inputs web_view - $inputType - $value 1`] = 
                   "tagName": "div",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -6948,6 +8010,34 @@ exports[`replay/transform transform inputs web_view with URL 1`] = `
                     },
                   ],
                   "id": 12365,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
                   "tagName": "div",
                   "type": 2,
                 },
@@ -7035,6 +8125,34 @@ exports[`replay/transform transform inputs wrapping with labels 1`] = `
                   "tagName": "label",
                   "type": 2,
                 },
+                {
+                  "attributes": {
+                    "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                    "data-rrweb-id": 9,
+                  },
+                  "childNodes": [],
+                  "id": 9,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 7,
+                  },
+                  "childNodes": [],
+                  "id": 7,
+                  "tagName": "div",
+                  "type": 2,
+                },
+                {
+                  "attributes": {
+                    "data-rrweb-id": 11,
+                  },
+                  "childNodes": [],
+                  "id": 11,
+                  "tagName": "div",
+                  "type": 2,
+                },
               ],
               "id": 5,
               "tagName": "body",
@@ -7106,6 +8224,34 @@ exports[`replay/transform transform omitting x and y is equivalent to setting th
                       },
                     ],
                     "id": 12345,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                      "data-rrweb-id": 9,
+                    },
+                    "childNodes": [],
+                    "id": 9,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 7,
+                    },
+                    "childNodes": [],
+                    "id": 7,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 11,
+                    },
+                    "childNodes": [],
+                    "id": 11,
                     "tagName": "div",
                     "type": 2,
                   },

--- a/ee/frontend/mobile-replay/transform.test.ts
+++ b/ee/frontend/mobile-replay/transform.test.ts
@@ -5,11 +5,18 @@ import { ifEeDescribe } from 'lib/ee.test'
 import { PostHogEE } from '../../../frontend/@posthog/ee/types'
 import * as incrementalSnapshotJson from './__mocks__/increment-with-child-duplication.json'
 import { validateAgainstWebSchema, validateFromMobile } from './index'
+import { wireframe } from './mobile.types'
+import { stripBarsFromWireframes } from './transformer/transformers'
 
 const unspecifiedBase64ImageURL =
     'iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII='
 
 const heartEyesEmojiURL = 'data:image/png;base64,' + unspecifiedBase64ImageURL
+
+function fakeWireframe(type: string, children?: wireframe[]): wireframe {
+    // this is a fake so we can force the type
+    return { type, childWireframes: children || [] } as Partial<wireframe> as wireframe
+}
 
 describe('replay/transform', () => {
     describe('validation', () => {
@@ -1047,6 +1054,42 @@ describe('replay/transform', () => {
                         timestamp: 1,
                     })
                 ).toMatchSnapshot()
+            })
+        })
+    })
+
+    describe('separate status and navbar from other wireframes', () => {
+        it('no-op', () => {
+            expect(stripBarsFromWireframes([])).toEqual({
+                appNodes: [],
+                statusBar: undefined,
+                navigationBar: undefined,
+            })
+        })
+
+        it('top-level status-bar', () => {
+            const statusBar = fakeWireframe('status_bar')
+            expect(stripBarsFromWireframes([statusBar])).toEqual({ appNodes: [], statusBar, navigationBar: undefined })
+        })
+
+        it('top-level nav-bar', () => {
+            const navBar = fakeWireframe('navigation_bar')
+            expect(stripBarsFromWireframes([navBar])).toEqual({
+                appNodes: [],
+                statusBar: undefined,
+                navigationBar: navBar,
+            })
+        })
+
+        it('nested nav-bar', () => {
+            const navBar = fakeWireframe('navigation_bar')
+            const sourceWithNavBar = [
+                fakeWireframe('div', [fakeWireframe('div'), fakeWireframe('div', [navBar, fakeWireframe('div')])]),
+            ]
+            expect(stripBarsFromWireframes(sourceWithNavBar)).toEqual({
+                appNodes: [fakeWireframe('div', [fakeWireframe('div'), fakeWireframe('div', [fakeWireframe('div')])])],
+                statusBar: undefined,
+                navigationBar: navBar,
             })
         })
     })

--- a/ee/frontend/mobile-replay/transformer/screen-chrome.ts
+++ b/ee/frontend/mobile-replay/transformer/screen-chrome.ts
@@ -1,7 +1,7 @@
-import { NodeType, serializedNodeWithId, wireframeDiv, wireframeStatusBar } from '../mobile.types'
-import { makeDivElement, STATUS_BAR_ID } from './transformers'
+import { NodeType, serializedNodeWithId, wireframeNavigationBar, wireframeStatusBar } from '../mobile.types'
+import { NAVIGATION_BAR_ID, STATUS_BAR_ID } from './transformers'
 import { ConversionContext, ConversionResult } from './types'
-import { asStyleString, makeStylesString, TOP_OF_STACK } from './wireframeStyle'
+import { asStyleString, makeStylesString } from './wireframeStyle'
 
 function spacerDiv(idSequence: Generator<number>): serializedNodeWithId {
     const spacerId = idSequence.next().value
@@ -18,14 +18,24 @@ function spacerDiv(idSequence: Generator<number>): serializedNodeWithId {
 }
 
 export function makeNavigationBar(
-    wireframe: wireframeDiv,
+    wireframe: wireframeNavigationBar,
     _children: serializedNodeWithId[],
     context: ConversionContext
 ): ConversionResult<serializedNodeWithId> | null {
-    return makeDivElement(wireframe, _children, {
-        ...context,
-        styleOverride: { ...context.styleOverride, 'z-index': TOP_OF_STACK },
-    })
+    const _id = wireframe.id || NAVIGATION_BAR_ID
+    return {
+        result: {
+            type: NodeType.Element,
+            tagName: 'div',
+            attributes: {
+                style: asStyleString([makeStylesString(wireframe)]),
+                'data-rrweb-id': _id,
+            },
+            id: _id,
+            childNodes: [],
+        },
+        context,
+    }
 }
 
 /**
@@ -63,7 +73,7 @@ export function makeStatusBar(
             tagName: 'div',
             attributes: {
                 style: asStyleString([
-                    makeStylesString(wireframe, { 'z-index': TOP_OF_STACK }),
+                    makeStylesString(wireframe),
                     'display:flex',
                     'flex-direction:row',
                     'align-items:center',

--- a/ee/frontend/mobile-replay/transformer/transformers.ts
+++ b/ee/frontend/mobile-replay/transformer/transformers.ts
@@ -305,6 +305,8 @@ function makePlaceholderElement(
 }
 
 export function dataURIOrPNG(src: string): string {
+    // replace all new lines in src
+    src = src.replace(/\r?\n|\r/g, '')
     if (!src.startsWith('data:image/')) {
         return 'data:image/png;base64,' + src
     }

--- a/ee/frontend/mobile-replay/transformer/transformers.ts
+++ b/ee/frontend/mobile-replay/transformer/transformers.ts
@@ -31,12 +31,14 @@ import {
     wireframeDiv,
     wireframeImage,
     wireframeInputComponent,
+    wireframeNavigationBar,
     wireframePlaceholder,
     wireframeProgress,
     wireframeRadio,
     wireframeRadioGroup,
     wireframeRectangle,
     wireframeSelect,
+    wireframeStatusBar,
     wireframeText,
     wireframeToggle,
 } from '../mobile.types'
@@ -44,7 +46,6 @@ import { makeNavigationBar, makeStatusBar } from './screen-chrome'
 import { ConversionContext, ConversionResult } from './types'
 import {
     asStyleString,
-    KEYBOARD_Z_INDEX,
     makeBodyStyles,
     makeColorStyles,
     makeDeterminateProgressStyles,
@@ -87,8 +88,14 @@ const HTML_DOC_TYPE_ID = 2
 const HTML_ELEMENT_ID = 3
 const HEAD_ID = 4
 const BODY_ID = 5
-const KEYBOARD_ID = 6
-export const STATUS_BAR_ID = 7
+// the nav bar should always be the last item in the body so that it is at the top of the stack
+const NAVIGATION_BAR_PARENT_ID = 7
+export const NAVIGATION_BAR_ID = 8
+// the keyboard so that it is still before the nav bar
+const KEYBOARD_PARENT_ID = 9
+const KEYBOARD_ID = 10
+export const STATUS_BAR_PARENT_ID = 11
+export const STATUS_BAR_ID = 12
 
 function isKeyboardEvent(x: unknown): x is keyboardEvent {
     return isObject(x) && 'data' in x && isObject(x.data) && 'tag' in x.data && x.data.tag === 'keyboard'
@@ -132,14 +139,13 @@ export const makeCustomEvent = (
                     idSequence: globalIdSequence,
                     skippableNodes: new Set(),
                     styleOverride: {
-                        'z-index': KEYBOARD_Z_INDEX,
                         ...(shouldAbsolutelyPosition ? {} : { bottom: true }),
                     },
                 }
             )
             if (keyboardPlaceHolder) {
                 adds.push({
-                    parentId: BODY_ID,
+                    parentId: KEYBOARD_PARENT_ID,
                     nextId: null,
                     node: keyboardPlaceHolder.result,
                 })
@@ -1145,6 +1151,109 @@ export const makeIncrementalEvent = (
     return converted
 }
 
+function makeKeyboardParent(): serializedNodeWithId {
+    return {
+        type: NodeType.Element,
+        tagName: 'div',
+        attributes: {
+            'data-render-reason': 'a fixed placeholder to contain the keyboard in the correct stacking position',
+            'data-rrweb-id': KEYBOARD_PARENT_ID,
+        },
+        id: KEYBOARD_PARENT_ID,
+        childNodes: [],
+    }
+}
+
+function makeStatusBarNode(
+    statusBar: wireframeStatusBar | undefined,
+    context: ConversionContext
+): serializedNodeWithId {
+    const childNodes = statusBar ? convertWireframesFor([statusBar], context).result : []
+    return {
+        type: NodeType.Element,
+        tagName: 'div',
+        attributes: {
+            'data-rrweb-id': STATUS_BAR_PARENT_ID,
+        },
+        id: STATUS_BAR_PARENT_ID,
+        childNodes,
+    }
+}
+
+function makeNavBarNode(
+    navigationBar: wireframeNavigationBar | undefined,
+    context: ConversionContext
+): serializedNodeWithId {
+    const childNodes = navigationBar ? convertWireframesFor([navigationBar], context).result : []
+    return {
+        type: NodeType.Element,
+        tagName: 'div',
+        attributes: {
+            'data-rrweb-id': NAVIGATION_BAR_PARENT_ID,
+        },
+        id: NAVIGATION_BAR_PARENT_ID,
+        childNodes,
+    }
+}
+
+function stripBarsFromWireframe(wireframe: wireframe): {
+    wireframe: wireframe | undefined
+    statusBar: wireframeStatusBar | undefined
+    navBar: wireframeNavigationBar | undefined
+} {
+    if (wireframe.type === 'status_bar') {
+        return { wireframe: undefined, statusBar: wireframe, navBar: undefined }
+    } else if (wireframe.type === 'navigation_bar') {
+        return { wireframe: undefined, statusBar: undefined, navBar: wireframe }
+    } else {
+        let statusBar: wireframeStatusBar | undefined
+        let navBar: wireframeNavigationBar | undefined
+        const wireframeToReturn: wireframe | undefined = { ...wireframe }
+        wireframeToReturn.childWireframes = []
+        for (const child of wireframe.childWireframes || []) {
+            const {
+                wireframe: childWireframe,
+                statusBar: childStatusBar,
+                navBar: childNavBar,
+            } = stripBarsFromWireframe(child)
+            statusBar = statusBar || childStatusBar
+            navBar = navBar || childNavBar
+            if (childWireframe) {
+                wireframeToReturn.childWireframes.push(childWireframe)
+            }
+        }
+        return { wireframe: wireframeToReturn, statusBar, navBar }
+    }
+}
+
+/**
+ * We want to be able to place the status bar and navigation bar in the correct stacking order.
+ * So, we lift them out of the tree, and return them separately.
+ */
+export function stripBarsFromWireframes(wireframes: wireframe[]): {
+    statusBar: wireframeStatusBar | undefined
+    navigationBar: wireframeNavigationBar | undefined
+    appNodes: wireframe[]
+} {
+    let statusBar: wireframeStatusBar | undefined
+    let navigationBar: wireframeNavigationBar | undefined
+    const copiedNodes: wireframe[] = []
+
+    wireframes.forEach((w) => {
+        const matches = stripBarsFromWireframe(w)
+        if (matches.statusBar) {
+            statusBar = matches.statusBar
+        }
+        if (matches.navBar) {
+            navigationBar = matches.navBar
+        }
+        if (matches.wireframe) {
+            copiedNodes.push(matches.wireframe)
+        }
+    })
+    return { statusBar, navigationBar, appNodes: copiedNodes }
+}
+
 export const makeFullEvent = (
     mobileEvent: MobileFullSnapshotEvent & {
         timestamp: number
@@ -1162,6 +1271,19 @@ export const makeFullEvent = (
             timestamp: number
             delay?: number
         }
+    }
+
+    const conversionContext = {
+        timestamp: mobileEvent.timestamp,
+        idSequence: globalIdSequence,
+    }
+
+    const { statusBar, navigationBar, appNodes } = stripBarsFromWireframes(mobileEvent.data.wireframes)
+
+    const nodeGroups = {
+        appNodes: convertWireframesFor(appNodes, conversionContext).result || [],
+        statusBarNode: makeStatusBarNode(statusBar, conversionContext),
+        navBarNode: makeNavBarNode(navigationBar, conversionContext),
     }
 
     return {
@@ -1196,11 +1318,14 @@ export const makeFullEvent = (
                                 tagName: 'body',
                                 attributes: { style: makeBodyStyles(), 'data-rrweb-id': BODY_ID },
                                 id: BODY_ID,
-                                childNodes:
-                                    convertWireframesFor(mobileEvent.data.wireframes, {
-                                        timestamp: mobileEvent.timestamp,
-                                        idSequence: globalIdSequence,
-                                    }).result || [],
+                                childNodes: [
+                                    // in the order they should stack if they ever clash
+                                    // lower is higher in the stacking context
+                                    ...nodeGroups.appNodes,
+                                    makeKeyboardParent(),
+                                    nodeGroups.navBarNode,
+                                    nodeGroups.statusBarNode,
+                                ],
                             },
                         ],
                     },

--- a/ee/frontend/mobile-replay/transformer/types.ts
+++ b/ee/frontend/mobile-replay/transformer/types.ts
@@ -22,4 +22,4 @@ export interface ConversionContext {
 // StyleOverride is defined here and not in the schema
 // because these are overrides that the transformer is allowed to make
 // not that clients are allowed to request
-export type StyleOverride = MobileStyles & { bottom?: true; 'z-index'?: number }
+export type StyleOverride = MobileStyles & { bottom?: true }

--- a/ee/frontend/mobile-replay/transformer/wireframeStyle.ts
+++ b/ee/frontend/mobile-replay/transformer/wireframeStyle.ts
@@ -2,10 +2,6 @@ import { wireframe, wireframeProgress } from '../mobile.types'
 import { dataURIOrPNG } from './transformers'
 import { StyleOverride } from './types'
 
-/** all other z-indexes must be set less than this */
-export const TOP_OF_STACK = 9999999
-export const KEYBOARD_Z_INDEX = 9999998
-
 function ensureTrailingSemicolon(styles: string): string {
     return styles.endsWith(';') ? styles : styles + ';'
 }


### PR DESCRIPTION
# status bar and nav bar

I'm a fool and forgot that we can't use z-index because we have fixed position elements. Which means we have to rely on order of elements.

I don't want to restrict what comes over the API. So, we process the tree of elements to lift a single status bar and a single navigation bar out of the tree of elements.

we then place the status bar, nav bar, and any keyboard element so that they stack as expected

in the gif below you can see the keyboard no longer obscures the nav bar

# data uris

the data uris had new lines in... this is unexpected and breaks the css we generate. would be better not to have them, but for now let's strip any new lines in data uris

![2024-01-30 16 12 11](https://github.com/PostHog/posthog/assets/984817/0a3f3fed-2943-42a6-8c85-58059f45151c)
