### PR TITLE
fix: notebooks nodes

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePlaylist.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePlaylist.tsx
@@ -166,7 +166,7 @@ export const NotebookNodePlaylist = createPostHogWidgetNode<NotebookNodePlaylist
         },
     },
     pasteOptions: {
-        find: urls.replay(ReplayTabs.Recent),
+        find: urls.replay(ReplayTabs.Recent) + '(.*)',
         getAttributes: async (match) => {
             const url = new URL(match[0])
             const filters = url.searchParams.get('filters')

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePlaylist.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePlaylist.tsx
@@ -1,5 +1,5 @@
 import { createPostHogWidgetNode } from 'scenes/notebooks/Nodes/NodeWrapper'
-import { FilterType, NotebookNodeType, RecordingFilters } from '~/types'
+import { FilterType, NotebookNodeType, RecordingFilters, ReplayTabs } from '~/types'
 import {
     SessionRecordingPlaylistLogicProps,
     addedAdvancedFilters,
@@ -163,6 +163,14 @@ export const NotebookNodePlaylist = createPostHogWidgetNode<NotebookNodePlaylist
         },
         pinned: {
             default: undefined,
+        },
+    },
+    pasteOptions: {
+        find: urls.replay(ReplayTabs.Recent),
+        getAttributes: async (match) => {
+            const url = new URL(match[0])
+            const filters = url.searchParams.get('filters')
+            return { filters: filters ? JSON.parse(filters) : {}, pinned: [] }
         },
     },
     Settings,

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -36,6 +36,9 @@ const Component = ({
     const { expanded } = useValues(nodeLogic)
     const { setTitlePlaceholder } = useActions(nodeLogic)
     const summarizeInsight = useSummarizeInsight()
+    const { insightName } = useValues(
+        insightLogic({ dashboardItemId: query.kind === NodeKind.SavedInsightNode ? query.shortId : 'new' })
+    )
 
     useEffect(() => {
         let title = 'Query'
@@ -58,13 +61,13 @@ const Component = ({
                 }
             }
         }
+
         if (query.kind === NodeKind.SavedInsightNode) {
-            const logic = insightLogic.findMounted({ dashboardItemId: query.shortId })
-            title = (logic?.values.insight.name || logic?.values.insight.derived_name) ?? 'Saved Insight'
+            title = insightName ?? 'Saved Insight'
         }
 
         setTitlePlaceholder(title)
-    }, [query])
+    }, [query, insightName])
 
     const modifiedQuery = useMemo(() => {
         const modifiedQuery = { ...query, full: false }

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeRecording.tsx
@@ -157,7 +157,7 @@ export const NotebookNodeRecording = createPostHogWidgetNode<NotebookNodeRecordi
         },
     },
     pasteOptions: {
-        find: urls.replaySingle('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'),
+        find: urls.replaySingle('([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})'),
         getAttributes: async (match) => {
             return { id: match[1], noInspector: false }
         },


### PR DESCRIPTION
## Problem

We had a number of Notebook issues reported

## Changes

- Some URL changes (possibly the new project urls) meant that paste handlers were not working as before for individual replays. Added a capture group so we can reference it when setting the attributes on a replay node
- Added a paste handler to the playlist node to parse filters & generate playlist
- Implemented the `useValues` hook to make sure the title is generated correctly on page load. We cannot always rely on the insights being immediately available

## How did you test this code?

