### PR TITLE
fix: Add missing underscore to healthcheck routes

### DIFF
--- a/unit.json
+++ b/unit.json
@@ -21,8 +21,8 @@
                 "match": {
                     "uri": [
                         "/_health",
-                        "/readyz",
-                        "/livez"
+                        "/_readyz",
+                        "/_livez"
                     ]
                 },
                 "action": {


### PR DESCRIPTION
## Problem

fix for #20923 (it's /_readyz not /readyz :/)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
