### PR TITLE
fix: add labelnames to prometheus metrics

### DIFF
--- a/ee/session_recordings/ai/embeddings_runner.py
+++ b/ee/session_recordings/ai/embeddings_runner.py
@@ -33,42 +33,50 @@ RECORDING_EMBEDDING_TOKEN_COUNT = Histogram(
     "posthog_session_recordings_recording_embedding_token_count",
     "Token count for individual recordings generated during embedding",
     buckets=[0, 100, 500, 1000, 2000, 3000, 4000, 5000, 6000, 8000, 10000],
+    labelnames=["source_type"],
 )
 
 GENERATE_RECORDING_EMBEDDING_TIMING = Histogram(
     "posthog_session_recordings_generate_recording_embedding",
     "Time spent generating recording embeddings for a single session",
     buckets=[0.1, 0.2, 0.3, 0.4, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 18, 20],
+    labelnames=["source_type"],
 )
 
 SESSION_EMBEDDINGS_GENERATED = Counter(
     "posthog_session_recordings_embeddings_generated",
     "Number of session embeddings generated",
+    labelnames=["source_type"],
 )
 
 SESSION_EMBEDDINGS_FAILED = Counter(
     "posthog_session_recordings_embeddings_failed",
     "Instance of an embedding request to open AI (and its surrounding work) failing and being swallowed",
+    labelnames=["source_type"],
 )
 
 SESSION_EMBEDDINGS_FATAL_FAILED = Counter(
     "posthog_session_recordings_embeddings_fatal_failed",
     "Instance of the embeddings task failing and raising an exception",
+    labelnames=["source_type"],
 )
 
 SESSION_EMBEDDINGS_WRITTEN_TO_CLICKHOUSE = Counter(
     "posthog_session_recordings_embeddings_written_to_clickhouse",
     "Number of session embeddings written to Clickhouse",
+    labelnames=["source_type"],
 )
 
 SESSION_SKIPPED_WHEN_GENERATING_EMBEDDINGS = Counter(
     "posthog_session_recordings_skipped_when_generating_embeddings",
     "Number of sessions skipped when generating embeddings",
+    labelnames=["source_type", "reason"],
 )
 
 SESSION_EMBEDDINGS_FAILED_TO_CLICKHOUSE = Counter(
     "posthog_session_recordings_embeddings_failed_to_clickhouse",
     "Number of session embeddings failed to Clickhouse",
+    labelnames=["source_type"],
 )
 
 


### PR DESCRIPTION
## Problem

Follow on fix from https://github.com/PostHog/posthog/pull/20752

## Changes

I didn't realise you have to specify the Prometheus label names upfront

## How did you test this code?

Found other examples in the code