### PR TITLE
fix(tests): cohort tests are flapping

### DIFF
--- a/posthog/hogql/functions/test/__snapshots__/test_cohort.ambr
+++ b/posthog/hogql/functions/test/__snapshots__/test_cohort.ambr
@@ -8,7 +8,7 @@
   WHERE and(equals(events.team_id, 420), in(events.person_id, (
   SELECT cohortpeople.person_id AS person_id 
   FROM cohortpeople 
-  WHERE and(equals(cohortpeople.team_id, 420), equals(cohortpeople.cohort_id, 6)) 
+  WHERE and(equals(cohortpeople.team_id, 420), equals(cohortpeople.cohort_id, XX)) 
   GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, cohortpeople.version 
   HAVING ifNull(greater(sum(cohortpeople.sign), 0), 0))), equals(events.event, %(hogql_val_0)s)) 
   LIMIT 100 
@@ -21,7 +21,7 @@
   WHERE and(in(person_id, (
   SELECT person_id 
   FROM raw_cohort_people 
-  WHERE equals(cohort_id, 6) 
+  WHERE equals(cohort_id, XX) 
   GROUP BY person_id, cohort_id, version 
   HAVING greater(sum(sign), 0))), equals(event, 'RANDOM_TEST_ID::UUID')) 
   LIMIT 100
@@ -36,7 +36,7 @@
   WHERE and(equals(events.team_id, 420), in(events.person_id, (
   SELECT person_static_cohort.person_id AS person_id 
   FROM person_static_cohort 
-  WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, 7))))) 
+  WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, XX))))) 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
   
@@ -47,7 +47,7 @@
   WHERE in(person_id, (
   SELECT person_id 
   FROM static_cohort_people 
-  WHERE equals(cohort_id, 7))) 
+  WHERE equals(cohort_id, XX))) 
   LIMIT 100
   '''
 # ---
@@ -60,7 +60,7 @@
   WHERE and(equals(events.team_id, 420), in(events.person_id, (
   SELECT person_static_cohort.person_id AS person_id 
   FROM person_static_cohort 
-  WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, 8))))) 
+  WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, XX))))) 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
   
@@ -71,7 +71,7 @@
   WHERE in(person_id, (
   SELECT person_id 
   FROM static_cohort_people 
-  WHERE equals(cohort_id, 8))) 
+  WHERE equals(cohort_id, XX))) 
   LIMIT 100
   '''
 # ---

--- a/posthog/hogql/test/__snapshots__/test_query.ambr
+++ b/posthog/hogql/test/__snapshots__/test_query.ambr
@@ -245,7 +245,7 @@
   WHERE and(equals(events.team_id, 420), ifNull(in(events__pdi.person_id, (
   SELECT cohortpeople.person_id AS person_id 
   FROM cohortpeople 
-  WHERE and(equals(cohortpeople.team_id, 420), equals(cohortpeople.cohort_id, 13)) 
+  WHERE and(equals(cohortpeople.team_id, 420), equals(cohortpeople.cohort_id, XX)) 
   GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, cohortpeople.version 
   HAVING ifNull(greater(sum(cohortpeople.sign), 0), 0))), 0)) 
   GROUP BY events.event 
@@ -259,7 +259,7 @@
   WHERE in(person_id, (
   SELECT person_id 
   FROM raw_cohort_people 
-  WHERE equals(cohort_id, 13) 
+  WHERE equals(cohort_id, XX) 
   GROUP BY person_id, cohort_id, version 
   HAVING greater(sum(sign), 0))) 
   GROUP BY event 
@@ -275,7 +275,7 @@
   WHERE and(equals(events.team_id, 420), in(events.person_id, (
   SELECT cohortpeople.person_id AS person_id 
   FROM cohortpeople 
-  WHERE and(equals(cohortpeople.team_id, 420), equals(cohortpeople.cohort_id, 13)) 
+  WHERE and(equals(cohortpeople.team_id, 420), equals(cohortpeople.cohort_id, XX)) 
   GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, cohortpeople.version 
   HAVING ifNull(greater(sum(cohortpeople.sign), 0), 0)))) 
   GROUP BY events.event 
@@ -289,7 +289,7 @@
   WHERE in(person_id, (
   SELECT person_id 
   FROM raw_cohort_people 
-  WHERE equals(cohort_id, 13) 
+  WHERE equals(cohort_id, XX) 
   GROUP BY person_id, cohort_id, version 
   HAVING greater(sum(sign), 0))) 
   GROUP BY event 
