### PR TITLE
fix(cohorts): Add API scopes for cohort actions

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -329,6 +329,7 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
             *api_settings.DEFAULT_RENDERER_CLASSES,
             csvrenderers.PaginatedCSVRenderer,
         ],
+        required_scopes=["cohort:read", "person:read"],
     )
     def persons(self, request: Request, **kwargs) -> Response:
         cohort: Cohort = self.get_object()

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -576,7 +576,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         return response.Response({"success": True}, status=201)
 
-    @action(methods=["GET"], detail=False)
+    @action(methods=["GET"], detail=False, required_scopes=["person:read", "cohort:read"])
     def cohorts(self, request: request.Request) -> response.Response:
         from posthog.api.cohort import CohortSerializer
 


### PR DESCRIPTION
## Problem

Allow accessing `/persons` on cohorts and `/cohorts` on persons via the API

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Run locally, check right scope works, wrong scope doesn't work

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
