### PR TITLE
chore: add experimental label to Discussions

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/SidePanelDiscussion.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/SidePanelDiscussion.tsx
@@ -1,4 +1,5 @@
 import { IconChat } from '@posthog/icons'
+import { LemonTag, Tooltip } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { humanizeScope } from 'lib/components/ActivityLog/humanizeActivity'
 import { WarningHog } from 'lib/components/hedgehogs'
@@ -54,14 +55,19 @@ export const SidePanelDiscussion = (): JSX.Element => {
         <div className="flex flex-col overflow-hidden flex-1">
             <SidePanelPaneHeader
                 title={
-                    <>
-                        Discussion{' '}
-                        {scope ? (
-                            <span className="font-normal text-muted-alt">
-                                about {item_id ? 'this' : ''} {humanizeScope(scope, !!item_id)}
-                            </span>
-                        ) : null}
-                    </>
+                    <div className="flex space-x-2">
+                        <span>
+                            Discussion{' '}
+                            {scope ? (
+                                <span className="font-normal text-muted-alt">
+                                    about {item_id ? 'this' : ''} {humanizeScope(scope, !!item_id)}
+                                </span>
+                            ) : null}
+                        </span>
+                        <Tooltip title="The Discussions feature might be removed at some point in the future">
+                            <LemonTag type="completion">Experimental</LemonTag>
+                        </Tooltip>
+                    </div>
                 }
             />
 

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/SidePanelDiscussion.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/SidePanelDiscussion.tsx
@@ -64,7 +64,7 @@ export const SidePanelDiscussion = (): JSX.Element => {
                                 </span>
                             ) : null}
                         </span>
-                        <Tooltip title="The Discussions feature might be removed at some point in the future">
+                        <Tooltip title="We may choose to remove Discussions at some point in the future">
                             <LemonTag type="completion">Experimental</LemonTag>
                         </Tooltip>
                     </div>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/SidePanelDiscussion.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/SidePanelDiscussion.tsx
@@ -64,7 +64,7 @@ export const SidePanelDiscussion = (): JSX.Element => {
                                 </span>
                             ) : null}
                         </span>
-                        <Tooltip title="We may choose to remove Discussions at some point in the future">
+                        <Tooltip title="This is a feature we are experimenting with! We'd love to get your feedback on it and whether this is something useful for working with PostHog.">
                             <LemonTag type="completion">Experimental</LemonTag>
                         </Tooltip>
                     </div>


### PR DESCRIPTION
## Problem

We want to make it clear to customers that we're still deciding on what to do with Discussions

## Changes

Adds a warning
<img width="461" alt="Screenshot 2024-02-01 at 12 31 21" src="https://github.com/PostHog/posthog/assets/6685876/887beceb-6bcc-4e1f-b511-baa0c942be12">


## How did you test this code?

Visually