### PR TITLE
fix(hogql): Allow missing aggregate errors to reach the UI

### DIFF
--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -151,7 +151,7 @@ CLICKHOUSE_ERROR_CODE_LOOKUP: Dict[int, ErrorCodeMeta] = {
     60: ErrorCodeMeta("UNKNOWN_TABLE"),
     61: ErrorCodeMeta("ONLY_FILTER_COLUMN_IN_BLOCK"),
     62: ErrorCodeMeta("SYNTAX_ERROR"),
-    63: ErrorCodeMeta("UNKNOWN_AGGREGATE_FUNCTION"),
+    63: ErrorCodeMeta("UNKNOWN_AGGREGATE_FUNCTION", user_safe=True),
     64: ErrorCodeMeta("CANNOT_READ_AGGREGATE_FUNCTION_FROM_TEXT"),
     65: ErrorCodeMeta("CANNOT_WRITE_AGGREGATE_FUNCTION_AS_TEXT"),
     66: ErrorCodeMeta("NOT_A_COLUMN"),


### PR DESCRIPTION
## Problem
- When using an aggregate function that's not supported by HogQL, we hide the real error and show the user an unhelpful generic error
- Reported by Annika [here](https://posthog.slack.com/archives/C0368RPHLQH/p1710860949637839)

<img width="889" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/a319361a-0f24-4d79-8e1b-7cfb885c5cfd">


## Changes
- Allow the aggregate error to reach the user

![image](https://github.com/PostHog/posthog/assets/1459269/e68f5bdb-41a0-4d77-ba74-cd1e0608de7c)


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
- Via SQL queries