### PR TITLE
fix(insights): fix divider in page header

### DIFF
--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -143,10 +143,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                             >
                                                 Share or embed
                                             </LemonButton>
-                                        </>
-                                    )}
-                                    {insight.short_id && (
-                                        <>
                                             <SubscribeButton insightShortId={insight.short_id} />
                                             {exporterResourceParams ? (
                                                 <ExportButton
@@ -163,9 +159,9 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                     ]}
                                                 />
                                             ) : null}
+                                            <LemonDivider />
                                         </>
                                     )}
-                                    <LemonDivider />
                                     <LemonSwitch
                                         data-attr={`${showQueryEditor ? 'hide' : 'show'}-insight-source`}
                                         className="px-2 py-1"


### PR DESCRIPTION
## Problem

A divider was shown in the page header buttons, even if there were no more entries above.

<img width="181" alt="Screenshot 2024-02-01 at 12 06 03" src="https://github.com/PostHog/posthog/assets/1851359/d7f1fd72-a1fc-4b57-8e21-2ddb1224c36a">

## Changes

This PR moves the divider up.

## How did you test this code?

Tested locally