### PR TITLE
fix: Fix trends month label

### DIFF
--- a/posthog/hogql_queries/insights/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle_query_runner.py
@@ -25,6 +25,7 @@ from posthog.schema import (
     LifecycleQueryResponse,
     InsightActorsQueryOptionsResponse,
 )
+from posthog.utils import format_label_date
 
 
 class LifecycleQueryRunner(QueryRunner):
@@ -168,10 +169,7 @@ class LifecycleQueryRunner(QueryRunner):
         res = []
         for val in results:
             counts = val[1]
-            labels = [
-                item.strftime("%-d-%b-%Y{}".format(" %H:%M" if self.query_date_range.interval_name == "hour" else ""))
-                for item in val[0]
-            ]
+            labels = [format_label_date(item, self.query_date_range.interval_name) for item in val[0]]
             days = [
                 item.strftime("%Y-%m-%d{}".format(" %H:%M:%S" if self.query_date_range.interval_name == "hour" else ""))
                 for item in val[0]

--- a/posthog/hogql_queries/insights/trends/test/test_trends.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends.py
@@ -2011,12 +2011,12 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                     "count": 3.0,
                     "data": [0.0, 2.0, 0.0, 0.0, 1.0, 0.0],
                     "labels": [
-                        "1-Jun-2020",
-                        "1-Jul-2020",
-                        "1-Aug-2020",
-                        "1-Sep-2020",
-                        "1-Oct-2020",
-                        "1-Nov-2020",
+                        "Jun 2020",
+                        "Jul 2020",
+                        "Aug 2020",
+                        "Sep 2020",
+                        "Oct 2020",
+                        "Nov 2020",
                     ],
                     "days": [
                         "2020-06-01",
@@ -2087,7 +2087,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                     "label": "event_name",
                     "count": 2.0,
                     "data": [1.0, 1.0],
-                    "labels": ["1-Jun-2020", "1-Jul-2020"],
+                    "labels": ["Jun 2020", "Jul 2020"],
                     "days": ["2020-06-01", "2020-07-01"],
                 }
             ],
@@ -2433,7 +2433,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                     "label": "event_name",
                     "count": 9,
                     "data": [1, 2, 6],
-                    "labels": ["1-Sep-2020", "1-Oct-2020", "1-Nov-2020"],
+                    "labels": ["Sep 2020", "Oct 2020", "Nov 2020"],
                     "days": ["2020-09-01", "2020-10-01", "2020-11-01"],
                 }
             ],
@@ -2469,7 +2469,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                     "label": "event_name",
                     "count": 6,
                     "data": [6],
-                    "labels": ["1-Nov-2020"],
+                    "labels": ["Nov 2020"],
                     "days": ["2020-11-01"],
                 }
             ],
@@ -2506,7 +2506,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                     "label": "event_name",
                     "count": 6,
                     "data": [6],
-                    "labels": ["1-Nov-2020"],
+                    "labels": ["Nov 2020"],
                     "days": ["2020-11-01"],
                 }
             ],
@@ -2542,7 +2542,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                     "label": "event_name",
                     "count": 5.0,
                     "data": [2.0, 2.0, 1.0, 0.0],
-                    "labels": ["1-Jan-2020", "1-Feb-2020", "1-Mar-2020", "1-Apr-2020"],
+                    "labels": ["Jan 2020", "Feb 2020", "Mar 2020", "Apr 2020"],
                     "days": ["2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01"],
                 }
             ],
@@ -2577,7 +2577,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                     "label": "event_name",
                     "count": 5.0,
                     "data": [2.0, 2.0, 1.0, 0.0],
-                    "labels": ["1-Jan-2020", "1-Feb-2020", "1-Mar-2020", "1-Apr-2020"],
+                    "labels": ["Jan 2020", "Feb 2020", "Mar 2020", "Apr 2020"],
                     "days": ["2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01"],
                 }
             ],
@@ -3260,11 +3260,11 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                 ),
                 self.team,
             )
-        self.assertEqual(response[0]["labels"][0], "1-Sep-2019")
+        self.assertEqual(response[0]["labels"][0], "Sep 2019")
         self.assertEqual(response[0]["data"][0], 0)
-        self.assertEqual(response[0]["labels"][3], "1-Dec-2019")
+        self.assertEqual(response[0]["labels"][3], "Dec 2019")
         self.assertEqual(response[0]["data"][3], 1.0)
-        self.assertEqual(response[0]["labels"][4], "1-Jan-2020")
+        self.assertEqual(response[0]["labels"][4], "Jan 2020")
         self.assertEqual(response[0]["data"][4], 4.0)
 
     def test_interval_filtering_today_hourly(self):
@@ -4037,9 +4037,9 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                 ),
                 self.team,
             )
-        self.assertEqual(response[0]["labels"][3], "1-Dec-2019")
+        self.assertEqual(response[0]["labels"][3], "Dec 2019")
         self.assertEqual(response[0]["data"][3], 1.0)
