### PR TITLE
fix: Split healthcheck to separate nginx unit app

### DIFF
--- a/unit.json
+++ b/unit.json
@@ -6,7 +6,7 @@
     },
     "listeners": {
         "*:8000": {
-            "pass": "applications/posthog"
+            "pass": "routes/posthog"
         },
         "*:8001": {
             "pass": "routes/metrics"
@@ -16,6 +16,21 @@
         }
     },
     "routes": {
+        "posthog": [
+            {
+                "match": {
+                    "uri": ["/healthz"]
+                },
+                "action": {
+                    "pass": "applications/posthog-health"
+                }
+            },
+            {
+                "action": {
+                    "pass": "applications/posthog"
+                }
+            }
+        ],
         "metrics": [
             {
                 "match": {
@@ -38,6 +53,17 @@
         ]
     },
     "applications": {
+        "posthog-health": {
+            "type": "python 3.10",
+            "processes": 1,
+            "working_directory": "/code",
+            "path": ".",
+            "module": "posthog.wsgi",
+            "user": "nobody",
+            "limits": {
+                "requests": 5000
+            }
+        },
         "posthog": {
             "type": "python 3.10",
             "processes": 4,


### PR DESCRIPTION

## Problem
When posthog is under load the healthcheck can stop responding. Split it off into a separate app so it has a dedicated thread to handle it

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
