### PR TITLE
fix: allow reads/writes to description without team collab feature

### DIFF
--- a/ee/api/test/test_dashboard.py
+++ b/ee/api/test/test_dashboard.py
@@ -4,10 +4,8 @@ from django.utils import timezone
 from rest_framework import status
 
 from ee.api.test.base import APILicensedTest
-from ee.api.test.fixtures.available_product_features import AVAILABLE_PRODUCT_FEATURES
 from ee.models.explicit_team_membership import ExplicitTeamMembership
 from ee.models.license import License
-from posthog.constants import AvailableFeature
 from posthog.models import OrganizationMembership
 from posthog.models.dashboard import Dashboard
 from posthog.models.sharing_configuration import SharingConfiguration
@@ -269,7 +267,12 @@ class TestDashboardEnterpriseAPI(APILicensedTest):
             self.permission_denied_response("You don't have edit permissions for this dashboard."),
         )
 
-    def test_cannot_edit_dashboard_description_when_collaboration_not_available(self):
+    def test_can_edit_dashboard_description_when_collaboration_not_available(self):
+        """
+        Team collaboration feature is only available on some plans, but if the feature is
+        not available, the user should still be able to read/write for migration purposes.
+        The access to the feature is blocked in the UI, so this is unlikely to be truly abused.
+        """
         self.client.logout()
 
         self.organization.available_features = []
