### PR TITLE
fix(data-warehouse): Added .dlt foider to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ upgrade/
 hogvm/typescript/dist
 .wokeignore
 plugin-transpiler/dist
+.dlt


### PR DESCRIPTION
## Problem
- After doing a data warehouse load, the [`dlt`](https://pypi.org/project/dlt/) package creates a bunch of files that weren't ignored from git

## Changes
- Add the `.dlt` folder to gitignore
