### PR TITLE
feat: link to payload capture docs from config

### DIFF
--- a/frontend/src/scenes/settings/project/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/project/SessionRecordingSettings.tsx
@@ -191,7 +191,10 @@ function NetworkCaptureSettings(): JSX.Element {
                 </div>
                 <p>
                     When network capture is enabled, we always captured network timings. Use these switches to choose
-                    whether to capture headers and payloads of requests
+                    whether to capture headers and payloads of requests.{' '}
+                    <Link to="https://posthog.com/docs/session-replay/network-recording" target="blank">
+                        Learn how to mask header and payload values in our docs
+                    </Link>
                 </p>
             </FlaggedFeature>
         </>


### PR DESCRIPTION
let's link to docs from the payload capture section. "how do i mask values?" will be a common question

<img width="439" alt="Screenshot 2024-02-08 at 23 08 50" src="https://github.com/PostHog/posthog/assets/984817/6d95dfd8-2746-4c2b-8e96-965d5ccdd700">
