### PR TITLE
fix: Add back in write stream for v3 ingester

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager-v3.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager-v3.ts
@@ -364,7 +364,7 @@ export class SessionManagerV3 {
         histogramS3LinesWritten.observe(buffer.count)
         histogramS3KbWritten.observe(buffer.sizeEstimate / 1024)
 
-        await new Promise((resolve) => this.bufferWriteStream?.end(resolve))
+        await new Promise<void>((resolve) => this.bufferWriteStream ? this.bufferWriteStream.end(resolve) : resolve())
         await rename(this.file(BUFFER_FILE_NAME), this.file(fileName))
         this.buffer = undefined
 
@@ -518,9 +518,7 @@ export class SessionManagerV3 {
             this.inProgressUpload = null
         }
 
-        if (this.bufferWriteStream) {
-            await new Promise((resolve) => this.bufferWriteStream!.end(resolve))
-        }
+        await new Promise<void>((resolve) => (this.bufferWriteStream ? this.bufferWriteStream.end(resolve) : resolve()))
 
         if (await this.isEmpty()) {
             status.info('🧨', '[session-manager] removing empty session directory', {


### PR DESCRIPTION
## Problem

Things seemed much slower without so reverting back to it.

## Changes

* Create it only when needed (so we don't have needless streams hanging around)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
