### PR TITLE
feat: show currently selected file in the plugin UploadField

### DIFF
--- a/frontend/src/scenes/plugins/edit/UploadField.tsx
+++ b/frontend/src/scenes/plugins/edit/UploadField.tsx
@@ -2,12 +2,15 @@ import { LemonFileInput } from '@posthog/lemon-ui'
 
 export function UploadField({ value, onChange }: { value?: File; onChange?: (file: File) => void }): JSX.Element {
     return (
-        <LemonFileInput
-            accept="*"
-            multiple={false}
-            onChange={(files) => onChange?.(files[0])}
-            value={value?.size ? [value] : []}
-            showUploadedFiles={false}
-        />
+        <>
+            {value?.name ? <span>Selected file: {value.name}</span> : null}
+            <LemonFileInput
+                accept="*"
+                multiple={false}
+                onChange={(files) => onChange?.(files[0])}
+                value={value?.size ? [value] : []}
+                showUploadedFiles={false}
+            />
+        </>
     )
 }


### PR DESCRIPTION
## Problem

![2024-03-11 at 15 21 16](https://github.com/PostHog/posthog/assets/13001502/c680f281-1244-4426-a4bc-822cd79ee2ba)

## Changes

[This user](https://posthog.com/questions/how-not-to-send-data-on-localhost-dev-env) was confused because there was no feedback that a file had been selected. This will not show the file after reloading the page.
