### PR TITLE
fix: Revert healthcheck change

### DIFF
--- a/unit.json
+++ b/unit.json
@@ -18,14 +18,6 @@
     "routes": {
         "posthog": [
             {
-                "match": {
-                    "uri": ["/_health", "/_readyz", "/_livez"]
-                },
-                "action": {
-                    "pass": "applications/posthog-health"
-                }
-            },
-            {
                 "action": {
                     "pass": "applications/posthog"
                 }
@@ -53,17 +45,6 @@
         ]
     },
     "applications": {
-        "posthog-health": {
-            "type": "python 3.10",
-            "processes": 1,
-            "working_directory": "/code",
-            "path": ".",
-            "module": "posthog.wsgi",
-            "user": "nobody",
-            "limits": {
-                "requests": 5000
-            }
-        },
         "posthog": {
             "type": "python 3.10",
             "processes": 4,


### PR DESCRIPTION
## Problem
We suspect this is causing pods to come up before they are ready to serve traffic


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
