### PR TITLE
fix(insights): Fix set active view when changing insight

### DIFF
--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -1,4 +1,5 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { urlToAction } from 'kea-router'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -41,7 +42,7 @@ import {
     isStickinessQuery,
     isTrendsQuery,
 } from '~/queries/utils'
-import { BaseMathType, InsightLogicProps, InsightType } from '~/types'
+import { BaseMathType, FilterType, InsightLogicProps, InsightType } from '~/types'
 
 import { MathAvailability } from '../filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 import type { insightNavLogicType } from './insightNavLogicType'
@@ -276,6 +277,23 @@ export const insightNavLogic = kea<insightNavLogicType>([
             if (isInsightVizNode(query)) {
                 actions.updateQueryPropertyCache(cachePropertiesFromQuery(query.source, values.queryPropertyCache))
             }
+        },
+    })),
+    urlToAction(({ actions }) => ({
+        '/insights/:shortId(/:mode)(/:subscriptionId)': (
+            _, // url params
+            { dashboard, ...searchParams }, // search params
+            { filters: _filters } // hash params
+        ) => {
+            // capture any filters from the URL, either #filters={} or ?insight=X&bla=foo&bar=baz
+            const filters: Partial<FilterType> | null =
+                Object.keys(_filters || {}).length > 0 ? _filters : searchParams.insight ? searchParams : null
+
+            if (!filters?.insight) {
+                return
+            }
+
+            actions.setActiveView(filters?.insight)
         },
     })),
     afterMount(({ values, actions }) => {


### PR DESCRIPTION
## Problem

When viewing a funnel insight and then clicking to use a funnel step as a start point in paths insight, the active view doesn't switch.

## Changes

- found only one way to do it: go via `urlToAction`
- set the active view there
- still doesn't work for query based insights/URLs because setActiveView will reset them, I got stock trying to invoke it

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

- make funnel insight
- click to use in paths
- observe the insight tab changing, paths appear
