### PR TITLE
fix: move deletions back to alter statements and increase batch size

### DIFF
--- a/posthog/models/async_deletion/delete.py
+++ b/posthog/models/async_deletion/delete.py
@@ -11,7 +11,7 @@ logger = structlog.get_logger(__name__)
 
 
 class AsyncDeletionProcess(ABC):
-    CLICKHOUSE_CHUNK_SIZE = 1000
+    CLICKHOUSE_CHUNK_SIZE = 1_000_000
     DELETION_TYPES: List[DeletionType] = []
 
     def __init__(self) -> None:

--- a/posthog/models/async_deletion/delete.py
+++ b/posthog/models/async_deletion/delete.py
@@ -11,7 +11,7 @@ logger = structlog.get_logger(__name__)
 
 
 class AsyncDeletionProcess(ABC):
-    CLICKHOUSE_CHUNK_SIZE = 1_000_000
+    CLICKHOUSE_CHUNK_SIZE = 100_000
     DELETION_TYPES: List[DeletionType] = []
 
     def __init__(self) -> None:

--- a/posthog/models/async_deletion/delete_events.py
+++ b/posthog/models/async_deletion/delete_events.py
@@ -36,9 +36,9 @@ class AsyncEventDeletion(AsyncDeletionProcess):
         conditions, args = self._conditions(deletions)
         sync_execute(
             f"""
-            DELETE FROM sharded_events
+            ALTER TABLE sharded_events
             ON CLUSTER '{CLICKHOUSE_CLUSTER}'
-            WHERE {" OR ".join(conditions)}
+            DELETE WHERE {" OR ".join(conditions)}
             """,
             args,
         )
@@ -60,9 +60,9 @@ class AsyncEventDeletion(AsyncDeletionProcess):
         for table in TABLES_TO_DELETE_TEAM_DATA_FROM:
             sync_execute(
                 f"""
-                DELETE FROM {table}
+                ALTER TABLE {table}
                 ON CLUSTER '{CLICKHOUSE_CLUSTER}'
-                WHERE {" OR ".join(conditions)}
+                DELETE WHERE {" OR ".join(conditions)}
                 """,
                 args,
             )

--- a/posthog/models/test/__snapshots__/test_async_deletion_model.ambr
+++ b/posthog/models/test/__snapshots__/test_async_deletion_model.ambr
@@ -1,4 +1,132 @@
 # serializer version: 1
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team
+  '''
+  
+  ALTER TABLE sharded_events ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team.1
+  '''
+  
+  ALTER TABLE person ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team.2
+  '''
+  
+  ALTER TABLE person_distinct_id ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team.3
+  '''
+  
+  ALTER TABLE person_distinct_id2 ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team.4
+  '''
+  
+  ALTER TABLE groups ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team.5
+  '''
+  
+  ALTER TABLE cohortpeople ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team.6
+  '''
+  
+  ALTER TABLE person_static_cohort ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team.7
+  '''
+  
+  ALTER TABLE plugin_log_entries ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated
+  '''
+  
+  ALTER TABLE sharded_events ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated.1
+  '''
+  
+  ALTER TABLE person ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated.2
+  '''
+  
+  ALTER TABLE person_distinct_id ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated.3
+  '''
+  
+  ALTER TABLE person_distinct_id2 ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated.4
+  '''
+  
+  ALTER TABLE groups ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated.5
+  '''
+  
+  ALTER TABLE cohortpeople ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated.6
+  '''
+  
+  ALTER TABLE person_static_cohort ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated.7
+  '''
+  
+  ALTER TABLE plugin_log_entries ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
 # name: TestAsyncDeletion.test_delete_cohortpeople
   '''
   SELECT count()
@@ -9,6 +137,170 @@
   '''
   SELECT count()
   FROM cohortpeople
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_group
+  '''
+  
+  ALTER TABLE sharded_events ON CLUSTER 'posthog'
+  DELETE
+  WHERE (team_id = 2
+         AND $group_0 = 'foo')
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_group_unrelated
+  '''
+  
+  ALTER TABLE sharded_events ON CLUSTER 'posthog'
+  DELETE
+  WHERE (team_id = 2
+         AND $group_0 = 'foo')
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_person
+  '''
+  
+  ALTER TABLE sharded_events ON CLUSTER 'posthog'
+  DELETE
+  WHERE (team_id = 2
+         AND person_id = '00000000-0000-0000-0000-000000000000')
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_person_unrelated
+  '''
+  
+  ALTER TABLE sharded_events ON CLUSTER 'posthog'
+  DELETE
+  WHERE (team_id = 2
+         AND person_id = '00000000-0000-0000-0000-000000000000')
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams
+  '''
+  
+  ALTER TABLE sharded_events ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams.1
+  '''
+  
+  ALTER TABLE person ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams.2
+  '''
+  
+  ALTER TABLE person_distinct_id ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams.3
+  '''
+  
+  ALTER TABLE person_distinct_id2 ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams.4
+  '''
+  
+  ALTER TABLE groups ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams.5
+  '''
+  
+  ALTER TABLE cohortpeople ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams.6
+  '''
+  
+  ALTER TABLE person_static_cohort ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams.7
+  '''
+  
+  ALTER TABLE plugin_log_entries ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams_unrelated
+  '''
+  
+  ALTER TABLE sharded_events ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams_unrelated.1
+  '''
+  
+  ALTER TABLE person ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams_unrelated.2
+  '''
+  
+  ALTER TABLE person_distinct_id ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams_unrelated.3
+  '''
+  
+  ALTER TABLE person_distinct_id2 ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams_unrelated.4
+  '''
+  
+  ALTER TABLE groups ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams_unrelated.5
+  '''
+  
+  ALTER TABLE cohortpeople ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams_unrelated.6
+  '''
+  
+  ALTER TABLE person_static_cohort ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_teams_unrelated.7
+  '''
+  
+  ALTER TABLE plugin_log_entries ON CLUSTER 'posthog'
+  DELETE
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_mark_deletions_done_groups


### PR DESCRIPTION
## Problem

We need to move event deletion back to alter table statements from lightweight deletes because of lightweight delete's incompatability with projections on tables.

## Changes

- Move to alter table delete statements for async deletes
- Increase batch size to 1M

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
