### PR TITLE
fix: keyboard removal mutation

### DIFF
--- a/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
+++ b/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
@@ -1607,7 +1607,7 @@ exports[`replay/transform transform inputs closed keyboard custom event 1`] = `
     "removes": [
       {
         "id": 10,
-        "parentId": 5,
+        "parentId": 9,
       },
     ],
     "source": 0,

--- a/ee/frontend/mobile-replay/transformer/transformers.ts
+++ b/ee/frontend/mobile-replay/transformer/transformers.ts
@@ -166,7 +166,7 @@ export const makeCustomEvent = (
             }
         } else {
             removes.push({
-                parentId: BODY_ID,
+                parentId: KEYBOARD_PARENT_ID,
                 id: KEYBOARD_ID,
             })
         }


### PR DESCRIPTION
follow up to https://github.com/PostHog/posthog/pull/20037

I didn't change the keyboard removal IDs so we couldn't remove the keyboard