### PR TITLE
fix: Sparkline in pipeline 3000 to be 7 bars

### DIFF
--- a/frontend/src/scenes/pipeline/AppMetricSparkLine.tsx
+++ b/frontend/src/scenes/pipeline/AppMetricSparkLine.tsx
@@ -11,28 +11,29 @@ export function AppMetricSparkLine({ pipelineNode }: { pipelineNode: PipelineNod
         const logic = pipelineNodeMetricsLogic({ pluginConfigId: pipelineNode.id })
         const { appMetricsResponse } = useValues(logic)
 
+        // The metrics response has last 7 days time wise, we're showing the
+        // sparkline graph by day, so ignore the potential 8th day
+        const successes = appMetricsResponse ? appMetricsResponse.metrics.successes.slice(-7) : []
+        const failures = appMetricsResponse ? appMetricsResponse.metrics.failures.slice(-7) : []
+        const dates = appMetricsResponse ? appMetricsResponse.metrics.dates.slice(-7) : []
+
         const displayData: SparklineTimeSeries[] = [
             {
                 color: 'success',
                 name: 'Events sent',
-                values: appMetricsResponse ? appMetricsResponse.metrics.successes : [],
+                values: successes,
             },
         ]
         if (appMetricsResponse?.metrics.failures.some((failure) => failure > 0)) {
             displayData.push({
                 color: 'danger',
                 name: 'Events dropped',
-                values: appMetricsResponse ? appMetricsResponse.metrics.failures : [],
+                values: failures,
             })
         }
 
         return (
-            <Sparkline
-                loading={appMetricsResponse === null}
-                labels={appMetricsResponse ? appMetricsResponse.metrics.dates : []}
-                data={displayData}
-                className="max-w-24"
-            />
+            <Sparkline loading={appMetricsResponse === null} labels={dates} data={displayData} className="max-w-24" />
         )
     }
 }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Looks weird to have 8 or more bars there

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
