### PR TITLE
chore(ci): step name needs to be unique (without considering worfklow name) or its required

### DIFF
--- a/.github/workflows/ci-backend-depot.yml
+++ b/.github/workflows/ci-backend-depot.yml
@@ -236,7 +236,7 @@ jobs:
         needs: changes
         timeout-minutes: 30
 
-        name: Django tests – ${{ matrix.segment }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
+        name: Django tests – ${{ matrix.segment }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }}) (depot)
         runs-on: depot-ubuntu-latest
 
         strategy:

--- a/.github/workflows/ci-e2e-depot.yml
+++ b/.github/workflows/ci-e2e-depot.yml
@@ -93,7 +93,7 @@ jobs:
                   actions-id-token-request-url: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}
 
     cypress:
-        name: Cypress E2E tests (${{ strategy.job-index }})
+        name: Cypress E2E tests (${{ strategy.job-index }}) (depot)
         runs-on: depot-ubuntu-latest
         timeout-minutes: 60
         needs: [chunks, changes, container]


### PR DESCRIPTION
We're testing depot runners by duplicating some workflows

GH required steps doesn't consider the workflow name so I inadvertently made these experimental steps required which wasn't intended

This changes the names so they're not required