### PR TITLE
fix: Fix trends formula with empty values and breakdowns

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -1225,8 +1225,8 @@
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants.3
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT [now()] AS date,
-         [0] AS total,
+  SELECT now() AS date,
+         0 AS total,
          '' AS breakdown_value
   LIMIT 0
   '''

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -595,6 +595,10 @@ class TrendsQueryRunner(QueryRunner):
 
         series_data = map(lambda s: s["data"], results)
         new_series_data = FormulaAST(series_data).call(formula)
+
+        if not len(results):
+            return []
+
         new_result = results[0]
 
         new_result["data"] = new_series_data

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -229,7 +229,7 @@ class TrendsBreakdown:
             # It's a drop-in replacement for a "real" one, simply always returning 0 rows.
             # See https://github.com/PostHog/posthog/pull/5674 for context.
             return (
-                "SELECT [now()] AS date, [0] AS total, '' AS breakdown_value LIMIT 0",
+                "SELECT now() AS date, 0 AS total, '' AS breakdown_value LIMIT 0",
                 {},
                 lambda _: [],
             )


### PR DESCRIPTION
## Problem

A specific combination of variables in formula model fails when underlying data might be empty and there is also a breakdown applied.
This happens in legacy and HogQL versions of the trends query.

Error for legacy is

```
"Illegal types Array(UInt8) and UInt8 of arguments of function plus: While processing '' AS date, arrayMap(A -> (A + 100), [ifNull(total, 0)]), arrayFilter(x -> notEmpty(x), [replaceRegexpAll(breakdown_value, '^\"|\"$', '')])[1].",
```

Fixes ZEN-10196

## Changes

- made sure the query doesn't error
- not sure if this now results in it returning 0 altogether even if some values have data?!?

## How did you test this code?

- use formula mode
- select some variables
- apply filter if necessary so that some have no data behind them
- use formula A + B
- see that works, but add a breakdown and it doesn't (without this PR)

<details><summary>Try this query</summary>
<p>

http://localhost:8000/api/projects/1/insights/trend/?insight=TRENDS&filter_test_accounts=false&date_from=-30d&entity_type=events&events=%5B%7B%22type%22%3A%22events%22%2C%22id%22%3A%22paid_bill%22%2C%22order%22%3A0%2C%22name%22%3A%22paid_bill%22%2C%22math%22%3A%22sum%22%2C%22math_property%22%3A%22amount_usd%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22%24lib%22%2C%22value%22%3A%22is_not_set%22%2C%22operator%22%3A%22is_not_set%22%2C%22type%22%3A%22event%22%7D%5D%7D%5D&breakdown_type=person&breakdown=%24browser&interval=day&display=ActionsPie&formula=A%20%2B%20100&client_query_id=7706522a-a2a5-490a-9692-80b60a8ee620&session_id=018d87fd-6308-7c1b-86fa-5fce2ab460bf

</p>
</details> 