### PR TITLE
fix: use tz aware timestamp for requested_password_reset_at

### DIFF
--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -276,7 +276,7 @@ class PasswordResetSerializer(serializers.Serializer):
             user = None
 
         if user:
-            user.requested_password_reset_at = datetime.datetime.now()
+            user.requested_password_reset_at = datetime.datetime.now(datetime.timezone.utc)
             user.save()
             token = password_reset_token_generator.make_token(user)
             send_password_reset(user.id, token)


### PR DESCRIPTION
## Problem

Users are currently unable to reset their passwords - when they request the password reset email, it sends 3 emails, all of which have invalid/expired tokens. 

I'm not sure why this is broken, it works fine locally. I did notice a warning that this timestamp we save on the user wasn't timezone aware, so I'm fixing just in case that is causing problems? Doubtful, but one less warning/error is always a good thing.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds a timezone when saving to the `user.requested_password_reset_at` field 🤷‍♀️ 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Tests should cover it.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
