### PR TITLE
fix: update onboarding config plugins to use plugin name instead of id

### DIFF
--- a/frontend/src/scenes/onboarding/OnboardingProductConfiguration.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingProductConfiguration.tsx
@@ -30,10 +30,9 @@ interface PluginContent {
     title: string
     description: string
 }
-type PluginContentMapping = Record<number, PluginContent>
+type PluginContentMapping = Record<string, PluginContent>
 const pluginContentMapping: PluginContentMapping = {
-    // 1 is the id of the GEO IP plugin
-    1: {
+    GeoIP: {
         title: 'Capture location information',
         description:
             'Enrich PostHog events and persons with IP location data. This is useful for understanding where your users are coming from. This setting can be found under the data pipelines apps.',
@@ -70,7 +69,7 @@ export const OnboardingProductConfiguration = ({
             },
         })),
         ...defaultEnabledPlugins.map((plugin) => {
-            const pluginContent = pluginContentMapping[plugin.id]
+            const pluginContent = pluginContentMapping[plugin.name]
             return {
                 title: pluginContent?.title || plugin.name,
                 description: pluginContent?.description || plugin.description,

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -577,10 +577,10 @@ export const pluginsLogic = kea<pluginsLogicType>([
         defaultEnabledPlugins: [
             (s) => [s.filteredEnabledPlugins, s.filteredDisabledPlugins],
             (filteredEnabledPlugins, filteredDisabledPlugins) => {
-                const defaultEnabledPluginIds = [1] // GEO IP plugin
+                const defaultEnabledPluginIds = ['GeoIP']
                 return filteredEnabledPlugins
                     .concat(filteredDisabledPlugins)
-                    .filter((plugin) => defaultEnabledPluginIds.includes(plugin.id))
+                    .filter((plugin) => defaultEnabledPluginIds.includes(plugin.name))
             },
         ],
         pluginUrlToMaintainer: [


### PR DESCRIPTION
## Problem

The plugin ids are not the same across envs so the only identifying attribute that is consistent is the plugin name.

## Changes

Uses the plugin name instead of the id for the filter and content mapping.