### PR TITLE
fix: Don't swap person join order

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -430,14 +430,6 @@ export class PersonState {
         const properties: Properties = { ...otherPerson.properties, ...mergeInto.properties }
         this.applyEventPropertyUpdates(properties)
 
-        if (this.personOverrideWriter) {
-            // Optimize merging persons to keep using the person id that has longer history,
-            // which means we'll have less events to update during the squash later
-            if (otherPerson.created_at < mergeInto.created_at) {
-                ;[mergeInto, otherPerson] = [otherPerson, mergeInto]
-            }
-        }
-
         const [kafkaMessages, mergedPerson] = await this.handleMergeTransaction(
             mergeInto,
             otherPerson,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
This can cause graphs to look different if PoE writes and PoEv1 reads are enabled.
We'll likely want to revert this PR once we have shipped PoE reads with overrides, though note that while this would reduce how many rows we need to overwrite it might be confusing for persons exports in the future.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
