### PR TITLE
fix: Allow updating batch export with HogQL query

### DIFF
--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -260,6 +260,8 @@ def test_create_batch_export_with_custom_schema(client: HttpClient):
         assert response.status_code == status.HTTP_201_CREATED, response.json()
 
         data = response.json()
+        expected_hogql_query = " ".join(TEST_HOGQL_QUERY.split())  # Don't care about whitespace
+        assert data["schema"]["hogql_query"] == expected_hogql_query
 
         codec = EncryptionCodec(settings=settings)
         schedule = describe_schedule(temporal, data["id"])
@@ -288,6 +290,7 @@ def test_create_batch_export_with_custom_schema(client: HttpClient):
                 "hogql_val_0": "$browser",
                 "hogql_val_1": "custom",
             },
+            "hogql_query": expected_hogql_query,
         }
 
         assert batch_export.schema == expected_schema

--- a/posthog/api/test/batch_exports/test_update.py
+++ b/posthog/api/test/batch_exports/test_update.py
@@ -241,3 +241,97 @@ def test_can_patch_config_with_invalid_old_values(client: HttpClient, interval):
         args = json.loads(decoded_payload[0].data)
         assert args["bucket_name"] == "my-new-production-s3-bucket"
         assert args.get("invalid_key", None) is None
+
+
+def test_can_patch_hogql_query(client: HttpClient):
+    """Test we can patch a schema with a HogQL query."""
+    temporal = sync_connect()
+
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "my-production-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "posthog-events/",
+            "aws_access_key_id": "abc123",
+            "aws_secret_access_key": "secret",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    organization = create_organization("Test Org")
+    team = create_team(organization)
+    user = create_user("test@user.com", "Test User", organization)
+    client.force_login(user)
+
+    with start_test_worker(temporal):
+        batch_export = create_batch_export_ok(
+            client,
+            team.pk,
+            batch_export_data,
+        )
+        old_schedule = describe_schedule(temporal, batch_export["id"])
+
+        new_batch_export_data = {
+            "name": "my-production-s3-bucket-destination",
+            "hogql_query": "select toString(uuid) as uuid, 'test' as test, toInt(1+1) as n from events",
+        }
+
+        response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert (
+            response.json()["hogql_query"]
+            == "SELECT toString(uuid) AS uuid, 'test' AS test, toInt(plus(1, 1)) AS n FROM events"
+        ), response.json()
+
+        batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
+        assert batch_export["interval"] == "hour"
+        assert batch_export["destination"]["config"]["bucket_name"] == "my-production-s3-bucket"
+        assert batch_export["schema"] == {
+            "fields": [
+                {
+                    "alias": "uuid",
+                    "expression": "toString(events.uuid)",
+                },
+                {
+                    "alias": "test",
+                    "expression": "%(hogql_val_0)s",
+                },
+                {
+                    "alias": "n",
+                    "expression": "toInt64OrNull(plus(1, 1))",
+                },
+            ],
+            "values": {"hogql_val_0": "test"},
+        }
+
+        # validate the underlying temporal schedule has been updated
+        codec = EncryptionCodec(settings=settings)
+        new_schedule = describe_schedule(temporal, batch_export["id"])
+        assert old_schedule.schedule.spec.intervals[0].every == new_schedule.schedule.spec.intervals[0].every
+        decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
+        args = json.loads(decoded_payload[0].data)
+        assert args["bucket_name"] == "my-production-s3-bucket"
+        assert args["interval"] == "hour"
+        assert args["batch_export_schema"] == {
+            "fields": [
+                {
+                    "alias": "uuid",
+                    "expression": "toString(events.uuid)",
+                },
+                {
+                    "alias": "test",
+                    "expression": "%(hogql_val_0)s",
+                },
+                {
+                    "alias": "n",
+                    "expression": "toInt64OrNull(plus(1, 1))",
+                },
+            ],
+            "values": {"hogql_val_0": "test"},
+        }

--- a/posthog/api/test/batch_exports/test_update.py
+++ b/posthog/api/test/batch_exports/test_update.py
@@ -284,10 +284,6 @@ def test_can_patch_hogql_query(client: HttpClient):
 
         response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
         assert response.status_code == status.HTTP_200_OK, response.json()
-        assert (
-            response.json()["hogql_query"]
-            == "SELECT toString(uuid) AS uuid, 'test' AS test, toInt(plus(1, 1)) AS n FROM events"
-        ), response.json()
 
         batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
         assert batch_export["interval"] == "hour"
@@ -308,6 +304,7 @@ def test_can_patch_hogql_query(client: HttpClient):
                 },
             ],
             "values": {"hogql_val_0": "test"},
+            "hogql_query": "SELECT toString(uuid) AS uuid, 'test' AS test, toInt(plus(1, 1)) AS n FROM events",
         }
 
         # validate the underlying temporal schedule has been updated
@@ -334,4 +331,5 @@ def test_can_patch_hogql_query(client: HttpClient):
                 },
             ],
             "values": {"hogql_val_0": "test"},
+            "hogql_query": "SELECT toString(uuid) AS uuid, 'test' AS test, toInt(plus(1, 1)) AS n FROM events",
         }

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -643,7 +643,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_0')
+                                                      'user_one_2')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '''
 # ---

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -643,7 +643,7 @@
   FROM "posthog_persondistinctid"
   INNER JOIN "posthog_person" ON ("posthog_persondistinctid"."person_id" = "posthog_person"."id")
   WHERE ("posthog_persondistinctid"."distinct_id" IN ('user2',
-                                                      'user_one_2')
+                                                      'user_one_0')
          AND "posthog_persondistinctid"."team_id" = 2) /*controller='project_session_recordings-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/session_recordings/%3F%24'*/
   '''
 # ---


### PR DESCRIPTION
## Problem

A batch export schema can be created from a HogQL query, but we don't allow updating an existing batch export with a HogQL query. Let's allow it!

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- [x] Update now also takes a hogql query.
- [x] Patching a BE with a hogql query generates a schema.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Added test.