### PR TITLE
fix(exports): Add backoff to exporter limit if query size exceeded

### DIFF
--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from clickhouse_driver.errors import ServerException
 
-from posthog.exceptions import EstimatedQueryExecutionTimeTooLong
+from posthog.exceptions import EstimatedQueryExecutionTimeTooLong, QuerySizeExceeded
 
 
 class InternalCHQueryError(ServerException):
@@ -49,6 +49,9 @@ def wrap_query_error(err: Exception) -> Exception:
         return EstimatedQueryExecutionTimeTooLong(
             detail=f"{match.group(0)} Try reducing its scope by changing the time range."
         )
+    # Handle syntax error when "max query size exceeded" in the message
+    if "max query size exceeded" in err.message:
+        return QuerySizeExceeded()
 
     # :TRICKY: Return a custom class for every code by looking up the short name and creating a class dynamically.
     if hasattr(err, "code"):

--- a/posthog/exceptions.py
+++ b/posthog/exceptions.py
@@ -43,6 +43,10 @@ class EstimatedQueryExecutionTimeTooLong(APIException):
     default_detail = "Estimated query execution time is too long. Try reducing its scope by changing the time range."
 
 
+class QuerySizeExceeded(APIException):
+    default_detail = "Query size exceeded."
+
+
 class ExceptionContext(TypedDict):
     request: HttpRequest
 

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -22,8 +22,8 @@ from ..exporter import (
 from ...constants import CSV_EXPORT_LIMIT
 from ...hogql.query import LimitContext
 
-CSV_EXPORT_BREAKDOWN_LIMIT_INITIAL = 500
-CSV_EXPORT_BREAKDOWN_LIMIT_LOW = 50  # The lowest limit we want to go to
+CSV_EXPORT_BREAKDOWN_LIMIT_INITIAL = 512
+CSV_EXPORT_BREAKDOWN_LIMIT_LOW = 64  # The lowest limit we want to go to
 
 logger = structlog.get_logger(__name__)
 

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -24,6 +24,7 @@ from posthog.tasks.exports import csv_exporter
 from posthog.tasks.exports.csv_exporter import (
     UnexpectedEmptyJsonResponse,
     add_query_params,
+    CSV_EXPORT_BREAKDOWN_LIMIT_INITIAL,
 )
 from posthog.test.base import APIBaseTest, _create_event, flush_persons_and_events
 from posthog.utils import absolute_uri
@@ -242,7 +243,7 @@ class TestCSVExporter(APIBaseTest):
         mocked_request.assert_called_with(
             method="get",
             url="http://testserver/" + path,
-            params={"breakdown_limit": 200, "is_csv_export": "1"},
+            params={"breakdown_limit": CSV_EXPORT_BREAKDOWN_LIMIT_INITIAL, "is_csv_export": "1"},
             timeout=60,
             json=None,
             headers=ANY,
@@ -274,7 +275,7 @@ class TestCSVExporter(APIBaseTest):
                 csv_exporter.export_csv(exported_asset)
 
             assert patched_make_api_call.call_count == 4
-            patched_make_api_call.assert_called_with(mock.ANY, mock.ANY, 100, mock.ANY, mock.ANY, mock.ANY)
+            patched_make_api_call.assert_called_with(mock.ANY, mock.ANY, 64, mock.ANY, mock.ANY, mock.ANY)
 
     def test_limiting_query_as_expected(self) -> None:
         with self.settings(SITE_URL="https://app.posthog.com"):


### PR DESCRIPTION
## Problem

We are still facing problems when breakdown values are so long that even a lower limit makes queries too long.

## Changes

- make too long queries throw specific error
- make exporter look for this error
- try a lower limit when encountered

## How did you test this code?

- added test