### PR TITLE
fix: Fix Transition Between /products --> Onboarding --> Product Intro Pages

### DIFF
--- a/cypress/e2e/onboarding.cy.ts
+++ b/cypress/e2e/onboarding.cy.ts
@@ -1,0 +1,42 @@
+import { urls } from 'scenes/urls'
+import { decideResponse } from '../fixtures/api/decide'
+
+describe('Onboarding', () => {
+    beforeEach(() => {
+        cy.intercept('https://app.posthog.com/decide/*', (req) =>
+            req.reply(
+                decideResponse({
+                    'product-intro-pages': 'test',
+                })
+            )
+        )
+    })
+
+    it('Navigate between /products to /onboarding to a product intro page', () => {
+        cy.visit('/products')
+
+        // Get started on product analytics onboarding
+        cy.get('[data-attr=product_analytics-get-started-button]').click()
+
+        // Confirm product intro is not included as the first step in the upper right breadcrumbs
+        cy.get('[data-attr=onboarding-breadcrumbs] > :first-child > * span').should('not.contain', 'Product Intro')
+
+        // Navigate to the product intro page by clicking the left side bar
+        cy.get('[data-attr=menu-item-replay').click()
+
+        // Confirm we're on the product_intro page
+        cy.get('[data-attr=top-bar-name] > span').contains('Product intro')
+
+        // Go back to /products
+        cy.visit('/products')
+
+        // Again get started on product analytics onboarding
+        cy.get('[data-attr=product_analytics-get-started-button]').click()
+
+        // Navigate to the product intro page by changing the url
+        cy.visit(urls.onboarding('session_replay', 'product_intro'))
+
+        // Confirm we're on the product intro page
+        cy.get('[data-attr=top-bar-name] > span').contains('Product intro')
+    })
+})

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -32,6 +32,7 @@ beforeEach(() => {
                 'surveys-new-creation-flow': true,
                 'surveys-results-visualizations': true,
                 'auto-redirect': true,
+
                 notebooks: true,
             })
         )

--- a/frontend/src/scenes/onboarding/OnboardingProductConfiguration.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingProductConfiguration.tsx
@@ -36,7 +36,7 @@ export const OnboardingProductConfiguration = ({
                                 }}
                                 label={option.title}
                                 fullWidth={true}
-                                labelClassName="text-base font-semibold"
+                                labelClassName="text-base font-semibold -ml-2"
                                 checked={option.value || false}
                             />
                             <p className="prompt-text ml-0">{option.description}</p>

--- a/frontend/src/scenes/onboarding/OnboardingStep.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingStep.tsx
@@ -48,7 +48,7 @@ export const OnboardingStep = ({
                     <h1 className="font-bold m-0 pl-2">
                         {title || stepKeyToTitle(currentOnboardingStep?.props.stepKey)}
                     </h1>
-                    <div className="flex items-center gap-x-3">
+                    <div className="flex items-center gap-x-3" data-attr="onboarding-breadcrumbs">
                         {onboardingStepKeys.map((stepName, idx) => {
                             return (
                                 <React.Fragment key={`stepKey-${idx}`}>

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -347,6 +347,10 @@ export const onboardingLogic = kea<onboardingLogicType>([
             if (productKey !== values.productKey) {
                 actions.setProductKey(productKey)
             }
+
+            // Reset onboarding steps so they can be populated upon render in the component.
+            actions.setAllOnboardingSteps([])
+
             if (step) {
                 actions.setStepKey(step)
             } else {

--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -73,6 +73,7 @@ function OnboardingNotCompletedButton({
                 }
                 router.actions.push(url)
             }}
+            data-attr={`${productKey}-get-started-button`}
         >
             Get started
         </LemonButton>

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -15,7 +15,7 @@ import { AvailableFeature, ProductKey } from '~/types'
 
 import { appContextLogic } from './appContextLogic'
 import { handleLoginRedirect } from './authentication/loginLogic'
-import { OnboardingStepKey } from './onboarding/onboardingLogic'
+import { onboardingLogic, OnboardingStepKey } from './onboarding/onboardingLogic'
 import { organizationLogic } from './organizationLogic'
 import { preflightLogic } from './PreflightCheck/preflightLogic'
 import type { sceneLogicType } from './sceneLogicType'
@@ -289,6 +289,7 @@ export const sceneLogic = kea<sceneLogicType>([
                                 console.warn(
                                     `Onboarding not completed for ${productKeyFromUrl}, redirecting to onboarding intro`
                                 )
+                                onboardingLogic.actions.setIncludeIntro(true)
                                 router.actions.replace(
                                     urls.onboarding(productKeyFromUrl, OnboardingStepKey.PRODUCT_INTRO)
                                 )

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -289,7 +289,9 @@ export const sceneLogic = kea<sceneLogicType>([
                                 console.warn(
                                     `Onboarding not completed for ${productKeyFromUrl}, redirecting to onboarding intro`
                                 )
+                                onboardingLogic.mount()
                                 onboardingLogic.actions.setIncludeIntro(true)
+                                onboardingLogic.unmount()
                                 router.actions.replace(
                                     urls.onboarding(productKeyFromUrl, OnboardingStepKey.PRODUCT_INTRO)
                                 )


### PR DESCRIPTION
## Problem

Two problems: 
* We don't include the intro pages as a step in the onboarding wizard when entering onboarding from the /products page. Since we now embed onboarding within the app, users can click into a product_intro page on the side bar. This causes an infinite loop because we don't populate the onboardingSteps for a new productKey until AFTER render but urlToAction will attempt to `setOnboardingStep == PRODUCT_INTRO` before render. This will fail the validity check of a OnboardingStepKey because the PRODUCT_INTRO step doesn't exist in the previous set of steps that came from `/products`. The onboardingLogic will attempt to resetStepKey but stepKey at this point is `null` so the logic enters a loop of attempting to `setStepKey(null)` and then having to `resetStepKey` because null is an invalid stepKey. 😵‍💫 🌀 
* We forgot to set `includeIntro = true` when navigating directly to a product_intro page. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

1. Go to `/products`. Do some things but don't leave onboarding.
2. Click on any product in the side bar you know you'll see the product intro page for. 
3. Should work ❇️ 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
