### PR TITLE
feat(dashboards): Load dashboard items in a sensible order

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -153,6 +153,8 @@ export interface InsightCardProps extends Resizeable, React.HTMLAttributes<HTMLD
     /** buttons to add to the "more" menu on the card**/
     moreButtons?: JSX.Element | null
     placement: DashboardPlacement | 'SavedInsightGrid'
+    /** Priority for loading the insight, lower is earlier. */
+    loadPriority?: number
 }
 
 function VizComponentFallback(): JSX.Element {
@@ -246,6 +248,7 @@ function InsightCardInternal(
         children,
         moreButtons,
         placement,
+        loadPriority,
         ...divProps
     }: InsightCardProps,
     ref: React.Ref<HTMLDivElement>
@@ -254,6 +257,7 @@ function InsightCardInternal(
         dashboardItemId: insight.short_id,
         dashboardId: dashboardId,
         cachedInsight: insight,
+        loadPriority,
     }
 
     const { insightLoading } = useValues(insightLogic(insightLogicProps))

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -151,6 +151,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                         const response = await concurrencyController.run({
                             debugTag: props.query.kind,
                             abortController,
+                            priority: props.loadPriority,
                             fn: async (): Promise<{ duration: number; data: Record<string, any> }> => {
                                 const now = performance.now()
                                 try {

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -99,6 +99,9 @@ export function DashboardItems(): JSX.Element {
             >
                 {tiles?.map((tile: DashboardTile) => {
                     const { insight, text } = tile
+                    const smLayout = layouts['sm']?.find((l) => {
+                        return l.i == tile.id.toString()
+                    })
 
                     const commonTileProps = {
                         dashboardId: dashboard?.id,
@@ -140,6 +143,7 @@ export function DashboardItems(): JSX.Element {
                                 duplicate={() => duplicateInsight(insight)}
                                 showDetailsControls={placement != DashboardPlacement.Export}
                                 placement={placement}
+                                loadPriority={smLayout ? smLayout.y * 1000 + smLayout.x : undefined}
                                 {...commonTileProps}
                             />
                         )

--- a/frontend/src/scenes/insights/insightDataLogic.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.ts
@@ -40,7 +40,10 @@ export const insightDataLogic = kea<insightDataLogicType>([
         values: [
             insightLogic,
             ['filters', 'insight', 'savedInsight'],
-            dataNodeLogic({ key: insightVizDataNodeKey(props) } as DataNodeLogicProps),
+            dataNodeLogic({
+                key: insightVizDataNodeKey(props),
+                loadPriority: props.loadPriority,
+            } as DataNodeLogicProps),
             [
                 'query as insightQuery',
                 'response as insightDataRaw',


### PR DESCRIPTION
## Problem

Currently, with the concurrency limits set, the dashboard items don't load in a sensible order. With this change, they will load in approximately reading order

Internal thread https://posthog.slack.com/archives/C0368RPHLQH/p1707227500815189?thread_ts=1707075739.840749&cid=C0368RPHLQH

## Changes

Use the sm layout, and load the dashboard items from lowest y to highest y. Use x as a tie-breaker.

Includes some plumbing to get the loadPriority into the right spot

## How did you test this code?

Added a 1s delay to all my requests and made a big dashboard. Also looked in the React devtools inspector to make sure that the right loadPriority was being passed to the right components