### PR TITLE
feat(hogql): add support for using join contraint

### DIFF
--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -504,6 +504,11 @@ class JoinConstraint(Expr):
 
 
 @dataclass(kw_only=True)
+class JoinUsingConstraint(Expr):
+    exprs: Expr
+
+
+@dataclass(kw_only=True)
 class JoinExpr(Expr):
     # :TRICKY: When adding new fields, make sure they're handled in visitor.py and resolver.py
     type: Optional[TableOrSelectType] = None
@@ -513,7 +518,7 @@ class JoinExpr(Expr):
     table_args: Optional[List[Expr]] = None
     alias: Optional[str] = None
     table_final: Optional[bool] = None
-    constraint: Optional["JoinConstraint"] = None
+    constraint: Optional[Union["JoinConstraint", "JoinUsingConstraint"]] = None
     next_join: Optional["JoinExpr"] = None
     sample: Optional["SampleExpr"] = None
 

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -500,12 +500,8 @@ class Call(Expr):
 
 @dataclass(kw_only=True)
 class JoinConstraint(Expr):
-    expr: Expr
-
-
-@dataclass(kw_only=True)
-class JoinUsingConstraint(Expr):
-    exprs: Expr
+    join_type: Literal["ON", "USING"]
+    expr: Expr | List[Expr]
 
 
 @dataclass(kw_only=True)
@@ -518,7 +514,7 @@ class JoinExpr(Expr):
     table_args: Optional[List[Expr]] = None
     alias: Optional[str] = None
     table_final: Optional[bool] = None
-    constraint: Optional[Union["JoinConstraint", "JoinUsingConstraint"]] = None
+    constraint: Optional["JoinConstraint"] = None
     next_join: Optional["JoinExpr"] = None
     sample: Optional["SampleExpr"] = None
 

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -369,9 +369,9 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         raise NotImplementedException(f"Unsupported node: JoinOpCross")
 
     def visitJoinConstraintClause(self, ctx: HogQLParser.JoinConstraintClauseContext):
-        if ctx.USING():
-            raise NotImplementedException(f"Unsupported: JOIN ... USING")
         column_expr_list = self.visit(ctx.columnExprList())
+        if ctx.USING():
+            return ast.JoinUsingConstraint(exprs=column_expr_list)
         if len(column_expr_list) != 1:
             raise NotImplementedException(f"Unsupported: JOIN ... ON with multiple expressions")
         return ast.JoinConstraint(expr=column_expr_list[0])

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -371,10 +371,10 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
     def visitJoinConstraintClause(self, ctx: HogQLParser.JoinConstraintClauseContext):
         column_expr_list = self.visit(ctx.columnExprList())
         if ctx.USING():
-            return ast.JoinUsingConstraint(exprs=column_expr_list)
+            return ast.JoinConstraint(join_type="USING", expr=column_expr_list)
         if len(column_expr_list) != 1:
             raise NotImplementedException(f"Unsupported: JOIN ... ON with multiple expressions")
-        return ast.JoinConstraint(expr=column_expr_list[0])
+        return ast.JoinConstraint(join_type="ON", expr=column_expr_list[0])
 
     def visitSampleClause(self, ctx: HogQLParser.SampleClauseContext):
         ratio_expressions = ctx.ratioExpr()

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -454,6 +454,11 @@ class _Printer(Visitor):
     def visit_join_constraint(self, node: ast.JoinConstraint):
         return self.visit(node.expr)
 
+    def visit_join_using_constraint(self, node: ast.JoinUsingConstraint):
+        if len(node.exprs) == 1:
+            return self.visit(node.exprs[0])
+        return ", ".join([self.visit(expr) for expr in node.exprs])
+
     def visit_arithmetic_operation(self, node: ast.ArithmeticOperation):
         if node.op == ast.ArithmeticOperationOp.Add:
             return f"plus({self.visit(node.left)}, {self.visit(node.right)})"

