### PR TITLE
chore: Fix docker-compose circular dependecies

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -27,9 +27,7 @@ services:
         #
         image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:23.11.2.11-alpine}
         restart: on-failure
-        depends_on:
-            - kafka
-            - zookeeper
+
     zookeeper:
         image: zookeeper:3.7.0
         restart: on-failure
@@ -37,8 +35,6 @@ services:
     kafka:
         image: ghcr.io/posthog/kafka-container:v2.8.2
         restart: on-failure
-        depends_on:
-            - zookeeper
         environment:
             KAFKA_BROKER_ID: 1001
             KAFKA_CFG_RESERVED_BROKER_MAX_ID: 1001
@@ -50,8 +46,6 @@ services:
     kafka_ui:
         image: provectuslabs/kafka-ui:latest
         restart: on-failure
-        depends_on:
-            - kafka
         environment:
             KAFKA_CLUSTERS_0_NAME: local
             KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
@@ -94,12 +88,6 @@ services:
             PGUSER: posthog
             PGPASSWORD: posthog
             DEPLOYMENT: hobby
-        depends_on:
-            - db
-            - redis
-            - clickhouse
-            - kafka
-            - object_storage
 
     web:
         <<: *worker
@@ -114,9 +102,7 @@ services:
             KAFKA_TOPIC: 'events_plugin_ingestion'
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis:6379/'
-        depends_on:
-            - redis
-            - kafka
+
 
     plugins:
         command: ./bin/plugin-server --no-restart-loop
@@ -129,12 +115,6 @@ services:
             CLICKHOUSE_DATABASE: 'posthog'
             CLICKHOUSE_SECURE: 'false'
             CLICKHOUSE_VERIFY: 'false'
-        depends_on:
-            - db
-            - redis
-            - clickhouse
-            - kafka
-            - object_storage
 
     migrate:
         <<: *worker
@@ -172,9 +152,7 @@ services:
         volumes:
             - /var/lib/elasticsearch/data
     temporal:
-        depends_on:
-            db:
-                condition: service_healthy
+
 
         environment:
             - DB=postgresql
@@ -194,16 +172,12 @@ services:
         volumes:
             - ./docker/temporal/dynamicconfig:/etc/temporal/config/dynamicconfig
     temporal-admin-tools:
-        depends_on:
-            - temporal
         environment:
             - TEMPORAL_CLI_ADDRESS=temporal:7233
         image: temporalio/admin-tools:1.20.0
         stdin_open: true
         tty: true
     temporal-ui:
-        depends_on:
-            - temporal
         environment:
             - TEMPORAL_ADDRESS=temporal:7233
             - TEMPORAL_CORS_ORIGINS=http://localhost:3000
@@ -216,10 +190,4 @@ services:
         restart: on-failure
         environment:
             TEMPORAL_HOST: temporal
-        depends_on:
-            - db
-            - redis
-            - clickhouse
-            - kafka
-            - object_storage
-            - temporal
+

--- a/docker-compose.dev-full.yml
+++ b/docker-compose.dev-full.yml
@@ -37,6 +37,9 @@ services:
             - ./docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
             - ./docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
             - ./docker/clickhouse/users-dev.xml:/etc/clickhouse-server/users.xml
+        depends_on:
+            - kafka
+            - zookeeper
 
     zookeeper:
         extends:
@@ -49,6 +52,8 @@ services:
             service: kafka
         ports:
             - '9092:9092'
+        depends_on:
+            - zookeeper
 
     object_storage:
         extends:
@@ -88,6 +93,12 @@ services:
             - .:/app/posthog
         environment:
             - DEBUG=1
+        depends_on:
+            - db
+            - redis
+            - clickhouse
+            - kafka
+            - object_storage
 
     capture:
         extends:
@@ -97,6 +108,9 @@ services:
             - 3000:3000
         environment:
             - DEBUG=1
+        depends_on:
+            - redis
+            - kafka
 
     plugins:
         extends:
