### PR TITLE
chore: no 3k nav flag in dev mode plz

### DIFF
--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -4,7 +4,7 @@ from django.core.management.base import BaseCommand
 
 from posthog.models import FeatureFlag, Team, User
 
-INACTIVE_FLAGS = ["cloud-announcement", "session-reset-on-load"]
+INACTIVE_FLAGS = ["cloud-announcement", "session-reset-on-load", "posthog-3000-nav"]
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
I _always_ turn this flag off, and I think there is no active work on it, so let's not have it on when we `sync_feature_flags`