### PR TITLE
feat: take advantage of celery scaling

### DIFF
--- a/ee/session_recordings/ai/generate_embeddings.py
+++ b/ee/session_recordings/ai/generate_embeddings.py
@@ -69,7 +69,7 @@ logger = get_logger(__name__)
 # model_name = "text-embedding-3-small" for this usecase
 encoding = tiktoken.get_encoding("cl100k_base")
 
-BATCH_FLUSH_SIZE = settings.REPLAY_EMBEDDINGS_BATCH_SIZE
+PAGE_SIZE = settings.REPLAY_EMBEDDINGS_QUERY_PAGE_SIZE
 MIN_DURATION_INCLUDE_SECONDS = settings.REPLAY_EMBEDDINGS_MIN_DURATION_SECONDS
 MAX_TOKENS_FOR_MODEL = 8191
 
@@ -130,7 +130,7 @@ def fetch_recordings_without_embeddings(team: Team | int, offset=0) -> List[str]
             query,
             {
                 "team_id": team.pk,
-                "batch_flush_size": BATCH_FLUSH_SIZE,
+                "batch_flush_size": PAGE_SIZE,
                 "offset": offset,
                 "min_duration_include_seconds": MIN_DURATION_INCLUDE_SECONDS,
             },

--- a/ee/tasks/replay.py
+++ b/ee/tasks/replay.py
@@ -13,11 +13,10 @@ from posthog.tasks.utils import CeleryQueue
 
 logger = structlog.get_logger(__name__)
 
+BATCH_SIZE = settings.REPLAY_EMBEDDINGS_BATCH_SIZE
 
-# rate limits are per worker, and this task makes multiple calls to open AI
-# we currently are allowed 500 calls per minute, so let's rate limit each worker
-# to much less than that
-@shared_task(ignore_result=False, queue=CeleryQueue.SESSION_REPLAY_EMBEDDINGS.value, rate_limit="75/m")
+
+@shared_task(ignore_result=False, queue=CeleryQueue.SESSION_REPLAY_EMBEDDINGS.value, rate_limit="20/m")
 def embed_batch_of_recordings_task(recordings: List[Any], team_id: int) -> None:
     embed_batch_of_recordings(recordings, team_id)
 
@@ -29,15 +28,18 @@ def generate_recordings_embeddings_batch() -> None:
     # 1. get a batch of recordings
     # 2. for each recording - ideally in parallel - generate an embedding
     # 3. update CH with the embeddings in one update operation
-    # in Celery that's a chain of tasks
-    # with step 2 being a group of tasks
-    # chord(
-    #             embed_single_recording.si(recording.session_id, recording.team_id)
-    #             for recording in fetch_recordings_without_embeddings(int(team))
-    #         )(generate_recordings_embeddings_batch_on_complete.si())
-    # but even the docs call out performance impact of synchronising tasks
     #
-    # so, for now, we'll do that naively
+    # we have between 6 and 24 workers processing the session embeddings queue
+    # with 500 requests per minute allowed that means the rate limit needs to be
+    # 500 / 24 = 20.8 per minute
+    # we want to process as many recordings as possible - and don't have scaling rules per worker queue
+    # workers are set to concurrency of 4 but rate limits are per worker so that shouldn't affect this
+    # i.e. we can set 20 per minute and celery won't allow 20 per minute across the concurrency of 4
+    # not 20 * 4
+    # that means we want to force celery to scale for this queue
+    # which means we want to run this task infrequently
+    # but generate lots of children tasks
+    # so we'll load large pages, and then split them into batches
 
     for team in settings.REPLAY_EMBEDDINGS_ALLOWED_TEAMS:
         try:
@@ -48,7 +50,9 @@ def generate_recordings_embeddings_batch() -> None:
                 flow="embeddings",
                 team_id=team,
             )
-            embed_batch_of_recordings_task.si(recordings, int(team)).apply_async()
+            batches = [recordings[i : i + BATCH_SIZE] for i in range(0, len(recordings), BATCH_SIZE)]
+            for batch in batches:
+                embed_batch_of_recordings_task.si(batch, int(team)).apply_async()
         except Team.DoesNotExist:
             logger.info(f"[generate_recordings_embeddings_batch] Team {team} does not exist. Skipping.")
             pass

--- a/ee/tasks/replay.py
+++ b/ee/tasks/replay.py
@@ -16,31 +16,13 @@ logger = structlog.get_logger(__name__)
 BATCH_SIZE = settings.REPLAY_EMBEDDINGS_BATCH_SIZE
 
 
