### PR TITLE
fix(insights): Update some stuff around refreshing

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
@@ -112,7 +112,7 @@
 
 .InsightDetails__footer {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(3, 1fr);
 
     .profile-package {
         vertical-align: middle;

--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -353,6 +353,14 @@ function InsightDetailsInternal({ insight }: { insight: InsightModel }, ref: Rea
                         <TZLabel time={insight.last_modified_at} />
                     </section>
                 </div>
+                {insight.last_refresh && (
+                    <div>
+                        <h5>Last computed</h5>
+                        <section>
+                            <TZLabel time={insight.last_refresh} />
+                        </section>
+                    </div>
+                )}
             </div>
         </div>
     )

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1076,6 +1076,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             if (values.autoRefresh.enabled) {
                 // Refresh right now after enabling if we haven't refreshed recently
                 if (
+                    !values.itemsLoading &&
                     values.lastRefreshed &&
                     values.lastRefreshed.isBefore(now().subtract(values.autoRefresh.interval, 'seconds'))
                 ) {


### PR DESCRIPTION
## Problem

Toggling auto refresh makes it refresh more even when it's refreshing already. 

## Changes

- add one more condition to immediately refresh when toggling auto refresh
- add refresh time to dashboard items


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
