### PR TITLE
feat(plugin-server): Track and log partition offsets and message counts within a batch

### DIFF
--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -258,7 +258,7 @@ export const startBatchConsumer = async ({
 
                 // NOTE: we do not handle any retries. This should be handled by
                 // the implementation of `eachBatch`.
-                status.info('⏳', `Starting to process batch of ${messages.length} events...`, batchSummary)
+                status.debug('⏳', `Starting to process batch of ${messages.length} events...`, batchSummary)
                 await eachBatch(messages)
 
                 messagesProcessed += messages.length
@@ -271,7 +271,7 @@ export const startBatchConsumer = async ({
                 if (processingTimeMs > SLOW_BATCH_PROCESSING_LOG_THRESHOLD_MS) {
                     status.warn('🕒', `Slow batch: ${logSummary}`, batchSummary)
                 } else {
-                    status.info('⌛️', logSummary, batchSummary)
+                    status.debug('⌛️', logSummary, batchSummary)
                 }
 
                 if (autoCommit) {

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -23,6 +23,36 @@ export interface BatchConsumer {
 const STATUS_LOG_INTERVAL_MS = 10000
 const SLOW_BATCH_PROCESSING_LOG_THRESHOLD_MS = 10000
 
+type PartitionSummary = {
+    // number of messages received (often this can be derived from the
+    // difference between the minimum and maximum offset values + 1, but not
+    // always in case of messages deleted on the broker, or offset resets)
+    count: number
+    // minimum and maximum offsets observed
+    offsets: [number, number]
+}
+
+class BatchSummary {
+    // NOTE: ``Map`` would probably be more appropriate here, but ``Record`` is
+    // easier to JSON serialize.
+    private partitions: Record<number, PartitionSummary> = {}
+
+    public record(message: Message) {
+        let summary = this.partitions[message.partition]
+        if (summary === undefined) {
+            summary = {
+                count: 1,
+                offsets: [message.offset, message.offset],
+            }
+            this.partitions[message.partition] = summary
+        } else {
+            summary.count += 1
+            summary.offsets[0] = Math.min(summary.offsets[0], message.offset)
+            summary.offsets[1] = Math.max(summary.offsets[1], message.offset)
+        }
+    }
+}
+
 export const startBatchConsumer = async ({
     connectionConfig,
     groupId,
@@ -218,14 +248,17 @@ export const startBatchConsumer = async ({
                 }
 
                 const startProcessingTimeMs = new Date().valueOf()
+                const batchSummary = new BatchSummary()
 
                 consumerBatchSize.labels({ topic, groupId }).observe(messages.length)
                 for (const message of messages) {
                     consumedMessageSizeBytes.labels({ topic, groupId }).observe(message.size)
+                    batchSummary.record(message)
                 }
 
                 // NOTE: we do not handle any retries. This should be handled by
                 // the implementation of `eachBatch`.
+                status.info('⏳', `Starting to process batch of ${messages.length} events...`, batchSummary)
                 await eachBatch(messages)
 
                 messagesProcessed += messages.length
@@ -233,11 +266,12 @@ export const startBatchConsumer = async ({
 
                 const processingTimeMs = new Date().valueOf() - startProcessingTimeMs
                 consumedBatchDuration.labels({ topic, groupId }).observe(processingTimeMs)
+
+                const logSummary = `Processed ${messages.length} events in ${Math.round(processingTimeMs / 10) / 100}s`
                 if (processingTimeMs > SLOW_BATCH_PROCESSING_LOG_THRESHOLD_MS) {
-                    status.warn(
-                        '🕒',
-                        `Slow batch: ${messages.length} events in ${Math.round(processingTimeMs / 10) / 100}s`
-                    )
+                    status.warn('🕒', `Slow batch: ${logSummary}`, batchSummary)
+                } else {
+                    status.info('⌛️', logSummary, batchSummary)
                 }
 
                 if (autoCommit) {


### PR DESCRIPTION
## Problem

This lets us know what the consumer is doing when it gets stuck (what partitions its working on, what offsets, etc.)

## How did you test this code?

Run functional tests, observe log output:

```
[15:06:25.684] INFO (70287): [MAIN] ⏳ Starting to process batch of 15 events...
    partitions: {
      "0": {
        "count": 15,
        "offsets": [
          196,
          210
        ]
      }
    }
[15:06:25.686] INFO (70287): [MAIN] 🔌 setupPlugin succeeded for plugin test plugin ID 51 (organization ID 018dd838-46a6-0000-eeae-70e6dd9570d7).
[15:06:25.686] INFO (70287): [MAIN] 🔌 setupPlugin succeeded for plugin test plugin ID 51 (organization ID 018dd838-46a6-0000-eeae-70e6dd9570d7).
[15:06:25.686] INFO (70287): [MAIN] 🔌 setupPlugin succeeded for plugin test plugin ID 52 (organization ID 018dd838-46a6-0000-eeae-70e6dd9570d7).
[15:06:25.689] INFO (70287): [MAIN] 🔌 setupPlugin succeeded for plugin test plugin ID 49 (organization ID 018dd838-46a6-0000-eeae-70e6dd9570d7).
[15:06:25.701] INFO (70287): [MAIN] 🔁 main_loop
    messagesPerSecond: 0
    batchesProcessed: 0
    lastConsumeTime: "2024-02-23T23:06:25.609Z"
[15:06:25.721] INFO (70287): [MAIN] Inserting new event definition with last_seen_at undefined
[15:06:25.721] INFO (70287): [MAIN] Inserting new event definition with last_seen_at undefined
[15:06:25.722] INFO (70287): [MAIN] Inserting new event definition with last_seen_at undefined
[15:06:25.722] INFO (70287): [MAIN] Inserting new event definition with last_seen_at undefined
[15:06:25.722] INFO (70287): [MAIN] Inserting new event definition with last_seen_at undefined
[15:06:25.722] INFO (70287): [MAIN] Inserting new event definition with last_seen_at undefined
[15:06:25.723] INFO (70287): [MAIN] Inserting new event definition with last_seen_at undefined
[15:06:25.726] INFO (70287): [MAIN] 🔌 setupPlugin succeeded for plugin test plugin ID 50 (organization ID 018dd838-46a6-0000-eeae-70e6dd9570d7).
[15:06:25.727] INFO (70287): [MAIN] 🔌 setupPlugin succeeded for plugin test plugin ID 46 (organization ID 018dd838-46a6-0000-eeae-70e6dd9570d7).
[15:06:25.728] INFO (70287): [MAIN] 🔌 setupPlugin succeeded for plugin test plugin ID 48 (organization ID 018dd838-46a6-0000-eeae-70e6dd9570d7).
[15:06:25.729] ERROR (70287): [MAIN] 🤮 Unhandled Promise Rejection
    promise: {}
    error: {}
[15:06:25.732] INFO (70287): [MAIN] 🔌 setupPlugin succeeded for plugin test plugin ID 47 (organization ID 018dd838-46a6-0000-eeae-70e6dd9570d7).
[15:06:25.763] INFO (70287): [MAIN] Inserting new event definition with last_seen_at undefined
[worker(worker-07019e71a5c7ab8167)] INFO: Completed task 11 (pluginJob) with success (0.89ms)
[worker(worker-07019e71a5c7ab8167)] INFO: Completed task 12 (pluginJob) with success (0.35ms)
[15:06:26.656] INFO (70287): [MAIN] Inserting new event definition with last_seen_at undefined
[15:06:26.657] INFO (70287): [MAIN] Inserting new event definition with last_seen_at undefined
[15:06:26.657] INFO (70287): [MAIN] Inserting new event definition with last_seen_at undefined
[15:06:26.658] INFO (70287): [MAIN] Inserting new event definition with last_seen_at undefined
[15:06:26.658] INFO (70287): [MAIN] Inserting new event definition with last_seen_at undefined
[15:06:26.658] INFO (70287): [MAIN] Inserting new event definition with last_seen_at undefined
[15:06:26.684] INFO (70287): [MAIN] ⌛️ Processed 15 events in 1s
    partitions: {
      "0": {
        "count": 15,
        "offsets": [
          196,
          210
        ]
      }
    }
```

You can also see them in the functional test output in CI in their less expanded form:

```
{"level":"info","time":1708730122116,"pid":7644,"hostname":"fv-az1542-913","partitions":{"0":{"count":18,"offsets":[0,17]}},"msg":"[MAIN] ⌛️ Processed 18 events in 3.13s"}
```