### PR TITLE
fix: Saved query with datetime type

### DIFF
--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -31,6 +31,7 @@ CLICKHOUSE_HOGQL_MAPPING = {
     "String": StringDatabaseField,
     "DateTime64": DateTimeDatabaseField,
     "DateTime32": DateTimeDatabaseField,
+    "DateTime": DateTimeDatabaseField,
     "Date": DateDatabaseField,
     "Date32": DateDatabaseField,
     "UInt8": IntegerDatabaseField,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Saved query with DateTime type would fail

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
