### PR TITLE
chore: fix inspector item expansion

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -2,7 +2,6 @@ import { customEvent, eventWithTime } from '@rrweb/types'
 import FuseClass from 'fuse.js'
 import { actions, connect, events, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-// import { subscriptions } from 'kea-subscriptions'
 import api from 'lib/api'
 import { Dayjs, dayjs } from 'lib/dayjs'
 import { getKeyMapping } from 'lib/taxonomy'
@@ -133,7 +132,6 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
     actions(() => ({
         setWindowIdFilter: (windowId: string | null) => ({ windowId }),
         setItemExpanded: (index: number, expanded: boolean) => ({ index, expanded }),
-        resetItemsExpanded: true,
         setSyncScrollPaused: (paused: boolean) => ({ paused }),
     })),
     reducers(() => ({
@@ -759,11 +757,6 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
             }
         },
     })),
-    // subscriptions(({ actions }) => ({
-    //     items: () => {
-    //         actions.setItemExpanded
-    //     },
-    // })),
     events(({ actions }) => ({
         afterMount: () => {
             actions.loadMatchingEvents()

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -2,6 +2,7 @@ import { customEvent, eventWithTime } from '@rrweb/types'
 import FuseClass from 'fuse.js'
 import { actions, connect, events, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+// import { subscriptions } from 'kea-subscriptions'
 import api from 'lib/api'
 import { Dayjs, dayjs } from 'lib/dayjs'
 import { getKeyMapping } from 'lib/taxonomy'
@@ -104,7 +105,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
     connect((props: PlayerInspectorLogicProps) => ({
         actions: [
             playerSettingsLogic,
-            ['setTab', 'setMiniFilter', 'setSyncScroll'],
+            ['setTab', 'setMiniFilter', 'setSyncScroll', 'setSearchQuery'],
             eventUsageLogic,
             ['reportRecordingInspectorItemExpanded'],
             sessionRecordingDataLogic(props),
@@ -132,6 +133,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
     actions(() => ({
         setWindowIdFilter: (windowId: string | null) => ({ windowId }),
         setItemExpanded: (index: number, expanded: boolean) => ({ index, expanded }),
+        resetItemsExpanded: true,
         setSyncScrollPaused: (paused: boolean) => ({ paused }),
     })),
     reducers(() => ({
@@ -150,6 +152,8 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
 
                 setTab: () => [],
                 setMiniFilter: () => [],
+                setSearchQuery: () => [],
+                setWindowIdFilter: () => [],
             },
         ],
 
@@ -755,6 +759,11 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
             }
         },
     })),
+    // subscriptions(({ actions }) => ({
+    //     items: () => {
+    //         actions.setItemExpanded
+    //     },
+    // })),
     events(({ actions }) => ({
         afterMount: () => {
             actions.loadMatchingEvents()


### PR DESCRIPTION
## Problem

Reported in https://posthog.slack.com/archives/C03PB072FMJ/p1706781876783959

The expanded items in the inspector list were not being cleared in all cases. We cannot maintain id references because we don't have ids :( So the next best thing is to collapse when any change is made

## Changes

Clear expansion settings when any change is made to the inspector search / filtering, and does it consistently now!

https://github.com/PostHog/posthog/assets/6685876/63044dd8-bd3b-4f8a-adf0-a156068388ae


## How did you test this code?

Manually