### PR TITLE
fix(batch-export): Copy Postgres non-retryable errors over to Redshift

### DIFF
--- a/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
@@ -31,7 +31,7 @@
   FROM events LEFT JOIN (
   SELECT person_static_cohort.person_id AS cohort_person_id, 1 AS matched, person_static_cohort.cohort_id AS cohort_id 
   FROM person_static_cohort 
-  WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [13]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
+  WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [12]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
   WHERE and(equals(events.team_id, 420), 1, ifNull(equals(__in_cohort.matched, 1), 0)) 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
@@ -42,7 +42,7 @@
   FROM events LEFT JOIN (
   SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
   FROM static_cohort_people 
-  WHERE in(cohort_id, [13])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
+  WHERE in(cohort_id, [12])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
   WHERE and(1, equals(__in_cohort.matched, 1)) 
   LIMIT 100
   '''
@@ -55,7 +55,7 @@
   FROM events LEFT JOIN (
   SELECT person_static_cohort.person_id AS cohort_person_id, 1 AS matched, person_static_cohort.cohort_id AS cohort_id 
   FROM person_static_cohort 
-  WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [14]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
+  WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [13]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
   WHERE and(equals(events.team_id, 420), 1, ifNull(equals(__in_cohort.matched, 1), 0)) 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
@@ -66,7 +66,7 @@
   FROM events LEFT JOIN (
   SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
   FROM static_cohort_people 
-  WHERE in(cohort_id, [14])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
+  WHERE in(cohort_id, [13])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
   WHERE and(1, equals(__in_cohort.matched, 1)) 
   LIMIT 100
   '''

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
@@ -357,7 +357,7 @@
                         if(and(equals(e.event, 'user signed up'), ifNull(in(e__pdi.person_id,
                                                                               (SELECT cohortpeople.person_id AS person_id
                                                                                FROM cohortpeople
-                                                                               WHERE and(equals(cohortpeople.team_id, 2), equals(cohortpeople.cohort_id, 21))
+                                                                               WHERE and(equals(cohortpeople.team_id, 2), equals(cohortpeople.cohort_id, 20))
                                                                                GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, cohortpeople.version
                                                                                HAVING ifNull(greater(sum(cohortpeople.sign), 0), 0))), 0)), 1, 0) AS step_0,
                         if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
@@ -872,7 +872,7 @@
                         if(and(equals(e.event, 'user signed up'), ifNull(in(e__pdi.person_id,
                                                                               (SELECT person_static_cohort.person_id AS person_id
                                                                                FROM person_static_cohort
-                                                                               WHERE and(equals(person_static_cohort.team_id, 2), equals(person_static_cohort.cohort_id, 22)))), 0)), 1, 0) AS step_0,
+                                                                               WHERE and(equals(person_static_cohort.team_id, 2), equals(person_static_cohort.cohort_id, 21)))), 0)), 1, 0) AS step_0,
                         if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                         if(equals(e.event, 'paid'), 1, 0) AS step_1,
                         if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1

