### PR TITLE
fix(api): Restore browsable API JSON indentation

### DIFF
--- a/posthog/renderers.py
+++ b/posthog/renderers.py
@@ -12,4 +12,9 @@ class SafeJSONRenderer(JSONRenderer):
         if data is None:
             return b""
 
-        return orjson.dumps(data, default=JSONEncoder().default, option=orjson.OPT_UTC_Z)
+        option = orjson.OPT_UTC_Z
+
+        if renderer_context and renderer_context.get("indent"):
+            option |= orjson.OPT_INDENT_2
+
+        return orjson.dumps(data, default=JSONEncoder().default, option=option)


### PR DESCRIPTION
## Problem

JSON rendering got updated in #20302  with no indents (cause faster)

## Changes

We can look at the context to see if we are in the browsable API render.

## How did you test this code?

- go to http://localhost:8000/api/projects/1 with browser and see that it looks nice again