### PR TITLE
chore: Update getsentry/action-github-app-token to v3

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -76,7 +76,7 @@ jobs:
 
             - name: get deployer token
               id: deployer
-              uses: getsentry/action-github-app-token@v2
+              uses: getsentry/action-github-app-token@v3
               with:
                   app_id: ${{ secrets.DEPLOYER_APP_ID }}
                   private_key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

GitHub actions has deprecated node 16, impacting the [getsentry/action-github-app-token](https://github.com/getsentry/action-github-app-token) v2 currently in use, which relies on this node version. See the announcement [here](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).

## Changes

Updated the action to v3 to ensure compatibility with node20, aligning with GitHub action's current environment.

## How did you test this code?

N/A
