### PR TITLE
fix(surveys): Appropriate error response on toasts

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -61,6 +61,8 @@ DATABASE_FOR_LOCAL_EVALUATION = (
     else "replica"
 )
 
+BEHAVIOURAL_COHORT_FOUND_ERROR_CODE = "behavioral_cohort_found"
+
 
 class FeatureFlagThrottle(BurstRateThrottle):
     # Throttle class that's scoped just to the local evaluation endpoint.
@@ -222,8 +224,8 @@ class FeatureFlagSerializer(TaggedItemSerializerMixin, serializers.HyperlinkedMo
                         for cohort in [initial_cohort, *dependent_cohorts]:
                             if [prop for prop in cohort.properties.flat if prop.type == "behavioral"]:
                                 raise serializers.ValidationError(
-                                    detail=f"Cohort '{cohort.name}' with behavioral filters cannot be used in feature flags.",
-                                    code="behavioral_cohort_found",
+                                    detail=f"Cohort '{cohort.name}' with filters on events cannot be used in feature flags.",
+                                    code=BEHAVIOURAL_COHORT_FOUND_ERROR_CODE,
                                 )
                     except Cohort.DoesNotExist:
                         raise serializers.ValidationError(

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from typing import Type
 
 from django.http import JsonResponse
@@ -9,7 +10,11 @@ from posthog.exceptions import generate_exception_response
 from posthog.models.feedback.survey import Survey
 from rest_framework.response import Response
 from rest_framework.decorators import action
-from posthog.api.feature_flag import FeatureFlagSerializer, MinimalFeatureFlagSerializer
+from posthog.api.feature_flag import (
+    BEHAVIOURAL_COHORT_FOUND_ERROR_CODE,
+    FeatureFlagSerializer,
+    MinimalFeatureFlagSerializer,
+)
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from rest_framework import serializers, viewsets, request
 from rest_framework.request import Request
@@ -183,8 +188,8 @@ class SurveySerializerCreateUpdateOnly(SurveySerializer):
 
         validated_data["team_id"] = self.context["team_id"]
         if validated_data.get("targeting_flag_filters"):
-            targeting_feature_flag = self._create_new_targeting_flag(
-                validated_data["name"], validated_data["targeting_flag_filters"]
+            targeting_feature_flag = self._create_or_update_targeting_flag(
+                None, validated_data["targeting_flag_filters"], validated_data["name"]
             )
             validated_data["targeting_flag_id"] = targeting_feature_flag.id
             validated_data.pop("targeting_flag_filters")
@@ -211,16 +216,11 @@ class SurveySerializerCreateUpdateOnly(SurveySerializer):
                     **existing_targeting_flag.filters,
                     **new_filters,
                 }
-                existing_flag_serializer = FeatureFlagSerializer(
-                    existing_targeting_flag,
-                    data={"filters": serialized_data_filters},
-                    partial=True,
-                    context=self.context,
-                )
-                existing_flag_serializer.is_valid(raise_exception=True)
-                existing_flag_serializer.save()
+                self._create_or_update_targeting_flag(instance.targeting_flag, serialized_data_filters)
             else:
-                new_flag = self._create_new_targeting_flag(instance.name, new_filters, bool(instance.start_date))
+                new_flag = self._create_or_update_targeting_flag(
+                    None, new_filters, instance.name, bool(instance.start_date)
+                )
                 validated_data["targeting_flag_id"] = new_flag.id
             validated_data.pop("targeting_flag_filters")
 
@@ -235,21 +235,33 @@ class SurveySerializerCreateUpdateOnly(SurveySerializer):
 
         return super().update(instance, validated_data)
 
-    def _create_new_targeting_flag(self, name, filters, active=False):
-        feature_flag_key = slugify(f"{SURVEY_TARGETING_FLAG_PREFIX}{name}")
-        feature_flag_serializer = FeatureFlagSerializer(
-            data={
-                "key": feature_flag_key,
-                "name": f"Targeting flag for survey {name}",
-                "filters": filters,
-                "active": active,
-            },
-            context=self.context,
-        )
+    def _create_or_update_targeting_flag(self, existing_flag=None, filters=None, name=None, active=False):
+        with create_flag_with_survey_errors():
+            if existing_flag:
+                existing_flag_serializer = FeatureFlagSerializer(
+                    existing_flag,
+                    data={"filters": filters},
+                    partial=True,
+                    context=self.context,
+                )
+                existing_flag_serializer.is_valid(raise_exception=True)
+                return existing_flag_serializer.save()
+            elif name and filters:
+                feature_flag_key = slugify(f"{SURVEY_TARGETING_FLAG_PREFIX}{name}")
+                feature_flag_serializer = FeatureFlagSerializer(
+                    data={
+                        "key": feature_flag_key,
+                        "name": f"Targeting flag for survey {name}",
+                        "filters": filters,
+                        "active": active,
+                    },
+                    context=self.context,
+                )
 
-        feature_flag_serializer.is_valid(raise_exception=True)
-        targeting_feature_flag = feature_flag_serializer.save()
-        return targeting_feature_flag
+                feature_flag_serializer.is_valid(raise_exception=True)
+                return feature_flag_serializer.save()
+            else:
+                raise serializers.ValidationError("Targeting flag for survey failed, invalid parameters.")
 
 
 class SurveyViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
@@ -350,6 +362,28 @@ def surveys(request: Request):
     ).data
 
     return cors_response(request, JsonResponse({"surveys": surveys}))
+
+
+@contextmanager
+def create_flag_with_survey_errors():
+    # context manager to raise error with a different message when flag creation fails
+    try:
+        yield
+    except serializers.ValidationError as e:
+        # get the full details of the error to figure out if it's a behavioural cohort error
+        error_details = e.get_full_details()
+        matching_errors = [
+            detail
+            for detail in error_details.get("filters", [{}])
+            if detail.get("code") == BEHAVIOURAL_COHORT_FOUND_ERROR_CODE
+        ]
+        if matching_errors:
+            original_detail = matching_errors[0].get("message")
+            raise serializers.ValidationError(
+                detail=original_detail.replace("feature flags", "surveys"),
+                code=BEHAVIOURAL_COHORT_FOUND_ERROR_CODE,
+            )
+        raise e
 
 
 def nh3_clean_with_allow_list(to_clean: str):

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -3273,7 +3273,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             {
                 "type": "validation_error",
                 "code": "behavioral_cohort_found",
-                "detail": "Cohort 'cohort2' with behavioral filters cannot be used in feature flags.",
+                "detail": "Cohort 'cohort2' with filters on events cannot be used in feature flags.",
                 "attr": "filters",
             },
             cohort_request.json(),
@@ -3313,7 +3313,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             {
                 "type": "validation_error",
                 "code": "behavioral_cohort_found",
-                "detail": "Cohort 'cohort2' with behavioral filters cannot be used in feature flags.",
+                "detail": "Cohort 'cohort2' with filters on events cannot be used in feature flags.",
                 "attr": "filters",
             },
             response.json(),
@@ -3373,7 +3373,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             {
                 "type": "validation_error",
                 "code": "behavioral_cohort_found",
-                "detail": "Cohort 'cohort-behavioural' with behavioral filters cannot be used in feature flags.",
+                "detail": "Cohort 'cohort-behavioural' with filters on events cannot be used in feature flags.",
                 "attr": "filters",
             },
             cohort_request.json(),
@@ -3389,7 +3389,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             {
                 "type": "validation_error",
                 "code": "behavioral_cohort_found",
-                "detail": "Cohort 'cohort-behavioural' with behavioral filters cannot be used in feature flags.",
+                "detail": "Cohort 'cohort-behavioural' with filters on events cannot be used in feature flags.",
                 "attr": "filters",
             },
             cohort_request.json(),

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from django.core.cache import cache
 from django.test.client import Client
 from posthog.api.survey import nh3_clean_with_allow_list
+from posthog.models.cohort.cohort import Cohort
 
 from posthog.models.feedback.survey import Survey
 from posthog.test.base import (
@@ -271,6 +272,61 @@ class TestSurvey(APIBaseTest):
                 [(res["key"], [survey["id"] for survey in res["surveys"]]) for res in result["results"]],
                 [("flag_0", []), (ff_key, [created_survey1, created_survey2])],
             )
+
+    def test_updating_survey_with_invalid_targeting_throws_appropriate_error(self):
+        cohort_not_valid_for_ff = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "$pageview",
+                            "event_type": "events",
+                            "time_value": 2,
+                            "time_interval": "week",
+                            "value": "performed_event_first_time",
+                            "type": "behavioral",
+                        },
+                        {"key": "email", "value": "test@posthog.com", "type": "person"},
+                    ],
+                }
+            },
+            name="cohort2",
+        )
+        survey_with_targeting = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "survey with targeting",
+                "type": "popover",
+                "targeting_flag_filters": {
+                    "groups": [
+                        {
+                            "variant": None,
+                            "rollout_percentage": None,
+                            "properties": [
+                                {
+                                    "key": "id",
+                                    "value": cohort_not_valid_for_ff.pk,
+                                    "operator": "exact",
+                                    "type": "cohort",
+                                }
+                            ],
+                        }
+                    ]
+                },
+                "conditions": {"url": "https://app.posthog.com/notebooks"},
+            },
+            format="json",
+        )
+
+        assert survey_with_targeting.status_code == status.HTTP_400_BAD_REQUEST
+        assert survey_with_targeting.json() == {
+            "type": "validation_error",
+            "code": "behavioral_cohort_found",
+            "detail": "Cohort 'cohort2' with filters on events cannot be used in surveys.",
+            "attr": None,
+        }
 
     def test_updating_survey_with_targeting_creates_or_updates_targeting_flag(self):
         survey_with_targeting = self.client.post(

--- a/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
@@ -31,30 +31,6 @@
   FROM events LEFT JOIN (
   SELECT person_static_cohort.person_id AS cohort_person_id, 1 AS matched, person_static_cohort.cohort_id AS cohort_id 
   FROM person_static_cohort 
-  WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [12]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
-  WHERE and(equals(events.team_id, 420), 1, ifNull(equals(__in_cohort.matched, 1), 0)) 
-  LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
-  
-  -- HogQL
-  
-  SELECT event 
-  FROM events LEFT JOIN (
-  SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
-  FROM static_cohort_people 
-  WHERE in(cohort_id, [12])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
-  WHERE and(1, equals(__in_cohort.matched, 1)) 
-  LIMIT 100
-  '''
-# ---
-# name: TestInCohort.test_in_cohort_conjoined_string
-  '''
-  -- ClickHouse
-  
-  SELECT events.event AS event 
-  FROM events LEFT JOIN (
-  SELECT person_static_cohort.person_id AS cohort_person_id, 1 AS matched, person_static_cohort.cohort_id AS cohort_id 
-  FROM person_static_cohort 
   WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [13]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
   WHERE and(equals(events.team_id, 420), 1, ifNull(equals(__in_cohort.matched, 1), 0)) 
   LIMIT 100 
@@ -67,6 +43,30 @@
   SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
   FROM static_cohort_people 
   WHERE in(cohort_id, [13])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
+  WHERE and(1, equals(__in_cohort.matched, 1)) 
+  LIMIT 100
+  '''
+# ---
+# name: TestInCohort.test_in_cohort_conjoined_string
+  '''
+  -- ClickHouse
+  
+  SELECT events.event AS event 
+  FROM events LEFT JOIN (
+  SELECT person_static_cohort.person_id AS cohort_person_id, 1 AS matched, person_static_cohort.cohort_id AS cohort_id 
+  FROM person_static_cohort 
+  WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [14]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
+  WHERE and(equals(events.team_id, 420), 1, ifNull(equals(__in_cohort.matched, 1), 0)) 
+  LIMIT 100 
+  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  
+  -- HogQL
+  
+  SELECT event 
+  FROM events LEFT JOIN (
+  SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
+  FROM static_cohort_people 
+  WHERE in(cohort_id, [14])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
   WHERE and(1, equals(__in_cohort.matched, 1)) 
   LIMIT 100
   '''

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
@@ -350,7 +350,7 @@
                         if(and(equals(e.event, 'user signed up'), ifNull(in(e__pdi.person_id,
                                                                               (SELECT cohortpeople.person_id AS person_id
                                                                                FROM cohortpeople
-                                                                               WHERE and(equals(cohortpeople.team_id, 2), equals(cohortpeople.cohort_id, 20))
+                                                                               WHERE and(equals(cohortpeople.team_id, 2), equals(cohortpeople.cohort_id, 21))
                                                                                GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, cohortpeople.version
                                                                                HAVING ifNull(greater(sum(cohortpeople.sign), 0), 0))), 0)), 1, 0) AS step_0,
                         if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
@@ -871,7 +871,7 @@
                         if(and(equals(e.event, 'user signed up'), ifNull(in(e__pdi.person_id,
                                                                               (SELECT person_static_cohort.person_id AS person_id
                                                                                FROM person_static_cohort
-                                                                               WHERE and(equals(person_static_cohort.team_id, 2), equals(person_static_cohort.cohort_id, 21)))), 0)), 1, 0) AS step_0,
+                                                                               WHERE and(equals(person_static_cohort.team_id, 2), equals(person_static_cohort.cohort_id, 22)))), 0)), 1, 0) AS step_0,
                         if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                         if(equals(e.event, 'paid'), 1, 0) AS step_1,
                         if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1


### PR DESCRIPTION
## Problem

We want better error messages when targeting surveys. Fixes it

<img width="661" alt="image" src="https://github.com/PostHog/posthog/assets/7115141/c143fb2d-78da-4742-96d7-0c8ac6eb348a">


<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
