### PR TITLE
fix: toolbar selector fangling

### DIFF
--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -2,7 +2,7 @@ import './Elements.scss'
 
 import { useActions, useValues } from 'kea'
 import { compactNumber } from 'lib/utils'
-import React from 'react'
+import { Fragment } from 'react'
 
 import { ElementInfoWindow } from '~/toolbar/elements/ElementInfoWindow'
 import { elementsLogic } from '~/toolbar/elements/elementsLogic'
@@ -75,7 +75,7 @@ export function Elements(): JSX.Element {
 
                 {heatmapElements.map(({ rect, count, clickCount, rageclickCount, element }, index) => {
                     return (
-                        <React.Fragment key={`heatmap-${index}`}>
+                        <Fragment key={`heatmap-${index}`}>
                             <HeatmapElement
                                 rect={rect}
                                 style={{
@@ -155,7 +155,7 @@ export function Elements(): JSX.Element {
                                     {compactNumber(rageclickCount)}&#128545;
                                 </HeatmapLabel>
                             )}
-                        </React.Fragment>
+                        </Fragment>
                     )
                 })}
 

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -2,7 +2,6 @@ import { finder } from '@medv/finder'
 import { CLICK_TARGET_SELECTOR, CLICK_TARGETS, escapeRegex, TAGS_TO_IGNORE } from 'lib/actionUtils'
 import { cssEscape } from 'lib/utils/cssEscape'
 import { querySelectorAllDeep } from 'query-selector-shadow-dom'
-import wildcardMatch from 'wildcard-match'
 
 import { ActionStepForm, BoxColor, ElementRect } from '~/toolbar/types'
 import { ActionStepType, StringMatching } from '~/types'
@@ -43,9 +42,13 @@ export function elementToQuery(element: HTMLElement, dataAttributes: string[]): 
 
     try {
         return finder(element, {
-            attr: (name) => dataAttributes.some((dataAttribute) => wildcardMatch(dataAttribute)(name)),
             tagName: (name) => !TAGS_TO_IGNORE.includes(name),
             seedMinLength: 5, // include several selectors e.g. prefer .project-homepage > .project-header > .project-title over .project-title
+            attr: (name) => {
+                // preference to data attributes if they exist
+                // that aren't in the PostHog preferred list - they were returned early above
+                return name.startsWith('data-')
+            },
         })
     } catch (error) {
         console.warn('Error while trying to find a selector for element', element, error)

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@floating-ui/react": "^0.16.0",
         "@lottiefiles/react-lottie-player": "^3.4.7",
-        "@medv/finder": "^2.1.0",
+        "@medv/finder": "^3.1.0",
         "@microlink/react-json-view": "^1.21.3",
         "@monaco-editor/react": "4.4.6",
         "@posthog/icons": "0.5.1",
@@ -173,7 +173,6 @@
         "tailwindcss": "^3.4.0",
         "use-debounce": "^9.0.3",
         "use-resize-observer": "^8.0.0",
-        "wildcard-match": "^5.1.2",
         "zxcvbn": "^4.4.2"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ dependencies:
     specifier: ^3.4.7
     version: 3.4.7(react@18.2.0)
   '@medv/finder':
-    specifier: ^2.1.0
-    version: 2.1.0
+    specifier: ^3.1.0
+    version: 3.1.0
   '@microlink/react-json-view':
     specifier: ^1.21.3
     version: 1.22.2(@types/react@17.0.52)(react-dom@18.2.0)(react@18.2.0)
@@ -340,9 +340,6 @@ dependencies:
   use-resize-observer:
     specifier: ^8.0.0
     version: 8.0.0(react-dom@18.2.0)(react@18.2.0)
-  wildcard-match:
-    specifier: ^5.1.2
-    version: 5.1.2
   zxcvbn:
     specifier: ^4.4.2
     version: 4.4.2
@@ -4921,8 +4918,8 @@ packages:
       react: 18.2.0
     dev: true
 
-  /@medv/finder@2.1.0:
-    resolution: {integrity: sha512-Egrg5XO4kLol24b1Kv50HDfi5hW0yQ6aWSsO0Hea1eJ4rogKElIN0M86FdVnGF4XIGYyA7QWx0MgbOzVPA0qkA==}
+  /@medv/finder@3.1.0:
+    resolution: {integrity: sha512-ojkXjR3K0Zz3jnCR80tqPL+0yvbZk/lEodb6RIVjLz7W8RVA2wrw8ym/CzCpXO9SYVUIKHFUpc7jvf8UKfIM3w==}
     dev: false
 
   /@microlink/react-json-view@1.22.2(@types/react@17.0.52)(react-dom@18.2.0)(react@18.2.0):
@@ -21382,10 +21379,6 @@ packages:
     dependencies:
       isexe: 2.0.0
     dev: true
-
-  /wildcard-match@5.1.2:
-    resolution: {integrity: sha512-qNXwI591Z88c8bWxp+yjV60Ch4F8Riawe3iGxbzquhy8Xs9m+0+SLFBGb/0yCTIDElawtaImC37fYZ+dr32KqQ==}
-    dev: false
 
   /wildcard@2.0.0:
     resolution: {integrity: sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==}


### PR DESCRIPTION
When choosing a selector in the toolbar we prefer those set in project settings

<img width="997" alt="Screenshot 2024-02-13 at 22 28 34" src="https://github.com/PostHog/posthog/assets/984817/af5ef4e4-ad21-412e-bc22-c4faaa5ae21b">

But if one of those isn't present - we then also only suggest those when choosing a unique selector... wat - that doesn't make sense. If one of those is present we won't hit the uniquifier

----

* This upgrades the medv/finder library because why not
* and switches so that if there isn't a data attribute we can short circuit to choose we'll prefer data attributes when they're present


Tested by checking we could still generate other types of selectors and seeing it prefer a data attribute when present

![2024-02-13 22 42 17](https://github.com/PostHog/posthog/assets/984817/a8519e00-1476-40e6-acd4-58d6dda17151)

