### PR TITLE
fix: onboarding navigation

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -343,81 +343,80 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
             ): NavbarItem[][] => {
                 const isUsingSidebar = featureFlags[FEATURE_FLAGS.POSTHOG_3000_NAV]
                 const hasOnboardedFeatureFlags = currentTeam?.has_completed_onboarding_for?.[ProductKey.FEATURE_FLAGS]
-                const sectionOne: NavbarItem[] = [
-                    {
-                        identifier: Scene.Dashboards,
-                        label: 'Dashboards',
-                        icon: <IconDashboard />,
-                        logic: isUsingSidebar ? dashboardsSidebarLogic : undefined,
-                        to: isUsingSidebar ? undefined : urls.dashboards(),
-                        sideAction: {
-                            identifier: 'pinned-dashboards-dropdown',
-                            dropdown: {
-                                overlay: (
-                                    <LemonMenuOverlay
-                                        items={[
-                                            {
-                                                title: 'Pinned dashboards',
-                                                items: pinnedDashboards.map((dashboard) => ({
-                                                    label: dashboard.name,
-                                                    to: urls.dashboard(dashboard.id),
-                                                })),
-                                                footer: dashboardsLoading && (
-                                                    <div className="px-2 py-1 text-text-secondary-3000">
-                                                        <Spinner /> Loading…
-                                                    </div>
-                                                ),
-                                            },
-                                        ]}
-                                    />
-                                ),
-                                placement: 'bottom-end',
-                            },
-                        },
-                    },
-                    {
-                        identifier: Scene.Notebooks,
-                        label: 'Notebooks',
-                        icon: <IconNotebook />,
-                        to: urls.notebooks(),
-                    },
-                    {
-                        identifier: Scene.DataManagement,
-                        label: 'Data management',
-                        icon: <IconDatabase />,
-                        logic: isUsingSidebar ? dataManagementSidebarLogic : undefined,
-                        to: isUsingSidebar ? undefined : urls.eventDefinitions(),
-                    },
-                    {
-                        identifier: Scene.PersonsManagement,
-                        label: 'People',
-                        icon: <IconPeople />,
-                        logic: isUsingSidebar ? personsAndGroupsSidebarLogic : undefined,
-                        to: isUsingSidebar ? undefined : urls.persons(),
-                    },
-                    {
-                        identifier: Scene.Events,
-                        label: 'Activity',
-                        icon: <IconLive />,
-                        to: urls.events(),
-                    },
-                ]
-
-                sectionOne.unshift(
-                    hasOnboardedAnyProduct
-                        ? {
+                const sectionOne: NavbarItem[] = hasOnboardedAnyProduct
+                    ? [
+                          {
                               identifier: Scene.ProjectHomepage,
                               label: 'Home',
                               icon: <IconHome />,
                               to: urls.projectHomepage(),
-                          }
-                        : {
+                          },
+                          {
+                              identifier: Scene.Dashboards,
+                              label: 'Dashboards',
+                              icon: <IconDashboard />,
+                              logic: isUsingSidebar ? dashboardsSidebarLogic : undefined,
+                              to: isUsingSidebar ? undefined : urls.dashboards(),
+                              sideAction: {
+                                  identifier: 'pinned-dashboards-dropdown',
+                                  dropdown: {
+                                      overlay: (
+                                          <LemonMenuOverlay
+                                              items={[
+                                                  {
+                                                      title: 'Pinned dashboards',
+                                                      items: pinnedDashboards.map((dashboard) => ({
+                                                          label: dashboard.name,
+                                                          to: urls.dashboard(dashboard.id),
+                                                      })),
+                                                      footer: dashboardsLoading && (
+                                                          <div className="px-2 py-1 text-text-secondary-3000">
+                                                              <Spinner /> Loading…
+                                                          </div>
+                                                      ),
+                                                  },
+                                              ]}
+                                          />
+                                      ),
+                                      placement: 'bottom-end',
+                                  },
+                              },
+                          },
+                          {
+                              identifier: Scene.Notebooks,
+                              label: 'Notebooks',
+                              icon: <IconNotebook />,
+                              to: urls.notebooks(),
+                          },
+                          {
+                              identifier: Scene.DataManagement,
+                              label: 'Data management',
+                              icon: <IconDatabase />,
+                              logic: isUsingSidebar ? dataManagementSidebarLogic : undefined,
+                              to: isUsingSidebar ? undefined : urls.eventDefinitions(),
+                          },
+                          {
+                              identifier: Scene.PersonsManagement,
+                              label: 'People',
+                              icon: <IconPeople />,
+                              logic: isUsingSidebar ? personsAndGroupsSidebarLogic : undefined,
+                              to: isUsingSidebar ? undefined : urls.persons(),
+                          },
+                          {
+                              identifier: Scene.Events,
+                              label: 'Activity',
+                              icon: <IconLive />,
+                              to: urls.events(),
+                          },
+                      ]
+                    : [
+                          {
                               identifier: Scene.Products,
                               label: 'Welcome to PostHog',
                               icon: <IconLogomark />,
                               to: urls.products(),
-                          }
-                )
+                          },
+                      ]
 
                 return [
                     sectionOne,
@@ -478,20 +477,24 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                                   to: urls.earlyAccessFeatures(),
                               }
                             : null,
-                        {
-                            identifier: Scene.DataWarehouse,
-                            label: 'Data warehouse',
-                            icon: <IconServer />,
-                            to: urls.dataWarehouse(),
-                            featureFlag: FEATURE_FLAGS.DATA_WAREHOUSE,
-                            tag: 'beta' as const,
-                        },
-                        {
-                            identifier: Scene.Apps,
-                            label: 'Data pipeline',
-                            icon: <IconDecisionTree />,
-                            to: urls.projectApps(),
-                        },
+                        hasOnboardedAnyProduct
+                            ? {
+                                  identifier: Scene.DataWarehouse,
+                                  label: 'Data warehouse',
+                                  icon: <IconServer />,
+                                  to: urls.dataWarehouse(),
+                                  featureFlag: FEATURE_FLAGS.DATA_WAREHOUSE,
+                                  tag: 'beta' as const,
+                              }
+                            : null,
+                        hasOnboardedAnyProduct
+                            ? {
+                                  identifier: Scene.Apps,
+                                  label: 'Data pipeline',
+                                  icon: <IconDecisionTree />,
+                                  to: urls.projectApps(),
+                              }
+                            : null,
                         {
                             identifier: Scene.Pipeline,
                             label: 'Data pipeline 3000',

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -264,10 +264,7 @@ export const sceneLogic = kea<sceneLogicType>([
                         const allProductUrls = Object.values(productUrlMapping).flat()
                         if (
                             !teamLogic.values.hasOnboardedAnyProduct &&
-                            (values.featureFlags[FEATURE_FLAGS.PRODUCT_INTRO_PAGES] !== 'test' ||
-                                !allProductUrls.some((path) =>
-                                    removeProjectIdIfPresent(location.pathname).startsWith(path)
-                                ))
+                            !allProductUrls.some((path) => removeProjectIdIfPresent(location.pathname).startsWith(path))
                         ) {
                             console.warn('No onboarding completed, redirecting to /products')
                             router.actions.replace(urls.products())
@@ -295,7 +292,10 @@ export const sceneLogic = kea<sceneLogicType>([
                                 did_view_intro: values.featureFlags[FEATURE_FLAGS.PRODUCT_INTRO_PAGES] === 'test',
                                 product_key: productKeyFromUrl,
                             })
-                            if (values.featureFlags[FEATURE_FLAGS.PRODUCT_INTRO_PAGES] === 'test') {
+                            if (
+                                values.featureFlags[FEATURE_FLAGS.PRODUCT_INTRO_PAGES] === 'test' ||
+                                !teamLogic.values.hasOnboardedAnyProduct
+                            ) {
                                 console.warn(
                                     `Onboarding not completed for ${productKeyFromUrl}, redirecting to onboarding intro`
                                 )


### PR DESCRIPTION
## Problem

Now that onboarding exists inside the app we show the normal left navigation. But, clicking any of these buttons would not do anything, it would just take you back to the products page. 

On the `product-intro-pages` experiment you could click one of the products on the side and see the intro page, which is nice. But this didn't work on the control version.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- Removes the first non-products section from the sidebar as those aren't useful until you've onboarded into a product.
- Lets people on the `control` variant of the product-intro-pages experiment see the intro pages, but only if they haven't onboarded to another product yet (so we can still get valid results for that experiment for second+ products)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

🐁 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
