### PR TITLE
fix(legacy): stickiness groups

### DIFF
--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -39,8 +39,8 @@ actors_only_math_types = [
     BaseMathType.dau,
     BaseMathType.weekly_active,
     BaseMathType.monthly_active,
-    Literal["unique_group"],
-    Literal["hogql"],
+    "unique_group",
+    "hogql",
 ]
 
 


### PR DESCRIPTION
## Problem

Unique groups were still showing bad results for the stickiness query:

<img width="1234" alt="Screenshot 2024-02-08 at 16 01 24" src="https://github.com/PostHog/posthog/assets/53387/58bae4c1-a21d-4320-9eef-95a625d19566">

## Changes

Changes literals to strings

## How did you test this code?

When modifying the array directly in the python shell, the query returns good results.