### PR TITLE
fix: always say subscribe, not upgrade

### DIFF
--- a/frontend/src/scenes/billing/PlanComparison.tsx
+++ b/frontend/src/scenes/billing/PlanComparison.tsx
@@ -130,7 +130,7 @@ export const PlanComparison = ({
                         }
                     }}
                 >
-                    {plan.current_plan ? 'Current plan' : 'Upgrade'}
+                    {plan.current_plan ? 'Current plan' : 'Subscribe'}
                 </LemonButton>
                 {!plan.current_plan && includeAddons && product.addons?.length > 0 && (
                     <p className="text-center ml-0 mt-2 mb-0">
@@ -139,7 +139,7 @@ export const PlanComparison = ({
                             className="text-muted text-xs"
                             disableClientSideRouting
                         >
-                            or upgrade without addons
+                            or subscribe without addons
                         </Link>
                     </p>
                 )}


### PR DESCRIPTION
## Problem

Sometimes we said subscribe, sometimes we said upgrade. For now, we don't really have an "upgrade" concept (you're either sub'd or not) so we'll go with subscribe for now.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Uses "subscribe" instead of "upgrade"

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
