### PR TITLE
chore: remove code for finished experiment

### DIFF
--- a/frontend/src/lib/components/Support/SupportForm.tsx
+++ b/frontend/src/lib/components/Support/SupportForm.tsx
@@ -1,6 +1,5 @@
 import { IconBug, IconInfo, IconQuestion } from '@posthog/icons'
 import {
-    LemonBanner,
     LemonInput,
     LemonSegmentedButton,
     LemonSegmentedButtonOption,
@@ -16,7 +15,6 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonFileInput } from 'lib/lemon-ui/LemonFileInput/LemonFileInput'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect/LemonSelect'
 import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea/LemonTextArea'
-import posthog from 'posthog-js'
 import { useEffect, useRef } from 'react'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { userLogic } from 'scenes/userLogic'
@@ -97,40 +95,6 @@ export function SupportForm(): JSX.Element | null {
             <LemonField name="target_area" label="Topic">
                 <LemonSelect fullWidth options={TARGET_AREA_TO_NAME} />
             </LemonField>
-            {posthog.getFeatureFlag('show-troubleshooting-docs-in-support-form') === 'test-replay-banner' &&
-                sendSupportRequest.target_area === 'session_replay' && (
-                    <LemonBanner type="info">
-                        <>
-                            We're pretty proud of our docs. Check out these helpful links:
-                            <ul>
-                                <li>
-                                    <Link target="_blank" to="https://posthog.com/docs/session-replay/troubleshooting">
-                                        Session replay troubleshooting
-                                    </Link>
-                                </li>
-                                <li>
-                                    <Link
-                                        target="_blank"
-                                        to="https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record"
-                                    >
-                                        How to control which sessions you record
-                                    </Link>
-                                </li>
-                            </ul>
-                        </>
-                    </LemonBanner>
-                )}
-            {posthog.getFeatureFlag('show-troubleshooting-docs-in-support-form') === 'test-replay-banner' &&
-                sendSupportRequest.target_area === 'toolbar' && (
-                    <LemonBanner type="info">
-                        <>
-                            We're pretty proud of our docs.{' '}
-                            <Link target="_blank" to="https://posthog.com/docs/toolbar#troubleshooting-and-faq">
-                                Check out this troubleshooting guide
-                            </Link>
-                        </>
-                    </LemonBanner>
-                )}
             <LemonField
                 name="message"
                 label={sendSupportRequest.kind ? SUPPORT_TICKET_KIND_TO_PROMPT[sendSupportRequest.kind] : 'Content'}


### PR DESCRIPTION
We've finished the experiment for showing docs links when people choose replay or toolbar while logging a ticket

it didn't have significant impact https://us.posthog.com/project/2/experiments/16810

_and_ the entire modal has been redesigned

_and_ the experiment is over so folk aren't getting the flag variant that would show this anymore

so we can remove the code

|before (when in test group) | after (or in control group|
|-|-|
|<img width="686" alt="Screenshot 2024-03-19 at 19 06 41" src="https://github.com/PostHog/posthog/assets/984817/84659bc5-735f-4915-af43-be1158dcb13f">|<img width="699" alt="Screenshot 2024-03-19 at 19 02 46" src="https://github.com/PostHog/posthog/assets/984817/4a5bfff5-3f95-4709-b6ea-96a14aa2997c">|
