### PR TITLE
fix: close button overlap on modal

### DIFF
--- a/frontend/src/lib/components/UpgradeModal/UpgradeModal.tsx
+++ b/frontend/src/lib/components/UpgradeModal/UpgradeModal.tsx
@@ -10,7 +10,7 @@ export function UpgradeModal(): JSX.Element {
     const { hideUpgradeModal } = useActions(upgradeModalLogic)
 
     return upgradeModalFeatureKey ? (
-        <LemonModal onClose={hideUpgradeModal} isOpen={!!upgradeModalFeatureKey}>
+        <LemonModal onClose={hideUpgradeModal} closeIconSize="xsmall" isOpen={!!upgradeModalFeatureKey}>
             <div className="max-w-2xl">
                 <PayGateMini
                     feature={upgradeModalFeatureKey}
@@ -18,7 +18,7 @@ export function UpgradeModal(): JSX.Element {
                     isGrandfathered={upgradeModalIsGrandfathered ?? undefined}
                     background={false}
                 >
-                    <div className="pr-7">
+                    <div className="mt-6 px-2">
                         You should have access to this feature already. If you are still seeing this modal, please let
                         us know 🙂
                     </div>

--- a/frontend/src/lib/lemon-ui/LemonModal/LemonModal.tsx
+++ b/frontend/src/lib/lemon-ui/LemonModal/LemonModal.tsx
@@ -43,6 +43,7 @@ export interface LemonModalProps {
      * A modal launched from a popover can appear behind the popover. This allows you to force the modal to appear above the popover.
      * */
     forceAbovePopovers?: boolean
+    closeIconSize?: string
     contentRef?: React.RefCallback<HTMLDivElement>
     overlayRef?: React.RefCallback<HTMLDivElement>
     'data-attr'?: string
@@ -76,6 +77,7 @@ export function LemonModal({
     footer,
     inline,
     simple,
+    closeIconSize = 'small',
     closable = true,
     hasUnsavedInput,
     fullScreen = false,
@@ -120,7 +122,7 @@ export function LemonModal({
                     >
                         <LemonButton
                             icon={<IconX />}
-                            size="small"
+                            size={closeIconSize}
                             onClick={onClose}
                             aria-label="close"
                             onMouseEnter={() => setIgnoredOverlayClickCount(0)}

--- a/frontend/src/lib/lemon-ui/LemonModal/LemonModal.tsx
+++ b/frontend/src/lib/lemon-ui/LemonModal/LemonModal.tsx
@@ -43,7 +43,7 @@ export interface LemonModalProps {
      * A modal launched from a popover can appear behind the popover. This allows you to force the modal to appear above the popover.
      * */
     forceAbovePopovers?: boolean
-    closeIconSize?: string
+    closeIconSize?: 'small' | 'xsmall' | 'medium' | 'large'
     contentRef?: React.RefCallback<HTMLDivElement>
     overlayRef?: React.RefCallback<HTMLDivElement>
     'data-attr'?: string


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->

Fix screenshot:

<img width="786" alt="Screenshot 2024-03-07 at 22 08 08" src="https://github.com/PostHog/posthog/assets/64887299/52889aef-695b-4cd0-b076-84e0dd690c4b">


<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
