### PR TITLE
fix(insights): don't wrap entity names in rename modal

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/RenameModal.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/RenameModal.tsx
@@ -48,7 +48,7 @@ export function RenameModal({ typeKey, view }: RenameModalProps): JSX.Element {
                 onPressEnter={() => renameFilter(name)}
                 onChange={(value) => setName(value)}
                 suffix={
-                    <span className="text-muted-alt">
+                    <span className="text-muted-alt whitespace-nowrap">
                         {getDisplayNameFromEntityFilter(selectedFilter, false) ?? ''}
                     </span>
                 }


### PR DESCRIPTION
## Problem

<img width="535" alt="Screenshot 2024-02-21 at 11 45 47" src="https://github.com/PostHog/posthog/assets/1851359/0549801d-f6df-4f6e-a93b-5631e894393a">

## Changes

<img width="549" alt="Screenshot 2024-02-21 at 11 46 04" src="https://github.com/PostHog/posthog/assets/1851359/40508ba5-ba3c-4dc8-9380-eff943069022">

## How did you test this code?

:eyes: