### PR TITLE
chore(plugin-server): bring !USE_KAFKA_FOR_SCHEDULED_TASKS branch err…

### DIFF
--- a/plugin-server/src/main/graphile-worker/schedule.ts
+++ b/plugin-server/src/main/graphile-worker/schedule.ts
@@ -2,9 +2,11 @@ import { JobHelpers } from 'graphile-worker'
 
 import { KAFKA_SCHEDULED_TASKS } from '../../config/kafka-topics'
 import { Hub, PluginConfigId } from '../../types'
+import { DependencyUnavailableError } from '../../utils/db/error'
 import { status } from '../../utils/status'
 import { delay } from '../../utils/utils'
 import Piscina from '../../worker/piscina'
+import { scheduledTaskCounter } from '../ingestion-queues/metrics'
 import { graphileScheduledTaskCounter } from './metrics'
 
 type TaskTypes = 'runEveryMinute' | 'runEveryHour' | 'runEveryDay'
@@ -61,8 +63,46 @@ export async function runScheduledTasks(
         }
     } else {
         for (const pluginConfigId of server.pluginSchedule?.[taskType] || []) {
-            status.info('⏲️', `Running ${taskType} for plugin config with ID ${pluginConfigId}`)
-            await piscina.run({ task: taskType, args: { pluginConfigId } })
+            try {
+                status.info('⏲️', 'running_scheduled_task', {
+                    taskType,
+                    pluginConfigId,
+                })
+                const startTime = performance.now()
+
+                // The part that actually runs the task.
+                await piscina.run({ task: taskType, args: { pluginConfigId } })
+
+                status.info('⏲️', 'finished_scheduled_task', {
+                    taskType,
+                    pluginConfigId,
+                    durationSeconds: (performance.now() - startTime) / 1000,
+                })
+                scheduledTaskCounter.labels({ status: 'completed', task: taskType }).inc()
+            } catch (error) {
+                if (error instanceof DependencyUnavailableError) {
+                    // For errors relating to PostHog dependencies that are unavailable,
+                    // e.g. Postgres, Kafka, Redis, we don't want to log the error to Sentry
+                    // but rather bubble this up the stack for someone else to decide on
+                    // what to do with it.
+                    status.warn('⚠️', `dependency_unavailable`, {
+                        taskType,
+                        pluginConfigId,
+                        error: error,
+                        stack: error.stack,
+                    })
+                    scheduledTaskCounter.labels({ status: 'error', task: taskType }).inc()
+                    throw error
+                }
+
+                status.error('⚠️', 'scheduled_task_failed', {
+                    taskType: taskType,
+                    pluginConfigId,
+                    error: error,
+                    stack: error.stack,
+                })
+                scheduledTaskCounter.labels({ status: 'failed', task: taskType }).inc()
+            }
             graphileScheduledTaskCounter.labels({ status: 'completed', task: taskType }).inc()
         }
     }


### PR DESCRIPTION
…or handling/metrics/logging in sync with alternate

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
The non-Kafka branch got out of sync with respect to errors/metrics/logs.

## Changes

Bring in sync so they behave the same (modulo concurrency).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
