### PR TITLE
feat(ingestion): pass PLUGIN_SERVER_MODE as pg app name

### DIFF
--- a/plugin-server/functional_tests/api.ts
+++ b/plugin-server/functional_tests/api.ts
@@ -33,7 +33,7 @@ beforeAll(async () => {
     // Setup connections to kafka, clickhouse, and postgres
     postgres = new PostgresRouter({ ...defaultConfig, POSTGRES_CONNECTION_POOL_SIZE: 1 }, null)
     graphileWorker = await makeWorkerUtils({
-        pgPool: createPostgresPool(defaultConfig.DATABASE_URL!, 1),
+        pgPool: createPostgresPool(defaultConfig.DATABASE_URL!, 1, 'functional_tests'),
     })
     clickHouseClient = new ClickHouse({
         host: defaultConfig.CLICKHOUSE_HOST,

--- a/plugin-server/src/main/graphile-worker/graphile-worker.ts
+++ b/plugin-server/src/main/graphile-worker/graphile-worker.ts
@@ -192,9 +192,11 @@ export class GraphileWorker {
                 }
             }
 
+            const role_name = this.hub.PLUGIN_SERVER_MODE ?? 'unknown'
             const pool = createPostgresPool(
                 this.hub.JOB_QUEUE_GRAPHILE_URL,
                 this.hub.POSTGRES_CONNECTION_POOL_SIZE,
+                `${role_name}-graphile`,
                 onError
             )
             try {

--- a/plugin-server/src/utils/db/postgres.ts
+++ b/plugin-server/src/utils/db/postgres.ts
@@ -30,8 +30,13 @@ export class PostgresRouter {
     private pools: Map<PostgresUse, Pool>
 
     constructor(serverConfig: PluginsServerConfig) {
+        const app_name = serverConfig.PLUGIN_SERVER_MODE ?? 'unknown'
         status.info('🤔', `Connecting to common Postgresql...`)
-        const commonClient = createPostgresPool(serverConfig.DATABASE_URL, serverConfig.POSTGRES_CONNECTION_POOL_SIZE)
+        const commonClient = createPostgresPool(
+            serverConfig.DATABASE_URL,
+            serverConfig.POSTGRES_CONNECTION_POOL_SIZE,
+            app_name
+        )
         status.info('👍', `Common Postgresql ready`)
         // We fill the pools maps with the default client by default as a safe fallback for hobby,
         // the rest of the constructor overrides entries if more database URLs are passed.
@@ -45,7 +50,11 @@ export class PostgresRouter {
             status.info('🤔', `Connecting to read-only common Postgresql...`)
             this.pools.set(
                 PostgresUse.COMMON_READ,
-                createPostgresPool(serverConfig.DATABASE_READONLY_URL, serverConfig.POSTGRES_CONNECTION_POOL_SIZE)
+                createPostgresPool(
+                    serverConfig.DATABASE_READONLY_URL,
+                    serverConfig.POSTGRES_CONNECTION_POOL_SIZE,
+                    app_name
+                )
             )
             status.info('👍', `Read-only common Postgresql ready`)
         }
@@ -53,7 +62,11 @@ export class PostgresRouter {
             status.info('🤔', `Connecting to plugin-storage Postgresql...`)
             this.pools.set(
                 PostgresUse.PLUGIN_STORAGE_RW,
-                createPostgresPool(serverConfig.PLUGIN_STORAGE_DATABASE_URL, serverConfig.POSTGRES_CONNECTION_POOL_SIZE)
+                createPostgresPool(
+                    serverConfig.PLUGIN_STORAGE_DATABASE_URL,
+                    serverConfig.POSTGRES_CONNECTION_POOL_SIZE,
+                    app_name
+                )
             )
             status.info('👍', `Plugin-storage Postgresql ready`)
         }

--- a/plugin-server/src/utils/utils.ts
+++ b/plugin-server/src/utils/utils.ts
@@ -395,10 +395,16 @@ export function pluginDigest(plugin: Plugin | Plugin['id'], teamId?: number): st
     return `plugin ${plugin.name} ID ${plugin.id} (${extras.join(' - ')})`
 }
 
-export function createPostgresPool(connectionString: string, poolSize: number, onError?: (error: Error) => any): Pool {
+export function createPostgresPool(
+    connectionString: string,
+    poolSize: number,
+    applicationName: string,
+    onError?: (error: Error) => any
+): Pool {
     const pgPool = new Pool({
         connectionString,
         idleTimeoutMillis: 500,
+        application_name: applicationName,
         max: poolSize,
         ssl: process.env.DYNO // Means we are on Heroku
             ? {


### PR DESCRIPTION
## Problem

When looking at PG's query stats, it would be great to know what plugin-server role is creating PG load without looking at individual queries

## Changes

- Specify the application name when connecting to PG. Jobs and scheduler have a separate conpool for graphile, add it as a suffix to the name to differentiate from the rest of the PG uses.

## How did you test this code?

- Run `PLUGIN_SERVER_MODE=scheduler ./bin/start`
- PG query `select application_name, count(*) from pg_stat_activity group by application_name;`

```
+--------------------+-----+
|application_name    |count|
+--------------------+-----+
|                    |8    |
|scheduler           |1    |
|scheduler-graphile  |1    |
+--------------------+-----+
```