### PR TITLE
fix: return error=emailIsTaken when strapi account creating fails

### DIFF
--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -494,6 +494,11 @@ def redirect_to_website(request):
             strapi_id = json_data["user"]["id"]
             request.user.strapi_id = strapi_id
             request.user.save()
+        else:
+            print("Strapi account creation failed")
+            error_message = response.json()['error']['message']
+            if (response.text and error_message == 'Email or Username are already taken'):
+                return redirect("https://posthog.com/auth?error=emailIsTaken")
     else:
         token = jwt.encode(
             {

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -495,7 +495,6 @@ def redirect_to_website(request):
             request.user.strapi_id = strapi_id
             request.user.save()
         else:
-            print("Strapi account creation failed")
             error_message = response.json()['error']['message']
             if (response.text and error_message == 'Email or Username are already taken'):
                 return redirect("https://posthog.com/auth?error=emailIsTaken")

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -495,8 +495,8 @@ def redirect_to_website(request):
             request.user.strapi_id = strapi_id
             request.user.save()
         else:
-            error_message = response.json()['error']['message']
-            if (response.text and error_message == 'Email or Username are already taken'):
+            error_message = response.json()["error"]["message"]
+            if response.text and error_message == "Email or Username are already taken":
                 return redirect("https://posthog.com/auth?error=emailIsTaken")
     else:
         token = jwt.encode(


### PR DESCRIPTION
When trying to login into the forum on posthog.com, the cloud will create a new strapi account in case there isn't one connected. When the email is already used (in case the user already logged in with his EU account and now tries to log in using his US account) we will return a different error.

related: https://github.com/PostHog/posthog.com/issues/5847

## How did you test this code?

manually
