### PR TITLE
fix(exports): Adjust export to use modern query based on flags

### DIFF
--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -46,13 +46,14 @@ const QUERY_ASYNC_TOTAL_POLL_SECONDS = 300
 export function queryExportContext<N extends DataNode = DataNode>(
     query: N,
     methodOptions?: ApiMethodOptions,
-    refresh?: boolean
+    refresh?: boolean,
+    maintainLegacy: boolean = true
 ): OnlineExportContext | QueryExportContext {
     if (isInsightVizNode(query) || isDataTableNode(query) || isDataVisualizationNode(query)) {
-        return queryExportContext(query.source, methodOptions, refresh)
+        return queryExportContext(query.source, methodOptions, refresh, maintainLegacy)
     } else if (isPersonsNode(query)) {
         return { path: getPersonsEndpoint(query) }
-    } else if (isInsightQueryNode(query)) {
+    } else if (isInsightQueryNode(query) && maintainLegacy) {
         return legacyInsightQueryExportContext({
             filters: queryNodeToFilter(query),
             currentTeamId: getCurrentTeamId(),

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -46,22 +46,15 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
 
     // insightLogic
     const logic = insightLogic(insightLogicProps)
-    const {
-        insightProps,
-        canEditInsight,
-        insight,
-        insightChanged,
-        insightSaving,
-        hasDashboardItemId,
-        exporterResourceParams,
-    } = useValues(logic)
+    const { insightProps, canEditInsight, insight, insightChanged, insightSaving, hasDashboardItemId } =
+        useValues(logic)
     const { setInsightMetadata } = useActions(logic)
 
     // savedInsightsLogic
     const { duplicateInsight, loadInsights } = useActions(savedInsightsLogic)
 
     // insightDataLogic
-    const { queryChanged, showQueryEditor, hogQL } = useValues(insightDataLogic(insightProps))
+    const { queryChanged, showQueryEditor, hogQL, exportContext } = useValues(insightDataLogic(insightProps))
     const { saveInsight, saveAs, toggleQueryEditorPanel } = useActions(insightDataLogic(insightProps))
 
     // other logics
@@ -144,7 +137,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                 Share or embed
                                             </LemonButton>
                                             <SubscribeButton insightShortId={insight.short_id} />
-                                            {exporterResourceParams ? (
+                                            {exportContext ? (
                                                 <ExportButton
                                                     fullWidth
                                                     items={[
@@ -154,11 +147,11 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                         },
                                                         {
                                                             export_format: ExporterFormat.CSV,
-                                                            export_context: exporterResourceParams,
+                                                            export_context: exportContext,
                                                         },
                                                         {
                                                             export_format: ExporterFormat.XLSX,
-                                                            export_context: exporterResourceParams,
+                                                            export_context: exportContext,
                                                         },
                                                     ]}
                                                 />

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -479,7 +479,7 @@ export const insightLogic = kea<insightLogicType>([
                 const filename = ['export', insight.name || insight.derived_name].join('-')
 
                 if (insight.query) {
-                    return { ...queryExportContext(insight.query), filename }
+                    return { ...queryExportContext(insight.query, undefined, undefined, false), filename }
                 } else {
                     if (isTrendsFilter(filters) || isStickinessFilter(filters) || isLifecycleFilter(filters)) {
                         return {


### PR DESCRIPTION
## Problem

The export buttons seem to use the query that is available, and turn it into the legacy URL with filters. They don't have any knowledge if the query is a modern one or legacy.

## Changes

- use feature flags to decide if to use modern or legacy query
- somewhat awkwardly pass that info to the export context function

## How did you test this code?

- look at the POST request made to the export endpoint
- flip the feature flag back and forth - observe the request changing