### PR TITLE
refactor(insights): Improve clarity of async querying and timeout handling

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -10,6 +10,7 @@ from rest_framework.exceptions import ValidationError, NotAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import capture_exception
+from rest_framework import status
 
 from posthog.api.documentation import extend_schema
 from posthog.api.mixins import PydanticModelMixin
@@ -64,7 +65,7 @@ class QueryViewSet(PydanticModelMixin, TeamAndOrgViewSetMixin, viewsets.ViewSet)
                 query_id=client_query_id,
                 refresh_requested=data.refresh,
             )
-            return Response(query_status.model_dump())
+            return Response(query_status.model_dump(), status=status.HTTP_202_ACCEPTED)
 
         tag_queries(query=request.data["query"])
         try:

--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -155,6 +155,30 @@
                     allow_experimental_object_type=1
   '''
 # ---
+# name: TestQuery.test_full_hogql_query_async
+  '''
+  /* user_id:971 celery:posthog.tasks.tasks.process_query_task */
+  SELECT events.uuid AS uuid,
+         events.event AS event,
+         events.properties AS properties,
+         toTimeZone(events.timestamp, 'UTC') AS timestamp,
+         events.distinct_id AS distinct_id,
+         events.elements_chain AS elements_chain,
+         toTimeZone(events.created_at, 'UTC') AS created_at,
+         events.`$session_id` AS `$session_id`,
+         events.`$group_0` AS `$group_0`,
+         events.`$group_1` AS `$group_1`,
+         events.`$group_2` AS `$group_2`,
+         events.`$group_3` AS `$group_3`,
+         events.`$group_4` AS `$group_4`
+  FROM events
+  WHERE equals(events.team_id, 2)
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=600,
+                    allow_experimental_object_type=1
+  '''
+# ---
 # name: TestQuery.test_full_hogql_query_materialized
   '''
   /* user_id:0 request:_snapshot_ */

--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -157,7 +157,7 @@
 # ---
 # name: TestQuery.test_full_hogql_query_async
   '''
-  /* user_id:971 celery:posthog.tasks.tasks.process_query_task */
+  /* user_id:459 celery:posthog.tasks.tasks.process_query_task */
   SELECT events.uuid AS uuid,
          events.event AS event,
          events.properties AS properties,

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -40,11 +40,6 @@ from posthog.queries.stickiness import Stickiness
 from posthog.queries.trends.trends import Trends
 from posthog.types import FilterType
 
-# ClickHouse query timeout in seconds
-# From https://github.com/PostHog/posthog-cloud-infra/blob/master/ansible/config/clickhouse-users.xml#L11
-# Keep in sync with the above!
-CLICKHOUSE_MAX_EXECUTION_TIME = 180
-
 CACHE_TYPE_TO_INSIGHT_CLASS = {
     CacheType.TRENDS: Trends,
     CacheType.STICKINESS: Stickiness,

--- a/posthog/caching/insights_api.py
+++ b/posthog/caching/insights_api.py
@@ -112,7 +112,7 @@ def _is_refresh_currently_running_somewhere_else(caching_state: Optional[Insight
         # A refresh must have been queued at some point in the past
         and caching_state.last_refresh_queued_at is not None
         # That point was recent enough that the query might still be running
-        and caching_state.last_refresh_queued_at > now - timedelta(seconds=CLICKHOUSE_MAX_EXECUTION_TIME)
+        and caching_state.last_refresh_queued_at > now - CLICKHOUSE_MAX_EXECUTION_TIME
         # And refreshing must have either never finished or last finished before it was queued now
         and (caching_state.last_refresh is None or caching_state.last_refresh < caching_state.last_refresh_queued_at)
     ):

--- a/posthog/caching/insights_api.py
+++ b/posthog/caching/insights_api.py
@@ -20,7 +20,7 @@ or not to refresh an insight upon a client request to do so
 
 # ClickHouse query timeout in seconds
 # From https://github.com/PostHog/posthog-cloud-infra/blob/master/ansible/config/clickhouse-users.xml#L11
-# Keep in sync with the above!
+# Keep in sync with the above! And note that this doesn't hold for async queries (which are flagged as of Feb 2023)
 CLICKHOUSE_MAX_EXECUTION_TIME = timedelta(seconds=180)
 
 # Default minimum wait time for refreshing an insight

--- a/posthog/caching/insights_api.py
+++ b/posthog/caching/insights_api.py
@@ -6,7 +6,6 @@ import zoneinfo
 from rest_framework import request
 
 from posthog.caching.calculate_results import (
-    CLICKHOUSE_MAX_EXECUTION_TIME,
     calculate_cache_key,
 )
 from posthog.caching.insight_caching_state import InsightCachingState
@@ -18,6 +17,11 @@ from posthog.utils import refresh_requested_by_client
 Utilities used by the insights API to determine whether
 or not to refresh an insight upon a client request to do so
 """
+
+# ClickHouse query timeout in seconds
+# From https://github.com/PostHog/posthog-cloud-infra/blob/master/ansible/config/clickhouse-users.xml#L11
+# Keep in sync with the above!
+CLICKHOUSE_MAX_EXECUTION_TIME = timedelta(seconds=180)
 
 # Default minimum wait time for refreshing an insight
 BASE_MINIMUM_INSIGHT_REFRESH_INTERVAL = timedelta(minutes=15)

--- a/posthog/caching/test/test_should_refresh_insight.py
+++ b/posthog/caching/test/test_should_refresh_insight.py
@@ -155,7 +155,7 @@ class TestShouldRefreshInsight(ClickhouseTestMixin, BaseTest):
             # earlier than the recent refresh has been queued
             last_refresh_queued_at=datetime.now(tz=ZoneInfo("UTC"))
             - CLICKHOUSE_MAX_EXECUTION_TIME
-            - timedelta(seconds=0.5),  # Half a second before timeout
+            + timedelta(seconds=0.5),  # Half a second before latest possible timeout
         )
 
         should_refresh_now, _ = should_refresh_insight(insight, None, request=self.refresh_request)


### PR DESCRIPTION
## Changes

Finally dove into how the async queries system works and cleaned a few small things up along the way. The only behavioral change is that we'll now return HTTP code 202 for async queries, which is more correct semantically: it means "the request has been accepted but you'll have to check back for results", differently from 200 which means "OK, here are the results".

## How did you test this code?

No behavior changes, except for the 202 one – I couldn't find an existing test for async query requests though, let me know where to put one in so that the 202 behavior is codified.