### PR TITLE
fix: missing flutter semicolon snippet

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -343,7 +343,7 @@ export function FlutterSnippet({ flagKey, multivariant, payload }: FeatureFlagSn
     if (payload) {
         return (
             <CodeSnippet language={Language.Dart} wrap>
-                {`${clientSuffix}getFeatureFlagPayload('${flagKey}')`}
+                {`${clientSuffix}getFeatureFlagPayload('${flagKey}');`}
             </CodeSnippet>
         )
     }


### PR DESCRIPTION
## Problem

I wish https://github.com/dart-lang/language/issues/69

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
