### PR TITLE
chore(plugin-server): cleanup around ACKs

### DIFF
--- a/plugin-server/src/kafka/producer.ts
+++ b/plugin-server/src/kafka/producer.ts
@@ -65,20 +65,21 @@ export const createKafkaProducer = async (globalConfig: ProducerGlobalConfig, pr
 
     return producer
 }
+
 export const produce = async ({
     producer,
     topic,
     value,
     key,
     headers = [],
-    waitForAck = true,
+    waitForAck,
 }: {
     producer: RdKafkaProducer
     topic: string
     value: MessageValue
     key: MessageKey
     headers?: MessageHeader[]
-    waitForAck?: boolean
+    waitForAck: boolean
 }): Promise<number | null | undefined> => {
     status.debug('📤', 'Producing message', { topic: topic })
     const produceSpan = getSpan()?.startChild({ op: 'kafka_produce' })

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -41,7 +41,7 @@ type IngestionSplitBatch = {
 type IngestResult = {
     // Promises that the batch handler should await on before committing offsets,
     // contains the Kafka producer ACKs, to avoid blocking after every message.
-    promises?: Array<Promise<void>>
+    ackPromises?: Array<Promise<void>>
 }
 
 async function handleProcessingError(
@@ -166,7 +166,7 @@ export async function eachBatchParallelIngestion(
                             return await runner.runEventPipeline(pluginEvent)
                         })) as IngestResult
 
-                        result.promises?.forEach((promise) =>
+                        result.ackPromises?.forEach((promise) =>
                             processingPromises.push(
                                 promise.catch(async (error) => {
                                     await handleProcessingError(error, message, pluginEvent, queue)

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
@@ -163,6 +163,7 @@ export class ConsoleLogsIngester {
                     topic: KAFKA_LOG_ENTRIES,
                     value: Buffer.from(JSON.stringify(cle)),
                     key: event.session_id,
+                    waitForAck: true,
                 })
             )
         } catch (error) {

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
@@ -171,6 +171,7 @@ export class ReplayEventsIngester {
                     topic: KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS,
                     value: Buffer.from(JSON.stringify(replayRecord)),
                     key: event.session_id,
+                    waitForAck: true,
                 }),
             ]
         } catch (error) {

--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -35,7 +35,7 @@ export class KafkaProducerWrapper {
         key: MessageKey
         topic: string
         headers?: MessageHeader[]
-        waitForAck?: boolean
+        waitForAck: boolean
     }): Promise<void> {
         try {
             kafkaProducerMessagesQueuedCounter.labels({ topic_name: topic }).inc()
@@ -66,7 +66,7 @@ export class KafkaProducerWrapper {
         }
     }
 
-    async queueMessage(kafkaMessage: ProducerRecord, waitForAck?: boolean) {
+    async queueMessage(kafkaMessage: ProducerRecord, waitForAck = false) {
         return await Promise.all(
             kafkaMessage.messages.map((message) =>
                 this.produce({
@@ -80,7 +80,7 @@ export class KafkaProducerWrapper {
         )
     }
 
-    async queueMessages(kafkaMessages: ProducerRecord[], waitForAck?: boolean): Promise<void> {
+    async queueMessages(kafkaMessages: ProducerRecord[], waitForAck = false): Promise<void> {
         await Promise.all(kafkaMessages.map((message) => this.queueMessage(message, waitForAck)))
     }
 
@@ -88,7 +88,7 @@ export class KafkaProducerWrapper {
         topic: string,
         key: Message['key'],
         object: Record<string, any>,
-        waitForAck?: boolean
+        waitForAck = false
     ): Promise<void> {
         await this.queueMessage(
             {

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -25,7 +25,7 @@ import { processPersonsStep } from './processPersonsStep'
 export type EventPipelineResult = {
     // Promises that the batch handler should await on before committing offsets,
     // contains the Kafka producer ACKs, to avoid blocking after every message.
-    promises?: Array<Promise<void>>
+    ackPromises?: Array<Promise<void>>
     // Only used in tests
     // TODO: update to test for side-effects of running the pipeline rather than
     // this return type.
@@ -135,9 +135,9 @@ export class EventPipelineRunner {
         return this.registerLastStep('createEventStep', [rawClickhouseEvent, person], [eventAck])
     }
 
-    registerLastStep(stepName: string, args: any[], promises?: Array<Promise<void>>): EventPipelineResult {
+    registerLastStep(stepName: string, args: any[], ackPromises?: Array<Promise<void>>): EventPipelineResult {
         pipelineLastStepCounter.labels(stepName).inc()
-        return { promises: promises, lastStep: stepName, args }
+        return { ackPromises, lastStep: stepName, args }
     }
 
     protected runStep<Step extends (...args: any[]) => any>(


### PR DESCRIPTION
…, make it required in produce calls## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We had some big footguns around `waitForAck`. I think we expected all callers of `queueMessage` and friends were waiting, because that's what it looked like, but we were actually passing `undefined` all the way down, and thus not waiting. 

## Changes

No functionality change. Cleanups and clarifications.

We can't just change `waitForAck` to true, it would likely kill pipeline performance, but this at least helps make clear what _is_ going on.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->
Yes.

## How did you test this code?

Existing / no functional change.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
