### PR TITLE
chore(ci): report workflow running time to PostHog

### DIFF
--- a/.github/workflows/ci-backend-depot.yml
+++ b/.github/workflows/ci-backend-depot.yml
@@ -371,3 +371,37 @@ jobs:
             - name: Run async migrations tests
               run: |
                   pytest -m "async_migrations"
+    calculate-running-time:
+        name: Calculate running time
+        needs: [django, async-migrations]
+        runs-on: ubuntu-latest
+        if: needs.changes.outputs.backend == 'true'
+        steps:
+            - name: Calculate running time
+              run: |
+                  echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+                  run_id=${GITHUB_RUN_ID}
+                  repo=${GITHUB_REPOSITORY}
+                  run_info=$(gh api repos/${repo}/actions/runs/${run_id})
+                  echo run_info: ${run_info}
+                  # name is the name of the workflow file
+                  # run_started_at is the start time of the workflow
+                  # we want to get the number of seconds between the start time and now
+                  name=$(echo ${run_info} | jq -r '.name')
+                  run_url=$(echo ${run_info} | jq -r '.url')
+                  run_started_at=$(echo ${run_info} | jq -r '.run_started_at')
+                  run_attempt=$(echo ${run_info} | jq -r '.run_attempt')
+                  start_seconds=$(date -d "${run_started_at}" +%s)
+                  now_seconds=$(date +%s)
+                  duration=$((now_seconds-start_seconds))
+                  echo running_time_duration_seconds=${duration} >> $GITHUB_ENV
+                  echo running_time_run_url=${run_url} >> $GITHUB_ENV
+                  echo running_time_run_attempt=${run_attempt} >> $GITHUB_ENV
+                  echo running_time_run_id=${run_id} >> $GITHUB_ENV
+                  echo running_time_run_started_at=${run_started_at} >> $GITHUB_ENV
+            - name: Capture running time to PostHog
+              uses: PostHog/posthog-github-action@v0.1
+              with:
+                  posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
+                  event: 'posthog-ci-running-time'
+                  properties: '{"duration_seconds": ${{ env.running_time_duration_seconds }}, "run_url": "${{ env.running_time_run_url }}", "run_attempt": "${{ env.running_time_run_attempt }}", "run_id": "${{ env.running_time_run_id }}", "run_started_at": "${{ env.running_time_run_started_at }}"}'

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -371,3 +371,38 @@ jobs:
             - name: Run async migrations tests
               run: |
                   pytest -m "async_migrations"
+
+    calculate-running-time:
+        name: Calculate running time
+        needs: [django, async-migrations]
+        runs-on: ubuntu-latest
+        if: needs.changes.outputs.backend == 'true'
+        steps:
+            - name: Calculate running time
+              run: |
+                  echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+                  run_id=${GITHUB_RUN_ID}
+                  repo=${GITHUB_REPOSITORY}
+                  run_info=$(gh api repos/${repo}/actions/runs/${run_id})
+                  echo run_info: ${run_info}
+                  # name is the name of the workflow file
+                  # run_started_at is the start time of the workflow
+                  # we want to get the number of seconds between the start time and now
+                  name=$(echo ${run_info} | jq -r '.name')
+                  run_url=$(echo ${run_info} | jq -r '.url')
+                  run_started_at=$(echo ${run_info} | jq -r '.run_started_at')
+                  run_attempt=$(echo ${run_info} | jq -r '.run_attempt')
+                  start_seconds=$(date -d "${run_started_at}" +%s)
+                  now_seconds=$(date +%s)
+                  duration=$((now_seconds-start_seconds))
+                  echo running_time_duration_seconds=${duration} >> $GITHUB_ENV
+                  echo running_time_run_url=${run_url} >> $GITHUB_ENV
+                  echo running_time_run_attempt=${run_attempt} >> $GITHUB_ENV
+                  echo running_time_run_id=${run_id} >> $GITHUB_ENV
+                  echo running_time_run_started_at=${run_started_at} >> $GITHUB_ENV
+            - name: Capture running time to PostHog
+              uses: PostHog/posthog-github-action@v0.1
+              with:
+                  posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
+                  event: 'posthog-ci-running-time'
+                  properties: '{"duration_seconds": ${{ env.running_time_duration_seconds }}, "run_url": "${{ env.running_time_run_url }}", "run_attempt": "${{ env.running_time_run_attempt }}", "run_id": "${{ env.running_time_run_id }}", "run_started_at": "${{ env.running_time_run_started_at }}"}'


### PR DESCRIPTION
We're comparing depot runners and GH actions runners

But have to do that manually

If only we knew a good analytics platform 💡

(this could be packaged as an action, but let's prove it works first)