### PR TITLE
chore(plugin-server): add hook rolloutage percentage env var

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -133,6 +133,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         POE_WRITES_EXCLUDE_TEAMS: '',
         RELOAD_PLUGIN_JITTER_MAX_MS: 60000,
         RUSTY_HOOK_FOR_TEAMS: '',
+        RUSTY_HOOK_ROLLOUT_PERCENTAGE: 0,
         RUSTY_HOOK_URL: '',
 
         STARTUP_PROFILE_DURATION_SECONDS: 300, // 5 minutes

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -361,6 +361,7 @@ export async function startPluginsServer(
                 hub?.rustyHook ??
                 new RustyHook(
                     buildIntegerMatcher(serverConfig.RUSTY_HOOK_FOR_TEAMS, true),
+                    serverConfig.RUSTY_HOOK_ROLLOUT_PERCENTAGE,
                     serverConfig.RUSTY_HOOK_URL,
                     serverConfig.EXTERNAL_REQUEST_TIMEOUT_MS
                 )

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -204,6 +204,7 @@ export interface PluginsServerConfig {
     POE_WRITES_EXCLUDE_TEAMS: string
     RELOAD_PLUGIN_JITTER_MAX_MS: number
     RUSTY_HOOK_FOR_TEAMS: string
+    RUSTY_HOOK_ROLLOUT_PERCENTAGE: number
     RUSTY_HOOK_URL: string
     SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
 

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -144,6 +144,7 @@ export async function createHub(
     const rootAccessManager = new RootAccessManager(db)
     const rustyHook = new RustyHook(
         buildIntegerMatcher(serverConfig.RUSTY_HOOK_FOR_TEAMS, true),
+        serverConfig.RUSTY_HOOK_ROLLOUT_PERCENTAGE,
         serverConfig.RUSTY_HOOK_URL,
         serverConfig.EXTERNAL_REQUEST_TIMEOUT_MS
     )

--- a/plugin-server/src/worker/rusty-hook.ts
+++ b/plugin-server/src/worker/rusty-hook.ts
@@ -24,6 +24,7 @@ interface RustyWebhookPayload {
 export class RustyHook {
     constructor(
         private enabledForTeams: ValueMatcher<number>,
+        private rolloutPercentage: number,
         private serviceUrl: string,
         private requestTimeoutMs: number
     ) {}
@@ -39,7 +40,10 @@ export class RustyHook {
         pluginId: number
         pluginConfigId: number
     }): Promise<boolean> {
-        if (!this.enabledForTeams(teamId)) {
+        // A simple and blunt rollout that just uses the last digits of the Team ID as a stable
+        // selection against the `rolloutPercentage`.
+        const enabledByRolloutPercentage = (teamId % 1000) / 1000 < this.rolloutPercentage
+        if (!enabledByRolloutPercentage && !this.enabledForTeams(teamId)) {
             return false
         }
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We need to roll out rusty-hook in prod, but we'd rather not do it all at once.

## Changes

Add `RUSTY_HOOK_ROLLOUT_PERCENTAGE` which rolls out based on part of the Team ID. This is of course blunt, a 10% rollout by Team ID does not mean exactly 10% of Webhook traffic. My thinking here is that it's best to roll out and watch for support from a subset of teams, rather than rolling out by randomly selecting on each hook send. I could be easily convinced to change it to totally random, though.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
