### PR TITLE
fix: fix plugin file upload button

### DIFF
--- a/frontend/src/scenes/plugins/edit/UploadField.tsx
+++ b/frontend/src/scenes/plugins/edit/UploadField.tsx
@@ -1,19 +1,13 @@
-import { LemonButton, LemonFileInput } from '@posthog/lemon-ui'
-import { IconUploadFile } from 'lib/lemon-ui/icons'
+import { LemonFileInput } from '@posthog/lemon-ui'
 
 export function UploadField({ value, onChange }: { value?: File; onChange?: (file: File) => void }): JSX.Element {
     return (
         <LemonFileInput
-            accept={'image/*'}
+            accept="*"
             multiple={false}
             onChange={(files) => onChange?.(files[0])}
             value={value?.size ? [value] : []}
             showUploadedFiles={false}
-            callToAction={
-                <LemonButton className="ph-ignore-input" icon={<IconUploadFile />}>
-                    Click to upload
-                </LemonButton>
-            }
         />
     )
 }


### PR DESCRIPTION
## Problem

since this commit https://github.com/PostHog/posthog/commit/f22c21fa3450d06adc823b92c2dbc8b365fd3f0f
you can only open the file selector when clicking in the marked area, but only images are accepted 🤷‍♂️
![2024-02-05 at 16 45 09@2x](https://github.com/PostHog/posthog/assets/13001502/6fa40438-4bad-4791-a174-ec4ea0fc5024)

## Changes

This PR allows you to click anywhere in the marked area, plus it will allow all file types. Not sure if there are plugins that require files other than JSON.
![2024-02-05 at 16 46 26@2x](https://github.com/PostHog/posthog/assets/13001502/8dd7777b-88fd-45f0-a653-1105329f5465)


## How did you test this code?

manually
