### PR TITLE
fix(funnels): fix adding exclusion

### DIFF
--- a/frontend/src/scenes/insights/filters/FunnelExclusionsFilter/FunnelExclusionsFilter.tsx
+++ b/frontend/src/scenes/insights/filters/FunnelExclusionsFilter/FunnelExclusionsFilter.tsx
@@ -43,7 +43,8 @@ export function FunnelExclusionsFilter(): JSX.Element {
                 id: '$pageview',
                 name: '$pageview',
                 type: EntityTypes.EVENTS,
-                ...exclusionDefaultStepRange,
+                funnel_from_step: exclusionDefaultStepRange.funnelFromStep,
+                funnel_to_step: exclusionDefaultStepRange.funnelToStep,
             }}
             disabled={!isFunnelWithEnoughSteps}
             buttonCopy="Add exclusion"


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/20089 broke adding a new exlusion to funnels

## Changes

This PR fixes it by converting the default step range to the legacy format for the `ActionFilter`, which still uses legacy entities entirely.

## How did you test this code?

Added a new exlusion entity