### PR TITLE
fix: Loop requests in toolbar

### DIFF
--- a/frontend/src/toolbar/actions/ActionsListView.tsx
+++ b/frontend/src/toolbar/actions/ActionsListView.tsx
@@ -1,7 +1,6 @@
 import { Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { Spinner } from 'lib/lemon-ui/Spinner'
-import { useEffect } from 'react'
 
 import { actionsLogic } from '~/toolbar/actions/actionsLogic'
 import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
@@ -13,12 +12,7 @@ interface ActionsListViewProps {
 
 export function ActionsListView({ actions }: ActionsListViewProps): JSX.Element {
     const { allActionsLoading, searchTerm } = useValues(actionsLogic)
-    const { getActions } = useActions(actionsLogic)
     const { selectAction } = useActions(actionsTabLogic)
-
-    useEffect(() => {
-        getActions()
-    }, [])
 
     return (
         <div className="flex flex-col h-full overflow-y-scoll space-y-px">

--- a/frontend/src/toolbar/actions/ActionsToolbarMenu.tsx
+++ b/frontend/src/toolbar/actions/ActionsToolbarMenu.tsx
@@ -5,6 +5,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { Link } from 'lib/lemon-ui/Link'
 import { Spinner } from 'lib/lemon-ui/Spinner'
+import { useEffect } from 'react'
 import { urls } from 'scenes/urls'
 
 import { ActionsEditingToolbarMenu } from '~/toolbar/actions/ActionsEditingToolbarMenu'
@@ -16,12 +17,16 @@ import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 
 const ActionsListToolbarMenu = (): JSX.Element => {
     const { searchTerm } = useValues(actionsLogic)
-    const { setSearchTerm } = useActions(actionsLogic)
+    const { setSearchTerm, getActions } = useActions(actionsLogic)
 
     const { newAction } = useActions(actionsTabLogic)
     const { allActions, sortedActions, allActionsLoading } = useValues(actionsLogic)
 
     const { apiURL } = useValues(toolbarConfigLogic)
+
+    useEffect(() => {
+        getActions()
+    }, [])
 
     return (
         <ToolbarMenu>


### PR DESCRIPTION
## Problem

I had moved the loading action to inside the component which was the right idea, but had a bad side effect in that it's parent would conditionally render it based on a loading state. This meant if the api request failed, it would re-render the component, triggering another request and entering a loop.

## Changes

* Moves this effect one level up to stop this happening

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Manually