@@ -310,7 +310,7 @@
   WHERE and(equals(events.team_id, 420), ifNull(in(events__pdi.person_id, (
   SELECT person_static_cohort.person_id AS person_id 
   FROM person_static_cohort 
-  WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, 14)))), 0)) 
+  WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, XX)))), 0)) 
   GROUP BY events.event 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
@@ -322,7 +322,7 @@
   WHERE in(person_id, (
   SELECT person_id 
   FROM static_cohort_people 
-  WHERE equals(cohort_id, 14))) 
+  WHERE equals(cohort_id, XX))) 
   GROUP BY event 
   LIMIT 100
   '''
@@ -336,7 +336,7 @@
   WHERE and(equals(events.team_id, 420), in(events.person_id, (
   SELECT person_static_cohort.person_id AS person_id 
   FROM person_static_cohort 
-  WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, 14))))) 
+  WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, XX))))) 
   GROUP BY events.event 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
@@ -348,7 +348,7 @@
   WHERE in(person_id, (
   SELECT person_id 
   FROM static_cohort_people 
-  WHERE equals(cohort_id, 14))) 
+  WHERE equals(cohort_id, XX))) 
   GROUP BY event 
   LIMIT 100
   '''

--- a/posthog/hogql/test/utils.py
+++ b/posthog/hogql/test/utils.py
@@ -7,9 +7,7 @@ from pydantic import BaseModel
 
 
 def pretty_print_in_tests(query: str, team_id: int) -> str:
-    return re.sub(
-        r"RANDOM_TEST_ID::[a-f0-9\-]+",
-        "RANDOM_TEST_ID::UUID",
+    query = (
         query.replace("SELECT", "\nSELECT")
         .replace("FROM", "\nFROM")
         .replace("WHERE", "\nWHERE")
@@ -17,8 +15,12 @@ def pretty_print_in_tests(query: str, team_id: int) -> str:
         .replace("HAVING", "\nHAVING")
         .replace("LIMIT", "\nLIMIT")
         .replace("SETTINGS", "\nSETTINGS")
-        .replace(f"team_id, {team_id})", "team_id, 420)"),
+        .replace(f"team_id, {team_id})", "team_id, 420)")
     )
+    query = re.sub(r"in_cohort__[0-9]+", "in_cohort__XX", query)
+    query = re.sub(r"cohort_id, [0-9]+", "cohort_id, XX", query)
+    query = re.sub(r"RANDOM_TEST_ID::[a-f0-9\-]+", "RANDOM_TEST_ID::UUID", query)
+    return query
 
 
 def pretty_print_response_in_tests(response: Any, team_id: int) -> str:

--- a/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
@@ -79,10 +79,10 @@
   FROM events LEFT JOIN (
   SELECT cohortpeople.person_id AS person_id, 1 AS matched 
   FROM cohortpeople 
-  WHERE and(equals(cohortpeople.team_id, 420), equals(cohortpeople.cohort_id, 1)) 
+  WHERE and(equals(cohortpeople.team_id, 420), equals(cohortpeople.cohort_id, XX)) 
   GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, cohortpeople.version 
-  HAVING ifNull(greater(sum(cohortpeople.sign), 0), 0)) AS in_cohort__1 ON equals(in_cohort__1.person_id, events.person_id) 
-  WHERE and(equals(events.team_id, 420), ifNull(equals(in_cohort__1.matched, 1), 0), equals(events.event, %(hogql_val_0)s)) 
+  HAVING ifNull(greater(sum(cohortpeople.sign), 0), 0)) AS in_cohort__XX ON equals(in_cohort__XX.person_id, events.person_id) 
+  WHERE and(equals(events.team_id, 420), ifNull(equals(in_cohort__XX.matched, 1), 0), equals(events.event, %(hogql_val_0)s)) 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
   
