### PR TITLE
fix: Fix rendering of nan and inf in JSON responses

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -187,7 +187,7 @@ class ClickhouseGroupsView(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewse
 
         group_type_index_to_properties = defaultdict(list)
         for group_type_index, key, count in rows:
-            group_type_index_to_properties[group_type_index].append({"name": key, "count": count})
+            group_type_index_to_properties[str(group_type_index)].append({"name": key, "count": count})
 
         return response.Response(group_type_index_to_properties)
 

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -565,7 +565,7 @@ class FeatureFlagViewSet(
                             seen_cohorts_cache[id] = cohort or ""
 
                         if cohort and not cohort.is_static:
-                            cohorts[cohort.pk] = cohort.properties.to_dict()
+                            cohorts[str(cohort.pk)] = cohort.properties.to_dict()
 
         # Add request for analytics
         increment_request_count(self.team.pk, 1, FlagRequestType.LOCAL_EVALUATION)

--- a/posthog/renderers.py
+++ b/posthog/renderers.py
@@ -1,8 +1,9 @@
 import math
 from typing import Dict, Tuple
 
-from orjson import orjson
+import orjson
 from rest_framework.renderers import JSONRenderer
+from rest_framework.utils.encoders import JSONEncoder
 
 CleaningMarker = bool | Dict[int, "CleaningMarker"]
 
@@ -47,4 +48,4 @@ class SafeJSONRenderer(JSONRenderer):
         if data is None:
             return b""
 
-        return orjson.dumps(data)
+        return orjson.dumps(data, default=JSONEncoder().default)

--- a/posthog/renderers.py
+++ b/posthog/renderers.py
@@ -1,5 +1,4 @@
-import math
-from typing import Dict, Tuple
+from typing import Dict
 
 import orjson
 from rest_framework.renderers import JSONRenderer
@@ -8,44 +7,9 @@ from rest_framework.utils.encoders import JSONEncoder
 CleaningMarker = bool | Dict[int, "CleaningMarker"]
 
 
-def clean_data_for_json(data) -> Tuple[CleaningMarker, CleaningMarker]:
-    """Replace NaNs and Infinities with None, in-place, marking which fields had to be scrubbed.
-    Return markers that should be set at the parent level, which is used for setting the markers recursively."""
-    if isinstance(data, float):
-        return (math.isnan(data), math.isinf(data))
-    if isinstance(data, list):
-        nan_map: Dict[int, CleaningMarker] = {}
-        inf_map: Dict[int, CleaningMarker] = {}
-        for index, item in enumerate(data):
-            nan, inf = clean_data_for_json(item)
-            if nan:
-                nan_map[index] = nan
-                if nan is True:
-                    data[index] = None
-            if inf:
-                inf_map[index] = inf
-                if inf is True:
-                    data[index] = None
-        return (nan_map, inf_map)
-    if isinstance(data, dict):
-        marker_payload: Dict[str, CleaningMarker] = {}
-        for key, value in data.items():
-            nan, inf = clean_data_for_json(value)
-            if nan:
-                marker_payload[f"{key}::nan"] = nan
-                if nan is True:
-                    data[key] = None
-            if inf:
-                marker_payload[f"{key}::inf"] = inf
-                if inf is True:
-                    data[key] = None
-        data.update(marker_payload)
-    return (False, False)
-
-
 class SafeJSONRenderer(JSONRenderer):
-    def render(self, data, accepted_media_type=None, renderer_context=None):
+    def render(self, data, accepted_media_type=None, renderer_context=None) -> bytes:
         if data is None:
             return b""
 
-        return orjson.dumps(data, default=JSONEncoder().default)
+        return orjson.dumps(data, default=JSONEncoder().default, option=orjson.OPT_UTC_Z)

--- a/posthog/renderers.py
+++ b/posthog/renderers.py
@@ -1,5 +1,7 @@
 import math
 from typing import Dict, Tuple
+
+from orjson import orjson
 from rest_framework.renderers import JSONRenderer
 
 CleaningMarker = bool | Dict[int, "CleaningMarker"]
@@ -42,5 +44,7 @@ def clean_data_for_json(data) -> Tuple[CleaningMarker, CleaningMarker]:
 
 class SafeJSONRenderer(JSONRenderer):
     def render(self, data, accepted_media_type=None, renderer_context=None):
-        clean_data_for_json(data)
-        return super().render(data, accepted_media_type, renderer_context)
+        if data is None:
+            return b""
+
+        return orjson.dumps(data)

--- a/posthog/test/test_renderers.py
+++ b/posthog/test/test_renderers.py
@@ -1,49 +1,60 @@
+import json
+
 from django.test import TestCase
 
-from posthog.renderers import clean_data_for_json
+from posthog.renderers import SafeJSONRenderer
 
 
 class TestCleanDataForJSON(TestCase):
     def test_cleans_dict_with_nan_and_inf_scalars(self):
-        data = {
+        response = {
             "control": 1.0,
             "test_1": float("nan"),
             "test_2": float("inf"),
         }
-        top_level_markers = clean_data_for_json(data)
+        data = SafeJSONRenderer().render(response)
 
-        self.assertEqual(top_level_markers, (False, False))
         self.assertDictEqual(
-            data,
+            json.loads(data),
             {
                 "control": 1.0,
                 "test_1": None,
-                "test_1::nan": True,
                 "test_2": None,
-                "test_2::inf": True,
             },
         )
 
     def test_cleans_dict_with_nan_and_inf_list(self):
-        data = {
+        response = {
             "control": 1.0,
             "test": [float("inf"), 1.0, float("nan")],
         }
-        top_level_markers = clean_data_for_json(data)
+        data = SafeJSONRenderer().render(response)
 
-        self.assertEqual(top_level_markers, (False, False))
         self.assertDictEqual(
+            json.loads(data),
             {
                 "control": 1.0,
                 "test": [None, 1.0, None],
-                "test::nan": {2: True},
-                "test::inf": {0: True},
             },
-            data,
+        )
+
+    def test_cleans_dict_with_nan_and_inf_tuple(self):
+        response = {
+            "control": 1.0,
+            "test": (float("inf"), 1.0, float("nan")),
+        }
+        data = SafeJSONRenderer().render(response)
+
+        self.assertDictEqual(
+            json.loads(data),
+            {
+                "control": 1.0,
+                "test": [None, 1.0, None],
+            },
         )
 
     def test_cleans_dict_with_nan_and_inf_nested_list(self):
-        data = {
+        response = {
             "control": 1.0,
             "test": [
                 float("inf"),
@@ -52,31 +63,33 @@ class TestCleanDataForJSON(TestCase):
                 5.0,
             ],
         }
-        top_level_markers = clean_data_for_json(data)
+        data = SafeJSONRenderer().render(response)
 
-        self.assertEqual(top_level_markers, (False, False))
         self.assertDictEqual(
+            json.loads(data),
             {
                 "control": 1.0,
                 "test": [None, [None, None, 1.0], None, 5.0],
-                "test::nan": {1: {1: True}, 2: True},
-                "test::inf": {0: True, 1: {0: True}},
             },
-            data,
         )
 
     def test_cleans_dict_with_nan_nested_dict(self):
-        data = {
+        response = {
             "control": 1.0,
             "test": [{"yup": True, "meh": [], "nope": float("nan")}],
         }
-        top_level_markers = clean_data_for_json(data)
+        data = SafeJSONRenderer().render(response)
 
-        self.assertEqual(top_level_markers, (False, False))
         self.assertDictEqual(
+            json.loads(data),
             {
                 "control": 1.0,
-                "test": [{"yup": True, "meh": [], "nope": None, "nope::nan": True}],
+                "test": [
+                    {
+                        "yup": True,
+                        "meh": [],
+                        "nope": None,
+                    }
+                ],
             },
-            data,
         )

--- a/requirements.in
+++ b/requirements.in
@@ -55,6 +55,7 @@ kombu==5.3.2
 lzstring==1.0.4
 numpy==1.23.3
 openapi-spec-validator==0.7.1
+orjson==3.9.13
 parso==0.8.1
 pexpect==4.7.0
 pickleshare==0.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ aioboto3==12.0.0
 aiobotocore[boto3]==2.7.0
     # via
     #   aioboto3
+    #   aiobotocore
     #   s3fs
 aiohttp==3.9.0
     # via
@@ -252,6 +253,7 @@ giturlparse==0.12.0
     # via dlt
 google-api-core[grpc]==2.11.1
     # via
+    #   google-api-core
     #   google-cloud-bigquery
     #   google-cloud-core
 google-auth==2.22.0
@@ -385,8 +387,10 @@ openapi-schema-validator==0.6.2
     # via openapi-spec-validator
 openapi-spec-validator==0.7.1
     # via -r requirements.in
-orjson==3.9.10
-    # via dlt
+orjson==3.9.13
+    # via
+    #   -r requirements.in
+    #   dlt
 oscrypto==1.3.0
     # via snowflake-connector-python
 outcome==1.1.0
@@ -681,6 +685,7 @@ urllib3[secure,socks]==1.26.18
     #   selenium
     #   sentry-sdk
     #   snowflake-connector-python
+    #   urllib3
 urllib3-secure-extra==0.1.0
     # via urllib3
 vine==5.0.0


### PR DESCRIPTION
## Problem

We still have a problem with inf and nan values in JSON, if they appear in tuples.

## Changes

- we can just swap out the whole JSON serializer 👏🏻 
- use [orjson](https://github.com/ijl/orjson) 🚀 
- it makes nan and inf values `null` by default, no more traversing the whole response with our own loops 🚀 
- it's also anyways faster than standard JSON serialization because Rust 🚀 
- adjusted some dict keys to strings: previously they also got serialized to strings, and now orjson would've complained
- and also added a test for these tuples ^^

## How did you test this code?

- tests
