### PR TITLE
fix: Add metrics for all celery queues

### DIFF
--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -121,7 +121,7 @@ def _deliver_subscription_report(
         subscription.save()
 
 
-@shared_task(queue=CeleryQueue.SUBSCRIPTION_DELIVERY)
+@shared_task(queue=CeleryQueue.SUBSCRIPTION_DELIVERY.value)
 def schedule_all_subscriptions() -> None:
     """
     Schedule all past notifications (with a buffer) to be delivered
@@ -152,7 +152,7 @@ report_timeout_seconds = settings.PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES 
 @shared_task(
     soft_time_limit=report_timeout_seconds,
     time_limit=report_timeout_seconds + 10,
-    queue=CeleryQueue.SUBSCRIPTION_DELIVERY,
+    queue=CeleryQueue.SUBSCRIPTION_DELIVERY.value,
 )
 def deliver_subscription_report(subscription_id: int) -> None:
     return _deliver_subscription_report(subscription_id)
@@ -161,7 +161,7 @@ def deliver_subscription_report(subscription_id: int) -> None:
 @shared_task(
     soft_time_limit=report_timeout_seconds,
     time_limit=report_timeout_seconds + 10,
-    queue=CeleryQueue.SUBSCRIPTION_DELIVERY,
+    queue=CeleryQueue.SUBSCRIPTION_DELIVERY.value,
 )
 def handle_subscription_value_change(
     subscription_id: int, previous_value: str, invite_message: Optional[str] = None

--- a/posthog/email.py
+++ b/posthog/email.py
@@ -43,7 +43,7 @@ def is_email_available(with_absolute_urls: bool = False) -> bool:
 
 
 EMAIL_TASK_KWARGS = dict(
-    queue=CeleryQueue.EMAIL,
+    queue=CeleryQueue.EMAIL.value,
     ignore_result=True,
     autoretry_for=(Exception,),
     max_retries=3,

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -43,7 +43,7 @@ EXPORT_TIMER = Histogram(
     acks_late=True,
     ignore_result=False,
     time_limit=settings.ASSET_GENERATION_MAX_TIMEOUT_SECONDS,
-    queue=CeleryQueue.EXPORTS,
+    queue=CeleryQueue.EXPORTS.value,
 )
 def export_asset(exported_asset_id: int, limit: Optional[int] = None) -> None:
     from posthog.tasks.exports import csv_exporter, image_exporter

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -27,7 +27,7 @@ def redis_heartbeat() -> None:
     get_client().set("POSTHOG_HEARTBEAT", int(time.time()))
 
 
-@shared_task(ignore_result=True, queue=CeleryQueue.ANALYTICS_QUERIES)
+@shared_task(ignore_result=True, queue=CeleryQueue.ANALYTICS_QUERIES.value)
 def process_query_task(
     team_id: str, query_id: str, query_json: Any, limit_context: Any = None, refresh_requested: bool = False
 ) -> None:
@@ -450,7 +450,7 @@ def clear_clickhouse_deleted_person() -> None:
     remove_deleted_person_data()
 
 
-@shared_task(ignore_result=True, queue=CeleryQueue.STATS)
+@shared_task(ignore_result=True, queue=CeleryQueue.STATS.value)
 def redis_celery_queue_depth() -> None:
     try:
         with pushed_metrics_registry("redis_celery_queue_depth_registry") as registry:
@@ -460,8 +460,10 @@ def redis_celery_queue_depth() -> None:
                 registry=registry,
             )
 
-            llen = get_client().llen("celery")
-            celery_task_queue_depth_gauge.set(llen)
+            for queue in CeleryQueue:
+                llen = get_client().llen(queue.value)
+                celery_task_queue_depth_gauge.labels(queue_name=queue.value).set(llen)
+
     except:
         # if we can't generate the metric don't complain about it.
         return

--- a/posthog/tasks/utils.py
+++ b/posthog/tasks/utils.py
@@ -22,7 +22,10 @@
 
 
 # NOTE: Keep in sync with bin/celery-queues.env
-class CeleryQueue:
+from enum import Enum
+
+
+class CeleryQueue(Enum):
     DEFAULT = "celery"
     STATS = "stats"
     EMAIL = "email"


### PR DESCRIPTION
## Problem

We only monitor the depth of one queue. Now we monitor all of them

## Changes

* Swaps over to an enum class so we have better ways of working with it.
* Iterate over the queue and get all lengths from redis instead
* This will allows us to link the autoscalers to the queue depths per worker I believe

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