@@ -291,41 +294,8 @@ class TestDashboardEnterpriseAPI(APILicensedTest):
         response = self.client.patch(
             f"/api/projects/{self.team.id}/dashboards/{dashboard.id}",
             {
-                "description": "i should not be allowed to edit this",
-                "name": "even though I am allowed to edit this",
-            },
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-        dashboard.refresh_from_db()
-        self.assertEqual(dashboard.description, "")
-        self.assertEqual(dashboard.name, "example dashboard")
-
-    def test_can_edit_dashboard_description_when_collaboration_is_available(self):
-        self.client.logout()
-
-        self.organization.available_features = [AvailableFeature.TEAM_COLLABORATION]
-        self.organization.available_product_features = AVAILABLE_PRODUCT_FEATURES
-        self.organization.save()
-        self.team.access_control = True
-        self.team.save()
-
-        user_with_collaboration = User.objects.create_and_join(
-            self.organization, "no-collaboration-feature@posthog.com", None
-        )
-        self.client.force_login(user_with_collaboration)
-
-        dashboard: Dashboard = Dashboard.objects.create(
-            team=self.team,
-            name="example dashboard",
-        )
-
-        response = self.client.patch(
-            f"/api/projects/{self.team.id}/dashboards/{dashboard.id}",
-            {
                 "description": "i should be allowed to edit this",
-                "name": "and so also to edit this",
+                "name": "as well as this",
             },
         )
 
@@ -333,4 +303,4 @@ class TestDashboardEnterpriseAPI(APILicensedTest):
 
         dashboard.refresh_from_db()
         self.assertEqual(dashboard.description, "i should be allowed to edit this")
-        self.assertEqual(dashboard.name, "and so also to edit this")
+        self.assertEqual(dashboard.name, "as well as this")

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: ClickhouseTestExperimentSecondaryResults.test_basic_secondary_metric_results
   '''
-  /* user_id:108 celery:posthog.tasks.tasks.sync_insight_caching_state */
+  /* user_id:107 celery:posthog.tasks.tasks.sync_insight_caching_state */
   SELECT team_id,
          date_diff('second', max(timestamp), now()) AS age
   FROM events

--- a/frontend/src/lib/components/UpgradeModal/upgradeModalLogic.ts
+++ b/frontend/src/lib/components/UpgradeModal/upgradeModalLogic.ts
@@ -9,7 +9,7 @@ import { AvailableFeature } from '~/types'
 import type { upgradeModalLogicType } from './upgradeModalLogicType'
 
 export type GuardAvailableFeatureFn = (
-    featureKey: AvailableFeature,
+    featureKey?: AvailableFeature,
     featureAvailableCallback?: () => void,
     options?: {
         guardOnCloud?: boolean
@@ -60,6 +60,10 @@ export const upgradeModalLogic = kea<upgradeModalLogicType>([
             (s) => [s.preflight, s.hasAvailableFeature],
             (preflight, hasAvailableFeature): GuardAvailableFeatureFn => {
                 return (featureKey, featureAvailableCallback, options): boolean => {
+                    if (!featureKey) {
+                        featureAvailableCallback?.()
+                        return true
+                    }
                     const {
                         guardOnCloud = true,
                         guardOnSelfHosted = true,

--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -15,7 +15,6 @@ import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { compactNumber, uuid } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
-import { userLogic } from 'scenes/userLogic'
 
 import { tagsModel } from '~/models/tagsModel'
 import { ActionStepType, AvailableFeature } from '~/types'
@@ -32,7 +31,6 @@ export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): 
     const { action, actionLoading, actionCount, actionCountLoading } = useValues(logic)
     const { submitAction, deleteAction } = useActions(logic)
     const { currentTeam } = useValues(teamLogic)
-    const { hasAvailableFeature } = useValues(userLogic)
     const { tags } = useValues(tagsModel)
 
     const slackEnabled = currentTeam?.slack_incoming_webhook
@@ -96,7 +94,7 @@ export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): 
                                         className="action-description"
                                         compactButtons
                                         maxLength={600} // No limit on backend model, but enforce shortish description
-                                        paywall={!hasAvailableFeature(AvailableFeature.INGESTION_TAXONOMY)}
+                                        paywallFeature={AvailableFeature.INGESTION_TAXONOMY}
                                     />
                                 )}
                             </LemonField>

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -308,7 +308,11 @@ export function DashboardHeader(): JSX.Element | null {
                                 multiline
                                 name="description"
                                 markdown
-                                value={dashboard.description || ''}
+                                value={
+                                    (hasAvailableFeature(AvailableFeature.TEAM_COLLABORATION) &&
+                                        dashboard.description) ||
+                                    ''
+                                }
                                 placeholder="Description (optional)"
                                 onSave={(value) =>
                                     updateDashboard({ id: dashboard.id, description: value, allowUndo: true })
@@ -316,7 +320,7 @@ export function DashboardHeader(): JSX.Element | null {
                                 saveOnBlur={true}
                                 compactButtons
                                 mode={!canEditDashboard ? 'view' : undefined}
-                                paywall={!hasAvailableFeature(AvailableFeature.TEAM_COLLABORATION)}
+                                paywallFeature={AvailableFeature.TEAM_COLLABORATION}
                             />
                         )}
                         {dashboard?.tags && (

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -17,7 +17,6 @@ import { definitionLogic, DefinitionLogicProps } from 'scenes/data-management/de
 import { EventDefinitionProperties } from 'scenes/data-management/events/EventDefinitionProperties'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
-import { userLogic } from 'scenes/userLogic'
 
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { Query } from '~/queries/Query/Query'
@@ -37,7 +36,6 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
     const { definition, definitionLoading, definitionMissing, hasTaxonomyFeatures, singular, isEvent, isProperty } =
         useValues(logic)
     const { deleteDefinition } = useActions(logic)
-    const { hasAvailableFeature } = useValues(userLogic)
 
     if (definitionLoading) {
         return <SpinnerOverlay sceneLevel />
@@ -146,7 +144,7 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
                     className="definition-description"
                     compactButtons
                     maxLength={600}
-                    paywall={!hasAvailableFeature(AvailableFeature.INGESTION_TAXONOMY)}
+                    paywallFeature={AvailableFeature.INGESTION_TAXONOMY}
                 />
 
                 <ObjectTags

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -25,7 +25,6 @@ import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/Note
 import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
-import { userLogic } from 'scenes/userLogic'
 
 import { tagsModel } from '~/models/tagsModel'
 import { DataTableNode, NodeKind } from '~/queries/schema'
@@ -59,7 +58,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
 
     // other logics
     useMountedLogic(insightCommandLogic(insightProps))
-    const { hasAvailableFeature } = useValues(userLogic)
     const { tags } = useValues(tagsModel)
     const { currentTeamId } = useValues(teamLogic)
     const { push } = useActions(router)
@@ -292,7 +290,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                 mode={!canEditInsight ? 'view' : undefined}
                                 data-attr="insight-description"
                                 compactButtons
-                                paywall={!hasAvailableFeature(AvailableFeature.TEAM_COLLABORATION)}
+                                paywallFeature={AvailableFeature.TEAM_COLLABORATION}
                             />
                         )}
                         {canEditInsight ? (

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -7,7 +7,6 @@ from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
 from rest_framework import exceptions, serializers, viewsets
 from rest_framework.decorators import action
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -22,14 +21,12 @@ from posthog.api.insight import InsightSerializer, InsightViewSet
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSetMixin
-from posthog.constants import AvailableFeature
 from posthog.event_usage import report_user_action
 from posthog.helpers import create_dashboard_from_template
 from posthog.helpers.dashboard_templates import create_from_template
 from posthog.models import Dashboard, DashboardTile, Insight, Text
 from posthog.models.dashboard_templates import DashboardTemplate
 from posthog.models.tagged_item import TaggedItem
-from posthog.models.team.team import check_is_feature_available_for_team
 from posthog.models.user import User
 from posthog.user_permissions import UserPermissionsSerializerMixin
 
@@ -157,13 +154,6 @@ class DashboardSerializer(DashboardBasicSerializer):
             "effective_privilege_level",
         ]
         read_only_fields = ["creation_mode", "effective_restriction_level", "is_shared"]
-
-    def validate_description(self, value: str) -> str:
-        if value and not check_is_feature_available_for_team(
-            self.context["team_id"], AvailableFeature.TEAM_COLLABORATION
-        ):
-            raise PermissionDenied("You must have paid for dashboard collaboration to set the dashboard description")
-        return value
 
     def validate_filters(self, value) -> Dict:
         if not isinstance(value, dict):


### PR DESCRIPTION
## Problem

If someone has dashboard descriptions saved, but no longer has the `TEAM_COLLABORATION` feature, trying to get this resource from the API would 403. However, the migration script depends on being able to read/write these descriptions, and we don't want to _not_ migrate them because if the team wants them back at some point, re-migrating just these bits is a pain.

See: https://posthog.slack.com/archives/C043VJ93L3B/p1710161924625399

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- Allows read/writes of this field from the API. 
- No longer shows the description in the UI if they don't have the feature. 
- Modifies EditableField paywall functionality to use standard UpgradeModal instead of a different custom implementation

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It should!

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

We may see some cypress failures here, if so I'll fix, if not I'll update.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
