### PR TITLE
refactor(plugin-server): Remove a few layers of passthrough functions in event ingestion

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -7,7 +7,7 @@ import { formPipelineEvent } from '../../../utils/event'
 import { retryIfRetriable } from '../../../utils/retries'
 import { status } from '../../../utils/status'
 import { ConfiguredLimiter, LoggingLimiter, OverflowWarningLimiter } from '../../../utils/token-bucket'
-import { runEventPipeline } from '../../../worker/ingestion/event-pipeline/runner'
+import { EventPipelineRunner } from '../../../worker/ingestion/event-pipeline/runner'
 import { captureIngestionWarning } from '../../../worker/ingestion/utils'
 import { ingestionPartitionKeyOverflowed } from '../analytics-events-ingestion-consumer'
 import { IngestionConsumer } from '../kafka-queue'
@@ -156,7 +156,8 @@ export async function eachBatchParallelIngestion(
                 for (const { message, pluginEvent } of currentBatch) {
                     try {
                         const result = (await retryIfRetriable(async () => {
-                            return await runEventPipeline(queue.pluginsServer, pluginEvent)
+                            const runner = new EventPipelineRunner(queue.pluginsServer, pluginEvent)
+                            return await runner.runEventPipeline(pluginEvent)
                         })) as IngestResult
 
                         result.promises?.forEach((promise) =>

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -2,12 +2,12 @@ import * as Sentry from '@sentry/node'
 import { Message, MessageHeader } from 'node-rdkafka'
 
 import { KAFKA_EVENTS_PLUGIN_INGESTION_DLQ, KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW } from '../../../config/kafka-topics'
-import { Hub, PipelineEvent, ValueMatcher } from '../../../types'
+import { PipelineEvent, ValueMatcher } from '../../../types'
 import { formPipelineEvent } from '../../../utils/event'
 import { retryIfRetriable } from '../../../utils/retries'
 import { status } from '../../../utils/status'
 import { ConfiguredLimiter, LoggingLimiter, OverflowWarningLimiter } from '../../../utils/token-bucket'
-import { EventPipelineResult, runEventPipeline } from '../../../worker/ingestion/event-pipeline/runner'
+import { runEventPipeline } from '../../../worker/ingestion/event-pipeline/runner'
 import { captureIngestionWarning } from '../../../worker/ingestion/utils'
 import { ingestionPartitionKeyOverflowed } from '../analytics-events-ingestion-consumer'
 import { IngestionConsumer } from '../kafka-queue'
@@ -156,7 +156,7 @@ export async function eachBatchParallelIngestion(
                 for (const { message, pluginEvent } of currentBatch) {
                     try {
                         const result = (await retryIfRetriable(async () => {
-                            return await ingestEvent(queue.pluginsServer, pluginEvent)
+                            return await runEventPipeline(queue.pluginsServer, pluginEvent)
                         })) as IngestResult
 
                         result.promises?.forEach((promise) =>
@@ -241,16 +241,6 @@ export async function eachBatchParallelIngestion(
     } finally {
         transaction.finish()
     }
-}
-
-async function ingestEvent(
-    server: Hub,
-    event: PipelineEvent,
-    checkAndPause?: () => void // pause incoming messages if we are slow in getting them out again
-): Promise<EventPipelineResult> {
-    checkAndPause?.()
-    const result = await runEventPipeline(server, event)
-    return result
 }
 
 function computeKey(pluginEvent: PipelineEvent): string {

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -43,12 +43,6 @@ class StepErrorNoRetry extends Error {
         this.args = args
     }
 }
-
-export async function runEventPipeline(hub: Hub, event: PipelineEvent): Promise<EventPipelineResult> {
-    const runner = new EventPipelineRunner(hub, event)
-    return runner.runEventPipeline(event)
-}
-
 export class EventPipelineRunner {
     hub: Hub
     originalEvent: PipelineEvent

--- a/plugin-server/src/worker/ingestion/utils.ts
+++ b/plugin-server/src/worker/ingestion/utils.ts
@@ -20,7 +20,7 @@ export function generateEventDeadLetterQueueMessage(
     teamId: number,
     errorLocation = 'plugin_server_ingest_event'
 ): ProducerRecord {
-    let errorMessage = 'ingestEvent failed. '
+    let errorMessage = 'Event ingestion failed. '
     if (error instanceof Error) {
         errorMessage += `Error: ${error.message}`
     }

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
@@ -5,14 +5,17 @@ import {
     IngestionOverflowMode,
 } from '../../../src/main/ingestion-queues/batch-processing/each-batch-ingestion'
 import { ConfiguredLimiter } from '../../../src/utils/token-bucket'
-import { runEventPipeline } from './../../../src/worker/ingestion/event-pipeline/runner'
 import { captureIngestionWarning } from './../../../src/worker/ingestion/utils'
 
 jest.mock('../../../src/utils/status')
 jest.mock('./../../../src/worker/ingestion/utils')
 
+const runEventPipeline = jest.fn().mockResolvedValue('default value')
+
 jest.mock('./../../../src/worker/ingestion/event-pipeline/runner', () => ({
-    runEventPipeline: jest.fn().mockResolvedValue('default value'),
+    EventPipelineRunner: jest.fn().mockImplementation(() => ({
+        runEventPipeline: runEventPipeline,
+    })),
 }))
 
 const captureEndpointEvent1 = {

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
@@ -4,13 +4,17 @@ import {
     IngestionOverflowMode,
 } from '../../../src/main/ingestion-queues/batch-processing/each-batch-ingestion'
 import { OverflowWarningLimiter } from '../../../src/utils/token-bucket'
-import { runEventPipeline } from './../../../src/worker/ingestion/event-pipeline/runner'
 import { captureIngestionWarning } from './../../../src/worker/ingestion/utils'
 
 jest.mock('../../../src/utils/status')
 jest.mock('./../../../src/worker/ingestion/utils')
+
+const runEventPipeline = jest.fn().mockResolvedValue('default value')
+
 jest.mock('./../../../src/worker/ingestion/event-pipeline/runner', () => ({
-    runEventPipeline: jest.fn().mockResolvedValue('default value'),
+    EventPipelineRunner: jest.fn().mockImplementation(() => ({
+        runEventPipeline: runEventPipeline,
+    })),
 }))
 
 const captureEndpointEvent1 = {

--- a/plugin-server/tests/main/teardown.test.ts
+++ b/plugin-server/tests/main/teardown.test.ts
@@ -4,7 +4,7 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 import { waitForExpect } from '../../functional_tests/expectations'
 import { startPluginsServer } from '../../src/main/pluginsServer'
 import { Hub, LogLevel, PluginLogEntry, PluginLogEntrySource, PluginLogEntryType } from '../../src/types'
-import { runEventPipeline } from '../../src/worker/ingestion/event-pipeline/runner'
+import { EventPipelineRunner } from '../../src/worker/ingestion/event-pipeline/runner'
 import { makePiscina } from '../../src/worker/piscina'
 import { pluginConfig39 } from '../helpers/plugins'
 import { resetTestDatabase } from '../helpers/sql'
@@ -36,7 +36,7 @@ async function getLogEntriesForPluginConfig(hub: Hub, pluginConfigId: number) {
 
 describe('teardown', () => {
     const processEvent = async (hub: Hub, event: PluginEvent) => {
-        const result = await runEventPipeline(hub, event)
+        const result = await new EventPipelineRunner(hub, event).runEventPipeline(event)
         const resultEvent = result.args[0]
         return resultEvent
     }

--- a/plugin-server/tests/worker/dead-letter-queue.test.ts
+++ b/plugin-server/tests/worker/dead-letter-queue.test.ts
@@ -3,7 +3,7 @@ import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
 import { Hub, LogLevel } from '../../src/types'
 import { createHub } from '../../src/utils/db/hub'
 import { UUIDT } from '../../src/utils/utils'
-import { runEventPipeline } from '../../src/worker/ingestion/event-pipeline/runner'
+import { EventPipelineRunner } from '../../src/worker/ingestion/event-pipeline/runner'
 import { generateEventDeadLetterQueueMessage } from '../../src/worker/ingestion/utils'
 import { delayUntilEventIngested, resetTestDatabaseClickhouse } from '../helpers/clickhouse'
 import { resetTestDatabase } from '../helpers/sql'
@@ -59,7 +59,8 @@ describe('events dead letter queue', () => {
     })
 
     test('events get sent to dead letter queue on error', async () => {
-        const ingestResponse1 = await runEventPipeline(hub, createEvent())
+        const event = createEvent()
+        const ingestResponse1 = await new EventPipelineRunner(hub, event).runEventPipeline(event)
         expect(ingestResponse1).toEqual({
             lastStep: 'prepareEventStep',
             error: 'database unavailable',

--- a/plugin-server/tests/worker/dead-letter-queue.test.ts
+++ b/plugin-server/tests/worker/dead-letter-queue.test.ts
@@ -78,7 +78,7 @@ describe('events dead letter queue', () => {
         expect(dlqEvent.team_id).toEqual(2)
         expect(dlqEvent.team_id).toEqual(2)
         expect(dlqEvent.error_location).toEqual('plugin_server_ingest_event:prepareEventStep')
-        expect(dlqEvent.error).toEqual('ingestEvent failed. Error: database unavailable')
+        expect(dlqEvent.error).toEqual('Event ingestion failed. Error: database unavailable')
         expect(dlqEvent.properties).toEqual(JSON.stringify({ key: 'value', $ip: '127.0.0.1' }))
         expect(dlqEvent.event_uuid).toEqual(EVENT_UUID)
     })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -222,7 +222,7 @@ describe('EventPipelineRunner', () => {
                 expect(JSON.parse(hub.db.kafkaProducer.queueMessage.mock.calls[0][0].messages[0].value)).toMatchObject({
                     team_id: 2,
                     distinct_id: 'my_id',
-                    error: 'ingestEvent failed. Error: testError',
+                    error: 'Event ingestion failed. Error: testError',
                     error_location: 'plugin_server_ingest_event:prepareEventStep',
                 })
                 expect(pipelineStepDLQCounterSpy).toHaveBeenCalledWith('prepareEventStep')


### PR DESCRIPTION
## Problem

Just a small cleanup: removes a couple layers of [passthrough methods](https://www.mattduck.com/2021-04-a-philosophy-of-software-design.html#pass-through-methods-are-shallow-and-add-complexity) to make things easier to follow.

## How did you test this code?

Covered by existing tests.