### PR TITLE
feat: Added code for handling internal events

### DIFF
--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -15,10 +15,11 @@
          count(distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) as count
   FROM events
   WHERE timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND event != '$feature_flag_called'
-    AND event NOT IN ('survey sent',
+    AND event NOT IN ('$feature_flag_called',
+                      'survey sent',
                       'survey shown',
                       'survey dismissed')
+    AND NOT startsWith(event, '$$')
   GROUP BY team_id
   '''
 # ---
@@ -199,10 +200,11 @@
          count(1) as count
   FROM events
   WHERE timestamp between '2022-01-01 00:00:00' AND '2022-01-10 23:59:59'
-    AND event != '$feature_flag_called'
-    AND event NOT IN ('survey sent',
+    AND event NOT IN ('$feature_flag_called',
+                      'survey sent',
                       'survey shown',
                       'survey dismissed')
+    AND NOT startsWith(event, '$$')
   GROUP BY team_id
   '''
 # ---

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -401,7 +401,7 @@ def get_teams_with_billable_event_count_in_period(
         f"""
         SELECT team_id, count({distinct_expression}) as count
         FROM events
-        WHERE timestamp between %(begin)s AND %(end)s AND event != '$feature_flag_called' AND event NOT IN ('survey sent', 'survey shown', 'survey dismissed')
+        WHERE timestamp between %(begin)s AND %(end)s AND event NOT IN ('$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed') AND NOT startsWith(event, '$$')
         GROUP BY team_id
     """,
         {"begin": begin, "end": end},


### PR DESCRIPTION
## Problem

We mostly stopped using internal events but we have some potential use cases coming up around client side rate limiting etc.

## Changes

* This change accounts for internal event types starting with $$

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yep

## How did you test this code?

Yep