### PR TITLE
fix(bi): Fixed resizing of data viz tiles and some css fixes for BI

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Chart.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Chart.tsx
@@ -1,5 +1,6 @@
 import './Chart.scss'
 
+import clsx from 'clsx'
 import { useValues } from 'kea'
 
 import { dataVisualizationLogic } from '../dataVisualizationLogic'
@@ -16,7 +17,11 @@ export const Chart = (): JSX.Element => {
                     <SideBar />
                 </div>
             )}
-            <div className="w-full flex flex-1 overflow-auto">
+            <div
+                className={clsx('w-full h-full flex-1 overflow-auto', {
+                    'pt-[46px]': showEditingUI,
+                })}
+            >
                 <LineGraph />
             </div>
         </div>

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -28,7 +28,7 @@ export const LineGraph = (): JSX.Element => {
 
     // TODO: Extract this logic out of this component and inject values in
     // via props. Make this a purely presentational component
-    const { xData, yData, presetChartHeight, visualizationType } = useValues(dataVisualizationLogic)
+    const { xData, yData, presetChartHeight, visualizationType, showEditingUI } = useValues(dataVisualizationLogic)
     const isBarChart = visualizationType === ChartDisplayType.ActionsBar
 
     const { goalLines } = useValues(displayLogic)
@@ -273,6 +273,8 @@ export const LineGraph = (): JSX.Element => {
         <div
             className={clsx('rounded bg-bg-light relative flex flex-1 flex-col p-2', {
                 DataVisualization__LineGraph: presetChartHeight,
+                'h-full': !presetChartHeight,
+                border: showEditingUI,
             })}
         >
             <div className="flex flex-1 w-full h-full overflow-hidden">

--- a/frontend/src/queries/nodes/DataVisualization/Components/SideBar.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SideBar.tsx
@@ -19,7 +19,7 @@ const TABS_TO_CONTENT = {
 }
 
 const ContentWrapper = ({ children }: { children: JSX.Element }): JSX.Element => {
-    return <div className="SideBar bg-bg-light border p-4">{children}</div>
+    return <div className="SideBar bg-bg-light border p-4 rounded-t-none border-t-0">{children}</div>
 }
 
 export const SideBar = (): JSX.Element => {


### PR DESCRIPTION
## Problem
- Resizing data viz nodes on dashboards would cause scrollbars to appear and the underlying chart canvas wouldn't resize
- The `borderless` prop of LemonTabs was removed, and so we were getting double borders in the data viz sidebar

## Changes
- Fixed resizing data viz charts
- Fixed the double border in the data viz chart sidebar 
- Other small css fixes to make the editor a bit nicer

https://github.com/PostHog/posthog/assets/1459269/d460b646-80f4-4d50-91da-e7bcc5083364


<img width="1361" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/6b6cacbe-101b-4547-bdb4-d2b9791dce7a">

## How did you test this code?
- Manually in browser