### PR TITLE
feat(web-analytics): Hide the LoadMore component in web analytics

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -557,7 +557,12 @@ export function DataTable({
                                         result && result[0] && result[0]['event'] === '$exception',
                                 })
                             }
-                            footer={(dataTableRows ?? []).length > 0 ? <LoadNext query={query.source} /> : null}
+                            footer={
+                                (dataTableRows ?? []).length > 0 &&
+                                !sourceFeatures.has(QueryFeature.hideLoadNextButton) ? (
+                                    <LoadNext query={query.source} />
+                                ) : null
+                            }
                             onRow={context?.rowProps}
                         />
                     )}

--- a/frontend/src/queries/nodes/DataTable/queryFeatures.ts
+++ b/frontend/src/queries/nodes/DataTable/queryFeatures.ts
@@ -22,6 +22,7 @@ export enum QueryFeature {
     resultIsArrayOfArrays,
     selectAndOrderByColumns,
     displayResponseError,
+    hideLoadNextButton,
 }
 
 export function getQueryFeatures(query: Node): Set<QueryFeature> {
@@ -57,6 +58,7 @@ export function getQueryFeatures(query: Node): Set<QueryFeature> {
     if (isWebOverviewQuery(query) || isWebTopClicksQuery(query) || isWebStatsTableQuery(query)) {
         features.add(QueryFeature.columnsInResponse)
         features.add(QueryFeature.resultIsArrayOfArrays)
+        features.add(QueryFeature.hideLoadNextButton)
     }
 
     return features


### PR DESCRIPTION
## Problem
The LoadMore text is confusing, see internal thread https://posthog.slack.com/archives/C05LJK1N3CP/p1707347272667879
![image](https://github.com/PostHog/posthog/assets/2056078/5f8c2cfa-b02b-4c38-9724-ce310554f213)


## Changes
Hide this text for these views

## How did you test this code?

Manually
