### PR TITLE
fix(web-analytics): fix styling for notice and filters

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsNotice.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsNotice.tsx
@@ -14,7 +14,7 @@ export const WebAnalyticsNotice = (): JSX.Element => {
     return (
         <LemonBanner type="info" className="my-4">
             <div className="flex items-center flex-wrap gap-2 justify-between">
-                <span className="flex-1 min-w-[25rem]">
+                <span className="flex-1">
                     PostHog Web Analytics is in opt-in Beta. Thanks for taking part! We'd love to hear what you think.
                 </span>
                 {showSupportOptions ? (

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -31,7 +31,7 @@ const Filters = (): JSX.Element => {
             // eslint-disable-next-line react/forbid-dom-props
             style={{
                 backgroundColor: 'var(--bg-3000)',
-                top: 'var(--breadcrumbs-height)',
+                top: 'var(--breadcrumbs-height-compact)',
             }}
         >
             <div className="flex flex-row flex-wrap gap-2">

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -17,6 +17,7 @@ import { WebTabs } from 'scenes/web-analytics/WebTabs'
 import { Query } from '~/queries/Query/Query'
 import { NodeKind, QuerySchema } from '~/queries/schema'
 import { InsightLogicProps } from '~/types'
+import { navigationLogic } from '~/layout/navigation/navigationLogic'
 
 const Filters = (): JSX.Element => {
     const {
@@ -24,6 +25,7 @@ const Filters = (): JSX.Element => {
         dateFilter: { dateTo, dateFrom },
     } = useValues(webAnalyticsLogic)
     const { setWebAnalyticsFilters, setDates } = useActions(webAnalyticsLogic)
+    const { mobileLayout } = useValues(navigationLogic)
 
     return (
         <div
@@ -31,7 +33,7 @@ const Filters = (): JSX.Element => {
             // eslint-disable-next-line react/forbid-dom-props
             style={{
                 backgroundColor: 'var(--bg-3000)',
-                top: 'var(--breadcrumbs-height-compact)',
+                top: mobileLayout ? 'var(--breadcrumbs-height-full)' : 'var(--breadcrumbs-height-compact)',
             }}
         >
             <div className="flex flex-row flex-wrap gap-2">

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -14,10 +14,10 @@ import {
 } from 'scenes/web-analytics/WebAnalyticsTile'
 import { WebTabs } from 'scenes/web-analytics/WebTabs'
 
+import { navigationLogic } from '~/layout/navigation/navigationLogic'
 import { Query } from '~/queries/Query/Query'
 import { NodeKind, QuerySchema } from '~/queries/schema'
 import { InsightLogicProps } from '~/types'
-import { navigationLogic } from '~/layout/navigation/navigationLogic'
 
 const Filters = (): JSX.Element => {
     const {


### PR DESCRIPTION
## Problem

* There was a min-width that caused horizontal scroll on mobile viewports
* The filters were no longer sticky

## Changes

Before
<img width="406" alt="Screenshot 2024-01-31 at 07 27 37" src="https://github.com/PostHog/posthog/assets/2056078/87c4701f-7b29-47a6-a47b-cbbb38d8bd24">
<img width="405" alt="Screenshot 2024-01-31 at 07 27 41" src="https://github.com/PostHog/posthog/assets/2056078/2ee6cf2f-7e93-40e7-8b2d-16f8f4202427">

After
<img width="397" alt="Screenshot 2024-01-31 at 07 27 06" src="https://github.com/PostHog/posthog/assets/2056078/32d8d007-086a-41c0-ac43-92a60cdd55ad">
<img width="391" alt="Screenshot 2024-01-31 at 07 27 12" src="https://github.com/PostHog/posthog/assets/2056078/98d32010-902a-490b-9b3c-44d805f140a7">

## How did you test this code?
Manually
