### PR TITLE
chore(dev): add hogql imports to shell plus

### DIFF
--- a/posthog/settings/shell_plus.py
+++ b/posthog/settings/shell_plus.py
@@ -17,4 +17,7 @@ SHELL_PLUS_POST_IMPORTS = [
     ("posthog.models.filters", ("Filter",)),
     ("posthog.models.property", ("Property",)),
     ("posthog.client", ("sync_execute",)),
+    ("posthog.hogql", ("ast")),
+    ("posthog.hogql.parser", ("parse_select", "parse_expr")),
+    ("posthog.hogql.query", ("execute_hogql_query")),
 ]


### PR DESCRIPTION
## Problem

I've been using these imports frequently when building/debugging HogQL insights.

## Changes

This PR adds (automatic) imports for select HogQL methods to shell plus.

## How did you test this code?

Parsed a query without importing in shell plus