### PR TITLE
fix: Properly drop join table after using

### DIFF
--- a/posthog/temporal/batch_exports/__init__.py
+++ b/posthog/temporal/batch_exports/__init__.py
@@ -53,6 +53,7 @@ ACTIVITIES = [
     create_batch_export_backfill_model,
     create_export_run,
     delete_squashed_person_overrides_from_clickhouse,
+    drop_delete_join_table,
     drop_dictionary,
     get_schedule_frequency,
     insert_into_bigquery_activity,

--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -343,9 +343,11 @@ async def squash_events_partition(inputs: SquashEventsPartitionInputs) -> str:
     """
     from django.conf import settings
 
-    async with get_client() as clickhouse_client:
-        activity.logger.info("Updating events with person overrides in partition %s", inputs.partition_id)
+    activity.logger.info(
+        "Submitting mutation to update events with person overrides in partition %s", inputs.partition_id
+    )
 
+    async with get_client() as clickhouse_client:
         query = SQUASH_EVENTS_QUERY.format(
             database=settings.CLICKHOUSE_DATABASE,
             cluster=settings.CLICKHOUSE_CLUSTER,
@@ -406,6 +408,8 @@ async def wait_for_mutation(inputs: WaitForMutationInputs) -> None:
     """
     from django.conf import settings
 
+    activity.logger.info("Waiting for mutation in table %s", inputs.table)
+
     if inputs.dry_run is True:
         activity.logger.info("This is a DRY RUN so nothing will be waited for.")
         return
@@ -439,7 +443,7 @@ async def wait_for_mutation(inputs: WaitForMutationInputs) -> None:
                     if mutations_in_progress == 0 and total_mutations > 0:
                         break
 
-                    activity.logger.info("Waiting for mutation in table %s", {inputs.table})
+                    activity.logger.info("Still waiting for mutation in table %s", inputs.table)
 
                     await asyncio.sleep(5)
 

--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -75,7 +75,7 @@ DROP DICTIONARY {database}.{dictionary_name} ON CLUSTER {cluster}
 """
 
 CREATE_JOIN_TABLE_FOR_DELETES_QUERY = """
-CREATE TABLE {database}.person_overrides_to_delete ON CLUSTER {cluster}
+CREATE OR REPLACE TABLE {database}.person_overrides_to_delete ON CLUSTER {cluster}
 ENGINE = Join(ANY, LEFT, team_id, distinct_id) AS
 SELECT
     team_id, distinct_id, groupUniqArray(_partition_id) AS partitions

--- a/posthog/temporal/tests/persons_on_events_squash/test_squash_person_overrides_workflow.py
+++ b/posthog/temporal/tests/persons_on_events_squash/test_squash_person_overrides_workflow.py
@@ -23,6 +23,7 @@ from posthog.temporal.batch_exports.squash_person_overrides import (
     SquashPersonOverridesWorkflow,
     WaitForMutationInputs,
     delete_squashed_person_overrides_from_clickhouse,
+    drop_delete_join_table,
     drop_dictionary,
     optimize_person_distinct_id_overrides,
     prepare_dictionary,
@@ -775,6 +776,7 @@ async def test_delete_squashed_person_overrides_from_clickhouse(
         await activity_environment.run(delete_squashed_person_overrides_from_clickhouse, delete_inputs)
     finally:
         await activity_environment.run(drop_dictionary, dictionary_inputs)
+        await activity_environment.run(drop_delete_join_table, False)
 
     response = await clickhouse_client.read_query(
         "SELECT team_id, distinct_id, person_id FROM person_distinct_id_overrides"
@@ -835,6 +837,7 @@ async def test_delete_squashed_person_overrides_from_clickhouse_within_grace_per
 
     finally:
         await activity_environment.run(drop_dictionary, dictionary_inputs)
+        await activity_environment.run(drop_delete_join_table, False)
 
     response = await clickhouse_client.read_query(
         "SELECT team_id, distinct_id, person_id, _timestamp FROM person_distinct_id_overrides"
@@ -909,6 +912,7 @@ async def test_squash_person_overrides_workflow(
         activities=[
             delete_squashed_person_overrides_from_clickhouse,
             drop_dictionary,
+            drop_delete_join_table,
             optimize_person_distinct_id_overrides,
             prepare_dictionary,
             squash_events_partition,
@@ -955,6 +959,7 @@ async def test_squash_person_overrides_workflow_with_newer_overrides(
         activities=[
             delete_squashed_person_overrides_from_clickhouse,
             drop_dictionary,
+            drop_delete_join_table,
             optimize_person_distinct_id_overrides,
             prepare_dictionary,
             squash_events_partition,
@@ -998,6 +1003,7 @@ async def test_squash_person_overrides_workflow_with_limited_team_ids(
         activities=[
             delete_squashed_person_overrides_from_clickhouse,
             drop_dictionary,
+            drop_delete_join_table,
             optimize_person_distinct_id_overrides,
             prepare_dictionary,
             squash_events_partition,


### PR DESCRIPTION
## Problem

We are dropping the join table to early, let's wait until the end.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Move join table drop to end of workflow.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
