### PR TITLE
fix(hogql): Fix actor modal load more

### DIFF
--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -182,7 +182,7 @@ export function PersonsModal({
                             </>
                         ) : (
                             <span>
-                                {actorsResponse?.next || actorsResponse?.next_offset ? 'More than ' : ''}
+                                {actorsResponse?.next || actorsResponse?.offset ? 'More than ' : ''}
                                 <b>
                                     {totalActorsCount || 'No'} unique{' '}
                                     {pluralize(totalActorsCount, actorLabel.singular, actorLabel.plural, false)}
@@ -221,7 +221,7 @@ export function PersonsModal({
                             </div>
                         )}
 
-                        {(actorsResponse?.next || actorsResponse?.next_offset) && (
+                        {(actorsResponse?.next || actorsResponse?.offset) && (
                             <div className="m-4 flex justify-center">
                                 <LemonButton type="primary" onClick={loadNextActors} loading={actorsResponseLoading}>
                                     Load more {actorLabel.plural}

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -47,7 +47,7 @@ export interface ListActorsResponse {
     }[]
     missing_persons?: number
     next?: string
-    next_offset?: number
+    offset?: number // Offset for HogQL queries
 }
 
 export const personsModalLogic = kea<personsModalLogicType>([
@@ -110,8 +110,8 @@ export const personsModalLogic = kea<personsModalLogicType>([
                         const response = await performQuery(
                             {
                                 ...values.actorsQuery,
-                                limit: RESULTS_PER_PAGE,
-                                offset: offset || 0,
+                                limit: offset ? offset * 2 : RESULTS_PER_PAGE,
+                                offset,
                             } as ActorsQuery,
                             undefined,
                             undefined,
@@ -128,34 +128,30 @@ export const personsModalLogic = kea<personsModalLogicType>([
                             results: [
                                 {
                                     count: response.results.length,
-                                    people: response.results
-                                        .slice(0, RESULTS_PER_PAGE)
-                                        .map((result): PersonActorType => {
-                                            const person: PersonActorType = {
-                                                type: 'person',
-                                                id: result[0].id,
-                                                uuid: result[0].id,
-                                                distinct_ids: result[0].distinct_ids,
-                                                is_identified: result[0].is_identified,
-                                                properties: result[0].properties,
-                                                created_at: result[0].created_at,
-                                                matched_recordings: [],
-                                                value_at_data_point: null,
-                                            }
+                                    people: response.results.map((result): PersonActorType => {
+                                        const person: PersonActorType = {
+                                            type: 'person',
+                                            id: result[0].id,
+                                            uuid: result[0].id,
+                                            distinct_ids: result[0].distinct_ids,
+                                            is_identified: result[0].is_identified,
+                                            properties: result[0].properties,
+                                            created_at: result[0].created_at,
+                                            matched_recordings: [],
+                                            value_at_data_point: null,
+                                        }
 
-                                            Object.keys(additionalSelect || {}).forEach((field, index) => {
-                                                person[field] = result[additionalFieldIndices[index]]
-                                            })
+                                        Object.keys(additionalSelect || {}).forEach((field, index) => {
+                                            person[field] = result[additionalFieldIndices[index]]
+                                        })
 
-                                            return person
-                                        }),
+                                        return person
+                                    }),
                                 },
                             ],
                         }
-                        if (response.results.length > RESULTS_PER_PAGE) {
-                            newResponse.results[0].count = newResponse.results[0].people.length
-                            newResponse.next_offset = (offset || 0) + newResponse.results[0].count
-                        }
+                        newResponse.offset = response.hasMore ? response.offset + response.limit : undefined
+                        newResponse.missing_persons = response.missing_actors_count
                         if (clear) {
                             actions.resetActors()
                         }
@@ -270,8 +266,8 @@ export const personsModalLogic = kea<personsModalLogicType>([
             if (values.actorsResponse?.next) {
                 actions.loadActors({ url: values.actorsResponse.next })
             }
-            if (values.actorsResponse?.next_offset) {
-                actions.loadActors({ offset: values.actorsResponse.next_offset })
+            if (values.actorsResponse?.offset) {
+                actions.loadActors({ offset: values.actorsResponse.offset })
             }
         },
         loadActors: () => {

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -59,21 +59,10 @@ export const personsModalLogic = kea<personsModalLogicType>([
         resetActors: () => true,
         closeModal: () => true,
         setIsCohortModalOpen: (isOpen: boolean) => ({ isOpen }),
-        loadActors: ({
+        loadActors: ({ url, clear, offset }: { url?: string | null; clear?: boolean; offset?: number }) => ({
             url,
             clear,
             offset,
-            additionalSelect,
-        }: {
-            url?: string | null
-            clear?: boolean
-            offset?: number
-            additionalSelect?: PersonModalLogicProps['additionalSelect']
-        }) => ({
-            url,
-            clear,
-            offset,
-            additionalSelect,
         }),
         loadNextActors: true,
         updateQuery: (query: InsightActorsQuery) => ({ query }),
@@ -85,11 +74,11 @@ export const personsModalLogic = kea<personsModalLogicType>([
         actions: [eventUsageLogic, ['reportCohortCreatedFromPersonsModal', 'reportPersonsModalViewed']],
     }),
 
-    loaders(({ values, actions }) => ({
+    loaders(({ values, actions, props }) => ({
         actorsResponse: [
             null as ListActorsResponse | null,
             {
-                loadActors: async ({ url, clear, offset, additionalSelect }, breakpoint) => {
+                loadActors: async ({ url, clear, offset }, breakpoint) => {
                     if (url) {
                         url += '&include_recordings=true'
 
@@ -121,7 +110,7 @@ export const personsModalLogic = kea<personsModalLogicType>([
                         breakpoint()
 
                         const assembledSelectFields = values.selectFields
-                        const additionalFieldIndices = Object.values(additionalSelect || {}).map((field) =>
+                        const additionalFieldIndices = Object.values(props.additionalSelect || {}).map((field) =>
                             assembledSelectFields.indexOf(field)
                         )
                         const newResponse: ListActorsResponse = {
@@ -141,7 +130,7 @@ export const personsModalLogic = kea<personsModalLogicType>([
                                             value_at_data_point: null,
                                         }
 
-                                        Object.keys(additionalSelect || {}).forEach((field, index) => {
+                                        Object.keys(props.additionalSelect || {}).forEach((field, index) => {
                                             person[field] = result[additionalFieldIndices[index]]
                                         })
 
@@ -361,7 +350,7 @@ export const personsModalLogic = kea<personsModalLogicType>([
     }),
 
     afterMount(({ actions, props }) => {
-        actions.loadActors({ url: props.url, additionalSelect: props.additionalSelect })
+        actions.loadActors({ url: props.url })
 
         actions.reportPersonsModalViewed({
             url: props.url,


### PR DESCRIPTION
## Problem

"Load more" did not show up for actors modal on e.g. trends and paths. The `hasMore` from the new query results was not taken into account. I guess some stuff still relied on the old `+1` technique.

## Changes

- make `offset` align with my work on retention modal
- adjust counts and offsets
- fix total actors count which was also broken due to slicing results

## How did you test this code?

- 👀 
