### PR TITLE
fix(posthog-3000): Fix layout for mobile safari

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.scss
+++ b/frontend/src/layout/navigation-3000/Navigation.scss
@@ -6,6 +6,7 @@
     --scene-padding: 1rem;
 
     // handle notched devices and mobile safari's bottom nav bar
+    // provide a fallback of 80px as Safari's approach to safe-area-inset-bottom is not consistent across versions
     --scene-padding-bottom: calc(var(--scene-padding) + max(env(safe-area-inset-bottom), 80px));
 
     display: flex;

--- a/frontend/src/layout/navigation-3000/Navigation.scss
+++ b/frontend/src/layout/navigation-3000/Navigation.scss
@@ -4,10 +4,7 @@
     --breadcrumbs-height-full: 3.75rem;
     --breadcrumbs-height-compact: 2.75rem; // Sync with BREADCRUMBS_HEIGHT_COMPACT
     --scene-padding: 1rem;
-
-    // handle notched devices and mobile safari's bottom nav bar
-    // provide a fallback of 80px as Safari's approach to safe-area-inset-bottom is not consistent across versions
-    --scene-padding-bottom: calc(var(--scene-padding) + max(env(safe-area-inset-bottom), 80px));
+    --scene-padding-bottom: var(--scene-padding);
 
     display: flex;
     width: 100%;
@@ -25,6 +22,12 @@
         height: 100%;
         overflow: visible;
         background: none;
+    }
+
+    @media screen and (max-width: $sm) {
+        // handle notched devices and mobile safari's bottom nav bar
+        // provide a fallback of 80px as Safari's approach to safe-area-inset-bottom is not consistent across versions
+        --scene-padding-bottom: calc(var(--scene-padding) + max(env(safe-area-inset-bottom), 80px));
     }
 
     @media screen and (max-width: $lg) {

--- a/frontend/src/layout/navigation-3000/Navigation.scss
+++ b/frontend/src/layout/navigation-3000/Navigation.scss
@@ -5,6 +5,9 @@
     --breadcrumbs-height-compact: 2.75rem; // Sync with BREADCRUMBS_HEIGHT_COMPACT
     --scene-padding: 1rem;
 
+    // handle notched devices and mobile safari's bottom nav bar
+    --scene-padding-bottom: calc(var(--scene-padding) + max(env(safe-area-inset-bottom), 80px));
+
     display: flex;
     width: 100%;
     height: 100vh;
@@ -31,8 +34,9 @@
 .Navigation3000__scene {
     // `relative` is for positioning of the scene-level spinner
     position: relative;
-    min-height: calc(100vh - var(--breadcrumbs-height-full) - var(--scene-padding) * 2);
+    min-height: calc(100vh - var(--breadcrumbs-height-full) - var(--scene-padding) - var(--scene-padding-bottom));
     margin: var(--scene-padding);
+    margin-bottom: var(--scene-padding-bottom);
 
     &.Navigation3000__scene--raw {
         --scene-padding: 0px;


### PR DESCRIPTION
## Problem

The content at the bottom of the screen can be hidden on mobile safari
https://posthoghelp.zendesk.com/agent/tickets/10394 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/12516)

Before:
![Simulator Screenshot - iPhone 15 Pro Max - 2024-02-12 at 12 24 20](https://github.com/PostHog/posthog/assets/2056078/4bdd659b-80a1-4507-b25f-e9e60033e394)


## Changes
Use `env(safe-area-inset-bottom)` and a fallback of `80px` which is the approximate size of the nav bar on mobile Safari. See the comment for more info.

After:
![Simulator Screenshot - iPhone 15 Pro Max - 2024-02-12 at 12 24 01](https://github.com/PostHog/posthog/assets/2056078/60423dd9-1acf-4cb9-ad0c-d31a9441a537)

It's behind a media tag, so desktop, or e.g. an ipad (which has the bar at the top) is unaffected.
<img width="1604" alt="Screenshot 2024-02-12 at 12 48 56" src="https://github.com/PostHog/posthog/assets/2056078/ef1bcb69-fa55-4946-a1a0-b7c799ac21bf">


## How did you test this code?

Manually tested on different browsers:
* iphone before and after
* sideways iphone (this doesn't work but so many things in the app don't work with this layout, so not worth fixing this until a customer asks for it)
* ipad
* desktop

With different scenes:
* The home screen dashboard (i.e. a scene with a lot of content)
* The dashboard list screen (i.e. a scene with minimal content that doesn't have scroll bars)