### PR TITLE
feat(kafka): Always prefer resetting to the earliest available offset

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -427,11 +427,6 @@ export class SessionRecordingIngester {
             eachBatch: async (messages) => {
                 return await this.handleEachBatch(messages)
             },
-            topicConfig: {
-                // NOTE: In the event of a failover we want to reset fully to the earliest offset
-                // There is unlikely any other reason why the topic would not have offsets
-                'auto.offset.reset': 'earliest',
-            },
         })
 
         this.totalNumPartitions = (await getPartitionsForTopic(this.connectedBatchConsumer)).length


### PR DESCRIPTION
This applies the same logic from #20191 to all rdkafka-derived Kafka consumers.