### PR TITLE
fix(insights): Fix paths display for use with hash based routing

### DIFF
--- a/frontend/src/scenes/paths/pathUtils.test.ts
+++ b/frontend/src/scenes/paths/pathUtils.test.ts
@@ -1,0 +1,194 @@
+import { RGBColor } from 'd3'
+
+import { pageUrl, PathNodeData } from './pathUtils'
+
+describe('pageUrl', () => {
+    it('should correctly process PathNodeData with hash based URL', () => {
+        const testData = {
+            name: '2_https://example.com/#/auth/login',
+            targetLinks: [
+                {
+                    average_conversion_time: 0,
+                    index: 0,
+                    value: 0,
+                    width: 0,
+                    y0: 0,
+                    color: { r: 0, g: 0, b: 0 } as RGBColor,
+                    target: {
+                        name: '1_https://example.com/',
+                        targetLinks: [],
+                        sourceLinks: [],
+                        depth: 0,
+                        width: 0,
+                        height: 0,
+                        index: 0,
+                        value: 0,
+                        x0: 0,
+                        x1: 0,
+                        y0: 0,
+                        y1: 0,
+                        layer: 0,
+                        visible: true,
+                    },
+                    source: {
+                        name: '1_https://example.com/',
+                        targetLinks: [],
+                        sourceLinks: [],
+                        depth: 0,
+                        width: 0,
+                        height: 0,
+                        index: 0,
+                        value: 0,
+                        x0: 0,
+                        x1: 0,
+                        y0: 0,
+                        y1: 0,
+                        layer: 0,
+                        visible: true,
+                    },
+                },
+            ],
+            sourceLinks: [],
+            depth: 0,
+            width: 0,
+            height: 0,
+            index: 0,
+            value: 0,
+            x0: 0,
+            x1: 0,
+            y0: 0,
+            y1: 0,
+            layer: 0,
+            visible: true,
+        } as unknown as PathNodeData
+
+        const result = pageUrl(testData, true)
+        expect(result).toBe('/#/auth/login')
+    })
+
+    it('should correctly process PathNodeData with unrelated hash in URL', () => {
+        const testData = {
+            name: '2_https://example.com/auth/login#sidepanel=explore',
+            targetLinks: [
+                {
+                    average_conversion_time: 0,
+                    index: 0,
+                    value: 0,
+                    width: 0,
+                    y0: 0,
+                    color: { r: 0, g: 0, b: 0 } as RGBColor,
+                    target: {
+                        name: '1_https://example.com/',
+                        targetLinks: [],
+                        sourceLinks: [],
+                        depth: 0,
+                        width: 0,
+                        height: 0,
+                        index: 0,
+                        value: 0,
+                        x0: 0,
+                        x1: 0,
+                        y0: 0,
+                        y1: 0,
+                        layer: 0,
+                        visible: true,
+                    },
+                    source: {
+                        name: '1_https://example.com/',
+                        targetLinks: [],
+                        sourceLinks: [],
+                        depth: 0,
+                        width: 0,
+                        height: 0,
+                        index: 0,
+                        value: 0,
+                        x0: 0,
+                        x1: 0,
+                        y0: 0,
+                        y1: 0,
+                        layer: 0,
+                        visible: true,
+                    },
+                },
+            ],
+            sourceLinks: [],
+            depth: 0,
+            width: 0,
+            height: 0,
+            index: 0,
+            value: 0,
+            x0: 0,
+            x1: 0,
+            y0: 0,
+            y1: 0,
+            layer: 0,
+            visible: true,
+        } as unknown as PathNodeData
+
+        const result = pageUrl(testData, true)
+        expect(result).toBe('/auth/login')
+    })
+
+    it('should correctly process PathNodeData with regular URL', () => {
+        const testData = {
+            name: '2_https://example.com/path',
+            targetLinks: [
+                {
+                    average_conversion_time: 0,
+                    index: 0,
+                    value: 0,
+                    width: 0,
+                    y0: 0,
+                    color: { r: 0, g: 0, b: 0 } as RGBColor,
+                    target: {
+                        name: '1_https://example.com/',
+                        targetLinks: [],
+                        sourceLinks: [],
+                        depth: 0,
+                        width: 0,
+                        height: 0,
+                        index: 0,
+                        value: 0,
+                        x0: 0,
+                        x1: 0,
+                        y0: 0,
+                        y1: 0,
+                        layer: 0,
+                        visible: true,
+                    },
+                    source: {
+                        name: '1_https://example.com/',
+                        targetLinks: [],
+                        sourceLinks: [],
+                        depth: 0,
+                        width: 0,
+                        height: 0,
+                        index: 0,
+                        value: 0,
+                        x0: 0,
+                        x1: 0,
+                        y0: 0,
+                        y1: 0,
+                        layer: 0,
+                        visible: true,
+                    },
+                },
+            ],
+            sourceLinks: [],
+            depth: 0,
+            width: 0,
+            height: 0,
+            index: 0,
+            value: 0,
+            x0: 0,
+            x1: 0,
+            y0: 0,
+            y1: 0,
+            layer: 0,
+            visible: true,
+        } as unknown as PathNodeData
+
+        const result = pageUrl(testData, true)
+        expect(result).toBe('/path')
+    })
+})

--- a/frontend/src/scenes/paths/pathUtils.ts
+++ b/frontend/src/scenes/paths/pathUtils.ts
@@ -101,6 +101,9 @@ export function pageUrl(d: PathNodeData, display?: boolean): string {
     try {
         const url = new URL(name)
         name = incomingDomains.length !== 1 ? url.href.replace(/(^\w+:|^)\/\//, '') : url.pathname + url.search
+        if (url.hash?.includes('/')) {
+            name += url.hash
+        }
     } catch {
         // discard if invalid url
     }


### PR DESCRIPTION
## Problem

When using hash based routing and having URLs like `/#/auth/login` the paths insight shows just `/`.

Fixes ZEN-11482

## Changes

Take into account URL fragments when they include `/`

## How did you test this code?

Added tests