### PR TITLE
feat(webhook): Be able to use event timestamp in action webhooks

### DIFF
--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -203,6 +203,8 @@ export function getValueOfToken(
             markdown = text = webhookEscape(event.event, webhookType)
         } else if (tokenParts[1] === 'event') {
             markdown = text = webhookEscape(event.event, webhookType)
+        } else if (tokenParts[1] === 'timestamp') {
+            markdown = text = webhookEscape(event.timestamp, webhookType)
         } else if (tokenParts[1] === 'distinct_id') {
             markdown = text = webhookEscape(event.distinctId, webhookType)
         } else if (tokenParts[1] === 'properties' && tokenParts.length > 2) {


### PR DESCRIPTION
## Changes
- Added the ability to use `[event.timestamp]` in action webhooks
- Request came in via [this community question](https://posthog.com/questions/event-timestamp-1)

## How did you test this code?
👀 