### PR TITLE
fix(insights): legacy hourly start time

### DIFF
--- a/posthog/queries/properties_timeline/properties_timeline_event_query.py
+++ b/posthog/queries/properties_timeline/properties_timeline_event_query.py
@@ -80,7 +80,7 @@ class PropertiesTimelineEventQuery(EventQuery):
         # We need to explicitly replace tzinfo in those datetimes with the team's timezone, because QueryDateRange
         # does not reliably make those datetimes timezone-aware. That's annoying, but it'd be a significant effort
         # to refactor QueryDateRange fo full timezone awareness - before that happens, it's simpler to override here.
-        self.effective_date_from = query_date_range.date_from_param().replace(tzinfo=effective_timezone)
+        self.effective_date_from = query_date_range.date_from_param.replace(tzinfo=effective_timezone)
         self.effective_date_to = query_date_range.date_to_param.replace(tzinfo=effective_timezone)
         parsed_date_from, date_from_params = query_date_range.date_from
         parsed_date_to, date_to_params = query_date_range.date_to

--- a/posthog/queries/properties_timeline/properties_timeline_event_query.py
+++ b/posthog/queries/properties_timeline/properties_timeline_event_query.py
@@ -80,7 +80,7 @@ class PropertiesTimelineEventQuery(EventQuery):
         # We need to explicitly replace tzinfo in those datetimes with the team's timezone, because QueryDateRange
         # does not reliably make those datetimes timezone-aware. That's annoying, but it'd be a significant effort
         # to refactor QueryDateRange fo full timezone awareness - before that happens, it's simpler to override here.
-        self.effective_date_from = query_date_range.date_from_param.replace(tzinfo=effective_timezone)
+        self.effective_date_from = query_date_range.date_from_param().replace(tzinfo=effective_timezone)
         self.effective_date_to = query_date_range.date_to_param.replace(tzinfo=effective_timezone)
         parsed_date_from, date_from_params = query_date_range.date_from
         parsed_date_to, date_to_params = query_date_range.date_to

--- a/posthog/queries/query_date_range.py
+++ b/posthog/queries/query_date_range.py
@@ -73,6 +73,7 @@ class QueryDateRange:
     def get_earliest_timestamp(self):
         return get_earliest_timestamp(self._team.pk)
 
+    @property
     def date_from_param(self) -> datetime:
         date_from: datetime
         if self._filter._date_from == "all":
@@ -130,7 +131,7 @@ class QueryDateRange:
     @cached_property
     def date_from(self) -> Tuple[str, Dict]:
         date_from_query = self.date_from_clause
-        date_from = self.date_from_param()
+        date_from = self.date_from_param
 
         date_from_param = {
             "date_from": date_from.strftime("%Y-%m-%d %H:%M:%S"),
@@ -175,14 +176,14 @@ class QueryDateRange:
 
     @cached_property
     def delta(self) -> timedelta:
-        return self.date_to_param - self.date_from_param()
+        return self.date_to_param - self.date_from_param
 
     @cached_property
     def num_intervals(self) -> int:
         if not hasattr(self._filter, "interval"):
             return 1
         if self._filter.interval == "month":
-            rel_delta = relativedelta(self.date_to_param, self.date_from_param())
+            rel_delta = relativedelta(self.date_to_param, self.date_from_param)
             return (rel_delta.years * 12) + rel_delta.months + 1
 
         return int(self.delta.total_seconds() / TIME_IN_SECONDS[self._filter.interval]) + 1

--- a/posthog/queries/query_date_range.py
+++ b/posthog/queries/query_date_range.py
@@ -90,7 +90,12 @@ class QueryDateRange:
             date_from = date_from.replace(hour=0, minute=0, second=0, microsecond=0)
 
         # For legacy insights, if filtering by days (e.g. -7d), clamp to the start of the day
-        elif self._filter.interval == "hour" and self._filter._date_from and "d" in self._filter._date_from:
+        elif (
+            hasattr(self._filter, "interval")
+            and self._filter.interval == "hour"
+            and isinstance(self._filter._date_from, str)
+            and "d" in self._filter._date_from
+        ):
             date_from = date_from.replace(hour=0, minute=0, second=0, microsecond=0)
 
         return date_from

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -725,15 +725,15 @@
         FROM
           (SELECT toUInt16(0) AS total,
                   toStartOfHour(toDateTime('2020-01-03 13:59:59', 'UTC')) - toIntervalHour(number) AS day_start
-           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
+           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
            UNION ALL SELECT toUInt16(0) AS total,
-                            toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC'))
+                            toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC'))
            UNION ALL SELECT sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) AS total,
                             toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
            FROM events e
            WHERE team_id = 2
              AND event = 'session start'
-             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC')), 'UTC')
              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:59:59', 'UTC')
            GROUP BY date)
         GROUP BY day_start
@@ -747,15 +747,15 @@
         FROM
           (SELECT toUInt16(0) AS total,
                   toStartOfHour(toDateTime('2020-01-03 13:59:59', 'UTC')) - toIntervalHour(number) AS day_start
-           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
+           FROM numbers(dateDiff('hour', toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC')), toDateTime('2020-01-03 13:59:59', 'UTC')))
            UNION ALL SELECT toUInt16(0) AS total,
-                            toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC'))
+                            toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC'))
            UNION ALL SELECT avg(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'session duration'), '^"|"$', ''))) AS total,
                             toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
            FROM events e
            WHERE team_id = 2
              AND event = 'session start'
-             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 13:05:01', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-02 00:00:00', 'UTC')), 'UTC')
              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-03 13:59:59', 'UTC')
            GROUP BY date)
         GROUP BY day_start

--- a/posthog/queries/trends/test/test_formula.py
+++ b/posthog/queries/trends/test/test_formula.py
@@ -195,7 +195,20 @@ class TestFormula(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             data,
             [
-                1200.0,  # starting at 2020-01-02 13:00 - 24 h before run_at (rounded to start of interval, i.e. hour)
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1200.0,  # 2020-01-02 13:00 - 24 h before run_at (rounded to start of interval, i.e. hour)
                 0.0,
                 0.0,
                 0.0,


### PR DESCRIPTION
## Problem

We've concluded that in the case of a "last 7 days" filter, by hour, we would like to see the last full 7 days. This is implemented in the new insights.

A similar yet different (clamp-in-SQL) fix was implemented to solve the same case with stickiness here: https://github.com/PostHog/posthog/pull/20183

## Changes

Adds this tweak to the old insights.

## How did you test this code?

- Clicked around locally, saw that now both queries returned the same date ranges.
- Used CI to modify the relevant broken test.