### PR TITLE
fix: nobody sees these buttons

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorControls.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspectorControls.tsx
@@ -174,6 +174,7 @@ export function PlayerInspectorControls({ onClose }: { onClose: () => void }): J
                 <div className="flex items-center gap-1">
                     <LemonButton
                         size="small"
+                        type="secondary"
                         noPadding
                         onClick={() => setTimestampMode(timestampMode === 'absolute' ? 'relative' : 'absolute')}
                         tooltipPlacement="left"
@@ -191,14 +192,15 @@ export function PlayerInspectorControls({ onClose }: { onClose: () => void }): J
 
                     <LemonButton
                         size="small"
+                        type="secondary"
                         noPadding
                         active={syncScroll}
                         onClick={() => {
-                            // If the user has syncScrolling on but it is paused due to interacting with the Inspector, we want to resume it
+                            // If the user has syncScrolling on, but it is paused due to interacting with the Inspector, we want to resume it
                             if (syncScroll && syncScrollingPaused) {
                                 setSyncScrollPaused(false)
                             } else {
-                                // Otherwise we are just toggling the settting
+                                // Otherwise we are just toggling the setting
                                 setSyncScroll(!syncScroll)
                             }
                         }}


### PR DESCRIPTION
I think everybody that has ever used these buttons has had to be told about them...

|before|after|
|-|-|
|![Screenshot 2024-03-21 at 13 59 33](https://github.com/PostHog/posthog/assets/984817/3ad8fdf1-7860-4efe-ad58-75d390269dea)|![Screenshot 2024-03-21 at 13 57 30](https://github.com/PostHog/posthog/assets/984817/8c37cb67-0135-4d3b-a1bc-dfc0e2ec39b6)|
