### PR TITLE
fix: only get org invites if an org exists

### DIFF
--- a/frontend/src/scenes/settings/organization/inviteLogic.ts
+++ b/frontend/src/scenes/settings/organization/inviteLogic.ts
@@ -62,7 +62,9 @@ export const inviteLogic = kea<inviteLogicType>([
             [] as OrganizationInviteType[],
             {
                 loadInvites: async () => {
-                    return (await api.get('api/organizations/@current/invites/')).results
+                    return organizationLogic.values.currentOrganization
+                        ? (await api.get('api/organizations/@current/invites/')).results
+                        : []
                 },
                 deleteInvite: async (invite: OrganizationInviteType) => {
                     await api.delete(`api/organizations/@current/invites/${invite.id}/`)


### PR DESCRIPTION
## Problem

Any time you go to the signup page there is this error:

<img width="451" alt="image" src="https://github.com/PostHog/posthog/assets/18598166/28edbc6e-6443-4b0a-8730-7cd9e99352df">

I'm not entirely sure why this is happening, I can't reproduce it locally. It seems like this logic should never be mounting if someone is unauth'd, but it is being mounted somewhere, and thus it's trying to load invites. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Only get org invites if an org exists. Seems like a possible solution? I have no idea if it works because I can't reproduce locally..

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
