### PR TITLE
fix: Set nginx unit max body size to 21MiB

### DIFF
--- a/unit.json
+++ b/unit.json
@@ -1,6 +1,8 @@
 {
     "settings": {
-        "max_body_size": 22020096
+        "http": {
+            "max_body_size": 22020096
+        }
     },
     "listeners": {
         "*:8000": {

--- a/unit.json
+++ b/unit.json
@@ -1,4 +1,7 @@
 {
+    "settings": {
+        "max_body_size": 22020096
+    },
     "listeners": {
         "*:8000": {
             "pass": "applications/posthog"


### PR DESCRIPTION
## Problem

We expect up to 20M for session replays. Our nginx setup has 20M as the limit and the default for nginx unit inadvertently dropped it to 8M

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
