### PR TITLE
feat(flags): Add configuration option to skip DB

### DIFF
--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -5257,6 +5257,7 @@ class TestResiliency(TransactionTestCase, QueryMatchingTest):
         with self.assertNumQueries(0), self.settings(DECIDE_SKIP_DATABASE_FLAGS=True):
             # No queries because of config parameter
             all_flags, _, _, errors = get_all_feature_flags(team_id, "example_id")
+            mock_postgres_check.assert_not_called()
             self.assertTrue("property-flag" not in all_flags)
             self.assertTrue(all_flags["default-flag"])
             self.assertTrue(errors)
@@ -5272,6 +5273,7 @@ class TestResiliency(TransactionTestCase, QueryMatchingTest):
             self.assertTrue("property-flag" not in all_flags)
             self.assertTrue(all_flags["default-flag"])
             self.assertTrue(errors)
+            mock_postgres_check.assert_not_called()
 
             # decide was sent email parameter with correct email
             with self.assertNumQueries(0):
@@ -5283,6 +5285,7 @@ class TestResiliency(TransactionTestCase, QueryMatchingTest):
                 self.assertTrue(all_flags["property-flag"])
                 self.assertTrue(all_flags["default-flag"])
                 self.assertFalse(errors)
+                mock_postgres_check.assert_not_called()
 
             # # now db is down, but decide was sent email parameter with different email
             with self.assertNumQueries(0):
@@ -5294,6 +5297,7 @@ class TestResiliency(TransactionTestCase, QueryMatchingTest):
                 self.assertFalse(all_flags["property-flag"])
                 self.assertTrue(all_flags["default-flag"])
                 self.assertFalse(errors)
+                mock_postgres_check.assert_not_called()
 
     @patch("posthog.models.feature_flag.flag_matching.FLAG_EVALUATION_ERROR_COUNTER")
     def test_feature_flags_v3_with_slow_db_doesnt_try_to_compute_conditions_again(self, mock_counter, *args):

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -5254,7 +5254,7 @@ class TestResiliency(TransactionTestCase, QueryMatchingTest):
         self.assertTrue(serialized_data.is_valid())
         serialized_data.save()
 
-        with self.assertNumQueries(0), self.settings(DECIDE_SKIP_DATABASE_FLAGS=True):
+        with self.assertNumQueries(0), self.settings(DECIDE_SKIP_POSTGRES_FLAGS=True):
             # No queries because of config parameter
             all_flags, _, _, errors = get_all_feature_flags(team_id, "example_id")
             mock_postgres_check.assert_not_called()
@@ -5266,7 +5266,7 @@ class TestResiliency(TransactionTestCase, QueryMatchingTest):
         with self.assertNumQueries(0), connection.execute_wrapper(slow_query), patch(
             "posthog.models.feature_flag.flag_matching.FLAG_MATCHING_QUERY_TIMEOUT_MS",
             500,
-        ), self.settings(DECIDE_SKIP_DATABASE_FLAGS=True):
+        ), self.settings(DECIDE_SKIP_POSTGRES_FLAGS=True):
             mock_postgres_check.return_value = False
             all_flags, _, _, errors = get_all_feature_flags(team_id, "example_id")
 

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -701,8 +701,7 @@ def get_all_feature_flags(
 
     with start_span(op="without_experience_continuity"):
         # check every 10 seconds whether the database is alive or not
-        is_database_alive = postgres_healthcheck.is_connected()
-
+        is_database_alive = (not settings.DECIDE_SKIP_DATABASE_FLAGS) and postgres_healthcheck.is_connected()
         if not is_database_alive or not flags_have_experience_continuity_enabled:
             return _get_all_feature_flags(
                 all_feature_flags,

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -701,7 +701,7 @@ def get_all_feature_flags(
 
     with start_span(op="without_experience_continuity"):
         # check every 10 seconds whether the database is alive or not
-        is_database_alive = (not settings.DECIDE_SKIP_DATABASE_FLAGS) and postgres_healthcheck.is_connected()
+        is_database_alive = (not settings.DECIDE_SKIP_POSTGRES_FLAGS) and postgres_healthcheck.is_connected()
         if not is_database_alive or not flags_have_experience_continuity_enabled:
             return _get_all_feature_flags(
                 all_feature_flags,

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -25,6 +25,10 @@ DECIDE_RATE_LIMIT_ENABLED = get_from_env("DECIDE_RATE_LIMIT_ENABLED", False, typ
 DECIDE_BUCKET_CAPACITY = get_from_env("DECIDE_BUCKET_CAPACITY", type_cast=int, default=500)
 DECIDE_BUCKET_REPLENISH_RATE = get_from_env("DECIDE_BUCKET_REPLENISH_RATE", type_cast=float, default=10.0)
 
+# Decide db settings
+
+DECIDE_SKIP_DATABASE_FLAGS = get_from_env("DECIDE_SKIP_DATABASE_FLAGS", False, type_cast=str_to_bool)
+
 # Decide billing analytics
 
 DECIDE_BILLING_SAMPLING_RATE = get_from_env("DECIDE_BILLING_SAMPLING_RATE", 0.1, type_cast=float)

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -27,7 +27,7 @@ DECIDE_BUCKET_REPLENISH_RATE = get_from_env("DECIDE_BUCKET_REPLENISH_RATE", type
 
 # Decide db settings
 
-DECIDE_SKIP_DATABASE_FLAGS = get_from_env("DECIDE_SKIP_DATABASE_FLAGS", False, type_cast=str_to_bool)
+DECIDE_SKIP_POSTGRES_FLAGS = get_from_env("DECIDE_SKIP_POSTGRES_FLAGS", False, type_cast=str_to_bool)
 
 # Decide billing analytics
 


### PR DESCRIPTION
## Problem

We currently have no way to shed load quickly (except rate limiting). This is a much superior option, where given properties, we evaluate as many flags as we can without going to the db, and let the client know to upsert cached flags instead of replace them.

Handy during incidents to quickly bring decide back up.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unit test
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
