### PR TITLE
fix: Track last updated at for batch export run

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -439,8 +439,11 @@ def create_batch_export_run(
     return run
 
 
-def update_batch_export_run_status(
-    run_id: UUID, status: str, latest_error: str | None, records_completed: int = 0
+def update_batch_export_run(
+    run_id: UUID,
+    status: str,
+    latest_error: str | None,
+    records_completed: int = 0,
 ) -> BatchExportRun:
     """Update the status of an BatchExportRun with given id.
 
@@ -448,7 +451,14 @@ def update_batch_export_run_status(
         id: The id of the BatchExportRun to update.
     """
     model = BatchExportRun.objects.filter(id=run_id)
-    updated = model.update(status=status, latest_error=latest_error, records_completed=records_completed)
+    update_at = dt.datetime.now()
+
+    updated = model.update(
+        status=status,
+        latest_error=latest_error,
+        records_completed=records_completed,
+        last_updated_at=update_at,
+    )
 
     if not updated:
         raise ValueError(f"BatchExportRun with id {run_id} not found.")

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -22,7 +22,7 @@ from posthog.batch_exports.service import (
     create_batch_export_backfill,
     create_batch_export_run,
     update_batch_export_backfill_status,
-    update_batch_export_run_status,
+    update_batch_export_run,
 )
 from posthog.temporal.batch_exports.metrics import (
     get_export_finished_metric,
@@ -542,7 +542,7 @@ async def update_export_run_status(inputs: UpdateBatchExportRunStatusInputs) -> 
     """Activity that updates the status of an BatchExportRun."""
     logger = await bind_temporal_worker_logger(team_id=inputs.team_id)
 
-    batch_export_run = await sync_to_async(update_batch_export_run_status)(
+    batch_export_run = await sync_to_async(update_batch_export_run)(
         run_id=uuid.UUID(inputs.id),
         status=inputs.status,
         latest_error=inputs.latest_error,


### PR DESCRIPTION
## Problem

Turns out django won't bump the `auto_now` field `last_updated_at` when calling `update`, only when calling save: https://docs.djangoproject.com/en/4.2/ref/models/fields/#django.db.models.DateField.auto_now.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Bump `last_updated_at` ourselves.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
