### PR TITLE
fix: Added handling for v3 ingester metadata.json file being corrupted

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager-v3.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager-v3.ts
@@ -25,7 +25,7 @@ const metricPrefix = 'v3_'
 export const FILE_EXTENSION = '.jsonl'
 export const BUFFER_FILE_NAME = `buffer${FILE_EXTENSION}`
 export const FLUSH_FILE_EXTENSION = `.flush${FILE_EXTENSION}`
-export const METADATA_FILE_NAME = `metadata2.json`
+export const METADATA_FILE_NAME = `metadata.json`
 
 const counterS3FilesWritten = new Counter({
     name: metricPrefix + 'recording_s3_files_written',

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager-v3.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager-v3.ts
@@ -147,6 +147,10 @@ export class SessionManagerV3 {
         let context: SessionManagerBufferContext | undefined
 
         if (!bufferFileExists) {
+            status.info('📦', '[session-manager] started new manager', {
+                ...this.context,
+                ...(this.buffer?.context ?? {}),
+            })
             return
         }
 
@@ -205,7 +209,7 @@ export class SessionManagerV3 {
             fileStream: this.createFileStreamFor(path.join(this.context.dir, BUFFER_FILE_NAME)),
         }
 
-        status.info('📦', '[session-manager] started new manager', {
+        status.info('📦', '[session-manager] started new manager from existing file', {
             ...this.context,
             ...(this.buffer?.context ?? {}),
         })

--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/session-manager-v3.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/session-manager-v3.test.ts
@@ -253,42 +253,6 @@ describe('session-manager', () => {
     })
 
     it('handles a corrupted metadata.json file', async () => {
-        const now = Date.now()
-        const sm1 = await createSessionManager('session_id_2', 2, 2)
-
-        await sm1.add(
-            createIncomingRecordingMessage({
-                events: [
-                    { timestamp: 170000000, type: 4, data: { href: 'http://localhost:3001/' } },
-                    { timestamp: 170000000 + 1000, type: 4, data: { href: 'http://localhost:3001/' } },
-                ],
-            })
-        )
-
-        await sm1.stop()
-
-        await fs.writeFile(`${sm1.context.dir}/metadata.json`, 'CORRUPTEDDD', 'utf-8')
-
-        const sm2 = await createSessionManager('session_id_2', 2, 2)
-
-        expect(sm2.buffer?.context).toEqual({
-            count: 1,
-            createdAt: expect.any(Number),
-            eventsRange: {
-                firstTimestamp: expect.any(Number),
-                lastTimestamp: expect.any(Number),
-            },
-            sizeEstimate: 185,
-        })
-
-        expect(sm2.buffer?.context.createdAt).toBeGreaterThanOrEqual(now)
-        expect(sm2.buffer?.context.eventsRange?.firstTimestamp).toBeGreaterThanOrEqual(now)
-        expect(sm2.buffer?.context.eventsRange?.lastTimestamp).toBeGreaterThanOrEqual(
-            sm2.buffer!.context.eventsRange!.firstTimestamp
-        )
-    })
-
-    it('handles a corrupted metadata.json file', async () => {
         const sm1 = await createSessionManager('session_id_2', 2, 2)
 
         await sm1.add(

--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/session-manager-v3.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/session-manager-v3.test.ts
@@ -251,4 +251,76 @@ describe('session-manager', () => {
             '{"window_id":"window_id_1","data":[{"timestamp":170000000,"type":4,"data":{"href":"http://localhost:3001/"}}]}\n'
         )
     })
+
+    it('handles a corrupted metadata.json file', async () => {
+        const now = Date.now()
+        const sm1 = await createSessionManager('session_id_2', 2, 2)
+
+        await sm1.add(
+            createIncomingRecordingMessage({
+                events: [
+                    { timestamp: 170000000, type: 4, data: { href: 'http://localhost:3001/' } },
+                    { timestamp: 170000000 + 1000, type: 4, data: { href: 'http://localhost:3001/' } },
+                ],
+            })
+        )
+
+        await sm1.stop()
+
+        await fs.writeFile(`${sm1.context.dir}/metadata.json`, 'CORRUPTEDDD', 'utf-8')
+
+        const sm2 = await createSessionManager('session_id_2', 2, 2)
+
+        expect(sm2.buffer?.context).toEqual({
+            count: 1,
+            createdAt: expect.any(Number),
+            eventsRange: {
+                firstTimestamp: expect.any(Number),
+                lastTimestamp: expect.any(Number),
+            },
+            sizeEstimate: 185,
+        })
+
+        expect(sm2.buffer?.context.createdAt).toBeGreaterThanOrEqual(now)
+        expect(sm2.buffer?.context.eventsRange?.firstTimestamp).toBeGreaterThanOrEqual(now)
+        expect(sm2.buffer?.context.eventsRange?.lastTimestamp).toBeGreaterThanOrEqual(
+            sm2.buffer!.context.eventsRange!.firstTimestamp
+        )
+    })
+
+    it('handles a corrupted metadata.json file', async () => {
+        const now = Date.now()
+        const sm1 = await createSessionManager('session_id_2', 2, 2)
+
+        await sm1.add(
+            createIncomingRecordingMessage({
+                events: [
+                    { timestamp: 170000000, type: 4, data: { href: 'http://localhost:3001/' } },
+                    { timestamp: 170000000 + 1000, type: 4, data: { href: 'http://localhost:3001/' } },
+                ],
+            })
+        )
+
+        await sm1.stop()
+
+        await fs.writeFile(`${sm1.context.dir}/metadata.json`, 'CORRUPTEDDD', 'utf-8')
+
+        const sm2 = await createSessionManager('session_id_2', 2, 2)
+
+        expect(sm2.buffer?.context).toEqual({
+            count: 1,
+            createdAt: expect.any(Number),
+            eventsRange: {
+                firstTimestamp: expect.any(Number),
+                lastTimestamp: expect.any(Number),
+            },
+            sizeEstimate: 185,
+        })
+
+        expect(sm2.buffer?.context.createdAt).toBeGreaterThanOrEqual(now)
+        expect(sm2.buffer?.context.eventsRange?.firstTimestamp).toBeGreaterThanOrEqual(now)
+        expect(sm2.buffer?.context.eventsRange?.lastTimestamp).toBeGreaterThanOrEqual(
+            sm2.buffer!.context.eventsRange!.firstTimestamp
+        )
+    })
 })

--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/session-manager-v3.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/session-manager-v3.test.ts
@@ -289,7 +289,6 @@ describe('session-manager', () => {
     })
 
     it('handles a corrupted metadata.json file', async () => {
-        const now = Date.now()
         const sm1 = await createSessionManager('session_id_2', 2, 2)
 
         await sm1.add(
@@ -317,8 +316,8 @@ describe('session-manager', () => {
             sizeEstimate: 185,
         })
 
-        expect(sm2.buffer?.context.createdAt).toBeGreaterThanOrEqual(now)
-        expect(sm2.buffer?.context.eventsRange?.firstTimestamp).toBeGreaterThanOrEqual(now)
+        expect(sm2.buffer?.context.createdAt).toBeGreaterThanOrEqual(0)
+        expect(sm2.buffer?.context.eventsRange?.firstTimestamp).toBe(sm2.buffer!.context.createdAt)
         expect(sm2.buffer?.context.eventsRange?.lastTimestamp).toBeGreaterThanOrEqual(
             sm2.buffer!.context.eventsRange!.firstTimestamp
         )


### PR DESCRIPTION
## Problem

We're working with a distributed file system - things can go wrong, particularly when we are parallel writing to the same files (note this shouldn't be the case anymore after the grouped batching.

We need to account for this regardless.

## Changes

* Adds error checking for the metadata.json parsing going wrong
* Falls back to loading from the meta of the buffer file
* Which finally falls back to deleting the files, allowing the service to continue ingesting (otherwise it just gets stuck creating and destroying the same file.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
