### PR TITLE
fix: change version checker cache prefix to bust cache

### DIFF
--- a/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
+++ b/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
@@ -76,7 +76,8 @@ export const versionCheckerLogic = kea<versionCheckerLogicType>([
         ],
         versionWarning: [
             null as SDKVersionWarning | null,
-            { persist: true },
+            // bumping cache key due to an incorrect tag being cached on 2024-02-12
+            { persist: true, prefix: '2024-02-12' },
             {
                 setVersionWarning: (_, { versionWarning }) => versionWarning,
             },


### PR DESCRIPTION
see https://twitter.com/parvezvai/status/1756990764783935679 and https://github.com/PostHog/posthog/issues/20260

The new release code in posthog-js incorrectly tagged the version which means a bunch of people have an "incorrect" tag list cached.

Let's bump the prefix so everyone has to pull the latest (and now correct) list of versions