### PR TITLE
fix: clarify masking function

### DIFF
--- a/frontend/src/scenes/settings/project/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/project/SessionRecordingSettings.tsx
@@ -1,5 +1,5 @@
 import { IconPlus } from '@posthog/icons'
-import { LemonButton, LemonSelect, LemonSwitch, LemonTag, Link } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonSelect, LemonSwitch, LemonTag, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
 import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
@@ -115,6 +115,17 @@ function NetworkCaptureSettings(): JSX.Element {
                         Learn how to mask header and payload values in our docs
                     </Link>
                 </p>
+                <LemonBanner type="info" className="mb-4">
+                    We automatically scrub some sensitive information from network headers, but if your request or
+                    response payloads could contain sensitive data, you can provide a function to mask the data when you
+                    initialise PostHog.{' '}
+                    <Link
+                        to="https://posthog.com/docs/session-replay/network-recording#sensitive-information"
+                        target="blank"
+                    >
+                        Learn how to mask header and payload values in our docs
+                    </Link>
+                </LemonBanner>
                 <div className="flex flex-row space-x-2">
                     <LemonSwitch
                         data-attr="opt-in-capture-network-headers-switch"


### PR DESCRIPTION
Add a note in config letting people know they might need to mask payloads when they capture them

![Screenshot 2024-02-29 at 12 21 53](https://github.com/PostHog/posthog/assets/984817/4b1450b9-8a25-4e3e-aa66-a743e4ec9f79)
