### PR TITLE
fix(retention): do not set interval for retention as date range side effect

### DIFF
--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -423,6 +423,7 @@ const handleQuerySourceUpdateSideEffects = (
      * Date range change side effects.
      */
     if (
+        !isRetentionQuery(currentState) &&
         !isPathsQuery(currentState) && // TODO: Apply side logic more elegantly
         update.dateRange &&
         update.dateRange.date_from &&


### PR DESCRIPTION
## Problem

Query validation error in Sentry:

```
1 validation error for QueryRequest
query.RetentionQuery.interval
  Extra inputs are not permitted [type=extra_forbidden, input_value='day', input_type=str]
    For further information visit https://errors.pydantic.dev/2.5/v/extra_forbidden
```

A similar issue exists for lifecycle insights, but I couldn't find a good Replay to reproduce it yet :/

### Repro

1. Enable flag `hogql-insights-retention`
2. Go to the new insights page
3. While still on a trends insight, select a different date range e.g. "14 days"
4. Switch to retention insight
5. Select a different start date for the insight
6. Observe that there is a "There was an error completing this query" error


## Changes

This PR does not set an `interval` on retention type queries when changing the date range.

## How did you test this code?

Tried the repro before and after