### PR TITLE
fix: Return BAD_REQUEST on unsupported HogQL query

### DIFF
--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -176,7 +176,7 @@ class HogQLSelectQueryField(serializers.Field):
                 ),
             )
         except errors.ResolverException:
-            raise serializers.ValidationError(f"Invalid HogQL query")
+            raise serializers.ValidationError("Invalid HogQL query")
 
         return prepared_select_query
 
@@ -265,11 +265,15 @@ class BatchExportSerializer(serializers.ModelSerializer):
             limit_top_select=False,
         )
 
-        batch_export_schema: BatchExportsSchema = {
-            "fields": [],
-            "values": {},
-            "hogql_query": print_prepared_ast(hogql_query, context=context, dialect="hogql"),
-        }
+        try:
+            batch_export_schema: BatchExportsSchema = {
+                "fields": [],
+                "values": {},
+                "hogql_query": print_prepared_ast(hogql_query, context=context, dialect="hogql"),
+            }
+        except errors.HogQLException:
+            raise serializers.ValidationError("Unsupported HogQL query")
+
         for field in hogql_query.select:
             expression = print_prepared_ast(
                 field.expr,  # type: ignore


### PR DESCRIPTION
## Problem

A `HogQLException` is raised when trying to print a HogQL query that has some unsupported component. We should instead return a 400, maybe later expand the error details.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Return 400 on unsupported HogQL query.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added unit test.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
