### PR TITLE
fix: allow spaces when filtering for contains

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -260,7 +260,7 @@ export function PropertyValue({
             }}
             onSelect={(val, option) => {
                 setInput(option.title)
-                setValue(toString(val))
+                setValue(toString(val).trim())
             }}
             ref={autoCompleteRef}
         >

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -115,7 +115,7 @@ export function PropertyValue({
 
     const commonInputProps = {
         onSearch: (newInput: string) => {
-            setInput(newInput.trim())
+            setInput(newInput)
             if (!Object.keys(options).includes(newInput) && !(operator && isOperatorFlag(operator))) {
                 load(newInput.trim())
             }


### PR DESCRIPTION
## Problem

![2024-02-13 at 14 38 57](https://github.com/PostHog/posthog/assets/13001502/adaf7528-d9c0-41ca-b2cd-f1d60b32e3fd)

## Changes

- it will be possible to enter spaces into the filter field for `contains`

## Additional context

https://posthoghelp.zendesk.com/agent/tickets/10461 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/12907)

## How did you test this code?

manually