### PR TITLE
chore(plugin-server): add created_at to rusty-hook enqueue metadata

### DIFF
--- a/plugin-server/src/worker/rusty-hook.ts
+++ b/plugin-server/src/worker/rusty-hook.ts
@@ -18,6 +18,7 @@ interface RustyWebhookPayload {
         team_id: number
         plugin_id: number
         plugin_config_id: number
+        created_at: string
     }
 }
 
@@ -60,6 +61,7 @@ export class RustyHook {
                 team_id: teamId,
                 plugin_id: pluginId,
                 plugin_config_id: pluginConfigId,
+                created_at: new Date().toISOString(),
             },
         }
         const body = JSON.stringify(rustyWebhookPayload, undefined, 4)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We'd like to track end-to-end time from Webhook payload creation to delivery.

## Changes

Add `created_at` to Webhook metadata. This way time spent sending (and possibly having to retry sending) to rusty-hook itself can be tracked.

(We could just use the time the row gets created in rusty-hook PG, but this seems superior and easy enough.)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
