### PR TITLE
fix(hogql): regex match returns false if value is null

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -204,11 +204,20 @@ def property_to_expr(
                 right=ast.Constant(value=f"%{value}%"),
             )
         elif operator == PropertyOperator.regex:
-            return ast.Call(name="match", args=[field, ast.Constant(value=value)])
+            return ast.Call(
+                name="ifNull",
+                args=[ast.Call(name="match", args=[field, ast.Constant(value=value)]), ast.Constant(value=False)],
+            )
         elif operator == PropertyOperator.not_regex:
             return ast.Call(
-                name="not",
-                args=[ast.Call(name="match", args=[field, ast.Constant(value=value)])],
+                name="ifNull",
+                args=[
+                    ast.Call(
+                        name="not",
+                        args=[ast.Call(name="match", args=[field, ast.Constant(value=value)])],
+                    ),
+                    ast.Constant(value=False),
+                ],
             )
         elif operator == PropertyOperator.exact or operator == PropertyOperator.is_date_exact:
             op = ast.CompareOperationOp.Eq

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -145,11 +145,11 @@ class TestProperty(BaseTest):
         )
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "a", "value": ".*", "operator": "regex"}),
-            self._parse_expr("match(properties.a, '.*')"),
+            self._parse_expr("ifNull(match(properties.a, '.*'), false)"),
         )
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "a", "value": ".*", "operator": "not_regex"}),
-            self._parse_expr("not(match(properties.a, '.*'))"),
+            self._parse_expr("ifNull(not(match(properties.a, '.*')), false)"),
         )
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "a", "value": [], "operator": "exact"}),
@@ -214,7 +214,7 @@ class TestProperty(BaseTest):
         )
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "a", "value": ["b", "c"], "operator": "regex"}),
-            self._parse_expr("match(properties.a, 'b') or match(properties.a, 'c')"),
+            self._parse_expr("ifNull(match(properties.a, 'b'), false) or ifNull(match(properties.a, 'c'), false)"),
         )
         # negative
         self.assertEqual(
@@ -241,7 +241,9 @@ class TestProperty(BaseTest):
                     "operator": "not_regex",
                 }
             ),
-            self._parse_expr("not(match(properties.a, 'b')) and not(match(properties.a, 'c'))"),
+            self._parse_expr(
+                "ifNull(not(match(properties.a, 'b')), false) and ifNull(not(match(properties.a, 'c')), false)"
+            ),
         )
 
     def test_property_to_expr_feature(self):


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C045L1VEG87/p1706694796394389

## Changes

Regex matches like `a *~ b` that gets converted to `match(null, 'regex')` would return `null`, not `false` if the first argument is null, possibly messing up the entire query. Now it returns `false` if the first argument is null.

## How did you test this code?

Updated relevant tests