@@ -92,10 +92,10 @@
   FROM events LEFT JOIN (
   SELECT person_id, 1 AS matched 
   FROM raw_cohort_people 
-  WHERE equals(cohort_id, 1) 
+  WHERE equals(cohort_id, XX) 
   GROUP BY person_id, cohort_id, version 
-  HAVING greater(sum(sign), 0)) AS in_cohort__1 ON equals(in_cohort__1.person_id, person_id) 
-  WHERE and(equals(in_cohort__1.matched, 1), equals(event, 'RANDOM_TEST_ID::UUID')) 
+  HAVING greater(sum(sign), 0)) AS in_cohort__XX ON equals(in_cohort__XX.person_id, person_id) 
+  WHERE and(equals(in_cohort__XX.matched, 1), equals(event, 'RANDOM_TEST_ID::UUID')) 
   LIMIT 100
   '''
 # ---
@@ -107,8 +107,8 @@
   FROM events LEFT JOIN (
   SELECT person_static_cohort.person_id AS person_id, 1 AS matched 
   FROM person_static_cohort 
-  WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, 2))) AS in_cohort__2 ON equals(in_cohort__2.person_id, events.person_id) 
-  WHERE and(equals(events.team_id, 420), ifNull(equals(in_cohort__2.matched, 1), 0)) 
+  WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, XX))) AS in_cohort__XX ON equals(in_cohort__XX.person_id, events.person_id) 
+  WHERE and(equals(events.team_id, 420), ifNull(equals(in_cohort__XX.matched, 1), 0)) 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
   
@@ -118,8 +118,8 @@
   FROM events LEFT JOIN (
   SELECT person_id, 1 AS matched 
   FROM static_cohort_people 
-  WHERE equals(cohort_id, 2)) AS in_cohort__2 ON equals(in_cohort__2.person_id, person_id) 
-  WHERE equals(in_cohort__2.matched, 1) 
+  WHERE equals(cohort_id, XX)) AS in_cohort__XX ON equals(in_cohort__XX.person_id, person_id) 
+  WHERE equals(in_cohort__XX.matched, 1) 
   LIMIT 100
   '''
 # ---
@@ -131,8 +131,8 @@
   FROM events LEFT JOIN (
   SELECT person_static_cohort.person_id AS person_id, 1 AS matched 
   FROM person_static_cohort 
-  WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, 3))) AS in_cohort__3 ON equals(in_cohort__3.person_id, events.person_id) 
-  WHERE and(equals(events.team_id, 420), ifNull(equals(in_cohort__3.matched, 1), 0)) 
+  WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, XX))) AS in_cohort__XX ON equals(in_cohort__XX.person_id, events.person_id) 
+  WHERE and(equals(events.team_id, 420), ifNull(equals(in_cohort__XX.matched, 1), 0)) 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
   
@@ -142,8 +142,8 @@
   FROM events LEFT JOIN (
   SELECT person_id, 1 AS matched 
   FROM static_cohort_people 
-  WHERE equals(cohort_id, 3)) AS in_cohort__3 ON equals(in_cohort__3.person_id, person_id) 
-  WHERE equals(in_cohort__3.matched, 1) 
+  WHERE equals(cohort_id, XX)) AS in_cohort__XX ON equals(in_cohort__XX.person_id, person_id) 
+  WHERE equals(in_cohort__XX.matched, 1) 
   LIMIT 100
   '''
 # ---

--- a/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
@@ -7,7 +7,7 @@
   FROM events LEFT JOIN (
   SELECT cohortpeople.person_id AS cohort_person_id, 1 AS matched, cohortpeople.cohort_id AS cohort_id 
   FROM cohortpeople 
-  WHERE and(equals(cohortpeople.team_id, 420), equals(cohortpeople.cohort_id, 15), equals(cohortpeople.version, 0))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
+  WHERE and(equals(cohortpeople.team_id, 420), equals(cohortpeople.cohort_id, XX), equals(cohortpeople.version, 0))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
   WHERE and(equals(events.team_id, 420), and(1, equals(events.event, %(hogql_val_0)s)), ifNull(equals(__in_cohort.matched, 1), 0)) 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
@@ -18,7 +18,7 @@
   FROM events LEFT JOIN (
   SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
   FROM raw_cohort_people 
-  WHERE and(equals(cohort_id, 15), equals(version, 0))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
+  WHERE and(equals(cohort_id, XX), equals(version, 0))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
   WHERE and(and(1, equals(event, 'RANDOM_TEST_ID::UUID')), equals(__in_cohort.matched, 1)) 
   LIMIT 100
   '''


### PR DESCRIPTION
## Problem

I've gotten HogQL cohort tests flapping a in different PRs, most recently [here](https://github.com/PostHog/posthog/pull/20183).

## Changes

Removes the flapping by changing cohort ID-s with "XX".

## How did you test this code?

With snapshots.