### PR TITLE
fix: Fix single property materialization command

### DIFF
--- a/ee/management/commands/materialize_columns.py
+++ b/ee/management/commands/materialize_columns.py
@@ -75,7 +75,6 @@ class Command(BaseCommand):
                         options["property_table"],
                         options["table_column"],
                         options["property"],
-                        0,
                     )
                 ],
                 backfill_period_days=options["backfill_period"],

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -59,7 +59,7 @@ MATERIALIZE_COLUMNS_ANALYSIS_PERIOD_HOURS = get_from_env(
     "MATERIALIZE_COLUMNS_ANALYSIS_PERIOD_HOURS", 7 * 24, type_cast=int
 )
 # How big of a timeframe to backfill when materializing event properties. 0 for no backfilling
-MATERIALIZE_COLUMNS_BACKFILL_PERIOD_DAYS = get_from_env("MATERIALIZE_COLUMNS_BACKFILL_PERIOD_DAYS", 90, type_cast=int)
+MATERIALIZE_COLUMNS_BACKFILL_PERIOD_DAYS = get_from_env("MATERIALIZE_COLUMNS_BACKFILL_PERIOD_DAYS", 0, type_cast=int)
 # Maximum number of columns to materialize at once. Avoids running into resource bottlenecks (storage + ingest + backfilling).
 MATERIALIZE_COLUMNS_MAX_AT_ONCE = get_from_env("MATERIALIZE_COLUMNS_MAX_AT_ONCE", 100, type_cast=int)
 


### PR DESCRIPTION
## Problem

Running a management command to materialize a single property didn't work. Also, default to not backfilling unless specified.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

now it does
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
