### PR TITLE
fix(toolbar): Keep flags in sync

### DIFF
--- a/frontend/src/toolbar/flags/FlagsToolbarMenu.tsx
+++ b/frontend/src/toolbar/flags/FlagsToolbarMenu.tsx
@@ -16,11 +16,18 @@ import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 
 export const FlagsToolbarMenu = (): JSX.Element => {
     const { searchTerm, filteredFlags, userFlagsLoading } = useValues(flagsToolbarLogic)
-    const { setSearchTerm, setOverriddenUserFlag, deleteOverriddenUserFlag, getUserFlags, checkLocalOverrides } =
-        useActions(flagsToolbarLogic)
-    const { apiURL } = useValues(toolbarConfigLogic)
+    const {
+        setSearchTerm,
+        setOverriddenUserFlag,
+        deleteOverriddenUserFlag,
+        getUserFlags,
+        checkLocalOverrides,
+        setFeatureFlagValueFromPostHogClient,
+    } = useActions(flagsToolbarLogic)
+    const { apiURL, posthog: posthogClient } = useValues(toolbarConfigLogic)
 
     useEffect(() => {
+        posthogClient?.onFeatureFlags(setFeatureFlagValueFromPostHogClient)
         getUserFlags()
         checkLocalOverrides()
     }, [])

--- a/frontend/src/toolbar/flags/flagsToolbarLogic.test.ts
+++ b/frontend/src/toolbar/flags/flagsToolbarLogic.test.ts
@@ -50,6 +50,30 @@ describe('toolbar featureFlagsLogic', () => {
         })
     })
 
+    it('uses posthog client values if present', async () => {
+        const flags = {
+            'flag 1': false,
+            'flag 2': true,
+            'flag 3': 'value',
+        }
+        await expectLogic(logic, () => {
+            logic.actions.setFeatureFlagValueFromPostHogClient(Object.keys(flags), flags)
+        }).toMatchValues({
+            userFlags: featureFlags,
+            searchTerm: '',
+            filteredFlags: [
+                { currentValue: false, hasOverride: false, hasVariants: false, feature_flag: { key: 'flag 1' } },
+                { currentValue: true, hasOverride: false, hasVariants: false, feature_flag: { key: 'flag 2' } },
+                {
+                    currentValue: 'value',
+                    hasOverride: false,
+                    hasVariants: false,
+                    feature_flag: { key: 'flag 3', name: 'mentions 2' },
+                },
+            ],
+        })
+    })
+
     it('can filter the flags', async () => {
         await expectLogic(logic, () => {
             logic.actions.setSearchTerm('2')


### PR DESCRIPTION
## Problem

The `my_flags` endpoint used to load flag values can be unreliable, because the distinct id can change / not all property overrides might be the same.

Instead, since we already have posthogJs in context, we should always use the current flag values to populate the toolbar, rather than requesting our own.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
Run locally 👀 , force flags to be inconsistent with old code, see flags are always consistent with new code..
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
