### PR TITLE
fix: Add authentication for person overrides dict

### DIFF
--- a/posthog/models/person_overrides/sql.py
+++ b/posthog/models/person_overrides/sql.py
@@ -17,6 +17,8 @@ from posthog.kafka_client.topics import KAFKA_PERSON_OVERRIDE
 from posthog.settings.data_stores import (
     CLICKHOUSE_CLUSTER,
     CLICKHOUSE_DATABASE,
+    CLICKHOUSE_PASSWORD,
+    CLICKHOUSE_USER,
     KAFKA_HOSTS,
 )
 
@@ -171,7 +173,7 @@ PERSON_OVERRIDES_CREATE_DICTIONARY_SQL = f"""
         override_person_id UUID
     )
     PRIMARY KEY team_id, old_person_id
-    SOURCE(CLICKHOUSE(QUERY '{GET_LATEST_PERSON_OVERRIDE_ID_SQL}'))
+    SOURCE(CLICKHOUSE(USER '{CLICKHOUSE_USER}' PASSWORD '{CLICKHOUSE_PASSWORD}' QUERY '{GET_LATEST_PERSON_OVERRIDE_ID_SQL}'))
     LAYOUT(COMPLEX_KEY_HASHED(PREALLOCATE 1))
 
     -- The LIFETIME setting indicates to ClickHouse to automatically update this dictionary


### PR DESCRIPTION
## Problem

ClickHouse dictionaries need auth.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add USER PASSWORD to query. This will need migration to be re-run, we can:
* Run this manually once ourselves.
* Make a new migration that is just a copy of the old one. The query has a `REPLACE` clause so it will update the old ddl.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
