### PR TITLE
fix(insights): Fix paths node names truncation when custom events

### DIFF
--- a/frontend/src/scenes/paths/PathNodeCardButton.tsx
+++ b/frontend/src/scenes/paths/PathNodeCardButton.tsx
@@ -33,8 +33,11 @@ export function PathNodeCardButton({
     const { user } = useValues(userLogic)
     const hasAdvancedPaths = user?.organization?.available_features?.includes(AvailableFeature.PATHS_ADVANCED)
 
-    const setAsPathStart = (): void => setFilter({ startPoint: pageUrl(node) })
-    const setAsPathEnd = (): void => setFilter({ endPoint: pageUrl(node) })
+    const nodeName = pageUrl(node)
+    const isPath = nodeName.includes('/')
+
+    const setAsPathStart = (): void => setFilter({ startPoint: nodeName })
+    const setAsPathEnd = (): void => setFilter({ endPoint: nodeName })
     const excludePathItem = (): void => {
         setFilter({ excludeEvents: [...(filter.excludeEvents || []), pageUrl(node, false)] })
     }
@@ -42,15 +45,15 @@ export function PathNodeCardButton({
         viewPathToFunnel(node)
     }
     const copyName = (): void => {
-        void copyToClipboard(pageUrl(node)).then(captureException)
+        void copyToClipboard(nodeName).then(captureException)
     }
     const openModal = (): void => openPersonsModal({ path_end_key: name })
 
     return (
         <div className="flex justify-between items-center w-full">
-            <div className="flex items-center font-semibold">
+            <div className="font-semibold overflow-hidden max-h-16">
                 <span className="text-xxs text-muted mr-1">{`0${name[0]}`}</span>
-                <span className="text-xs">{pageUrl(node, true)}</span>
+                <span className="text-xs break-words">{pageUrl(node, isPath)}</span>
             </div>
             <div className="flex flex-nowrap">
                 <LemonButton size="small" onClick={openModal}>


### PR DESCRIPTION
## Problem

Custom event names are truncated ugly in paths insight. Customers want to read them.

## Changes

- show in full
- adjust wrapping and overflow handling

<img width="387" alt="Screenshot 2024-03-12 at 15 35 32" src="https://github.com/PostHog/posthog/assets/59713/889caad7-a1d4-456a-a369-3822f9a0ff45">


## How did you test this code?

- tested a few sizes