### PR TITLE
fix: don't show billing step on self-hosted

### DIFF
--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -4,6 +4,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic, FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -92,6 +93,8 @@ export const onboardingLogic = kea<onboardingLogicType>([
             ['featureFlags'],
             userLogic,
             ['user'],
+            preflightLogic,
+            ['isCloudOrDev'],
         ],
         actions: [billingLogic, ['loadBillingSuccess'], teamLogic, ['updateCurrentTeam', 'updateCurrentTeamSuccess']],
     }),
@@ -200,8 +203,11 @@ export const onboardingLogic = kea<onboardingLogicType>([
             },
         ],
         shouldShowBillingStep: [
-            (s) => [s.product, s.subscribedDuringOnboarding],
-            (product: BillingProductV2Type | null, subscribedDuringOnboarding: boolean) => {
+            (s) => [s.product, s.subscribedDuringOnboarding, s.isCloudOrDev],
+            (product: BillingProductV2Type | null, subscribedDuringOnboarding: boolean, isCloudOrDev) => {
+                if (!isCloudOrDev) {
+                    return false
+                }
                 const hasAllAddons = product?.addons?.every((addon) => addon.subscribed)
                 return !product?.subscribed || !hasAllAddons || subscribedDuringOnboarding
             },


### PR DESCRIPTION
## Problem

Apparently we were showing the billing step on onboarding for self-hosted 😬 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Only shows it if `isCloudOrDev === true`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
