### PR TITLE
feat: Added heartbeat check for processing

### DIFF
--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -175,7 +175,6 @@ export const startBatchConsumer = async ({
     instrumentConsumerMetrics(consumer, groupId)
 
     let isShuttingDown = false
-    // let lastHeartbeatTime = 0
     let lastHeartbeatTime = 0
 
     // Before subscribing, we need to ensure that the topic exists. We don't

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -69,6 +69,7 @@ export const startBatchConsumer = async ({
     topicCreationTimeoutMs,
     eachBatch,
     queuedMinMessages = 100000,
+    callEachBatchWhenEmpty = false,
     debug,
 }: {
     connectionConfig: GlobalConfig
@@ -84,8 +85,9 @@ export const startBatchConsumer = async ({
     fetchBatchSize: number
     batchingTimeoutMs: number
     topicCreationTimeoutMs: number
-    eachBatch: (messages: Message[]) => Promise<void>
+    eachBatch: (messages: Message[], context: { heartbeat: () => void }) => Promise<void>
     queuedMinMessages?: number
+    callEachBatchWhenEmpty?: boolean
     debug?: string
 }): Promise<BatchConsumer> => {
     // Starts consuming from `topic` in batches of `fetchBatchSize` messages,
@@ -173,7 +175,8 @@ export const startBatchConsumer = async ({
     instrumentConsumerMetrics(consumer, groupId)
 
     let isShuttingDown = false
-    let lastConsumeTime = 0
+    // let lastHeartbeatTime = 0
+    let lastHeartbeatTime = 0
 
     // Before subscribing, we need to ensure that the topic exists. We don't
     // currently have a way to manage topic creation elsewhere (we handle this
@@ -217,7 +220,7 @@ export const startBatchConsumer = async ({
             status.info('🔁', 'main_loop', {
                 messagesPerSecond: messagesProcessed / (STATUS_LOG_INTERVAL_MS / 1000),
                 batchesProcessed: batchesProcessed,
-                lastConsumeTime: new Date(lastConsumeTime).toISOString(),
+                lastHeartbeatTime: new Date(lastHeartbeatTime).toISOString(),
             })
 
             messagesProcessed = 0
@@ -231,11 +234,11 @@ export const startBatchConsumer = async ({
                     return await consumeMessages(consumer, fetchBatchSize)
                 })
 
-                // It's important that we only set the `lastConsumeTime` after a successful consume
+                // It's important that we only set the `lastHeartbeatTime` after a successful consume
                 // call. Even if we received 0 messages, a successful call means we are actually
                 // subscribed and didn't receive, for example, an error about an inconsistent group
                 // protocol. If we never manage to consume, we don't want our health checks to pass.
-                lastConsumeTime = Date.now()
+                lastHeartbeatTime = Date.now()
 
                 for (const [topic, count] of countPartitionsPerTopic(consumer.assignments())) {
                     kafkaAbsolutePartitionCount.labels({ topic }).set(count)
@@ -248,7 +251,7 @@ export const startBatchConsumer = async ({
                 }
 
                 status.debug('🔁', 'main_loop_consumed', { messagesLength: messages.length })
-                if (!messages.length) {
+                if (!messages.length && !callEachBatchWhenEmpty) {
                     status.debug('🔁', 'main_loop_empty_batch', { cause: 'empty' })
                     consumerBatchSize.labels({ topic, groupId }).observe(0)
                     continue
@@ -266,7 +269,11 @@ export const startBatchConsumer = async ({
                 // NOTE: we do not handle any retries. This should be handled by
                 // the implementation of `eachBatch`.
                 status.debug('⏳', `Starting to process batch of ${messages.length} events...`, batchSummary)
-                await eachBatch(messages)
+                await eachBatch(messages, {
+                    heartbeat: () => {
+                        lastHeartbeatTime = Date.now()
+                    },
+                })
 
                 messagesProcessed += messages.length
                 batchesProcessed += 1
@@ -304,7 +311,7 @@ export const startBatchConsumer = async ({
     const isHealthy = () => {
         // We define health as the last consumer loop having run in the last
         // minute. This might not be bullet-proof, let's see.
-        return Date.now() - lastConsumeTime < 60000
+        return Date.now() - lastHeartbeatTime < 60000
     }
 
     const stop = async () => {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v3.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer-v3.ts
@@ -127,6 +127,10 @@ export class SessionRecordingIngesterV3 {
         return this.connectedBatchConsumer?.assignments() ?? []
     }
 
+    private get assignedPartitions(): TopicPartition['partition'][] {
+        return this.assignedTopicPartitions.map((x) => x.partition)
+    }
+
     private scheduleWork<T>(promise: Promise<T>): Promise<T> {
         /**
          * Helper to handle graceful shutdowns. Every time we do some work we add a promise to this array and remove it when finished.
@@ -167,21 +171,13 @@ export class SessionRecordingIngesterV3 {
         await this.sessions[key]?.add(event)
     }
 
-    public async handleEachBatch(messages: Message[]): Promise<void> {
+    public async handleEachBatch(messages: Message[], heartbeat: () => void): Promise<void> {
         status.info('🔁', `session-replay-ingestion - handling batch`, {
             size: messages.length,
             partitionsInBatch: [...new Set(messages.map((x) => x.partition))],
             assignedPartitions: this.assignedTopicPartitions.map((x) => x.partition),
             sessionsHandled: Object.keys(this.sessions).length,
         })
-
-        // TODO: Add a timer or something to fire this "handleEachBatch" with an empty batch for quite partitions
-        const startTime = Date.now()
-        const timeRemaining = () => {
-            // We try to force steps that can be slow to finish before the session timeout
-            const elapsed = Date.now() - startTime
-            return Math.max(KAFKA_CONSUMER_SESSION_TIMEOUT_MS * 0.9 - elapsed, 0)
-        }
 
         await runInstrumentedFunction({
             statsKey: `recordingingester.handleEachBatch`,
@@ -214,18 +210,22 @@ export class SessionRecordingIngesterV3 {
                     },
                 })
 
+                heartbeat()
+
                 await runInstrumentedFunction({
                     statsKey: `recordingingester.handleEachBatch.ensureSessionsAreLoaded`,
                     func: async () => {
-                        await this.syncSessionsWithDisk(timeRemaining())
+                        await this.syncSessionsWithDisk(heartbeat)
                     },
                 })
+
+                heartbeat()
 
                 await runInstrumentedFunction({
                     statsKey: `recordingingester.handleEachBatch.consumeBatch`,
                     func: async () => {
                         if (this.config.SESSION_RECORDING_PARALLEL_CONSUMPTION) {
-                            await Promise.all(recordingMessages.map((x) => this.consume(x)))
+                            await Promise.all(recordingMessages.map((x) => this.consume(x).then(heartbeat)))
                         } else {
                             for (const message of recordingMessages) {
                                 await this.consume(message)
@@ -234,11 +234,13 @@ export class SessionRecordingIngesterV3 {
                     },
                 })
 
+                heartbeat()
+
                 await runInstrumentedFunction({
                     statsKey: `recordingingester.handleEachBatch.flushAllReadySessions`,
                     func: async () => {
                         // TODO: This can time out if it ends up being overloaded - we should have a max limit here
-                        await this.flushAllReadySessions(timeRemaining())
+                        await this.flushAllReadySessions(heartbeat)
                     },
                 })
 
@@ -296,9 +298,10 @@ export class SessionRecordingIngesterV3 {
             fetchBatchSize: this.config.SESSION_RECORDING_KAFKA_BATCH_SIZE,
             batchingTimeoutMs: this.config.KAFKA_CONSUMPTION_BATCHING_TIMEOUT_MS,
             topicCreationTimeoutMs: this.config.KAFKA_TOPIC_CREATION_TIMEOUT_MS,
-            eachBatch: async (messages) => {
-                return await this.scheduleWork(this.handleEachBatch(messages))
+            eachBatch: async (messages, { heartbeat }) => {
+                return await this.scheduleWork(this.handleEachBatch(messages, heartbeat))
             },
+            callEachBatchWhenEmpty: true, // Useful as we will still want to account for flushing sessions
             debug: this.config.SESSION_RECORDING_KAFKA_DEBUG,
         })
 
@@ -341,23 +344,12 @@ export class SessionRecordingIngesterV3 {
         return this.batchConsumer?.isHealthy()
     }
 
-    async flushAllReadySessions(timeLimit: number = KAFKA_CONSUMER_SESSION_TIMEOUT_MS): Promise<void> {
-        const startTime = Date.now()
-        const assignedPartitions = this.assignedTopicPartitions.map((x) => x.partition)
+    async flushAllReadySessions(heartbeat: () => void): Promise<void> {
         const sessions = Object.entries(this.sessions)
-        let flushedCount = 0
 
         // TODO: We could probably parallelize this to some extent
         for (const [key, sessionManager] of sessions) {
-            if (Date.now() - startTime > timeLimit) {
-                status.warn(
-                    '⚠️',
-                    `session-replay-ingestion - flushing sessions took too long, stopping at ${flushedCount} of ${sessions.length} sessions`
-                )
-                return
-            }
-
-            if (!assignedPartitions.includes(sessionManager.context.partition)) {
+            if (!this.assignedPartitions.includes(sessionManager.context.partition)) {
                 await this.destroySession(key, sessionManager)
                 continue
             }
@@ -382,16 +374,20 @@ export class SessionRecordingIngesterV3 {
                         await this.destroySession(key, sessionManager)
                     }
                 })
-            flushedCount++
+            heartbeat()
         }
         gaugeSessionsHandled.set(Object.keys(this.sessions).length)
     }
 
-    private async syncSessionsWithDisk(timeLimit: number = KAFKA_CONSUMER_SESSION_TIMEOUT_MS): Promise<void> {
-        // As we may get assigned and reassigned partitions, we want to make sure that we have all sessions loaded into memory
-        const startTime = Date.now()
+    private async syncSessionsWithDisk(heartbeat: () => void): Promise<void> {
+        // NOTE: With a lot of files on disk this can take a long time
+        // We need to ensure that as we loop we double check that we are still in charge of the partitions
 
-        for (const { partition } of this.assignedTopicPartitions) {
+        // TODO: Implement that (and also for flushing) it sync the assigned partitions with the current state of the consumer
+
+        // As we may get assigned and reassigned partitions, we want to make sure that we have all sessions loaded into memory
+
+        for (const partition of this.assignedPartitions) {
             const keys = await readdir(path.join(this.rootDir, `${partition}`)).catch(() => {
                 // This happens if there are no files on disk for that partition yet
                 return []
@@ -400,16 +396,13 @@ export class SessionRecordingIngesterV3 {
             const relatedKeys = keys.filter((x) => /\d+__[a-zA-Z0-9\-]+/.test(x))
 
             for (const key of relatedKeys) {
-                if (Date.now() - startTime > timeLimit) {
-                    status.warn(
-                        '⚠️',
-                        `session-replay-ingestion - syncing sessions from disk is taking too long, stopping.`
-                    )
-                    return
-                }
-
                 // TODO: Ensure sessionId can only be a uuid
                 const [teamId, sessionId] = key.split('__')
+
+                if (!this.assignedPartitions.includes(partition)) {
+                    // Account for rebalances
+                    continue
+                }
 
                 if (!this.sessions[key]) {
                     this.sessions[key] = new SessionManagerV3(this.config, this.objectStorage.s3, {
@@ -421,6 +414,7 @@ export class SessionRecordingIngesterV3 {
 
                     await this.sessions[key].setupPromise
                 }
+                heartbeat()
             }
         }
     }

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v3.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer-v3.test.ts
@@ -340,4 +340,15 @@ describe('ingester', () => {
             expect(ingester.sessions).toEqual({})
         })
     })
+
+    describe('heartbeats', () => {
+        it('it should send them whilst processing', async () => {
+            const heartbeat = jest.fn()
+            // non-zero offset because the code can't commit offset 0
+            const partitionMsgs1 = [createMessage('session_id_1', 1), createMessage('session_id_2', 1)]
+            await ingester.handleEachBatch(partitionMsgs1, heartbeat)
+
+            expect(heartbeat).toBeCalledTimes(5)
+        })
+    })
 })


### PR DESCRIPTION
## Problem

We currently have a simple timeout mechanism. With Blobby v3 we may have a situation where the first batch takes a while to process as we are potentially flushing a lot of data from disk where it would be acceptable to "pause" the consumption whilst we work through that backlog

## Changes

* Provide a heartbeat function to each batch which the user can call to extend the timeout
* This works great for the overall health check - does it work for the Kafka consumer though? (I think not - how can we use the heartbeat to extend the timeout? 
* Adds a proper check for active partitions as we are flushing (reason being we might rebalance during a flush or syncing with the disk)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
