### PR TITLE
fix(insights): Fix math selector dropdown arrow

### DIFF
--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -221,53 +221,59 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
             )}
             <FloatingPortal root={floatingContainer}>
                 <CSSTransition in={visible} timeout={50} classNames="Popover-" appear mountOnEnter unmountOnExit>
-                    <PopoverOverlayContext.Provider value={[visible, currentPopoverLevel]}>
-                        <div
-                            className={clsx(
-                                'Popover',
-                                padded && 'Popover--padded',
-                                maxContentWidth && 'Popover--max-content-width',
-                                !isAttached && 'Popover--top-centered',
-                                showArrow && 'Popover--with-arrow',
-                                className
-                            )}
-                            data-placement={effectivePlacement}
-                            ref={(el) => {
-                                setFloatingElement(el)
-                                floatingRef.current = el
-                                if (extraFloatingRef) {
-                                    extraFloatingRef.current = el
-                                }
-                            }}
-                            // eslint-disable-next-line react/forbid-dom-props
-                            style={{
-                                display: middlewareData.hide?.referenceHidden ? 'none' : undefined,
-                                position: strategy,
-                                top,
-                                left,
-                                ...style,
-                            }}
-                            onClick={_onClickInside}
-                            onMouseEnter={onMouseEnterInside}
-                            onMouseLeave={onMouseLeaveInside}
-                            aria-level={currentPopoverLevel}
-                        >
-                            <div className="Popover__box">
-                                {showArrow && isAttached && (
-                                    // Arrow is outside of .Popover__content to avoid affecting :nth-child for content
-                                    <div
-                                        ref={arrowRef}
-                                        className="Popover__arrow"
-                                        // eslint-disable-next-line react/forbid-dom-props
-                                        style={arrowStyle}
-                                    />
+                    <PopoverReferenceContext.Provider value={null /* Resetting the reference, since there's none */}>
+                        <PopoverOverlayContext.Provider value={[visible, currentPopoverLevel]}>
+                            <div
+                                className={clsx(
+                                    'Popover',
+                                    padded && 'Popover--padded',
+                                    maxContentWidth && 'Popover--max-content-width',
+                                    !isAttached && 'Popover--top-centered',
+                                    showArrow && 'Popover--with-arrow',
+                                    className
                                 )}
-                                <ScrollableShadows className="Popover__content" ref={contentRef} direction="vertical">
-                                    {overlay}
-                                </ScrollableShadows>
+                                data-placement={effectivePlacement}
+                                ref={(el) => {
+                                    setFloatingElement(el)
+                                    floatingRef.current = el
+                                    if (extraFloatingRef) {
+                                        extraFloatingRef.current = el
+                                    }
+                                }}
+                                // eslint-disable-next-line react/forbid-dom-props
+                                style={{
+                                    display: middlewareData.hide?.referenceHidden ? 'none' : undefined,
+                                    position: strategy,
+                                    top,
+                                    left,
+                                    ...style,
+                                }}
+                                onClick={_onClickInside}
+                                onMouseEnter={onMouseEnterInside}
+                                onMouseLeave={onMouseLeaveInside}
+                                aria-level={currentPopoverLevel}
+                            >
+                                <div className="Popover__box">
+                                    {showArrow && isAttached && (
+                                        // Arrow is outside of .Popover__content to avoid affecting :nth-child for content
+                                        <div
+                                            ref={arrowRef}
+                                            className="Popover__arrow"
+                                            // eslint-disable-next-line react/forbid-dom-props
+                                            style={arrowStyle}
+                                        />
+                                    )}
+                                    <ScrollableShadows
+                                        className="Popover__content"
+                                        ref={contentRef}
+                                        direction="vertical"
+                                    >
+                                        {overlay}
+                                    </ScrollableShadows>
+                                </div>
                             </div>
-                        </div>
-                    </PopoverOverlayContext.Provider>
+                        </PopoverOverlayContext.Provider>
+                    </PopoverReferenceContext.Provider>
                 </CSSTransition>
             </FloatingPortal>
         </>

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -535,7 +535,8 @@ function useMathSelectorOptions({
     if (mathAvailability !== MathAvailability.ActorsOnly) {
         options.splice(1, 0, {
             value: countPerActorMathTypeShown,
-            label: (
+            label: `Count per user ${COUNT_PER_ACTOR_MATH_DEFINITIONS[countPerActorMathTypeShown].shortName}`,
+            labelInMenu: (
                 <div className="flex items-center gap-2">
                     <span>Count per user</span>
                     <LemonSelect
@@ -562,7 +563,8 @@ function useMathSelectorOptions({
         })
         options.push({
             value: propertyMathTypeShown,
-            label: (
+            label: `Property value ${PROPERTY_MATH_DEFINITIONS[propertyMathTypeShown].shortName}`,
+            labelInMenu: (
                 <div className="flex items-center gap-2">
                     <span>Property value</span>
                     <LemonSelect


### PR DESCRIPTION
## Problem

These arrows [were confusing](https://posthog.slack.com/archives/C04L2CV12V9/p1701800278222049), since they didn't mean anything – they were just an artifact:

<img width="284" alt="Screenshot 2024-02-19 at 12 59 09" src="https://github.com/PostHog/posthog/assets/4550621/359d98f2-9e28-4280-8187-662ce4816e33">

## Changes

I made a change in `Popover.tsx` fixing the unexpected arrows, but thought the buttons-within-buttons were still a bit… too much. Hence I also propose removing that pattern, making the dropdown the only way to choose the aggregation function:

<img width="264" alt="Screenshot 2024-02-19 at 12 57 54" src="https://github.com/PostHog/posthog/assets/4550621/f1969d0b-1f2e-4027-9f53-913fd26d3d6a">