-        self.assertEqual(response[0]["labels"][4], "1-Jan-2020")
+        self.assertEqual(response[0]["labels"][4], "Jan 2020")
         self.assertEqual(response[0]["data"][4], 4.0)
 
         with freeze_time("2020-01-02 23:30"):

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -323,6 +323,15 @@ class TrendsQueryRunner(QueryRunner):
 
         return TrendsQueryResponse(results=res, timings=timings, hogql=response_hogql)
 
+    def format_date_label(self, date: datetime) -> str:
+        date_formats = {
+            "default": "%-d-%b-%Y",
+            "hour": "%-d-%b-%Y %H:%M",
+            "month": "%b %Y",
+        }
+        format_string = date_formats.get(self.query_date_range.interval_name, date_formats["default"])
+        return date.strftime(format_string)
+
     def build_series_response(self, response: HogQLQueryResponse, series: SeriesWithExtras, series_count: int):
         if response.results is None:
             return []
@@ -379,12 +388,7 @@ class TrendsQueryRunner(QueryRunner):
 
                 series_object = {
                     "data": get_value("total", val),
-                    "labels": [
-                        item.strftime(
-                            "%-d-%b-%Y{}".format(" %H:%M" if self.query_date_range.interval_name == "hour" else "")
-                        )
-                        for item in get_value("date", val)
-                    ],
+                    "labels": [self.format_date_label(item) for item in get_value("date", val)],
                     "days": [
                         item.strftime(
                             "%Y-%m-%d{}".format(" %H:%M:%S" if self.query_date_range.interval_name == "hour" else "")

--- a/posthog/test/test_format_label_date.py
+++ b/posthog/test/test_format_label_date.py
@@ -1,0 +1,37 @@
+import datetime
+from posthog.utils import format_label_date
+
+
+def test_format_label_date_with_hour_interval():
+    date = datetime.datetime(2022, 12, 31, 23, 59)
+    interval = "hour"
+    formatted_date = format_label_date(date, interval)
+    assert formatted_date == "31-Dec-2022 23:59"
+
+
+def test_format_label_date_with_month_interval():
+    date = datetime.datetime(2022, 12, 31)
+    interval = "month"
+    formatted_date = format_label_date(date, interval)
+    assert formatted_date == "Dec 2022"
+
+
+def test_format_label_date_with_default_interval():
+    date = datetime.datetime(2022, 12, 31)
+    interval = "year"
+    formatted_date = format_label_date(date, interval)
+    assert formatted_date == "31-Dec-2022"
+
+
+def test_format_label_date_with_no_interval():
+    date = datetime.datetime(2022, 12, 31)
+    interval = None
+    formatted_date = format_label_date(date, interval)
+    assert formatted_date == "31-Dec-2022"
+
+
+def test_format_label_date_with_empty_string_interval():
+    date = datetime.datetime(2022, 12, 31)
+    interval = ""
+    formatted_date = format_label_date(date, interval)
+    assert formatted_date == "31-Dec-2022"

--- a/posthog/test/test_format_label_date.py
+++ b/posthog/test/test_format_label_date.py
@@ -23,10 +23,9 @@ def test_format_label_date_with_default_interval():
     assert formatted_date == "31-Dec-2022"
 
 
-def test_format_label_date_with_no_interval():
+def test_format_label_date_with_missing_interval():
     date = datetime.datetime(2022, 12, 31)
-    interval = None
-    formatted_date = format_label_date(date, interval)
+    formatted_date = format_label_date(date)
     assert formatted_date == "31-Dec-2022"
 
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -79,7 +79,7 @@ logger = structlog.get_logger(__name__)
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 
-def format_label_date(date: datetime.datetime, interval: Optional[str]) -> str:
+def format_label_date(date: datetime.datetime, interval: Optional[str] = "default") -> str:
     date_formats = {
         "default": "%-d-%b-%Y",
         "hour": "%-d-%b-%Y %H:%M",

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -79,10 +79,13 @@ logger = structlog.get_logger(__name__)
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 
-def format_label_date(date: datetime.datetime, interval: str) -> str:
-    labels_format = "%-d-%b-%Y"
-    if interval == "hour":
-        labels_format += " %H:%M"
+def format_label_date(date: datetime.datetime, interval: Optional[str]) -> str:
+    date_formats = {
+        "default": "%-d-%b-%Y",
+        "hour": "%-d-%b-%Y %H:%M",
+        "month": "%b %Y",
+    }
+    labels_format = date_formats.get(interval, date_formats["default"])
     return date.strftime(labels_format)
 
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -79,7 +79,7 @@ logger = structlog.get_logger(__name__)
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 
-def format_label_date(date: datetime.datetime, interval: Optional[str] = "default") -> str:
+def format_label_date(date: datetime.datetime, interval: str = "default") -> str:
     date_formats = {
         "default": "%-d-%b-%Y",
         "hour": "%-d-%b-%Y %H:%M",


### PR DESCRIPTION
## Problem

For trends grouping by month we label each month with the first day in addition, which might be misleading.
The value might be the aggregate, sum, average, or similar for the whole of the month.

Fixes #20137

## Changes

- remove day when interval is month

## How did you test this code?

- adjusted test and checked frontend