### PR TITLE
fix(hogql): throw error for missing actions in funnels

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -134,8 +134,11 @@ class FunnelEventQuery:
             if isinstance(node, EventsNode) or isinstance(node, FunnelExclusionEventsNode):
                 events.add(node.event)
             elif isinstance(node, ActionsNode) or isinstance(node, FunnelExclusionActionsNode):
-                action = Action.objects.get(pk=int(node.id), team=team)
-                events.update(action.get_step_events())
+                try:
+                    action = Action.objects.get(pk=int(node.id), team=team)
+                    events.update(action.get_step_events())
+                except Action.DoesNotExist:
+                    raise ValidationError(f"Action ID {node.id} does not exist!")
             else:
                 raise ValidationError("Series and exclusions must be compose of action and event nodes")
 


### PR DESCRIPTION
## Problem

Funnels have been throwing a `Action.DoesNotExist` error instead of a  `ValidationError`.

## Changes

This PR adapts HogQL funnels so that the behaviour is the same as legacy funnels.

## How did you test this code?

Tried an insight with a missing action