### PR TITLE
chore(cohorts): make data table read only

### DIFF
--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -252,7 +252,7 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                     minutes.
                                 </div>
                             ) : (
-                                <Query query={query} setQuery={setQuery} />
+                                <Query query={query} setQuery={setQuery} readOnly={true} />
                             )}
                         </div>
                     </>


### PR DESCRIPTION
## Changes

Hide the Reload button and filters from the cohorts data table.

<img width="832" alt="image" src="https://github.com/PostHog/posthog/assets/22996112/d006ad80-d5b3-4f34-98fd-d5d08408a9fe">

This is the simplest solution, but now we also lose the search functionality, which might be useful for quick checks. If we want to keep it, I'd suggest to hide _just_ the Reload button and filtering with CSS.

## How did you test this code?
👀 