### PR TITLE
chore: a little more lessening

### DIFF
--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -72,18 +72,23 @@ await buildInParallel(
                         // we can add a plugin just for the toolbar build to mark lemon-ui as having no side effects
                         // that will allow tree-shaking and reduce the toolbar bundle size
                         // by over 40% at implementation time
-                        build.onResolve({ filter: /^(lib|@posthog)\/lemon-ui/ }, async (args) => {
-                            if (args.pluginData) {
-                                return
-                            } // Ignore this if we called ourselves
 
-                            const { path, ...rest } = args
-                            rest.pluginData = true // Avoid infinite recursion
-                            const result = await build.resolve(path, rest)
+                        const sideEffectFreeMatches = [/^(lib|@posthog)\/lemon-ui/, /^lib\/api\.ts$/]
 
-                            result.sideEffects = false
+                        sideEffectFreeMatches.forEach((match) => {
+                            build.onResolve({ filter: match }, async (args) => {
+                                if (args.pluginData) {
+                                    return
+                                } // Ignore this if we called ourselves
 
-                            return result
+                                const { path, ...rest } = args
+                                rest.pluginData = true // Avoid infinite recursion
+                                const result = await build.resolve(path, rest)
+
+                                result.sideEffects = false
+
+                                return result
+                            })
                         })
                     },
                 },


### PR DESCRIPTION
We import api.ts in the toolbar, which doesn't use every endpoint. 

api.ts isn't marked as sideeffect free so we don't treeshake any code away.

but it is

and so we can

I expect to be able to shout: begone another 20 or so kb