### PR TITLE
feat(hogql): Allow lazy join tables to be resolved by str

### DIFF
--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -6,6 +6,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.hogql.constants import LimitContext
+from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import create_hogql_database, serialize_database
 from posthog.hogql.autocomplete import get_hogql_autocomplete
 from posthog.hogql.metadata import get_hogql_metadata
@@ -91,7 +92,8 @@ def process_query_model(
         result = metadata_response
     elif isinstance(query, DatabaseSchemaQuery):
         database = create_hogql_database(team.pk, modifiers=create_default_modifiers_for_team(team))
-        result = serialize_database(database)
+        context = HogQLContext(team_id=team.pk, team=team, database=database)
+        result = serialize_database(context)
     elif isinstance(query, TimeToSeeDataSessionsQuery):
         sessions_query_serializer = SessionsQuerySerializer(data=query)
         sessions_query_serializer.is_valid(raise_exception=True)

--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -59,7 +59,7 @@ def write_sql_from_prompt(prompt: str, *, current_query: Optional[str] = None, t
         database=database,
         modifiers=create_default_modifiers_for_team(team),
     )
-    serialized_database = serialize_database(database)
+    serialized_database = serialize_database(context)
     schema_description = "\n\n".join(
         (
             f"Table {table_name} with fields:\n"

--- a/posthog/hogql/base.py
+++ b/posthog/hogql/base.py
@@ -1,11 +1,13 @@
 import re
 from dataclasses import dataclass, field
 
-from typing import Literal, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 from posthog.hogql.constants import ConstantDataType
 from posthog.hogql.errors import NotImplementedException
 
+if TYPE_CHECKING:
+    from posthog.hogql.context import HogQLContext
 
 # Given a string like "CorrectHorseBS", match the "H" and "B", so that we can convert this to "correct_horse_bs"
 camel_case_pattern = re.compile(r"(?<!^)(?<![A-Z])(?=[A-Z])")
@@ -35,13 +37,13 @@ class AST:
 
 @dataclass(kw_only=True)
 class Type(AST):
-    def get_child(self, name: str) -> "Type":
+    def get_child(self, name: str, context: "HogQLContext") -> "Type":
         raise NotImplementedException("Type.get_child not overridden")
 
-    def has_child(self, name: str) -> bool:
-        return self.get_child(name) is not None
+    def has_child(self, name: str, context: "HogQLContext") -> bool:
+        return self.get_child(name, context) is not None
 
-    def resolve_constant_type(self) -> Optional["ConstantType"]:
+    def resolve_constant_type(self, context: "HogQLContext") -> Optional["ConstantType"]:
         return UnknownType()
 
 
@@ -64,7 +66,7 @@ class CTE(Expr):
 class ConstantType(Type):
     data_type: ConstantDataType
 
-    def resolve_constant_type(self) -> "ConstantType":
+    def resolve_constant_type(self, context: "HogQLContext") -> "ConstantType":
         return self
 
     def print_type(self) -> str:

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Literal, Optional, TypedDict
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from pydantic import ConfigDict, BaseModel
+from posthog.hogql.context import HogQLContext
 
 from posthog.hogql.database.models import (
     FieldTraverser,
@@ -234,24 +235,27 @@ class SerializedField(_SerializedFieldBase, total=False):
     chain: List[str]
 
 
-def serialize_database(database: Database) -> Dict[str, List[SerializedField]]:
+def serialize_database(context: HogQLContext) -> Dict[str, List[SerializedField]]:
     tables: Dict[str, List[SerializedField]] = {}
 
-    for table_key in database.model_fields.keys():
+    if context.database is None:
+        raise HogQLException("Must provide database to serialize_database")
+
+    for table_key in context.database.model_fields.keys():
         field_input: Dict[str, Any] = {}
-        table = getattr(database, table_key, None)
+        table = getattr(context.database, table_key, None)
         if isinstance(table, FunctionCallTable):
             field_input = table.get_asterisk()
         elif isinstance(table, Table):
             field_input = table.fields
 
-        field_output: List[SerializedField] = serialize_fields(field_input)
+        field_output: List[SerializedField] = serialize_fields(field_input, context)
         tables[table_key] = field_output
 
     return tables
 
 
-def serialize_fields(field_input) -> List[SerializedField]:
+def serialize_fields(field_input, context: HogQLContext) -> List[SerializedField]:
     from posthog.hogql.database.models import SavedQuery
 
     field_output: List[SerializedField] = []
@@ -276,13 +280,13 @@ def serialize_fields(field_input) -> List[SerializedField]:
             elif isinstance(field, StringArrayDatabaseField):
                 field_output.append({"key": field_key, "type": "array"})
         elif isinstance(field, LazyJoin):
-            is_view = isinstance(field.join_table, SavedQuery)
+            is_view = isinstance(field.resolve_table(context), SavedQuery)
             field_output.append(
                 {
                     "key": field_key,
                     "type": "view" if is_view else "lazy_table",
-                    "table": field.join_table.to_printed_hogql(),
-                    "fields": list(field.join_table.fields.keys()),
+                    "table": field.resolve_table(context).to_printed_hogql(),
+                    "fields": list(field.resolve_table(context).fields.keys()),
                 }
             )
         elif isinstance(field, VirtualTable):

--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -113,8 +113,17 @@ class LazyJoin(FieldOrTable):
     model_config = ConfigDict(extra="forbid")
 
     join_function: Callable[[str, str, Dict[str, Any], "HogQLContext", "SelectQuery"], Any]
-    join_table: Table
+    join_table: Table | str
     from_field: str
+
+    def resolve_table(self, context: "HogQLContext") -> Table:
+        if isinstance(self.join_table, Table):
+            return self.join_table
+
+        if context.database is None:
+            raise HogQLException("Database is not set")
+
+        return context.database.get_table(self.join_table)
 
 
 class LazyTable(Table):

--- a/posthog/hogql/database/schema/cohort_people.py
+++ b/posthog/hogql/database/schema/cohort_people.py
@@ -8,7 +8,7 @@ from posthog.hogql.database.models import (
     LazyTable,
     FieldOrTable,
 )
-from posthog.hogql.database.schema.persons import PersonsTable, join_with_persons_table
+from posthog.hogql.database.schema.persons import join_with_persons_table
 from posthog.schema import HogQLQueryModifiers
 
 COHORT_PEOPLE_FIELDS = {
@@ -17,7 +17,7 @@ COHORT_PEOPLE_FIELDS = {
     "team_id": IntegerDatabaseField(name="team_id"),
     "person": LazyJoin(
         from_field="person_id",
-        join_table=PersonsTable(),
+        join_table="persons",
         join_function=join_with_persons_table,
     ),
 }

--- a/posthog/hogql/database/schema/person_distinct_ids.py
+++ b/posthog/hogql/database/schema/person_distinct_ids.py
@@ -12,7 +12,7 @@ from posthog.hogql.database.models import (
     LazyTable,
     FieldOrTable,
 )
-from posthog.hogql.database.schema.persons import PersonsTable, join_with_persons_table
+from posthog.hogql.database.schema.persons import join_with_persons_table
 from posthog.hogql.errors import HogQLException
 from posthog.schema import HogQLQueryModifiers
 
@@ -22,7 +22,7 @@ PERSON_DISTINCT_IDS_FIELDS = {
     "person_id": StringDatabaseField(name="person_id"),
     "person": LazyJoin(
         from_field="person_id",
-        join_table=PersonsTable(),
+        join_table="persons",
         join_function=join_with_persons_table,
     ),
 }

--- a/posthog/hogql/database/schema/static_cohort_people.py
+++ b/posthog/hogql/database/schema/static_cohort_people.py
@@ -7,7 +7,7 @@ from posthog.hogql.database.models import (
     LazyJoin,
     FieldOrTable,
 )
-from posthog.hogql.database.schema.persons import PersonsTable, join_with_persons_table
+from posthog.hogql.database.schema.persons import join_with_persons_table
 
 
 class StaticCohortPeople(Table):
@@ -17,7 +17,7 @@ class StaticCohortPeople(Table):
         "team_id": IntegerDatabaseField(name="team_id"),
         "person": LazyJoin(
             from_field="person_id",
-            join_table=PersonsTable(),
+            join_table="persons",
             join_function=join_with_persons_table,
         ),
     }

--- a/posthog/hogql/database/schema/test/test_event_sessions.py
+++ b/posthog/hogql/database/schema/test/test_event_sessions.py
@@ -23,7 +23,7 @@ class TestWhereClauseExtractor(BaseTest):
 
     def _compare_operators(self, query: ast.SelectQuery, table_name: str) -> List[ast.Expr]:
         assert query.where is not None and query.type is not None
-        return WhereClauseExtractor(query.where, table_name, query.type).compare_operators
+        return WhereClauseExtractor(query.where, table_name, query.type, self.context).compare_operators
 
     def test_with_simple_equality_clause(self):
         query = self._select(

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -290,7 +290,9 @@
                   "team_id",
                   "properties",
                   "is_identified",
-                  "pdi"
+                  "pdi",
+                  "$virt_initial_referring_domain_type",
+                  "$virt_initial_channel_type"
               ]
           }
       ],
@@ -424,7 +426,9 @@
                   "team_id",
                   "properties",
                   "is_identified",
-                  "pdi"
+                  "pdi",
+                  "$virt_initial_referring_domain_type",
+                  "$virt_initial_channel_type"
               ]
           }
       ],
