### PR TITLE
fix: some embeddings faff

### DIFF
--- a/ee/session_recordings/ai/generate_embeddings.py
+++ b/ee/session_recordings/ai/generate_embeddings.py
@@ -30,6 +30,7 @@ GENERATE_RECORDING_EMBEDDING_TIMING = Histogram(
 RECORDING_EMBEDDING_TOKEN_COUNT = Histogram(
     "posthog_session_recordings_recording_embedding_token_count",
     "Token count for individual recordings generated during embedding",
+    buckets=[0, 100, 500, 1000, 2000, 3000, 4000, 5000, 6000, 8000, 10000],
 )
 
 SESSION_SKIPPED_WHEN_GENERATING_EMBEDDINGS = Counter(

--- a/ee/session_recordings/ai/generate_embeddings.py
+++ b/ee/session_recordings/ai/generate_embeddings.py
@@ -112,6 +112,7 @@ def fetch_recordings_without_embeddings(team: Team | int, offset=0) -> List[str]
                 and session_id in replay_with_events
             GROUP BY session_id
             HAVING dateDiff('second', min(min_first_timestamp), max(max_last_timestamp)) > %(min_duration_include_seconds)s
+            order by rand()
             LIMIT %(batch_flush_size)s
             -- when running locally the offset is used for paging
             -- when running in celery the offset is not used

--- a/ee/session_recordings/ai/similar_recordings.py
+++ b/ee/session_recordings/ai/similar_recordings.py
@@ -23,7 +23,7 @@ def closest_embeddings(session_id: str, team_id: int):
     query = """
             WITH (
                 SELECT
-                    embeddings
+                    argMax(embeddings, generation_timestamp) as target_embeddings
                 FROM
                     session_replay_embeddings
                 WHERE
@@ -31,6 +31,7 @@ def closest_embeddings(session_id: str, team_id: int):
                     -- don't load all data for all time
                     AND generation_timestamp > now() - INTERVAL 7 DAY
                     AND session_id = %(session_id)s
+                group by session_id
                 LIMIT 1
             ) as target_embeddings
             SELECT


### PR DESCRIPTION
* we have a histogram for token count, but didn't set appropriate buckets
* we could have more than one embedding for a session lets always take the most recent
* we hadn't specified an order when loading recordings eligible for embedding, let's specify random