--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -457,7 +457,15 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
         await execute_batch_export_insert_activity(
             insert_into_redshift_activity,
             insert_inputs,
-            non_retryable_error_types=[],
+            non_retryable_error_types=[
+                # Raised on errors that are related to database operation.
+                # For example: unexpected disconnect, database or other object not found.
+                "OperationalError",
+                # The schema name provided is invalid (usually because it doesn't exist).
+                "InvalidSchemaName",
+                # Missing permissions to, e.g., insert into table.
+                "InsufficientPrivilege",
+            ],
             update_inputs=update_inputs,
             # Disable heartbeat timeout until we add heartbeat support.
             heartbeat_timeout_seconds=None,

--- a/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
@@ -12,6 +12,8 @@ import pytest_asyncio
 from django.conf import settings
 from django.test import override_settings
 from psycopg import sql
+from temporalio import activity
+from temporalio.client import WorkflowFailureError
 from temporalio.common import RetryPolicy
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
@@ -66,12 +68,12 @@ async def assert_clickhouse_records_in_redshfit(
     """Assert expected records are written to a given Redshift table.
 
     The steps this function takes to assert records are written are:
-    1. Read all records inserted into given PostgreSQL table.
-    2. Cast records read from PostgreSQL to a Python list of dicts.
-    3. Assert records read from PostgreSQL have the expected column names.
+    1. Read all records inserted into given Redshift table.
+    2. Cast records read from Redshift to a Python list of dicts.
+    3. Assert records read from Redshift have the expected column names.
     4. Read all records that were supposed to be inserted from ClickHouse.
     5. Cast records returned by ClickHouse to a Python list of dicts.
-    6. Compare each record returned by ClickHouse to each record read from PostgreSQL.
+    6. Compare each record returned by ClickHouse to each record read from Redshift.
 
     Caveats:
     * Casting records to a Python list of dicts means losing some type precision.
@@ -79,10 +81,10 @@ async def assert_clickhouse_records_in_redshfit(
         * `iter_records` has its own set of related unit tests to control for this.
 
     Arguments:
-        postgres_connection: A PostgreSQL connection used to read inserted events.
+        redshift_connection: A Redshift connection used to read inserted events.
         clickhouse_client: A ClickHouseClient used to read events that are expected to be inserted.
-        schema_name: PostgreSQL schema name.
-        table_name: PostgreSQL table name.
+        schema_name: Redshift schema name.
+        table_name: Redshift table name.
         team_id: The ID of the team that we are testing events for.
         batch_export_schema: Custom schema used in the batch export.
     """
@@ -460,3 +462,100 @@ async def test_redshift_export_workflow(
 def test_remove_escaped_whitespace_recursive(value, expected):
     """Test we remove some whitespace values."""
     assert remove_escaped_whitespace_recursive(value) == expected
+
+
+async def test_redshift_export_workflow_handles_insert_activity_errors(ateam, redshift_batch_export, interval):
+    """Test that Redshift Export Workflow can gracefully handle errors when inserting Redshift data."""
+    data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
+
+    workflow_id = str(uuid4())
+    inputs = RedshiftBatchExportInputs(
+        team_id=ateam.pk,
+        batch_export_id=str(redshift_batch_export.id),
+        data_interval_end=data_interval_end.isoformat(),
+        interval=interval,
+        **redshift_batch_export.destination.config,
+    )
+
+    @activity.defn(name="insert_into_redshift_activity")
+    async def insert_into_redshift_activity_mocked(_: RedshiftInsertInputs) -> str:
+        raise ValueError("A useful error message")
+
+    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+        async with Worker(
+            activity_environment.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[RedshiftBatchExportWorkflow],
+            activities=[
+                create_export_run,
+                insert_into_redshift_activity_mocked,
+                update_export_run_status,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            with pytest.raises(WorkflowFailureError):
+                await activity_environment.client.execute_workflow(
+                    RedshiftBatchExportWorkflow.run,
+                    inputs,
+                    id=workflow_id,
+                    task_queue=settings.TEMPORAL_TASK_QUEUE,
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                )
+
+    runs = await afetch_batch_export_runs(batch_export_id=redshift_batch_export.id)
+    assert len(runs) == 1
+
+    run = runs[0]
+    assert run.status == "FailedRetryable"
+    assert run.latest_error == "ValueError: A useful error message"
+
+
+async def test_redshift_export_workflow_handles_insert_activity_non_retryable_errors(
+    ateam, redshift_batch_export, interval
+):
+    """Test that Redshift Export Workflow can gracefully handle non-retryable errors when inserting Redshift data."""
+    data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
+
+    workflow_id = str(uuid4())
+    inputs = RedshiftBatchExportInputs(
+        team_id=ateam.pk,
+        batch_export_id=str(redshift_batch_export.id),
+        data_interval_end=data_interval_end.isoformat(),
+        interval=interval,
+        **redshift_batch_export.destination.config,
+    )
+
+    @activity.defn(name="insert_into_redshift_activity")
+    async def insert_into_redshift_activity_mocked(_: RedshiftInsertInputs) -> str:
+        class InsufficientPrivilege(Exception):
+            pass
+
+        raise InsufficientPrivilege("A useful error message")
+
+    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+        async with Worker(
+            activity_environment.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[RedshiftBatchExportWorkflow],
+            activities=[
+                create_export_run,
+                insert_into_redshift_activity_mocked,
+                update_export_run_status,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            with pytest.raises(WorkflowFailureError):
+                await activity_environment.client.execute_workflow(
+                    RedshiftBatchExportWorkflow.run,
+                    inputs,
+                    id=workflow_id,
+                    task_queue=settings.TEMPORAL_TASK_QUEUE,
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                )
+
+    runs = await afetch_batch_export_runs(batch_export_id=redshift_batch_export.id)
+    assert len(runs) == 1
+
+    run = runs[0]
+    assert run.status == "Failed"
+    assert run.latest_error == "InsufficientPrivilege: A useful error message"


### PR DESCRIPTION
## Problem

A customer wrote in a about a `InsufficientPrivilege` error and I noticed we don't have these on Redshift.

These should be the same between the two anyway.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Copy Postgres non-retryable errors over to Redshift.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
