### PR TITLE
chore: only run depot runner comparison when labelled

### DIFF
--- a/.github/workflows/ci-backend-depot.yml
+++ b/.github/workflows/ci-backend-depot.yml
@@ -5,15 +5,7 @@
 name: Backend CI (depot)
 
 on:
-    push:
-        branches:
-            - master
     pull_request:
-    workflow_dispatch:
-        inputs:
-            clickhouseServerVersion:
-                description: ClickHouse server version. Leave blank for default
-                type: string
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -41,7 +33,7 @@ jobs:
     changes:
         runs-on: depot-ubuntu-latest-4
         timeout-minutes: 5
-        if: github.repository == 'PostHog/posthog'
+        if: ${{ github.event.label.name == 'test-depot' }}
         name: Determine need to run backend checks
         # Set job outputs to values from filter step
         outputs:

--- a/.github/workflows/ci-backend-depot.yml
+++ b/.github/workflows/ci-backend-depot.yml
@@ -33,7 +33,7 @@ jobs:
     changes:
         runs-on: depot-ubuntu-latest-4
         timeout-minutes: 5
-        if: ${{ github.event.label.name == 'test-depot' }}
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'test-depot') }}
         name: Determine need to run backend checks
         # Set job outputs to values from filter step
         outputs:

--- a/.github/workflows/ci-e2e-depot.yml
+++ b/.github/workflows/ci-e2e-depot.yml
@@ -16,7 +16,7 @@ jobs:
     changes:
         runs-on: depot-ubuntu-latest-4
         timeout-minutes: 5
-        if: ${{ github.event.label.name == 'test-depot' }}
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'test-depot') }}
         name: Determine need to run E2E checks
         # Set job outputs to values from filter step
         outputs:

--- a/.github/workflows/ci-e2e-depot.yml
+++ b/.github/workflows/ci-e2e-depot.yml
@@ -16,7 +16,7 @@ jobs:
     changes:
         runs-on: depot-ubuntu-latest-4
         timeout-minutes: 5
-        if: github.repository == 'PostHog/posthog'
+        if: ${{ github.event.label.name == 'test-depot' }}
         name: Determine need to run E2E checks
         # Set job outputs to values from filter step
         outputs:


### PR DESCRIPTION
let's not test on every PR for a little while

confirmed this skipped the depot copies of the long tests jobs when not labelled and ran them when labelled