@@ -108,6 +122,12 @@ services:
         environment:
             - DEBUG=1
             - DOCKER=1
+        depends_on:
+            - db
+            - redis
+            - clickhouse
+            - kafka
+            - object_storage
 
     migrate:
         extends:
@@ -136,12 +156,19 @@ services:
         extends:
             file: docker-compose.base.yml
             service: temporal-admin-tools
+        depends_on:
+            - temporal
     temporal-ui:
         extends:
             file: docker-compose.base.yml
             service: temporal-ui
         ports:
             - 8081:8080
+        depends_on:
+            temporal:
+                condition: service_started
+            db:
+                condition: service_healthy
     temporal-django-worker:
         extends:
             file: docker-compose.base.yml
@@ -149,3 +176,10 @@ services:
         build: .
         volumes:
             - .:/app/posthog
+        depends_on:
+            - db
+            - redis
+            - clickhouse
+            - kafka
+            - object_storage
+            - temporal

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,6 +50,9 @@ services:
             - ./docker/clickhouse/users-dev.xml:/etc/clickhouse-server/users.xml
         extra_hosts:
             - 'host.docker.internal:host-gateway'
+        depends_on:
+            - kafka
+            - zookeeper
 
     zookeeper:
         extends:
@@ -64,6 +67,8 @@ services:
             service: kafka
         ports:
             - '9092:9092'
+        depends_on:
+            - zookeeper
 
     kafka_ui:
         extends:
@@ -71,6 +76,8 @@ services:
             service: kafka_ui
         ports:
             - '9093:8080'
+        depends_on:
+            - kafka
 
     object_storage:
         extends:
@@ -98,6 +105,9 @@ services:
             - 3000:3000
         environment:
             - DEBUG=1
+        depends_on:
+            - redis
+            - kafka
 
     # Temporal containers
     elasticsearch:
@@ -115,7 +125,14 @@ services:
         extends:
             file: docker-compose.base.yml
             service: temporal-admin-tools
+        depends_on:
+            - temporal
     temporal-ui:
         extends:
             file: docker-compose.base.yml
             service: temporal-ui
+        depends_on:
+            temporal:
+                condition: service_started
+            db:
+                condition: service_healthy

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -52,6 +52,8 @@ services:
         extends:
             file: docker-compose.base.yml
             service: kafka
+        depends_on:
+            - zookeeper
 
     worker:
         extends:
@@ -75,6 +77,12 @@ services:
             SITE_URL: https://$DOMAIN
             SECRET_KEY: $POSTHOG_SECRET
             RECORDINGS_INGESTER_URL: http://plugins:6738
+        depends_on:
+            - db
+            - redis
+            - clickhouse
+            - kafka
+            - object_storage
 
     plugins:
         extends:
@@ -85,6 +93,12 @@ services:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
             SECRET_KEY: $POSTHOG_SECRET
+        depends_on:
+            - db
+            - redis
+            - clickhouse
+            - kafka
+            - object_storage
 
     caddy:
         image: caddy:2.6.1
@@ -130,12 +144,19 @@ services:
         extends:
             file: docker-compose.base.yml
             service: temporal-admin-tools
+        depends_on:
+            - temporal
     temporal-ui:
         extends:
             file: docker-compose.base.yml
             service: temporal-ui
         ports:
             - 8081:8080
+        depends_on:
+            temporal:
+                condition: service_started
+            db:
+                condition: service_healthy
     temporal-django-worker:
         command: /compose/temporal-django-worker
         extends:
@@ -147,6 +168,13 @@ services:
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
+        depends_on:
+            - db
+            - redis
+            - clickhouse
+            - kafka
+            - object_storage
+            - temporal
 
 volumes:
     zookeeper-data:


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

`docker-compose` 2.24 does not allow [circular dependencies](https://github.com/docker/compose/issues/11544), with this PR we are fixing the error:

```
service "temporal" can't be used with `extends` as it declare `depends_on`
```

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
