### PR TITLE
fix: Extend timeout for backfill

### DIFF
--- a/posthog/management/commands/backfill_sessions_table.py
+++ b/posthog/management/commands/backfill_sessions_table.py
@@ -123,7 +123,7 @@ WHERE `$session_id` IS NOT NULL AND `$session_id` != '' AND {where}
             date = self.start_date + timedelta(days=i)
             logging.info("Writing the sessions for day %s", date.strftime("%Y-%m-%d"))
             sync_execute(
-                query=f"""INSERT INTO writable_sessions {select_query(select_date=date)}""",
+                query=f"""INSERT INTO writable_sessions {select_query(select_date=date)} SETTINGS max_execution_time=3600""",
                 workload=Workload.OFFLINE if self.use_offline_workload else Workload.DEFAULT,
             )
 


### PR DESCRIPTION
## Problem

The backfill can timeout just inserting events from one day if the timeout is only 2 minutes

## Changes

Change the timeout to an hour

## How did you test this code?
Ran the command locally (didn't test that the timeout was different, just that it doesn't fail, and that it does fail if I change the spelling of the setting)