### PR TITLE
fix(exports): Adjust lowest exporter limit

### DIFF
--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -157,7 +157,7 @@
 # ---
 # name: TestQuery.test_full_hogql_query_async
   '''
-  /* user_id:462 celery:posthog.tasks.tasks.process_query_task */
+  /* user_id:463 celery:posthog.tasks.tasks.process_query_task */
   SELECT events.uuid AS uuid,
          events.event AS event,
          events.properties AS properties,

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -23,7 +23,7 @@ from ...constants import CSV_EXPORT_LIMIT
 from ...hogql.query import LimitContext
 
 CSV_EXPORT_BREAKDOWN_LIMIT_INITIAL = 512
-CSV_EXPORT_BREAKDOWN_LIMIT_LOW = 32  # The lowest limit we want to go to
+CSV_EXPORT_BREAKDOWN_LIMIT_LOW = 64  # The lowest limit we want to go to
 
 logger = structlog.get_logger(__name__)
 

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -272,8 +272,8 @@ class TestCSVExporter(APIBaseTest):
 
             csv_exporter.export_csv(exported_asset)
 
-            assert patched_make_api_call.call_count == 5
-            patched_make_api_call.assert_called_with(mock.ANY, mock.ANY, 32, mock.ANY, mock.ANY, mock.ANY)
+            assert patched_make_api_call.call_count == 4
+            patched_make_api_call.assert_called_with(mock.ANY, mock.ANY, 64, mock.ANY, mock.ANY, mock.ANY)
 
     def test_limiting_query_as_expected(self) -> None:
         with self.settings(SITE_URL="https://app.posthog.com"):


### PR DESCRIPTION
## Problem

With lowest limit, some customer still never got the export.

## Changes

- trying higher limit again, so at least something returns

## How did you test this code?

- tests