### PR TITLE
feat: doctor tab in the player inspector

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -205,6 +205,7 @@ export const FEATURE_FLAGS = {
     AI_SESSION_SUMMARY: 'ai-session-summary', // owner: #team-replay
     PRODUCT_INTRO_PAGES: 'product-intro-pages', // owner: @raquelmsmith
     DATANODE_CONCURRENCY_LIMIT: 'datanode-concurrency-limit', // owner: @robbie-c
+    SESSION_REPLAY_DOCTOR: 'session-replay-doctor', // owner: #team-replay
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemDoctor.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemDoctor.tsx
@@ -1,0 +1,30 @@
+import { LemonButton } from '@posthog/lemon-ui'
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+
+import { InspectorListItemDoctor } from '../playerInspectorLogic'
+
+export interface ItemDoctorProps {
+    item: InspectorListItemDoctor
+    expanded: boolean
+    setExpanded: (expanded: boolean) => void
+}
+
+export function ItemDoctor({ item, expanded, setExpanded }: ItemDoctorProps): JSX.Element {
+    return (
+        <>
+            <LemonButton noPadding onClick={() => setExpanded(!expanded)} fullWidth data-attr="item-doctor-item">
+                <div className="p-2 text-xs cursor-pointer truncate font-mono flex-1">{item.tag}</div>
+            </LemonButton>
+
+            {expanded && (
+                <div className="p-2 text-xs border-t">
+                    {item.data && (
+                        <CodeSnippet language={Language.JSON} wrap thing={`custom event - ${item.tag}`}>
+                            {JSON.stringify(item.data, null, 2)}
+                        </CodeSnippet>
+                    )}
+                </div>
+            )}
+        </>
+    )
+}

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
@@ -1,4 +1,5 @@
 import { TZLabel } from '@posthog/apps-common'
+import { IconGear } from '@posthog/icons'
 import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
@@ -16,6 +17,7 @@ import { playerSettingsLogic } from '../../playerSettingsLogic'
 import { sessionRecordingPlayerLogic } from '../../sessionRecordingPlayerLogic'
 import { InspectorListItem, playerInspectorLogic } from '../playerInspectorLogic'
 import { ItemConsoleLog } from './ItemConsoleLog'
+import { ItemDoctor } from './ItemDoctor'
 import { ItemEvent } from './ItemEvent'
 import { ItemPerformanceEvent } from './ItemPerformanceEvent'
 
@@ -39,6 +41,14 @@ const typeToIconAndDescription = {
     ['offline-status']: {
         Icon: IconOffline,
         tooltip: 'browser went offline or returned online',
+    },
+    ['$session_config']: {
+        Icon: IconGear,
+        tooltip: 'Session recording config',
+    },
+    ['doctor']: {
+        Icon: undefined,
+        tooltip: 'Doctor event',
     },
 }
 const PLAYER_INSPECTOR_LIST_ITEM_MARGIN = 4
@@ -165,6 +175,8 @@ export function PlayerInspectorListItem({
                     <div className="flex items-start p-2 text-xs">
                         {item.offline ? 'Browser went offline' : 'Browser returned online'}
                     </div>
+                ) : item.type === SessionRecordingPlayerTab.DOCTOR ? (
+                    <ItemDoctor item={item} {...itemProps} />
                 ) : null}
 
                 {isExpanded ? (

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -246,10 +246,22 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
         doctorEvents: [
             (s) => [s.start, s.sessionPlayerData],
             (start, sessionPlayerData): InspectorListItemDoctor[] => {
+                if (!start) {
+                    return []
+                }
+
                 const items: InspectorListItemDoctor[] = []
 
+                const snapshotCounts: Record<string, Record<string, number>> = {}
+
                 Object.entries(sessionPlayerData.snapshotsByWindowId).forEach(([windowId, snapshots]) => {
+                    if (!snapshotCounts[windowId]) {
+                        snapshotCounts[windowId] = {}
+                    }
+
                     snapshots.forEach((snapshot: eventWithTime) => {
+                        snapshotCounts[windowId][snapshot.type] = (snapshotCounts[windowId][snapshot.type] || 0) + 1
+
                         if (snapshot.type === 5) {
                             const customEvent = snapshot as customEvent
                             const tag = customEvent.data.tag
@@ -286,6 +298,15 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                             })
                         }
                     })
+                })
+
+                items.push({
+                    type: SessionRecordingPlayerTab.DOCTOR,
+                    timestamp: start,
+                    timeInRecording: 0,
+                    tag: 'count of snapshot types by window',
+                    search: 'count of snapshot types by window',
+                    data: snapshotCounts,
                 })
 
                 return items

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -468,7 +468,9 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                         return values.sessionPlayerSnapshotData
                     }
 
-                    cache.snapshotsStartTime = performance.now()
+                    if (!cache.snapshotsStartTime) {
+                        cache.snapshotsStartTime = performance.now()
+                    }
 
                     const data: SessionPlayerSnapshotData = {
                         ...(values.sessionPlayerSnapshotData || {}),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -813,6 +813,7 @@ export enum SessionRecordingPlayerTab {
     EVENTS = 'events',
     CONSOLE = 'console',
     NETWORK = 'network',
+    DOCTOR = 'doctor',
 }
 
 export enum SessionPlayerState {


### PR DESCRIPTION
I made a separate recording analyser but it was a pain to have to export recordings to check info about them.

This adds a doctor tab to the player when a particular flag is on _or when you're impersonating a user_ 

The doctor tab shows 

* counts of different types of snapshot in the recording
* each full snapshot and its time
* all custom events (other than $pageview events which are just for URL tracking)

![2024-02-03 11 06 45](https://github.com/PostHog/posthog/assets/984817/c77ba475-a309-430e-8957-632372d08fc4)
