### PR TITLE
fix: update data pipeline docs to cdp

### DIFF
--- a/frontend/src/lib/components/PayGateMini/PayGateMini.tsx
+++ b/frontend/src/lib/components/PayGateMini/PayGateMini.tsx
@@ -88,7 +88,7 @@ const FEATURE_SUMMARIES: Record<
     [AvailableFeature.DATA_PIPELINES]: {
         description: 'Create export workflows to send your data to a destination of your choice.',
         umbrella: 'data pipelines',
-        docsHref: 'https://posthog.com/docs/data-pipelines',
+        docsHref: 'https://posthog.com/docs/cdp',
     },
 }
 


### PR DESCRIPTION
https://posthoghelp.zendesk.com/agent/tickets/9859 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/12671)

The data pipeline docs do not exist, let's link them to the cdp docs for the time being