### PR TITLE
fix: onboarding session replay config saving

### DIFF
--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -100,6 +100,8 @@ const ProductAnalyticsOnboarding = (): JSX.Element => {
 }
 const SessionReplayOnboarding = (): JSX.Element => {
     const { hasAvailableFeature } = useValues(userLogic)
+    const { currentTeam } = useValues(teamLogic)
+
     const configOptions: ProductConfigOption[] = [
         {
             type: 'toggle',
@@ -107,7 +109,10 @@ const SessionReplayOnboarding = (): JSX.Element => {
             description: `Capture console logs as a part of user session recordings. 
                             Use the console logs alongside recordings to debug any issues with your app.`,
             teamProperty: 'capture_console_log_opt_in',
-            value: true,
+            value:
+                typeof currentTeam?.capture_console_log_opt_in === 'boolean'
+                    ? currentTeam.capture_console_log_opt_in
+                    : true,
         },
         {
             type: 'toggle',
@@ -115,7 +120,10 @@ const SessionReplayOnboarding = (): JSX.Element => {
             description: `Capture performance and network information alongside recordings. Use the
                             network requests and timings in the recording player to help you debug issues with your app.`,
             teamProperty: 'capture_performance_opt_in',
-            value: true,
+            value:
+                typeof currentTeam?.capture_performance_opt_in === 'boolean'
+                    ? currentTeam.capture_performance_opt_in
+                    : true,
         },
     ]
 
@@ -126,7 +134,7 @@ const SessionReplayOnboarding = (): JSX.Element => {
             description: `Only record sessions that are longer than the specified duration. 
                             Start with it low and increase it later if you're getting too many short sessions.`,
             teamProperty: 'session_recording_minimum_duration_milliseconds',
-            value: null,
+            value: currentTeam?.session_recording_minimum_duration_milliseconds || null,
             selectOptions: SESSION_REPLAY_MINIMUM_DURATION_OPTIONS,
         })
     }

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -109,10 +109,7 @@ const SessionReplayOnboarding = (): JSX.Element => {
             description: `Capture console logs as a part of user session recordings. 
                             Use the console logs alongside recordings to debug any issues with your app.`,
             teamProperty: 'capture_console_log_opt_in',
-            value:
-                typeof currentTeam?.capture_console_log_opt_in === 'boolean'
-                    ? currentTeam?.capture_console_log_opt_in
-                    : true,
+            value: currentTeam?.capture_console_log_opt_in ?? true,
         },
         {
             type: 'toggle',
@@ -120,10 +117,7 @@ const SessionReplayOnboarding = (): JSX.Element => {
             description: `Capture performance and network information alongside recordings. Use the
                             network requests and timings in the recording player to help you debug issues with your app.`,
             teamProperty: 'capture_performance_opt_in',
-            value:
-                typeof currentTeam?.capture_performance_opt_in === 'boolean'
-                    ? currentTeam?.capture_performance_opt_in
-                    : true,
+            value: currentTeam?.capture_performance_opt_in ?? true,
         },
     ]
 

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -111,7 +111,7 @@ const SessionReplayOnboarding = (): JSX.Element => {
             teamProperty: 'capture_console_log_opt_in',
             value:
                 typeof currentTeam?.capture_console_log_opt_in === 'boolean'
-                    ? currentTeam.capture_console_log_opt_in
+                    ? currentTeam?.capture_console_log_opt_in
                     : true,
         },
         {
@@ -122,7 +122,7 @@ const SessionReplayOnboarding = (): JSX.Element => {
             teamProperty: 'capture_performance_opt_in',
             value:
                 typeof currentTeam?.capture_performance_opt_in === 'boolean'
-                    ? currentTeam.capture_performance_opt_in
+                    ? currentTeam?.capture_performance_opt_in
                     : true,
         },
     ]

--- a/frontend/src/scenes/onboarding/OnboardingProductConfiguration.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingProductConfiguration.tsx
@@ -1,6 +1,6 @@
 import { LemonDivider, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
 
 import { OnboardingStepKey } from './onboardingLogic'
@@ -51,6 +51,12 @@ export const OnboardingProductConfiguration = ({
     const { setConfigOptions, saveConfiguration } = useActions(onboardingProductConfigurationLogic)
     const { toggleEnabled } = useActions(pluginsLogic)
 
+    const configOptionsRef = useRef(configOptions)
+
+    useEffect(() => {
+        configOptionsRef.current = configOptions
+    }, [configOptions])
+
     useEffect(() => {
         setConfigOptions(options)
     }, [])
@@ -63,9 +69,12 @@ export const OnboardingProductConfiguration = ({
             selectOptions: option.selectOptions,
             value: option.value,
             onChange: (newValue: boolean | string | number) => {
-                setConfigOptions(
-                    configOptions.map((o) => (o.teamProperty === option.teamProperty ? { ...o, value: newValue } : o))
+                // Use the current value from the ref to ensure that onChange always accesses
+                // the latest state of configOptions, preventing the closure from using stale data.
+                const updatedConfigOptions = configOptionsRef.current.map((o) =>
+                    o.teamProperty === option.teamProperty ? { ...o, value: newValue } : o
                 )
+                setConfigOptions(updatedConfigOptions)
             },
         })),
         ...defaultEnabledPlugins.map((plugin) => {


### PR DESCRIPTION
## Problem

There were two bugs on the session replay onboarding config step:
- If a user changed one of the toggles and then changed the min session duration select, the toggle values would reset
- If a user set of one of the toggles to false or set the min session duration and came back to the page, their saved values weren't being loaded in (making it look like it didn't save)

Related issue https://github.com/PostHog/posthog/issues/20895

## Changes

- For the first issue, this was a closure issue. The select onChange callback was accessing an old version of the `configOptions`, adding a ref to the value so the callback could access the latest data solved the issue
- For the second issue, I confirmed the data was saving, the issue was the default values on the form were static. The fix was to load in the saved values from the team _if and only if_ they were already set, otherwise fallback to the defaults. 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.