### PR TITLE
feat: Check actual person ids for override deletion

### DIFF
--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -136,8 +136,8 @@ ALTER TABLE
 ON CLUSTER
     {cluster}
 DELETE WHERE
-    joinGet('{database}.person_overrides_to_delete', 'total_not_override_person_id', team_id, distinct_id) = 0
-    AND joinGet('{database}.person_overrides_to_delete', 'total_override_person_id', team_id, distinct_id) > 0
+    (joinGet('{database}.person_distinct_id_overrides_join_to_delete', 'total_not_override_person_id', team_id, distinct_id) = 0)
+    AND (joinGet('{database}.person_distinct_id_overrides_join_to_delete', 'total_override_person_id', team_id, distinct_id) > 0)
     AND ((now() - _timestamp) > %(grace_period)s)
     AND (joinGet('{database}.person_distinct_id_overrides_join', 'latest_version', team_id, distinct_id) >= version)
 SETTINGS
@@ -726,7 +726,7 @@ class SquashPersonOverridesWorkflow(PostHogWorkflow):
     1. Build a JOIN table from person_distinct_id_overrides.
     2. For each partition issue an ALTER TABLE UPDATE. This query uses joinGet
         to efficiently find the override for each (team_id, distinct_id) pair
-        in the dictionary we built in 1.
+        in the JOIN table we built in 1.
     3. Delete from person_distinct_id_overrides any overrides that were squashed
         and are past the grace period. We construct an auxiliary JOIN table to
         identify the persons that can be deleted.

--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -28,8 +28,12 @@ AS
     SELECT
         team_id,
         distinct_id,
+<<<<<<< HEAD
         argMax(person_id, version) AS person_id,
         max(version) AS latest_version
+=======
+        argMax(person_id, version) AS person_id
+>>>>>>> ca1e88b081 (refactor: Squash workflow uses less activities and a join table)
     FROM
         {database}.person_distinct_id_overrides
     WHERE
@@ -45,7 +49,11 @@ SETTINGS
 DROP_TABLE_PERSON_DISTINCT_ID_OVERRIDES_JOIN = """
 DROP TABLE IF EXISTS {database}.person_distinct_id_overrides_join ON CLUSTER {cluster}
 SETTINGS
+<<<<<<< HEAD
     distributed_ddl_task_timeout = 0
+=======
+    distributed_ddl_task_timeout = -1
+>>>>>>> ca1e88b081 (refactor: Squash workflow uses less activities and a join table)
 """
 
 SUBMIT_UPDATE_EVENTS_WITH_PERSON_OVERRIDES = """

--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -28,12 +28,8 @@ AS
     SELECT
         team_id,
         distinct_id,
-<<<<<<< HEAD
         argMax(person_id, version) AS person_id,
         max(version) AS latest_version
-=======
-        argMax(person_id, version) AS person_id
->>>>>>> ca1e88b081 (refactor: Squash workflow uses less activities and a join table)
     FROM
         {database}.person_distinct_id_overrides
     WHERE
@@ -49,11 +45,7 @@ SETTINGS
 DROP_TABLE_PERSON_DISTINCT_ID_OVERRIDES_JOIN = """
 DROP TABLE IF EXISTS {database}.person_distinct_id_overrides_join ON CLUSTER {cluster}
 SETTINGS
-<<<<<<< HEAD
     distributed_ddl_task_timeout = 0
-=======
-    distributed_ddl_task_timeout = -1
->>>>>>> ca1e88b081 (refactor: Squash workflow uses less activities and a join table)
 """
 
 SUBMIT_UPDATE_EVENTS_WITH_PERSON_OVERRIDES = """

--- a/posthog/temporal/tests/persons_on_events_squash/test_squash_person_overrides_workflow.py
+++ b/posthog/temporal/tests/persons_on_events_squash/test_squash_person_overrides_workflow.py
@@ -766,7 +766,8 @@ ALTER TABLE
 ON CLUSTER
     {settings.CLICKHOUSE_CLUSTER}
 DELETE WHERE
-    hasAll(joinGet('{settings.CLICKHOUSE_DATABASE}.person_distinct_id_overrides_join_to_delete', 'partitions', team_id, distinct_id), ['202001'])
+    (joinGet('{settings.CLICKHOUSE_DATABASE}.person_distinct_id_overrides_join_to_delete', 'total_not_override_person_id', team_id, distinct_id) = 0)
+    AND (joinGet('{settings.CLICKHOUSE_DATABASE}.person_distinct_id_overrides_join_to_delete', 'total_override_person_id', team_id, distinct_id) > 0)
     AND ((now() - _timestamp) > 111111)
     AND (joinGet('{settings.CLICKHOUSE_DATABASE}.person_distinct_id_overrides_join', 'latest_version', team_id, distinct_id) >= version)
 SETTINGS


### PR DESCRIPTION
## Problem

The current way we detect which persons are to be deleted at the end of a squash workflow is by checking if the partitions that contain all events for a (team_id, distinct_id) pair are covered by the current squash workflow's parameters. So, we gather all partitions that contain events for each (team_id, distinct_id) pair, and see if that set of partitions is a subset of the `partition_ids` input.

This has a problem: We cannot split a single squash into multiple workflows. Since the query checks that all partitions are covered by only _this_ workflow, it doesn't account for partitions that already were squashed by a different workflow. In real-life scenarios, workflows may fail, and this means that if we want to ensure deletes run, we have to process all partitions again, even if some did succeed.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Implement a more straight-forward way to determine which persons are safe to delete:
* For each (team_id, distinct_id) pair in the overrides dictionary:
  * Gather person_ids grouped by (team_id, distinct_id) pair.
  * The row is deemed safe to delete if there is only one person_id associated with the pair and that only person_id matches the dictionary value with the same (team_id, distinct_id) pair as key.

With this algorithm, in the event a squash workflow fails, we can run a follow-up workflow with whatever partitions were not squashed, while still deleting from the overrides table. After it's done with the remaining partitions, the new workflow will see no more person_ids remain to be squashed, and will delete corresponding rows from the overrides table.

Important: This check is independent of the grace period check, and it will not override it. This means that even if we do detect  a person to delete, we will not delete it if it was created within the grace period. This is the same behavior as before with the previous partition check.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Current unit tests should continue to work, but had to be updated to actually squash the data.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