@@ -447,7 +451,9 @@
                   "team_id",
                   "properties",
                   "is_identified",
-                  "pdi"
+                  "pdi",
+                  "$virt_initial_referring_domain_type",
+                  "$virt_initial_channel_type"
               ]
           }
       ],
@@ -633,7 +639,9 @@
                   "team_id",
                   "properties",
                   "is_identified",
-                  "pdi"
+                  "pdi",
+                  "$virt_initial_referring_domain_type",
+                  "$virt_initial_channel_type"
               ]
           },
           {
@@ -722,7 +730,9 @@
                   "team_id",
                   "properties",
                   "is_identified",
-                  "pdi"
+                  "pdi",
+                  "$virt_initial_referring_domain_type",
+                  "$virt_initial_channel_type"
               ]
           },
           {
@@ -1055,7 +1065,9 @@
                   "team_id",
                   "properties",
                   "is_identified",
-                  "pdi"
+                  "pdi",
+                  "$virt_initial_referring_domain_type",
+                  "$virt_initial_channel_type"
               ]
           }
       ],
@@ -1189,7 +1201,9 @@
                   "team_id",
                   "properties",
                   "is_identified",
-                  "pdi"
+                  "pdi",
+                  "$virt_initial_referring_domain_type",
+                  "$virt_initial_channel_type"
               ]
           }
       ],
