### PR TITLE
fix: Use env var instead of License to determine instance type

### DIFF
--- a/posthog/cloud_utils.py
+++ b/posthog/cloud_utils.py
@@ -12,38 +12,8 @@ is_instance_licensed_cached: Optional[bool] = None
 instance_license_cached: Optional["License"] = None
 
 
-# NOTE: This is cached for the lifetime of the instance but this is not an issue as the value is not expected to change
-def is_cloud():
-    global is_cloud_cached
-
-    if not settings.EE_AVAILABLE:
-        return False
-
-    if isinstance(is_cloud_cached, bool):
-        return is_cloud_cached
-
-    if not is_cloud_cached:
-        try:
-            # NOTE: Important not to import this from ee.models as that will cause a circular import for celery
-            from ee.models.license import License
-
-            # TRICKY - The license table may not exist if a migration is running
-            license = License.objects.first_valid()
-            is_cloud_cached = license.plan == "cloud" if license else False
-        except ProgrammingError:
-            # TRICKY - The license table may not exist if a migration is running
-            pass
-        except Exception as e:
-            print("ERROR: Unable to check license", e)  # noqa: T201
-            capture_exception(e)
-
-    return is_cloud_cached
-
-
-# NOTE: This is purely for testing purposes
-def TEST_clear_cloud_cache(value: Optional[bool] = None):
-    global is_cloud_cached
-    is_cloud_cached = value
+def is_cloud() -> bool:
+    return bool(settings.REGION)
 
 
 def get_cached_instance_license() -> Optional["License"]:

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from infi.clickhouse_orm import Database
 
 from posthog.client import sync_execute
-from posthog.test.base import TestMixin, run_clickhouse_statement_in_parallel
+from posthog.test.base import PostHogTestCase, run_clickhouse_statement_in_parallel
 
 
 def create_clickhouse_tables(num_tables: int):
@@ -124,7 +124,7 @@ def django_db_setup(django_db_setup, django_db_keepdb):
 
 @pytest.fixture
 def base_test_mixin_fixture():
-    kls = TestMixin()
+    kls = PostHogTestCase()
     kls.setUp()
     kls.setUpTestData()
 

--- a/posthog/session_recordings/queries/test/test_session_recording_list_from_session_replay.py
+++ b/posthog/session_recordings/queries/test/test_session_recording_list_from_session_replay.py
@@ -7,7 +7,6 @@ from freezegun.api import freeze_time
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.log_entries import TRUNCATE_LOG_ENTRIES_TABLE_SQL
-from posthog.cloud_utils import TEST_clear_cloud_cache
 from posthog.constants import AvailableFeature
 from posthog.models import Person, Cohort, GroupTypeMapping
 from posthog.models.action import Action
@@ -690,7 +689,6 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
     def test_ttl_days(self):
         assert ttl_days(self.team) == 21
 
-        TEST_clear_cloud_cache()
         with self.is_cloud(True):
             # Far enough in the future from `days_since_blob_ingestion` but not paid
             with freeze_time("2023-09-01T12:00:01Z"):

--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -13,9 +13,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 DEBUG = get_from_env("DEBUG", False, type_cast=str_to_bool)
 TEST = "test" in sys.argv or sys.argv[0].endswith("pytest") or get_from_env("TEST", False, type_cast=str_to_bool)  # type: bool
 DEMO = get_from_env("DEMO", False, type_cast=str_to_bool)  # Whether this is a managed demo environment
