### PR TITLE
fix(experiment): revert default goal back to Trends

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -354,7 +354,17 @@ export const experimentLogic = kea<experimentLogicType>([
         setNewExperimentInsight: async ({ filters }) => {
             let newInsightFilters
             const aggregationGroupTypeIndex = values.experiment.parameters?.aggregation_group_type_index
-            if (filters?.insight === InsightType.TRENDS) {
+            if (filters?.insight === InsightType.FUNNELS) {
+                newInsightFilters = cleanFilters({
+                    insight: InsightType.FUNNELS,
+                    funnel_viz_type: FunnelVizType.Steps,
+                    date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
+                    date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
+                    layout: FunnelLayout.horizontal,
+                    aggregation_group_type_index: aggregationGroupTypeIndex,
+                    ...filters,
+                })
+            } else {
                 const groupAggregation =
                     aggregationGroupTypeIndex !== undefined
                         ? { math: 'unique_group', math_group_type_index: aggregationGroupTypeIndex }
@@ -369,17 +379,6 @@ export const experimentLogic = kea<experimentLogicType>([
                     date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
                     ...eventAddition,
                     ...filters,
-                })
-            } else {
-                newInsightFilters = cleanFilters({
-                    insight: InsightType.FUNNELS,
-                    funnel_viz_type: FunnelVizType.Steps,
-                    date_from: dayjs().subtract(DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
-                    date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
-                    layout: FunnelLayout.horizontal,
-                    ...(aggregationGroupTypeIndex !== undefined && {
-                        aggregation_group_type_index: aggregationGroupTypeIndex,
-                    }),
                 })
             }
 
@@ -664,7 +663,7 @@ export const experimentLogic = kea<experimentLogicType>([
         experimentInsightType: [
             (s) => [s.experiment],
             (experiment): InsightType => {
-                return experiment?.filters?.insight || InsightType.FUNNELS
+                return experiment?.filters?.insight || InsightType.TRENDS
             },
         ],
         isExperimentRunning: [


### PR DESCRIPTION
## Changes
^^

Fixing the existing issue for now, will revisit how to set the default goal to Funnels later.

|Before|After|
|----|----|
|<img width="412" alt="image" src="https://github.com/PostHog/posthog/assets/22996112/86366762-319c-47a6-8a05-28a1552775a5">|<img width="410" alt="image" src="https://github.com/PostHog/posthog/assets/22996112/2df62c3c-73c6-4e18-90ee-a1be1534f7ba">|

## How did you test this code?
👀 
