### PR TITLE
feat(HogQL): Add support for JSONExtract

### DIFF
--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -484,6 +484,7 @@ HOGQL_CLICKHOUSE_FUNCTIONS: Dict[str, HogQLFunctionMeta] = {
     "JSONLength": HogQLFunctionMeta("JSONLength", 1, None),
     "JSONArrayLength": HogQLFunctionMeta("JSONArrayLength", 1, None),
     "JSONType": HogQLFunctionMeta("JSONType", 1, None),
+    "JSONExtract": HogQLFunctionMeta("JSONExtract", 1, None),
     "JSONExtractUInt": HogQLFunctionMeta("JSONExtractUInt", 1, None),
     "JSONExtractInt": HogQLFunctionMeta("JSONExtractInt", 1, None),
     "JSONExtractFloat": HogQLFunctionMeta("JSONExtractFloat", 1, None),


### PR DESCRIPTION
## Problem

I want to be able to use `JSONExtract` https://clickhouse.com/docs/en/sql-reference/functions/json-functions#jsonextractjson-indices_or_keys-return_type
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
