### PR TITLE
fix(insights): Update debounce for filter search

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -99,7 +99,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 loadRemoteItems: async ({ offset, limit }, breakpoint) => {
                     // avoid the 150ms delay on first load
                     if (!values.remoteItems.first) {
-                        await breakpoint(150)
+                        await breakpoint(500)
                     } else {
                         // These connected values below might be read before they are available due to circular logic mounting.
                         // Adding a slight delay (breakpoint) fixes this.
@@ -347,8 +347,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 }
             }
         },
-        setSearchQuery: async (_query, breakpoint) => {
-            await breakpoint(300)
+        setSearchQuery: async () => {
             if (values.hasRemoteDataSource) {
                 actions.loadRemoteItems({ offset: 0, limit: values.limit })
             } else {


### PR DESCRIPTION
## Problem

Typing into the filter search bar still fires requests quickly. Or is that just me?

## Changes

- upped and consolidated breakpoint time

## How did you test this code?

- test by typing fast -> one query for typed word (per group)
- test by typing a little slower -> still one query for typed word (per group)
- test by typing really slow -> ookay this fires more queries 🤷🏻 