### PR TITLE
fix: Wrong posthog-js host

### DIFF
--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -20,6 +20,7 @@
     <script>
         window.JS_POSTHOG_API_KEY = {{js_posthog_api_key | safe}};
         window.JS_POSTHOG_HOST = {{js_posthog_host | safe}};
+        window.JS_POSTHOG_UI_HOST = {{js_posthog_ui_host | safe}};
         window.JS_POSTHOG_SELF_CAPTURE = {{self_capture | yesno:"true,false" }};
         window.POSTHOG_USER_IDENTITY_WITH_FLAGS = JSON.parse("{{ posthog_bootstrap | escapejs }}")
         window.IMPERSONATED_SESSION = {{is_impersonated_session | yesno:"true,false"}};


### PR DESCRIPTION
## Problem

One line missed out that is pretty vital for the client to get the server value...
Noticed in support tickets the session replay url was wrong

## Changes

* Fixed it

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