-REGION = get_from_env(
+REGION = get_from_env(  # Whether this is the "US" or "EU" Cloud region (REGION's only set on Cloud)
     "REGION", optional=True
-)  # Whether this is the "US" or "EU" Cloud region (REGION's only set on Cloud)
+)
 SELF_CAPTURE = get_from_env("SELF_CAPTURE", DEBUG and not DEMO, type_cast=str_to_bool)
 E2E_TESTING = get_from_env(
     "E2E_TESTING", False, type_cast=str_to_bool

--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -13,7 +13,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 DEBUG = get_from_env("DEBUG", False, type_cast=str_to_bool)
 TEST = "test" in sys.argv or sys.argv[0].endswith("pytest") or get_from_env("TEST", False, type_cast=str_to_bool)  # type: bool
 DEMO = get_from_env("DEMO", False, type_cast=str_to_bool)  # Whether this is a managed demo environment
-REGION = get_from_env("REGION", "US")  # Whether this is a Cloud US or Cloud EU instance
+REGION = get_from_env(
+    "REGION", optional=True
+)  # Whether this is the "US" or "EU" Cloud region (REGION's only set on Cloud)
 SELF_CAPTURE = get_from_env("SELF_CAPTURE", DEBUG and not DEMO, type_cast=str_to_bool)
 E2E_TESTING = get_from_env(
     "E2E_TESTING", False, type_cast=str_to_bool

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -231,17 +231,17 @@ class PostHogTestCase(SimpleTestCase):
             )
         global persons_ordering_int
         persons_ordering_int = 0
-        super().tearDown()  # type: ignore
+        super().tearDown()
 
     def validate_basic_html(self, html_message, site_url, preheader=None):
         # absolute URLs are used
-        self.assertIn(f"{site_url}/static/posthog-logo.png", html_message)  # type: ignore
+        self.assertIn(f"{site_url}/static/posthog-logo.png", html_message)
 
         # CSS is inlined
-        self.assertIn('style="display: none;', html_message)  # type: ignore
+        self.assertIn('style="display: none;', html_message)
 
         if preheader:
-            self.assertIn(preheader, html_message)  # type: ignore
+            self.assertIn(preheader, html_message)
 
     @contextmanager
     def is_cloud(self, value: bool):

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -311,8 +311,6 @@ class APIBaseTest(PostHogTestCase, ErrorResponsesMixin, DRFTestCase):
     Functional API tests using Django REST Framework test suite.
     """
 
-    initial_cloud_mode: Optional[bool] = False
-
     def setUp(self):
         super().setUp()
 

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -20,7 +20,7 @@ from django.apps import apps
 from django.core.cache import cache
 from django.db import connection, connections
 from django.db.migrations.executor import MigrationExecutor
-from django.test import TestCase, TransactionTestCase, override_settings
+from django.test import SimpleTestCase, TestCase, TransactionTestCase, override_settings
 from django.test.utils import CaptureQueriesContext
 from rest_framework.test import APITestCase as DRFTestCase
 
@@ -183,7 +183,7 @@ class ErrorResponsesMixin:
         }
 
 
-class TestMixin:
+class PostHogTestCase(SimpleTestCase):
     CONFIG_ORGANIZATION_NAME: str = "Test"
     CONFIG_EMAIL: Optional[str] = "user1@posthog.com"
     CONFIG_PASSWORD: Optional[str] = "testpassword12345"
@@ -284,7 +284,7 @@ class MemoryLeakTestMixin:
         )
 
 
-class BaseTest(TestMixin, ErrorResponsesMixin, TestCase):
+class BaseTest(PostHogTestCase, ErrorResponsesMixin, TestCase):
     """
     Base class for performing Postgres-based backend unit tests on.
     Each class and each test is wrapped inside an atomic block to rollback DB commits after each test.
@@ -294,7 +294,7 @@ class BaseTest(TestMixin, ErrorResponsesMixin, TestCase):
     pass
 
 
-class NonAtomicBaseTest(TestMixin, ErrorResponsesMixin, TransactionTestCase):
+class NonAtomicBaseTest(PostHogTestCase, ErrorResponsesMixin, TransactionTestCase):
     """
     Django wraps tests in TestCase inside atomic transactions to speed up the run time. TransactionTestCase is the base
     class for TestCase that doesn't implement this atomic wrapper.
@@ -306,7 +306,7 @@ class NonAtomicBaseTest(TestMixin, ErrorResponsesMixin, TransactionTestCase):
         cls.setUpTestData()
 
 
-class APIBaseTest(TestMixin, ErrorResponsesMixin, DRFTestCase):
+class APIBaseTest(PostHogTestCase, ErrorResponsesMixin, DRFTestCase):
     """
     Functional API tests using Django REST Framework test suite.
     """

--- a/posthog/test/test_cloud_utils.py
+++ b/posthog/test/test_cloud_utils.py
@@ -4,10 +4,8 @@ import pytest
 
 from ee.models.license import License
 from posthog.cloud_utils import (
-    TEST_clear_cloud_cache,
     TEST_clear_instance_license_cache,
     get_cached_instance_license,
-    is_cloud,
 )
 from posthog.test.base import BaseTest
 
@@ -15,29 +13,6 @@ from posthog.test.base import BaseTest
 class TestCloudUtils(BaseTest):
     def setUp(self):
         assert License.objects.count() == 0
-
-    @pytest.mark.ee
-    def test_is_cloud_returns_correctly(self):
-        TEST_clear_cloud_cache()
-        assert is_cloud() is False
-
-    @pytest.mark.ee
-    def test_is_cloud_checks_license(self):
-        assert is_cloud() is False
-        License.objects.create(key="key", plan="cloud", valid_until=datetime.now() + timedelta(days=30))
-
-        TEST_clear_cloud_cache()
-        assert is_cloud()
-
-    @pytest.mark.ee
-    def test_is_cloud_caches_result(self):
-        TEST_clear_cloud_cache()
-        assert not is_cloud()
-        assert not is_cloud()
-
-        License.objects.create(key="key", plan="cloud", valid_until=datetime.now() + timedelta(days=30))
-
-        assert not is_cloud()
 
     @pytest.mark.ee
     def test_get_cached_instance_license_returns_correctly(self):

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -311,8 +311,8 @@ class TestAutoProjectMiddleware(APIBaseTest):
         assert response_users_api.json().get("team", {}).get("id") == self.team.id
 
 
+@override_settings(REGION="US")  # As PostHog Cloud
 class TestPostHogTokenCookieMiddleware(APIBaseTest):
-    initial_cloud_mode = True
     CONFIG_AUTO_LOGIN = False
 
     def test_logged_out_client(self):

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -815,11 +815,9 @@ def get_instance_realm() -> str:
 
 def get_instance_region() -> Optional[str]:
     """
-    Returns the region for the current instance. `US` or 'EU'.
+    Returns the region for the current Cloud instance. `US` or 'EU'.
     """
-    if is_cloud():
-        return settings.REGION
-    return None
+    return settings.REGION
 
 
 def get_can_create_org(user: Union["AbstractBaseUser", "AnonymousUser"]) -> bool:

--- a/posthog/warehouse/api/test/test_external_data_source.py
+++ b/posthog/warehouse/api/test/test_external_data_source.py
@@ -7,7 +7,6 @@ from posthog.temporal.data_imports.pipelines.schemas import (
 )
 from django.test import override_settings
 from django.conf import settings
-from posthog.cloud_utils import TEST_clear_cloud_cache
 from posthog.models import Team
 import psycopg
 
@@ -193,8 +192,6 @@ class TestSavedQuery(APIBaseTest):
     @patch("posthog.warehouse.api.external_data_source.get_postgres_schemas")
     def test_internal_postgres(self, patch_get_postgres_schemas):
         patch_get_postgres_schemas.return_value = ["table_1"]
-
-        TEST_clear_cloud_cache(True)
 
         with override_settings(REGION="US"):
             team_2, _ = Team.objects.get_or_create(id=2, organization=self.team.organization)


### PR DESCRIPTION
## Problem

I was just checking Sentry to see what errors our users see the most, but turns out the error that comes up the most – 1 MILLION times a month – is this: [`AppRegistryNotReady`](https://posthog.sentry.io/issues/4887929982/events/daee4dda76a44a5d9ed1746c85c2c6fb/?project=1899813&query=is%3Aunresolved&referrer=previous-event&sort=freq&statsPeriod=7d&stream_index=0&utc=true)

## Changes

Looks like we're trying to use a Django model in `is_cloud()` while Django is still initializing itself, which just doesn't work. This doesn't seem to be a show-stopper and we seem to be able to get actual results in `is_cloud()` at some point, but there is just a ton of errors. I've been seeing them locally too, but had no idea this is such a high volume in production.

## How did you test this code?

This in fact removes some tests for the License-based checking, since using env vars is so simple.