### PR TITLE
fix: Where clause in kill mutation query

### DIFF
--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -473,7 +473,7 @@ async def manage_table(
         table_activity_inputs,
         start_to_close_timeout=timedelta(hours=6),
         retry_policy=RetryPolicy(
-            maximum_attempts=100, initial_interval=timedelta(seconds=20), maximum_interval=timedelta(minutes=2)
+            maximum_attempts=0, initial_interval=timedelta(seconds=20), maximum_interval=timedelta(minutes=2)
         ),
         heartbeat_timeout=timedelta(minutes=2),
     )
@@ -653,7 +653,7 @@ async def submit_and_wait_for_mutation(
         mutation_activity_inputs,
         start_to_close_timeout=timedelta(hours=6),
         retry_policy=RetryPolicy(
-            maximum_attempts=100, initial_interval=timedelta(seconds=20), maximum_interval=timedelta(minutes=2)
+            maximum_attempts=0, initial_interval=timedelta(seconds=20), maximum_interval=timedelta(minutes=2)
         ),
         heartbeat_timeout=timedelta(minutes=2),
     )

--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -473,7 +473,7 @@ async def manage_table(
         table_activity_inputs,
         start_to_close_timeout=timedelta(hours=6),
         retry_policy=RetryPolicy(
-            maximum_attempts=20, initial_interval=timedelta(seconds=20), maximum_interval=timedelta(minutes=2)
+            maximum_attempts=100, initial_interval=timedelta(seconds=20), maximum_interval=timedelta(minutes=2)
         ),
         heartbeat_timeout=timedelta(minutes=2),
     )
@@ -653,7 +653,7 @@ async def submit_and_wait_for_mutation(
         mutation_activity_inputs,
         start_to_close_timeout=timedelta(hours=6),
         retry_policy=RetryPolicy(
-            maximum_attempts=20, initial_interval=timedelta(seconds=20), maximum_interval=timedelta(minutes=2)
+            maximum_attempts=100, initial_interval=timedelta(seconds=20), maximum_interval=timedelta(minutes=2)
         ),
         heartbeat_timeout=timedelta(minutes=2),
     )

--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -464,7 +464,7 @@ async def manage_table(
         create_table,
         table_activity_inputs,
         start_to_close_timeout=timedelta(minutes=5),
-        retry_policy=RetryPolicy(maximum_attempts=10, initial_interval=timedelta(seconds=20)),
+        retry_policy=RetryPolicy(maximum_attempts=1),
         heartbeat_timeout=timedelta(minutes=1),
     )
 
@@ -472,7 +472,9 @@ async def manage_table(
         wait_for_table,
         table_activity_inputs,
         start_to_close_timeout=timedelta(hours=6),
-        retry_policy=RetryPolicy(maximum_attempts=20, initial_interval=timedelta(seconds=20)),
+        retry_policy=RetryPolicy(
+            maximum_attempts=20, initial_interval=timedelta(seconds=20), maximum_interval=timedelta(minutes=2)
+        ),
         heartbeat_timeout=timedelta(minutes=2),
     )
 
@@ -483,7 +485,9 @@ async def manage_table(
             drop_table,
             table_activity_inputs,
             start_to_close_timeout=timedelta(hours=1),
-            retry_policy=RetryPolicy(maximum_attempts=1, initial_interval=timedelta(seconds=20)),
+            retry_policy=RetryPolicy(
+                maximum_attempts=2, initial_interval=timedelta(seconds=5), maximum_interval=timedelta(seconds=10)
+            ),
             heartbeat_timeout=timedelta(minutes=1),
         )
 
@@ -493,7 +497,9 @@ async def manage_table(
             table_activity_inputs,
             # Assuming clean-up should be relatively fast.
             start_to_close_timeout=timedelta(minutes=3),
-            retry_policy=RetryPolicy(maximum_attempts=1),
+            retry_policy=RetryPolicy(
+                maximum_attempts=2, initial_interval=timedelta(seconds=5), maximum_interval=timedelta(seconds=10)
+            ),
             heartbeat_timeout=timedelta(seconds=20),
         )
 
@@ -646,7 +652,9 @@ async def submit_and_wait_for_mutation(
         wait_for_mutation,
         mutation_activity_inputs,
         start_to_close_timeout=timedelta(hours=6),
-        retry_policy=RetryPolicy(maximum_attempts=20, initial_interval=timedelta(seconds=20)),
+        retry_policy=RetryPolicy(
+            maximum_attempts=20, initial_interval=timedelta(seconds=20), maximum_interval=timedelta(minutes=2)
+        ),
         heartbeat_timeout=timedelta(minutes=2),
     )
 

--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -93,7 +93,7 @@ WHERE
 KILL_MUTATION_IN_PROGRESS_ON_CLUSTER = """
 KILL MUTATION ON CLUSTER {cluster}
 WHERE is_done = 0
-WHERE table = '{table}'
+AND table = '{table}'
 AND database = '{database}'
 AND command LIKE %(query)s
 """


### PR DESCRIPTION
## Problem

Bugfix + retry policy changes.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Small bugfix in the kill mutation query 
* Tweaks to retry policy: 
  * Only one attempt to activities that submit an operation
    * Except `DROP TABLE` clean up, as it's running with `IF NOT EXISTS`.
  * No retry limit to activities that wait for operations, and do not wait much in between retries (up to two minutes).
    * This helps with random disconnects and errors from CH as these activities are long-running.
    * But we also don't want to start waiting too much between retries if clickhouse throws 3-4 disconnects in a row, hence the upper limit to wait between retries.
    * Moreover, I am going for the optimistic approach of assuming this will eventually work, so setting `maximum_attempts=0` helps things out.
    
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
