### PR TITLE
chore(plugin-server): make sessionTimeout and rebalanceTimeout configurable by env for all kafkajs consumers

### DIFF
--- a/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/on-event-handler-consumer.ts
@@ -70,6 +70,7 @@ export const startAsyncWebhooksHandlerConsumer = async ({
         // NOTE: This should never clash with the group ID specified for the kafka engine posthog/ee/clickhouse/sql/clickhouse.py
         groupId: `${KAFKA_PREFIX}clickhouse-plugin-server-async-webhooks`,
         sessionTimeout: serverConfig.KAFKA_CONSUMPTION_SESSION_TIMEOUT_MS,
+        rebalanceTimeout: serverConfig.KAFKA_CONSUMPTION_REBALANCE_TIMEOUT_MS ?? undefined,
         readUncommitted: false,
     })
     setupEventHandlers(consumer)

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -277,6 +277,7 @@ export async function startPluginsServer(
                     piscina: piscina,
                     producer: hub.kafkaProducer,
                     kafka: hub.kafka,
+                    serverConfig,
                     partitionConcurrency: serverConfig.KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY,
                 })
             }
@@ -286,6 +287,7 @@ export async function startPluginsServer(
                     kafka: hub.kafka,
                     producer: hub.kafkaProducer,
                     graphileWorker: graphileWorker,
+                    serverConfig,
                 })
             }
         }


### PR DESCRIPTION
## Problem

Multiple callsites only used [the defaults](https://kafka.js.org/docs/consuming#options), but we have reason to change the values in some places (and already did in other places, making the *existing* env var extra confusing!).

## Changes

Pass down sessionTimeout and rebalanceTimeout from `serverConfig` (`env`).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
