### PR TITLE
feat: Add more ad/campaign ids

### DIFF
--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -75,12 +75,19 @@ const eventToPersonProperties = new Set([
     'utm_content',
     'utm_name',
     'utm_term',
-    'gclid',
-    'gad_source',
-    'gbraid',
-    'wbraid',
-    'fbclid',
-    'msclkid',
+    'gclid', // google ads
+    'gad_source', // google ads
+    'gclsrc', // google ads 360
+    'dclid', // google display ads
+    'gbraid', // google ads, web to app
+    'wbraid', // google ads, app to web
+    'fbclid', // facebook
+    'msclkid', // microsoft
+    'twclid', // twitter
+    'li_fat_id', // linkedin
+    'mc_cid', // mailchimp campaign id
+    'igshid', // instagram
+    'ttclid', // tiktok
 ])
 
 /** If we get new UTM params, make sure we set those  **/


### PR DESCRIPTION
## Problem

There are some major platforms where we don't capture the relevant ids. I've added support for Google Ads 360, Twitter, LinkedIn, Bing, Instagram, TikTok, and Mailchimp

## Changes

Add
* gclcsrc
* dclid
* twclid
* li_fat_id
* mc_cid
* igshid
* ttclid

See https://github.com/PostHog/posthog-js/pull/1057 for where I've added this to posthog-js

## How did you test this code?

n/a
