### PR TITLE
fix(hogql): do not traverse the entire table when looking at one field

### DIFF
--- a/posthog/hogql/database/schema/event_sessions.py
+++ b/posthog/hogql/database/schema/event_sessions.py
@@ -66,6 +66,9 @@ class ContainsLazyJoinType(TraversingVisitor):
     def visit_lazy_join_type(self, node: ast.LazyJoinType):
         self.contains_lazy_join = True
 
+    def visit_field_type(self, node: ast.FieldType):
+        self.visit(node.table_type)
+
 
 class WhereClauseExtractor:
     compare_operators: List[ast.Expr]

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -144,7 +144,7 @@ class TraversingVisitor(Visitor):
         self.visit(node.type)
 
     def visit_field_type(self, node: ast.FieldType):
-        self.visit(node.table_type)
+        pass
 
     def visit_select_query_type(self, node: ast.SelectQueryType):
         for expr in node.tables.values():


### PR DESCRIPTION
## Problem

Deeply nested funnel queries [like this one](https://gist.githubusercontent.com/thmsobrmlr/4a3fcf2eb84b226d2642ff1af5da12be/raw/4357b3d0757900320f86e58f466a76ab7ac3ac0a/_funnel_3_steps_for_compare.sql) cause the HogQL property types matcher to never finish.

## Changes

I noticed too many `SelectQueryType`-s, always after `FieldType`.

<img width="1687" alt="image" src="https://github.com/PostHog/posthog/assets/53387/3b2dd69a-ded8-4a3c-83d4-5bbc9d16f51b">

Removing that followup `visit` changed the running time from `near-Infinity` to `0.02s` for the affected code.

## How did you test this code?

- Hoped CI would give a green light.
- Found that the `EventSessions` virtual query's `ContainsLazyJoinType(TraversingVisitor)` failed. 
- So I added the resolving back to just it. I don't thing we need it anywhere else. The resolver is a `CloningVisitor`, as are most others. 