### PR TITLE
fix: Reload dictionary on cluster

### DIFF
--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -31,11 +31,11 @@ SOURCE(CLICKHOUSE(
     QUERY 'SELECT team_id, distinct_id, argMax(person_id, version) AS person_id FROM {database}.person_distinct_id_overrides GROUP BY team_id, distinct_id'
 ))
 LAYOUT(complex_key_hashed())
-LIFETIME(MIN 0 MAX 0)
+LIFETIME(0)
 """
 
 RELOAD_DICTIONARY_QUERY = """
-SYSTEM RELOAD DICTIONARY {database}.{dictionary_name}
+SYSTEM RELOAD DICTIONARY {database}.{dictionary_name} ON CLUSTER {cluster_name}
 """
 
 SQUASH_EVENTS_QUERY = """
@@ -173,6 +173,7 @@ async def prepare_dictionary(inputs: QueryInputs) -> None:
                 RELOAD_DICTIONARY_QUERY.format(
                     database=settings.CLICKHOUSE_DATABASE,
                     dictionary_name=inputs.dictionary_name,
+                    cluster_name=settings.CLICKHOUSE_CLUSTER,
                 )
             )
 


### PR DESCRIPTION
## Problem

Occassionally, `SYSTEM RELOAD DICTIONARY` is failing. 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Trying out if this reload needs to be `ON CLUSTER` too.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
