### PR TITLE
fix: activity log org filter

### DIFF
--- a/posthog/api/activity_log.py
+++ b/posthog/api/activity_log.py
@@ -77,7 +77,7 @@ class ActivityLogViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, mixins
     pagination_class = ActivityLogPagination
 
     def filter_queryset_by_parents_lookups(self, queryset) -> QuerySet:
-        return queryset.filter(team_id=self.team.pk)
+        return queryset.filter(team_id=self.team.id)
 
     def get_queryset(self) -> QuerySet:
         queryset = super().get_queryset()

--- a/posthog/api/activity_log.py
+++ b/posthog/api/activity_log.py
@@ -77,8 +77,7 @@ class ActivityLogViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, mixins
     pagination_class = ActivityLogPagination
 
     def filter_queryset_by_parents_lookups(self, queryset) -> QuerySet:
-        team = self.team
-        return queryset.filter(team_id=team.id)
+        return queryset.filter(team_id=self.team.pk)
 
     def get_queryset(self) -> QuerySet:
         queryset = super().get_queryset()

--- a/posthog/api/activity_log.py
+++ b/posthog/api/activity_log.py
@@ -78,7 +78,7 @@ class ActivityLogViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, mixins
 
     def filter_queryset_by_parents_lookups(self, queryset) -> QuerySet:
         team = self.team
-        return queryset.filter(Q(organization_id=team.organization_id) | Q(team_id=team.id))
+        return queryset.filter(team_id=team.id)
 
     def get_queryset(self) -> QuerySet:
         queryset = super().get_queryset()


### PR DESCRIPTION
Am interested to see if any tests fail here

I don't remember why but the activity log endpoint by default shows activity in your org or your team. 

But we don't want to show activity in your org without also filtering by whether teams are visible to the user

So, let's default to team only filtering until we implement org filtering properly