### PR TITLE
fix(insights): Add POST to sharing token authentication

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -574,7 +574,7 @@ class InsightViewSet(
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["short_id", "created_by"]
     include_in_docs = True
-    sharing_enabled_actions = ["retrieve", "list"]
+    sharing_enabled_actions = ["retrieve", "list", "trend", "funnel", "retention", "path", "timing"]
 
     retention_query_class = Retention
     stickiness_query_class = Stickiness

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -192,18 +192,19 @@ class SharingAccessTokenAuthentication(authentication.BaseAuthentication):
     sharing_configuration: SharingConfiguration
 
     def authenticate(self, request: Union[HttpRequest, Request]) -> Optional[Tuple[Any, Any]]:
+        if request.method not in ("POST", "GET", "HEAD"):
+            raise AuthenticationFailed(detail="Sharing access token cannot be used with this request method.")
+
         if sharing_access_token := request.GET.get("sharing_access_token"):
-            if request.method not in ["GET", "HEAD"]:
-                raise AuthenticationFailed(detail="Sharing access token can only be used for GET requests.")
             try:
                 sharing_configuration = SharingConfiguration.objects.get(
                     access_token=sharing_access_token, enabled=True
                 )
             except SharingConfiguration.DoesNotExist:
                 raise AuthenticationFailed(detail="Sharing access token is invalid.")
-            else:
-                self.sharing_configuration = sharing_configuration
-                return (AnonymousUser(), None)
+
+            self.sharing_configuration = sharing_configuration
+            return AnonymousUser(), None
         return None
 
 

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -192,10 +192,10 @@ class SharingAccessTokenAuthentication(authentication.BaseAuthentication):
     sharing_configuration: SharingConfiguration
 
     def authenticate(self, request: Union[HttpRequest, Request]) -> Optional[Tuple[Any, Any]]:
-        if request.method not in ("POST", "GET", "HEAD"):
-            raise AuthenticationFailed(detail="Sharing access token cannot be used with this request method.")
-
         if sharing_access_token := request.GET.get("sharing_access_token"):
+            if request.method not in ("POST", "GET", "HEAD"):
+                raise AuthenticationFailed(detail="Sharing access token cannot be used with this request method.")
+
             try:
                 sharing_configuration = SharingConfiguration.objects.get(
                     access_token=sharing_access_token, enabled=True


### PR DESCRIPTION
## Problem

We haven't thought of GET requests with an access token in https://github.com/PostHog/posthog/pull/19859

Closes #20355 

## Changes

- make it possible with POST as well, since we have permissions checks anyways

## How did you test this code?

- not sure... cannot reproduce locally 😅 