### PR TITLE
fix: Billing page has error on plan_key 

### DIFF
--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -68,7 +68,7 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
         addon.type === 'data_pipelines' &&
         addon.subscribed &&
         featureFlags['data-pipelines-notice'] &&
-        addon.plans?.[0].plan_key === 'addon-20240111-og-customers'
+        addon.plans?.[0]?.plan_key === 'addon-20240111-og-customers'
 
     if (showPipelineAddonNotice) {
         setProductSpecificAlert({


### PR DESCRIPTION
## Problem

Seems like this should fix it.
<img width="1552" alt="Screenshot 2024-02-05 at 4 56 26 PM" src="https://github.com/PostHog/posthog/assets/21014901/f682b341-992f-42f6-9a06-014c4dfd6cd6">

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
