### PR TITLE
fix(web-analytics): Don't try to "compare" when the time period is all time

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -355,7 +355,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     date_from: dateFrom,
                     date_to: dateTo,
                 }
-                const compare = !!dateRange.date_from
+                const compare = !!(dateRange.date_from && dateRange.date_to)
 
                 const sampling = {
                     enabled: !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_SAMPLING],


### PR DESCRIPTION
## Problem

Currently when you set the time period to all time, the compare flag is set.

## Changes

Set the compare flag to false if the time period is all time.

## How did you test this code?

Manually
