### PR TITLE
fix: remove the duplicate port config for temporal containers

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -111,8 +111,6 @@ services:
         extends:
             file: docker-compose.base.yml
             service: temporal
-        ports:
-            - 7233:7233
     temporal-admin-tools:
         extends:
             file: docker-compose.base.yml
@@ -121,5 +119,3 @@ services:
         extends:
             file: docker-compose.base.yml
             service: temporal-ui
-        ports:
-            - 8081:8080


### PR DESCRIPTION
## Problem

I ran into this when running the repo locally:
```
Ports are not available: exposing port TCP 0.0.0.0:7233 -> 0.0.0.0:0: listen tcp 0.0.0.0:7233: bind: address already in use
```

In the the Docker UI I could see it was trying to bind the same ports twice for the `temporal` and `temporal-ui` containers.

## Changes

The fix was to remove the duplicate port config in the dev docker compose since the base already did it.