### PR TITLE
fix(batch-exports): handle null end_at in workflow_id

### DIFF
--- a/posthog/batch_exports/models.py
+++ b/posthog/batch_exports/models.py
@@ -306,5 +306,5 @@ class BatchExportBackfill(UUIDModel):
     def workflow_id(self) -> str:
         """Return the Workflow id that corresponds to this BatchExportBackfill model."""
         start_at = self.start_at.strftime("%Y-%m-%dT%H:%M:%S")
-        end_at = self.end_at.strftime("%Y-%m-%dT%H:%M:%S")
+        end_at = self.end_at and self.end_at.strftime("%Y-%m-%dT%H:%M:%S")
         return f"{self.batch_export.id}-Backfill-{start_at}-{end_at}"


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
`end_at` is nullable and we didn't handle it here.

## Changes

Easy fix.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
