### PR TITLE
feat: Added UA parser to the event processing

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -82,6 +82,7 @@
         "re2": "^1.20.3",
         "safe-stable-stringify": "^2.4.0",
         "tail": "^2.2.6",
+        "ua-parser-js": "^1.0.37",
         "uuid": "^8.3.2",
         "v8-profiler-next": "^1.9.0",
         "vm2": "3.9.18"
@@ -111,6 +112,7 @@
         "@types/redlock": "^4.0.1",
         "@types/snowflake-sdk": "^1.5.1",
         "@types/tar-stream": "^2.2.0",
+        "@types/ua-parser-js": "^0.7.39",
         "@types/uuid": "^8.3.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -139,6 +139,9 @@ dependencies:
   tail:
     specifier: ^2.2.6
     version: 2.2.6
+  ua-parser-js:
+    specifier: ^1.0.37
+    version: 1.0.37
   uuid:
     specifier: ^8.3.2
     version: 8.3.2
@@ -222,6 +225,9 @@ devDependencies:
   '@types/tar-stream':
     specifier: ^2.2.0
     version: 2.2.2
+  '@types/ua-parser-js':
+    specifier: ^0.7.39
+    version: 0.7.39
   '@types/uuid':
     specifier: ^8.3.0
     version: 8.3.4
@@ -3770,6 +3776,10 @@ packages:
     resolution: {integrity: sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==}
     dependencies:
       '@types/node': 16.18.25
+    dev: true
+
+  /@types/ua-parser-js@0.7.39:
+    resolution: {integrity: sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==}
     dev: true
 
   /@types/uuid@8.3.4:
@@ -10253,6 +10263,10 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
+
+  /ua-parser-js@1.0.37:
+    resolution: {integrity: sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==}
+    dev: false
 
   /uc.micro@1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}


### PR DESCRIPTION
## Problem

We do all the parsing client side which is fiddly and means keeping multiple SDKs up to date.

## Changes

- [x] Adds server side processing using ua parser lib
- [ ] Add tests to make sure we match existing values
- [ ] Maybe even revert to the JS code if we find it too hard to rely on the ua parser.

Personally I like this approach as it is simple, we have a lot of control over it and we can make it configurable when we get the new CDP stuff up and running rather than fudging all this into a plugin.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
