### PR TITLE
fix: Attempt to speed up squash

### DIFF
--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -32,6 +32,8 @@ AS
         max(version) AS latest_version
     FROM
         {database}.person_distinct_id_overrides
+    WHERE
+        ((length(%(team_ids)s) = 0) OR (team_id IN %(team_ids)s))
     GROUP BY
         team_id, distinct_id
 SETTINGS
@@ -105,6 +107,7 @@ FROM
     {database}.sharded_events
 WHERE
     (joinGet('{database}.person_distinct_id_overrides_join', 'person_id', team_id, distinct_id) != defaultValueOfTypeName('UUID'))
+    AND ((length(%(team_ids)s) = 0) OR (team_id IN %(team_ids)s))
 GROUP BY
     team_id, distinct_id
 SETTINGS

--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -39,7 +39,8 @@ AS
 SETTINGS
     max_execution_time = 0,
     max_memory_usage = 0,
-    distributed_ddl_task_timeout = 0
+    distributed_ddl_task_timeout = 0,
+    persistent = 0
 """
 
 DROP_TABLE_PERSON_DISTINCT_ID_OVERRIDES_JOIN = """
@@ -113,7 +114,8 @@ GROUP BY
 SETTINGS
     max_execution_time = 0,
     max_memory_usage = 0,
-    distributed_ddl_task_timeout = 0
+    distributed_ddl_task_timeout = 0,
+    persistent = 0
 """
 
 DROP_TABLE_PERSON_DISTINCT_ID_OVERRIDES_JOIN_TO_DELETE = """

--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -457,8 +457,8 @@ async def manage_table(table_name: str, dry_run: bool) -> collections.abc.AsyncG
     await workflow.execute_activity(
         wait_for_table,
         table_activity_inputs,
-        start_to_close_timeout=timedelta(hours=4),
-        retry_policy=RetryPolicy(maximum_attempts=6, initial_interval=timedelta(seconds=20)),
+        start_to_close_timeout=timedelta(hours=6),
+        retry_policy=RetryPolicy(maximum_attempts=20, initial_interval=timedelta(seconds=20)),
         heartbeat_timeout=timedelta(minutes=2),
     )
 
@@ -634,8 +634,8 @@ async def submit_and_wait_for_mutation(
     await workflow.execute_activity(
         wait_for_mutation,
         mutation_activity_inputs,
-        start_to_close_timeout=timedelta(hours=4),
-        retry_policy=RetryPolicy(maximum_attempts=6, initial_interval=timedelta(seconds=20)),
+        start_to_close_timeout=timedelta(hours=6),
+        retry_policy=RetryPolicy(maximum_attempts=20, initial_interval=timedelta(seconds=20)),
         heartbeat_timeout=timedelta(minutes=2),
     )
 

--- a/posthog/temporal/tests/persons_on_events_squash/test_squash_person_overrides_workflow.py
+++ b/posthog/temporal/tests/persons_on_events_squash/test_squash_person_overrides_workflow.py
@@ -136,6 +136,7 @@ async def test_create_person_distinct_id_overrides_join_table(
 
     inputs = TableActivityInputs(
         name="person_distinct_id_overrides_join",
+        query_parameters={"team_ids": []},
         dry_run=False,
     )
     await activity_environment.run(create_table, inputs)
@@ -232,6 +233,7 @@ async def test_create_person_distinct_id_overrides_join_with_older_overrides_pre
     """
     inputs = TableActivityInputs(
         name="person_distinct_id_overrides_join",
+        query_parameters={"team_ids": []},
         dry_run=False,
     )
 
@@ -270,6 +272,7 @@ async def test_create_person_distinct_id_overrides_join_with_newer_overrides_aft
     """Test `person_distinct_id_overrides_join` contains a static set of mappings."""
     inputs = TableActivityInputs(
         name="person_distinct_id_overrides_join",
+        query_parameters={"team_ids": []},
         dry_run=False,
     )
 
@@ -323,6 +326,7 @@ async def test_create_wait_and_drop_table(activity_environment, person_overrides
     """Test if a table is created, waited on, and dropped in a normal workflow."""
     inputs = TableActivityInputs(
         name="person_distinct_id_overrides_join",
+        query_parameters={"team_ids": []},
         dry_run=False,
     )
 
@@ -447,6 +451,7 @@ async def overrides_join_table(optimized_person_overrides, activity_environment)
     """
     inputs = TableActivityInputs(
         name="person_distinct_id_overrides_join",
+        query_parameters={"team_ids": []},
         dry_run=False,
     )
 
@@ -579,6 +584,7 @@ async def test_update_events_with_person_overrides_mutation_with_older_overrides
     await activity_environment.run(optimize_person_distinct_id_overrides, False)
     inputs = TableActivityInputs(
         name="person_distinct_id_overrides_join",
+        query_parameters={"team_ids": []},
         dry_run=False,
     )
 
@@ -616,6 +622,7 @@ async def test_update_events_with_person_overrides_mutation_with_newer_overrides
     await activity_environment.run(optimize_person_distinct_id_overrides, False)
     inputs = TableActivityInputs(
         name="person_distinct_id_overrides_join",
+        query_parameters={"team_ids": []},
         dry_run=False,
     )
 
@@ -709,6 +716,7 @@ async def test_delete_person_overrides_mutation(
 
     join_table_inputs = TableActivityInputs(
         name="person_distinct_id_overrides_join",
+        query_parameters={"team_ids": []},
         dry_run=False,
     )
 
@@ -717,6 +725,7 @@ async def test_delete_person_overrides_mutation(
 
     delete_table_inputs = TableActivityInputs(
         name="person_distinct_id_overrides_join_to_delete",
+        query_parameters={"team_ids": []},
         dry_run=False,
     )
 
@@ -790,6 +799,7 @@ async def test_delete_person_overrides_mutation_within_grace_period(
 
     join_table_inputs = TableActivityInputs(
         name="person_distinct_id_overrides_join",
+        query_parameters={"team_ids": []},
         dry_run=False,
     )
 
@@ -798,6 +808,7 @@ async def test_delete_person_overrides_mutation_within_grace_period(
 
     delete_table_inputs = TableActivityInputs(
         name="person_distinct_id_overrides_join_to_delete",
+        query_parameters={"team_ids": []},
         dry_run=False,
     )
 
@@ -856,6 +867,7 @@ async def test_delete_squashed_person_overrides_from_clickhouse_dry_run(
 
     join_table_inputs = TableActivityInputs(
         name="person_distinct_id_overrides_join",
+        query_parameters={"team_ids": []},
         dry_run=False,
     )
 
@@ -864,6 +876,7 @@ async def test_delete_squashed_person_overrides_from_clickhouse_dry_run(
 
     delete_table_inputs = TableActivityInputs(
         name="person_distinct_id_overrides_join_to_delete",
+        query_parameters={"team_ids": []},
         dry_run=False,
     )
 


### PR DESCRIPTION
## Problem

Squash can be slow. Although we have a higher tolerance for slowness, let's try to be somewhat faster.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Use `team_id` filters whenever possible.
* ~Disable persistency of join tables.~ This is apparently not a setting (despite the clickhouse docs explicitly calling it out).
* Higher timeouts and retries for long-running activities.
  * Just as a precaution, clickhouse can be not so happy about our long-running connection and kill 2-3 attempts.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
