### PR TITLE
feat: Redshift supports custom schemas

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -879,8 +879,6 @@ posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py:0: error: 
 posthog/temporal/tests/batch_exports/test_backfill_batch_export.py:0: error: Argument "name" to "acreate_batch_export" has incompatible type "object"; expected "str"  [arg-type]
 posthog/temporal/tests/batch_exports/test_backfill_batch_export.py:0: error: Argument "destination_data" to "acreate_batch_export" has incompatible type "object"; expected "dict[Any, Any]"  [arg-type]
 posthog/temporal/tests/batch_exports/test_backfill_batch_export.py:0: error: Argument "interval" to "acreate_batch_export" has incompatible type "object"; expected "str"  [arg-type]
-posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py:0: error: Unsupported left operand type for + ("None")  [operator]
-posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py:0: note: Left operand is of type "Any | None"
 posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py:0: error: Incompatible types in assignment (expression has type "str | int", variable has type "int")  [assignment]
 posthog/api/test/batch_exports/conftest.py:0: error: Argument "activities" to "ThreadedWorker" has incompatible type "list[function]"; expected "Sequence[Callable[..., Any]]"  [arg-type]
 posthog/management/commands/test/test_create_batch_export_from_app.py:0: error: Incompatible return value type (got "dict[str, Collection[str]]", expected "dict[str, str]")  [return-value]

--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -284,8 +284,6 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs):
             extra_query_parameters=query_parameters,
         )
 
-        first_record, record_iterator = peek_first_and_rewind(record_iterator)
-
         if inputs.batch_export_schema is None:
             table_fields = [
                 ("uuid", "VARCHAR(200)"),
@@ -302,6 +300,8 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs):
             ]
 
         else:
+            first_record, record_iterator = peek_first_and_rewind(record_iterator)
+
             column_names = [column for column in first_record.schema.names if column != "_inserted_at"]
             record_schema = first_record.select(column_names).schema
             table_fields = get_postgres_fields_from_record_schema(

--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -450,6 +450,7 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
             properties_data_type=inputs.properties_data_type,
+            batch_export_schema=inputs.batch_export_schema,
         )
 
         await execute_batch_export_insert_activity(

--- a/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
@@ -126,7 +126,7 @@ async def assert_clickhouse_records_in_redshfit(
                         remove_escaped_whitespace_recursive(json.loads(v)), ensure_ascii=False
                     )
                 elif isinstance(v, dt.datetime):
-                    expected_record[k] = v.replace(tzinfo=dt.timezone.utc)
+                    expected_record[k] = v.replace(tzinfo=dt.timezone.utc)  # type: ignore
                 else:
                     expected_record[k] = v
 

--- a/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import json
+import operator
 import os
 import warnings
 from random import randint
@@ -134,6 +135,9 @@ async def assert_clickhouse_records_in_redshfit(
 
     inserted_column_names = [column_name for column_name in inserted_records[0].keys()].sort()
     expected_column_names = [column_name for column_name in expected_records[0].keys()].sort()
+
+    inserted_records.sort(key=operator.itemgetter("event"))
+    expected_records.sort(key=operator.itemgetter("event"))
 
     assert inserted_column_names == expected_column_names
     assert inserted_records[0] == expected_records[0]
@@ -272,6 +276,7 @@ async def test_insert_into_redshift_activity_inserts_data_into_redshift_table(
         count_other_team=0,
         properties=None,
         person_properties=None,
+        event_name="test-no-prop-{i}",
     )
 
     if exclude_events:


### PR DESCRIPTION
## Problem

With the setup work done in https://github.com/PostHog/posthog/pull/20013 and https://github.com/PostHog/posthog/pull/20022, we are ready to start supporting custom schemas in batch export destinations. This is for Redshift batch exports.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Very similar to support for Postgres #20095

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Updated tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
