### PR TITLE
fix(support): Show new tickets as "New"

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -68,7 +68,6 @@ export const TARGET_AREA_TO_NAME = {
     toolbar: 'Toolbar & Heatmaps',
     surveys: 'Surveys',
     web_analytics: 'Web Analytics',
-    'posthog-3000': 'PostHog 3000',
 }
 
 export const SEVERITY_LEVEL_TO_NAME = {
@@ -234,7 +233,8 @@ export const supportLogic = kea<supportLogicType>([
             const payload = {
                 request: {
                     requester: { name: name, email: email },
-                    subject: subject,
+                    subject,
+                    status: 'new',
                     custom_fields: [
                         {
                             id: 22084126888475,


### PR DESCRIPTION
## Problem

Unhandled Zendesk tickets (those without a reply or note in Zendesk) currently show up as "Open", which blends in with tickets awaiting _further_ activity from the team. This makes it harder to provide a great experience for our users.

Note that we do already use the "New" status, but only for community questions.

## Changes

New tickets from the app will now show up as "New".