### PR TITLE
fix(bi): Only show the giant loading icon when not showing the editing UI

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -74,7 +74,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
     )
 
     let component: JSX.Element | null = null
-    if (!response && responseLoading) {
+    if (!response && responseLoading && !showEditingUI) {
         return (
             <div className="flex flex-col flex-1 justify-center items-center border rounded bg-bg-light">
                 <Animation type={AnimationType.LaptopHog} />


### PR DESCRIPTION
## Problem
- When loading the SQL editor with the BI feature flag turned on, we'd not show any of the editing UI until the default query has fully run
- Reported here: https://posthog.slack.com/archives/C0368RPHLQH/p1705597079594709?thread_ts=1705592933.720769&cid=C0368RPHLQH

## Changes
- This only shows the giant hedgehog loading state when we're not in "edit" mode

## How did you test this code?
- Browser clicks and network throttling