### PR TITLE
fix: Return no content on password reset

### DIFF
--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -179,6 +179,10 @@ class NonCreatingViewSetMixin(mixins.CreateModelMixin):
         """
         response = super().create(request, *args, **kwargs)
         response.status_code = getattr(self, "SUCCESS_STATUS_CODE", status.HTTP_200_OK)
+
+        if response.status_code == status.HTTP_204_NO_CONTENT:
+            response.data = None
+
         return response
 
 

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -317,6 +317,7 @@ class TestPasswordResetAPI(APIBaseTest):
             response = self.client.post("/api/reset/", {"email": self.CONFIG_EMAIL})
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(response.content.decode(), "")
+        self.assertEqual(response.headers["Content-Length"], "0")
 
         user: User = User.objects.get(email=self.CONFIG_EMAIL)
         self.assertEqual(


### PR DESCRIPTION
## Problem

Resetting a password returns a body when it should return nothing (204)

## Changes

* Fixes this to do that

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

* Added a test