### PR TITLE
feat: show the "move to cloud" cta on dev

### DIFF
--- a/frontend/src/layout/navigation/TopBar/AccountPopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/AccountPopover.tsx
@@ -192,7 +192,7 @@ export function AccountPopoverOverlay(): JSX.Element {
     const { currentOrganization } = useValues(organizationLogic)
     const { mobileLayout } = useValues(navigationLogic)
     const { openSidePanel } = useActions(sidePanelStateLogic)
-    const { preflight, isCloudOrDev } = useValues(preflightLogic)
+    const { preflight, isCloudOrDev, isCloud } = useValues(preflightLogic)
     const { closeAccountPopover } = useActions(navigationLogic)
 
     return (
@@ -248,7 +248,7 @@ export function AccountPopoverOverlay(): JSX.Element {
                 <FeaturePreviewsButton />
                 {user?.is_staff && <InstanceSettings />}
             </AccountPopoverSection>
-            {!isCloudOrDev && (
+            {!isCloud && (
                 <AccountPopoverSection>
                     <LemonButton
                         onClick={closeAccountPopover}

--- a/frontend/src/scenes/PreflightCheck/preflightLogic.tsx
+++ b/frontend/src/scenes/PreflightCheck/preflightLogic.tsx
@@ -261,6 +261,12 @@ export const preflightLogic = kea<preflightLogicType>([
                 return preflight?.cloud || preflight?.is_debug
             },
         ],
+        isCloud: [
+            (s) => [s.preflight],
+            (preflight): boolean | undefined => {
+                return preflight?.cloud
+            },
+        ],
         isDev: [
             (s) => [s.preflight],
             (preflight): boolean | undefined => {


### PR DESCRIPTION
## Problem

We have a new "Move to PostHog Cloud" page that tells people to try using Cloud. It was hidden on Dev, so it would be easy to forget it exists.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Show the item in the nav menu on anything that isn't cloud (ie dev and hobby deploy)

![image](https://github.com/PostHog/posthog/assets/18598166/a79e5dcf-bd17-44ef-841e-73798ca81056)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
