### PR TITLE
feat: Allow rest hooks to format the message

### DIFF
--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -8,7 +8,7 @@ import { PostgresRouter, PostgresUse } from '../../utils/db/postgres'
 import { trackedFetch } from '../../utils/fetch'
 import { status } from '../../utils/status'
 import { getPropertyValueByPath, stringify } from '../../utils/utils'
-import { AppMetrics } from './app-metrics'
+import { AppMetric, AppMetrics } from './app-metrics'
 import { OrganizationManager } from './organization-manager'
 import { TeamManager } from './team-manager'
 
@@ -303,7 +303,7 @@ export class HookCommander {
             await instrumentWebhookStep('postWebhook', async () => {
                 const webhookRequests = actionMatches
                     .filter((action) => action.post_to_slack)
-                    .map((action) => this.postWebhook(webhookUrl, action, event, team))
+                    .map((action) => this.postWebhook(event, action, team))
                 await Promise.all(webhookRequests).catch((error) =>
                     captureException(error, { tags: { team_id: event.teamId } })
                 )
@@ -312,10 +312,12 @@ export class HookCommander {
 
         if (await this.organizationManager.hasAvailableFeature(team.id, 'zapier')) {
             await instrumentWebhookStep('postRestHook', async () => {
-                const restHooks = actionMatches.map(({ hooks }) => hooks).flat()
+                const restHooks = actionMatches.flatMap((action) => action.hooks.map((hook) => ({ hook, action })))
 
                 if (restHooks.length > 0) {
-                    const restHookRequests = restHooks.map((hook) => this.postRestHook(hook, event))
+                    const restHookRequests = restHooks.map(({ hook, action }) =>
+                        this.postWebhook(event, action, team, hook)
+                    )
                     await Promise.all(restHookRequests).catch((error) =>
                         captureException(error, { tags: { team_id: event.teamId } })
                     )
@@ -344,27 +346,57 @@ export class HookCommander {
         }
     }
 
-    private async postWebhook(
-        webhookUrl: string,
-        action: Action,
-        event: PostIngestionEvent,
-        team: Team
-    ): Promise<void> {
-        const end = webhookProcessStepDuration.labels('messageFormatting').startTimer()
-        const message = this.formatMessage(webhookUrl, action, event, team)
-        end()
+    public async postWebhook(event: PostIngestionEvent, action: Action, team: Team, hook?: Hook): Promise<void> {
+        // Used if no hook is provided
+        const defaultWebhookUrl = team.slack_incoming_webhook
+        // -2 is hardcoded to mean webhooks, -1 for resthooks
+        const SPECIAL_CONFIG_ID = hook ? -1 : -2
+        const partialMetric: AppMetric = {
+            teamId: event.teamId,
+            pluginConfigId: SPECIAL_CONFIG_ID,
+            category: 'webhook',
+            successes: 1,
+        }
 
-        const body = JSON.stringify(message, undefined, 4)
+        const url = hook ? hook.target : defaultWebhookUrl
+        let body: any
+
+        if (!url) {
+            // NOTE: Typically this is covered by the caller already
+            return
+        }
+
+        if (hook) {
+            let sendablePerson: Record<string, any> = {}
+            const { person_id, person_created_at, person_properties, ...data } = event
+            if (person_id) {
+                sendablePerson = {
+                    uuid: person_id,
+                    properties: person_properties,
+                    created_at: person_created_at,
+                }
+            }
+
+            body = {
+                hook: { id: hook.id, event: hook.event, target: hook.target },
+                data: { ...data, person: sendablePerson },
+            }
+        } else {
+            const end = webhookProcessStepDuration.labels('messageFormatting').startTimer()
+            body = this.formatMessage(url, action, event, team)
+            end()
+        }
+
         const enqueuedInRustyHook = await this.rustyHook.enqueueIfEnabledForTeam({
             webhook: {
-                url: webhookUrl,
+                url,
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body,
+                body: JSON.stringify(body, undefined, 4),
             },
             teamId: event.teamId,
-            pluginId: -2, // -2 is hardcoded to mean webhooks
-            pluginConfigId: -2, // -2 is hardcoded to mean webhooks
+            pluginId: SPECIAL_CONFIG_ID,
+            pluginConfigId: SPECIAL_CONFIG_ID, // -2 is hardcoded to mean webhooks
         })
 
         if (enqueuedInRustyHook) {
@@ -376,26 +408,29 @@ export class HookCommander {
         const timeout = setTimeout(() => {
             status.warn(
                 '⌛',
-                `Posting Webhook slow. Timeout warning after ${
-                    slowWarningTimeout / 1000
-                } sec! url=${webhookUrl} team_id=${team.id} event_id=${event.eventUuid}`
+                `Posting Webhook slow. Timeout warning after ${slowWarningTimeout / 1000} sec! url=${url} team_id=${
+                    team.id
+                } event_id=${event.eventUuid}`
             )
         }, slowWarningTimeout)
         try {
             await instrumentWebhookStep('fetch', async () => {
-                const request = await trackedFetch(webhookUrl, {
+                const request = await trackedFetch(url, {
                     method: 'POST',
                     body,
                     headers: { 'Content-Type': 'application/json' },
                     timeout: this.EXTERNAL_REQUEST_TIMEOUT,
                 })
+                // special handling for hooks
+                if (hook && request.status === 410) {
+                    // Delete hook on our side if it's gone on Zapier's
+                    await this.deleteRestHook(hook.id)
+                }
                 if (!request.ok) {
                     status.warn('⚠️', `HTTP status ${request.status} for team ${team.id}`)
                     await this.appMetrics.queueError(
                         {
-                            teamId: event.teamId,
-                            pluginConfigId: -2, // -2 is hardcoded to mean webhooks
-                            category: 'webhook',
+                            ...partialMetric,
                             failures: 1,
                         },
                         {
@@ -405,9 +440,7 @@ export class HookCommander {
                     )
                 } else {
                     await this.appMetrics.queueMetric({
-                        teamId: event.teamId,
-                        pluginConfigId: -2, // -2 is hardcoded to mean webhooks
-                        category: 'webhook',
+                        ...partialMetric,
                         successes: 1,
                     })
                 }
@@ -415,104 +448,7 @@ export class HookCommander {
         } catch (error) {
             await this.appMetrics.queueError(
                 {
-                    teamId: event.teamId,
-                    pluginConfigId: -2, // -2 is hardcoded to mean webhooks
-                    category: 'webhook',
-                    failures: 1,
-                },
-                {
-                    error,
-                    event,
-                }
-            )
-            throw error
-        } finally {
-            clearTimeout(timeout)
-        }
-    }
-
-    public async postRestHook(hook: Hook, event: PostIngestionEvent): Promise<void> {
-        let sendablePerson: Record<string, any> = {}
-        const { person_id, person_created_at, person_properties, ...data } = event
-        if (person_id) {
-            sendablePerson = {
-                uuid: person_id,
-                properties: person_properties,
-                created_at: person_created_at,
-            }
-        }
-
-        const payload = {
-            hook: { id: hook.id, event: hook.event, target: hook.target },
-            data: { ...data, person: sendablePerson },
-        }
-
-        const body = JSON.stringify(payload, undefined, 4)
-        const enqueuedInRustyHook = await this.rustyHook.enqueueIfEnabledForTeam({
-            webhook: {
-                url: hook.target,
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body,
-            },
-            teamId: event.teamId,
-            pluginId: -1, // -1 is hardcoded to mean resthooks
-            pluginConfigId: -1, // -1 is hardcoded to mean resthooks
-        })
-
-        if (enqueuedInRustyHook) {
-            // Rusty-Hook handles it from here, so we're done.
-            return
-        }
-
-        const slowWarningTimeout = this.EXTERNAL_REQUEST_TIMEOUT * 0.7
-        const timeout = setTimeout(() => {
-            status.warn(
-                '⌛',
-                `Posting RestHook slow. Timeout warning after ${slowWarningTimeout / 1000} sec! url=${
-                    hook.target
-                } team_id=${event.teamId} event_id=${event.eventUuid}`
-            )
-        }, slowWarningTimeout)
-        try {
-            const request = await trackedFetch(hook.target, {
-                method: 'POST',
-                body,
-                headers: { 'Content-Type': 'application/json' },
-                timeout: this.EXTERNAL_REQUEST_TIMEOUT,
-            })
-            if (request.status === 410) {
-                // Delete hook on our side if it's gone on Zapier's
-                await this.deleteRestHook(hook.id)
-            }
-            if (!request.ok) {
-                status.warn('⚠️', `Rest hook failed status ${request.status} for team ${event.teamId}`)
-                await this.appMetrics.queueError(
-                    {
-                        teamId: event.teamId,
-                        pluginConfigId: -1, // -1 is hardcoded to mean resthooks
-                        category: 'webhook',
-                        failures: 1,
-                    },
-                    {
-                        error: `Request failed with HTTP status ${request.status}`,
-                        event,
-                    }
-                )
-            } else {
-                await this.appMetrics.queueMetric({
-                    teamId: event.teamId,
-                    pluginConfigId: -1, // -1 is hardcoded to mean resthooks
-                    category: 'webhook',
-                    successes: 1,
-                })
-            }
-        } catch (error) {
-            await this.appMetrics.queueError(
-                {
-                    teamId: event.teamId,
-                    pluginConfigId: -1, // -1 is hardcoded to mean resthooks
-                    category: 'webhook',
+                    ...partialMetric,
                     failures: 1,
                 },
                 {


### PR DESCRIPTION
## Problem

Realised in the current code we have 99% of what we need to offer multiple destination for actions. Part 1 of this is to make the code work basically the same regardless of resthooks or webhooks. Once we have that we just need to modify the UI to create rest hooks rathe than using the action property and walah - multiple configurable webhooks rather than one global one!

## Changes

- [x] Refactors the hooks code as it was almost entirely copy-paste anyways
- [x] Add additional property to hooks to allow the same formatting as before
- [x] Update the UI to only show existing webhook config if it is there, otherwise show the new webhook config
- [ ] Handle removing webhooks when an action gets deleted

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
