### PR TITLE
chore: run clustering in background task

### DIFF
--- a/ee/session_recordings/ai/error_clustering.py
+++ b/ee/session_recordings/ai/error_clustering.py
@@ -1,7 +1,7 @@
 from prometheus_client import Histogram
 from django.conf import settings
 from posthog.clickhouse.client import sync_execute
-from posthog.models import Team, User
+from posthog.models import Team
 from sklearn.cluster import DBSCAN
 import pandas as pd
 import numpy as np
@@ -24,7 +24,7 @@ DBSCAN_EPS = settings.REPLAY_EMBEDDINGS_CLUSTERING_DBSCAN_EPS
 DBSCAN_MIN_SAMPLES = settings.REPLAY_EMBEDDINGS_CLUSTERING_DBSCAN_MIN_SAMPLES
 
 
-def error_clustering(team: Team, user: User):
+def error_clustering(team: Team):
     results = fetch_error_embeddings(team.pk)
 
     if not results:
@@ -36,7 +36,7 @@ def error_clustering(team: Team, user: User):
 
     CLUSTER_REPLAY_ERRORS_CLUSTER_COUNT.labels(team_id=team.pk).observe(df["cluster"].nunique())
 
-    return construct_response(df, team, user)
+    return construct_response(df, team)
 
 
 def fetch_error_embeddings(team_id: int):
@@ -66,9 +66,9 @@ def cluster_embeddings(embeddings):
     return dbscan.labels_
 
 
-def construct_response(df: pd.DataFrame, team: Team, user: User):
+def construct_response(df: pd.DataFrame, team: Team):
     viewed_session_ids = list(
-        SessionRecordingViewed.objects.filter(team=team, user=user, session_id__in=df["session_id"].unique())
+        SessionRecordingViewed.objects.filter(team=team, session_id__in=df["session_id"].unique())
         .values_list("session_id", flat=True)
         .distinct()
     )

--- a/ee/tasks/__init__.py
+++ b/ee/tasks/__init__.py
@@ -7,7 +7,12 @@ from .subscriptions import (
     handle_subscription_value_change,
     schedule_all_subscriptions,
 )
-from .replay import embed_batch_of_recordings_task, generate_recordings_embeddings_batch
+from .replay import (
+    embed_batch_of_recordings_task,
+    generate_recordings_embeddings_batch,
+    generate_replay_embedding_error_clusters,
+    cluster_replay_error_embeddings,
+)
 
 # As our EE tasks are not included at startup for Celery, we need to ensure they are declared here so that they are imported by posthog/settings/celery.py
 
@@ -19,4 +24,6 @@ __all__ = [
     "handle_subscription_value_change",
     "embed_batch_of_recordings_task",
     "generate_recordings_embeddings_batch",
+    "generate_replay_embedding_error_clusters",
+    "cluster_replay_error_embeddings",
 ]

--- a/ee/tasks/replay.py
+++ b/ee/tasks/replay.py
@@ -66,31 +66,34 @@ def generate_recordings_embeddings_batch() -> None:
                 team_id=team_id,
             )
             embed_batch_of_recordings_task.si(recordings, int(team_id)).apply_async()
-        except Team.DoesNotExist:
-            logger.info(f"[generate_recordings_embeddings_batch] Team {team_id} does not exist. Skipping.")
-            pass
         except Exception as e:
             logger.error(f"[generate_recordings_embeddings_batch] Error: {e}.", exc_info=True, error=e)
             pass
 
 
-@shared_task(ignore_result=True, queue=CeleryQueue.SESSION_REPLAY_EMBEDDINGS.value)
+@shared_task(ignore_result=True)
 def generate_replay_embedding_error_clusters() -> None:
     for team_id in settings.REPLAY_EMBEDDINGS_ALLOWED_TEAMS:
         try:
-            team = Team.objects.get(id=team_id)
-            clusters = error_clustering(team)
-
-            cache.set(f"cluster_errors_{team.pk}", clusters, settings.CACHED_RESULTS_TTL)
-
-            logger.info(
-                f"[generate_replay_error_clusters] Completed for team",
-                flow="embeddings",
-                team_id=team_id,
-            )
-        except Team.DoesNotExist:
-            logger.info(f"[generate_replay_error_clusters] Team {team_id} does not exist. Skipping.")
-            pass
+            cluster_replay_error_embeddings.si(int(team_id)).apply_async()
         except Exception as e:
             logger.error(f"[generate_replay_error_clusters] Error: {e}.", exc_info=True, error=e)
             pass
+
+
+@shared_task(ignore_result=True, queue=CeleryQueue.SESSION_REPLAY_EMBEDDINGS.value)
+def cluster_replay_error_embeddings(team_id: int) -> None:
+    try:
+        team = Team.objects.get(id=team_id)
+        clusters = error_clustering(team)
+
+        cache.set(f"cluster_errors_{team.pk}", clusters, settings.CACHED_RESULTS_TTL)
+
+        logger.info(
+            f"[generate_replay_error_clusters] Completed for team",
+            flow="embeddings",
+            team_id=team_id,
+        )
+    except Team.DoesNotExist:
+        logger.info(f"[generate_replay_error_clusters] Team {team} does not exist. Skipping.")
+        pass

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -603,10 +603,10 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             raise exceptions.ValidationError("clustered errors is not enabled for this user")
 
         # Clustering will eventually be done during a scheduled background task
-        clusters = error_clustering(self.team, user)
+        clusters = error_clustering(self.team)
 
         if clusters:
-            cache.set(cache_key, clusters, timeout=30)
+            cache.set(cache_key, clusters, settings.CACHED_RESULTS_TTL)
 
         # let the browser cache for half the time we cache on the server
         r = Response(clusters, headers={"Cache-Control": "max-age=15"})

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -46,6 +46,7 @@ from posthog.tasks.tasks import (
     update_quota_limiting,
     verify_persons_data_in_sync,
     calculate_replay_embeddings,
+    calculate_replay_error_clusters,
 )
 from posthog.utils import get_crontab
 
@@ -248,6 +249,13 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
             calculate_replay_embeddings.s(),
             name="calculate replay embeddings",
         )
+
+        add_periodic_task_with_expiry(
+            sender,
+            crontab(hour="10", minute=str(randrange(0, 40))),
+            calculate_replay_error_clusters.s(),
+            name="calculate replay error clusters",
+        )  # every day at a random minute past 10am. Randomize to avoid overloading license.posthog.com
 
         sender.add_periodic_task(
             crontab(hour="0", minute=str(randrange(0, 40))),

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -750,3 +750,15 @@ def calculate_replay_embeddings() -> None:
         pass
     except Exception as e:
         logger.error("Failed to calculate replay embeddings", error=e, exc_info=True)
+
+
+@shared_task(ignore_result=True)
+def calculate_replay_error_clusters() -> None:
+    try:
+        from ee.tasks.replay import generate_replay_embedding_error_clusters
+
+        generate_replay_embedding_error_clusters()
+    except ImportError:
+        pass
+    except Exception as e:
+        logger.error("Failed to calculate replay error clusters", error=e, exc_info=True)

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -752,6 +752,8 @@ def calculate_replay_embeddings() -> None:
         logger.error("Failed to calculate replay embeddings", error=e, exc_info=True)
 
 
+# this task triggers other tasks
+# it can run on the default queue
 @shared_task(ignore_result=True)
 def calculate_replay_error_clusters() -> None:
     try:


### PR DESCRIPTION
## Problem

Clusters take about 20-30s to generate every time you visit the page

## Changes

- Run clustering as a single operation for an entire team on a daily basis
- Store results in a cache that can be read from on the `/error_clusters` API endpoint

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Just a background job