-@shared_task(ignore_result=False, queue=CeleryQueue.SESSION_REPLAY_EMBEDDINGS.value, rate_limit="20/m")
+@shared_task(ignore_result=False, queue=CeleryQueue.SESSION_REPLAY_EMBEDDINGS.value, rate_limit="6/m")
 def embed_batch_of_recordings_task(recordings: List[Any], team_id: int) -> None:
     embed_batch_of_recordings(recordings, team_id)
 
 
 @shared_task(ignore_result=True)
 def generate_recordings_embeddings_batch() -> None:
-    # see https://docs.celeryq.dev/en/stable/userguide/canvas.html
-    # we have three jobs to do here
-    # 1. get a batch of recordings
-    # 2. for each recording - ideally in parallel - generate an embedding
-    # 3. update CH with the embeddings in one update operation
-    #
-    # we have between 6 and 24 workers processing the session embeddings queue
-    # with 500 requests per minute allowed that means the rate limit needs to be
-    # 500 / 24 = 20.8 per minute
-    # we want to process as many recordings as possible - and don't have scaling rules per worker queue
-    # workers are set to concurrency of 4 but rate limits are per worker so that shouldn't affect this
-    # i.e. we can set 20 per minute and celery won't allow 20 per minute across the concurrency of 4
-    # not 20 * 4
-    # that means we want to force celery to scale for this queue
-    # which means we want to run this task infrequently
-    # but generate lots of children tasks
-    # so we'll load large pages, and then split them into batches
-
     for team in settings.REPLAY_EMBEDDINGS_ALLOWED_TEAMS:
         try:
             recordings = fetch_recordings_without_embeddings(int(team))

--- a/posthog/settings/session_replay.py
+++ b/posthog/settings/session_replay.py
@@ -22,8 +22,13 @@ REALTIME_SNAPSHOTS_FROM_REDIS_ATTEMPT_TIMEOUT_SECONDS = get_from_env(
 RECORDINGS_INGESTER_URL = get_from_env("RECORDINGS_INGESTER_URL", "")
 
 REPLAY_EMBEDDINGS_ALLOWED_TEAMS: List[str] = get_list(get_from_env("REPLAY_EMBEDDINGS_ALLOWED_TEAM", "", type_cast=str))
-REPLAY_EMBEDDINGS_BATCH_SIZE = get_from_env("REPLAY_EMBEDDINGS_BATCH_SIZE", 10, type_cast=int)
+# how many recordings are passed into the loading task
+# there is only one CH write per the N recordings passed in
+REPLAY_EMBEDDINGS_BATCH_SIZE = get_from_env("REPLAY_EMBEDDINGS_BATCH_SIZE", 20, type_cast=int)
+# how many recordings are fetched at once
+# these are split into tasks of REPLAY_EMBEDDINGS_BATCH_SIZE each
+REPLAY_EMBEDDINGS_QUERY_PAGE_SIZE = get_from_env("REPLAY_EMBEDDINGS_QUERY_PAGE_SIZE", 25000, type_cast=int)
 REPLAY_EMBEDDINGS_MIN_DURATION_SECONDS = get_from_env("REPLAY_EMBEDDINGS_MIN_DURATION_SECONDS", 30, type_cast=int)
 REPLAY_EMBEDDINGS_CALCULATION_CELERY_INTERVAL_SECONDS = get_from_env(
-    "REPLAY_EMBEDDINGS_CALCULATION_CELERY_INTERVAL_SECONDS", 150, type_cast=int
+    "REPLAY_EMBEDDINGS_CALCULATION_CELERY_INTERVAL_SECONDS", 3600, type_cast=int
 )


### PR DESCRIPTION
the problem with celery is it isn't actually very good at queuing tasks

we now have a separate task queue, a rate limit of 500/m to open ai, and lots and lots of work to do

we know that (right now) celery will scale between 6 and 24 workers, and the scaling means its hard to know what rate of requests we'll make to open ai and to clickhouse

so, let's put lots in the queue, which will force celery to scale, and then we can rate limit how fast celery will process the items in the queue

----

so

* load a page of 25,000 recordings
* split them into chunks of M size
* push those chunks onto the task queue
* limit the task queue to N per minute

this should force celery to scale the pool to max 🤞

so hopefully, we prime a queue with many recordings to embed and then chug through them without such a gappy processing as we have right now
