### PR TITLE
feat: Enable parallel batch processing for v3 ingester

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager-v3.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager-v3.ts
@@ -114,6 +114,8 @@ export class SessionManagerV3 {
     inProgressUpload: Upload | null = null
     flushJitterMultiplier: number
 
+    readonly setupPromise: Promise<void>
+
     constructor(
         public readonly serverConfig: PluginsServerConfig,
         public readonly s3Client: ObjectStorage['s3'],
@@ -121,47 +123,42 @@ export class SessionManagerV3 {
     ) {
         // We add a jitter multiplier to the buffer age so that we don't have all sessions flush at the same time
         this.flushJitterMultiplier = 1 - Math.random() * serverConfig.SESSION_RECORDING_BUFFER_AGE_JITTER
+        this.setupPromise = this.setup()
     }
 
     private file(name: string): string {
         return path.join(this.context.dir, name)
     }
 
-    public static async create(
-        serverConfig: PluginsServerConfig,
-        s3Client: ObjectStorage['s3'],
-        context: SessionManagerContext
-    ): Promise<SessionManagerV3> {
-        const manager = new SessionManagerV3(serverConfig, s3Client, context)
-        await mkdir(context.dir, { recursive: true })
+    private async setup(): Promise<void> {
+        await mkdir(this.context.dir, { recursive: true })
 
         try {
-            const fileExists = await stat(manager.file('metadata.json')).then(
+            const fileExists = await stat(this.file('metadata.json')).then(
                 () => true,
                 () => false
             )
             if (fileExists) {
                 const bufferMetadata: SessionManagerBufferContext = JSON.parse(
-                    await readFile(manager.file('metadata.json'), 'utf-8')
+                    await readFile(this.file('metadata.json'), 'utf-8')
                 )
-                manager.buffer = {
+                this.buffer = {
                     context: bufferMetadata,
-                    fileStream: manager.createFileStreamFor(path.join(context.dir, BUFFER_FILE_NAME)),
+                    fileStream: this.createFileStreamFor(path.join(this.context.dir, BUFFER_FILE_NAME)),
                 }
             }
         } catch (error) {
             // Indicates no buffer metadata file or it's corrupted
             status.error('🧨', '[session-manager] failed to read buffer metadata', {
-                ...context,
+                ...this.context,
                 error,
             })
         }
 
         status.info('📦', '[session-manager] started new manager', {
-            ...manager.context,
-            ...(manager.buffer?.context ?? {}),
+            ...this.context,
+            ...(this.buffer?.context ?? {}),
         })
-        return manager
     }
 
     private async syncMetadata(): Promise<void> {
@@ -195,6 +192,8 @@ export class SessionManagerV3 {
         if (this.destroying) {
             return
         }
+
+        await this.setupPromise
 
         try {
             const buffer = this.getOrCreateBuffer()
@@ -241,6 +240,8 @@ export class SessionManagerV3 {
         if (this.destroying) {
             return
         }
+
+        await this.setupPromise
 
         if (!force) {
             await this.maybeFlushCurrentBuffer()

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v3.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v3.ts
@@ -163,7 +163,8 @@ export class SessionRecordingIngesterV3 {
         if (!this.sessions[key]) {
             const { partition } = event.metadata
 
-            this.sessions[key] = await SessionManagerV3.create(this.config, this.objectStorage.s3, {
+            // NOTE: It's important that this stays sync so that parallel calls will not create multiple session managers
+            this.sessions[key] = new SessionManagerV3(this.config, this.objectStorage.s3, {
                 teamId: team_id,
                 sessionId: session_id,
                 dir: this.dirForSession(partition, team_id, session_id),
@@ -226,8 +227,12 @@ export class SessionRecordingIngesterV3 {
                 await runInstrumentedFunction({
                     statsKey: `recordingingester.handleEachBatch.consumeBatch`,
                     func: async () => {
-                        for (const message of recordingMessages) {
-                            await this.consume(message)
+                        if (this.config.SESSION_RECORDING_PARALLEL_CONSUMPTION) {
+                            await Promise.all(recordingMessages.map((x) => this.consume(x)))
+                        } else {
+                            for (const message of recordingMessages) {
+                                await this.consume(message)
+                            }
                         }
                     },
                 })
@@ -388,23 +393,19 @@ export class SessionRecordingIngesterV3 {
                 })
 
                 // TODO: Below regex is a little crude. We should fix it
-                await Promise.all(
-                    keys
-                        .filter((x) => /\d+__[a-zA-Z0-9\-]+/.test(x))
-                        .map(async (key) => {
-                            // TODO: Ensure sessionId can only be a uuid
-                            const [teamId, sessionId] = key.split('__')
+                keys.filter((x) => /\d+__[a-zA-Z0-9\-]+/.test(x)).forEach((key) => {
+                    // TODO: Ensure sessionId can only be a uuid
+                    const [teamId, sessionId] = key.split('__')
 
-                            if (!this.sessions[key]) {
-                                this.sessions[key] = await SessionManagerV3.create(this.config, this.objectStorage.s3, {
-                                    teamId: parseInt(teamId),
-                                    sessionId,
-                                    dir: this.dirForSession(partition, parseInt(teamId), sessionId),
-                                    partition,
-                                })
-                            }
+                    if (!this.sessions[key]) {
+                        this.sessions[key] = new SessionManagerV3(this.config, this.objectStorage.s3, {
+                            teamId: parseInt(teamId),
+                            sessionId,
+                            dir: this.dirForSession(partition, parseInt(teamId), sessionId),
+                            partition,
                         })
-                )
+                    }
+                })
             })
         )
     }

--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/session-manager-v3.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/session-manager-v3.test.ts
@@ -39,12 +39,15 @@ describe('session-manager', () => {
         teamId = 1,
         partition = 1
     ): Promise<SessionManagerV3> => {
-        return await SessionManagerV3.create(defaultConfig, mockS3Client, {
+        const manager = new SessionManagerV3(defaultConfig, mockS3Client, {
             sessionId,
             teamId,
             partition,
             dir: path.join(tmpDir, `${partition}`, `${teamId}__${sessionId}`),
         })
+
+        await manager.setupPromise
+        return manager
     }
 
     const flushThreshold = defaultConfig.SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS * 1000

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v3.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v3.test.ts
@@ -188,6 +188,14 @@ describe('ingester', () => {
         expect(ingester.sessions['1__session_id_2']).toBeDefined()
     })
 
+    it('handles parallel ingestion of the same session', async () => {
+        const event = createIncomingRecordingMessage()
+        const event2 = createIncomingRecordingMessage()
+        await Promise.all([ingester.consume(event), ingester.consume(event2)])
+        expect(Object.keys(ingester.sessions).length).toBe(1)
+        expect(ingester.sessions['1__session_id_1']).toBeDefined()
+    })
+
     it('destroys a session manager if finished', async () => {
         const sessionId = `destroys-a-session-manager-if-finished-${randomUUID()}`
         const event = createIncomingRecordingMessage({


### PR DESCRIPTION
## Problem

I want to try parallel processing in the batch to see if that relieves some things (its considerably slower currently than the v2 ingester.

## Changes

* Adds an extra timing metric for backpressure (it could be worse with EFS than we realise)
* Moves out the async creation so that we can parellise the batch consumption

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
