### PR TITLE
chore(batch-exports): add team migration management command

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -678,6 +678,7 @@ posthog/queries/trends/test/test_person.py:0: error: "str" has no attribute "get
 posthog/queries/trends/test/test_person.py:0: error: Invalid index type "int" for "HttpResponse"; expected type "str | bytes"  [index]
 posthog/queries/trends/test/test_person.py:0: error: "str" has no attribute "get"  [attr-defined]
 posthog/queries/trends/test/test_person.py:0: error: Invalid index type "int" for "HttpResponse"; expected type "str | bytes"  [index]
+posthog/management/commands/migrate_team.py:0: error: Incompatible types in assignment (expression has type "None", variable has type "BatchExport")  [assignment]
 posthog/hogql/test/test_query.py:0: error: Argument 1 to "len" has incompatible type "list[Any] | None"; expected "Sized"  [arg-type]
 posthog/hogql/test/test_query.py:0: error: Value of type "list[QueryTiming] | None" is not indexable  [index]
 posthog/hogql/test/test_query.py:0: error: Value of type "list[QueryTiming] | None" is not indexable  [index]

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -28,11 +28,9 @@ from posthog.batch_exports.service import (
     BatchExportSchema,
     BatchExportServiceError,
     BatchExportServiceRPCError,
-    BatchExportServiceScheduleNotFound,
     BatchExportWithNoEndNotAllowedError,
     backfill_export,
-    batch_export_delete_schedule,
-    cancel_running_batch_export_backfill,
+    disable_and_delete_export,
     pause_batch_export,
     sync_batch_export,
     unpause_batch_export,
@@ -43,7 +41,6 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
 from posthog.models import (
     BatchExport,
-    BatchExportBackfill,
     BatchExportDestination,
     BatchExportRun,
     Team,
@@ -436,23 +433,7 @@ class BatchExportViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         since we are deleting, we assume that we can recover from this state by finishing the delete operation by calling
         instance.save().
         """
-        temporal = sync_connect()
-
-        instance.deleted = True
-
-        try:
-            batch_export_delete_schedule(temporal, str(instance.pk))
-        except BatchExportServiceScheduleNotFound as e:
-            logger.warning(
-                "The Schedule %s could not be deleted as it was not found",
-                e.schedule_id,
-            )
-
-        instance.save()
-
-        for backfill in BatchExportBackfill.objects.filter(batch_export=instance):
-            if backfill.status == BatchExportBackfill.Status.RUNNING:
-                cancel_running_batch_export_backfill(temporal, backfill.workflow_id)
+        disable_and_delete_export(instance)
 
 
 class BatchExportOrganizationViewSet(BatchExportViewSet):

--- a/posthog/management/commands/migrate_team.py
+++ b/posthog/management/commands/migrate_team.py
@@ -1,0 +1,270 @@
+import datetime as dt
+import logging
+
+from django.db import transaction
+from django.core.management.base import BaseCommand, CommandError
+
+from posthog.batch_exports.models import BATCH_EXPORT_INTERVALS
+from posthog.batch_exports.service import (
+    backfill_export,
+    sync_batch_export,
+    disable_and_delete_export,
+)
+from posthog.models import (
+    BatchExport,
+    BatchExportBackfill,
+    BatchExportDestination,
+    BatchExportRun,
+    Team,
+)
+from posthog.temporal.common.client import sync_connect
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+EXPORT_NAME = "PostHog HTTP Migration"
+VALID_INTERVALS = {i[0] for i in BATCH_EXPORT_INTERVALS}
+REGION_URLS = {
+    "us": "https://app.posthog.com/batch",
+    "eu": "https://eu.posthog.com/batch",
+}
+
+
+class Command(BaseCommand):
+    help = "Creates an HTTP batch export for a team to migrate data to another PostHog instance, \
+            or another team within the same instance."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--team-id", default=None, type=int, help="Team ID to migrate from (on this instance)")
+        parser.add_argument("--interval", default=None, type=str, help="Interval to use for the batch export")
+        parser.add_argument(
+            "--start-at",
+            default=None,
+            type=str,
+            help="Timestamp to start the backfill from in UTC, 'YYYY-MM-DD' or 'YYYY-MM-DD HH:MM:SS'",
+        )
+        parser.add_argument(
+            "--delete-existing", default=False, type=bool, help="Delete existing batch export if it exists"
+        )
+        parser.add_argument("--dest-token", default=None, type=str, help="Destination Project API Key (token)")
+        parser.add_argument("--dest-region", default=None, type=str, help="Destination region")
+        parser.add_argument(
+            "--end-days-from-now",
+            default=30,
+            type=int,
+            help="Number of days from now to automatically end the ongoing export at, the default is usually fine",
+        )
+
+    def handle(self, **options):
+        team_id = options["team_id"]
+        interval = options["interval"]
+        start_at = options["start_at"]
+        dest_token = options["dest_token"]
+        dest_region = options["dest_region"]
+        verbose = options["verbosity"] > 1
+
+        create_args = [
+            interval,
+            start_at,
+            dest_token,
+            dest_region,
+        ]
+        create_requested = any(create_args)
+
+        if not team_id:
+            raise CommandError("source Team ID is required")
+
+        team = Team.objects.select_related("organization").get(id=team_id)
+
+        display(
+            "Team",
+            name=team.name,
+            organization=team.organization.name,
+        )
+
+        try:
+            existing_export = BatchExport.objects.get(
+                team=team, destination__type="HTTP", name=EXPORT_NAME, deleted=False
+            )
+
+            display_existing(existing_export=existing_export, verbose=verbose)
+
+            if options["delete_existing"]:
+                result = input("Enter [y] to continue deleting the existing migration (Ctrl+C to cancel) ")
+                if result.lower() != "y":
+                    raise CommandError("Didn't receive 'y', exiting")
+                print()  # noqa: T201
+
+                disable_and_delete_export(existing_export)
+                existing_export = None
+                display("Deleted existing batch export and backfill")
+        except BatchExport.DoesNotExist:
+            existing_export = None
+            display("No existing migration was found")
+        except BatchExport.MultipleObjectsReturned:
+            raise CommandError(
+                "More than one existing migration found! This should never happen if the management command is used, we don't know enough to proceed"
+            )
+
+        if not create_requested:
+            # User didn't provide any arguments to create a migration, so they must have just wanted
+            # to check the status and/or delete the existing migration.
+            return
+        elif existing_export:
+            display(
+                "Existing migration job already exists and it wasn't deleted, exiting without creating a new batch export"
+            )
+            return
+
+        end_days_from_now = options["end_days_from_now"]
+
+        create_migration(
+            team_id=team_id,
+            interval=interval,
+            start_at=start_at,
+            dest_token=dest_token,
+            dest_region=dest_region,
+            end_days_from_now=end_days_from_now,
+        )
+
+
+def display_existing(*, existing_export: BatchExport, verbose: bool):
+    existing_backfill = BatchExportBackfill.objects.get(batch_export=existing_export)
+    most_recent_run = BatchExportRun.objects.filter(batch_export=existing_export).order_by("-created_at").first()
+
+    if verbose:
+        display(
+            "Existing migration batch export (verbose details)",
+            batch_export_id=existing_export.id,
+            paused=existing_export.paused,
+            interval=existing_export.interval,
+            created_at=existing_export.created_at,
+            last_updated_at=existing_export.last_updated_at,
+        )
+        display(
+            "Existing migration backfill (verbose details)",
+            backfill_id=existing_backfill.id,
+            status=existing_backfill.status,
+            start_at=existing_backfill.start_at,
+            created_at=existing_backfill.created_at,
+            last_updated_at=existing_backfill.last_updated_at,
+        )
+
+    if not most_recent_run:
+        display("No batch export runs found, is the migration brand new?")
+    else:
+        most_recent_completed_run = (
+            BatchExportRun.objects.filter(batch_export=existing_export, status=BatchExportRun.Status.COMPLETED)
+            .order_by("-finished_at")
+            .first()
+        )
+
+        if most_recent_completed_run:
+            data_start_at = existing_backfill.start_at
+            data_end_at = most_recent_completed_run.data_interval_end
+            display(
+                "Found an existing migration, range of data migrated:",
+                start=data_start_at,
+                end=data_end_at,
+                interval=existing_export.interval,
+            )
+            if existing_export.paused:
+                display("The batch export backfill is still catching up to realtime")
+            else:
+                display(
+                    "The batch export is unpaused, meaning the primary backfill completed and this is now in realtime export mode",
+                )
+
+        if not most_recent_completed_run or verbose:
+            display(
+                "Most recent run (verbose details)",
+                run_id=most_recent_run.id,
+                status=most_recent_run.status,
+                error=most_recent_run.latest_error,
+                data_interval_start=most_recent_run.data_interval_start,
+                data_interval_end=most_recent_run.data_interval_end,
+                created_at=most_recent_run.created_at,
+                last_updated_at=most_recent_run.last_updated_at,
+            )
+
+
+def create_migration(
+    *, team_id: int, interval: str, start_at: str, dest_token: str, dest_region: str, end_days_from_now: int
+):
+    if interval not in VALID_INTERVALS:
+        raise CommandError("invalid interval, choices are: %s" % VALID_INTERVALS)
+
+    if not dest_token.startswith("phc_"):
+        raise CommandError("invalid destination token, must start with 'phc_'")
+
+    dest_region = dest_region.lower()
+    if dest_region not in REGION_URLS:
+        raise CommandError("invalid destination region, choices are: 'us', 'eu'")
+    url = REGION_URLS[dest_region]
+
+    try:
+        start_at_datetime = parse_to_utc(start_at)
+    except ValueError as e:
+        raise CommandError("couldn't parse start_at: %s" % e)
+
+    display(
+        "Creating migration",
+        interval=interval,
+        start_at=start_at_datetime,
+        dest_token=dest_token,
+        dest_region=dest_region,
+        url=url,
+    )
+    result = input("Enter [y] to continue creating a new migration (Ctrl+C to cancel) ")
+    if result.lower() != "y":
+        raise CommandError("Didn't receive 'y', exiting")
+    print()  # noqa: T201
+
+    now = dt.datetime.now(dt.timezone.utc)
+    # This is a precaution so we don't accidentally leave the export running indefinitely.
+    end_at = now + dt.timedelta(days=end_days_from_now)
+
+    destination = BatchExportDestination(
+        type=BatchExportDestination.Destination.HTTP,
+        config={"url": url, "token": dest_token},
+    )
+    batch_export = BatchExport(
+        team_id=team_id,
+        destination=destination,
+        name=EXPORT_NAME,
+        interval=interval,
+        paused=True,
+        end_at=end_at,
+    )
+    sync_batch_export(batch_export, created=True)
+
+    with transaction.atomic():
+        destination.save()
+        batch_export.save()
+
+    temporal = sync_connect()
+    backfill_id = backfill_export(temporal, str(batch_export.pk), team_id, start_at_datetime, end_at=None)
+    display("Backfill started", batch_export_id=batch_export.id, backfill_id=backfill_id)
+
+
+def display(message, **kwargs):
+    print(message)  # noqa: T201
+    for key, value in kwargs.items():
+        if isinstance(value, dt.datetime):
+            value = value.strftime("%Y-%m-%d %H:%M:%S")
+        print(f"  {key} = {value}")  # noqa: T201
+    print()  # noqa: T201
+
+
+def parse_to_utc(date_str: str) -> dt.datetime:
+    try:
+        parsed_datetime = dt.datetime.strptime(date_str, "%Y-%m-%d")
+    except ValueError:
+        try:
+            parsed_datetime = dt.datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            raise ValueError("Invalid date format. Expected 'YYYY-MM-DD' or 'YYYY-MM-DD HH:MM:SS'.")
+
+    utc_datetime = parsed_datetime.replace(tzinfo=dt.timezone.utc)
+    return utc_datetime


### PR DESCRIPTION
## Problem

We need easier management of migrations.

## Changes

Add management command! Some usage examples are below (runbook in progress):

Team with no ongoing migrations:
```
# ./manage.py migrate_team --team-id 1
Team
  name = PostHog
  organization = PostHog

No existing migration was found
```

Team with an ongoing migration that isn't caught up:
```
# ./manage.py migrate_team --team-id 2
Team
  name = ATeam
  organization = AnOrg

Found an existing migration, range of data migrated:
  start = 2022-01-19 00:00:00
  end = 2022-12-27 00:00:00
  interval = day

The batch export backfill is still catching up to realtime
```

Team with an ongoing migration that is now just a normal ongoing ("realtime") batch export:
```
# ./manage.py migrate_team --team-id 3
Team
  name = AnotherTeam
  organization = AnotherOrg

Found an existing migration, range of data migrated:
  start = 2023-06-28 00:00:00
  end = 2024-03-08 00:00:00
  interval = day

The batch export is unpaused, meaning the primary backfill completed and this is now in realtime export mode
```

Let's delete the migration:
```
# ./manage.py migrate_team --team-id 3 --delete-existing true
Team
  name = AnotherTeam
  organization = AnotherOrg

Found an existing migration, range of data migrated:
  start = 2023-06-28 00:00:00
  end = 2024-03-08 00:00:00
  interval = day

The batch export is unpaused, meaning the primary backfill completed and this is now in realtime export mode

Enter [y] to continue deleting the existing migration (Ctrl+C to cancel) y

Deleted existing batch export and backfill
```

And recreate it where it left off (this would also be an opportunity to adjust the interval if desired):
```
./manage.py migrate_team \
  --team-id 3 \
  --interval day \
  --start-at "2024-03-08 00:00:00" \
  --dest-token phc_REDACTED \
  --dest-region eu
Team
  name = AnotherTeam
  organization = AnotherOrg

No existing migration was found

Creating migration
  interval = day
  start_at = 2024-03-08 00:00:00
  dest_token = phc_REDACTED
  dest_region = eu
  url = https://eu.posthog.com/batch

Enter [y] to continue creating a new migration (Ctrl+C to cancel) y

Backfill started
  batch_export_id = 018e1fc2-3f66-0001-caf8-c0d0ddedae32
  backfill_id = 018e1fc2-3f66-0001-caf8-c0d0ddedae32-Backfill-2024-03-08T00:00:00+00:00-None
```