### PR TITLE
fix: no insight data logic loading in session replay filters

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
@@ -74,10 +74,12 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
     path((key) => ['scenes', 'insights', 'ActionFilter', 'entityFilterLogic', key]),
     connect((props: EntityFilterProps) => ({
         logic: [eventUsageLogic],
-        // this can be mounted in replay filters in which case there's not really an insightDataLogic to mount
         actions: [
             insightDataLogic({
                 dashboardItemId: props.typeKey as InsightShortId,
+                // this can be mounted in replay filters
+                // in which case there's not really an insightDataLogic to mount
+                // disable attempts to load data that will never work
                 doNotLoad: props.typeKey === 'session-recordings',
             }),
             ['loadData'],

--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
@@ -74,7 +74,14 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
     path((key) => ['scenes', 'insights', 'ActionFilter', 'entityFilterLogic', key]),
     connect((props: EntityFilterProps) => ({
         logic: [eventUsageLogic],
-        actions: [insightDataLogic({ dashboardItemId: props.typeKey as InsightShortId }), ['loadData']],
+        // this can be mounted in replay filters in which case there's not really an insightDataLogic to mount
+        actions: [
+            insightDataLogic({
+                dashboardItemId: props.typeKey as InsightShortId,
+                doNotLoad: props.typeKey === 'session-recordings',
+            }),
+            ['loadData'],
+        ],
     })),
     actions({
         selectFilter: (filter: EntityFilter | ActionFilter | null) => ({ filter }),


### PR DESCRIPTION
follow up to https://github.com/PostHog/posthog/pull/20709

That added a connection from `entityFilterLogic` to `insightDataLogic` assuming that there is always an insight data logic for every entity filter

But there is filtering in session replay and no insight linked to the entityFilterLogic. So this is causing errors in the console

I don't want to get trapped in the web of insight logic interactions so I won't try and break the dependency. 

If we set the doNotLoad prop when the `typeKey` is "session-recordings" then the connected insight data logic at least doesn't make any API calls 