### PR TITLE
feat: Make pipeline step stalled log configurable

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -130,6 +130,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         POE_EMBRACE_JOIN_FOR_TEAMS: '',
         POE_WRITES_ENABLED_MAX_TEAM_ID: 0,
         POE_WRITES_EXCLUDE_TEAMS: '',
+        PIPELINE_STEP_STALLED_LOG_TIMEOUT: 30,
         RELOAD_PLUGIN_JITTER_MAX_MS: 60000,
         RUSTY_HOOK_FOR_TEAMS: '',
         RUSTY_HOOK_ROLLOUT_PERCENTAGE: 0,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -206,6 +206,7 @@ export interface PluginsServerConfig {
     RUSTY_HOOK_ROLLOUT_PERCENTAGE: number
     RUSTY_HOOK_URL: string
     SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
+    PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
 
     // dump profiles to disk, covering the first N seconds of runtime
     STARTUP_PROFILE_DURATION_SECONDS: number

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -165,7 +165,7 @@ export class EventPipelineRunner {
             },
             async () => {
                 const timeout = timeoutGuard(
-                    `Event pipeline step stalled. Timeout warning after 30 sec! step=${step.name} team_id=${teamId} distinct_id=${this.originalEvent.distinct_id}`,
+                    `Event pipeline step stalled. Timeout warning after ${this.hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT} sec! step=${step.name} team_id=${teamId} distinct_id=${this.originalEvent.distinct_id}`,
                     {
                         step: step.name,
                         event: JSON.stringify(this.originalEvent),

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -169,7 +169,8 @@ export class EventPipelineRunner {
                     {
                         step: step.name,
                         event: JSON.stringify(this.originalEvent),
-                    }
+                    },
+                    this.hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT * 1000
                 )
                 try {
                     const result = await step(...args)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
This would allow us to tune the logging up/down to discover why ingestion is being slow

Matched the current default of 30s (based on 

https://github.com/PostHog/posthog/blob/05a06d27e4ea7199b105b21450a1458d24c4f94e/plugin-server/src/utils/db/utils.ts#L42 

& 

https://github.com/PostHog/posthog/blob/05a06d27e4ea7199b105b21450a1458d24c4f94e/plugin-server/src/config/config.ts#L73 

) but didn't want to use `TASK_TIMEOUT` as it's used in many places and I'm not sure of all the functions

Related thread: https://posthog.slack.com/archives/C06L567N5NF/p1708626482398959?thread_ts=1708626071.772089&cid=C06L567N5NF

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
