### PR TITLE
refactor(plugin-server): Clean up Person Postgres & Kafka code a little bit

### DIFF
--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -367,15 +367,9 @@ describe('DB', () => {
             expect(updatedPerson.properties).toEqual({ c: 'aaa' })
 
             // verify correct Kafka message was sent
-            const expected_message = generateKafkaPersonUpdateMessage(
-                updateTs,
-                { c: 'aaa' },
-                personDbBefore.team_id,
-                personDbBefore.is_identified,
-                personDbBefore.uuid,
-                1
+            expect(db.kafkaProducer!.queueMessage).toHaveBeenLastCalledWith(
+                generateKafkaPersonUpdateMessage(updatedPerson)
             )
-            expect(db.kafkaProducer!.queueMessage).toHaveBeenLastCalledWith(expected_message)
         })
     })
 

--- a/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
+++ b/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
@@ -78,13 +78,16 @@ describe('postgres parity', () => {
         await delayUntilEventIngested(() => hub.db.fetchDistinctIdValues(person, Database.ClickHouse), 2)
         await delayUntilEventIngested(() => hub.db.fetchDistinctIds(person, Database.ClickHouse), 2)
 
-        const clickHousePersons = await hub.db.fetchPersons(Database.ClickHouse)
+        const clickHousePersons = (await hub.db.fetchPersons(Database.ClickHouse)).map((row) => ({
+            ...row,
+            properties: JSON.parse(row.properties), // avoids depending on key sort order
+        }))
         expect(clickHousePersons).toEqual([
             {
                 id: uuid,
                 created_at: expect.any(String), // '2021-02-04 00:18:26.472',
                 team_id: teamId,
-                properties: '{"userPropOnce":"propOnceValue","userProp":"propValue"}',
+                properties: { userPropOnce: 'propOnceValue', userProp: 'propValue' },
                 is_identified: 1,
                 is_deleted: 0,
                 _timestamp: expect.any(String),


### PR DESCRIPTION
## Problem

This just tidies up a few things that were bugging me when working on other changes that are blocked by #20162. Nothing functional here, but easy to review on its own and should make the other changes I'm working on simpler.

## Changes

- Consolidates all `RawPerson` to `Person` conversions.
- Cleans up a bunch of typing related code.
- Updates `generateKafkaPersonUpdateMessage` so that it expects an entire `Person` instance, as that is what it needs to publish anyway.

## How did you test this code?

Covered by existing tests.