### PR TITLE
feat: fewer tokens sent to embed from urls

### DIFF
--- a/ee/session_recordings/ai/generate_embeddings.py
+++ b/ee/session_recordings/ai/generate_embeddings.py
@@ -15,6 +15,7 @@ from ee.session_recordings.ai.utils import (
     simplify_window_id,
     format_dates,
     collapse_sequence_of_events,
+    only_pageview_urls,
 )
 from structlog import get_logger
 from posthog.clickhouse.client import sync_execute
@@ -220,11 +221,13 @@ def generate_recording_embeddings(session_id: str, team: Team | int) -> List[flo
         return None
 
     processed_sessions = collapse_sequence_of_events(
-        format_dates(
-            reduce_elements_chain(
-                simplify_window_id(SessionSummaryPromptData(columns=session_events[0], results=session_events[1]))
-            ),
-            start=datetime.datetime(1970, 1, 1, tzinfo=pytz.UTC),  # epoch timestamp
+        only_pageview_urls(
+            format_dates(
+                reduce_elements_chain(
+                    simplify_window_id(SessionSummaryPromptData(columns=session_events[0], results=session_events[1]))
+                ),
+                start=datetime.datetime(1970, 1, 1, tzinfo=pytz.UTC),  # epoch timestamp
+            )
         )
     )
 

--- a/ee/session_recordings/ai/generate_embeddings.py
+++ b/ee/session_recordings/ai/generate_embeddings.py
@@ -1,3 +1,5 @@
+import json
+
 from django.conf import settings
 from openai import OpenAI
 import tiktoken
@@ -256,7 +258,10 @@ def generate_recording_embeddings(session_id: str, team: Team | int) -> List[flo
     RECORDING_EMBEDDING_TOKEN_COUNT.observe(token_count)
     if token_count > MAX_TOKENS_FOR_MODEL:
         logger.error(
-            f"embedding input exceeds max token count for model", flow="embeddings", session_id=session_id, input=input
+            f"embedding input exceeds max token count for model",
+            flow="embeddings",
+            session_id=session_id,
+            input=json.dumps(input),
         )
         SESSION_SKIPPED_WHEN_GENERATING_EMBEDDINGS.inc()
         return None


### PR DESCRIPTION
open AI is rejecting some sessions based don token count where the token count is being forced way high because we have long URLs with filter query params, we don't really need this data

so

1. only include the full URL on a pageview event
2. on a non-pageview event we hash the URL this _should_ mean we send one token instead of many