### PR TITLE
fix: show modals outside of full screen

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerMetaLinks.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMetaLinks.tsx
@@ -46,7 +46,7 @@ function PinToPlaylistButton(): JSX.Element {
 
 export function PlayerMetaLinks(): JSX.Element {
     const { sessionRecordingId, logicProps } = useValues(sessionRecordingPlayerLogic)
-    const { setPause, deleteRecording } = useActions(sessionRecordingPlayerLogic)
+    const { setPause, deleteRecording, setIsFullScreen } = useActions(sessionRecordingPlayerLogic)
     const nodeLogic = useNotebookNode()
     const { closeSessionPlayer } = useActions(sessionPlayerModalLogic())
 
@@ -58,6 +58,7 @@ export function PlayerMetaLinks(): JSX.Element {
 
     const onShare = (): void => {
         setPause()
+        setIsFullScreen(false)
         openPlayerShareDialog({
             seconds: getCurrentPlayerTime(),
             id: sessionRecordingId,
@@ -65,6 +66,7 @@ export function PlayerMetaLinks(): JSX.Element {
     }
 
     const onDelete = (): void => {
+        setIsFullScreen(false)
         LemonDialog.open({
             title: 'Delete recording',
             description: 'Are you sure you want to delete this recording? This cannot be undone.',


### PR DESCRIPTION
## Problem

We were opening Lemon confirmation dialogs outside of the full screen context

## Changes

Close the full screen before showing the dialogs

## How did you test this code?

|Before|After|
|----|----|
| https://github.com/PostHog/posthog/assets/6685876/00c0fdcb-7347-4d8a-94e5-bf5a086a3ed0 | https://github.com/PostHog/posthog/assets/6685876/d5b8b484-5028-47f4-a9e3-3404d5923d37 |