### PR TITLE
fix(dashboards): Refresh missing data in shared dashboards

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -949,7 +949,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
             let refreshesFinished = 0
             let totalResponseBytes = 0
 
-            const hardRefreshWithoutCache = action === 'refresh_manual' || action === 'refresh_above_threshold'
+            const hardRefreshWithoutCache = ['refresh_manual', 'refresh_above_threshold', 'load_missing'].includes(
+                action
+            )
 
             // array of functions that reload each item
             const fetchItemFunctions = insights.map((insight) => async () => {


### PR DESCRIPTION
## Problem

We haven't been calculating insight results on shared dashboard where cached data isn't available since https://github.com/PostHog/posthog/pull/18987. That's because the mechanism from https://github.com/PostHog/posthog/pull/15153 which enables that data to be loaded relies on `refresh=true` being set, which #18987 set to `false` for this particular use case.

## Changes

Added `load_missing` to the list of cases where we use `refresh=true`, fixing shared dashboards.

## How did you test this code?

Will try to add an E2E test, but it requires clearing the cache from Cypress, which I'm not sure is possible.