### PR TITLE
fix: Change autoplay direction to select

### DIFF
--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
@@ -175,7 +175,7 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
         setSpeed: (speed: number) => ({ speed }),
         setShowOnlyMatching: (showOnlyMatching: boolean) => ({ showOnlyMatching }),
         setHideViewedRecordings: (hideViewedRecordings: boolean) => ({ hideViewedRecordings }),
-        toggleAutoplayDirection: true,
+        setAutoplayDirection: (autoplayDirection: AutoplayDirection) => ({ autoplayDirection }),
         setTab: (tab: SessionRecordingPlayerTab) => ({ tab }),
         setTimestampMode: (mode: 'absolute' | 'relative') => ({ mode }),
         setMiniFilter: (key: string, enabled: boolean) => ({ key, enabled }),
@@ -246,9 +246,7 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
             'older' as AutoplayDirection,
             { persist: true },
             {
-                toggleAutoplayDirection: (state) => {
-                    return !state ? 'older' : state === 'older' ? 'newer' : null
-                },
+                setAutoplayDirection: (_, { autoplayDirection }) => autoplayDirection,
             },
         ],
         hideViewedRecordings: [

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -13,17 +13,18 @@ export function SessionRecordingsPlaylistSettings(): JSX.Element {
 
     return (
         <div className="relative flex flex-col gap-2 p-3 bg-side border-b">
-            <div className="flex flex-row items-center justify-between space-x-2">
-                <span className="text-black font-medium">Autoplay</span>
-                <Tooltip
-                    title={
-                        <div className="text-center">
-                            Autoplay next recording
-                            <br />({!autoplayDirection ? 'off' : autoplayDirection})
-                        </div>
-                    }
-                    placement="bottom"
-                >
+            <Tooltip
+                title={
+                    <div className="text-center">
+                        Autoplay next recording
+                        <br />({!autoplayDirection ? 'off' : autoplayDirection})
+                    </div>
+                }
+                placement="right"
+            >
+                <div className="flex flex-row items-center justify-between space-x-2">
+                    <span className="text-black font-medium">Autoplay</span>
+
                     <LemonSelect
                         value={autoplayDirection}
                         aria-label="Autoplay next recording"
@@ -36,8 +37,8 @@ export function SessionRecordingsPlaylistSettings(): JSX.Element {
                         ]}
                         size="small"
                     />
-                </Tooltip>
-            </div>
+                </div>
+            </Tooltip>
             <div className="flex flex-row items-center justify-between space-x-2">
                 <span className="text-black font-medium">Hide viewed</span>
                 <LemonSwitch

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -1,8 +1,5 @@
-import { IconPlay } from '@posthog/icons'
-import { LemonSwitch } from '@posthog/lemon-ui'
-import clsx from 'clsx'
+import { LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
-import { IconPause } from 'lib/lemon-ui/icons'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { DurationTypeSelect } from 'scenes/session-recordings/filters/DurationTypeSelect'
 
@@ -11,7 +8,7 @@ import { sessionRecordingsPlaylistLogic } from './sessionRecordingsPlaylistLogic
 
 export function SessionRecordingsPlaylistSettings(): JSX.Element {
     const { autoplayDirection, durationTypeToShow, hideViewedRecordings } = useValues(playerSettingsLogic)
-    const { toggleAutoplayDirection, setDurationTypeToShow, setHideViewedRecordings } = useActions(playerSettingsLogic)
+    const { setAutoplayDirection, setDurationTypeToShow, setHideViewedRecordings } = useActions(playerSettingsLogic)
     const { orderBy } = useValues(sessionRecordingsPlaylistLogic)
 
     return (
@@ -22,27 +19,22 @@ export function SessionRecordingsPlaylistSettings(): JSX.Element {
                     title={
                         <div className="text-center">
                             Autoplay next recording
-                            <br />({!autoplayDirection ? 'disabled' : autoplayDirection})
+                            <br />({!autoplayDirection ? 'off' : autoplayDirection})
                         </div>
                     }
                     placement="bottom"
                 >
-                    <LemonSwitch
+                    <LemonSelect
+                        value={autoplayDirection}
                         aria-label="Autoplay next recording"
-                        checked={!!autoplayDirection}
-                        onChange={toggleAutoplayDirection}
-                        handleContent={
-                            <span
-                                className={clsx(
-                                    'transition-all flex items-center',
-                                    !autoplayDirection && 'text-border text-sm',
-                                    !!autoplayDirection && 'text-white text-xs pl-px',
-                                    autoplayDirection === 'newer' && 'rotate-180'
-                                )}
-                            >
-                                {autoplayDirection ? <IconPlay /> : <IconPause />}
-                            </span>
-                        }
+                        onChange={setAutoplayDirection}
+                        dropdownMatchSelectWidth={false}
+                        options={[
+                            { value: null, label: 'off' },
+                            { value: 'newer', label: 'newer recordings' },
+                            { value: 'older', label: 'older recordings' },
+                        ]}
+                        size="small"
                     />
                 </Tooltip>
             </div>


### PR DESCRIPTION
## Problem

Since 3000 the toggle UI for autoplay misses the direction indicator.
Now that is part of a submenu its easier to simply make it a Select.

## Changes

|Before|After|
|----|----|
| <img width="359" alt="Screenshot 2024-03-18 at 15 06 59" src="https://github.com/PostHog/posthog/assets/2536520/50d3054c-dfef-4e43-8a1a-adb8defbabd4"> | <img width="373" alt="Screenshot 2024-03-18 at 14 59 40" src="https://github.com/PostHog/posthog/assets/2536520/0d27c691-c311-482a-b926-da21496bd0a1"> |


## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
