### PR TITLE
fix: don't load recordings we know we'll skip

### DIFF
--- a/ee/session_recordings/ai/generate_embeddings.py
+++ b/ee/session_recordings/ai/generate_embeddings.py
@@ -66,7 +66,7 @@ def fetch_recordings_without_embeddings(team: Team | int, offset=0) -> List[str]
                 from
                     events
                 where
-                    team_id = 2
+                    team_id = %(team_id)s
                     -- don't load all data for all time
                     and timestamp > now() - INTERVAL 7 DAY
                     and timestamp < now()


### PR DESCRIPTION
We have to have events in order to generate embedddings, lets not load a recording from clickhouse, only to try and load events that don't exist and then skip it

We're not storing any state for the embedding generation so we'd just endlessly reprocess invalid recordings 😅 