### PR TITLE
fix: log level

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/AdvancedSessionRecordingsFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/AdvancedSessionRecordingsFilters.tsx
@@ -166,11 +166,11 @@ function ConsoleFilters({
                             <LemonCheckbox
                                 size="small"
                                 fullWidth
-                                checked={!!filters.console_logs?.includes('log')}
+                                checked={!!filters.console_logs?.includes('info')}
                                 onChange={(checked) => {
-                                    updateLevelChoice(checked, 'log')
+                                    updateLevelChoice(checked, 'info')
                                 }}
-                                label="log"
+                                label="info"
                             />
                             <LemonCheckbox
                                 size="small"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -869,7 +869,7 @@ export interface RecordingDurationFilter extends BasePropertyFilter {
 
 export type DurationType = 'duration' | 'active_seconds' | 'inactive_seconds'
 
-export type FilterableLogLevel = 'log' | 'warn' | 'error'
+export type FilterableLogLevel = 'info' | 'warn' | 'error'
 export interface RecordingFilters {
     date_from?: string | null
     date_to?: string | null

--- a/plugin-server/src/main/ingestion-queues/session-recording/process-event.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/process-event.ts
@@ -48,7 +48,7 @@ export interface SummarizedSessionRecordingEvent {
 export type ConsoleLogEntry = {
     team_id: number
     message: string
-    log_level: 'info' | 'warn' | 'error'
+    level: 'info' | 'warn' | 'error'
     log_source: 'session_replay'
     // the session_id
     log_source_id: string
@@ -132,7 +132,7 @@ export const gatherConsoleLogEvents = (
                     team_id,
                     // TODO when is it not a single item array?
                     message: message,
-                    log_level: level,
+                    level: level,
                     log_source: 'session_replay',
                     log_source_id: session_id,
                     instance_id: null,
@@ -144,6 +144,9 @@ export const gatherConsoleLogEvents = (
             }
         }
     })
+
+    console.log('DAVID WAS ERE')
+    console.log(consoleLogEntries)
 
     return consoleLogEntries
 }

--- a/plugin-server/src/main/ingestion-queues/session-recording/process-event.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/process-event.ts
@@ -130,7 +130,6 @@ export const gatherConsoleLogEvents = (
                 const message = safeString(event.data.payload?.payload)
                 consoleLogEntries.push({
                     team_id,
-                    // TODO when is it not a single item array?
                     message: message,
                     level: level,
                     log_source: 'session_replay',

--- a/plugin-server/src/main/ingestion-queues/session-recording/process-event.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/process-event.ts
@@ -145,9 +145,6 @@ export const gatherConsoleLogEvents = (
         }
     })
 
-    console.log('DAVID WAS ERE')
-    console.log(consoleLogEntries)
-
     return consoleLogEntries
 }
 export const getTimestampsFrom = (events: RRWebEvent[]): ClickHouseTimestamp[] =>

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
@@ -30,7 +30,7 @@ function deduplicateConsoleLogEvents(consoleLogEntries: ConsoleLogEntry[]): Cons
     const deduped: ConsoleLogEntry[] = []
 
     for (const cle of consoleLogEntries) {
-        const fingerPrint = `${cle.log_level}-${cle.message}`
+        const fingerPrint = `${cle.level}-${cle.message}`
         if (!seen.has(fingerPrint)) {
             deduped.push(cle)
             seen.add(fingerPrint)

--- a/plugin-server/tests/main/ingestion-queues/session-recording/process-event.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/process-event.test.ts
@@ -385,7 +385,7 @@ describe('session recording process event', () => {
         expect(getTimestampsFrom(events)).toEqual(expectedTimestamps)
     })
 
-    function consoleMessageFor(payload: any[], level = 'info') {
+    function consoleMessageFor(payload: any[], level: string | null | undefined = 'info') {
         return {
             timestamp: 1682449093469,
             type: 6,

--- a/plugin-server/tests/main/ingestion-queues/session-recording/process-event.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/process-event.test.ts
@@ -459,6 +459,10 @@ describe('session recording process event', () => {
         { browserLogLevel: 'error', logLevel: 'error' },
         { browserLogLevel: 'assert', logLevel: 'error' },
         { browserLogLevel: 'countReset', logLevel: 'warn' },
+        { browserLogLevel: 'wakanda forever', logLevel: 'info' },
+        { browserLogLevel: '\\n\\r\\t\\0\\b\\f', logLevel: 'info' },
+        { browserLogLevel: null, logLevel: 'info' },
+        { browserLogLevel: undefined, logLevel: 'info' },
     ])('log level console log processing: %s', ({ browserLogLevel, logLevel }) => {
         const consoleLogEntries = gatherConsoleLogEvents(12345, 'session_id', [
             consoleMessageFor(['test'], browserLogLevel),

--- a/plugin-server/tests/main/ingestion-queues/session-recording/process-event.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/process-event.test.ts
@@ -401,7 +401,7 @@ describe('session recording process event', () => {
         expect(consoleLogEntries).toEqual([
             {
                 team_id: 12345,
-                log_level: 'info',
+                level: 'info',
                 log_source: 'session_replay',
                 log_source_id: 'session_id',
                 instance_id: null,

--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
@@ -56,7 +56,7 @@ describe('console log ingester', () => {
                     [
                         {
                             plugin: 'rrweb/console@1',
-                            payload: { level: 'log', payload: ['a'.repeat(3001)] },
+                            payload: { level: 'info', payload: ['a'.repeat(3001)] },
                         },
                     ],
                     true
@@ -73,7 +73,7 @@ describe('console log ingester', () => {
                             JSON.stringify({
                                 team_id: 0,
                                 message: 'a'.repeat(2999),
-                                level: 'log',
+                                level: 'info',
                                 log_source: 'session_replay',
                                 log_source_id: '',
                                 instance_id: null,
@@ -91,15 +91,15 @@ describe('console log ingester', () => {
                     [
                         {
                             plugin: 'rrweb/console@1',
-                            payload: { level: 'log', payload: ['aaaaa'] },
+                            payload: { level: 'info', payload: ['aaaaa'] },
                         },
                         {
                             plugin: 'rrweb/something-else@1',
-                            payload: { level: 'log', payload: ['bbbbb'] },
+                            payload: { level: 'info', payload: ['bbbbb'] },
                         },
                         {
                             plugin: 'rrweb/console@1',
-                            payload: { level: 'log', payload: ['ccccc'] },
+                            payload: { level: 'info', payload: ['ccccc'] },
                         },
                     ],
                     true
@@ -117,7 +117,7 @@ describe('console log ingester', () => {
                             JSON.stringify({
                                 team_id: 0,
                                 message: 'aaaaa',
-                                level: 'log',
+                                level: 'info',
                                 log_source: 'session_replay',
                                 log_source_id: '',
                                 instance_id: null,
@@ -135,7 +135,7 @@ describe('console log ingester', () => {
                             JSON.stringify({
                                 team_id: 0,
                                 message: 'ccccc',
-                                level: 'log',
+                                level: 'info',
                                 log_source: 'session_replay',
                                 log_source_id: '',
                                 instance_id: null,
@@ -153,11 +153,11 @@ describe('console log ingester', () => {
                     [
                         {
                             plugin: 'rrweb/console@1',
-                            payload: { level: 'log', payload: ['aaaaa'] },
+                            payload: { level: 'info', payload: ['aaaaa'] },
                         },
                         {
                             plugin: 'rrweb/console@1',
-                            payload: { level: 'log', payload: ['aaaaa'] },
+                            payload: { level: 'info', payload: ['aaaaa'] },
                         },
                     ],
                     true
@@ -174,7 +174,7 @@ describe('console log ingester', () => {
                             JSON.stringify({
                                 team_id: 0,
                                 message: 'aaaaa',
-                                level: 'log',
+                                level: 'info',
                                 log_source: 'session_replay',
                                 log_source_id: '',
                                 instance_id: null,

--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
@@ -73,7 +73,7 @@ describe('console log ingester', () => {
                             JSON.stringify({
                                 team_id: 0,
                                 message: 'a'.repeat(2999),
-                                log_level: 'log',
+                                level: 'log',
                                 log_source: 'session_replay',
                                 log_source_id: '',
                                 instance_id: null,
@@ -117,7 +117,7 @@ describe('console log ingester', () => {
                             JSON.stringify({
                                 team_id: 0,
                                 message: 'aaaaa',
-                                log_level: 'log',
+                                level: 'log',
                                 log_source: 'session_replay',
                                 log_source_id: '',
                                 instance_id: null,
@@ -135,7 +135,7 @@ describe('console log ingester', () => {
                             JSON.stringify({
                                 team_id: 0,
                                 message: 'ccccc',
-                                log_level: 'log',
+                                level: 'log',
                                 log_source: 'session_replay',
                                 log_source_id: '',
                                 instance_id: null,
@@ -174,7 +174,7 @@ describe('console log ingester', () => {
                             JSON.stringify({
                                 team_id: 0,
                                 message: 'aaaaa',
-                                log_level: 'log',
+                                level: 'log',
                                 log_source: 'session_replay',
                                 log_source_id: '',
                                 instance_id: null,

--- a/posthog/models/filters/mixins/session_recordings.py
+++ b/posthog/models/filters/mixins/session_recordings.py
@@ -19,11 +19,11 @@ class SessionRecordingsMixin(BaseParamMixin):
         return self._data.get("console_search_query", None)
 
     @cached_property
-    def console_logs_filter(self) -> List[Literal["error", "warn", "log"]]:
+    def console_logs_filter(self) -> List[Literal["error", "warn", "info"]]:
         user_value = self._data.get("console_logs", None) or []
         if isinstance(user_value, str):
             user_value = json.loads(user_value)
-        valid_values = [x for x in user_value if x in ["error", "warn", "log"]]
+        valid_values = [x for x in user_value if x in ["error", "warn", "info"]]
         return valid_values
 
     @cached_property

--- a/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
@@ -124,7 +124,7 @@ class LogQuery:
 
     @staticmethod
     def _get_console_log_clause(
-        console_logs_filter: List[Literal["error", "warn", "log"]],
+        console_logs_filter: List[Literal["error", "warn", "info"]],
     ) -> Tuple[str, Dict[str, Any]]:
         return (
             (
@@ -771,6 +771,6 @@ class SessionRecordingListFromReplaySummary(EventQuery):
         return duration_clause, duration_params
 
     @staticmethod
-    def _get_console_log_clause(console_logs_filter: List[Literal["error", "warn", "log"]]) -> str:
+    def _get_console_log_clause(console_logs_filter: List[Literal["error", "warn", "info"]]) -> str:
         filters = [f"console_{log}_count > 0" for log in console_logs_filter]
         return f"AND ({' OR '.join(filters)})" if filters else ""

--- a/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
@@ -772,5 +772,6 @@ class SessionRecordingListFromReplaySummary(EventQuery):
 
     @staticmethod
     def _get_console_log_clause(console_logs_filter: List[Literal["error", "warn", "info"]]) -> str:
-        filters = [f"console_{log}_count > 0" for log in console_logs_filter]
+        # to avoid a CH migration we map from info to log when constructing the query here
+        filters = [f"console_{'log' if log == 'info' else log}_count > 0" for log in console_logs_filter]
         return f"AND ({' OR '.join(filters)})" if filters else ""

--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_session_replay.ambr
@@ -2956,7 +2956,7 @@
        AND timestamp >= '2021-01-13 12:00:00'
        AND timestamp <= '2021-01-22 08:00:00'
        WHERE 1=1
-         AND level in ['log']
+         AND level in ['info']
          AND positionCaseInsensitive(message, 'message 5') > 0 ) as log_text_matching
   GROUP BY session_id
   HAVING 1=1

--- a/posthog/session_recordings/queries/test/test_session_recording_list_from_session_replay.py
+++ b/posthog/session_recordings/queries/test/test_session_recording_list_from_session_replay.py
@@ -2074,7 +2074,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["log"]})
+        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["info"]})
 
         assert sorted(
             [(sr["session_id"], sr["console_log_count"]) for sr in session_recordings],
@@ -2118,7 +2118,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
             (with_logs_session_id, 4),
         ]
 
-        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["log"]})
+        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["info"]})
 
         assert session_recordings == []
 
@@ -2153,7 +2153,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
             (with_logs_session_id, 4),
         ]
 
-        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["log"]})
+        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["info"]})
 
         assert session_recordings == []
 
@@ -2207,7 +2207,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
             ]
         )
 
-        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["log"]})
+        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["info"]})
 
         assert sorted([sr["session_id"] for sr in session_recordings]) == sorted(
             [
@@ -2233,7 +2233,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
             team_id=self.team.id,
             console_log_count=4,
             log_messages={
-                "log": [
+                "info": [
                     "log message 1",
                     "log message 2",
                     "log message 3",
@@ -2286,7 +2286,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
                     "error message 3",
                     "error message 4",
                 ],
-                "log": ["log message 1", "log message 2", "log message 3"],
+                "info": ["log message 1", "log message 2", "log message 3"],
             },
         )
 
@@ -2336,8 +2336,8 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
 
         (session_recordings, _) = self._filter_recordings_by(
             {
-                # message 5 does not match log level "log
-                "console_logs": ["log"],
+                # message 5 does not match log level "info"
+                "console_logs": ["info"],
                 "console_search_query": "message 5",
             }
         )


### PR DESCRIPTION
## Problem

We noticed that no `session_replay` row in the `log_entries` table in ClickHouse had the associated `level`

## Changes

We were incorrectly producing Kafka messages with the key `log_level` but the column in the ClickHouse table is called `level`

## How did you test this code?

Updated tests

running locally and seeing it work

![2024-03-06 20 13 31](https://github.com/PostHog/posthog/assets/984817/bf09dd73-51c1-414c-ba36-9e6f8c03c6c1)
