### PR TITLE
feat: don't clone replay event data

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
@@ -6,7 +6,6 @@ import path from 'path'
 import { KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS } from '../../../config/kafka-topics'
 import { PipelineEvent, RawEventMessage, RRWebEvent } from '../../../types'
 import { status } from '../../../utils/status'
-import { cloneObject } from '../../../utils/utils'
 import { eventDroppedCounter } from '../metrics'
 import { TeamIDWithConfig } from './session-recordings-consumer'
 import { IncomingRecordingMessage, PersistedRecordingMessage } from './types'
@@ -257,10 +256,7 @@ export const reduceRecordingMessages = (messages: IncomingRecordingMessage[]): I
     for (const message of messages) {
         const key = `${message.team_id}-${message.session_id}`
         if (!reducedMessages[key]) {
-            // cloning the object here so that when we mutate it
-            // we're not also mutating its reference in the inbound messages array
-            // this is maybe overly defensive, but better safe than sorry
-            reducedMessages[key] = cloneObject(message)
+            reducedMessages[key] = message
         } else {
             const existingMessage = reducedMessages[key]
             for (const [windowId, events] of Object.entries(message.eventsByWindowId)) {

--- a/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
@@ -255,38 +255,37 @@ export const reduceRecordingMessages = (messages: IncomingRecordingMessage[]): I
     const reducedMessages: Record<string, IncomingRecordingMessage> = {}
 
     for (const message of messages) {
-        const clonedMessage = cloneObject(message)
-        const key = `${clonedMessage.team_id}-${clonedMessage.session_id}`
+        const key = `${message.team_id}-${message.session_id}`
         if (!reducedMessages[key]) {
-            reducedMessages[key] = clonedMessage
+            // cloning the object here so that when we mutate it
+            // we're not also mutating its reference in the inbound messages array
+            // this is maybe overly defensive, but better safe than sorry
+            reducedMessages[key] = cloneObject(message)
         } else {
             const existingMessage = reducedMessages[key]
-            for (const [windowId, events] of Object.entries(clonedMessage.eventsByWindowId)) {
+            for (const [windowId, events] of Object.entries(message.eventsByWindowId)) {
                 if (existingMessage.eventsByWindowId[windowId]) {
                     existingMessage.eventsByWindowId[windowId].push(...events)
                 } else {
                     existingMessage.eventsByWindowId[windowId] = events
                 }
             }
-            existingMessage.metadata.rawSize += clonedMessage.metadata.rawSize
+            existingMessage.metadata.rawSize += message.metadata.rawSize
 
             // Update the events ranges
             existingMessage.metadata.lowOffset = Math.min(
                 existingMessage.metadata.lowOffset,
-                clonedMessage.metadata.lowOffset
+                message.metadata.lowOffset
             )
 
             existingMessage.metadata.highOffset = Math.max(
                 existingMessage.metadata.highOffset,
-                clonedMessage.metadata.highOffset
+                message.metadata.highOffset
             )
 
             // Update the events ranges
-            existingMessage.eventsRange.start = Math.min(
-                existingMessage.eventsRange.start,
-                clonedMessage.eventsRange.start
-            )
-            existingMessage.eventsRange.end = Math.max(existingMessage.eventsRange.end, clonedMessage.eventsRange.end)
+            existingMessage.eventsRange.start = Math.min(existingMessage.eventsRange.start, message.eventsRange.start)
+            existingMessage.eventsRange.end = Math.max(existingMessage.eventsRange.end, message.eventsRange.end)
         }
     }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
@@ -6,6 +6,7 @@ import path from 'path'
 import { KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS } from '../../../config/kafka-topics'
 import { PipelineEvent, RawEventMessage, RRWebEvent } from '../../../types'
 import { status } from '../../../utils/status'
+import { cloneObject } from '../../../utils/utils'
 import { eventDroppedCounter } from '../metrics'
 import { TeamIDWithConfig } from './session-recordings-consumer'
 import { IncomingRecordingMessage, PersistedRecordingMessage } from './types'
@@ -256,7 +257,7 @@ export const reduceRecordingMessages = (messages: IncomingRecordingMessage[]): I
     for (const message of messages) {
         const key = `${message.team_id}-${message.session_id}`
         if (!reducedMessages[key]) {
-            reducedMessages[key] = message
+            reducedMessages[key] = cloneObject(message)
         } else {
             const existingMessage = reducedMessages[key]
             for (const [windowId, events] of Object.entries(message.eventsByWindowId)) {


### PR DESCRIPTION
see: https://posthog.slack.com/archives/C0374DA782U/p1711031505674169?thread_ts=1711030142.540499&cid=C0374DA782U

@benjackwhite do you remember why we clone? 

we reducing events so that every session in a batch handled by a consumer is represented by a single message

```
[
{sessionId: 1, events: [a]}, {sessionId: 1, events: [b]}, {sessionId: 2, events: [c]}, 
]
```

becomes

```
[
{sessionId: 1, events: [a, b]}, {sessionId: 2, events: [c]}, 
]
```

in doing that we clone each object, but the `events` array can be large

If we do not access the original array of messages after reducing then i think it's safe to reduce without cloning at all.

(looking at usage we parse each message into an array variable and then reduce those parsed messages into the array variable used elsewhere in the code so I _think_ it's safe to not copy here)
