### PR TITLE
fix(flags): optimise defending against invalid cohorts

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -206,7 +206,7 @@ class CohortSerializer(serializers.ModelSerializer):
                             )
 
                     if prop.type == "cohort":
-                        nested_cohort = Cohort.objects.get(pk=prop.value)
+                        nested_cohort = Cohort.objects.get(pk=prop.value, team_id=self.context["team_id"])
                         dependent_cohorts = get_dependent_cohorts(nested_cohort)
                         for dependent_cohort in [nested_cohort, *dependent_cohorts]:
                             if (
@@ -597,7 +597,7 @@ def get_cohort_actors_for_feature_flag(cohort_id: int, flag: str, team_id: int, 
     if not feature_flag.active or feature_flag.deleted or feature_flag.aggregation_group_type_index is not None:
         return []
 
-    cohort = Cohort.objects.get(pk=cohort_id)
+    cohort = Cohort.objects.get(pk=cohort_id, team_id=team_id)
     matcher_cache = FlagsMatcherCache(team_id)
     uuids_to_add_to_cohort = []
     cohorts_cache: Dict[int, CohortOrEmpty] = {}

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -38,7 +38,7 @@ from posthog.models.activity_logging.activity_log import (
     log_activity,
 )
 from posthog.models.activity_logging.activity_page import activity_page_response
-from posthog.models.cohort import Cohort
+from posthog.models.cohort import Cohort, CohortOrEmpty
 from posthog.models.cohort.util import get_dependent_cohorts
 from posthog.models.feature_flag import (
     FeatureFlagDashboards,
@@ -523,7 +523,7 @@ class FeatureFlagViewSet(
         should_send_cohorts = "send_cohorts" in request.GET
 
         cohorts = {}
-        seen_cohorts_cache: Dict[int, Cohort] = {}
+        seen_cohorts_cache: Dict[int, CohortOrEmpty] = {}
 
         if should_send_cohorts:
             seen_cohorts_cache = {
@@ -570,10 +570,14 @@ class FeatureFlagViewSet(
                         if id in seen_cohorts_cache:
                             cohort = seen_cohorts_cache[id]
                         else:
-                            cohort = Cohort.objects.using(DATABASE_FOR_LOCAL_EVALUATION).get(id=id)
-                            seen_cohorts_cache[id] = cohort
+                            cohort = (
+                                Cohort.objects.using(DATABASE_FOR_LOCAL_EVALUATION)
+                                .filter(id=id, team_id=self.team_id, deleted=False)
+                                .first()
+                            )
+                            seen_cohorts_cache[id] = cohort or ""
 
-                        if not cohort.is_static:
+                        if cohort and not cohort.is_static:
                             cohorts[cohort.pk] = cohort.properties.to_dict()
 
         # Add request for analytics

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -378,7 +378,8 @@
          "posthog_cohort"."is_static",
          "posthog_cohort"."groups"
   FROM "posthog_cohort"
-  WHERE "posthog_cohort"."id" = 2
+  WHERE ("posthog_cohort"."id" = 2
+         AND "posthog_cohort"."team_id" = 2)
   LIMIT 21
   '''
 # ---
@@ -619,7 +620,8 @@
          "posthog_cohort"."is_static",
          "posthog_cohort"."groups"
   FROM "posthog_cohort"
-  WHERE "posthog_cohort"."id" = 2
+  WHERE ("posthog_cohort"."id" = 2
+         AND "posthog_cohort"."team_id" = 2)
   LIMIT 21
   '''
 # ---
@@ -939,7 +941,8 @@
          "posthog_cohort"."is_static",
          "posthog_cohort"."groups"
   FROM "posthog_cohort"
-  WHERE "posthog_cohort"."id" = 2
+  WHERE ("posthog_cohort"."id" = 2
+         AND "posthog_cohort"."team_id" = 2)
   LIMIT 21
   '''
 # ---
@@ -1237,7 +1240,8 @@
          "posthog_cohort"."is_static",
          "posthog_cohort"."groups"
   FROM "posthog_cohort"
-  WHERE "posthog_cohort"."id" = 2
+  WHERE ("posthog_cohort"."id" = 2
+         AND "posthog_cohort"."team_id" = 2)
   LIMIT 21
   '''
 # ---
@@ -1303,7 +1307,8 @@
          "posthog_cohort"."is_static",
          "posthog_cohort"."groups"
   FROM "posthog_cohort"
-  WHERE "posthog_cohort"."id" = 2
+  WHERE ("posthog_cohort"."id" = 2
+         AND "posthog_cohort"."team_id" = 2)
   LIMIT 21
   '''
 # ---
@@ -1930,7 +1935,8 @@
          "posthog_cohort"."is_static",
          "posthog_cohort"."groups"
   FROM "posthog_cohort"
-  WHERE "posthog_cohort"."id" = 2
+  WHERE ("posthog_cohort"."id" = 2
+         AND "posthog_cohort"."team_id" = 2)
   LIMIT 21 /*controller='project_feature_flags-create-static-cohort-for-flag',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/feature_flags/%28%3FP%3Cpk%3E%5B%5E/.%5D%2B%29/create_static_cohort_for_flag/%3F%24'*/
   '''
 # ---

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -2207,9 +2207,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
             created_by=self.user,
         )
 
-        with self.assertNumQueries(7):
-            # multiple queries to get the same cohort, because it doesn't exist
-            # TODO: Find a better way to optimise this in cache
+        with self.assertNumQueries(6):
             response = self._post_decide(api_version=3, distinct_id="example_id_1")
             self.assertEqual(response.json()["featureFlags"], {"cohort-flag": False, "simple-flag": True})
             self.assertEqual(response.json()["errorsWhileComputingFlags"], False)

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -2214,6 +2214,167 @@ class TestDecide(BaseTest, QueryMatchingTest):
             self.assertEqual(response.json()["featureFlags"], {"cohort-flag": False, "simple-flag": True})
             self.assertEqual(response.json()["errorsWhileComputingFlags"], False)
 
+    def test_flag_with_multiple_complex_unknown_cohort(self, *args):
+        self.team.app_urls = ["https://example.com"]
+        self.team.save()
+
+        other_team = Team.objects.create(
+            organization=self.organization,
+            api_token="bazinga_new",
+            name="New Team",
+        )
+        self.client.logout()
+
+        Person.objects.create(
+            team=self.team,
+            distinct_ids=["example_id_1"],
+            properties={"$some_prop_1": "something_1"},
+        )
+
+        deleted_cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[
+                {
+                    "properties": [
+                        {
+                            "key": "$some_prop_1",
+                            "value": "something_1",
+                            "type": "person",
+                        }
+                    ]
+                },
+            ],
+            name="cohort1",
+            deleted=True,
+        )
+
+        cohort_from_other_team = Cohort.objects.create(
+            team=other_team,
+            groups=[
+                {
+                    "properties": [
+                        {
+                            "key": "$some_prop_1",
+                            "value": "something_1",
+                            "type": "person",
+                        }
+                    ]
+                },
+            ],
+            name="cohort1",
+        )
+
+        cohort_with_nested_invalid = Cohort.objects.create(
+            team=self.team,
+            groups=[
+                {
+                    "properties": [
+                        {
+                            "key": "$some_prop_1",
+                            "value": "something_1",
+                            "type": "person",
+                        },
+                        {
+                            "key": "id",
+                            "value": 99999,
+                            "type": "cohort",
+                        },
+                        {
+                            "key": "id",
+                            "value": deleted_cohort.pk,
+                            "type": "cohort",
+                        },
+                        {
+                            "key": "id",
+                            "value": cohort_from_other_team.pk,
+                            "type": "cohort",
+                        },
+                    ]
+                },
+            ],
+            name="cohort1",
+        )
+
+        cohort_valid = Cohort.objects.create(
+            team=self.team,
+            groups=[
+                {
+                    "properties": [
+                        {
+                            "key": "$some_prop_1",
+                            "value": "something_1",
+                            "type": "person",
+                        },
+                    ]
+                },
+            ],
+            name="cohort1",
+        )
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            filters={"groups": [{"properties": [{"key": "id", "value": 99999, "type": "cohort"}]}]},
+            name="This is a cohort-based flag",
+            key="cohort-flag",
+            created_by=self.user,
+        )
+        FeatureFlag.objects.create(
+            team=self.team,
+            filters={
+                "groups": [{"properties": [{"key": "id", "value": cohort_with_nested_invalid.pk, "type": "cohort"}]}]
+            },
+            name="This is a cohort-based flag",
+            key="cohort-flag-2",
+            created_by=self.user,
+        )
+        FeatureFlag.objects.create(
+            team=self.team,
+            filters={"groups": [{"properties": [{"key": "id", "value": cohort_from_other_team.pk, "type": "cohort"}]}]},
+            name="This is a cohort-based flag",
+            key="cohort-flag-3",
+            created_by=self.user,
+        )
+        FeatureFlag.objects.create(
+            team=self.team,
+            filters={
+                "groups": [
+                    {"properties": [{"key": "id", "value": cohort_valid.pk, "type": "cohort"}]},
+                    {"properties": [{"key": "id", "value": cohort_with_nested_invalid.pk, "type": "cohort"}]},
+                    {"properties": [{"key": "id", "value": 99999, "type": "cohort"}]},
+                    {"properties": [{"key": "id", "value": deleted_cohort.pk, "type": "cohort"}]},
+                ]
+            },
+            name="This is a cohort-based flag",
+            key="cohort-flag-4",
+            created_by=self.user,
+        )
+        FeatureFlag.objects.create(
+            team=self.team,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+            name="This is a regular flag",
+            key="simple-flag",
+            created_by=self.user,
+        )
+
+        with self.assertNumQueries(8):
+            # Each invalid cohort is queried only once
+            # 1. Select all valid cohorts
+            # 2. Select 99999 cohort
+            # 3. Select deleted cohort
+            # 4. Select cohort from other team
+            response = self._post_decide(api_version=3, distinct_id="example_id_1")
+            self.assertEqual(
+                response.json()["featureFlags"],
+                {
+                    "cohort-flag": False,
+                    "simple-flag": True,
+                    "cohort-flag-2": False,
+                    "cohort-flag-3": False,
+                    "cohort-flag-4": True,
+                },
+            )
+            self.assertEqual(response.json()["errorsWhileComputingFlags"], False)
+
     @snapshot_postgres_queries
     def test_flag_with_behavioural_cohorts(self, *args):
         self.team.app_urls = ["https://example.com"]

--- a/posthog/api/test/test_feature_flag_utils.py
+++ b/posthog/api/test/test_feature_flag_utils.py
@@ -1,4 +1,5 @@
-from typing import Dict, Set
+from typing import Set
+from posthog.models.cohort.cohort import CohortOrEmpty
 from posthog.test.base import (
     APIBaseTest,
 )
@@ -68,6 +69,6 @@ class TestFeatureFlagUtils(APIBaseTest):
 
     def test_empty_cohorts_set(self):
         cohort_ids: Set[int] = set()
-        seen_cohorts_cache: Dict[int, Cohort] = {}
+        seen_cohorts_cache: dict[int, CohortOrEmpty] = {}
         topologically_sorted_cohort_ids = sort_cohorts_topologically(cohort_ids, seen_cohorts_cache)
         self.assertEqual(topologically_sorted_cohort_ids, [])

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -1,6 +1,6 @@
 import time
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional, cast
+from typing import Any, Dict, List, Literal, Optional, Union, cast
 
 import structlog
 from django.conf import settings
@@ -16,6 +16,10 @@ from posthog.models.person import Person
 from posthog.models.property import BehavioralPropertyType, Property, PropertyGroup
 from posthog.models.utils import sane_repr
 from posthog.settings.base_variables import TEST
+
+# The empty string literal helps us determine when the cohort is invalid/deleted, when
+# set in cohorts_cache
+CohortOrEmpty = Union["Cohort", Literal[""], None]
 
 logger = structlog.get_logger(__name__)
 

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -483,7 +483,7 @@ def get_dependent_cohorts(
                     pk=cohort_id, team_id=cohort.team_id, deleted=False
                 )
                 seen_cohorts_cache[cohort_id] = current_cohort
-            if cohort.id not in seen_cohort_ids:
+            if current_cohort.id not in seen_cohort_ids:
                 cohorts.append(current_cohort)
                 seen_cohort_ids.add(current_cohort.id)
 

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -16,7 +16,7 @@ from posthog.hogql.printer import print_ast
 from posthog.models import Action, Filter, Team
 from posthog.models.action.util import format_action_filter
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
-from posthog.models.cohort.cohort import Cohort
+from posthog.models.cohort.cohort import Cohort, CohortOrEmpty
 from posthog.models.cohort.sql import (
     CALCULATE_COHORT_PEOPLE_SQL,
     GET_COHORT_SIZE_SQL,
@@ -454,7 +454,7 @@ def get_all_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> List[int]:
 def get_dependent_cohorts(
     cohort: Cohort,
     using_database: str = "default",
-    seen_cohorts_cache: Optional[Dict[int, Cohort]] = None,
+    seen_cohorts_cache: Optional[Dict[int, CohortOrEmpty]] = None,
 ) -> List[Cohort]:
     if seen_cohorts_cache is None:
         seen_cohorts_cache = {}
@@ -475,15 +475,19 @@ def get_dependent_cohorts(
         cohort_id = queue.pop()
         try:
             if cohort_id in seen_cohorts_cache:
-                cohort = seen_cohorts_cache[cohort_id]
+                current_cohort = seen_cohorts_cache[cohort_id]
+                if not current_cohort:
+                    continue
             else:
-                cohort = Cohort.objects.using(using_database).get(pk=cohort_id)
-                seen_cohorts_cache[cohort_id] = cohort
+                current_cohort = Cohort.objects.using(using_database).get(
+                    pk=cohort_id, team_id=cohort.team_id, deleted=False
+                )
+                seen_cohorts_cache[cohort_id] = current_cohort
             if cohort.id not in seen_cohort_ids:
-                cohorts.append(cohort)
-                seen_cohort_ids.add(cohort.id)
+                cohorts.append(current_cohort)
+                seen_cohort_ids.add(current_cohort.id)
 
-                for prop in cohort.properties.flat:
+                for prop in current_cohort.properties.flat:
                     if prop.type == "cohort" and not isinstance(prop.value, list):
                         try:
                             queue.append(int(prop.value))
@@ -491,12 +495,13 @@ def get_dependent_cohorts(
                             continue
 
         except Cohort.DoesNotExist:
+            seen_cohorts_cache[cohort_id] = ""
             continue
 
     return cohorts
 
 
-def sort_cohorts_topologically(cohort_ids: Set[int], seen_cohorts_cache: Dict[int, Cohort]) -> List[int]:
+def sort_cohorts_topologically(cohort_ids: Set[int], seen_cohorts_cache: Dict[int, CohortOrEmpty]) -> List[int]:
     """
     Sorts the given cohorts in an order where cohorts with no dependencies are placed first,
     followed by cohorts that depend on the preceding ones. It ensures that each cohort in the sorted list
@@ -519,12 +524,17 @@ def sort_cohorts_topologically(cohort_ids: Set[int], seen_cohorts_cache: Dict[in
                 dependency_graph[cohort.id].append(int(prop.value))
 
                 neighbor_cohort = seen_cohorts_cache[int(prop.value)]
+                if not neighbor_cohort:
+                    continue
+
                 if cohort.id not in seen:
                     seen.add(cohort.id)
                     traverse(neighbor_cohort)
 
     for cohort_id in cohort_ids:
         cohort = seen_cohorts_cache[int(cohort_id)]
+        if not cohort:
+            continue
         traverse(cohort)
 
     # post-order DFS (children first, then the parent)

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -22,7 +22,7 @@ from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.person import Person, PersonDistinctId
 from posthog.models.property import GroupTypeIndex, GroupTypeName
 from posthog.models.property.property import Property
-from posthog.models.cohort import Cohort
+from posthog.models.cohort import Cohort, CohortOrEmpty
 from posthog.models.utils import execute_with_timeout
 from posthog.queries.base import match_property, properties_to_Q, sanitize_property_key
 from posthog.database_healthcheck import (
@@ -138,7 +138,7 @@ class FeatureFlagMatcher:
         property_value_overrides: Dict[str, Union[str, int]] = {},
         group_property_value_overrides: Dict[str, Dict[str, Union[str, int]]] = {},
         skip_database_flags: bool = False,
-        cohorts_cache: Optional[Dict[int, Cohort]] = None,
+        cohorts_cache: Optional[Dict[int, CohortOrEmpty]] = None,
     ):
         self.feature_flags = feature_flags
         self.distinct_id = distinct_id
@@ -397,13 +397,14 @@ class FeatureFlagMatcher:
                 person_fields: List[str] = []
 
                 def condition_eval(key, condition):
+                    team_id = self.feature_flags[0].team_id
                     expr = None
                     annotate_query = True
                     nonlocal person_query
 
                     property_list = Filter(data=condition).property_groups.flat
                     properties_with_math_operators = get_all_properties_with_math_operators(
-                        property_list, self.cohorts_cache
+                        property_list, self.cohorts_cache, team_id
                     )
 
                     if len(condition.get("properties", {})) > 0:
@@ -416,6 +417,7 @@ class FeatureFlagMatcher:
                             )
 
                         expr = properties_to_Q(
+                            team_id,
                             property_list,
                             override_property_values=target_properties,
                             cohorts_cache=self.cohorts_cache,
@@ -935,7 +937,7 @@ def key_and_field_for_property(property: Property) -> Tuple[str, str]:
 
 
 def get_all_properties_with_math_operators(
-    properties: List[Property], cohorts_cache: Dict[int, Cohort]
+    properties: List[Property], cohorts_cache: Dict[int, CohortOrEmpty], team_id: int
 ) -> List[Tuple[str, str]]:
     all_keys_and_fields = []
 
@@ -943,15 +945,17 @@ def get_all_properties_with_math_operators(
         if prop.type == "cohort":
             cohort_id = int(cast(Union[str, int], prop.value))
             if cohorts_cache.get(cohort_id) is None:
-                queried_cohort = Cohort.objects.using(DATABASE_FOR_FLAG_MATCHING).filter(pk=cohort_id).first()
-                if queried_cohort:
-                    cohorts_cache[cohort_id] = queried_cohort
-                cohort = queried_cohort
-            else:
-                cohort = cohorts_cache[cohort_id]
+                queried_cohort = (
+                    Cohort.objects.using(DATABASE_FOR_FLAG_MATCHING)
+                    .filter(pk=cohort_id, team_id=team_id, deleted=False)
+                    .first()
+                )
+                cohorts_cache[cohort_id] = queried_cohort or ""
+
+            cohort = cohorts_cache[cohort_id]
             if cohort:
                 all_keys_and_fields.extend(
-                    get_all_properties_with_math_operators(cohort.properties.flat, cohorts_cache)
+                    get_all_properties_with_math_operators(cohort.properties.flat, cohorts_cache, team_id)
                 )
         elif prop.operator in ["gt", "lt", "gte", "lte"] and prop.type in ("person", "group"):
             all_keys_and_fields.append(key_and_field_for_property(prop))

--- a/posthog/models/filters/test/__snapshots__/test_filter.ambr
+++ b/posthog/models/filters/test/__snapshots__/test_filter.ambr
@@ -394,7 +394,9 @@
          "posthog_cohort"."is_static",
          "posthog_cohort"."groups"
   FROM "posthog_cohort"
-  WHERE "posthog_cohort"."id" = 2
+  WHERE (NOT "posthog_cohort"."deleted"
+         AND "posthog_cohort"."id" = 2
+         AND "posthog_cohort"."team_id" = 2)
   ORDER BY "posthog_cohort"."id" ASC
   LIMIT 1
   '''
@@ -468,7 +470,9 @@
          "posthog_cohort"."is_static",
          "posthog_cohort"."groups"
   FROM "posthog_cohort"
-  WHERE "posthog_cohort"."id" = 2
+  WHERE (NOT "posthog_cohort"."deleted"
+         AND "posthog_cohort"."id" = 2
+         AND "posthog_cohort"."team_id" = 2)
   ORDER BY "posthog_cohort"."id" ASC
   LIMIT 1
   '''
@@ -533,7 +537,9 @@
          "posthog_cohort"."is_static",
          "posthog_cohort"."groups"
   FROM "posthog_cohort"
-  WHERE "posthog_cohort"."id" = 2
+  WHERE (NOT "posthog_cohort"."deleted"
+         AND "posthog_cohort"."id" = 2
+         AND "posthog_cohort"."team_id" = 2)
   ORDER BY "posthog_cohort"."id" ASC
   LIMIT 1
   '''
@@ -558,7 +564,9 @@
          "posthog_cohort"."is_static",
          "posthog_cohort"."groups"
   FROM "posthog_cohort"
-  WHERE "posthog_cohort"."id" = 2
+  WHERE (NOT "posthog_cohort"."deleted"
+         AND "posthog_cohort"."id" = 2
+         AND "posthog_cohort"."team_id" = 2)
   ORDER BY "posthog_cohort"."id" ASC
   LIMIT 1
   '''
@@ -583,7 +591,9 @@
          "posthog_cohort"."is_static",
          "posthog_cohort"."groups"
   FROM "posthog_cohort"
-  WHERE "posthog_cohort"."id" = 2
+  WHERE (NOT "posthog_cohort"."deleted"
+         AND "posthog_cohort"."id" = 2
+         AND "posthog_cohort"."team_id" = 2)
   ORDER BY "posthog_cohort"."id" ASC
   LIMIT 1
   '''
@@ -608,7 +618,9 @@
          "posthog_cohort"."is_static",
          "posthog_cohort"."groups"
   FROM "posthog_cohort"
-  WHERE "posthog_cohort"."id" = 2
+  WHERE (NOT "posthog_cohort"."deleted"
+         AND "posthog_cohort"."id" = 2
+         AND "posthog_cohort"."team_id" = 2)
   ORDER BY "posthog_cohort"."id" ASC
   LIMIT 1
   '''

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -577,7 +577,7 @@ def property_to_Q_test_factory(filter_persons: Callable, person_factory):
 
 def _filter_persons(filter: Filter, team: Team):
     flush_persons_and_events()
-    persons = Person.objects.filter(properties_to_Q(filter.property_groups.flat))
+    persons = Person.objects.filter(properties_to_Q(team.pk, filter.property_groups.flat))
     persons = persons.filter(team_id=team.pk)
     return [str(uuid) for uuid in persons.values_list("uuid", flat=True)]
 
@@ -609,7 +609,7 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
             }
         )
 
-        persons = Person.objects.filter(property_group_to_Q(filter.property_groups))
+        persons = Person.objects.filter(property_group_to_Q(self.team.pk, filter.property_groups))
         persons = persons.filter(team_id=self.team.pk)
         results = sorted([person.distinct_ids[0] for person in persons])
 
@@ -634,7 +634,7 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
                     team_id=self.team.pk,
                     persondistinctid__distinct_id=person1_distinct_id,
                 )
-                .filter(properties_to_Q(filter.property_groups.flat))
+                .filter(properties_to_Q(self.team.pk, filter.property_groups.flat))
                 .exists()
             )
         self.assertTrue(matched_person)
@@ -657,7 +657,7 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
                     team_id=self.team.pk,
                     persondistinctid__distinct_id=person1_distinct_id,
                 )
-                .filter(properties_to_Q(filter.property_groups.flat))
+                .filter(properties_to_Q(self.team.pk, filter.property_groups.flat))
                 .exists()
             )
         self.assertTrue(matched_person)
@@ -745,7 +745,7 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
                     team_id=self.team.pk,
                     persondistinctid__distinct_id=person1_distinct_id,
                 )
-                .filter(properties_to_Q(filter.property_groups.flat))
+                .filter(properties_to_Q(self.team.pk, filter.property_groups.flat))
                 .exists()
             )
         self.assertTrue(matched_person)
@@ -763,7 +763,7 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
                 ]
             }
         )
-        query_filter = properties_to_Q(filter.property_groups.flat)
+        query_filter = properties_to_Q(self.team.pk, filter.property_groups.flat)
         self.assertEqual(
             query_filter,
             Q(
@@ -790,7 +790,7 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
                     team_id=self.team.pk,
                     persondistinctid__distinct_id=person1_distinct_id,
                 )
-                .filter(properties_to_Q(filter.property_groups.flat))
+                .filter(properties_to_Q(self.team.pk, filter.property_groups.flat))
                 .exists()
             )
         self.assertTrue(matched_person)
@@ -814,7 +814,9 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
                 )
                 .filter(
                     properties_to_Q(
-                        filter.property_groups.flat, override_property_values={"created_at": "2022-10-06T10:00:00Z"}
+                        self.team.pk,
+                        filter.property_groups.flat,
+                        override_property_values={"created_at": "2022-10-06T10:00:00Z"},
                     )
                 )
                 .exists()
@@ -843,7 +845,7 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
                     team_id=self.team.pk,
                     persondistinctid__distinct_id=person1_distinct_id,
                 )
-                .filter(properties_to_Q(filter.property_groups.flat))
+                .filter(properties_to_Q(self.team.pk, filter.property_groups.flat))
                 .exists()
             )
             # needs an exact match
@@ -861,7 +863,7 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
                     team_id=self.team.pk,
                     persondistinctid__distinct_id=person1_distinct_id,
                 )
-                .filter(properties_to_Q(filter.property_groups.flat))
+                .filter(properties_to_Q(self.team.pk, filter.property_groups.flat))
                 .exists()
             )
             self.assertFalse(matched_person)
@@ -893,7 +895,7 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
                         F("properties__$a_number"), function="JSONB_TYPEOF", output_field=CharField()
                     )
                 }
-            ).filter(properties_to_Q(filter.property_groups.flat))
+            ).filter(properties_to_Q(self.team.pk, filter.property_groups.flat))
             persons = persons.filter(team_id=team.pk)
             return [str(uuid) for uuid in persons.values_list("uuid", flat=True)]
 
@@ -943,7 +945,7 @@ class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _creat
                         F("properties__$key"), function="JSONB_TYPEOF", output_field=CharField()
                     )
                 }
-            ).filter(properties_to_Q(filter.property_groups.flat))
+            ).filter(properties_to_Q(self.team.pk, filter.property_groups.flat))
             persons = persons.filter(team_id=team.pk)
             return [str(uuid) for uuid in persons.values_list("uuid", flat=True)]
 
@@ -994,7 +996,7 @@ def filter_persons_with_property_group(
     filter: Filter, team: Team, property_overrides: Dict[str, Any] = {}
 ) -> List[str]:
     flush_persons_and_events()
-    persons = Person.objects.filter(property_group_to_Q(filter.property_groups, property_overrides))
+    persons = Person.objects.filter(property_group_to_Q(team.pk, filter.property_groups, property_overrides))
     persons = persons.filter(team_id=team.pk)
     return sorted([person.distinct_ids[0] for person in persons])
 


### PR DESCRIPTION
## Problem

When we have invalid cohorts for flags, we re-query them again and again because they aren't stored in the cache. Now, I'm adding a sentinel value to the cache, representing an empty cohort. This means whenever we access the cache now, need to check and confirm we have a `Cohort`.

Further, noticed in some places we didn't have a team_id filter, which was very bad because it could match on random invalid for current team cohorts.

Added tests for all of these cases^^

Potential cause of a latency spike, we'll see

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
