### PR TITLE
fix: fix structure of group properties param in feature_enabled call

### DIFF
--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -96,9 +96,7 @@ def org_quota_limited_until(organization: Organization, resource: QuotaResource)
         QUOTA_LIMIT_DATA_RETENTION_FLAG,
         organization.id,
         groups={"organization": str(organization.id)},
-        group_properties={
-            "organization": str(organization.id),
-        },
+        group_properties={"organization": {"id": str(organization.id)}},
     ):
         # Don't drop data for this org but record that they __would have__ been
         # limited.

--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -60,7 +60,7 @@ class TestQuotaLimiting(BaseTest):
             QUOTA_LIMIT_DATA_RETENTION_FLAG,
             self.organization.id,
             groups={"organization": str(self.organization.id)},
-            group_properties={"organization": str(self.organization.id)},
+            group_properties={"organization": {"id": str(self.organization.id)}},
         )
         patch_capture.assert_called_once_with(
             str(self.organization.id),


### PR DESCRIPTION
## Problem

The billing page is broken because the group properties param is formatted incorrectly. 

Tested locally and confirmed the api calls go through now. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
