### PR TITLE
fix(queries): Adjust breakdown limit for showing other

### DIFF
--- a/posthog/hogql_queries/insights/trends/breakdown_values.py
+++ b/posthog/hogql_queries/insights/trends/breakdown_values.py
@@ -149,6 +149,8 @@ class BreakdownValues:
                 values = [BREAKDOWN_NULL_STRING_LABEL if value in (None, "") else value for value in values]
                 values.insert(0, BREAKDOWN_OTHER_STRING_LABEL)
 
+            breakdown_limit += 1  # Add one to the limit to account for the "other" value
+
         return values[:breakdown_limit]
 
     def _to_bucketing_expression(self) -> ast.Expr:

--- a/posthog/queries/breakdown_props.py
+++ b/posthog/queries/breakdown_props.py
@@ -212,6 +212,10 @@ def get_breakdown_prop_values(
             **entity_format_params,
         )
 
+    limit = filter.breakdown_limit_or_default + 1
+    if filter.breakdown_hide_other_aggregation:
+        limit += 1  # Account for the "other" aggregation
+
     response = insight_sync_execute(
         elements_query,
         {


### PR DESCRIPTION
## Problem

When I select "show other" I would expect this to be in addition to the already shown breakdown categories when using a breakdown limit.

E.g. I limit to "5 browsers" and I select "show other" makes 5 + other instead of taking away 1 browser and showing 4 + other.

## Changes

- adjust limit

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
