### PR TITLE
feat(web-analytics): remove duplicate channel type definition, and add to sessions table

### DIFF
--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -41,8 +41,29 @@ if(
 def create_initial_channel_type(name: str):
     return ExpressionField(
         name=name,
-        expr=parse_expr(
-            """
+        expr=create_channel_type_expr(
+            campaign=ast.Call(name="toString", args=[ast.Field(chain=["properties", "$initial_utm_campaign"])]),
+            medium=ast.Call(name="toString", args=[ast.Field(chain=["properties", "$initial_utm_medium"])]),
+            source=ast.Call(name="toString", args=[ast.Field(chain=["properties", "$initial_utm_source"])]),
+            referring_domain=ast.Call(
+                name="toString", args=[ast.Field(chain=["properties", "$initial_referring_domain"])]
+            ),
+            gclid=ast.Call(name="toString", args=[ast.Field(chain=["properties", "$initial_gclid"])]),
+            gad_source=ast.Call(name="toString", args=[ast.Field(chain=["properties", "$initial_gad_source"])]),
+        ),
+    )
+
+
+def create_channel_type_expr(
+    campaign: ast.Expr,
+    medium: ast.Expr,
+    source: ast.Expr,
+    referring_domain: ast.Expr,
+    gclid: ast.Expr,
+    gad_source: ast.Expr,
+) -> ast.Expr:
+    return parse_expr(
+        """
 multiIf(
     match({campaign}, 'cross-network'),
     'Cross Network',
@@ -99,16 +120,13 @@ multiIf(
         )
     )
 )""",
-            start=None,
-            placeholders={
-                "campaign": ast.Call(name="toString", args=[ast.Field(chain=["properties", "$initial_utm_campaign"])]),
-                "medium": ast.Call(name="toString", args=[ast.Field(chain=["properties", "$initial_utm_medium"])]),
-                "source": ast.Call(name="toString", args=[ast.Field(chain=["properties", "$initial_utm_source"])]),
-                "referring_domain": ast.Call(
-                    name="toString", args=[ast.Field(chain=["properties", "$initial_referring_domain"])]
-                ),
-                "gclid": ast.Call(name="toString", args=[ast.Field(chain=["properties", "$initial_gclid"])]),
-                "gad_source": ast.Call(name="toString", args=[ast.Field(chain=["properties", "$initial_gad_source"])]),
-            },
-        ),
+        start=None,
+        placeholders={
+            "campaign": campaign,
+            "medium": medium,
+            "source": source,
+            "referring_domain": referring_domain,
+            "gclid": gclid,
+            "gad_source": gad_source,
+        },
     )

--- a/posthog/hogql/database/schema/sessions.py
+++ b/posthog/hogql/database/schema/sessions.py
@@ -34,7 +34,6 @@ SESSIONS_COMMON_FIELDS: Dict[str, FieldOrTable] = {
     "event_count_map": DatabaseField(name="event_count_map"),
     "pageview_count": IntegerDatabaseField(name="pageview_count"),
     "autocapture_count": IntegerDatabaseField(name="autocapture_count"),
-    "channel_type": StringDatabaseField(name="channel_type"),
 }
 
 
@@ -146,6 +145,7 @@ class SessionsTable(LazyTable):
     fields: Dict[str, FieldOrTable] = {
         **SESSIONS_COMMON_FIELDS,
         "duration": IntegerDatabaseField(name="duration"),
+        "channel_type": StringDatabaseField(name="channel_type"),
     }
 
     def lazy_select(self, requested_fields: Dict[str, List[str | int]], modifiers: HogQLQueryModifiers):

--- a/posthog/hogql/database/schema/test/test_sessions.py
+++ b/posthog/hogql/database/schema/test/test_sessions.py
@@ -50,7 +50,7 @@ class TestReferringDomainType(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
 
-        result = response.results[0]
+        result = (response.results or [])[0]
         self.assertEqual(
             result[0],
             "Paid Search",

--- a/posthog/hogql/database/schema/test/test_sessions.py
+++ b/posthog/hogql/database/schema/test/test_sessions.py
@@ -1,3 +1,4 @@
+from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 from posthog.test.base import (
@@ -9,16 +10,19 @@ from posthog.test.base import (
 
 class TestReferringDomainType(ClickhouseTestMixin, APIBaseTest):
     def test_select_star(self):
+        session_id = "session_test_select_star"
+
         _create_event(
             event="$pageview",
             team=self.team,
             distinct_id="d1",
-            properties={"$current_url": "https://example.com", "$session_id": "s1"},
+            properties={"$current_url": "https://example.com", "$session_id": session_id},
         )
 
         response = execute_hogql_query(
             parse_select(
-                "select * from sessions",
+                "select * from sessions where session_id = {session_id}",
+                placeholders={"session_id": ast.Constant(value=session_id)},
             ),
             self.team,
         )
@@ -26,4 +30,28 @@ class TestReferringDomainType(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             len(response.results or []),
             1,
+        )
+
+    def test_channel_type(self):
+        session_id = "session_test_channel_type"
+
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="d1",
+            properties={"gad_source": "1", "$session_id": session_id},
+        )
+
+        response = execute_hogql_query(
+            parse_select(
+                "select channel_type from sessions where session_id = {session_id}",
+                placeholders={"session_id": ast.Constant(value=session_id)},
+            ),
+            self.team,
+        )
+
+        result = response.results[0]
+        self.assertEqual(
+            result[0],
+            "Paid Search",
         )

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -567,6 +567,10 @@
           {
               "key": "duration",
               "type": "integer"
+          },
+          {
+              "key": "channel_type",
+              "type": "string"
           }
       ],
       "raw_session_replay_events": [
@@ -1406,6 +1410,10 @@
           {
               "key": "duration",
               "type": "integer"
+          },
+          {
+              "key": "channel_type",
+              "type": "string"
           }
       ],
       "raw_session_replay_events": [


### PR DESCRIPTION
## Problem

We have the code for channel type duplicated

## Changes

Abstract the channel type code into a function, and remove the duplicate usage. Additionally, add it to the sessions table.

## How did you test this code?

Tests still pass, ran locally, and added a new test for the session table version
