### PR TITLE
feat: Ability to create http batch export if impersonating

### DIFF
--- a/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
@@ -11,6 +11,7 @@ import { LemonSelectMultiple } from 'lib/lemon-ui/LemonSelectMultiple/LemonSelec
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { userLogic } from 'scenes/userLogic'
 
 import { BatchExportConfigurationForm, batchExportsEditLogic, BatchExportsEditLogicProps } from './batchExportEditLogic'
 
@@ -75,6 +76,7 @@ export function BatchExportsEditFields({
     batchExportConfigForm: BatchExportConfigurationForm
 }): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
+    const { user } = useValues(userLogic)
     const highFrequencyBatchExports = featureFlags[FEATURE_FLAGS.HIGH_FREQUENCY_BATCH_EXPORTS]
 
     return (
@@ -170,6 +172,7 @@ export function BatchExportsEditFields({
                             { value: 'Redshift', label: 'Redshift' },
                             { value: 'S3', label: 'S3' },
                             { value: 'Snowflake', label: 'Snowflake' },
+                            ...(user?.is_impersonated ? [{ value: 'HTTP', label: 'HTTP' }] : []),
                         ]}
                     />
                 </LemonField>
@@ -472,6 +475,29 @@ export function BatchExportsEditFields({
                             </LemonField>
                         ) : null}
 
+                        <LemonField name="exclude_events" label="Events to exclude" className="flex-1">
+                            <LemonSelectMultiple
+                                mode="multiple-custom"
+                                options={[]}
+                                placeholder="Input one or more events to exclude from the export (optional)"
+                            />
+                        </LemonField>
+                        <LemonField name="include_events" label="Events to include" className="flex-1">
+                            <LemonSelectMultiple
+                                mode="multiple-custom"
+                                options={[]}
+                                placeholder="Input one or more events to include in the export (optional)"
+                            />
+                        </LemonField>
+                    </>
+                ) : batchExportConfigForm.destination === 'HTTP' ? (
+                    <>
+                        <LemonField name="url" label="URL">
+                            <LemonInput />
+                        </LemonField>
+                        <LemonField name="token" label="token">
+                            <LemonInput />
+                        </LemonField>
                         <LemonField name="exclude_events" label="Events to exclude" className="flex-1">
                             <LemonSelectMultiple
                                 mode="multiple-custom"

--- a/frontend/src/scenes/batch_exports/BatchExportsListScene.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportsListScene.tsx
@@ -5,6 +5,7 @@ import { PageHeader } from 'lib/components/PageHeader'
 import { LemonMenu, LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
 import { batchExportsListLogic } from './batchExportsListLogic'
 import { BatchExportRunIcon, BatchExportTag } from './components'
@@ -38,9 +39,12 @@ export function BatchExportsListScene(): JSX.Element {
 export function BatchExportsList(): JSX.Element {
     const { batchExportConfigs, batchExportConfigsLoading, pagination } = useValues(batchExportsListLogic)
     const { unpause, pause } = useActions(batchExportsListLogic)
+    const { user } = useValues(userLogic)
     const hasDataPipelines = showBatchExports()
 
-    const configs = batchExportConfigs?.results ?? []
+    const configs =
+        batchExportConfigs?.results.filter((config) => config.destination.type !== 'HTTP' || user?.is_impersonated) ??
+        []
 
     if (configs.length === 0 && !hasDataPipelines) {
         return <></>

--- a/frontend/src/scenes/batch_exports/batchExportEditLogic.ts
+++ b/frontend/src/scenes/batch_exports/batchExportEditLogic.ts
@@ -10,6 +10,7 @@ import {
     BatchExportConfiguration,
     BatchExportDestination,
     BatchExportDestinationBigQuery,
+    BatchExportDestinationHTTP,
     BatchExportDestinationPostgres,
     BatchExportDestinationRedshift,
     BatchExportDestinationS3,
@@ -32,8 +33,9 @@ export type BatchExportConfigurationForm = Omit<
     Partial<BatchExportDestinationRedshift['config']> &
     Partial<BatchExportDestinationBigQuery['config']> &
     Partial<BatchExportDestinationS3['config']> &
-    Partial<BatchExportDestinationSnowflake['config']> & {
-        destination: 'S3' | 'Snowflake' | 'Postgres' | 'BigQuery' | 'Redshift'
+    Partial<BatchExportDestinationSnowflake['config']> &
+    Partial<BatchExportDestinationHTTP['config']> & {
+        destination: 'S3' | 'Snowflake' | 'Postgres' | 'BigQuery' | 'Redshift' | 'HTTP'
         start_at: Dayjs | null
         end_at: Dayjs | null
         json_config_file?: File[] | null
@@ -111,6 +113,13 @@ export const batchExportFormFields = (
                   include_events: '',
                   use_json_type: '',
               }
+            : destination === 'HTTP'
+            ? {
+                  url: !config.url ? 'This field is required' : '',
+                  token: !config.token ? 'This field is required' : '',
+                  exclude_events: '',
+                  include_events: '',
+              }
             : destination === 'Snowflake'
             ? {
                   account: !config.account ? 'This field is required' : '',
@@ -169,6 +178,11 @@ export const batchExportsEditLogic = kea<batchExportsEditLogicType>([
                               type: 'BigQuery',
                               config: config,
                           } as unknown as BatchExportDestinationBigQuery)
+                        : destination === 'HTTP'
+                        ? ({
+                              type: 'HTTP',
+                              config: config,
+                          } as unknown as BatchExportDestinationHTTP)
                         : ({
                               type: 'Snowflake',
                               config: config,

--- a/frontend/src/scenes/pipeline/utils.tsx
+++ b/frontend/src/scenes/pipeline/utils.tsx
@@ -6,6 +6,7 @@ import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import posthog from 'posthog-js'
+import HTTPIcon from 'public/hedgehog/running-hog.png'
 import BigQueryIcon from 'public/pipeline/BigQuery.png'
 import PostgresIcon from 'public/pipeline/Postgres.png'
 import RedshiftIcon from 'public/pipeline/Redshift.svg'
@@ -156,6 +157,7 @@ export function RenderBatchExportIcon({ type }: { type: BatchExportDestination['
         Redshift: RedshiftIcon,
         S3: S3Icon,
         Snowflake: SnowflakeIcon,
+        HTTP: HTTPIcon,
     }[type]
 
     return (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3603,6 +3603,16 @@ export type BatchExportDestinationBigQuery = {
     }
 }
 
+export type BatchExportDestinationHTTP = {
+    type: 'HTTP'
+    config: {
+        url: string
+        token: string
+        exclude_events: string[]
+        include_events: string[]
+    }
+}
+
 export type BatchExportDestinationRedshift = {
     type: 'Redshift'
     config: {
@@ -3628,6 +3638,7 @@ export type BatchExportDestination =
     | BatchExportDestinationPostgres
     | BatchExportDestinationBigQuery
     | BatchExportDestinationRedshift
+    | BatchExportDestinationHTTP
 
 export type BatchExportConfiguration = {
     // User provided data for the export. This is the data that the user


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We can now create migration batch exports if impersonating in the UI 

Tested creating a batch export in the batch exports existing UI that's visible to everyone, this is what it looks like in 3000 though:

<img width="911" alt="Screenshot 2024-02-29 at 22 53 39" src="https://github.com/PostHog/posthog/assets/890921/b925e7b3-0e73-497b-9474-eb67ac3e5570">



## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
