### PR TITLE
docs(frontend): fix broken lemon-ui README link

### DIFF
--- a/frontend/@posthog/lemon-ui/README.md
+++ b/frontend/@posthog/lemon-ui/README.md
@@ -4,4 +4,4 @@
 [![MIT License](https://img.shields.io/badge/License-MIT-red.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 
 Please see [PostHog Storybook](https://storybook.posthog.net/).
-Specifically, [Lemon UI Overview](https://storybook.posthog.net/?path=/docs/lemon-ui-overview--page).
+Specifically, [Lemon UI Overview](https://storybook.posthog.net/?path=/docs/lemon-ui-overview--docs).


### PR DESCRIPTION
## Problem

The link to the "Lemon UI Overview" Storybook was broken.

## Changes

The link now points to https://storybook.posthog.net/?path=/docs/lemon-ui-overview--docs.

## How did you test this code?

n/a
