### PR TITLE
feat: support banner experiment

### DIFF
--- a/frontend/src/lib/components/Support/SupportForm.tsx
+++ b/frontend/src/lib/components/Support/SupportForm.tsx
@@ -1,4 +1,11 @@
-import { LemonInput, LemonSegmentedButton, LemonSegmentedButtonOption, lemonToast, Link } from '@posthog/lemon-ui'
+import {
+    LemonBanner,
+    LemonInput,
+    LemonSegmentedButton,
+    LemonSegmentedButtonOption,
+    lemonToast,
+    Link,
+} from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { useUploadFiles } from 'lib/hooks/useUploadFiles'
@@ -7,6 +14,7 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonFileInput } from 'lib/lemon-ui/LemonFileInput/LemonFileInput'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect/LemonSelect'
 import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea/LemonTextArea'
+import posthog from 'posthog-js'
 import { useEffect, useRef } from 'react'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { userLogic } from 'scenes/userLogic'
@@ -93,6 +101,40 @@ export function SupportForm(): JSX.Element | null {
                     }))}
                 />
             </LemonField>
+            {posthog.getFeatureFlag('show-troubleshooting-docs-in-support-form') === 'test-replay-banner' &&
+                sendSupportRequest.target_area === 'session_replay' && (
+                    <LemonBanner type="info">
+                        <>
+                            We're pretty proud of our docs. Check out these helpful links:
+                            <ul>
+                                <li>
+                                    <Link target="_blank" to="https://posthog.com/docs/session-replay/troubleshooting">
+                                        Session replay troubleshooting
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link
+                                        target="_blank"
+                                        to="https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record"
+                                    >
+                                        How to control which sessions you record
+                                    </Link>
+                                </li>
+                            </ul>
+                        </>
+                    </LemonBanner>
+                )}
+            {posthog.getFeatureFlag('show-troubleshooting-docs-in-support-form') === 'test-replay-banner' &&
+                sendSupportRequest.target_area === 'toolbar' && (
+                    <LemonBanner type="info">
+                        <>
+                            We're pretty proud of our docs.{' '}
+                            <Link target="_blank" to="https://posthog.com/docs/toolbar#troubleshooting-and-faq">
+                                Check out this troubleshooting guide
+                            </Link>
+                        </>
+                    </LemonBanner>
+                )}
             <LemonField name="severity_level" label="What is the severity of this issue?">
                 <LemonSelect
                     fullWidth


### PR DESCRIPTION
We want to test the impact of sharing links to information we commonly share in support tickets in the support form

This sets up the feature flag code for that
 
![2024-02-13 22 04 26](https://github.com/PostHog/posthog/assets/984817/e0760b05-dfd3-4ccf-af7a-228a72d529d3)