--- a/posthog/hogql/test/test_using.py
+++ b/posthog/hogql/test/test_using.py
@@ -1,0 +1,109 @@
+from dataclasses import asdict, dataclass
+from typing import List
+
+from posthog.clickhouse.client.execute import sync_execute
+from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
+from posthog.test.base import BaseTest
+
+
+@dataclass
+class TestRow:
+    a: int
+    b: int
+
+
+def insert(table: str, rows: List):
+    columns = asdict(rows[0]).keys()
+
+    all_values, params = [], {}
+    for i, row in enumerate(rows):
+        values = ", ".join([f"%(p_{i}_{j})s" for j, _ in enumerate(columns)])
+        all_values.append(f"({values})")
+
+        for j, column in enumerate(columns):
+            params[f"p_{i}_{j}"] = getattr(row, column)
+
+    sync_execute(
+        f"""
+            INSERT INTO {table} ({', '.join(columns)})
+            VALUES {', '.join(all_values)}
+        """,
+        params,
+    )
+
+
+CREATE_T_1 = "CREATE TABLE t_1 (a UInt16 NOT NULL, b UInt8 NOT NULL) ENGINE = Memory"
+CREATE_T_2 = "CREATE TABLE t_2 (a Int16 NOT NULL, b Int64 NULL) ENGINE = Memory"
+DROP_T_1 = "DROP TABLE t_1 SYNC"
+DROP_T_2 = "DROP TABLE t_2 SYNC"
+
+
+class TestUsing(BaseTest):
+    def setUp(self):
+        super().setUp()
+        try:
+            sync_execute(CREATE_T_1)
+            sync_execute(CREATE_T_2)
+        except:
+            pass
+
+    def tearDown(self):
+        super().tearDown()
+        sync_execute(DROP_T_1)
+        sync_execute(DROP_T_2)
+
+    def test_using(self):
+        # INSERT INTO t_1 (a, b)
+        # VALUES
+        # (1, 1),
+        # (2, 2);
+
+        # INSERT INTO t_2 (a, b)
+        # VALUES
+        # (-1, 1),
+        # (1, -1),
+        # (1, 1);
+
+        insert("t_1", [TestRow(a=1, b=1), TestRow(a=2, b=2)])
+        insert("t_2", [TestRow(a=-1, b=1), TestRow(a=1, b=-1), TestRow(a=1, b=1)])
+
+        # query = parse_select(
+        #     "SELECT a, b, toTypeName(a), toTypeName(b) FROM t_1 FULL JOIN t_2 ON t_1.a = t_2.a AND t_1.b = t_2.b",
+        #     backend="python",
+        # )
+
+        # query = parse_select(
+        #     "SELECT a, b, toTypeName(a), toTypeName(b) FROM t_1 FULL JOIN t_2 USING (a, b)",
+        #     backend="python",
+        # )
+
+        query = parse_select(
+            "SELECT event, timestamp, pdi.distinct_id FROM events e LEFT JOIN person_distinct_ids pdi USING distinct_id",
+            backend="python",
+        )
+
+        #         65:76
+        # children: [
+        #     0: TerminalNode - "USING" 65:69
+        #     1: TerminalNode - "("
+        #     2: ColumnExprListContext - children:
+        #       0: ColumnExprIdentifier 'a'
+        #       1: TerminalNode ','
+        #       2: ColumnExprIdentifier 'a'
+        #     3: TerminalNode - ")"
+        # ]
+
+        response = execute_hogql_query(
+            query,
+            team=self.team,
+        )
+
+        self.assertEqual(response, 1)
+
+    def test_using_asterisk(self):
+        pass
+
+        # "SELECT * FROM COUNTRIES JOIN CITIES USING (COUNTRY)"
+        # "SELECT COUNTRIES.* FROM COUNTRIES JOIN CITIES USING (COUNTRY)"
+        # "SELECT * FROM COUNTRIES JOIN CITIES USING (COUNTRY, COUNTRY_ISO_CODE)"

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -242,11 +242,11 @@ class TraversingVisitor(Visitor):
         pass
 
     def visit_join_constraint(self, node: ast.JoinConstraint):
-        self.visit(node.expr)
-
-    def visit_join_using_constraint(self, node: ast.JoinUsingConstraint):
-        for expr in node.exprs:
-            self.visit(expr)
+        if node.join_type == "ON":
+            self.visit(node.expr)
+        elif node.join_type == "USING":
+            for expr in node.expr:
+                self.visit(expr)
 
     def visit_hogqlx_tag(self, node: ast.HogQLXTag):
         for attribute in node.attributes:
@@ -523,10 +523,10 @@ class CloningVisitor(Visitor):
         )
 
     def visit_join_constraint(self, node: ast.JoinConstraint):
-        return ast.JoinConstraint(expr=self.visit(node.expr))
-
-    def visit_join_using_constraint(self, node: ast.JoinUsingConstraint):
-        return ast.JoinUsingConstraint(exprs=[self.visit(expr) for expr in node.exprs])
+        if node.join_type == "ON":
+            return ast.JoinConstraint(join_type=node.join_type, expr=self.visit(node.expr))
+        elif node.join_type == "USING":
+            return ast.JoinConstraint(join_type=node.join_type, expr=[self.visit(expr) for expr in node.expr])
 
     def visit_hogqlx_tag(self, node: ast.HogQLXTag):
         return ast.HogQLXTag(kind=node.kind, attributes=[self.visit(a) for a in node.attributes])

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -244,6 +244,10 @@ class TraversingVisitor(Visitor):
     def visit_join_constraint(self, node: ast.JoinConstraint):
         self.visit(node.expr)
 
+    def visit_join_using_constraint(self, node: ast.JoinUsingConstraint):
+        for expr in node.exprs:
+            self.visit(expr)
+
     def visit_hogqlx_tag(self, node: ast.HogQLXTag):
         for attribute in node.attributes:
             self.visit(attribute)
@@ -520,6 +524,9 @@ class CloningVisitor(Visitor):
 
     def visit_join_constraint(self, node: ast.JoinConstraint):
         return ast.JoinConstraint(expr=self.visit(node.expr))
+
+    def visit_join_using_constraint(self, node: ast.JoinUsingConstraint):
+        return ast.JoinUsingConstraint(exprs=[self.visit(expr) for expr in node.exprs])
 
     def visit_hogqlx_tag(self, node: ast.HogQLXTag):
         return ast.HogQLXTag(kind=node.kind, attributes=[self.visit(a) for a in node.attributes])


### PR DESCRIPTION
## Problem

We need support for `JOIN USING ...` in HogQL.

## Changes

This PR adds support for it.
- This is a CH example for a join that is only possible with `USING`, but not with `ON`:
 https://clickhouse.com/docs/en/sql-reference/statements/select/join#:~:text=The%20USING%20clause%20specifies%20one,join%20conditions%20are%20not%20supported.
- This is a good spec for `JOIN USING`: https://docs.oracle.com/javadb/10.10.1.2/ref/rrefsqljusing.html

### Todos
- [ ] Make it work (Current issue is "posthog.hogql.errors.ResolverException: Ambiguous query. Found multiple sources for field: distinct_id")
- [ ] Make the cpp parser work

## How did you test this code?

- [ ] test_using -> test_query
- [ ] test_printer
- [ ] test_parser

