### PR TITLE
fix(insights): hogql stickiness interval ranges

### DIFF
--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -136,7 +136,7 @@ class StickinessQueryRunner(QueryRunner):
 
             interval_addition = ast.Call(
                 name=f"toInterval{date_range.interval_name.capitalize()}",
-                args=[ast.Constant(value=0 if date_range.interval_name == "week" else 1)],
+                args=[ast.Constant(value=1)],
             )
 
             select_query = parse_select(
@@ -146,7 +146,7 @@ class StickinessQueryRunner(QueryRunner):
                         SELECT sum(aggregation_target) as aggregation_target, num_intervals
                         FROM (
                             SELECT 0 as aggregation_target, (number + 1) as num_intervals
-                            FROM numbers(dateDiff({interval}, {date_from}, {date_to} + {interval_addition}))
+                            FROM numbers(dateDiff({interval}, {date_from_start_of_interval}, {date_to_start_of_interval} + {interval_addition}))
                             UNION ALL
                             {events_query}
                         )

--- a/posthog/hogql_queries/insights/test/test_stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_stickiness_query_runner.py
@@ -348,6 +348,19 @@ class TestStickinessQueryRunner(APIBaseTest):
         assert result["days"] == [1, 2, 3]
         assert result["data"] == [0, 0, 2]
 
+    def test_interval_full_weeks(self):
+        self._create_test_events()
+
+        with freeze_time("2020-01-23T12:00:00Z"):
+            response = self._run_query(interval=IntervalType.week, date_from="-30d", date_to="now")
+
+            result = response.results[0]
+
+            assert result["label"] == "$pageview"
+            assert result["labels"] == ["1 week", "2 weeks", "3 weeks", "4 weeks", "5 weeks"]
+            assert result["days"] == [1, 2, 3, 4, 5]
+            assert result["data"] == [0, 0, 2, 0, 0]
+
     def test_interval_month(self):
         self._create_test_events()
 


### PR DESCRIPTION
## Problem

Every now and then the HogQL stickiness query returns one result less than the legacy one.

## Changes

Fixes the "num intervals" code to consider full interval ranges.

## How did you test this code?

Running queries in the browser.