### PR TITLE
chore: add input column to embeddings

### DIFF
--- a/posthog/clickhouse/migrations/0056_session_replay_embeddings_input.py
+++ b/posthog/clickhouse/migrations/0056_session_replay_embeddings_input.py
@@ -1,0 +1,12 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.session_recordings.sql.session_replay_embeddings_migrations import (
+    DISTRIBUTED_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_INPUT_COLUMN,
+    WRITEABLE_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_INPUT_COLUMN,
+    SHARDED_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_INPUT_COLUMN,
+)
+
+operations = [
+    run_sql_with_exceptions(DISTRIBUTED_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_INPUT_COLUMN()),
+    run_sql_with_exceptions(WRITEABLE_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_INPUT_COLUMN()),
+    run_sql_with_exceptions(SHARDED_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_INPUT_COLUMN()),
+]

--- a/posthog/session_recordings/sql/session_replay_embeddings_migrations.py
+++ b/posthog/session_recordings/sql/session_replay_embeddings_migrations.py
@@ -25,3 +25,29 @@ SHARDED_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_TYPE_COLUMN = (
         cluster=settings.CLICKHOUSE_CLUSTER,
     )
 )
+
+ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_INPUT_COLUMN = """
+    ALTER TABLE {table_name} on CLUSTER '{cluster}'
+        ADD COLUMN IF NOT EXISTS input String
+"""
+
+DISTRIBUTED_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_INPUT_COLUMN = (
+    lambda: ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_INPUT_COLUMN.format(
+        table_name="session_replay_embeddings",
+        cluster=settings.CLICKHOUSE_CLUSTER,
+    )
+)
+
+WRITEABLE_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_INPUT_COLUMN = (
+    lambda: ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_INPUT_COLUMN.format(
+        table_name="writable_session_replay_embeddings",
+        cluster=settings.CLICKHOUSE_CLUSTER,
+    )
+)
+
+SHARDED_TABLE_ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_INPUT_COLUMN = (
+    lambda: ALTER_SESSION_REPLAY_EMBEDDINGS_ADD_INPUT_COLUMN.format(
+        table_name="sharded_session_replay_embeddings",
+        cluster=settings.CLICKHOUSE_CLUSTER,
+    )
+)


### PR DESCRIPTION
## Problem

Once we embed we lose the context on the original text string

## Changes

Add a column that stores the `input` provided during embedding

## How did you test this code?

Ran the migration locally
<img width="523" alt="Screenshot 2024-03-12 at 14 42 44" src="https://github.com/PostHog/posthog/assets/6685876/bb6df551-c3bb-4c95-828b-2082acdf9288">
<img width="970" alt="Screenshot 2024-03-12 at 14 42 39" src="https://github.com/PostHog/posthog/assets/6685876/e6854b4b-04a6-4e95-9c94-02ff2b32a757">

