### PR TITLE
chore: Replace DOCKERHUB_USERNAME secret with plaintext

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -45,7 +45,7 @@ jobs:
             - name: Login to DockerHub
               uses: docker/login-action@v3
               with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  username: posthog
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
             - name: Configure AWS credentials

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Login to DockerHub
               uses: docker/login-action@v3
               with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  username: posthog
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
             - uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION

## Problem

This isn't a secret and it causes every instance of "posthog" in the action logs to be replaced by "***"  because it's the value of a secret

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
