### PR TITLE
fix(exports): Make exporter return when lowest limit still errors

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -23,7 +23,7 @@ from ...constants import CSV_EXPORT_LIMIT
 from ...hogql.query import LimitContext
 
 CSV_EXPORT_BREAKDOWN_LIMIT_INITIAL = 512
-CSV_EXPORT_BREAKDOWN_LIMIT_LOW = 64  # The lowest limit we want to go to
+CSV_EXPORT_BREAKDOWN_LIMIT_LOW = 32  # The lowest limit we want to go to
 
 logger = structlog.get_logger(__name__)
 
@@ -218,18 +218,22 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int) -> None:
             try:
                 response = make_api_call(access_token, body, limit, method, next_url, path)
             except HTTPError as e:
+                if "Query size exceeded" not in e.response.text:
+                    raise e
+
+                if limit <= CSV_EXPORT_BREAKDOWN_LIMIT_LOW:
+                    break  # Already tried with the lowest limit, so return what we have
+
                 # If error message contains "Query size exceeded", we try again with a lower limit
-                if "Query size exceeded" in e.response.text and limit > CSV_EXPORT_BREAKDOWN_LIMIT_LOW:
-                    limit = int(limit / 2)
-                    logger.warning(
-                        "csv_exporter.query_size_exceeded",
-                        exc=e,
-                        exc_info=True,
-                        response_text=e.response.text,
-                        limit=limit,
-                    )
-                    continue
-                raise e
+                limit = int(limit / 2)
+                logger.warning(
+                    "csv_exporter.query_size_exceeded",
+                    exc=e,
+                    exc_info=True,
+                    response_text=e.response.text,
+                    limit=limit,
+                )
+                continue
 
             # Figure out how to handle funnel polling....
             data = response.json()

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -270,11 +270,10 @@ class TestCSVExporter(APIBaseTest):
             mock_error.response.text = "Query size exceeded"
             patched_make_api_call.side_effect = mock_error
 
-            with pytest.raises(HTTPError, match="Query size exceeded"):
-                csv_exporter.export_csv(exported_asset)
+            csv_exporter.export_csv(exported_asset)
 
-            assert patched_make_api_call.call_count == 4
-            patched_make_api_call.assert_called_with(mock.ANY, mock.ANY, 64, mock.ANY, mock.ANY, mock.ANY)
+            assert patched_make_api_call.call_count == 5
+            patched_make_api_call.assert_called_with(mock.ANY, mock.ANY, 32, mock.ANY, mock.ANY, mock.ANY)
 
     def test_limiting_query_as_expected(self) -> None:
         with self.settings(SITE_URL="https://app.posthog.com"):


### PR DESCRIPTION
## Problem

After #20432 some exports still fail

## Changes

- return what we have if the query is too large at some point

## How did you test this code?

- tests