### PR TITLE
feat(sentry): enable sampling via http header

### DIFF
--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -73,9 +73,13 @@ def traces_sampler(sampling_context: dict) -> float:
 
     if op == "http.server":
         path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
+        force_sample = bool(sampling_context.get("wsgi_environ", {}).get("HTTP_FORCE_SAMPLE"))
 
+        # HTTP header to force sampling set
+        if force_sample:
+            return 1.0  # 100%
         # Ingestion endpoints (high volume)
-        if path.startswith("/batch"):
+        elif path.startswith("/batch"):
             return 0.00000001  # 0.000001%
         # Ingestion endpoints (high volume)
         elif path.startswith(("/capture", "/track", "/s", "/e")):


### PR DESCRIPTION
## Problem

I'd like to see the performance monitoring of specific pages in Sentry.

## Changes

This PR adds a `force-sample: 1` header to force sampling a request in Sentry.

## How did you test this code?

Stepping through relevant code with debugger (with and without header)