### PR TITLE
fix: picking embedding input samples

### DIFF
--- a/ee/session_recordings/ai/error_clustering.py
+++ b/ee/session_recordings/ai/error_clustering.py
@@ -48,6 +48,7 @@ def fetch_error_embeddings(team_id: int):
                 -- don't load all data for all time
                 AND generation_timestamp > now() - INTERVAL 7 DAY
                 AND source_type = 'error'
+                AND input != ''
         """
 
     return sync_execute(
@@ -67,7 +68,7 @@ def construct_response(df):
     return [
         {
             "cluster": cluster,
-            "samples": rows.sample(n=DBSCAN_MIN_SAMPLES)[["session_id", "input"]].to_dict("records"),
+            "samples": rows.head(n=DBSCAN_MIN_SAMPLES)[["session_id", "input"]].to_dict("records"),
             "occurrences": rows.size,
             "unique_sessions": rows["session_id"].count(),
         }


### PR DESCRIPTION
## Problem

Fixes https://posthog.sentry.io/issues/5062893762/?project=1899813

## Changes

- Picks the first 10 rather than sampling. Don't know why sampling gives an issue but easier to just work around it for now
- Excluding examples without an input from results. Should correct itself and not be needed in 7 days but no harm having it

## How did you test this code?

Downloaded the embeddings for team 2 and tried running clustering locally