### PR TITLE
feat: Added kafka hash to redis watermarks

### DIFF
--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -145,6 +145,7 @@ describe('ingester', () => {
     it('can parse debug partition config', () => {
         const config = {
             SESSION_RECORDING_DEBUG_PARTITION: '103',
+            KAFKA_HOSTS: 'localhost:9092',
         } satisfies Partial<PluginsServerConfig> as PluginsServerConfig
 
         const ingester = new SessionRecordingIngester(config, hub.postgres, hub.objectStorage)
@@ -152,7 +153,9 @@ describe('ingester', () => {
     })
 
     it('can parse absence of debug partition config', () => {
-        const config = {} satisfies Partial<PluginsServerConfig> as PluginsServerConfig
+        const config = {
+            KAFKA_HOSTS: 'localhost:9092',
+        } satisfies Partial<PluginsServerConfig> as PluginsServerConfig
 
         const ingester = new SessionRecordingIngester(config, hub.postgres, hub.objectStorage)
         expect(ingester['debugPartition']).toBeUndefined()


### PR DESCRIPTION
## Problem

We were unable to do a zero-downtime rollover to a new kafka cluster as redis gets in the way. The stored offsets are not aware of the kafka cluster, which means as we swap over the high offsets stored in redis will essentially block all traffic.

To get around this, we can use the kafka brokers as an ID of sorts to modify the redis keys, ensuring that a new kafka configuration effectively resets the offset watermarks
## Changes

* Compute an md5 hash of the kafka hosts and add it to the redis key prefix
* This has the downside of if we ever change the KAFKA_HOST var, even if the cluster is the same, then the offsets would effectively be cleared. Given that our approach to kafka changes will almost always be failing over to a new cluster however means this shouldn't be an issue.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
