### PR TITLE
fix: autocapture wording config

### DIFF
--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -86,7 +86,7 @@ const ProductAnalyticsOnboarding = (): JSX.Element => {
                     {
                         title: 'Autocapture frontend interactions',
                         description: `If you use our JavaScript or React Native libraries, we'll automagically 
-                        capture frontend interactions like pageviews, clicks, and more. Fine-tune what you 
+                        capture frontend interactions like clicks, submits, and more. Fine-tune what you 
                         capture directly in your code snippet.`,
                         teamProperty: 'autocapture_opt_out',
                         value: !currentTeam?.autocapture_opt_out,

--- a/frontend/src/scenes/settings/project/AutocaptureSettings.tsx
+++ b/frontend/src/scenes/settings/project/AutocaptureSettings.tsx
@@ -17,7 +17,7 @@ export function AutocaptureSettings(): JSX.Element {
     return (
         <>
             <p>
-                Automagically capture front-end interactions like pageviews, clicks, and more when using our web
+                Automagically capture front-end interactions like clicks, submits, and more when using our web
                 JavaScript SDK.{' '}
             </p>
             <p>


### PR DESCRIPTION
## Problem

`autocapture_opt_out` does not disable page views.
Only `$autocapture` events, which are: submit, change, click, and touch (touch is RN only via code).

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
