### PR TITLE
fix: explicit payload opt in

### DIFF
--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -183,7 +183,7 @@ export function AuthorizedUrlList({
                                                 onClick={() => {
                                                     LemonDialog.open({
                                                         title: <>Remove {keyedURL.url} ?</>,
-                                                        description: `Are you want to remove this authorized ${
+                                                        description: `Are you sure you want to remove this authorized ${
                                                             onlyAllowDomains ? 'domain' : 'URL'
                                                         }?`,
                                                         primaryButton: {

--- a/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
@@ -5,7 +5,10 @@ import { LemonModal, LemonModalProps } from 'lib/lemon-ui/LemonModal'
 import { ReactNode, useEffect, useRef, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 
-export type LemonDialogProps = Pick<LemonModalProps, 'title' | 'description' | 'width' | 'inline' | 'footer'> & {
+export type LemonDialogProps = Pick<
+    LemonModalProps,
+    'title' | 'description' | 'width' | 'maxWidth' | 'inline' | 'footer'
+> & {
     primaryButton?: LemonButtonProps | null
     secondaryButton?: LemonButtonProps | null
     tertiaryButton?: LemonButtonProps | null

--- a/frontend/src/lib/lemon-ui/LemonModal/LemonModal.tsx
+++ b/frontend/src/lib/lemon-ui/LemonModal/LemonModal.tsx
@@ -26,6 +26,7 @@ export interface LemonModalProps {
     onClose?: () => void
     onAfterClose?: () => void
     width?: number | string
+    maxWidth?: number | string
     inline?: boolean
     title?: React.ReactNode
     description?: React.ReactNode
@@ -64,6 +65,7 @@ export const LemonModalContent = ({ children, className, embedded = false }: Lem
 
 export function LemonModal({
     width,
+    maxWidth,
     children,
     isOpen = true,
     onClose,
@@ -152,12 +154,13 @@ export function LemonModal({
     )
 
     width = !fullScreen ? width : undefined
+    maxWidth = !fullScreen ? maxWidth : undefined
 
     const floatingContainer = useFloatingContainer()
 
     return inline ? (
         // eslint-disable-next-line react/forbid-dom-props
-        <div className="LemonModal ReactModal__Content--after-open" style={{ width }}>
+        <div className="LemonModal ReactModal__Content--after-open" style={{ width, maxWidth }}>
             {modalContent}
         </div>
     ) : (
@@ -184,6 +187,7 @@ export function LemonModal({
             style={{
                 content: {
                     width: width,
+                    maxWidth,
                 },
             }}
             appElement={document.getElementById('root') as HTMLElement}

--- a/frontend/src/scenes/settings/project/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/project/SessionRecordingSettings.tsx
@@ -101,12 +101,19 @@ function CanvasCaptureSettings(): JSX.Element | null {
 function PayloadWarning(): JSX.Element {
     return (
         <>
-            We automatically scrub some sensitive information from network headers and request and response bodies. If
-            they could contain sensitive data, you should provide a function to mask the data when you initialise
-            PostHog.{' '}
-            <Link to="https://posthog.com/docs/session-replay/network-recording#sensitive-information" target="blank">
-                Learn how to mask header and body values in our docs
-            </Link>
+            <p>
+                We automatically scrub some sensitive information from network headers and request and response bodies.
+            </p>{' '}
+            <p>
+                If they could contain sensitive data, you should provide a function to mask the data when you initialise
+                PostHog.{' '}
+                <Link
+                    to="https://posthog.com/docs/session-replay/network-recording#sensitive-information"
+                    target="blank"
+                >
+                    Learn how to mask header and body values in our docs
+                </Link>
+            </p>
         </>
     )
 }
@@ -174,6 +181,7 @@ function NetworkCaptureSettings(): JSX.Element {
                         onChange={(checked) => {
                             if (checked) {
                                 LemonDialog.open({
+                                    maxWidth: '650px',
                                     title: 'Network body capture',
                                     description: <PayloadWarning />,
                                     primaryButton: {

--- a/frontend/src/scenes/settings/project/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/project/SessionRecordingSettings.tsx
@@ -101,11 +101,11 @@ function CanvasCaptureSettings(): JSX.Element | null {
 function PayloadWarning(): JSX.Element {
     return (
         <>
-            We automatically scrub some sensitive information from network headers and payloads, but if your request or
-            response payloads could contain sensitive data, you should provide a function to mask the data when you
-            initialise PostHog.{' '}
+            We automatically scrub some sensitive information from network headers and request and response bodies. If
+            they could contain sensitive data, you should provide a function to mask the data when you initialise
+            PostHog.{' '}
             <Link to="https://posthog.com/docs/session-replay/network-recording#sensitive-information" target="blank">
-                Learn how to mask header and payload values in our docs
+                Learn how to mask header and body values in our docs
             </Link>
         </>
     )
@@ -142,7 +142,7 @@ function NetworkCaptureSettings(): JSX.Element {
                         Learn how to mask header and payload values in our docs
                     </Link>
                 </p>
-                <LemonBanner type="info" className="mb-4" dismissKey="payload-warning">
+                <LemonBanner type="info" className="mb-4">
                     <PayloadWarning />
                 </LemonBanner>
                 <div className="flex flex-row space-x-2">
@@ -174,11 +174,11 @@ function NetworkCaptureSettings(): JSX.Element {
                         onChange={(checked) => {
                             if (checked) {
                                 LemonDialog.open({
-                                    title: 'Enabling network payload capture',
+                                    title: 'Network body capture',
                                     description: <PayloadWarning />,
                                     primaryButton: {
                                         'data-attr': 'network-payload-capture-accept-warning-and-enable',
-                                        children: 'Enable payload capture',
+                                        children: 'Enable body capture',
                                         onClick: () => {
                                             updateCurrentTeam({
                                                 session_recording_network_payload_capture_config: {


### PR DESCRIPTION
We want to be sure that people consider whether they might capture sensitive information when they ingest payloads

Let's pop a dialog when they switch it on

(i'd also been using payload and body interchangeably this settles on body)

![2024-03-14 20 49 26](https://github.com/PostHog/posthog/assets/984817/cfb5203f-94c3-438e-8ae6-d641f251c1f7)
