### PR TITLE
fix: custom player inspector events should respect mini filters

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -610,7 +610,8 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                                 miniFiltersByKey['performance-all']?.enabled ||
                                 miniFiltersByKey['all-everything']?.enabled ||
                                 miniFiltersByKey['all-automatic']?.enabled ||
-                                miniFiltersByKey['console-all']?.enabled
+                                miniFiltersByKey['console-all']?.enabled ||
+                                miniFiltersByKey['events-all']?.enabled
                             )
                     }
 

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -604,7 +604,14 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
 
                     // always show offline status changes
                     if (item.type === 'offline-status' || item.type === 'browser-visibility') {
-                        include = true
+                        include =
+                            tab === SessionRecordingPlayerTab.DOCTOR ||
+                            !!(
+                                miniFiltersByKey['performance-all']?.enabled ||
+                                miniFiltersByKey['all-everything']?.enabled ||
+                                miniFiltersByKey['all-automatic']?.enabled ||
+                                miniFiltersByKey['console-all']?.enabled
+                            )
                     }
 
                     if (item.type === SessionRecordingPlayerTab.DOCTOR && tab === SessionRecordingPlayerTab.DOCTOR) {


### PR DESCRIPTION
custom player events like "browser went offline" or "browser was hidden" should respect the mini filters in the player inspector

![2024-03-14 14 33 35](https://github.com/PostHog/posthog/assets/984817/45226691-1c5d-4d8d-907a-5d2f7611d35f)
