### PR TITLE
fix: Re enable docs side panel link intercepting

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelDocsLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelDocsLogic.ts
@@ -1,5 +1,6 @@
-import { actions, afterMount, beforeUnmount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, afterMount, beforeUnmount, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { router } from 'kea-router'
+import { RefObject } from 'react'
 import { sceneLogic } from 'scenes/sceneLogic'
 
 import { sidePanelStateLogic } from '../sidePanelStateLogic'
@@ -21,10 +22,20 @@ export const getPathFromUrl = (urlOrPath: string): string => {
     }
 }
 
+export type DocsMenuOption = {
+    name: string
+    url: string
+}
+
+export type SidePanelDocsLogicProps = {
+    iframeRef: RefObject<HTMLIFrameElement | null>
+}
+
 export const sidePanelDocsLogic = kea<sidePanelDocsLogicType>([
     path(['scenes', 'navigation', 'sidepanel', 'sidePanelDocsLogic']),
+    props({} as SidePanelDocsLogicProps),
     connect({
-        actions: [sidePanelStateLogic, ['openSidePanel', 'closeSidePanel']],
+        actions: [sidePanelStateLogic, ['openSidePanel', 'closeSidePanel', 'setSidePanelOptions']],
         values: [sceneLogic, ['sceneConfig'], sidePanelStateLogic, ['selectedTabOptions']],
     }),
 
@@ -33,9 +44,31 @@ export const sidePanelDocsLogic = kea<sidePanelDocsLogicType>([
         setInitialPath: (path: string) => ({ path }),
         unmountIframe: true,
         handleExternalUrl: (urlOrPath: string) => ({ urlOrPath }),
+        setMenuOptions: (menuOptions: DocsMenuOption[] | null) => ({ menuOptions }),
+        setIframeReady: (ready: boolean) => ({ ready }),
+        setActiveMenuName: (activeMenuName: string | null) => ({ activeMenuName }),
+        navigateToPage: (path: string) => ({ path }),
     }),
 
     reducers(() => ({
+        iframeReady: [
+            false as boolean,
+            {
+                setIframeReady: (_, { ready }) => ready,
+            },
+        ],
+        menuOptions: [
+            null as DocsMenuOption[] | null,
+            {
+                setMenuOptions: (_, { menuOptions }) => menuOptions,
+            },
+        ],
+        activeMenuName: [
+            null as string | null,
+            {
+                setActiveMenuName: (_, { activeMenuName }) => activeMenuName,
+            },
+        ],
         currentPath: [
             null as string | null,
             {
@@ -66,11 +99,12 @@ export const sidePanelDocsLogic = kea<sidePanelDocsLogicType>([
         ],
     }),
 
-    listeners(({ actions, values }) => ({
+    listeners(({ actions, values, props }) => ({
         openSidePanel: ({ options }) => {
             if (options) {
                 const initialPath = getPathFromUrl(options)
                 actions.setInitialPath(initialPath)
+                actions.navigateToPage(initialPath)
             }
         },
 
@@ -82,9 +116,25 @@ export const sidePanelDocsLogic = kea<sidePanelDocsLogicType>([
         handleExternalUrl: ({ urlOrPath }) => {
             router.actions.push(getPathFromUrl(urlOrPath))
         },
+
+        navigateToPage: ({ path }) => {
+            if (path) {
+                props.iframeRef.current?.contentWindow?.postMessage(
+                    {
+                        type: 'navigate',
+                        url: path,
+                    },
+                    '*'
+                )
+            }
+        },
+
+        updatePath: ({ path }) => {
+            actions.setSidePanelOptions(path)
+        },
     })),
 
-    afterMount(({ actions, values }) => {
+    afterMount(({ actions, values, cache }) => {
         // If a destination was set in the options, use that
         // otherwise the default for the current scene
         // otherwise, whatever it last was set to
@@ -94,9 +144,44 @@ export const sidePanelDocsLogic = kea<sidePanelDocsLogicType>([
         } else if (values.sceneConfig?.defaultDocsPath) {
             actions.setInitialPath(values.sceneConfig?.defaultDocsPath)
         }
+
+        cache.onWindowMessage = (event: MessageEvent): void => {
+            if (event.origin === POSTHOG_WEBSITE_ORIGIN) {
+                if (event.data.type === 'internal-navigation') {
+                    actions.updatePath(event.data.url)
+                    return
+                }
+                if (event.data.type === 'docs-ready') {
+                    actions.setIframeReady(true)
+                    return
+                }
+
+                if (event.data.type === 'external-navigation') {
+                    // This should only be triggered for app|eu.posthog.com links
+                    actions.handleExternalUrl(event.data.url)
+                    return
+                }
+                if (event.data.type === 'docs-menu') {
+                    console.log('Setting menu options', event.data.menu)
+                    actions.setMenuOptions(event.data.menu)
+                    return
+                }
+
+                if (event.data.type === 'docs-active-menu') {
+                    actions.setActiveMenuName(event.data.activeMenuName)
+                    return
+                }
+
+                console.warn('Unhandled iframe message from Docs:', event.data)
+            }
+        }
+
+        window.addEventListener('message', cache.onWindowMessage)
     }),
 
-    beforeUnmount(({ actions, values }) => {
+    beforeUnmount(({ actions, values, cache }) => {
         actions.setInitialPath(values.currentPath ?? '/docs')
+
+        window.removeEventListener('message', cache.onWindowMessage)
     }),
 ])

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelDocsLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelDocsLogic.ts
@@ -162,7 +162,6 @@ export const sidePanelDocsLogic = kea<sidePanelDocsLogicType>([
                     return
                 }
                 if (event.data.type === 'docs-menu') {
-                    console.log('Setting menu options', event.data.menu)
                     actions.setMenuOptions(event.data.menu)
                     return
                 }

--- a/frontend/src/lib/lemon-ui/Link/Link.tsx
+++ b/frontend/src/lib/lemon-ui/Link/Link.tsx
@@ -1,12 +1,16 @@
 import './Link.scss'
 
 import clsx from 'clsx'
+import { useActions } from 'kea'
 import { router } from 'kea-router'
 import { isExternalLink } from 'lib/utils'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
 import { addProjectIdIfMissing } from 'lib/utils/router-utils'
 import React from 'react'
 import { useNotebookDrag } from 'scenes/notebooks/AddToNotebook/DraggableToNotebook'
+
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
+import { SidePanelTab } from '~/types'
 
 import { IconOpenInNew } from '../icons'
 import { Tooltip } from '../Tooltip'
@@ -57,10 +61,9 @@ const isDirectLink = (url: string): boolean => {
     return /^(mailto:|https?:\/\/|:\/\/)/.test(url)
 }
 
-// NOTE: Temporarily disabled - owner @corywatilo
-// const isPostHogComDocs = (url: string): boolean => {
-//     return /^https:\/\/(www\.)?posthog\.com\/docs/.test(url)
-// }
+const isPostHogComDocs = (url: string): boolean => {
+    return /^https:\/\/(www\.)?posthog\.com\/docs/.test(url)
+}
 
 /**
  * Link
@@ -91,8 +94,7 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
             href: typeof to === 'string' ? to : undefined,
         })
 
-        // NOTE: Temporarily disabled - owner @corywatilo
-        // const { openSidePanel } = useActions(sidePanelStateLogic)
+        const { openSidePanel } = useActions(sidePanelStateLogic)
 
         const onClick = (event: React.MouseEvent<HTMLElement>): void => {
             if (event.metaKey || event.ctrlKey) {
@@ -107,12 +109,11 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
                 return
             }
 
-            // NOTE: Temporarily disabled - owner @corywatilo
-            // if (typeof to === 'string' && isPostHogComDocs(to)) {
-            //     event.preventDefault()
-            //     openSidePanel(SidePanelTab.Docs, to)
-            //     return
-            // }
+            if (typeof to === 'string' && isPostHogComDocs(to)) {
+                event.preventDefault()
+                openSidePanel(SidePanelTab.Docs, to)
+                return
+            }
 
             if (!target && to && !isExternalLink(to) && !disableClientSideRouting && !shouldForcePageLoad(to)) {
                 event.preventDefault()


### PR DESCRIPTION
## Problem

Docs feels good - lets re-enable the sidepanel

## Changes

* Re-enables the automatic Link detection
* Improves and fixes some bugs in the panel by moving the iframe logic into the kea logic as well
* Fixes issues so that anytime a docs link is clicked or open from the url it definitely routes the iframe

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
