### PR TITLE
fix: Fix baked-in commit SHA in simplified version

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -33,11 +33,6 @@ jobs:
               with:
                   fetch-depth: 2
 
-            - name: Override git.py
-              run: >
-                  echo "def get_git_commit(): return '${GITHUB_SHA}'" > posthog/git.py
-                  echo "def get_git_branch(): return '${GITHUB_REF_NAME}'" >> posthog/git.py
-
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v2
 

--- a/posthog/git.py
+++ b/posthog/git.py
@@ -1,7 +1,14 @@
 import subprocess
 from typing import Optional
 
-# In production images, the two functions below are overwritten by container-images-cd.yml
+_git_commit_baked_in: Optional[str] = None
+try:
+    # Docker containers should have a commit.txt file in the base directory with the git
+    # commit hash used to generate them.
+    with open("commit.txt") as f:
+        _git_commit_baked_in = f.read()
+except FileNotFoundError:
+    pass
 
 
 def get_git_commit() -> Optional[str]:
@@ -9,6 +16,8 @@ def get_git_commit() -> Optional[str]:
 
     Example: get_git_commit() => "4ff54c8d"
     """
+    if _git_commit_baked_in:
+        return _git_commit_baked_in
     try:
         return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("utf-8").strip()
     except Exception:

--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -9,6 +9,7 @@ from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
+from posthog.git import get_git_commit
 
 from posthog.settings import get_from_env
 from posthog.settings.base_variables import TEST
@@ -143,15 +144,7 @@ def sentry_init() -> None:
         sentry_logging = LoggingIntegration(level=sentry_logging_level, event_level=None)
         profiles_sample_rate = get_from_env("SENTRY_PROFILES_SAMPLE_RATE", type_cast=float, default=0.0)
 
-        release = None
-        try:
-            # Docker containers should have a commit.txt file in the base directory with the git
-            # commit hash used to generate them.
-            with open("commit.txt") as f:
-                release = f.read()
-        except:
-            # The release isn't required, it's just nice to have.
-            pass
+        release = get_git_commit()
 
         sentry_sdk.init(
             send_default_pii=send_pii,


### PR DESCRIPTION
## Problem

David brought to my attention that the baked-in commit SHA hasn't been working recently, e.g. in the instance panel:

<img width="536" alt="Screenshot 2024-02-14 at 17 03 05" src="https://github.com/PostHog/posthog/assets/4550621/d9a2ee71-2329-4454-8741-4b8d04781870">

## Changes

This has been the case since #19900, although I'm not sure why. What this PR does however is simply get rid of the whole "overwriting git.py (previously gitsha.py)" mechanism, by relying on what we've been using for Sentry for some time: `commit.txt`.