### PR TITLE
fix: Add missing healthcheck routes to app

### DIFF
--- a/unit.json
+++ b/unit.json
@@ -19,7 +19,11 @@
         "posthog": [
             {
                 "match": {
-                    "uri": ["/healthz"]
+                    "uri": [
+                        "/healthz",
+                        "/readyz",
+                        "/livez"
+                    ]
                 },
                 "action": {
                     "pass": "applications/posthog-health"

--- a/unit.json
+++ b/unit.json
@@ -20,7 +20,7 @@
             {
                 "match": {
                     "uri": [
-                        "/healthz",
+                        "/_health",
                         "/readyz",
                         "/livez"
                     ]


### PR DESCRIPTION
## Problem

We run healthchecks on /readyz and /livez, not on /healthz :oops:

We also have `/_health` as a legacy healthcheck endpoint, lets include that too for completeness just in case

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
