### PR TITLE
fix: persons query optimisation by team

### DIFF
--- a/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
@@ -445,7 +445,7 @@ class SessionIdEventsQuery(EventQuery):
         (
             events_timestamp_clause,
             events_timestamp_params,
-        ) = self._get_events_timestamp_clause
+        ) = self.get_events_timestamp_clause
 
         groups_query, groups_params = self._get_groups_query()
 

--- a/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
@@ -678,7 +678,7 @@ class SessionRecordingListFromReplaySummary(EventQuery):
 
         persons_select, persons_select_params = ActorsQuery(filter=self._filter, team=self._team).get_query()
 
-        events_timestamp_clause_params = {}
+        events_timestamp_clause_params: Dict[str, str] = {}
         if persons_select:
             (
                 events_timestamp_clause,

--- a/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
@@ -677,7 +677,8 @@ class SessionRecordingListFromReplaySummary(EventQuery):
             events_select = f"AND s.session_id in (select `$session_id` as session_id from ({events_select}) as session_events_sub_query)"
 
         persons_select, persons_select_params = ActorsQuery(filter=self._filter, team=self._team).get_query()
-        events_timestamp_clause, events_timestamp_clause_params = "", {}
+
+        events_timestamp_clause_params = {}
         if persons_select:
             (
                 events_timestamp_clause,
@@ -685,7 +686,7 @@ class SessionRecordingListFromReplaySummary(EventQuery):
             ) = session_id_events_query.get_events_timestamp_clause
             persons_select = (
                 f"AND s.distinct_id in (select distinct_id from ({persons_select}) as session_persons_sub_query)"
-            ).format(events_timestamp_clause=events_timestamp_clause, default_event=get_default_event_name(self.team))
+            ).format(events_timestamp_clause=events_timestamp_clause, default_event=get_default_event_name(self._team))
 
         return (
             self._session_recordings_query.format(

--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -1,4 +1,195 @@
 # serializer version: 1
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter
+  '''
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2022-12-14 00:00:00'
+    AND s.min_first_timestamp >= '2022-12-28 00:00:00'
+    AND s.max_last_timestamp <= '2023-01-04 00:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2022-12-14 00:00:00'
+          AND e.timestamp <= now()
+          AND timestamp >= '2022-12-27 12:00:00'
+          AND timestamp <= '2023-01-04 12:00:00'
+          WHERE notEmpty(`$session_id`)
+            AND (((event = 'custom-event'
+                   AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))
+                        AND has(['test_action_filter-session-one'], "$session_id")
+                        AND has(['test_action_filter-window-id'], "$window_id")))))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '''
+# ---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter.1
+  '''
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2022-12-14 00:00:00'
+    AND s.min_first_timestamp >= '2022-12-28 00:00:00'
+    AND s.max_last_timestamp <= '2023-01-04 00:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2022-12-14 00:00:00'
+          AND e.timestamp <= now()
+          AND timestamp >= '2022-12-27 12:00:00'
+          AND timestamp <= '2023-01-04 12:00:00'
+          WHERE notEmpty(`$session_id`)
+            AND (((event = 'custom-event'
+                   AND (has(['test_action_filter-session-one'], "$session_id")
+                        AND has(['test_action_filter-window-id'], "$window_id")))))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '''
+# ---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter.2
+  '''
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2022-12-14 00:00:00'
+    AND s.min_first_timestamp >= '2022-12-28 00:00:00'
+    AND s.max_last_timestamp <= '2023-01-04 00:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2022-12-14 00:00:00'
+          AND e.timestamp <= now()
+          AND timestamp >= '2022-12-27 12:00:00'
+          AND timestamp <= '2023-01-04 12:00:00'
+          WHERE notEmpty(`$session_id`)
+            AND (((event = 'custom-event'
+                   AND (has(['test_action_filter-session-one'], "$session_id")
+                        AND has(['test_action_filter-window-id'], "$window_id"))))
+                 AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '''
+# ---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter.3
+  '''
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2022-12-14 00:00:00'
+    AND s.min_first_timestamp >= '2022-12-28 00:00:00'
+    AND s.max_last_timestamp <= '2023-01-04 00:00:00'
+    AND s.session_id in
+      (select `$session_id` as session_id
+       from
+         (SELECT groupUniqArray(event) as event_names,
+                 `$session_id`
+          FROM events e PREWHERE team_id = 2
+          AND e.timestamp >= '2022-12-14 00:00:00'
+          AND e.timestamp <= now()
+          AND timestamp >= '2022-12-27 12:00:00'
+          AND timestamp <= '2023-01-04 12:00:00'
+          WHERE notEmpty(`$session_id`)
+            AND (((event = 'custom-event'
+                   AND (has(['test_action_filter-session-one'], "$session_id")
+                        AND has(['test_action_filter-window-id'], "$window_id"))))
+                 AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+          GROUP BY `$session_id`
+          HAVING 1=1
+          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '''
+# ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_all_filters_at_once
   '''
   

--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -1,195 +1,4 @@
 # serializer version: 1
-# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter
-  '''
-  
-  SELECT s.session_id,
-         any(s.team_id),
-         any(s.distinct_id),
-         min(s.min_first_timestamp) as start_time,
-         max(s.max_last_timestamp) as end_time,
-         dateDiff('SECOND', start_time, end_time) as duration,
-         argMinMerge(s.first_url) as first_url,
-         sum(s.click_count),
-         sum(s.keypress_count),
-         sum(s.mouse_activity_count),
-         sum(s.active_milliseconds)/1000 as active_seconds,
-         duration-active_seconds as inactive_seconds,
-         sum(s.console_log_count) as console_log_count,
-         sum(s.console_warn_count) as console_warn_count,
-         sum(s.console_error_count) as console_error_count
-  FROM session_replay_events s
-  WHERE s.team_id = 2
-    AND s.min_first_timestamp >= '2022-12-14 00:00:00'
-    AND s.min_first_timestamp >= '2022-12-28 00:00:00'
-    AND s.max_last_timestamp <= '2023-01-04 00:00:00'
-    AND s.session_id in
-      (select `$session_id` as session_id
-       from
-         (SELECT groupUniqArray(event) as event_names,
-                 `$session_id`
-          FROM events e PREWHERE team_id = 2
-          AND e.timestamp >= '2022-12-14 00:00:00'
-          AND e.timestamp <= now()
-          AND timestamp >= '2022-12-27 12:00:00'
-          AND timestamp <= '2023-01-04 12:00:00'
-          WHERE notEmpty(`$session_id`)
-            AND (((event = 'custom-event'
-                   AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))
-                        AND has(['test_action_filter-session-one'], "$session_id")
-                        AND has(['test_action_filter-window-id'], "$window_id")))))
-          GROUP BY `$session_id`
-          HAVING 1=1
-          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
-  GROUP BY session_id
-  HAVING 1=1
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0
-  '''
-# ---
-# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter.1
-  '''
-  
-  SELECT s.session_id,
-         any(s.team_id),
-         any(s.distinct_id),
-         min(s.min_first_timestamp) as start_time,
-         max(s.max_last_timestamp) as end_time,
-         dateDiff('SECOND', start_time, end_time) as duration,
-         argMinMerge(s.first_url) as first_url,
-         sum(s.click_count),
-         sum(s.keypress_count),
-         sum(s.mouse_activity_count),
-         sum(s.active_milliseconds)/1000 as active_seconds,
-         duration-active_seconds as inactive_seconds,
-         sum(s.console_log_count) as console_log_count,
-         sum(s.console_warn_count) as console_warn_count,
-         sum(s.console_error_count) as console_error_count
-  FROM session_replay_events s
-  WHERE s.team_id = 2
-    AND s.min_first_timestamp >= '2022-12-14 00:00:00'
-    AND s.min_first_timestamp >= '2022-12-28 00:00:00'
-    AND s.max_last_timestamp <= '2023-01-04 00:00:00'
-    AND s.session_id in
-      (select `$session_id` as session_id
-       from
-         (SELECT groupUniqArray(event) as event_names,
-                 `$session_id`
-          FROM events e PREWHERE team_id = 2
-          AND e.timestamp >= '2022-12-14 00:00:00'
-          AND e.timestamp <= now()
-          AND timestamp >= '2022-12-27 12:00:00'
-          AND timestamp <= '2023-01-04 12:00:00'
-          WHERE notEmpty(`$session_id`)
-            AND (((event = 'custom-event'
-                   AND (has(['test_action_filter-session-one'], "$session_id")
-                        AND has(['test_action_filter-window-id'], "$window_id")))))
-          GROUP BY `$session_id`
-          HAVING 1=1
-          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
-  GROUP BY session_id
-  HAVING 1=1
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0
-  '''
-# ---
-# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter.2
-  '''
-  
-  SELECT s.session_id,
-         any(s.team_id),
-         any(s.distinct_id),
-         min(s.min_first_timestamp) as start_time,
-         max(s.max_last_timestamp) as end_time,
-         dateDiff('SECOND', start_time, end_time) as duration,
-         argMinMerge(s.first_url) as first_url,
-         sum(s.click_count),
-         sum(s.keypress_count),
-         sum(s.mouse_activity_count),
-         sum(s.active_milliseconds)/1000 as active_seconds,
-         duration-active_seconds as inactive_seconds,
-         sum(s.console_log_count) as console_log_count,
-         sum(s.console_warn_count) as console_warn_count,
-         sum(s.console_error_count) as console_error_count
-  FROM session_replay_events s
-  WHERE s.team_id = 2
-    AND s.min_first_timestamp >= '2022-12-14 00:00:00'
-    AND s.min_first_timestamp >= '2022-12-28 00:00:00'
-    AND s.max_last_timestamp <= '2023-01-04 00:00:00'
-    AND s.session_id in
-      (select `$session_id` as session_id
-       from
-         (SELECT groupUniqArray(event) as event_names,
-                 `$session_id`
-          FROM events e PREWHERE team_id = 2
-          AND e.timestamp >= '2022-12-14 00:00:00'
-          AND e.timestamp <= now()
-          AND timestamp >= '2022-12-27 12:00:00'
-          AND timestamp <= '2023-01-04 12:00:00'
-          WHERE notEmpty(`$session_id`)
-            AND (((event = 'custom-event'
-                   AND (has(['test_action_filter-session-one'], "$session_id")
-                        AND has(['test_action_filter-window-id'], "$window_id"))))
-                 AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
-          GROUP BY `$session_id`
-          HAVING 1=1
-          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
-  GROUP BY session_id
-  HAVING 1=1
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0
-  '''
-# ---
-# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter.3
-  '''
-  
-  SELECT s.session_id,
-         any(s.team_id),
-         any(s.distinct_id),
-         min(s.min_first_timestamp) as start_time,
-         max(s.max_last_timestamp) as end_time,
-         dateDiff('SECOND', start_time, end_time) as duration,
-         argMinMerge(s.first_url) as first_url,
-         sum(s.click_count),
-         sum(s.keypress_count),
-         sum(s.mouse_activity_count),
-         sum(s.active_milliseconds)/1000 as active_seconds,
-         duration-active_seconds as inactive_seconds,
-         sum(s.console_log_count) as console_log_count,
-         sum(s.console_warn_count) as console_warn_count,
-         sum(s.console_error_count) as console_error_count
-  FROM session_replay_events s
-  WHERE s.team_id = 2
-    AND s.min_first_timestamp >= '2022-12-14 00:00:00'
-    AND s.min_first_timestamp >= '2022-12-28 00:00:00'
-    AND s.max_last_timestamp <= '2023-01-04 00:00:00'
-    AND s.session_id in
-      (select `$session_id` as session_id
-       from
-         (SELECT groupUniqArray(event) as event_names,
-                 `$session_id`
-          FROM events e PREWHERE team_id = 2
-          AND e.timestamp >= '2022-12-14 00:00:00'
-          AND e.timestamp <= now()
-          AND timestamp >= '2022-12-27 12:00:00'
-          AND timestamp <= '2023-01-04 12:00:00'
-          WHERE notEmpty(`$session_id`)
-            AND (((event = 'custom-event'
-                   AND (has(['test_action_filter-session-one'], "$session_id")
-                        AND has(['test_action_filter-window-id'], "$window_id"))))
-                 AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
-          GROUP BY `$session_id`
-          HAVING 1=1
-          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
-  GROUP BY session_id
-  HAVING 1=1
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0
-  '''
-# ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_all_filters_at_once
   '''
   
@@ -3638,6 +3447,46 @@
   '''
 # ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_person_id_filter
+  '''
+  
+  SELECT s.session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(s.min_first_timestamp) as start_time,
+         max(s.max_last_timestamp) as end_time,
+         dateDiff('SECOND', start_time, end_time) as duration,
+         argMinMerge(s.first_url) as first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         sum(s.active_milliseconds)/1000 as active_seconds,
+         duration-active_seconds as inactive_seconds,
+         sum(s.console_log_count) as console_log_count,
+         sum(s.console_warn_count) as console_warn_count,
+         sum(s.console_error_count) as console_error_count
+  FROM session_replay_events s
+  WHERE s.team_id = 2
+    AND s.min_first_timestamp >= '2020-12-11 13:46:23'
+    AND s.min_first_timestamp >= '2020-12-25 00:00:00'
+    AND s.max_last_timestamp <= '2021-01-01 13:46:23'
+    AND s.distinct_id in
+      (select distinct_id
+       from
+         (SELECT distinct_id,
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2 as pdi
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0
+          and person_id = '00000000-0000-0000-0000-000000000000') as session_persons_sub_query)
+  GROUP BY session_id
+  HAVING 1=1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '''
+# ---
+# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_person_id_filter_with_distinct_id_optimization
   '''
   
   SELECT s.session_id,

--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -3486,56 +3486,6 @@
   OFFSET 0
   '''
 # ---
-# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_person_id_filter_with_distinct_id_optimization
-  '''
-  
-  SELECT s.session_id,
-         any(s.team_id),
-         any(s.distinct_id),
-         min(s.min_first_timestamp) as start_time,
-         max(s.max_last_timestamp) as end_time,
-         dateDiff('SECOND', start_time, end_time) as duration,
-         argMinMerge(s.first_url) as first_url,
-         sum(s.click_count),
-         sum(s.keypress_count),
-         sum(s.mouse_activity_count),
-         sum(s.active_milliseconds)/1000 as active_seconds,
-         duration-active_seconds as inactive_seconds,
-         sum(s.console_log_count) as console_log_count,
-         sum(s.console_warn_count) as console_warn_count,
-         sum(s.console_error_count) as console_error_count
-  FROM session_replay_events s
-  WHERE s.team_id = 2
-    AND s.min_first_timestamp >= '2020-12-11 13:46:23'
-    AND s.min_first_timestamp >= '2020-12-25 00:00:00'
-    AND s.max_last_timestamp <= '2021-01-01 13:46:23'
-    AND s.distinct_id in
-      (select distinct_id
-       from
-         (SELECT distinct_id,
-                 argMax(person_id, version) as person_id
-          FROM person_distinct_id2 as pdi
-          WHERE team_id = 2
-            AND distinct_id in
-              (SELECT distinct_id
-               FROM events e
-               WHERE team_id = 2
-                 AND e.timestamp >= '2020-12-11 13:46:23'
-                 AND e.timestamp <= now()
-                 AND timestamp >= '2020-12-24 12:00:00'
-                 AND timestamp <= '2021-01-02 01:46:23'
-                 and $session_id != ''
-                 and event = '$pageview') as load_fewer_rows
-          GROUP BY distinct_id
-          HAVING argMax(is_deleted, version) = 0
-          and person_id = '00000000-0000-0000-0000-000000000000') as session_persons_sub_query)
-  GROUP BY session_id
-  HAVING 1=1
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0
-  '''
-# ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_top_level_event_property_test_account_filter
   '''
   

--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -1,195 +1,4 @@
 # serializer version: 1
-# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter
-  '''
-  
-  SELECT s.session_id,
-         any(s.team_id),
-         any(s.distinct_id),
-         min(s.min_first_timestamp) as start_time,
-         max(s.max_last_timestamp) as end_time,
-         dateDiff('SECOND', start_time, end_time) as duration,
-         argMinMerge(s.first_url) as first_url,
-         sum(s.click_count),
-         sum(s.keypress_count),
-         sum(s.mouse_activity_count),
-         sum(s.active_milliseconds)/1000 as active_seconds,
-         duration-active_seconds as inactive_seconds,
-         sum(s.console_log_count) as console_log_count,
-         sum(s.console_warn_count) as console_warn_count,
-         sum(s.console_error_count) as console_error_count
-  FROM session_replay_events s
-  WHERE s.team_id = 2
-    AND s.min_first_timestamp >= '2022-12-14 00:00:00'
-    AND s.min_first_timestamp >= '2022-12-28 00:00:00'
-    AND s.max_last_timestamp <= '2023-01-04 00:00:00'
-    AND s.session_id in
-      (select `$session_id` as session_id
-       from
-         (SELECT groupUniqArray(event) as event_names,
-                 `$session_id`
-          FROM events e PREWHERE team_id = 2
-          AND e.timestamp >= '2022-12-14 00:00:00'
-          AND e.timestamp <= now()
-          AND timestamp >= '2022-12-27 12:00:00'
-          AND timestamp <= '2023-01-04 12:00:00'
-          WHERE notEmpty(`$session_id`)
-            AND (((event = 'custom-event'
-                   AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))
-                        AND has(['test_action_filter-session-one'], "$session_id")
-                        AND has(['test_action_filter-window-id'], "$window_id")))))
-          GROUP BY `$session_id`
-          HAVING 1=1
-          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
-  GROUP BY session_id
-  HAVING 1=1
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0
-  '''
-# ---
-# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter.1
-  '''
-  
-  SELECT s.session_id,
-         any(s.team_id),
-         any(s.distinct_id),
-         min(s.min_first_timestamp) as start_time,
-         max(s.max_last_timestamp) as end_time,
-         dateDiff('SECOND', start_time, end_time) as duration,
-         argMinMerge(s.first_url) as first_url,
-         sum(s.click_count),
-         sum(s.keypress_count),
-         sum(s.mouse_activity_count),
-         sum(s.active_milliseconds)/1000 as active_seconds,
-         duration-active_seconds as inactive_seconds,
-         sum(s.console_log_count) as console_log_count,
-         sum(s.console_warn_count) as console_warn_count,
-         sum(s.console_error_count) as console_error_count
-  FROM session_replay_events s
-  WHERE s.team_id = 2
-    AND s.min_first_timestamp >= '2022-12-14 00:00:00'
-    AND s.min_first_timestamp >= '2022-12-28 00:00:00'
-    AND s.max_last_timestamp <= '2023-01-04 00:00:00'
-    AND s.session_id in
-      (select `$session_id` as session_id
-       from
-         (SELECT groupUniqArray(event) as event_names,
-                 `$session_id`
-          FROM events e PREWHERE team_id = 2
-          AND e.timestamp >= '2022-12-14 00:00:00'
-          AND e.timestamp <= now()
-          AND timestamp >= '2022-12-27 12:00:00'
-          AND timestamp <= '2023-01-04 12:00:00'
-          WHERE notEmpty(`$session_id`)
-            AND (((event = 'custom-event'
-                   AND (has(['test_action_filter-session-one'], "$session_id")
-                        AND has(['test_action_filter-window-id'], "$window_id")))))
-          GROUP BY `$session_id`
-          HAVING 1=1
-          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
-  GROUP BY session_id
-  HAVING 1=1
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0
-  '''
-# ---
-# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter.2
-  '''
-  
-  SELECT s.session_id,
-         any(s.team_id),
-         any(s.distinct_id),
-         min(s.min_first_timestamp) as start_time,
-         max(s.max_last_timestamp) as end_time,
-         dateDiff('SECOND', start_time, end_time) as duration,
-         argMinMerge(s.first_url) as first_url,
-         sum(s.click_count),
-         sum(s.keypress_count),
-         sum(s.mouse_activity_count),
-         sum(s.active_milliseconds)/1000 as active_seconds,
-         duration-active_seconds as inactive_seconds,
-         sum(s.console_log_count) as console_log_count,
-         sum(s.console_warn_count) as console_warn_count,
-         sum(s.console_error_count) as console_error_count
-  FROM session_replay_events s
-  WHERE s.team_id = 2
-    AND s.min_first_timestamp >= '2022-12-14 00:00:00'
-    AND s.min_first_timestamp >= '2022-12-28 00:00:00'
-    AND s.max_last_timestamp <= '2023-01-04 00:00:00'
-    AND s.session_id in
-      (select `$session_id` as session_id
-       from
-         (SELECT groupUniqArray(event) as event_names,
-                 `$session_id`
-          FROM events e PREWHERE team_id = 2
-          AND e.timestamp >= '2022-12-14 00:00:00'
-          AND e.timestamp <= now()
-          AND timestamp >= '2022-12-27 12:00:00'
-          AND timestamp <= '2023-01-04 12:00:00'
-          WHERE notEmpty(`$session_id`)
-            AND (((event = 'custom-event'
-                   AND (has(['test_action_filter-session-one'], "$session_id")
-                        AND has(['test_action_filter-window-id'], "$window_id"))))
-                 AND (has(['Firefox'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
-          GROUP BY `$session_id`
-          HAVING 1=1
-          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
-  GROUP BY session_id
-  HAVING 1=1
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0
-  '''
-# ---
-# name: TestClickhouseSessionRecordingsListFromSessionReplay.test_action_filter.3
-  '''
-  
-  SELECT s.session_id,
-         any(s.team_id),
-         any(s.distinct_id),
-         min(s.min_first_timestamp) as start_time,
-         max(s.max_last_timestamp) as end_time,
-         dateDiff('SECOND', start_time, end_time) as duration,
-         argMinMerge(s.first_url) as first_url,
-         sum(s.click_count),
-         sum(s.keypress_count),
-         sum(s.mouse_activity_count),
-         sum(s.active_milliseconds)/1000 as active_seconds,
-         duration-active_seconds as inactive_seconds,
-         sum(s.console_log_count) as console_log_count,
-         sum(s.console_warn_count) as console_warn_count,
-         sum(s.console_error_count) as console_error_count
-  FROM session_replay_events s
-  WHERE s.team_id = 2
-    AND s.min_first_timestamp >= '2022-12-14 00:00:00'
-    AND s.min_first_timestamp >= '2022-12-28 00:00:00'
-    AND s.max_last_timestamp <= '2023-01-04 00:00:00'
-    AND s.session_id in
-      (select `$session_id` as session_id
-       from
-         (SELECT groupUniqArray(event) as event_names,
-                 `$session_id`
-          FROM events e PREWHERE team_id = 2
-          AND e.timestamp >= '2022-12-14 00:00:00'
-          AND e.timestamp <= now()
-          AND timestamp >= '2022-12-27 12:00:00'
-          AND timestamp <= '2023-01-04 12:00:00'
-          WHERE notEmpty(`$session_id`)
-            AND (((event = 'custom-event'
-                   AND (has(['test_action_filter-session-one'], "$session_id")
-                        AND has(['test_action_filter-window-id'], "$window_id"))))
-                 AND (has(['Chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
-          GROUP BY `$session_id`
-          HAVING 1=1
-          AND hasAll(event_names, ['custom-event'])) as session_events_sub_query)
-  GROUP BY session_id
-  HAVING 1=1
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0
-  '''
-# ---
 # name: TestClickhouseSessionRecordingsListFromSessionReplay.test_all_filters_at_once
   '''
   
@@ -3707,6 +3516,16 @@
                  argMax(person_id, version) as person_id
           FROM person_distinct_id2 as pdi
           WHERE team_id = 2
+            AND distinct_id in
+              (SELECT distinct_id
+               FROM events e
+               WHERE team_id = 2
+                 AND e.timestamp >= '2020-12-11 13:46:23'
+                 AND e.timestamp <= now()
+                 AND timestamp >= '2020-12-24 12:00:00'
+                 AND timestamp <= '2021-01-02 01:46:23'
+                 and $session_id != ''
+                 and event = '$pageview') as load_fewer_rows
           GROUP BY distinct_id
           HAVING argMax(is_deleted, version) = 0
           and person_id = '00000000-0000-0000-0000-000000000000') as session_persons_sub_query)

--- a/posthog/session_recordings/queries/test/test_session_recording_list_from_session_replay.py
+++ b/posthog/session_recordings/queries/test/test_session_recording_list_from_session_replay.py
@@ -1443,7 +1443,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
             # we've not set up the events realistically
             # which means we can check the filter is being applied
             # because not all the sessions are returned
-            # because we've only created one event and we're now filtering by events presence
+            # because we've only created one event, and we're now filtering by events presence
             assert sorted([r["session_id"] for r in session_recordings]) == sorted([])
 
     @snapshot_clickhouse_queries

--- a/posthog/session_recordings/queries/test/test_session_recording_list_from_session_replay.py
+++ b/posthog/session_recordings/queries/test/test_session_recording_list_from_session_replay.py
@@ -1444,7 +1444,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
             # which means we can check the filter is being applied
             # because not all the sessions are returned
             # because we've only created one event, and we're now filtering by events presence
-            assert sorted([r["session_id"] for r in session_recordings]) == sorted([])
+            assert sorted([r["session_id"] for r in session_recordings]) == sorted([session_id_one])
 
     @snapshot_clickhouse_queries
     def test_all_filters_at_once(self):

--- a/posthog/settings/session_replay.py
+++ b/posthog/settings/session_replay.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from posthog.settings import get_from_env
 from posthog.utils import str_to_bool
 
@@ -15,3 +17,17 @@ REALTIME_SNAPSHOTS_FROM_REDIS_ATTEMPT_MAX = get_from_env("REALTIME_SNAPSHOTS_FRO
 REALTIME_SNAPSHOTS_FROM_REDIS_ATTEMPT_TIMEOUT_SECONDS = get_from_env(
     "REALTIME_SNAPSHOTS_FROM_REDIS_ATTEMPT_TIMEOUT_SECONDS", 0.2, type_cast=float
 )
+
+REPLAY_LISTING_DISTINCT_IDS_FROM_EVENTS_OPTIMISATION_TEAM_IDS: List[int] = []
+try:
+    REPLAY_LISTING_DISTINCT_IDS_FROM_EVENTS_OPTIMISATION_TEAM_IDS = [
+        int(x)
+        for x in get_from_env("REPLAY_LISTING_DISTINCT_IDS_FROM_EVENTS_OPTIMISATION_TEAM_IDS", "", type_cast=str).split(
+            ","
+        )
+        if x
+    ]
+except Exception:
+    print(  # noqa: T201 - print is fine here
+        "Error parsing REPLAY_LISTING_DISTINCT_IDS_FROM_EVENTS_OPTIMISATION_TEAM_IDS, must be comma separated list of integers"
+    )  # noqa: T201 - print is fine here

--- a/posthog/settings/session_replay.py
+++ b/posthog/settings/session_replay.py
@@ -30,4 +30,4 @@ try:
 except Exception:
     print(  # noqa: T201 - print is fine here
         "Error parsing REPLAY_LISTING_DISTINCT_IDS_FROM_EVENTS_OPTIMISATION_TEAM_IDS, must be comma separated list of integers"
-    )  # noqa: T201 - print is fine here
+    )


### PR DESCRIPTION
follow-up to https://github.com/PostHog/posthog/pull/20087

we can't use that solution _yet_

but we still need to fix this at least for the customer that has reported a problem

this introduces a new config to opt teams into extending the person query in session replay so that we filter only for distinct ids that are attached to sessions in the events table

we can't add this for everyone since it assumes the presence of autocapture events or we still explode the query time/memory

but we can enable this for our team to test and then the reporting team

---

tested locally and see the query altered

testing the altered query in metabase for the reporting team this is still slow but does complete

----

roll out plan

* release the code
* turn it on for our team
* test that things are still working
* turn it on for the reporting team
* test that it fixes the issue
* see what the what