### PR TITLE
fix: Pass a buffered reader to aiohttp

### DIFF
--- a/posthog/temporal/batch_exports/http_batch_export.py
+++ b/posthog/temporal/batch_exports/http_batch_export.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime as dt
+import io
 import json
 from dataclasses import dataclass
 
@@ -135,8 +136,13 @@ async def post_json_file_to_url(url, batch_file, session: aiohttp.ClientSession)
     batch_file.seek(0)
 
     headers = {"Content-Type": "application/json"}
-    async with session.post(url, data=batch_file, headers=headers) as response:
+    data_reader = io.BufferedReader(batch_file)
+
+    async with session.post(url, data=data_reader, headers=headers) as response:
         raise_for_status(response)
+
+        data_reader.detach()  # BufferedReader closes the file otherwise.
+
         return response
 
 


### PR DESCRIPTION
## Problem

Http batch exports are not working as aiohttp does not accept `BatchExportTemporaryFile` only io.IOBase (even though we expose the same io.IOBase interface, but aiohttp is not a fan of ducks).
 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Wrap BatchExportTemporaryFile in a io.BufferedReader (remember to detach otherwise the file will be closed).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

~Not sure why tests didn't catch this.~ It's the mocking library. It patches the session object, so we never call the underlying `ClientSession.post`.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
