### PR TITLE
chore: Add team-id to log context

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -169,6 +169,7 @@ export class EventPipelineRunner {
                     {
                         step: step.name,
                         event: JSON.stringify(this.originalEvent),
+                        teamId: teamId,
                     },
                     this.hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT * 1000
                 )

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -170,6 +170,7 @@ export class EventPipelineRunner {
                         step: step.name,
                         event: JSON.stringify(this.originalEvent),
                         teamId: teamId,
+                        distinctId: this.originalEvent.distinct_id,
                     },
                     this.hub.PIPELINE_STEP_STALLED_LOG_TIMEOUT * 1000
                 )


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Can we do this, is the cardinality a problem here?
This goes to Sentry and log output
https://github.com/PostHog/posthog/blob/05a06d27e4ea7199b105b21450a1458d24c4f94e/plugin-server/src/utils/db/utils.ts#L44-L48

The purpose is that we can see which team_ids are slow in logs, currently we can only see step like this: 
<img width="642" alt="Screenshot 2024-02-22 at 21 08 29" src="https://github.com/PostHog/posthog/assets/890921/6079c17d-edea-45b3-9447-3024a7b9063f">


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
