### PR TITLE
feat: allow different types of embeddings

### DIFF
--- a/posthog/clickhouse/migrations/0055_session_replay_embeddings_types.py
+++ b/posthog/clickhouse/migrations/0055_session_replay_embeddings_types.py
@@ -1,0 +1,12 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.session_recordings.sql.session_replay_embeddings_migrations import (
+    DISTRIBUTED_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_TYPE_COLUMN,
+    WRITEABLE_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_TYPE_COLUMN,
+    SHARDED_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_TYPE_COLUMN,
+)
+
+operations = [
+    run_sql_with_exceptions(DISTRIBUTED_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_TYPE_COLUMN()),
+    run_sql_with_exceptions(WRITEABLE_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_TYPE_COLUMN()),
+    run_sql_with_exceptions(SHARDED_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_TYPE_COLUMN()),
+]

--- a/posthog/session_recordings/sql/session_replay_embeddings_migrations.py
+++ b/posthog/session_recordings/sql/session_replay_embeddings_migrations.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+
+ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_TYPE_COLUMN = """
+    ALTER TABLE {table_name} on CLUSTER '{cluster}'
+        ADD COLUMN IF NOT EXISTS source_type LowCardinality(String)
+"""
+
+DISTRIBUTED_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_TYPE_COLUMN = (
+    lambda: ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_TYPE_COLUMN.format(
+        table_name="session_replay_embeddings",
+        cluster=settings.CLICKHOUSE_CLUSTER,
+    )
+)
+
+WRITEABLE_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_TYPE_COLUMN = (
+    lambda: ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_TYPE_COLUMN.format(
+        table_name="writable_session_replay_embeddings",
+        cluster=settings.CLICKHOUSE_CLUSTER,
+    )
+)
+
+SHARDED_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_TYPE_COLUMN = (
+    lambda: ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_TYPE_COLUMN.format(
+        table_name="sharded_session_replay_embeddings",
+        cluster=settings.CLICKHOUSE_CLUSTER,
+    )
+)


### PR DESCRIPTION
we want to allow different types of embeddings so we can be more focussed in terms of _what_ is similar