### PR TITLE
feat: Add minmax index for inserted_at

### DIFF
--- a/posthog/clickhouse/migrations/0055_add_minmax_index_on_inserted_at.py
+++ b/posthog/clickhouse/migrations/0055_add_minmax_index_on_inserted_at.py
@@ -1,0 +1,7 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.events.sql import EVENTS_TABLE_INSERTED_AT_INDEX_SQL, EVENTS_TABLE_MATERIALIZE_INSERTED_AT_INDEX_SQL
+
+operations = [
+    run_sql_with_exceptions(EVENTS_TABLE_INSERTED_AT_INDEX_SQL),
+    run_sql_with_exceptions(EVENTS_TABLE_MATERIALIZE_INSERTED_AT_INDEX_SQL),
+]

--- a/posthog/clickhouse/migrations/0055_add_minmax_index_on_inserted_at.py
+++ b/posthog/clickhouse/migrations/0055_add_minmax_index_on_inserted_at.py
@@ -1,5 +1,5 @@
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.models.events.sql import EVENTS_TABLE_INSERTED_AT_INDEX_SQL, EVENTS_TABLE_MATERIALIZE_INSERTED_AT_INDEX_SQL
+from posthog.models.event.sql import EVENTS_TABLE_INSERTED_AT_INDEX_SQL, EVENTS_TABLE_MATERIALIZE_INSERTED_AT_INDEX_SQL
 
 operations = [
     run_sql_with_exceptions(EVENTS_TABLE_INSERTED_AT_INDEX_SQL),

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -106,6 +106,18 @@ ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64
     storage_policy=STORAGE_POLICY(),
 )
 
+EVENTS_TABLE_INSERTED_AT_INDEX_SQL = """
+ALTER TABLE {table_name} ON CLUSTER {cluster}
+ADD INDEX `minmax_inserted_at` `inserted_at`
+TYPE minmax
+GRANULARITY 1
+""".format(table_name=EVENTS_DATA_TABLE(), cluster=settings.CLICKHOUSE_CLUSTER)
+
+EVENTS_TABLE_MATERIALIZE_INSERTED_AT_INDEX_SQL = """
+ALTER TABLE {table_name} ON CLUSTER {cluster}
+MATERIALIZE INDEX `minmax_inserted_at`
+""".format(table_name=EVENTS_DATA_TABLE(), cluster=settings.CLICKHOUSE_CLUSTER)
+
 # we add the settings to prevent poison pills from stopping ingestion
 # kafka_skip_broken_messages is an int, not a boolean, so we explicitly set
 # the max block size to consume from kafka such that we skip _all_ broken messages

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -108,7 +108,7 @@ ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64
 
 EVENTS_TABLE_INSERTED_AT_INDEX_SQL = """
 ALTER TABLE {table_name} ON CLUSTER {cluster}
-ADD INDEX `minmax_inserted_at` `inserted_at`
+ADD INDEX `minmax_inserted_at` COALESCE(`inserted_at`, `_timestamp`)
 TYPE minmax
 GRANULARITY 1
 """.format(table_name=EVENTS_DATA_TABLE(), cluster=settings.CLICKHOUSE_CLUSTER)


### PR DESCRIPTION
## Problem

Querying events by `inserted_at`(1) in batch exports can become too expensive: `inserted_at` is not included in the events table primary key, so ClickHouse is forced to scan all granules finding rows that have `inserted_at` within the bounds of a batch export.

However, in normal latency scenarios, `inserted_at` should closely match the primary key `toDate(timestamp)`(2): Only events sent with a delay or processed with lag will show big discrepancies, and in most of these scenarios discrepancies will be within a week (with the exception of historical backfills(3)).

If ClickHouse knew the range of values of `inserted_at` within each granule, it could use that information to skip a lot of granules that contain no `inserted_at` matching the `where` clause range used in batch exports. But, it currently doesn't have that information...

So, let's give ClickHouse the information it needs with a `minmax` index on `inserted_at`!

The key question that will determine the performance of the index is how big will the `inserted_at` range be within a granule (or set of granules, depending on the `GRANULARITY` parameter). As I have been hinting, I believe that, in most scenarios, `inserted_at` ranges will be within a day for any granule or set of granules pointed at by any value of `toDate(timestamp)`. If this is true, data that is already sorted by `toDate(timestamp)` is likely to be loosely sorted by `inserted_at` too.

In scenarios with high latency, the number of granules ClickHouse will be able to skip goes down, as `inserted_at` ranges can be bigger than a single day. In the worst case, ClickHouse won't be able to skip any granules, because events have so much lag that every day has such a wide range of `inserted_at` that every granule matches the where clause. But, this is the case right now: As ClickHouse doesn't have the information to skip any granules we are reading everything. I also think that a realistic worst case is mobile events sent with a few days of lag, which is still a smaller range than the entire table for any user of PostHog that has been with us for more than a few days.

In conclusion, I think worst case will be the same (or even better realistically!), and best case has the potential to be so much better. Looking forward to hearing comments!

### Footnotes

(1) To be brief, I will be saying only `inserted_at`. However, batch exports query data by `COALESCE(inserted_at, _timestamp)`, and the index is defined on that expression.

(2) I am ignoring `team_id`, which is also part of the primary key, as we do use that in the where clause of batch exports. We are already doing the best we can with `team_id`, so I'm considering the next field in the key for this breakdown.

(3) Note that I am talking about users backfilling historical data to PostHog, not batch export backfills.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Add a `minmax` index on `COALESCE(inserted_at, _timestamp)`
* Materialize the index.
  * Should we materialize in the migration or do this async some other time?

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Created index in ClickHouse environment. Verified plan was using it.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
