### PR TITLE
fix: Set max_execution_time in mutations

### DIFF
--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -50,6 +50,8 @@ IN PARTITION
 WHERE
     dictHas('{database}.{dictionary_name}', (team_id, distinct_id))
     {in_team_ids}
+SETTINGS
+    max_execution_time=0
 """
 
 SQUASH_MUTATIONS_IN_PROGRESS_QUERY = """
@@ -97,6 +99,8 @@ ALTER TABLE
 DELETE WHERE
     hasAll(joinGet('{database}.person_overrides_to_delete', 'partitions', team_id, distinct_id), %(partition_ids)s)
     AND NOW() - _timestamp > %(grace_period)s
+SETTINGS
+    max_execution_time=0
 """
 
 


### PR DESCRIPTION
## Problem

Mutation is timing out in some nodes but not others :/. We have this setting on the client but not in the query, so I'm wondering if that will help...

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add `SETTINGS max_execution_time=0` to mutation queries that run on cluster.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
