### PR TITLE
fix(hogql): regex match returns false if value is null, part 2

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -216,7 +216,7 @@ def property_to_expr(
                         name="not",
                         args=[ast.Call(name="match", args=[field, ast.Constant(value=value)])],
                     ),
-                    ast.Constant(value=False),
+                    ast.Constant(value=True),
                 ],
             )
         elif operator == PropertyOperator.exact or operator == PropertyOperator.is_date_exact:

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -242,7 +242,7 @@ class TestProperty(BaseTest):
                 }
             ),
             self._parse_expr(
-                "ifNull(not(match(properties.a, 'b')), false) and ifNull(not(match(properties.a, 'c')), true)"
+                "ifNull(not(match(properties.a, 'b')), true) and ifNull(not(match(properties.a, 'c')), true)"
             ),
         )
 

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -149,7 +149,7 @@ class TestProperty(BaseTest):
         )
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "a", "value": ".*", "operator": "not_regex"}),
-            self._parse_expr("ifNull(not(match(properties.a, '.*')), false)"),
+            self._parse_expr("ifNull(not(match(properties.a, '.*')), true)"),
         )
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "a", "value": [], "operator": "exact"}),
@@ -242,7 +242,7 @@ class TestProperty(BaseTest):
                 }
             ),
             self._parse_expr(
-                "ifNull(not(match(properties.a, 'b')), false) and ifNull(not(match(properties.a, 'c')), false)"
+                "ifNull(not(match(properties.a, 'b')), false) and ifNull(not(match(properties.a, 'c')), true)"
             ),
         )
 


### PR DESCRIPTION
## Problem

Fix for https://github.com/PostHog/posthog/pull/20062

## Changes

The negative condition was reversed. 

The way it worked:

```
match("aaaa", "a") --> true
match("fish", "a") --> false
match(null, "a") --> false

not(match("aaaa", "a")) --> false
not(match("fish", "a")) --> true
not(match(null, "a")) --> false <-- null does not contain "a", so should be true
```

After this PR:

```
match("aaaa", "a") --> true
match("fish", "a") --> false
match(null, "a") --> false

not(match("aaaa", "a")) --> false
not(match("fish", "a")) --> true
not(match(null, "a")) --> true
```



## How did you test this code?

Updated the test