### PR TITLE
feat: show browser visbility events

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
@@ -180,9 +180,7 @@ export function PlayerInspectorListItem({
                         {item.offline ? 'Browser went offline' : 'Browser returned online'}
                     </div>
                 ) : item.type === 'browser-visibility' ? (
-                    <div className="flex items-start p-2 text-xs">
-                        <span>Window became</span> {item.status}
-                    </div>
+                    <div className="flex items-start p-2 text-xs">Window became {item.status}</div>
                 ) : item.type === SessionRecordingPlayerTab.DOCTOR ? (
                     <ItemDoctor item={item} {...itemProps} />
                 ) : null}

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
@@ -1,5 +1,5 @@
 import { TZLabel } from '@posthog/apps-common'
-import { IconDashboard, IconGear, IconTerminal } from '@posthog/icons'
+import { IconDashboard, IconEye, IconGear, IconTerminal } from '@posthog/icons'
 import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
@@ -41,6 +41,10 @@ const typeToIconAndDescription = {
     ['offline-status']: {
         Icon: IconOffline,
         tooltip: 'browser went offline or returned online',
+    },
+    ['browser-visibility']: {
+        Icon: IconEye,
+        tooltip: 'browser tab/window became visible or hidden',
     },
     ['$session_config']: {
         Icon: IconGear,
@@ -174,6 +178,10 @@ export function PlayerInspectorListItem({
                 ) : item.type === 'offline-status' ? (
                     <div className="flex items-start p-2 text-xs">
                         {item.offline ? 'Browser went offline' : 'Browser returned online'}
+                    </div>
+                ) : item.type === 'browser-visibility' ? (
+                    <div className="flex items-start p-2 text-xs">
+                        <span>Window became</span> {item.status}
                     </div>
                 ) : item.type === SessionRecordingPlayerTab.DOCTOR ? (
                     <ItemDoctor item={item} {...itemProps} />

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -75,6 +75,11 @@ export type InspectorListOfflineStatusChange = InspectorListItemBase & {
     offline: boolean
 }
 
+export type InspectorListBrowserVisibility = InspectorListItemBase & {
+    type: 'browser-visibility'
+    status: 'hidden' | 'visible'
+}
+
 export type InspectorListItemDoctor = InspectorListItemBase & {
     type: SessionRecordingPlayerTab.DOCTOR
     tag: string
@@ -88,6 +93,7 @@ export type InspectorListItem =
     | InspectorListItemPerformance
     | InspectorListOfflineStatusChange
     | InspectorListItemDoctor
+    | InspectorListBrowserVisibility
 
 export interface PlayerInspectorLogicProps extends SessionRecordingPlayerLogicProps {
     matchingEventsMatchType?: MatchingEventsMatchType
@@ -284,6 +290,39 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
             },
         ],
 
+        browserVisibilityChanges: [
+            (s) => [s.start, s.sessionPlayerData],
+            (start, sessionPlayerData): InspectorListBrowserVisibility[] => {
+                const logs: InspectorListBrowserVisibility[] = []
+
+                Object.entries(sessionPlayerData.snapshotsByWindowId).forEach(([windowId, snapshots]) => {
+                    snapshots.forEach((snapshot: eventWithTime) => {
+                        if (
+                            snapshot.type === 5 // RRWeb custom event type
+                        ) {
+                            const customEvent = snapshot as customEvent
+                            const tag = customEvent.data.tag
+
+                            if (['window hidden', 'window visible'].includes(tag)) {
+                                const { timestamp, timeInRecording } = timeRelativeToStart(snapshot, start)
+                                logs.push({
+                                    type: 'browser-visibility',
+                                    status: tag === 'window hidden' ? 'hidden' : 'visible',
+                                    timestamp: timestamp,
+                                    timeInRecording: timeInRecording,
+                                    search: tag,
+                                    windowId: windowId,
+                                    highlightColor: 'warning',
+                                } satisfies InspectorListBrowserVisibility)
+                            }
+                        }
+                    })
+                })
+
+                return logs
+            },
+        ],
+
         doctorEvents: [
             (s) => [s.start, s.sessionPlayerData],
             (start, sessionPlayerData): InspectorListItemDoctor[] => {
@@ -419,6 +458,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 s.matchingEventUUIDs,
                 s.offlineStatusChanges,
                 s.doctorEvents,
+                s.browserVisibilityChanges,
             ],
             (
                 start,
@@ -427,7 +467,8 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 eventsData,
                 matchingEventUUIDs,
                 offlineStatusChanges,
-                doctorEvents
+                doctorEvents,
+                browserVisibilityChanges
             ): InspectorListItem[] => {
                 // NOTE: Possible perf improvement here would be to have a selector to parse the items
                 // and then do the filtering of what items are shown, elsewhere
@@ -437,6 +478,11 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
 
                 // no conversion needed for offlineStatusChanges, they're ready to roll
                 for (const event of offlineStatusChanges || []) {
+                    items.push(event)
+                }
+
+                // no conversion needed for browserVisibilityChanges, they're ready to roll
+                for (const event of browserVisibilityChanges || []) {
                     items.push(event)
                 }
 
@@ -557,7 +603,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                     let include = false
 
                     // always show offline status changes
-                    if (item.type === 'offline-status') {
+                    if (item.type === 'offline-status' || item.type === 'browser-visibility') {
                         include = true
                     }
 


### PR DESCRIPTION
pairs with https://github.com/PostHog/posthog-js/pull/1071

Show when the browser was visible or hidden

<img width="633" alt="Screenshot 2024-03-12 at 11 16 43" src="https://github.com/PostHog/posthog/assets/984817/00281f8d-96bc-4a4f-8aea-73e7d03e58de">
