### PR TITLE
chore(data-warehouse): extend timeout on validate step

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -278,7 +278,7 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
             await workflow.execute_activity(
                 validate_schema_activity,
                 validate_inputs,
-                start_to_close_timeout=dt.timedelta(minutes=2),
+                start_to_close_timeout=dt.timedelta(minutes=10),
                 retry_policy=RetryPolicy(maximum_attempts=2),
             )
 


### PR DESCRIPTION
## Problem

- validate step was timing out too quickly

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- extend time 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
