### PR TITLE
fix(docker): inline docker-compose.base into dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,9 +9,16 @@
 
 services:
     db:
-        extends:
-            file: docker-compose.base.yml
-            service: db
+        image: postgres:12-alpine
+        restart: on-failure
+        environment:
+            POSTGRES_USER: posthog
+            POSTGRES_DB: posthog
+            POSTGRES_PASSWORD: posthog
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U posthog']
+            interval: 5s
+            timeout: 5s
         ports:
             - '5432:5432'
         # something in the django app when running in dev mode
@@ -21,23 +28,31 @@ services:
         command: postgres -c max_connections=1000 -c idle_in_transaction_session_timeout=300000
 
     redis:
-        extends:
-            file: docker-compose.base.yml
-            service: redis
+        image: redis:6.2.7-alpine
+        restart: on-failure
+        command: redis-server --maxmemory-policy allkeys-lru --maxmemory 200mb
         ports:
             - '6379:6379'
 
     flower:
-        extends:
-            file: docker-compose.base.yml
-            service: flower
+        image: mher/flower:2.0.0
+        restart: on-failure
+        environment:
+            FLOWER_PORT: 5555
+            CELERY_BROKER_URL: redis://redis:6379
         ports:
             - '5555:5555'
 
     clickhouse:
-        extends:
-            file: docker-compose.base.yml
-            service: clickhouse
+        #
+        # Note: please keep the default version in sync across
+        #       `posthog` and the `charts-clickhouse` repos
+        #
+        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:23.11.2.11-alpine}
+        restart: on-failure
+        depends_on:
+            - kafka
+            - zookeeper
         ports:
             - '8123:8123'
             - '9000:9000'
@@ -52,38 +67,53 @@ services:
             - 'host.docker.internal:host-gateway'
 
     zookeeper:
-        extends:
-            file: docker-compose.base.yml
-            service: zookeeper
+        image: zookeeper:3.7.0
+        restart: on-failure
         ports:
             - '2181:2181'
 
     kafka:
-        extends:
-            file: docker-compose.base.yml
-            service: kafka
+        image: ghcr.io/posthog/kafka-container:v2.8.2
+        restart: on-failure
+        depends_on:
+            - zookeeper
+        environment:
+            KAFKA_BROKER_ID: 1001
+            KAFKA_CFG_RESERVED_BROKER_MAX_ID: 1001
+            KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
+            KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+            KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+            ALLOW_PLAINTEXT_LISTENER: 'true'
         ports:
             - '9092:9092'
 
     kafka_ui:
-        extends:
-            file: docker-compose.base.yml
-            service: kafka_ui
+        image: provectuslabs/kafka-ui:latest
+        restart: on-failure
+        depends_on:
+            - kafka
+        environment:
+            KAFKA_CLUSTERS_0_NAME: local
+            KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+            DYNAMIC_CONFIG_ENABLED: 'true'
         ports:
             - '9093:8080'
 
     object_storage:
-        extends:
-            file: docker-compose.base.yml
-            service: object_storage
+        image: minio/minio:RELEASE.2022-06-25T15-50-16Z
+        restart: on-failure
+        environment:
+            MINIO_ROOT_USER: object_storage_root_user
+            MINIO_ROOT_PASSWORD: object_storage_root_password
+        entrypoint: sh
+        command: -c 'mkdir -p /data/posthog && minio server --address ":19000" --console-address ":19001" /data' # create the 'posthog' bucket before starting the service
         ports:
             - '19000:19000'
             - '19001:19001'
 
     maildev:
-        extends:
-            file: docker-compose.base.yml
-            service: maildev
+        image: maildev/maildev:2.0.5
+        restart: on-failure
         ports:
             - '1080:1080'
             - '1025:1025'
@@ -91,31 +121,71 @@ services:
     # Optional capture
     capture:
         profiles: ['capture-rs']
-        extends:
-            file: docker-compose.base.yml
-            service: capture
+        image: ghcr.io/posthog/capture:main
+        restart: on-failure
+        environment:
+            ADDRESS: '0.0.0.0:3000'
+            KAFKA_TOPIC: 'events_plugin_ingestion'
+            KAFKA_HOSTS: 'kafka:9092'
+            REDIS_URL: 'redis://redis:6379/'
+            DEBUG: '1'
+        depends_on:
+            - redis
+            - kafka
         ports:
             - 3000:3000
-        environment:
-            - DEBUG=1
 
     # Temporal containers
     elasticsearch:
-        extends:
-            file: docker-compose.base.yml
-            service: elasticsearch
+        environment:
+            - cluster.routing.allocation.disk.threshold_enabled=true
+            - cluster.routing.allocation.disk.watermark.low=512mb
+            - cluster.routing.allocation.disk.watermark.high=256mb
+            - cluster.routing.allocation.disk.watermark.flood_stage=128mb
+            - discovery.type=single-node
+            - ES_JAVA_OPTS=-Xms256m -Xmx256m
+            - xpack.security.enabled=false
+        image: elasticsearch:7.16.2
         expose:
             - 9200
-
+        volumes:
+            - /var/lib/elasticsearch/data
     temporal:
-        extends:
-            file: docker-compose.base.yml
-            service: temporal
+        depends_on:
+            db:
+                condition: service_healthy
+
+        environment:
+            - DB=postgresql
+            - DB_PORT=5432
+            - POSTGRES_USER=posthog
+            - POSTGRES_PWD=posthog
+            - POSTGRES_SEEDS=db
+            - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development-sql.yaml
+            - ENABLE_ES=true
+            - ES_SEEDS=elasticsearch
+            - ES_VERSION=v7
+        image: temporalio/auto-setup:1.20.0
+        ports:
+            - 7233:7233
+        labels:
+            kompose.volume.type: configMap
+        volumes:
+            - ./docker/temporal/dynamicconfig:/etc/temporal/config/dynamicconfig
     temporal-admin-tools:
-        extends:
-            file: docker-compose.base.yml
-            service: temporal-admin-tools
+        depends_on:
+            - temporal
+        environment:
+            - TEMPORAL_CLI_ADDRESS=temporal:7233
+        image: temporalio/admin-tools:1.20.0
+        stdin_open: true
+        tty: true
     temporal-ui:
-        extends:
-            file: docker-compose.base.yml
-            service: temporal-ui
+        depends_on:
+            - temporal
+        environment:
+            - TEMPORAL_ADDRESS=temporal:7233
+            - TEMPORAL_CORS_ORIGINS=http://localhost:3000
+        image: temporalio/ui:2.10.3
+        ports:
+            - 8081:8080


### PR DESCRIPTION
## Problem

Docker Compose 2.24.6+ doesn't support the `extends` syntax our `docker-compose.yml` files use.

## Changes

Quick fix to inline `docker-compose.base.yml` into `docker-compose.dev.yml` to spark a discussion on what's next.

## How did you test this code?

Didn't.