### PR TITLE
chore: Add NoSuchBucket to non-retryable

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -573,6 +573,8 @@ class S3BatchExportWorkflow(PostHogWorkflow):
                 "ParamValidationError",
                 # This error usually indicates credentials are incorrect or permissions are missing.
                 "ClientError",
+                # An S3 bucket doesn't exist.
+                "NoSuchBucket",
             ],
             update_inputs=update_inputs,
         )


### PR DESCRIPTION
## Problem

`NoSuchBucket` is popping up a lot as a retryable error, which means we are checking a lot for a bucket that will never exist (without user intervention). Let's set it as non-retryable.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

`NoSuchBucket` is now non-retryable.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
