### PR TITLE
fix(kea): log via localstorage toggle

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -114,7 +114,7 @@ export function initKea({ routerHistory, routerLocation, beforePlugins }: InitKe
         waitForPlugin,
     ]
 
-    if (window.JS_KEA_VERBOSE_LOGGING) {
+    if (window.JS_KEA_VERBOSE_LOGGING || ('localStorage' in window && window.localStorage.getItem('debug'))) {
         plugins.push(loggerPlugin)
     }
 

--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -114,6 +114,7 @@ export function initKea({ routerHistory, routerLocation, beforePlugins }: InitKe
         waitForPlugin,
     ]
 
+    // To enable logging, run localStorage.setItem("debug", true) in the console
     if (window.JS_KEA_VERBOSE_LOGGING || ('localStorage' in window && window.localStorage.getItem('debug'))) {
         plugins.push(loggerPlugin)
     }


### PR DESCRIPTION
## Problem

Redux devtools don't work with complex others. We store complex objects in Redux via Kea. We have an alternative logging approach, but this is hard to run.

## Changes

Now if you run `localStorage.setItem("debug", true)` in the browser console and reload, Kea will start logging to the console.

## How did you test this code?

Locally in the browser by doing the above.