### PR TITLE
feat: organization recordings

### DIFF
--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -140,7 +140,7 @@ export function Group(): JSX.Element {
                                 {!groupData.group_properties?.id ? (
                                     <div className="mb-4">
                                         <LemonBanner type="info">
-                                            Session recordings are not available for this group because it does not have
+                                            Cannot view recordings in this tab for this group because it does not have
                                             an <code>id</code> property.
                                         </LemonBanner>
                                     </div>

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -144,47 +144,48 @@ export function Group(): JSX.Element {
                                             an <code>id</code> property.
                                         </LemonBanner>
                                     </div>
-                                ) : null}
-                                <div className="SessionRecordingPlaylistHeightWrapper">
-                                    <SessionRecordingsPlaylist
-                                        logicKey="groups-recordings"
-                                        updateSearchParams
-                                        filters={{
-                                            events: [
-                                                {
-                                                    type: 'events',
-                                                    order: 0,
-                                                    name: 'All events',
-                                                    properties: [
-                                                        {
-                                                            key: 'id',
-                                                            value: [groupData.group_properties?.id],
-                                                            operator: 'exact',
-                                                            type: 'group',
-                                                            group_type_index: groupData.group_type_index,
-                                                        },
-                                                    ],
-                                                },
-                                            ],
-                                        }}
-                                        onFiltersChange={(filters) => {
-                                            const stillHasGroupFilter = filters.events?.some((event) => {
-                                                return event.properties.some(
-                                                    (prop) =>
-                                                        prop.type === 'group' &&
-                                                        prop.group_type_index === groupData.group_type_index &&
-                                                        prop.key === 'id'
-                                                )
-                                            })
-                                            if (!stillHasGroupFilter) {
-                                                lemonToast.warning(
-                                                    'Group filter removed. Please add it back to see recordings for this group.',
-                                                    { autoClose: 10000 }
-                                                )
-                                            }
-                                        }}
-                                    />
-                                </div>
+                                ) : (
+                                    <div className="SessionRecordingPlaylistHeightWrapper">
+                                        <SessionRecordingsPlaylist
+                                            logicKey="groups-recordings"
+                                            updateSearchParams
+                                            filters={{
+                                                events: [
+                                                    {
+                                                        type: 'events',
+                                                        order: 0,
+                                                        name: 'All events',
+                                                        properties: [
+                                                            {
+                                                                key: 'id',
+                                                                value: [groupData.group_properties?.id],
+                                                                operator: 'exact',
+                                                                type: 'group',
+                                                                group_type_index: groupData.group_type_index,
+                                                            },
+                                                        ],
+                                                    },
+                                                ],
+                                            }}
+                                            onFiltersChange={(filters) => {
+                                                const stillHasGroupFilter = filters.events?.some((event) => {
+                                                    return event.properties.some(
+                                                        (prop: Record<string, any>) =>
+                                                            prop.type === 'group' &&
+                                                            prop.group_type_index === groupData.group_type_index &&
+                                                            prop.key === 'id'
+                                                    )
+                                                })
+                                                if (!stillHasGroupFilter) {
+                                                    lemonToast.warning(
+                                                        'Group filter removed. Please add it back to see recordings for this group.',
+                                                        { autoClose: 10000 }
+                                                    )
+                                                }
+                                            }}
+                                        />
+                                    </div>
+                                )}
                             </>
                         ),
                     },

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -136,14 +136,6 @@ export function Group(): JSX.Element {
                                             and enable it.
                                         </LemonBanner>
                                     </div>
-                                ) : null}
-                                {!groupData.group_properties?.id ? (
-                                    <div className="mb-4">
-                                        <LemonBanner type="info">
-                                            Cannot view recordings in this tab for this group because it does not have
-                                            an <code>id</code> property.
-                                        </LemonBanner>
-                                    </div>
                                 ) : (
                                     <div className="SessionRecordingPlaylistHeightWrapper">
                                         <SessionRecordingsPlaylist
@@ -157,11 +149,8 @@ export function Group(): JSX.Element {
                                                         name: 'All events',
                                                         properties: [
                                                             {
-                                                                key: 'id',
-                                                                value: [groupData.group_properties?.id],
-                                                                operator: 'exact',
-                                                                type: 'group',
-                                                                group_type_index: groupData.group_type_index,
+                                                                key: `$group_${groupTypeIndex} = '${groupKey}'`,
+                                                                type: 'hogql',
                                                             },
                                                         ],
                                                     },
@@ -171,15 +160,12 @@ export function Group(): JSX.Element {
                                                 const stillHasGroupFilter = filters.events?.some((event) => {
                                                     return event.properties.some(
                                                         (prop: Record<string, any>) =>
-                                                            prop.type === 'group' &&
-                                                            prop.group_type_index === groupData.group_type_index &&
-                                                            prop.key === 'id'
+                                                            prop.key === `$group_${groupTypeIndex} = '${groupKey}'`
                                                     )
                                                 })
                                                 if (!stillHasGroupFilter) {
                                                     lemonToast.warning(
-                                                        'Group filter removed. Please add it back to see recordings for this group.',
-                                                        { autoClose: 10000 }
+                                                        'Group filter removed. Please add it back to see recordings for this group.'
                                                     )
                                                 }
                                             }}

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -5,7 +5,10 @@ import { NotFound } from 'lib/components/NotFound'
 import { PageHeader } from 'lib/components/PageHeader'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { TZLabel } from 'lib/components/TZLabel'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { Link } from 'lib/lemon-ui/Link'
 import { Spinner, SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
 import { GroupDashboard } from 'scenes/groups/GroupDashboard'
 import { groupLogic, GroupLogicProps } from 'scenes/groups/groupLogic'
@@ -13,6 +16,8 @@ import { RelatedGroups } from 'scenes/groups/RelatedGroups'
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
 import { RelatedFeatureFlags } from 'scenes/persons/RelatedFeatureFlags'
 import { SceneExport } from 'scenes/sceneTypes'
+import { SessionRecordingsPlaylist } from 'scenes/session-recordings/playlist/SessionRecordingsPlaylist'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { Query } from '~/queries/Query/Query'
@@ -22,6 +27,7 @@ interface GroupSceneProps {
     groupTypeIndex?: string
     groupKey?: string
 }
+
 export const scene: SceneExport = {
     component: Group,
     logic: groupLogic,
@@ -68,6 +74,7 @@ export function Group(): JSX.Element {
     } = useValues(groupLogic)
     const { groupKey, groupTypeIndex } = logicProps
     const { setGroupEventsQuery } = useActions(groupLogic)
+    const { currentTeam } = useValues(teamLogic)
 
     if (!groupData || !groupType) {
         return groupDataLoading ? <SpinnerOverlay sceneLevel /> : <NotFound object="group" />
@@ -96,7 +103,7 @@ export function Group(): JSX.Element {
                 tabs={[
                     {
                         key: PersonsTabType.PROPERTIES,
-                        label: <span data-attr="persons-properties-tab">Properties</span>,
+                        label: <span data-attr="groups-properties-tab">Properties</span>,
                         content: (
                             <PropertiesTable
                                 type={PropertyDefinitionType.Group}
@@ -108,11 +115,77 @@ export function Group(): JSX.Element {
                     },
                     {
                         key: PersonsTabType.EVENTS,
-                        label: <span data-attr="persons-events-tab">Events</span>,
+                        label: <span data-attr="groups-events-tab">Events</span>,
                         content: groupEventsQuery ? (
                             <Query query={groupEventsQuery} setQuery={setGroupEventsQuery} />
                         ) : (
                             <Spinner />
+                        ),
+                    },
+                    {
+                        key: PersonsTabType.SESSION_RECORDINGS,
+                        label: <span data-attr="group-session-recordings-tab">Recordings</span>,
+                        content: (
+                            <>
+                                {!currentTeam?.session_recording_opt_in ? (
+                                    <div className="mb-4">
+                                        <LemonBanner type="info">
+                                            Session recordings are currently disabled for this project. To use this
+                                            feature, please go to your{' '}
+                                            <Link to={`${urls.settings('project')}#recordings`}>project settings</Link>{' '}
+                                            and enable it.
+                                        </LemonBanner>
+                                    </div>
+                                ) : null}
+                                {!groupData.group_properties?.id ? (
+                                    <div className="mb-4">
+                                        <LemonBanner type="info">
+                                            Session recordings are not available for this group because it does not have
+                                            an <code>id</code> property.
+                                        </LemonBanner>
+                                    </div>
+                                ) : null}
+                                <div className="SessionRecordingPlaylistHeightWrapper">
+                                    <SessionRecordingsPlaylist
+                                        logicKey="groups-recordings"
+                                        updateSearchParams
+                                        filters={{
+                                            events: [
+                                                {
+                                                    type: 'events',
+                                                    order: 0,
+                                                    name: 'All events',
+                                                    properties: [
+                                                        {
+                                                            key: 'id',
+                                                            value: [groupData.group_properties?.id],
+                                                            operator: 'exact',
+                                                            type: 'group',
+                                                            group_type_index: groupData.group_type_index,
+                                                        },
+                                                    ],
+                                                },
+                                            ],
+                                        }}
+                                        onFiltersChange={(filters) => {
+                                            const stillHasGroupFilter = filters.events?.some((event) => {
+                                                return event.properties.some(
+                                                    (prop) =>
+                                                        prop.type === 'group' &&
+                                                        prop.group_type_index === groupData.group_type_index &&
+                                                        prop.key === 'id'
+                                                )
+                                            })
+                                            if (!stillHasGroupFilter) {
+                                                lemonToast.warning(
+                                                    'Group filter removed. Please add it back to see recordings for this group.',
+                                                    { autoClose: 10000 }
+                                                )
+                                            }
+                                        }}
+                                    />
+                                </div>
+                            </>
                         ),
                     },
                     {


### PR DESCRIPTION
Add a recordings tab to the groups scene

uses the group key and group type index to add a hogql filter for all events that have the appropriate $group_X set

![2024-01-31 14 49 57](https://github.com/PostHog/posthog/assets/984817/70128d59-0862-4255-b300-a3b6b1d229ea)
