### PR TITLE
chore: add read scope to seen_together action

### DIFF
--- a/posthog/api/property_definition.py
+++ b/posthog/api/property_definition.py
@@ -4,14 +4,8 @@ from typing import Any, Dict, List, Optional, Type, cast
 
 from django.db import connection
 from django.db.models import Prefetch
-from rest_framework import (
-    mixins,
-    serializers,
-    viewsets,
-    status,
-    request,
-    response,
-)
+from loginas.utils import is_impersonated_session
+from rest_framework import mixins, request, response, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.pagination import LimitOffsetPagination
@@ -23,10 +17,9 @@ from posthog.constants import GROUP_TYPES_LIMIT, AvailableFeature
 from posthog.event_usage import report_user_action
 from posthog.exceptions import EnterpriseFeatureException
 from posthog.filters import TermSearchFilterBackend, term_search_filter_sql
-from posthog.models import PropertyDefinition, TaggedItem, User, EventProperty
-from posthog.models.activity_logging.activity_log import log_activity, Detail
+from posthog.models import EventProperty, PropertyDefinition, TaggedItem, User
+from posthog.models.activity_logging.activity_log import Detail, log_activity
 from posthog.models.utils import UUIDT
-from loginas.utils import is_impersonated_session
 
 
 class SeenTogetherQuerySerializer(serializers.Serializer):
@@ -245,9 +238,11 @@ class QueryContext:
         )
         return dataclasses.replace(
             self,
-            excluded_properties_filter=f"AND {self.property_definition_table}.name NOT IN %(excluded_properties)s"
-            if len(excluded_list) > 0
-            else "",
+            excluded_properties_filter=(
+                f"AND {self.property_definition_table}.name NOT IN %(excluded_properties)s"
+                if len(excluded_list) > 0
+                else ""
+            ),
             params={
                 **self.params,
                 "excluded_properties": excluded_list,
@@ -580,7 +575,7 @@ class PropertyDefinitionViewSet(
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
 
-    @action(methods=["GET"], detail=False)
+    @action(methods=["GET"], detail=False, required_scopes=["property_definition:read"])
     def seen_together(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
         """
         Allows a caller to provide a list of event names and a single property name


### PR DESCRIPTION
## Problem

Customer [wrote in](https://posthoghelp.zendesk.com/agent/tickets/11519):

> The API docs for the property definitions endpoint show a pattern of requiring READ ONLY access for GET requests and WRITE access for POST or PATCH requests. Makes sense! However, the last endpoint listed on that api docs page (/seen_together) is missing a header for "Required API key scopes".
> 
> Now, I assumed since it's a GET request that a READ ONLY api key would work, but what I found is that neither READ nor WRITE permissions (via the "Personal API keys" UI thing in Settings) was sufficient -- both of them return the following response:
> 
> ```
> {'type': 'authentication_error',
> 'code': 'permission_denied',
> 'detail': 'This action does not support Personal API Key access',
> 'attr': None}
> ```
> When I tested it with an all access api key it worked fine. It seems pretty reasonable to allow READ ONLY keys to authenticate this request, so I assume this is a bug (vs. an omission of information in the endpoint docs).

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Seemed reasonable, so I've added the scope.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

I didn't 🤷‍♀️ 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
