### PR TITLE
fix(admin): follow up for org page performance improvements

### DIFF
--- a/posthog/admin/__init__.py
+++ b/posthog/admin/__init__.py
@@ -1,7 +1,25 @@
 from django.contrib import admin
 
 from posthog.admin.admins import *
-from posthog.models import *
+from posthog.models import (
+    Organization,
+    User,
+    Team,
+    Dashboard,
+    Insight,
+    Experiment,
+    FeatureFlag,
+    AsyncDeletion,
+    InstanceSetting,
+    PluginConfig,
+    Plugin,
+    Text,
+    Cohort,
+    Person,
+    PersonDistinctId,
+    Survey,
+    DataWarehouseTable,
+)
 
 admin.site.register(Organization, OrganizationAdmin)
 admin.site.register(User, UserAdmin)

--- a/posthog/admin/__init__.py
+++ b/posthog/admin/__init__.py
@@ -1,6 +1,24 @@
 from django.contrib import admin
 
-from posthog.admin.admins import *
+from posthog.admin.admins import (
+    OrganizationAdmin,
+    UserAdmin,
+    TeamAdmin,
+    DashboardAdmin,
+    InsightAdmin,
+    ExperimentAdmin,
+    FeatureFlagAdmin,
+    AsyncDeletionAdmin,
+    InstanceSettingAdmin,
+    PluginConfigAdmin,
+    PluginAdmin,
+    TextAdmin,
+    CohortAdmin,
+    PersonAdmin,
+    PersonDistinctIdAdmin,
+    SurveyAdmin,
+    DataWarehouseTableAdmin,
+)
 from posthog.models import (
     Organization,
     User,

--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -11,7 +11,6 @@ from posthog.models.organization import Organization
 class OrganizationAdmin(admin.ModelAdmin):
     show_full_result_count = False  # prevent count() queries to show the no of filtered results
     paginator = NoCountPaginator  # prevent count() queries and return a fix page count instead
-    date_hierarchy = "created_at"
     fields = [
         "name",
         "created_at",

--- a/posthog/admin/paginators/no_count_paginator.py
+++ b/posthog/admin/paginators/no_count_paginator.py
@@ -1,8 +1,7 @@
-from functools import cached_property
 from django.core.paginator import Paginator
 
 
 class NoCountPaginator(Paginator):
-    @cached_property
+    @property
     def count(self):
         return 999999


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/pull/20862. Unfortunately performance hasn't improved yet.

## Changes

This  PR addresses the review comments from above and prevents loading the date hierarchy, that resulted in two expensive queries. There are also two n+1 queries present, but they don't seem to impact performance much. Thus I didn't investigate a custom queryset, yet.

```sql
-- 1153ms (Seq Scan)
EXPLAIN ANALYZE SELECT MIN("posthog_organization"."created_at") AS "first", MAX("posthog_organization"."created_at") AS "last" FROM "posthog_organization"


-- 1180ms (Seq Scan)
EXPLAIN ANALYZE SELECT DISTINCT DATE_TRUNC('day', "posthog_organization"."created_at" AT TIME ZONE 'UTC') AS "datetimefield" FROM "posthog_organization" 
WHERE "posthog_organization"."created_at" IS NOT NULL ORDER BY "datetimefield" ASC


-- 0.042ms (Index Only Scan)
EXPLAIN ANALYZE  SELECT COUNT(*) AS "__count" 
FROM "posthog_user" 
INNER JOIN "posthog_organizationmembership" 
ON ("posthog_user"."id" = "posthog_organizationmembership"."user_id") 
WHERE "posthog_organizationmembership"."organization_id" = '018af1c4-0256-0000-3b16-c657f7026e32'::uuid

-- 0.029ms (Index Only Scan)
EXPLAIN ANALYZE SELECT COUNT(*) AS "__count" FROM "posthog_user" INNER JOIN "posthog_organizationmembership" ON ("posthog_user"."id" = "posthog_organizationmembership"."user_id") WHERE "posthog_organizationmembership"."organization_id" = '018c7eac-c74a-0000-e46e-40075e466922'::uuid


-- 0.036ms (Index Scan)
EXPLAIN ANALYZE SELECT "posthog_user"."id", "posthog_user"."password", "posthog_user"."last_login", "posthog_user"."first_name", "posthog_user"."last_name", "posthog_user"."is_staff", "posthog_user"."is_active", "posthog_user"."date_joined", "posthog_user"."uuid", "posthog_user"."current_organization_id", "posthog_user"."current_team_id", "posthog_user"."email", "posthog_user"."pending_email", "posthog_user"."temporary_token", "posthog_user"."distinct_id", "posthog_user"."is_email_verified", "posthog_user"."has_seen_product_intro_for", "posthog_user"."strapi_id", "posthog_user"."email_opt_in", "posthog_user"."theme_mode", "posthog_user"."partial_notification_settings", "posthog_user"."anonymize_data", "posthog_user"."toolbar_mode", "posthog_user"."events_column_config" FROM "posthog_user" INNER JOIN "posthog_organizationmembership" ON ("posthog_user"."id" = "posthog_organizationmembership"."user_id") WHERE "posthog_organizationmembership"."organization_id" = '018c7eac-c74a-0000-e46e-40075e466922'::uuid ORDER BY "posthog_user"."id" ASC LIMIT 1
```

## How did you test this code?

Tested locally while logging sql queries