### PR TITLE
chore: Remove deprecated action for triggering PostHog Cloud deployment

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -76,22 +76,6 @@ jobs:
                   app_id: ${{ secrets.DEPLOYER_APP_ID }}
                   private_key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
 
-            - name: Trigger PostHog Cloud deployment
-              # TODO: switch to https://github.com/marketplace/actions/repository-dispatch
-              # as this action is now deprecated.
-              uses: mvasigh/dispatch-action@main
-              with:
-                  token: ${{ steps.deployer.outputs.token }}
-                  repo: posthog-cloud-infra
-                  owner: PostHog
-                  event_type: posthog_cloud_build
-                  message: |
-                      {
-                        "image_tag": "${{ steps.build.outputs.digest }}",
-                        "image_tag_unit": "${{ steps.build.outputs.digest }}",
-                        "context": ${{ toJson(github) }}
-                      }
-
             - name: Trigger PostHog Cloud deployment from Charts
               uses: mvasigh/dispatch-action@main
               with:


### PR DESCRIPTION
## Problem

We are moving the cloud deployments to the charts repo

## Changes

- Do not trigger deployments from cloud infra repo anymore

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
