### PR TITLE
feat(data-management): add filters to count links

### DIFF
--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -126,14 +126,15 @@ export function EventDefinitionsTable(): JSX.Element {
                     to={urls.insightNewHogQL(
                         'SELECT event, count()\n' +
                             'FROM events\n' +
-                            'WHERE timestamp > now() - interval 1 month\n' +
+                            'WHERE {filters}\n' +
                             (filters.event_type === 'event_custom'
                                 ? "AND event NOT LIKE '$%'\n"
                                 : filters.event_type === 'event_posthog'
                                 ? "AND event LIKE '$%'\n"
                                 : '') +
                             'GROUP BY event\n' +
-                            'ORDER BY count() DESC'
+                            'ORDER BY count() DESC',
+                        { dateRange: { date_from: '-24h' } }
                     )}
                 >
                     Click here!

--- a/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.tsx
@@ -70,9 +70,10 @@ export function PropertyDefinitionsTable(): JSX.Element {
                     to={urls.insightNewHogQL(
                         'SELECT arrayJoin(JSONExtractKeys(properties)) AS property_key, count()\n' +
                             (filters.type === 'person' ? 'FROM persons\n' : 'FROM events\n') +
-                            (filters.type === 'person' ? '' : 'WHERE timestamp > now() - interval 1 month\n') +
+                            (filters.type === 'person' ? '' : 'WHERE {filters}\n') +
                             'GROUP BY property_key\n' +
-                            'ORDER BY count() DESC'
+                            'ORDER BY count() DESC',
+                        { dateRange: { date_from: '-24h' } }
                     )}
                 >
                     Click here!

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -2,6 +2,7 @@ import { combineUrl } from 'kea-router'
 import { toParams } from 'lib/utils'
 
 import { ExportOptions } from '~/exporter/types'
+import { HogQLFilters } from '~/queries/schema'
 import {
     ActionType,
     AnnotationType,
@@ -76,14 +77,14 @@ export const urls = {
             ...(filters ? { filters } : {}),
             ...(query ? { q: typeof query === 'string' ? query : JSON.stringify(query) } : {}),
         }).url,
-    insightNewHogQL: (query: string): string =>
+    insightNewHogQL: (query: string, filters?: HogQLFilters): string =>
         urls.insightNew(
             undefined,
             undefined,
             JSON.stringify({
                 kind: 'DataTableNode',
                 full: true,
-                source: { kind: 'HogQLQuery', query },
+                source: { kind: 'HogQLQuery', query, filters },
             })
         ),
     insightEdit: (id: InsightShortId): string => `/insights/${id}/edit`,


### PR DESCRIPTION
## Problem

These "click here" links opened a HogQL insight that didn't use the newer `{filters}` system, making it hard to change the date range:

<img width="1091" alt="image" src="https://github.com/PostHog/posthog/assets/53387/076d6965-6d15-4d8c-ae28-e8cd5d8894be">

<img width="580" alt="image" src="https://github.com/PostHog/posthog/assets/53387/5801abf1-4663-4fab-9b25-673a212faca7">

## Changes

Now they do:

<img width="637" alt="image" src="https://github.com/PostHog/posthog/assets/53387/dbe26590-222e-4aeb-8aa8-7e9e4c2bcc9b">

Also: Since the default "1 month" time range timed out for our team, I changed the default to "24 hours".

## How did you test this code?

Poked the UI