### PR TITLE
chore: mock real billing response for all storybook

### DIFF
--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -14,6 +14,7 @@ import {
 import { getAvailableFeatures } from '~/mocks/features'
 import { SharingConfigurationType } from '~/types'
 
+import { billingJson } from './fixtures/_billing_v2'
 import { Mocks, MockSignature, mocksToHandlers } from './utils'
 
 export const EMPTY_PAGINATED_RESPONSE = { count: 0, results: [] as any[], next: null, previous: null }
@@ -85,7 +86,6 @@ export const defaultMocks: Mocks = {
             },
         ],
         '/api/projects/@current/': MOCK_DEFAULT_TEAM,
-        '/api/billing-v2/': (): MockSignature => [200, {}],
         '/api/projects/:team_id/comments/count': { count: 0 },
         '/api/projects/:team_id/comments': { results: [] },
         '/_preflight': require('./fixtures/_preflight.json'),
@@ -101,6 +101,9 @@ export const defaultMocks: Mocks = {
         'https://www.gravatar.com/avatar/:gravatar_id': () => [404, ''],
         'https://app.posthog.com/api/early_access_features': {
             earlyAccessFeatures: [],
+        },
+        '/api/billing-v2/': {
+            ...billingJson,
         },
     },
     post: {

--- a/frontend/src/scenes/insights/Insights.stories.tsx
+++ b/frontend/src/scenes/insights/Insights.stories.tsx
@@ -4,7 +4,6 @@ import { createInsightStory } from 'scenes/insights/__mocks__/createInsightScene
 import { samplePersonProperties, sampleRetentionPeopleResponse } from 'scenes/insights/__mocks__/insight.mocks'
 
 import { mswDecorator } from '~/mocks/browser'
-import { billingJson } from '~/mocks/fixtures/_billing_v2'
 
 type Story = StoryObj<typeof App>
 const meta: Meta = {
@@ -24,9 +23,6 @@ const meta: Meta = {
                 '/api/projects/:team_id/persons/retention': sampleRetentionPeopleResponse,
                 '/api/projects/:team_id/persons/properties': samplePersonProperties,
                 '/api/projects/:team_id/groups_types': [],
-                '/api/billing-v2/': {
-                    ...billingJson,
-                },
             },
             post: {
                 '/api/projects/:team_id/cohorts/': { id: 1 },


### PR DESCRIPTION
## Problem

Billing is used in a number of places now, we may as well have a good default mock so that it doesn't have to be mocked individually for each story where it is used.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds default billing mock for storybook

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

We'll see what the storybook tests do 😄 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
