### PR TITLE
feat(hogql): Add always group by in actors query to prevent duplicate results

### DIFF
--- a/frontend/src/scenes/retention/queries.ts
+++ b/frontend/src/scenes/retention/queries.ts
@@ -12,7 +12,7 @@ export function retentionToActorsQuery(query: RetentionQuery, selectedInterval: 
     return {
         kind: NodeKind.ActorsQuery,
         select: [selectActor, ...selects],
-        orderBy: ['length(appearances) DESC', 'actor_id'],
+        orderBy: ['length(appearances) DESC', 'id'],
         source: {
             kind: NodeKind.InsightActorsQuery,
             interval: selectedInterval,

--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -181,16 +181,18 @@ class ActorsQueryRunner(QueryRunner):
                 elif input_column == "matched_recordings":
                     column = ast.Field(chain=["matching_events"])
 
-                outer_columns.append(column)
+                column_alias = ast.Alias(expr=column, alias=input_column)
+                column_accessor = ast.Field(chain=[input_column])
+                outer_columns.append(column_accessor)
 
                 if self.has_column(source_columns, input_column):
                     continue
 
-                columns.append(column)
+                columns.append(column_alias)
                 if has_aggregation(column):
-                    aggregations.append(column)
+                    aggregations.append(column_accessor)
                 elif not isinstance(column, ast.Constant):
-                    group_by.append(column)
+                    group_by.append(column_accessor)
 
             # Append strategy column in any case
             columns.append(ast.Field(chain=[self.strategy.origin_id]))


### PR DESCRIPTION
## Problem

Actors show up several times when they have multiple distinct ids AND we use search or something that puts a join to distinct ids table into the query. (Also the same might apply when some other query modification causes a similar other join – but I haven't checked that)

## Changes

- wrap actors in a select where we apply group by
- add tests:
  - for retention, because that queries with a `length(...)` in the order by which gets problematic if not in the group, hence good to test
  - for actors query in general

## How did you test this code?

- tests