@@ -1212,7 +1226,9 @@
                   "team_id",
                   "properties",
                   "is_identified",
-                  "pdi"
+                  "pdi",
+                  "$virt_initial_referring_domain_type",
+                  "$virt_initial_channel_type"
               ]
           }
       ],
@@ -1398,7 +1414,9 @@
                   "team_id",
                   "properties",
                   "is_identified",
-                  "pdi"
+                  "pdi",
+                  "$virt_initial_referring_domain_type",
+                  "$virt_initial_channel_type"
               ]
           },
           {
@@ -1487,7 +1505,9 @@
                   "team_id",
                   "properties",
                   "is_identified",
-                  "pdi"
+                  "pdi",
+                  "$virt_initial_referring_domain_type",
+                  "$virt_initial_channel_type"
               ]
           },
           {

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -24,19 +24,25 @@ class TestDatabase(BaseTest):
     @pytest.mark.usefixtures("unittest_snapshot")
     def test_serialize_database_no_person_on_events(self):
         with override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=False):
-            serialized_database = serialize_database(create_hogql_database(team_id=self.team.pk))
+            serialized_database = serialize_database(
+                HogQLContext(team_id=self.team.pk, database=create_hogql_database(team_id=self.team.pk))
+            )
             assert json.dumps(serialized_database, indent=4) == self.snapshot
 
     @pytest.mark.usefixtures("unittest_snapshot")
     def test_serialize_database_with_person_on_events_enabled(self):
         with override_settings(PERSON_ON_EVENTS_OVERRIDE=True):
-            serialized_database = serialize_database(create_hogql_database(team_id=self.team.pk))
+            serialized_database = serialize_database(
+                HogQLContext(team_id=self.team.pk, database=create_hogql_database(team_id=self.team.pk))
+            )
             assert json.dumps(serialized_database, indent=4) == self.snapshot
 
     @parameterized.expand([False, True])
     def test_can_select_from_each_table_at_all(self, poe_enabled: bool) -> None:
         with override_settings(PERSON_ON_EVENTS_OVERRIDE=poe_enabled):
