### PR TITLE
fix(ui): `PersonDisplay` shouldn't take up full width in table

### DIFF
--- a/frontend/src/scenes/persons/PersonDisplay.tsx
+++ b/frontend/src/scenes/persons/PersonDisplay.tsx
@@ -67,7 +67,7 @@ export function PersonDisplay({
     const notebookNode = useNotebookNode()
 
     let content = (
-        <span className={clsx('flex', 'items-center', isCentered && 'justify-center')}>
+        <span className={clsx('inline-flex items-center', isCentered && 'justify-center')}>
             {withIcon && <PersonIcon person={person} size={typeof withIcon === 'string' ? withIcon : 'md'} />}
             <span className={clsx('ph-no-capture', !noEllipsis && 'truncate')}>{display}</span>
         </span>


### PR DESCRIPTION
## Problem

`PersonDisplay` took up full width when used in tables, so the person popover was unusable:

<img width="820" alt="Screenshot 2024-02-19 at 13 26 12" src="https://github.com/PostHog/posthog/assets/4550621/98e1550b-fe35-489f-b165-8e8aef99da72">

## Changes

The component should now be sized properly:

<img width="820" alt="Screenshot 2024-02-19 at 13 27 30" src="https://github.com/PostHog/posthog/assets/4550621/beac5fa2-3a5a-43ae-9573-ec9d3155b7bb">
