### PR TITLE
fix: Fix calendar range end

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -97,7 +97,7 @@ export function DateFilter({
     const popoverOverlay =
         view === DateFilterView.FixedRange ? (
             <LemonCalendarRange
-                value={[rangeDateTo ?? dayjs(), rangeDateTo ?? dayjs()]}
+                value={[rangeDateFrom ?? dayjs(), rangeDateTo ?? dayjs()]}
                 onChange={([from, to]) => {
                     setRangeDateFrom(from)
                     setRangeDateTo(to)

--- a/frontend/src/lib/components/DateFilter/dateFilterLogic.ts
+++ b/frontend/src/lib/components/DateFilter/dateFilterLogic.ts
@@ -130,7 +130,7 @@ export const dateFilterLogic = kea<dateFilterLogicType>([
             if (values.rangeDateFrom) {
                 actions.setDate(
                     dayjs(values.rangeDateFrom).format('YYYY-MM-DD'),
-                    values.rangeDateTo ? dayjs(values.rangeDateTo).format('YYYY-MM-DD') : null
+                    values.rangeDateTo ? dayjs(values.rangeDateTo).format() : null
                 )
             }
         },

--- a/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRange.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRange.test.tsx
@@ -41,31 +41,31 @@ describe('LemonCalendarRange', () => {
 
         // click on 15
         await clickOn('15')
-        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-15'), dayjs('2022-02-28')])
+        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-15'), dayjs('2022-02-28T23:59:59.999Z')])
 
         // click on 27
         await clickOn('27')
-        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-15'), dayjs('2022-02-27')])
+        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-15'), dayjs('2022-02-27T23:59:59.999Z')])
 
         // click on 16
         await clickOn('16')
-        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-16'), dayjs('2022-02-27')])
+        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-16'), dayjs('2022-02-27T23:59:59.999Z')])
 
         // click on 26
         await clickOn('26')
-        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-16'), dayjs('2022-02-26')])
+        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-16'), dayjs('2022-02-26T23:59:59.999Z')])
 
         // click on 10
         await clickOn('10')
-        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-10'), dayjs('2022-02-26')])
+        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-10'), dayjs('2022-02-26T23:59:59.999Z')])
 
         // click on 28
         await clickOn('28')
-        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-10'), dayjs('2022-02-28')])
+        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-10'), dayjs('2022-02-28T23:59:59.999Z')])
 
         // click on 20
         await clickOn('20')
-        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-20'), dayjs('2022-02-28')])
+        expect(onChange).toHaveBeenCalledWith([dayjs('2022-02-20'), dayjs('2022-02-28T23:59:59.999Z')])
 
         userEvent.click(getByDataAttr(container, 'lemon-calendar-range-cancel'))
         expect(onClose).toHaveBeenCalled()

--- a/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRange.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRange.tsx
@@ -17,7 +17,7 @@ export function LemonCalendarRange({ value, onChange, onClose, months }: LemonCa
     // Keep a sanitised and cached copy of the selected range
     const [[rangeStart, rangeEnd], setRange] = useState([
         value?.[0] ? value[0].startOf('day') : null,
-        value?.[1] ? value[1].startOf('day') : null,
+        value?.[1] ? value[1].endOf('day') : null,
     ])
 
     return (

--- a/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRangeInline.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRangeInline.tsx
@@ -25,9 +25,9 @@ export function LemonCalendarRangeInline({
     ])
 
     function setRange([rangeStart, rangeEnd, lastChanged]: RangeState): void {
-        _setRange([rangeStart, rangeEnd, lastChanged])
+        _setRange([rangeStart, rangeEnd ? rangeEnd.endOf('day') : null, lastChanged])
         if (rangeStart && rangeEnd) {
-            onChange([rangeStart, rangeEnd])
+            onChange([rangeStart, rangeEnd.endOf('day')])
         }
     }
 

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -111,12 +111,6 @@ posthog/models/feature_flag/flag_matching.py:0: error: Statement is unreachable 
 posthog/hogql_queries/utils/query_date_range.py:0: error: Incompatible return value type (got "str", expected "Literal['hour', 'day', 'week', 'month']")  [return-value]
 posthog/hogql_queries/utils/query_date_range.py:0: error: Item "None" of "dict[str, int] | None" has no attribute "get"  [union-attr]
 posthog/hogql_queries/utils/query_date_range.py:0: error: Statement is unreachable  [unreachable]
-posthog/hogql_queries/utils/query_date_range.py:0: error: Argument "chain" to "Field" has incompatible type "list[str]"; expected "list[str | int]"  [arg-type]
-posthog/hogql_queries/utils/query_date_range.py:0: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
-posthog/hogql_queries/utils/query_date_range.py:0: note: Consider using "Sequence" instead, which is covariant
-posthog/hogql_queries/utils/query_date_range.py:0: error: Argument "chain" to "Field" has incompatible type "list[str]"; expected "list[str | int]"  [arg-type]
-posthog/hogql_queries/utils/query_date_range.py:0: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
-posthog/hogql_queries/utils/query_date_range.py:0: note: Consider using "Sequence" instead, which is covariant
 posthog/hogql_queries/utils/query_date_range.py:0: error: Unsupported operand types for * ("object" and "int")  [operator]
 posthog/hogql_queries/utils/query_date_range.py:0: error: Incompatible return value type (got "int", expected "timedelta")  [return-value]
 posthog/hogql_queries/utils/query_date_range.py:0: error: Item "None" of "IntervalType | None" has no attribute "name"  [union-attr]

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -6,7 +6,6 @@ from zoneinfo import ZoneInfo
 
 from dateutil.relativedelta import relativedelta
 
-from posthog.hogql.ast import CompareOperationOp
 from posthog.hogql.errors import HogQLException
 from posthog.hogql.parser import ast
 from posthog.models.team import Team, WeekStartDay
@@ -249,22 +248,6 @@ class QueryDateRange:
             if self.use_start_of_interval()
             else self.date_from_as_hogql(),
         }
-
-    def to_properties(self, field: Optional[List[str]] = None) -> List[ast.Expr]:
-        if not field:
-            field = ["timestamp"]
-        return [
-            ast.CompareOperation(
-                left=ast.Field(chain=field),
-                op=CompareOperationOp.LtEq,
-                right=self.date_to_as_hogql(),
-            ),
-            ast.CompareOperation(
-                left=ast.Field(chain=field),
-                op=CompareOperationOp.Gt,
-                right=self.date_to_as_hogql(),
-            ),
-        ]
 
 
 class QueryDateRangeWithIntervals(QueryDateRange):


### PR DESCRIPTION
## Problem

The date range picker picked full days (like ISO `2023-12-01` to `2023-12-02`) as range start and end, which the queries treat as from and to, or some as after and before. All queries will treat the end as meaning `00:00:00` in time however, so not show the day's data as intended.

Fixes  #17250

## Changes

Use the end of the day (= `23:59:59`) as the range end for the calendar range picker.

The reasoning is that we probably don't want to adjust all queries to treat just a day that is given as then end as the full day. Rather this change of the date picker seems pretty straightforward.

Additionally there was a glaring bug in making the start and end show up when loading the picker with state.

## How did you test this code?

- pick specific dates, look at query
- pick a single date, look that data for full day appears
- checked event table and trends page and others