### PR TITLE
fix: inability to scroll on signup page

### DIFF
--- a/frontend/src/lib/components/BridgePage/BridgePage.scss
+++ b/frontend/src/lib/components/BridgePage/BridgePage.scss
@@ -5,9 +5,8 @@
     display: flex;
     flex: 1;
     flex-direction: column;
-    height: 100%;
-    min-height: 100vh;
-    overflow: hidden;
+    height: 100vh;
+    overflow: scroll;
     background-color: var(--bg-bridge);
     -ms-overflow-style: none;
 


### PR DESCRIPTION
## Problem

Zach [noticed](https://posthog.slack.com/archives/C043VJ93L3B/p1707254025594759) that if your device window is shorter than the signup screen, it wouldn't scroll 😬  I think this happened with the move to posthog 3000 because we did overflow-hidden on the body.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Re-enables scrolling on the signup page, and any other bridge pages. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

🖱️ 👀  I looked at the other bridge pages (notably, the onboarding ones) and nothing seems affected there...

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
