### PR TITLE
fix: e2e running time should wait for after cypress tests

### DIFF
--- a/.github/workflows/ci-e2e-depot.yml
+++ b/.github/workflows/ci-e2e-depot.yml
@@ -280,6 +280,7 @@ jobs:
     calculate-running-time:
         name: Calculate running time
         runs-on: ubuntu-latest
+        needs: [cypress]
         if: needs.changes.outputs.shouldTriggerCypress == 'true'
         steps:
             - name: Calculate running time

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -280,6 +280,7 @@ jobs:
     calculate-running-time:
         name: Calculate running time
         runs-on: ubuntu-latest
+        needs: [cypress]
         if: needs.changes.outputs.shouldTriggerCypress == 'true'
         steps:
             - name: Calculate running time


### PR DESCRIPTION
measuring e2e running time but after it runs 🙈 