### PR TITLE
fix(cohorts): do not load endlessly

### DIFF
--- a/frontend/src/models/cohortsModel.ts
+++ b/frontend/src/models/cohortsModel.ts
@@ -8,6 +8,7 @@ import { permanentlyMount } from 'lib/utils/kea-logic-builders'
 import { BehavioralFilterKey } from 'scenes/cohorts/CohortFilters/types'
 import { personsLogic } from 'scenes/persons/personsLogic'
 import { isAuthenticatedTeam, teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
 
 import {
     AnyCohortCriteriaType,
@@ -131,7 +132,7 @@ export const cohortsModel = kea<cohortsModelType>([
     listeners(({ actions }) => ({
         loadCohortsSuccess: async ({ cohorts }: { cohorts: CohortType[] }) => {
             const is_calculating = cohorts.filter((cohort) => cohort.is_calculating).length > 0
-            if (!is_calculating) {
+            if (!is_calculating || !window.location.pathname.includes(urls.cohorts())) {
                 return
             }
             actions.setPollTimeout(window.setTimeout(actions.loadCohorts, POLL_TIMEOUT))


### PR DESCRIPTION
## Problem

The `cohortsModel` keeps polling for new cohorts if it sees any that are currently calculating. This causes endless polling if some cohorts get stuck in this state.

## Changes

Only reload cohorts if on the cohorts URL, not elsewhere in the app.

## How did you test this code?

👀 in the browser locally.