### PR TITLE
fix(support): Use a placeholder name if the user has no first name when submitting …

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -233,7 +233,7 @@ export const supportLogic = kea<supportLogicType>([
 
             const payload = {
                 request: {
-                    requester: { name: name, email: email },
+                    requester: { name: name || 'No Name', email: email },
                     subject: subject,
                     custom_fields: [
                         {


### PR DESCRIPTION
## Problem
- For some reason, on occasion, a users first name is not correctly passed through to Zendesk support tickets, and so, the users bug reports are failing and the user gets an error toast
- This is a horrible experience, someone experiences a bug and can't even submit it 

<img width="515" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/4129db4d-4a6d-4e50-a74e-c252faf75ecf">


## Changes
- The correct solution would be to figure out why their first name isn't reaching the support logic code, but from my couple of tests, there's no reason why this should be happening (even though it is)
- Fallback here is to just set the name to `"No Name"` when the zendesk ticket gets submitted - this likely isn't good long-term UX, and the user may get some emails with "No Name" (maybe?), but at least the ticket can get submitted (the lesser of 2 evils here). If need be, their name can be edited within the Zendesk ticket if we notice these coming in
