### PR TITLE
chore: Make a couple of errors non-retryable in bigquery

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -394,7 +394,7 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
                 initial_interval=dt.timedelta(seconds=10),
                 maximum_interval=dt.timedelta(seconds=60),
                 maximum_attempts=0,
-                non_retryable_error_types=["NotNullViolation", "IntegrityError"],
+                non_retryable_error_types=["NotNullViolation", "IntegrityError", "BadRequest"],
             ),
         )
 


### PR DESCRIPTION
## Problem

A couple of relatively common errors that shouldn't be retryable. In parallel to this PR, I'm working on documenting each common user error. In particular, I think we should wrap bigquery errors into our own exception classes, provide short but good error messages with the context of batch exports and have longer explanations in the docs for our own exception classes.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Added `BadRequest` and `InvalidFullyQualifiedIdError` as non-retryable.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
