### PR TITLE
Upgrade Chart.js to v4

### DIFF
--- a/frontend/src/lib/Chart.ts
+++ b/frontend/src/lib/Chart.ts
@@ -1,5 +1,6 @@
 import {
     ActiveElement,
+    BorderOptions,
     Chart as RawChart,
     ChartDataset,
     ChartEvent,
@@ -49,6 +50,7 @@ Tooltip.positioners.cursor = function (_, coordinates) {
 
 export type {
     ActiveElement,
+    BorderOptions,
     ChartDataset,
     ChartEvent,
     ChartItem,

--- a/frontend/src/lib/lemon-ui/Sparkline.tsx
+++ b/frontend/src/lib/lemon-ui/Sparkline.tsx
@@ -111,9 +111,11 @@ export function Sparkline({
                                     lineHeight: 1,
                                 },
                             },
+                            border: {
+                                dash: [2],
+                                display: false,
+                            },
                             grid: {
-                                borderDash: [2],
-                                drawBorder: false,
                                 display: true,
                                 tickLength: 0,
                             },

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -85,7 +85,7 @@ export const LineGraph = (): JSX.Element => {
             font: {
                 family: '-apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
                 size: 12,
-                weight: '500',
+                weight: 500,
             },
         }
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -4,7 +4,7 @@ import './LineGraph.scss'
 import '../../../../../scenes/insights/InsightTooltip/InsightTooltip.scss'
 
 import { LemonTable } from '@posthog/lemon-ui'
-import { ChartData, ChartType, Color, GridLineOptions, TickOptions, TooltipModel } from 'chart.js'
+import { BorderOptions, ChartData, ChartType, Color, GridLineOptions, TickOptions, TooltipModel } from 'chart.js'
 import annotationPlugin, { AnnotationPluginOptions, LineAnnotationOptions } from 'chartjs-plugin-annotation'
 import ChartDataLabels from 'chartjs-plugin-datalabels'
 import clsx from 'clsx'
@@ -89,11 +89,14 @@ export const LineGraph = (): JSX.Element => {
             },
         }
 
+        const borderOptions: Partial<BorderOptions> = {
+            color: colors.axisLine as Color,
+            dash: [4, 2],
+        }
+
         const gridOptions: Partial<GridLineOptions> = {
             color: colors.axisLine as Color,
-            borderColor: colors.axisLine as Color,
             tickColor: colors.axisLine as Color,
-            borderDash: [4, 2],
         }
 
         const options: ChartOptions = {
@@ -243,6 +246,7 @@ export const LineGraph = (): JSX.Element => {
                         drawOnChartArea: false,
                         tickLength: 12,
                     },
+                    border: borderOptions,
                 },
                 y: {
                     display: true,
@@ -254,6 +258,7 @@ export const LineGraph = (): JSX.Element => {
                         precision: 1,
                     },
                     grid: gridOptions,
+                    border: borderOptions,
                 },
             },
         }

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx'
 import { useValues } from 'kea'
 import {
     ActiveElement,
+    BorderOptions,
     Chart,
     ChartDataset,
     ChartEvent,
@@ -384,11 +385,13 @@ export function LineGraph_({
                 weight: '500',
             },
         }
+        const borderOptions: Partial<BorderOptions> = {
+            color: colors.axisLine as Color,
+            dash: [4, 2],
+        }
         const gridOptions: Partial<GridLineOptions> = {
             color: colors.axisLine as Color,
-            borderColor: colors.axisLine as Color,
             tickColor: colors.axisLine as Color,
-            borderDash: [4, 2],
         }
 
         const tooltipOptions: Partial<TooltipOptions> = {
@@ -607,6 +610,7 @@ export function LineGraph_({
                             : {}),
                     },
                     grid: inSurveyView ? { display: false } : gridOptions,
+                    border: borderOptions,
                 },
                 y: {
                     display: !hideYAxis,
@@ -621,6 +625,7 @@ export function LineGraph_({
                         },
                     },
                     grid: gridOptions,
+                    border: borderOptions,
                 },
             }
         } else if (type === GraphType.Line) {
@@ -637,6 +642,7 @@ export function LineGraph_({
                         drawOnChartArea: false,
                         tickLength: 12,
                     },
+                    border: borderOptions,
                 },
                 y: {
                     display: !hideYAxis,
@@ -651,6 +657,7 @@ export function LineGraph_({
                         },
                     },
                     grid: gridOptions,
+                    border: borderOptions,
                 },
             }
         } else if (isHorizontal) {
@@ -670,6 +677,7 @@ export function LineGraph_({
                         },
                     },
                     grid: gridOptions,
+                    border: borderOptions,
                 },
                 y: {
                     display: true,
@@ -722,6 +730,7 @@ export function LineGraph_({
                         ...gridOptions,
                         display: !inSurveyView,
                     },
+                    border: borderOptions,
                 },
             }
             options.indexAxis = 'y'

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -382,7 +382,7 @@ export function LineGraph_({
             font: {
                 family: '-apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
                 size: 12,
-                weight: '500',
+                weight: 500,
             },
         }
         const borderOptions: Partial<BorderOptions> = {
@@ -604,7 +604,7 @@ export function LineGraph_({
                                   padding: 10,
                                   font: {
                                       size: 14,
-                                      weight: '600',
+                                      weight: 600,
                                   },
                               }
                             : {}),

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "chartjs-plugin-annotation": "3.0.1",
         "chartjs-plugin-crosshair": "^2.0.0",
         "chartjs-plugin-datalabels": "^2.2.0",
-        "chartjs-plugin-stacked100": "^1.4.0",
+        "chartjs-plugin-stacked100": "^1.5.2",
         "chokidar": "^3.5.3",
         "clsx": "^1.1.1",
         "core-js": "^3.32.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
         "antd-dayjs-webpack-plugin": "^1.0.6",
         "autoprefixer": "^10.4.13",
         "babel-preset-nano-react-app": "^0.1.0",
-        "chart.js": "^3.9.1",
+        "chart.js": "^4.4.2",
         "chartjs-adapter-dayjs-3": "^1.2.3",
         "chartjs-plugin-annotation": "2.2.1",
         "chartjs-plugin-crosshair": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "chart.js": "^4.4.2",
         "chartjs-adapter-dayjs-3": "^1.2.3",
         "chartjs-plugin-annotation": "3.0.1",
-        "chartjs-plugin-crosshair": "^1.2.0",
+        "chartjs-plugin-crosshair": "^2.0.0",
         "chartjs-plugin-datalabels": "^2.2.0",
         "chartjs-plugin-stacked100": "^1.4.0",
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "babel-preset-nano-react-app": "^0.1.0",
         "chart.js": "^4.4.2",
         "chartjs-adapter-dayjs-3": "^1.2.3",
-        "chartjs-plugin-annotation": "2.2.1",
+        "chartjs-plugin-annotation": "3.0.1",
         "chartjs-plugin-crosshair": "^1.2.0",
         "chartjs-plugin-datalabels": "^2.2.0",
         "chartjs-plugin-stacked100": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/react-hooks": "^8.0.1",
         "@testing-library/user-event": "^13.5.0",
-        "@types/chartjs-plugin-crosshair": "^1.1.1",
+        "@types/chartjs-plugin-crosshair": "^1.1.4",
         "@types/clone": "^2.1.1",
         "@types/d3": "^7.4.0",
         "@types/d3-sankey": "^0.12.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,23 +119,23 @@ dependencies:
     specifier: ^0.1.0
     version: 0.1.0
   chart.js:
-    specifier: ^3.9.1
-    version: 3.9.1
+    specifier: ^4.4.2
+    version: 4.4.2
   chartjs-adapter-dayjs-3:
     specifier: ^1.2.3
-    version: 1.2.3(chart.js@3.9.1)(dayjs@1.11.6)
+    version: 1.2.3(chart.js@4.4.2)(dayjs@1.11.6)
   chartjs-plugin-annotation:
     specifier: 2.2.1
-    version: 2.2.1(chart.js@3.9.1)
+    version: 2.2.1(chart.js@4.4.2)
   chartjs-plugin-crosshair:
     specifier: ^1.2.0
-    version: 1.2.0(chart.js@3.9.1)
+    version: 1.2.0(chart.js@4.4.2)
   chartjs-plugin-datalabels:
     specifier: ^2.2.0
-    version: 2.2.0(chart.js@3.9.1)
+    version: 2.2.0(chart.js@4.4.2)
   chartjs-plugin-stacked100:
     specifier: ^1.4.0
-    version: 1.4.0(chart.js@3.9.1)
+    version: 1.4.0(chart.js@4.4.2)
   chokidar:
     specifier: ^3.5.3
     version: 3.5.3
@@ -4840,6 +4840,10 @@ packages:
 
   /@juggle/resize-observer@3.4.0:
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
+
+  /@kurkle/color@0.3.2:
+    resolution: {integrity: sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==}
+    dev: false
 
   /@linaria/core@3.0.0-beta.13:
     resolution: {integrity: sha512-3zEi5plBCOsEzUneRVuQb+2SAx3qaC1dj0FfFAI6zIJQoDWu0dlSwKijMRack7oO9tUWrchfj3OkKQAd1LBdVg==}
@@ -9777,51 +9781,54 @@ packages:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
     dev: false
 
-  /chart.js@3.9.1:
-    resolution: {integrity: sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w==}
+  /chart.js@4.4.2:
+    resolution: {integrity: sha512-6GD7iKwFpP5kbSD4MeRRRlTnQvxfQREy36uEtm1hzHzcOqwWx0YEHuspuoNlslu+nciLIB7fjjsHkUv/FzFcOg==}
+    engines: {pnpm: '>=8'}
+    dependencies:
+      '@kurkle/color': 0.3.2
     dev: false
 
-  /chartjs-adapter-dayjs-3@1.2.3(chart.js@3.9.1)(dayjs@1.11.6):
+  /chartjs-adapter-dayjs-3@1.2.3(chart.js@4.4.2)(dayjs@1.11.6):
     resolution: {integrity: sha512-H8m1c2cFi9zdiJ0IfY7txUSSZusnS671sUuE6dbmvcaHmSFTMNoWH5lJvNj+oM1hLRsiP5pSTiB7InAMDJP+rQ==}
     engines: {node: '>=10'}
     peerDependencies:
       chart.js: '>=2.8.0'
       dayjs: ^1.9.7
     dependencies:
-      chart.js: 3.9.1
+      chart.js: 4.4.2
       dayjs: 1.11.6
     dev: false
 
-  /chartjs-plugin-annotation@2.2.1(chart.js@3.9.1):
+  /chartjs-plugin-annotation@2.2.1(chart.js@4.4.2):
     resolution: {integrity: sha512-RL9UtrFr2SXd7C47zD0MZqn6ZLgrcRt3ySC6cYal2amBdANcYB1QcwFXcpKWAYnO4SGJYRok7P5rKDDNgJMA/w==}
     peerDependencies:
       chart.js: '>=3.7.0'
     dependencies:
-      chart.js: 3.9.1
+      chart.js: 4.4.2
     dev: false
 
-  /chartjs-plugin-crosshair@1.2.0(chart.js@3.9.1):
+  /chartjs-plugin-crosshair@1.2.0(chart.js@4.4.2):
     resolution: {integrity: sha512-yohsbME+wT1ODBdErBzWnC6xUDcn2tLeWmGjGDTykjpiT7+FMgibffajxqaCVmdzselxNPirpt76vx33EewSSQ==}
     peerDependencies:
       chart.js: ^3.4.0
     dependencies:
-      chart.js: 3.9.1
+      chart.js: 4.4.2
     dev: false
 
-  /chartjs-plugin-datalabels@2.2.0(chart.js@3.9.1):
+  /chartjs-plugin-datalabels@2.2.0(chart.js@4.4.2):
     resolution: {integrity: sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==}
     peerDependencies:
       chart.js: '>=3.0.0'
     dependencies:
-      chart.js: 3.9.1
+      chart.js: 4.4.2
     dev: false
 
-  /chartjs-plugin-stacked100@1.4.0(chart.js@3.9.1):
+  /chartjs-plugin-stacked100@1.4.0(chart.js@4.4.2):
     resolution: {integrity: sha512-49oWqcja9E++uVgmYE1AY8t1g56vZhhkt9CXO/eCMnuoTRjlJPD3lznMyemkZMEVpRoAujMw07eVLJcJnpcUKA==}
     peerDependencies:
       chart.js: '>=3.8.0'
     dependencies:
-      chart.js: 3.9.1
+      chart.js: 4.4.2
     dev: false
 
   /check-more-types@2.24.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,8 +441,8 @@ devDependencies:
     specifier: ^13.5.0
     version: 13.5.0(@testing-library/dom@8.19.0)
   '@types/chartjs-plugin-crosshair':
-    specifier: ^1.1.1
-    version: 1.1.1
+    specifier: ^1.1.4
+    version: 1.1.4
   '@types/clone':
     specifier: ^2.1.1
     version: 2.1.1
@@ -7562,16 +7562,16 @@ packages:
       '@types/node': 18.18.4
     dev: true
 
-  /@types/chart.js@2.9.37:
-    resolution: {integrity: sha512-9bosRfHhkXxKYfrw94EmyDQcdjMaQPkU1fH2tDxu8DWXxf1mjzWQAV4laJF51ZbC2ycYwNDvIm1rGez8Bug0vg==}
+  /@types/chart.js@2.9.41:
+    resolution: {integrity: sha512-3dvkDvueckY83UyUXtJMalYoH6faOLkWQoaTlJgB4Djde3oORmNP0Jw85HtzTuXyliUHcdp704s0mZFQKio/KQ==}
     dependencies:
-      moment: 2.29.4
+      moment: 2.30.1
     dev: true
 
-  /@types/chartjs-plugin-crosshair@1.1.1:
-    resolution: {integrity: sha512-fAO7SX8sJi4gJS0afd/50JFtzg9vNhQPwNx6Kjo5FLyibgmwzMiqO9LnSIvR6OWiX3oN/mDrAuvqKCRs6cFLNw==}
+  /@types/chartjs-plugin-crosshair@1.1.4:
+    resolution: {integrity: sha512-AvHMQMFh7aK+npOcyqezzaRpCgA5vqg3d885RD2xUyXULeUcgvxbLPf5v6yX5QqmbUZB3xRDOv52vCabBw+YKg==}
     dependencies:
-      '@types/chart.js': 2.9.37
+      '@types/chart.js': 2.9.41
     dev: true
 
   /@types/clone@2.1.1:
@@ -15629,6 +15629,11 @@ packages:
 
   /moment@2.29.4:
     resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
+    dev: false
+
+  /moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
+    dev: true
 
   /monaco-editor-webpack-plugin@7.0.1(monaco-editor@0.39.0)(webpack@5.88.2):
     resolution: {integrity: sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ dependencies:
     specifier: 3.0.1
     version: 3.0.1(chart.js@4.4.2)
   chartjs-plugin-crosshair:
-    specifier: ^1.2.0
-    version: 1.2.0(chart.js@4.4.2)
+    specifier: ^2.0.0
+    version: 2.0.0(chart.js@4.4.2)
   chartjs-plugin-datalabels:
     specifier: ^2.2.0
     version: 2.2.0(chart.js@4.4.2)
@@ -9807,10 +9807,10 @@ packages:
       chart.js: 4.4.2
     dev: false
 
-  /chartjs-plugin-crosshair@1.2.0(chart.js@4.4.2):
-    resolution: {integrity: sha512-yohsbME+wT1ODBdErBzWnC6xUDcn2tLeWmGjGDTykjpiT7+FMgibffajxqaCVmdzselxNPirpt76vx33EewSSQ==}
+  /chartjs-plugin-crosshair@2.0.0(chart.js@4.4.2):
+    resolution: {integrity: sha512-Vs6strRvYpzL92v40r/rAWhh+7au8VnfyC/m2ZHXcXeLEWeFjDgMvXjWdX+eARhbgHQo+uGIKyq9fmkS79GIyQ==}
     peerDependencies:
-      chart.js: ^3.4.0
+      chart.js: ^4.0.1
     dependencies:
       chart.js: 4.4.2
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,8 +125,8 @@ dependencies:
     specifier: ^1.2.3
     version: 1.2.3(chart.js@4.4.2)(dayjs@1.11.6)
   chartjs-plugin-annotation:
-    specifier: 2.2.1
-    version: 2.2.1(chart.js@4.4.2)
+    specifier: 3.0.1
+    version: 3.0.1(chart.js@4.4.2)
   chartjs-plugin-crosshair:
     specifier: ^1.2.0
     version: 1.2.0(chart.js@4.4.2)
@@ -9799,10 +9799,10 @@ packages:
       dayjs: 1.11.6
     dev: false
 
-  /chartjs-plugin-annotation@2.2.1(chart.js@4.4.2):
-    resolution: {integrity: sha512-RL9UtrFr2SXd7C47zD0MZqn6ZLgrcRt3ySC6cYal2amBdANcYB1QcwFXcpKWAYnO4SGJYRok7P5rKDDNgJMA/w==}
+  /chartjs-plugin-annotation@3.0.1(chart.js@4.4.2):
+    resolution: {integrity: sha512-hlIrXXKqSDgb+ZjVYHefmlZUXK8KbkCPiynSVrTb/HjTMkT62cOInaT1NTQCKtxKKOm9oHp958DY3RTAFKtkHg==}
     peerDependencies:
-      chart.js: '>=3.7.0'
+      chart.js: '>=4.0.0'
     dependencies:
       chart.js: 4.4.2
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,8 +134,8 @@ dependencies:
     specifier: ^2.2.0
     version: 2.2.0(chart.js@4.4.2)
   chartjs-plugin-stacked100:
-    specifier: ^1.4.0
-    version: 1.4.0(chart.js@4.4.2)
+    specifier: ^1.5.2
+    version: 1.5.2(chart.js@4.4.2)
   chokidar:
     specifier: ^3.5.3
     version: 3.5.3
@@ -9823,8 +9823,8 @@ packages:
       chart.js: 4.4.2
     dev: false
 
-  /chartjs-plugin-stacked100@1.4.0(chart.js@4.4.2):
-    resolution: {integrity: sha512-49oWqcja9E++uVgmYE1AY8t1g56vZhhkt9CXO/eCMnuoTRjlJPD3lznMyemkZMEVpRoAujMw07eVLJcJnpcUKA==}
+  /chartjs-plugin-stacked100@1.5.2(chart.js@4.4.2):
+    resolution: {integrity: sha512-2pai9PxbyisCjSCBSOsuk1Fi8O2dV/aJtbL4MYyaNIzLoi5R8Bp4F0bi8LIaKiMLCe0BPGmlTqfe3s5XlPgdeA==}
     peerDependencies:
       chart.js: '>=3.8.0'
     dependencies:


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

This PR upgrades Chart.js to v4 per [the migration guide](https://www.chartjs.org/docs/latest/migration/v4-migration.html) (Resolves #16828), in addition to chartjs plugin upgrades if newer versions are available.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
<!-- 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._ -->

| Dependency | Version Upgrade |
|--------|--------|
| chart.js | 3.9.1  →  4.4.2 |
| chartjs-plugin-annotation | 2.2.1  →  3.0.1 |
| chartjs-plugin-crosshair | 1.2.0  →  2.0.0 |
| chartjs-plugin-stacked100 | 1.4.0  →  1.5.2 |
| @types/chartjs-plugin-crosshair | 1.1.1  →  1.1.4 |

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

Yes

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

- [x] View a project and check that insight configurations work using the new version
- [x] Run storybook and check insight/chart components
- [ ] Ensure that visual regression tests run