### PR TITLE
fix(funnels): Removed the UI for turning off breakdown other group on funnels

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTagMenu.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTagMenu.tsx
@@ -14,7 +14,7 @@ export const BreakdownTagMenu = (): JSX.Element => {
     const { insightProps } = useValues(insightLogic)
     const { isHistogramable, isNormalizeable } = useValues(breakdownTagLogic)
     const { removeBreakdown } = useActions(breakdownTagLogic)
-    const { breakdownFilter } = useValues(insightVizDataLogic(insightProps))
+    const { breakdownFilter, isTrends } = useValues(insightVizDataLogic(insightProps))
     const { updateBreakdownFilter } = useActions(insightVizDataLogic(insightProps))
 
     const { histogramBinCount, breakdownLimit, histogramBinsUsed } = useValues(taxonomicBreakdownFilterLogic)
@@ -90,33 +90,36 @@ export const BreakdownTagMenu = (): JSX.Element => {
                 </>
             ) : (
                 <>
-                    <LemonSwitch
-                        fullWidth
-                        className="min-h-10 px-2"
-                        checked={!breakdownFilter?.breakdown_hide_other_aggregation}
-                        onChange={() =>
-                            updateBreakdownFilter({
-                                ...breakdownFilter,
-                                breakdown_hide_other_aggregation: !breakdownFilter?.breakdown_hide_other_aggregation,
-                            })
-                        }
-                        label={
-                            <div className="flex gap-1">
-                                <span>Group remaining values under "Other"</span>
-                                <Tooltip
-                                    title={
-                                        <>
-                                            If you have over {breakdownFilter?.breakdown_limit ?? 25} breakdown options,
-                                            the smallest ones are aggregated under the label "Other". Use this toggle to
-                                            show/hide the "Other" option.
-                                        </>
-                                    }
-                                >
-                                    <IconInfo className="text-muted text-xl shrink-0" />
-                                </Tooltip>
-                            </div>
-                        }
-                    />
+                    {isTrends && (
+                        <LemonSwitch
+                            fullWidth
+                            className="min-h-10 px-2"
+                            checked={!breakdownFilter?.breakdown_hide_other_aggregation}
+                            onChange={() =>
+                                updateBreakdownFilter({
+                                    ...breakdownFilter,
+                                    breakdown_hide_other_aggregation:
+                                        !breakdownFilter?.breakdown_hide_other_aggregation,
+                                })
+                            }
+                            label={
+                                <div className="flex gap-1">
+                                    <span>Group remaining values under "Other"</span>
+                                    <Tooltip
+                                        title={
+                                            <>
+                                                If you have over {breakdownFilter?.breakdown_limit ?? 25} breakdown
+                                                options, the smallest ones are aggregated under the label "Other". Use
+                                                this toggle to show/hide the "Other" option.
+                                            </>
+                                        }
+                                    >
+                                        <IconInfo className="text-muted text-xl shrink-0" />
+                                    </Tooltip>
+                                </div>
+                            }
+                        />
+                    )}
                     <div>
                         <LemonButton
                             onClick={() => {


### PR DESCRIPTION
## Problem
- We were showing the `Group remaining values under "Other"` option within breakdown tags on funnels when the backend of funnels doesn't support turning off the "other" group, meaning this switch effectively did nothing
- Reported by a customer via email

<img width="483" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/83078a56-6e3e-4e59-a830-f4a429fa07a1">


## Changes
- Removed the switch on the breakdown UI when using breakdowns on a funnel

<img width="587" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/d10ab34c-b163-4b44-a9eb-f63427f20679">


## How did you test this code?
- Browser clicks