### PR TITLE
chore(blobby): raise overflow threshold

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -164,7 +164,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_KAFKA_DEBUG: undefined,
         SESSION_RECORDING_MAX_PARALLEL_FLUSHES: 10,
         SESSION_RECORDING_OVERFLOW_ENABLED: false,
-        SESSION_RECORDING_OVERFLOW_BUCKET_REPLENISH_RATE: 1_000_000, // 1MB/second uncompressed, sustained
+        SESSION_RECORDING_OVERFLOW_BUCKET_REPLENISH_RATE: 2_000_000, // 2MB/second uncompressed, sustained
         SESSION_RECORDING_OVERFLOW_BUCKET_CAPACITY: 100_000_000, // 100MB burst
     }
 }


### PR DESCRIPTION
## Problem

Deployed to both prods with 1MB/s, a few dozen sessions are triggering, which means we are in the right order of magnitude but a tad low.

## Changes

- Raise the sustained threshold 1 -> 2 MB/s

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
