### PR TITLE
fix: CORS requests when Origin is invalid or null

### DIFF
--- a/posthog/test/test_utils_cors.py
+++ b/posthog/test/test_utils_cors.py
@@ -15,7 +15,7 @@ class TestCorsResponse(TestCase):
             ("my-amazing.site", "*"),
             ("my-amazing.site/path", "*"),
             ("null", "*"),
-            ("", "*"),
+            ("", None),
         ]
 
         FakeRequest = namedtuple("FakeRequest", "META")
@@ -24,6 +24,6 @@ class TestCorsResponse(TestCase):
                 request = FakeRequest(META={"HTTP_ORIGIN": origin})
                 self.assertEqual(
                     expected,
-                    cors_response(request, {})["Access-Control-Allow-Origin"],
+                    cors_response(request, {}).get("Access-Control-Allow-Origin"),
                     msg=f"with origin='{origin}', actual did not equal {expected}",
                 )

--- a/posthog/test/test_utils_cors.py
+++ b/posthog/test/test_utils_cors.py
@@ -1,0 +1,29 @@
+from collections import namedtuple
+from django.test import TestCase
+
+from posthog.utils_cors import cors_response
+
+
+class TestCorsResponse(TestCase):
+    def test_origin(self) -> None:
+        valid_origin_test_cases = [
+            ("https://my-amazing.site", "https://my-amazing.site"),
+            ("https://my-amazing.site/", "https://my-amazing.site"),
+            ("https://my-amazing.site/my/path", "https://my-amazing.site"),
+            ("http://my-amazing.site/my/path", "http://my-amazing.site"),
+            ("https://us.posthog.com/decide", "https://us.posthog.com"),
+            ("my-amazing.site", "*"),
+            ("my-amazing.site/path", "*"),
+            ("null", "*"),
+            ("", "*"),
+        ]
+
+        FakeRequest = namedtuple("Request", "META")
+        for origin, expected in valid_origin_test_cases:
+            with self.subTest():
+                request = FakeRequest(META={"HTTP_ORIGIN": origin})
+                self.assertEqual(
+                    expected,
+                    cors_response(request, {})["Access-Control-Allow-Origin"],
+                    msg=f"with origin='{origin}', actual did not equal {expected}",
+                )

--- a/posthog/test/test_utils_cors.py
+++ b/posthog/test/test_utils_cors.py
@@ -18,7 +18,7 @@ class TestCorsResponse(TestCase):
             ("", "*"),
         ]
 
-        FakeRequest = namedtuple("Request", "META")
+        FakeRequest = namedtuple("FakeRequest", "META")
         for origin, expected in valid_origin_test_cases:
             with self.subTest():
                 request = FakeRequest(META={"HTTP_ORIGIN": origin})

--- a/posthog/utils_cors.py
+++ b/posthog/utils_cors.py
@@ -15,7 +15,10 @@ def cors_response(request, response):
     if not request.META.get("HTTP_ORIGIN"):
         return response
     url = urlparse(request.META["HTTP_ORIGIN"])
-    response["Access-Control-Allow-Origin"] = f"{url.scheme}://{url.netloc}"
+    if url.netloc == "":
+        response["Access-Control-Allow-Origin"] = "*"
+    else:
+        response["Access-Control-Allow-Origin"] = f"{url.scheme}://{url.netloc}"
     response["Access-Control-Allow-Credentials"] = "true"
     response["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
 


### PR DESCRIPTION
## Problem

In some situations (such as calling posthog from within an iframe) the Origin header can be "null" or otherwise invalid

In these situations we can't echo back the requested origin so we need to send * instead

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
