### PR TITLE
fix: `createEventsToDropByToken` should handle tokens with multiple separators

### DIFF
--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -60,7 +60,9 @@ export function createEventsToDropByToken(eventsToDropByTokenStr?: string): Map<
     const eventsToDropByToken: Map<string, string[]> = new Map()
     if (eventsToDropByTokenStr) {
         eventsToDropByTokenStr.split(',').forEach((pair) => {
-            const [token, distinctID] = pair.split(':')
+            const separatorIndex = pair.indexOf(':')
+            const token = pair.substring(0, separatorIndex)
+            const distinctID = pair.substring(separatorIndex + 1)
             eventsToDropByToken.set(token, [...(eventsToDropByToken.get(token) || []), distinctID])
         })
     }

--- a/plugin-server/tests/utils/db/hub.test.ts
+++ b/plugin-server/tests/utils/db/hub.test.ts
@@ -1,0 +1,10 @@
+import { createEventsToDropByToken } from '../../../src/utils/db/hub'
+
+describe('createEventsToDropByToken', () => {
+    it('should split tokens on comma', () => {
+        expect(createEventsToDropByToken('x:y,x:z')).toEqual(new Map([['x', ['y', 'z']]]))
+    })
+    it('handles events with duplicate separators', () => {
+        expect(createEventsToDropByToken('x:a,x:y:z,x:b')).toEqual(new Map([['x', ['a', 'y:z', 'b']]]))
+    })
+})


### PR DESCRIPTION
## Problem

We can't currently drop tokens with multiple `:` in them.

## How did you test this code?

Added tests.