### PR TITLE
feat(trends): division by zero is zero

### DIFF
--- a/posthog/hogql_queries/utils/formula_ast.py
+++ b/posthog/hogql_queries/utils/formula_ast.py
@@ -52,6 +52,8 @@ class FormulaAST:
 
             try:
                 return self.op_map[type(op)](left, right)
+            except ZeroDivisionError:
+                return 0
             except KeyError:
                 raise ValueError(f"Operator {op.__class__.__name__} not supported")
 

--- a/posthog/hogql_queries/utils/test/test_formula_ast.py
+++ b/posthog/hogql_queries/utils/test/test_formula_ast.py
@@ -27,6 +27,11 @@ class TestFormulaAST(APIBaseTest):
         response = formula.call("A/2")
         self.assertListEqual([0.5, 1, 1.5, 2], response)
 
+    def test_division_zero(self):
+        formula = self._get_formula_ast()
+        response = formula.call("A/0")
+        self.assertListEqual([0, 0, 0, 0], response)
+
     def test_modulo(self):
         formula = self._get_formula_ast()
         response = formula.call("A%2")


### PR DESCRIPTION
## Problem

HogQL trends insights would error if they had to divide by zero.

## Changes

Returns zero. This is how the legacy version works.

## How did you test this code?

In the browser and added a test.