### PR TITLE
fix(hogql): fix schema for empty time-to-convert results

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1960,7 +1960,7 @@
             "additionalProperties": false,
             "properties": {
                 "average_conversion_time": {
-                    "type": "number"
+                    "type": ["number", "null"]
                 },
                 "bins": {
                     "items": {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -713,7 +713,7 @@ type BinNumber = number
 export type FunnelStepsResults = Record<string, any>[]
 export type FunnelStepsBreakdownResults = Record<string, any>[][]
 export type FunnelTimeToConvertResults = {
-    average_conversion_time: number
+    average_conversion_time: number | null
     bins: [BinNumber, BinNumber][]
 }
 export type FunnelTrendsResults = Record<string, any>[]

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -355,7 +355,7 @@ class FunnelTimeToConvertResults(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    average_conversion_time: float
+    average_conversion_time: Optional[float] = None
     bins: List[List[int]]
 
 


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/commit/0691130f39fb45a4e653d0a59c5819da0d6512ca, time-to-convert results can also have a null `average_conversion_time` for empty funnels.

## Changes

Fixes this.

## How did you test this code?

Tested a local example