### PR TITLE
chore(data-warehouse): make sure counts are updated at end of import

### DIFF
--- a/posthog/temporal/data_imports/pipelines/stripe/helpers.py
+++ b/posthog/temporal/data_imports/pipelines/stripe/helpers.py
@@ -8,7 +8,7 @@ from dlt.common import pendulum
 from dlt.sources import DltResource
 from pendulum import DateTime
 from asgiref.sync import sync_to_async
-from posthog.temporal.data_imports.pipelines.helpers import check_limit
+from posthog.temporal.data_imports.pipelines.helpers import check_limit, aupdate_job_count
 from posthog.warehouse.models import ExternalDataJob
 
 stripe.api_version = "2022-11-15"
@@ -91,6 +91,8 @@ async def stripe_pagination(
 
         if not response["has_more"] or status == ExternalDataJob.Status.CANCELLED:
             break
+
+    await aupdate_job_count(job_id, team_id, count)
 
 
 @dlt.source(max_table_nesting=0)

--- a/posthog/temporal/tests/external_data/test_external_data_job.py
+++ b/posthog/temporal/tests/external_data/test_external_data_job.py
@@ -387,6 +387,9 @@ async def test_run_stripe_job_cancelled(activity_environment, team, minio_client
         # if job was not canceled, this job would run indefinitely
         assert len(job_1_customer_objects["Contents"]) == 1
 
+        await sync_to_async(job_1.refresh_from_db)()
+        assert job_1.rows_synced == 1
+
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

- counts won't be updated at end of run

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- make sure counts are updated

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
