### PR TITLE
chore(capture): change 'is False' to 'not'

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -577,7 +577,7 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid=
 
     if (
         distinct_id.lower() not in LIKELY_ANONYMOUS_IDS
-        and is_randomly_partitioned(candidate_partition_key) is False
+        and not is_randomly_partitioned(candidate_partition_key)
         or historical
     ):
         kafka_partition_key = hashlib.sha256(candidate_partition_key.encode()).hexdigest()
@@ -613,7 +613,7 @@ def is_randomly_partitioned(candidate_partition_key: str) -> bool:
     if settings.PARTITION_KEY_AUTOMATIC_OVERRIDE_ENABLED:
         has_capacity = LIMITER.consume(candidate_partition_key)
 
-        if has_capacity is False:
+        if not has_capacity:
             if not LOG_RATE_LIMITER.consume(candidate_partition_key):
                 # Return early if we have logged this key already.
                 return True


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
This is a readability footgun IMO for folks used to Python.

## Changes

Use leading `not`, not trailing `is False`. No functional change.