### PR TITLE
fix(persons): Ensure Kafka producer is flushed before exiting when running management commands

### DIFF
--- a/posthog/management/commands/fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/fix_person_distinct_ids_after_delete.py
@@ -6,6 +6,7 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 
 from posthog.client import sync_execute
+from posthog.kafka_client.client import KafkaProducer
 from posthog.models.person import PersonDistinctId
 from posthog.models.person.util import create_person_distinct_id
 
@@ -43,6 +44,10 @@ def run(options, sync: bool = False):
         # since they no longer belong to deleted persons
         # it's safer to throw and exit if anything went wrong
         update_distinct_id(distinct_id, version, team_id, live_run, sync)
+
+    logger.info("Waiting on Kafka producer flush, for up to 5 minutes")
+    KafkaProducer().flush(5 * 60)
+    logger.info("Kafka producer queue flushed.")
 
 
 def get_distinct_ids_tied_to_deleted_persons(team_id: int) -> List[str]:

--- a/posthog/management/commands/sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/sync_persons_to_clickhouse.py
@@ -7,6 +7,7 @@ from django.core.management.base import BaseCommand
 from django.utils.timezone import now
 
 from posthog.client import sync_execute
+from posthog.kafka_client.client import KafkaProducer
 from posthog.models.group.group import Group
 from posthog.models.group.util import raw_create_group_ch
 from posthog.models.person import PersonDistinctId
@@ -67,6 +68,10 @@ def run(options, sync: bool = False):  # sync used for unittests
 
     if options["group"]:
         run_group_sync(team_id, live_run, sync)
+
+    logger.info("Waiting on Kafka producer flush, for up to 5 minutes")
+    KafkaProducer().flush(5 * 60)
+    logger.info("Kafka producer queue flushed.")
 
 
 def run_person_sync(team_id: int, live_run: bool, deletes: bool, sync: bool):


### PR DESCRIPTION
## Problem

The Kafka client that we use doesn't provide any built-in mechanisms for attempting to ensure that the producer buffer is flushed prior to exiting. The [atexit handler](https://github.com/dpkp/kafka-python/blob/5bb126bf20bbb5baeb4e9afc48008dbe411631bc/kafka/producer/kafka.py#L416-L417) stops everything without attempting to wait for any outstanding buffered or in-flight requests to complete. This can lead to lost writes, particularly in cases where the process exits immediately after producing, such as when calling management commands that have the primary intended purpose of writing to Kafka.

## How did you test this code?

0. Start with an empty database (or one you don't care much about trashing.)
1. Load demo data with `DEBUG=1 ./manage.py generate_demo_data`.
2. Create a bunch of deletion records in ClickHouse with:
```
(env) ted@revuelto posthog % DEBUG=1 ./manage.py shell                           
In [1]: from posthog.models import Person
In [2]: from posthog.models.person.util import delete_person
In [3]: [delete_person(p) for p in Person.objects.filter(team_id=1)]
```
3. Run the management commands, e.g. `DEBUG=1 ./manage.py fix_person_distinct_ids_after_delete --team-id 1 --live-run`, observe log output.