### PR TITLE
fix: Set max_execution_time in mutations to nonzero

### DIFF
--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -51,7 +51,7 @@ WHERE
     dictHas('{database}.{dictionary_name}', (team_id, distinct_id))
     {in_team_ids}
 SETTINGS
-    max_execution_time = 0
+    max_execution_time = 86400
 """
 
 MUTATIONS_IN_PROGRESS_QUERY = """
@@ -100,7 +100,7 @@ DELETE WHERE
     hasAll(joinGet('{database}.person_overrides_to_delete', 'partitions', team_id, distinct_id), %(partition_ids)s)
     AND ((now() - _timestamp) > %(grace_period)s)
 SETTINGS
-    max_execution_time=0
+    max_execution_time = 86400
 """
 
 


### PR DESCRIPTION
## Problem

Silly clickhouse doesn't take my max_execution_time.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
