### PR TITLE
fix: Move join table creation to different client

### DIFF
--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -360,12 +360,14 @@ async def delete_squashed_person_overrides_from_clickhouse(inputs: QueryInputs) 
 
     async with heartbeat_every():
         async with get_client(mutations_sync=2) as clickhouse_client:
-            await clickhouse_client.execute_query(
+            _ = await clickhouse_client.read_query(
                 CREATE_JOIN_TABLE_FOR_DELETES_QUERY.format(
                     database=settings.CLICKHOUSE_DATABASE, dictionary_name=inputs.dictionary_name
                 ),
             )
 
+    async with heartbeat_every():
+        async with get_client(mutations_sync=2) as clickhouse_client:
             try:
                 await clickhouse_client.execute_query(
                     DELETE_SQUASHED_PERSON_OVERRIDES_QUERY.format(


### PR DESCRIPTION
## Problem

Join table creation doesn't seem to be happening. Moving it to separate client context to force it to reconnect may work.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Hard to test in development.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