-            serialized_database = serialize_database(create_hogql_database(team_id=self.team.pk))
+            serialized_database = serialize_database(
+                HogQLContext(team_id=self.team.pk, database=create_hogql_database(team_id=self.team.pk))
+            )
             for table, possible_columns in serialized_database.items():
                 if table == "numbers":
                     execute_hogql_query(

--- a/posthog/hogql/test/__snapshots__/test_resolver.ambr
+++ b/posthog/hogql/test/__snapshots__/test_resolver.ambr
@@ -3268,16 +3268,7 @@
               lazy_join: {
                 from_field: "person_id",
                 join_function: <function>,
-                join_table: {
-                  fields: {
-                    created_at: {},
-                    id: {},
-                    is_identified: {},
-                    pdi: {},
-                    properties: {},
-                    team_id: {}
-                  }
-                }
+                join_table: "persons"
               }
               table_type: {
                 field: "pdi"
@@ -3404,16 +3395,7 @@
               lazy_join: {
                 from_field: "person_id",
                 join_function: <function>,
-                join_table: {
-                  fields: {
-                    created_at: {},
-                    id: {},
-                    is_identified: {},
-                    pdi: {},
-                    properties: {},
-                    team_id: {}
-                  }
-                }
+                join_table: "persons"
               }
               table_type: {
                 field: "pdi"
@@ -3743,16 +3725,7 @@
               lazy_join: {
                 from_field: "person_id",
                 join_function: <function>,
-                join_table: {
-                  fields: {
-                    created_at: {},
-                    id: {},
-                    is_identified: {},
-                    pdi: {},
-                    properties: {},
-                    team_id: {}
-                  }
-                }
+                join_table: "persons"
               }
               table_type: <recursion ...>
             }

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -307,16 +307,16 @@ class TestResolver(BaseTest):
         node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
 
         # all columns resolve to a type in the end
-        assert cast(ast.FieldType, node.select[0].type).resolve_database_field() == StringDatabaseField(
+        assert cast(ast.FieldType, node.select[0].type).resolve_database_field(self.context) == StringDatabaseField(
             name="event", array=None, nullable=None
         )
-        assert cast(ast.FieldType, node.select[1].type).resolve_database_field() == StringDatabaseField(
+        assert cast(ast.FieldType, node.select[1].type).resolve_database_field(self.context) == StringDatabaseField(
             name="person_id", array=None, nullable=None
         )
-        assert cast(ast.FieldType, node.select[2].type).resolve_database_field() == StringJSONDatabaseField(
+        assert cast(ast.FieldType, node.select[2].type).resolve_database_field(self.context) == StringJSONDatabaseField(
             name="person_properties"
         )
-        assert cast(ast.FieldType, node.select[3].type).resolve_database_field() == DateTimeDatabaseField(
+        assert cast(ast.FieldType, node.select[3].type).resolve_database_field(self.context) == DateTimeDatabaseField(
             name="created_at", array=None, nullable=None
         )
 

--- a/posthog/warehouse/api/saved_query.py
+++ b/posthog/warehouse/api/saved_query.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import NotAuthenticated
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import SerializedField, serialize_fields
+from posthog.hogql.database.database import SerializedField, create_hogql_database, serialize_fields
 from posthog.hogql.errors import HogQLException
 from posthog.hogql.metadata import is_valid_view
 from posthog.hogql.parser import parse_select
@@ -34,7 +34,10 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "created_by", "created_at", "columns"]
 
     def get_columns(self, view: DataWarehouseSavedQuery) -> List[SerializedField]:
-        return serialize_fields(view.hogql_definition().fields)
+        team_id = self.context["team_id"]
+        context = HogQLContext(team_id=team_id, database=create_hogql_database(team_id=team_id))
+
+        return serialize_fields(view.hogql_definition().fields, context)
 
     def create(self, validated_data):
         validated_data["team_id"] = self.context["team_id"]

--- a/posthog/warehouse/api/table.py
+++ b/posthog/warehouse/api/table.py
@@ -5,7 +5,8 @@ from rest_framework.exceptions import NotAuthenticated
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
-from posthog.hogql.database.database import SerializedField, serialize_fields
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import SerializedField, create_hogql_database, serialize_fields
 from posthog.models import User
 from posthog.warehouse.models import (
     DataWarehouseCredential,
@@ -54,7 +55,10 @@ class TableSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "created_by", "created_at", "columns", "external_data_source", "external_schema"]
 
     def get_columns(self, table: DataWarehouseTable) -> List[SerializedField]:
-        return serialize_fields(table.hogql_definition().fields)
+        team_id = self.context["team_id"]
+        context = HogQLContext(team_id=team_id, database=create_hogql_database(team_id=team_id))
+
+        return serialize_fields(table.hogql_definition().fields, context)
 
     def get_external_schema(self, instance: DataWarehouseTable):
         from posthog.warehouse.api.external_data_schema import SimpleExternalDataSchemaSerializer
@@ -88,7 +92,10 @@ class SimpleTableSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "name", "columns"]
 
     def get_columns(self, table: DataWarehouseTable) -> List[SerializedField]:
-        return serialize_fields(table.hogql_definition().fields)
+        team_id = table.team.pk
+        context = HogQLContext(team_id=team_id, database=create_hogql_database(team_id=team_id))
+
+        return serialize_fields(table.hogql_definition().fields, context)
 
 
 class TableViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
## Problem
- When setting up the HogQL database from `create_hogql_database`, we modify database fields on condition settings, such as PoE mode, and we set data warehouse lazy joins, e.g. adding a lazy join onto `persons`
- The problem we're having is that other subtables, such as `PersonDistinctIdsTable`, also define a `persons` field, but it initializes a new version of `PersonsTable` and therefore `persons` doesn't have access to any of the data warehouse joins

## Changes
- Allow Lazy Joins to be defined with either a `Table` or `str` for the `from_table` prop. If a `Table` is given, then everything acts as normal, if a `str` is given, then we'll attempt to read that table from `Database` via `get_table` - we raise an error if the table doesn't exist. This ensures that all subtables use the same reference of `PersonTable`
- This includes adding `HogQLContext` literally _everywhere_ in the parser/resolver/models etc

## How did you test this code?
- Updated unit tests and ensured we didn't encounter any errors when making queries