### PR TITLE
fix(funnels): Dont send the histogram attribute when breaking down a funnel by a nu…

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -107,7 +107,8 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
         addBreakdown: ({ breakdown, taxonomicGroup }) => {
             const breakdownType = taxonomicFilterTypeToPropertyFilterType(taxonomicGroup.type) as BreakdownType
             const propertyDefinitionType = propertyFilterTypeToPropertyDefinitionType(breakdownType)
-            const isHistogramable = !!values.getPropertyDefinition(breakdown, propertyDefinitionType)?.is_numerical
+            const isHistogramable =
+                !!values.getPropertyDefinition(breakdown, propertyDefinitionType)?.is_numerical && props.isTrends
 
             if (!props.updateBreakdownFilter || !breakdownType) {
                 return


### PR DESCRIPTION
## Problem
- When creating a new funnel, if you try to break it down by a numeric property, the funnel will show an error message
- This is because we're sending the `breakdown_histogram_bin_count` property in the query filters due to the property being a numerical value. So, when we try to get the breakdown values from the db, we're trying to cast an array of values to a string, and then to a float, like this: `toFloat64OrNull(toString(array(replaceRegexpAll(JSONExtractRaw(properties, '$browser_version'), '^"|"$', '')))) AS value`
- This just then eventually rolls up to `[NaN]` from the db, which then breaks the funnel query

## Changes
- When querying funnels, don't send the `breakdown_histogram_bin_count` prop to the backend, and all is good with the world again

## How did you test this code?
- DB queries and browser clicks