### PR TITLE
feat: send lib version to blobby in kafka headers

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -297,7 +297,7 @@ def drop_events_over_quota(token: str, events: List[Any]) -> List[Any]:
     return results
 
 
-def lib_from_query_params(request) -> str:
+def lib_version_from_query_params(request) -> str:
     # url has a ver parameter from posthog-js
     return request.GET.get("ver", "unknown")
 
@@ -480,7 +480,7 @@ def get_event(request):
 
     try:
         if replay_events:
-            lib_version = lib_from_query_params(request)
+            lib_version = lib_version_from_query_params(request)
 
             alternative_replay_events = preprocess_replay_events_for_blob_ingestion(
                 replay_events, settings.SESSION_RECORDING_KAFKA_MAX_REQUEST_SIZE_BYTES

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -297,11 +297,9 @@ def drop_events_over_quota(token: str, events: List[Any]) -> List[Any]:
     return results
 
 
-def lib_from_query_params(request) -> Tuple[str, str]:
+def lib_from_query_params(request) -> str:
     # url has a ver parameter from posthog-js
-    # for now we know mobile is newer than web, so we can ignore unknown
-    lib = request.GET.get("ver", "unknown")
-    return "web", lib
+    return request.GET.get("ver", "unknown")
 
 
 @csrf_exempt
@@ -482,7 +480,7 @@ def get_event(request):
 
     try:
         if replay_events:
-            lib, lib_version = lib_from_query_params(request)
+            lib_version = lib_from_query_params(request)
 
             alternative_replay_events = preprocess_replay_events_for_blob_ingestion(
                 replay_events, settings.SESSION_RECORDING_KAFKA_MAX_REQUEST_SIZE_BYTES

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -297,6 +297,13 @@ def drop_events_over_quota(token: str, events: List[Any]) -> List[Any]:
     return results
 
 
+def lib_from_query_params(request) -> Tuple[str, str]:
+    # url has a ver parameter from posthog-js
+    # for now we know mobile is newer than web, so we can ignore unknown
+    lib = request.GET.get("ver", "unknown")
+    return "web", lib
+
+
 @csrf_exempt
 @timed("posthog_cloud_event_endpoint")
 def get_event(request):
@@ -475,6 +482,8 @@ def get_event(request):
 
     try:
         if replay_events:
+            lib, lib_version = lib_from_query_params(request)
+
             alternative_replay_events = preprocess_replay_events_for_blob_ingestion(
                 replay_events, settings.SESSION_RECORDING_KAFKA_MAX_REQUEST_SIZE_BYTES
             )
@@ -496,6 +505,7 @@ def get_event(request):
                             sent_at,
                             event_uuid,
                             token,
+                            extra_headers=[("lib_version", lib_version)],
                         )
                     )
 
@@ -546,9 +556,23 @@ def parse_event(event):
     return event
 
 
-def capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid=None, token=None, historical=False):
+def capture_internal(
+    event,
+    distinct_id,
+    ip,
+    site_url,
+    now,
+    sent_at,
+    event_uuid=None,
+    token=None,
+    historical=False,
+    extra_headers: List[Tuple[str, str]] | None = None,
+):
     if event_uuid is None:
         event_uuid = UUIDT()
+
+    if extra_headers is None:
+        extra_headers = []
 
     parsed_event = build_kafka_event_data(
         distinct_id=distinct_id,
@@ -568,9 +592,11 @@ def capture_internal(event, distinct_id, ip, site_url, now, sent_at, event_uuid=
 
     if event["event"] in SESSION_RECORDING_EVENT_NAMES:
         kafka_partition_key = event["properties"]["$session_id"]
+
         headers = [
             ("token", token),
-        ]
+        ] + extra_headers
+
         return log_event(parsed_event, event["event"], partition_key=kafka_partition_key, headers=headers)
 
     candidate_partition_key = f"{token}:{distinct_id}"

--- a/posthog/api/test/__snapshots__/test_cohort.ambr
+++ b/posthog/api/test/__snapshots__/test_cohort.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestCohort.test_async_deletion_of_cohort
   '''
-  /* user_id:122 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:123 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -11,7 +11,7 @@
 # ---
 # name: TestCohort.test_async_deletion_of_cohort.1
   '''
-  /* user_id:122 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:123 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   INSERT INTO cohortpeople
   SELECT id,
          2 as cohort_id,
@@ -84,7 +84,7 @@
 # ---
 # name: TestCohort.test_async_deletion_of_cohort.2
   '''
-  /* user_id:122 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:123 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -94,7 +94,7 @@
 # ---
 # name: TestCohort.test_async_deletion_of_cohort.3
   '''
-  /* user_id:122 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
+  /* user_id:123 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
   SELECT count()
   FROM cohortpeople
   WHERE team_id = 2
@@ -104,7 +104,7 @@
 # ---
 # name: TestCohort.test_async_deletion_of_cohort.4
   '''
-  /* user_id:122 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:123 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -114,7 +114,7 @@
 # ---
 # name: TestCohort.test_async_deletion_of_cohort.5
   '''
-  /* user_id:122 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:123 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   INSERT INTO cohortpeople
   SELECT id,
          2 as cohort_id,
@@ -148,7 +148,7 @@
 # ---
 # name: TestCohort.test_async_deletion_of_cohort.6
   '''
-  /* user_id:122 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:123 celery:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2
@@ -158,7 +158,7 @@
 # ---
 # name: TestCohort.test_async_deletion_of_cohort.7
   '''
-  /* user_id:122 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
+  /* user_id:123 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
   SELECT count()
   FROM cohortpeople
   WHERE team_id = 2

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -1739,7 +1739,7 @@
 # ---
 # name: TestFeatureFlag.test_creating_static_cohort.14
   '''
-  /* user_id:196 celery:posthog.tasks.calculate_cohort.insert_cohort_from_feature_flag */
+  /* user_id:197 celery:posthog.tasks.calculate_cohort.insert_cohort_from_feature_flag */
   SELECT count(DISTINCT person_id)
   FROM person_static_cohort
   WHERE team_id = 2

--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -157,7 +157,7 @@
 # ---
 # name: TestQuery.test_full_hogql_query_async
   '''
-  /* user_id:463 celery:posthog.tasks.tasks.process_query_task */
+  /* user_id:464 celery:posthog.tasks.tasks.process_query_task */
   SELECT events.uuid AS uuid,
          events.event AS event,
          events.properties AS properties,


### PR DESCRIPTION
incident follow-up

older clients are missing optimisations in replay that can cause ingestion pressure

we want to start sending ingestion warnings from blob ingestion when we see traffic from older clients

this adds the version that posthog-js puts in a query parameter to capture into the kafka headers