### PR TITLE
feat: Use offline workload for sessions backfill

### DIFF
--- a/posthog/management/commands/backfill_sessions_table.py
+++ b/posthog/management/commands/backfill_sessions_table.py
@@ -7,12 +7,12 @@ from typing import Optional
 import structlog
 from django.core.management.base import BaseCommand
 
+from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.client.execute import sync_execute
 from posthog.models.property.util import get_property_string_expr
 from datetime import datetime, timedelta
 
 logger = structlog.get_logger(__name__)
-
 
 TARGET_TABLE = "sessions"
 
@@ -21,6 +21,7 @@ TARGET_TABLE = "sessions"
 class BackfillQuery:
     start_date: datetime
     end_date: datetime
+    use_offline_workload: bool
 
     def execute(
         self,
@@ -121,7 +122,10 @@ WHERE `$session_id` IS NOT NULL AND `$session_id` != '' AND {where}
         for i in range(num_days):
             date = self.start_date + timedelta(days=i)
             logging.info("Writing the sessions for day %s", date.strftime("%Y-%m-%d"))
-            sync_execute(f"""INSERT INTO writable_sessions {select_query(select_date=date)}""")
+            sync_execute(
+                query=f"""INSERT INTO writable_sessions {select_query(select_date=date)}""",
+                workload=Workload.OFFLINE if self.use_offline_workload else Workload.DEFAULT,
+            )
 
         # print the count of entries in the main sessions table
         count_query = f"SELECT count(), uniq(session_id) FROM {TARGET_TABLE}"
@@ -142,11 +146,14 @@ class Command(BaseCommand):
         parser.add_argument(
             "--live-run", action="store_true", help="actually execute INSERT queries (default is dry-run)"
         )
+        parser.add_argument(
+            "--use-offline-workload", action="store_true", help="actually execute INSERT queries (default is dry-run)"
+        )
 
-    def handle(self, *, live_run: bool, start_date: str, end_date: str, **options):
+    def handle(self, *, live_run: bool, start_date: str, end_date: str, use_offline_workload: bool, **options):
         logger.setLevel(logging.INFO)
 
         start_datetime = datetime.strptime(start_date, "%Y-%m-%d")
         end_datetime = datetime.strptime(end_date, "%Y-%m-%d")
 
-        BackfillQuery(start_datetime, end_datetime).execute(dry_run=not live_run)
+        BackfillQuery(start_datetime, end_datetime, use_offline_workload).execute(dry_run=not live_run)


### PR DESCRIPTION
## Problem

We need to backfill the session table, and should use the offline nodes on US prod

## Changes
Add a command line option to run the backfill using offline nodes

## How did you test this code?

Ran the backfill locally
