### PR TITLE
fix(lemon-ui): Drag slider handle following slider track click

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSlider/LemonSlider.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSlider/LemonSlider.tsx
@@ -73,6 +73,8 @@ export function LemonSlider({ value = 0, onChange, min, max, step = 1, className
                         newValue = Math.round(newValue / step) * step // Adjusted to step
                     }
                     onChange?.(newValue)
+                    movementStartValueWithX.current = [newValue, e.clientX]
+                    setDragging(true)
                 }}
             >
                 <div className="w-full bg-border rounded-full h-1" />

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -163,8 +163,8 @@ export function InsightErrorState({ excludeDetail, title, queryId }: InsightErro
                         We apologize for this unexpected situation. There are a couple of things you can do:
                         <ol>
                             <li>
-                                First and foremost you can <b>try again</b>. We recommended you wait a moment before
-                                doing so.
+                                First and foremost you can <b>try again</b>. We recommend you wait a moment before doing
+                                so.
                             </li>
                             <li>
                                 <Link


### PR DESCRIPTION
## Problem

If you click on LemonSlider's track to jump to a value, you aren't then able to continue sliding.

## Changes

![slide](https://github.com/PostHog/posthog/assets/4550621/d1fc4a96-1826-420d-8747-af3e0d097ede)
