### PR TITLE
fix: Optimize old events api endpoint

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -199,7 +199,7 @@ class EventViewSet(
             )
 
             # Retry the query without the 1 day optimization
-            if len(query_result) < limit and not request.GET.get("after"):
+            if len(query_result) < limit:
                 query_result = query_events_list(
                     unbounded_date_from=True,  # only this changed from the query above
                     filter=filter,

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -1687,7 +1687,7 @@
 # ---
 # name: TestFeatureFlag.test_creating_static_cohort.14
   '''
-  /* user_id:194 celery:posthog.tasks.calculate_cohort.insert_cohort_from_feature_flag */
+  /* user_id:195 celery:posthog.tasks.calculate_cohort.insert_cohort_from_feature_flag */
   SELECT count(DISTINCT person_id)
   FROM person_static_cohort
   WHERE team_id = 2

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -760,6 +760,42 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         response = self.client.get(f"/api/projects/{self.team.id}/events/").json()
         self.assertEqual(patch_query_with_columns.call_count, 3)
 
+    @patch("posthog.models.event.query_event_list.insight_query_with_columns")
+    def test_optimize_query_with_bounded_dates(self, patch_query_with_columns):
+        #  For ClickHouse we normally only query the last day,
+        # but if a user doesn't have many events we still want to return events that are older
+        patch_query_with_columns.return_value = [
+            {
+                "uuid": "event",
+                "event": "d",
+                "properties": "{}",
+                "timestamp": datetime.strptime("2024-01-01", "%Y-%m-%d"),
+                "team_id": "d",
+                "distinct_id": "d",
+                "elements_chain": "d",
+            }
+        ]
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/events/?after=2021-01-01&before=2024-01-01T02:02:02Z"
+        ).json()
+        self.assertEqual(len(response["results"]), 1)
+        self.assertEqual(patch_query_with_columns.call_count, 2)
+
+        patch_query_with_columns.return_value = [
+            {
+                "uuid": "event",
+                "event": "d",
+                "properties": "{}",
+                "timestamp": datetime.strptime("2024-01-01", "%Y-%m-%d"),
+                "team_id": "d",
+                "distinct_id": "d",
+                "elements_chain": "d",
+            }
+            for _ in range(0, 100)
+        ]
+        response = self.client.get(f"/api/projects/{self.team.id}/events/").json()
+        self.assertEqual(patch_query_with_columns.call_count, 3)
+
     def test_filter_events_by_being_after_properties_with_date_type(self):
         journeys_for(
             {

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -770,7 +770,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             team=self.team,
             event="sign up",
             distinct_id="2",
-            timestamp=datetime.strptime("2024-01-01", "%Y-%m-%d"),
+            timestamp=datetime(2024, 1, 1, 1, 0, 0),
             properties={"key": "test_val"},
         )
 
@@ -785,12 +785,14 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
                 team=self.team,
                 event="sign up",
                 distinct_id="2",
-                timestamp=datetime.strptime("2024-01-01", "%Y-%m-%d"),
+                timestamp=datetime(2024, 1, 1, 1, 0, 0),
                 properties={"key": "test_val"},
             )
             for _ in range(0, 100)
         ]
-        response = self.client.get(f"/api/projects/{self.team.id}/events/").json()
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/events/?after=2021-01-01&before=2024-01-01T02:02:02Z"
+        ).json()
         self.assertEqual(patch_query_with_columns.call_count, 3)
         self.assertEqual(len(response["results"]), 100)
 

--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -29,7 +29,7 @@ def parse_timestamp(timestamp: str, tzinfo: ZoneInfo) -> datetime:
 
 
 def parse_request_params(
-    conditions: Dict[str, Union[None, str, List[str]]], team: Team, tzinfo: ZoneInfo
+    conditions: Dict[str, Union[None, str, List[str], datetime]], team: Team, tzinfo: ZoneInfo
 ) -> Tuple[str, Dict]:
     result = ""
     params: Dict[str, Union[str, List[str]]] = {}

--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -29,7 +29,7 @@ def parse_timestamp(timestamp: str, tzinfo: ZoneInfo) -> datetime:
 
 
 def parse_request_params(
-    conditions: Dict[str, Union[None, str, List[str], datetime]], team: Team, tzinfo: ZoneInfo
+    conditions: Dict[str, Union[None, str, List[str]]], team: Team, tzinfo: ZoneInfo
 ) -> Tuple[str, Dict]:
     result = ""
     params: Dict[str, Union[str, List[str]]] = {}

--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -92,7 +92,7 @@ def query_events_list(
         condition_params["after"] = datetime.combine(condition_params["before"], time.min)
 
     condition_params["before"] = condition_params["before"].strftime("%Y-%m-%d %H:%M:%S.%f")
-    if condition_params["after"]:
+    if condition_params.get("after"):
         condition_params["after"] = condition_params["after"].strftime("%Y-%m-%d %H:%M:%S.%f")
 
     prop_filters, prop_filter_params = parse_prop_grouped_clauses(

--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import timedelta, datetime, time
 from typing import Dict, List, Optional, Tuple, Union
 from zoneinfo import ZoneInfo
 
@@ -21,8 +21,15 @@ from posthog.queries.insight import insight_query_with_columns
 from posthog.utils import relative_date_parse
 
 
-def determine_event_conditions(
-    conditions: Dict[str, Union[None, str, List[str]]], team: Team, tzinfo: ZoneInfo
+def parse_timestamp(timestamp: str, tzinfo: ZoneInfo) -> datetime:
+    try:
+        return isoparse(timestamp)
+    except ValueError:
+        return relative_date_parse(timestamp, tzinfo)
+
+
+def parse_request_params(
+    conditions: Dict[str, Union[None, str, List[str], datetime]], team: Team, tzinfo: ZoneInfo
 ) -> Tuple[str, Dict]:
     result = ""
     params: Dict[str, Union[str, List[str]]] = {}
@@ -30,17 +37,11 @@ def determine_event_conditions(
         if not isinstance(v, str):
             continue
         if k == "after":
-            try:
-                timestamp = isoparse(v).strftime("%Y-%m-%d %H:%M:%S.%f")
-            except ValueError:
-                timestamp = relative_date_parse(v, tzinfo).strftime("%Y-%m-%d %H:%M:%S.%f")
+            timestamp = parse_timestamp(v, tzinfo)
             result += "AND timestamp > %(after)s "
             params.update({"after": timestamp})
         elif k == "before":
-            try:
-                timestamp = isoparse(v).strftime("%Y-%m-%d %H:%M:%S.%f")
-            except ValueError:
-                timestamp = relative_date_parse(v, tzinfo).strftime("%Y-%m-%d %H:%M:%S.%f")
+            timestamp = parse_timestamp(v, tzinfo)
             result += "AND timestamp < %(before)s "
             params.update({"before": timestamp})
         elif k == "person_id":
@@ -76,17 +77,24 @@ def query_events_list(
     if offset > 0:
         limit_sql += " OFFSET %(offset)s"
 
-    workload = Workload.OFFLINE if unbounded_date_from else Workload.ONLINE
-
-    conditions, condition_params = determine_event_conditions(
-        {
-            "after": None if unbounded_date_from else (now() - timedelta(days=1)).isoformat(),
-            "before": (now() + timedelta(seconds=5)).isoformat(),
-            **request_get_query_dict,
-        },
+    order = "DESC" if len(order_by) == 1 and order_by[0] == "-timestamp" else "ASC"
+    conditions, condition_params = parse_request_params(
+        request_get_query_dict,
         team,
         tzinfo=team.timezone_info,
     )
+
+    if "before" not in condition_params:
+        condition_params["before"] = now() + timedelta(seconds=5)
+
+    if not unbounded_date_from and order == "DESC":
+        # If this is the first try, only load the current day
+        condition_params["after"] = datetime.combine(condition_params["before"], time.min)
+
+    condition_params["before"] = condition_params["before"].strftime("%Y-%m-%d %H:%M:%S.%f")
+    if condition_params["after"]:
+        condition_params["after"] = condition_params["after"].strftime("%Y-%m-%d %H:%M:%S.%f")
+
     prop_filters, prop_filter_params = parse_prop_grouped_clauses(
         team_id=team.pk,
         property_group=filter.property_groups,
@@ -106,7 +114,6 @@ def query_events_list(
         prop_filters += " AND {}".format(action_query)
         prop_filter_params = {**prop_filter_params, **params}
 
-    order = "DESC" if len(order_by) == 1 and order_by[0] == "-timestamp" else "ASC"
     if prop_filters != "":
         return insight_query_with_columns(
             SELECT_EVENT_BY_TEAM_AND_CONDITIONS_FILTERS_SQL.format(
@@ -124,7 +131,7 @@ def query_events_list(
                 **hogql_context.values,
             },
             query_type="events_list",
-            workload=workload,
+            workload=Workload.OFFLINE,
             team_id=team.pk,
         )
     else:
@@ -138,6 +145,6 @@ def query_events_list(
                 **hogql_context.values,
             },
             query_type="events_list",
-            workload=workload,
+            workload=Workload.OFFLINE,
             team_id=team.pk,
         )


### PR DESCRIPTION
## Problem

Noticed [one team in particular](http://metabase-prod-us/question/456-iops-by-team) doing a bunch of iops. Turns out that's the fivetran connector hitting the api/events endpoint in an inefficient way, querying almost 300GB queries for each  call.
<img width="741" alt="image" src="https://github.com/PostHog/posthog/assets/1727427/ff169d85-f722-4e8a-8678-f611819382f7">


## Changes

Do the 1-day optimization even if &after is already set.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
