### PR TITLE
chore(plugin-server): kafka ack cleanup and metric

### DIFF
--- a/plugin-server/functional_tests/api.ts
+++ b/plugin-server/functional_tests/api.ts
@@ -106,6 +106,7 @@ export const capture = async ({
             })
         ),
         key: teamId ? teamId.toString() : '',
+        waitForAck: true,
     })
 }
 

--- a/plugin-server/functional_tests/jobs-consumer.test.ts
+++ b/plugin-server/functional_tests/jobs-consumer.test.ts
@@ -43,7 +43,7 @@ describe('dlq handling', () => {
     test.concurrent(`handles empty messages`, async () => {
         const key = uuidv4()
 
-        await produce({ topic: 'jobs', message: null, key })
+        await produce({ topic: 'jobs', message: null, key, waitForAck: true })
 
         await waitForExpect(() => {
             const messages = dlq.filter((message) => message.key?.toString() === key)
@@ -54,7 +54,7 @@ describe('dlq handling', () => {
     test.concurrent(`handles invalid JSON`, async () => {
         const key = uuidv4()
 
-        await produce({ topic: 'jobs', message: Buffer.from('invalid json'), key })
+        await produce({ topic: 'jobs', message: Buffer.from('invalid json'), key, waitForAck: true })
 
         await waitForExpect(() => {
             const messages = dlq.filter((message) => message.key?.toString() === key)
@@ -72,7 +72,7 @@ describe('dlq handling', () => {
             labels: { topic: 'jobs', partition: '0', groupId: 'jobs-inserter' },
         })
 
-        await produce({ topic: 'jobs', message: Buffer.from(''), key: '' })
+        await produce({ topic: 'jobs', message: Buffer.from(''), key: '', waitForAck: true })
 
         await waitForExpect(async () => {
             const metricAfter = await getMetric({

--- a/plugin-server/functional_tests/kafka.ts
+++ b/plugin-server/functional_tests/kafka.ts
@@ -36,7 +36,17 @@ export async function createKafkaProducer() {
     return producer
 }
 
-export async function produce({ topic, message, key }: { topic: string; message: Buffer | null; key: string }) {
+export async function produce({
+    topic,
+    message,
+    key,
+    waitForAck,
+}: {
+    topic: string
+    message: Buffer | null
+    key: string
+    waitForAck: boolean
+}) {
     producer = producer ?? (await createKafkaProducer())
-    await defaultProduce({ producer, topic, value: message, key: Buffer.from(key) })
+    await defaultProduce({ producer, topic, value: message, key: Buffer.from(key), waitForAck })
 }

--- a/plugin-server/functional_tests/scheduled-tasks-runner.test.ts
+++ b/plugin-server/functional_tests/scheduled-tasks-runner.test.ts
@@ -43,7 +43,7 @@ describe('dlq handling', () => {
     test.concurrent(`handles empty messages`, async () => {
         const key = uuidv4()
 
-        await produce({ topic: 'scheduled_tasks', message: null, key })
+        await produce({ topic: 'scheduled_tasks', message: null, key, waitForAck: true })
 
         await waitForExpect(() => {
             const messages = dlq.filter((message) => message.key?.toString() === key)
@@ -54,7 +54,7 @@ describe('dlq handling', () => {
     test.concurrent(`handles invalid JSON`, async () => {
         const key = uuidv4()
 
-        await produce({ topic: 'scheduled_tasks', message: Buffer.from('invalid json'), key })
+        await produce({ topic: 'scheduled_tasks', message: Buffer.from('invalid json'), key, waitForAck: true })
 
         await waitForExpect(() => {
             const messages = dlq.filter((message) => message.key?.toString() === key)
@@ -69,6 +69,7 @@ describe('dlq handling', () => {
             topic: 'scheduled_tasks',
             message: Buffer.from(JSON.stringify({ taskType: 'invalidTaskType', pluginConfigId: 1 })),
             key,
+            waitForAck: true,
         })
 
         await waitForExpect(() => {
@@ -84,6 +85,7 @@ describe('dlq handling', () => {
             topic: 'scheduled_tasks',
             message: Buffer.from(JSON.stringify({ taskType: 'runEveryMinute', pluginConfigId: 'asdf' })),
             key,
+            waitForAck: true,
         })
 
         await waitForExpect(() => {
@@ -104,7 +106,7 @@ describe('dlq handling', () => {
 
         // NOTE: we don't actually care too much about the contents of the
         // message, just that it triggeres the consumer to try to process it.
-        await produce({ topic: 'scheduled_tasks', message: Buffer.from(''), key: '' })
+        await produce({ topic: 'scheduled_tasks', message: Buffer.from(''), key: '', waitForAck: true })
 
         await waitForExpect(async () => {
             const metricAfter = await getMetric({

--- a/plugin-server/functional_tests/session-recordings.test.ts
+++ b/plugin-server/functional_tests/session-recordings.test.ts
@@ -173,7 +173,12 @@ test.skip('consumer updates timestamp exported to prometheus', async () => {
         },
     })
 
-    await produce({ topic: KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS, message: Buffer.from(''), key: '' })
+    await produce({
+        topic: KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS,
+        message: Buffer.from(''),
+        key: '',
+        waitForAck: true,
+    })
 
     await waitForExpect(async () => {
         const metricAfter = await getMetric({
@@ -245,6 +250,7 @@ test.skip(`handles message with no token or with token and no associated team_id
         topic: KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS,
         message: Buffer.from(JSON.stringify({ uuid: noTokenUuid, data: JSON.stringify({}) })),
         key: noTokenKey,
+        waitForAck: true,
     })
     await produce({
         topic: KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS,
@@ -252,6 +258,7 @@ test.skip(`handles message with no token or with token and no associated team_id
             JSON.stringify({ uuid: noAssociatedTeamUuid, token: 'no associated team', data: JSON.stringify({}) })
         ),
         key: noAssociatedTeamKey,
+        waitForAck: true,
     })
 
     await capture(makeSessionMessage(teamId, 'should be ingested'))

--- a/plugin-server/src/kafka/producer.ts
+++ b/plugin-server/src/kafka/producer.ts
@@ -71,14 +71,14 @@ export const produce = async ({
     value,
     key,
     headers = [],
-    waitForAck = true,
+    waitForAck,
 }: {
     producer: RdKafkaProducer
     topic: string
     value: MessageValue
     key: MessageKey
     headers?: MessageHeader[]
-    waitForAck?: boolean
+    waitForAck: boolean
 }): Promise<number | null | undefined> => {
     status.debug('📤', 'Producing message', { topic: topic })
     const produceSpan = getSpan()?.startChild({ op: 'kafka_produce' })

--- a/plugin-server/src/main/graphile-worker/schedule.ts
+++ b/plugin-server/src/main/graphile-worker/schedule.ts
@@ -56,8 +56,11 @@ export async function runScheduledTasks(
         for (const pluginConfigId of server.pluginSchedule?.[taskType] || []) {
             status.info('⏲️', 'queueing_schedule_task', { taskType, pluginConfigId })
             await server.kafkaProducer.queueMessage({
-                topic: KAFKA_SCHEDULED_TASKS,
-                messages: [{ key: pluginConfigId.toString(), value: JSON.stringify({ taskType, pluginConfigId }) }],
+                kafkaMessage: {
+                    topic: KAFKA_SCHEDULED_TASKS,
+                    messages: [{ key: pluginConfigId.toString(), value: JSON.stringify({ taskType, pluginConfigId }) }],
+                },
+                waitForAck: true,
             })
             graphileScheduledTaskCounter.labels({ status: 'queued', task: taskType }).inc()
         }

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -41,7 +41,7 @@ type IngestionSplitBatch = {
 type IngestResult = {
     // Promises that the batch handler should await on before committing offsets,
     // contains the Kafka producer ACKs, to avoid blocking after every message.
-    promises?: Array<Promise<void>>
+    ackPromises?: Array<Promise<void>>
 }
 
 async function handleProcessingError(
@@ -166,7 +166,7 @@ export async function eachBatchParallelIngestion(
                             return await runner.runEventPipeline(pluginEvent)
                         })) as IngestResult
 
-                        result.promises?.forEach((promise) =>
+                        result.ackPromises?.forEach((promise) =>
                             processingPromises.push(
                                 promise.catch(async (error) => {
                                     await handleProcessingError(error, message, pluginEvent, queue)

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -15,6 +15,7 @@ import { eventDroppedCounter, latestOffsetTimestampGauge } from '../metrics'
 import {
     ingestEventBatchingBatchCountSummary,
     ingestEventBatchingInputLengthSummary,
+    ingestEventEachBatchKafkaAckWait,
     ingestionOverflowingMessagesTotal,
     ingestionParallelism,
     ingestionParallelismPotential,
@@ -227,7 +228,9 @@ export async function eachBatchParallelIngestion(
         // impact the success. Delaying ACKs allows the producer to write in big batches for
         // better throughput and lower broker load.
         const awaitSpan = transaction.startChild({ op: 'awaitACKs', data: { promiseCount: processingPromises.length } })
+        const kafkaAckWaitMetric = ingestEventEachBatchKafkaAckWait.startTimer()
         await Promise.all(processingPromises)
+        kafkaAckWaitMetric()
         awaitSpan.finish()
 
         for (const message of messages) {

--- a/plugin-server/src/main/ingestion-queues/batch-processing/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/metrics.ts
@@ -41,3 +41,9 @@ export const ingestEventBatchingBatchCountSummary = new Summary({
     help: 'Number of batches of events',
     percentiles: [0.5, 0.9, 0.95, 0.99],
 })
+
+export const ingestEventEachBatchKafkaAckWait = new Summary({
+    name: 'ingest_event_each_batch_kafka_ack_wait',
+    help: 'Wait time for the batch of Kafka ACKs at the end of eachBatchParallelIngestion',
+    percentiles: [0.5, 0.9, 0.95, 0.99],
+})

--- a/plugin-server/src/main/ingestion-queues/jobs-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/jobs-consumer.ts
@@ -54,8 +54,11 @@ export const startJobsConsumer = async ({
                 })
                 // TODO: handle resolving offsets asynchronously
                 await producer.queueMessage({
-                    topic: KAFKA_JOBS_DLQ,
-                    messages: [{ value: message.value, key: message.key }],
+                    kafkaMessage: {
+                        topic: KAFKA_JOBS_DLQ,
+                        messages: [{ value: message.value, key: message.key }],
+                    },
+                    waitForAck: true,
                 })
                 resolveOffset(message.offset)
                 continue
@@ -71,8 +74,11 @@ export const startJobsConsumer = async ({
                 })
                 // TODO: handle resolving offsets asynchronously
                 await producer.queueMessage({
-                    topic: KAFKA_JOBS_DLQ,
-                    messages: [{ value: message.value, key: message.key }],
+                    kafkaMessage: {
+                        topic: KAFKA_JOBS_DLQ,
+                        messages: [{ value: message.value, key: message.key }],
+                    },
+                    waitForAck: true,
                 })
                 resolveOffset(message.offset)
                 continue

--- a/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/scheduled-tasks-consumer.ts
@@ -163,8 +163,11 @@ const getTasksFromBatch = async (batch: Batch, producer: KafkaProducerWrapper) =
                 value: message.value,
             })
             await producer.queueMessage({
-                topic: KAFKA_SCHEDULED_TASKS_DLQ,
-                messages: [{ value: message.value, key: message.key }],
+                kafkaMessage: {
+                    topic: KAFKA_SCHEDULED_TASKS_DLQ,
+                    messages: [{ value: message.value, key: message.key }],
+                },
+                waitForAck: true,
             })
             continue
         }
@@ -181,8 +184,11 @@ const getTasksFromBatch = async (batch: Batch, producer: KafkaProducerWrapper) =
                 error: error.stack ?? error,
             })
             await producer.queueMessage({
-                topic: KAFKA_SCHEDULED_TASKS_DLQ,
-                messages: [{ value: message.value, key: message.key }],
+                kafkaMessage: {
+                    topic: KAFKA_SCHEDULED_TASKS_DLQ,
+                    messages: [{ value: message.value, key: message.key }],
+                },
+                waitForAck: true,
             })
             continue
         }
@@ -190,8 +196,11 @@ const getTasksFromBatch = async (batch: Batch, producer: KafkaProducerWrapper) =
         if (!taskTypes.includes(task.taskType) || isNaN(task.pluginConfigId)) {
             status.warn('⚠️', `Invalid schema for partition ${batch.partition} offset ${message.offset}.`, task)
             await producer.queueMessage({
-                topic: KAFKA_SCHEDULED_TASKS_DLQ,
-                messages: [{ value: message.value, key: message.key }],
+                kafkaMessage: {
+                    topic: KAFKA_SCHEDULED_TASKS_DLQ,
+                    messages: [{ value: message.value, key: message.key }],
+                },
+                waitForAck: true,
             })
             continue
         }

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
@@ -163,6 +163,7 @@ export class ConsoleLogsIngester {
                     topic: KAFKA_LOG_ENTRIES,
                     value: Buffer.from(JSON.stringify(cle)),
                     key: event.session_id,
+                    waitForAck: true,
                 })
             )
         } catch (error) {

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
@@ -171,6 +171,7 @@ export class ReplayEventsIngester {
                     topic: KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS,
                     value: Buffer.from(JSON.stringify(replayRecord)),
                     key: event.session_id,
+                    waitForAck: true,
                 }),
             ]
         } catch (error) {

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -159,13 +159,16 @@ export async function createHub(
         // chained, and if we do not manage to produce then the chain will be
         // broken.
         await kafkaProducer.queueMessage({
-            topic: KAFKA_JOBS,
-            messages: [
-                {
-                    value: Buffer.from(JSON.stringify(job)),
-                    key: Buffer.from(job.pluginConfigTeam.toString()),
-                },
-            ],
+            kafkaMessage: {
+                topic: KAFKA_JOBS,
+                messages: [
+                    {
+                        value: Buffer.from(JSON.stringify(job)),
+                        key: Buffer.from(job.pluginConfigTeam.toString()),
+                    },
+                ],
+            },
+            waitForAck: true,
         })
     }
 

--- a/plugin-server/src/worker/ingestion/app-metrics.ts
+++ b/plugin-server/src/worker/ingestion/app-metrics.ts
@@ -183,8 +183,11 @@ export class AppMetrics {
         }))
 
         await this.kafkaProducer.queueMessage({
-            topic: KAFKA_APP_METRICS,
-            messages: kafkaMessages,
+            kafkaMessage: {
+                topic: KAFKA_APP_METRICS,
+                messages: kafkaMessages,
+            },
+            waitForAck: true,
         })
         status.debug('🚽', `Finished flushing app metrics, took ${Date.now() - startTime}ms`)
     }

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -25,7 +25,7 @@ import { processPersonsStep } from './processPersonsStep'
 export type EventPipelineResult = {
     // Promises that the batch handler should await on before committing offsets,
     // contains the Kafka producer ACKs, to avoid blocking after every message.
-    promises?: Array<Promise<void>>
+    ackPromises?: Array<Promise<void>>
     // Only used in tests
     // TODO: update to test for side-effects of running the pipeline rather than
     // this return type.
@@ -135,9 +135,9 @@ export class EventPipelineRunner {
         return this.registerLastStep('createEventStep', [rawClickhouseEvent, person], [eventAck])
     }
 
-    registerLastStep(stepName: string, args: any[], promises?: Array<Promise<void>>): EventPipelineResult {
+    registerLastStep(stepName: string, args: any[], ackPromises?: Array<Promise<void>>): EventPipelineResult {
         pipelineLastStepCounter.labels(stepName).inc()
-        return { promises: promises, lastStep: stepName, args }
+        return { ackPromises, lastStep: stepName, args }
     }
 
     protected runStep<Step extends (...args: any[]) => any>(

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -213,7 +213,7 @@ export class EventPipelineRunner {
                     teamId,
                     `plugin_server_ingest_event:${currentStepName}`
                 )
-                await this.hub.db.kafkaProducer!.queueMessage(message)
+                await this.hub.db.kafkaProducer!.queueMessage({ kafkaMessage: message, waitForAck: true })
             } catch (dlqError) {
                 status.info('🔔', `Errored trying to add event to dead letter queue. Error: ${dlqError}`)
                 Sentry.captureException(dlqError, {

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -453,7 +453,7 @@ export class PersonState {
             olderCreatedAt, // Keep the oldest created_at (i.e. the first time we've seen either person)
             properties
         )
-        await this.db.kafkaProducer.queueMessages(kafkaMessages)
+        await this.db.kafkaProducer.queueMessages({ kafkaMessages, waitForAck: true })
         return mergedPerson
     }
 
@@ -767,7 +767,7 @@ export class DeferredPersonOverrideWorker {
                 // Postgres for some reason -- the same row state should be
                 // generated each call, and the receiving ReplacingMergeTree will
                 // ensure we keep only the latest version after all writes settle.)
-                await this.kafkaProducer.queueMessages(messages, true)
+                await this.kafkaProducer.queueMessages({ kafkaMessages: messages, waitForAck: true })
 
                 return rows.length
             }

--- a/plugin-server/src/worker/ingestion/utils.ts
+++ b/plugin-server/src/worker/ingestion/utils.ts
@@ -80,18 +80,21 @@ export async function captureIngestionWarning(
     const limiter_key = `${teamId}:${type}:${debounce?.key || ''}`
     if (!!debounce?.alwaysSend || IngestionWarningLimiter.consume(limiter_key, 1)) {
         await kafkaProducer.queueMessage({
-            topic: KAFKA_INGESTION_WARNINGS,
-            messages: [
-                {
-                    value: JSON.stringify({
-                        team_id: teamId,
-                        type: type,
-                        source: 'plugin-server',
-                        details: JSON.stringify(details),
-                        timestamp: castTimestampOrNow(null, TimestampFormat.ClickHouse),
-                    }),
-                },
-            ],
+            kafkaMessage: {
+                topic: KAFKA_INGESTION_WARNINGS,
+                messages: [
+                    {
+                        value: JSON.stringify({
+                            team_id: teamId,
+                            type: type,
+                            source: 'plugin-server',
+                            details: JSON.stringify(details),
+                            timestamp: castTimestampOrNow(null, TimestampFormat.ClickHouse),
+                        }),
+                    },
+                ],
+            },
+            waitForAck: true,
         })
     } else {
         return Promise.resolve()

--- a/plugin-server/src/worker/vm/extensions/posthog.ts
+++ b/plugin-server/src/worker/vm/extensions/posthog.ts
@@ -29,22 +29,25 @@ async function queueEvent(hub: Hub, pluginConfig: PluginConfig, data: InternalDa
     const partitionKey = partitionKeyHash.digest('hex')
 
     await hub.kafkaProducer.queueMessage({
-        topic: hub.KAFKA_CONSUMPTION_TOPIC!,
-        messages: [
-            {
-                key: partitionKey,
-                value: JSON.stringify({
-                    distinct_id: data.distinct_id,
-                    ip: '',
-                    site_url: '',
-                    data: JSON.stringify(data),
-                    team_id: pluginConfig.team_id,
-                    now: data.timestamp,
-                    sent_at: data.timestamp,
-                    uuid: data.uuid,
-                } as RawEventMessage),
-            },
-        ],
+        kafkaMessage: {
+            topic: hub.KAFKA_CONSUMPTION_TOPIC!,
+            messages: [
+                {
+                    key: partitionKey,
+                    value: JSON.stringify({
+                        distinct_id: data.distinct_id,
+                        ip: '',
+                        site_url: '',
+                        data: JSON.stringify(data),
+                        team_id: pluginConfig.team_id,
+                        now: data.timestamp,
+                        sent_at: data.timestamp,
+                        uuid: data.uuid,
+                    } as RawEventMessage),
+                },
+            ],
+        },
+        waitForAck: true,
     })
 }
 

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -367,9 +367,10 @@ describe('DB', () => {
             expect(updatedPerson.properties).toEqual({ c: 'aaa' })
 
             // verify correct Kafka message was sent
-            expect(db.kafkaProducer!.queueMessage).toHaveBeenLastCalledWith(
-                generateKafkaPersonUpdateMessage(updatedPerson)
-            )
+            expect(db.kafkaProducer!.queueMessage).toHaveBeenLastCalledWith({
+                kafkaMessage: generateKafkaPersonUpdateMessage(updatedPerson),
+                waitForAck: true,
+            })
         })
     })
 
@@ -416,7 +417,7 @@ describe('DB', () => {
                 await delayUntilEventIngested(fetchPersonsRows, 2)
 
                 const kafkaMessages = await db.deletePerson(person)
-                await db.kafkaProducer.queueMessages(kafkaMessages)
+                await db.kafkaProducer.queueMessages({ kafkaMessages, waitForAck: true })
                 await db.kafkaProducer.flush()
 
                 const persons = await delayUntilEventIngested(fetchPersonsRows, 3)

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-overflow-consumer.test.ts
@@ -97,20 +97,23 @@ describe('eachBatchParallelIngestion with overflow consume', () => {
             expect(queue.pluginsServer.teamManager.getTeamForEvent).toHaveBeenCalledTimes(1)
             expect(consume).toHaveBeenCalledWith('1:ingestion_capacity_overflow:id', 1)
             expect(mockQueueMessage).toHaveBeenCalledWith({
-                topic: 'clickhouse_ingestion_warnings_test',
-                messages: [
-                    {
-                        value: JSON.stringify({
-                            team_id: 1,
-                            type: 'ingestion_capacity_overflow',
-                            source: 'plugin-server',
-                            details: JSON.stringify({
-                                overflowDistinctId: 'id',
+                kafkaMessage: {
+                    topic: 'clickhouse_ingestion_warnings_test',
+                    messages: [
+                        {
+                            value: JSON.stringify({
+                                team_id: 1,
+                                type: 'ingestion_capacity_overflow',
+                                source: 'plugin-server',
+                                details: JSON.stringify({
+                                    overflowDistinctId: 'id',
+                                }),
+                                timestamp: castTimestampOrNow(null, TimestampFormat.ClickHouse),
                             }),
-                            timestamp: castTimestampOrNow(null, TimestampFormat.ClickHouse),
-                        }),
-                    },
-                ],
+                        },
+                    ],
+                },
+                waitForAck: true,
             })
 
             // Event is processed

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -408,7 +408,7 @@ describe('eachBatchX', () => {
             const batch = createBatch(captureEndpointEvent)
             runEventPipeline.mockImplementationOnce(() =>
                 Promise.resolve({
-                    promises: [Promise.resolve(), Promise.reject('deferred nopes out')],
+                    ackPromises: [Promise.resolve(), Promise.reject('deferred nopes out')],
                 })
             )
             const tokenBlockList = buildStringMatcher('another_token,more_token', false)

--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/console-log-ingester.test.ts
@@ -80,6 +80,7 @@ describe('console log ingester', () => {
                                 timestamp: '1970-01-01 00:00:00.000',
                             })
                         ),
+                        waitForAck: true,
                     },
                 ],
             ])
@@ -124,6 +125,7 @@ describe('console log ingester', () => {
                                 timestamp: '1970-01-01 00:00:00.000',
                             })
                         ),
+                        waitForAck: true,
                     },
                 ],
                 [
@@ -142,6 +144,7 @@ describe('console log ingester', () => {
                                 timestamp: '1970-01-01 00:00:00.000',
                             })
                         ),
+                        waitForAck: true,
                     },
                 ],
             ])
@@ -181,6 +184,7 @@ describe('console log ingester', () => {
                                 timestamp: '1970-01-01 00:00:00.000',
                             })
                         ),
+                        waitForAck: true,
                     },
                 ],
             ])

--- a/plugin-server/tests/main/jobs/schedule.test.ts
+++ b/plugin-server/tests/main/jobs/schedule.test.ts
@@ -37,120 +37,147 @@ describe('Graphile Worker schedule', () => {
         } as any)
 
         expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(1, {
-            topic: KAFKA_SCHEDULED_TASKS,
-            messages: [
-                {
-                    key: '1',
-                    value: JSON.stringify({
-                        taskType: 'runEveryMinute',
-                        pluginConfigId: 1,
-                    }),
-                },
-            ],
+            kafkaMessage: {
+                topic: KAFKA_SCHEDULED_TASKS,
+                messages: [
+                    {
+                        key: '1',
+                        value: JSON.stringify({
+                            taskType: 'runEveryMinute',
+                            pluginConfigId: 1,
+                        }),
+                    },
+                ],
+            },
+            waitForAck: true,
         })
         expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(2, {
-            topic: KAFKA_SCHEDULED_TASKS,
-            messages: [
-                {
-                    key: '2',
-                    value: JSON.stringify({
-                        taskType: 'runEveryMinute',
-                        pluginConfigId: 2,
-                    }),
-                },
-            ],
+            kafkaMessage: {
+                topic: KAFKA_SCHEDULED_TASKS,
+                messages: [
+                    {
+                        key: '2',
+                        value: JSON.stringify({
+                            taskType: 'runEveryMinute',
+                            pluginConfigId: 2,
+                        }),
+                    },
+                ],
+            },
+            waitForAck: true,
         })
         expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(3, {
-            topic: KAFKA_SCHEDULED_TASKS,
-            messages: [
-                {
-                    key: '3',
-                    value: JSON.stringify({
-                        taskType: 'runEveryMinute',
-                        pluginConfigId: 3,
-                    }),
-                },
-            ],
+            kafkaMessage: {
+                topic: KAFKA_SCHEDULED_TASKS,
+                messages: [
+                    {
+                        key: '3',
+                        value: JSON.stringify({
+                            taskType: 'runEveryMinute',
+                            pluginConfigId: 3,
+                        }),
+                    },
+                ],
+            },
+            waitForAck: true,
         })
 
         await runScheduledTasks(mockHubWithPluginSchedule, mockPiscina as any, 'runEveryHour', {
             job: { run_at: new Date() },
         } as any)
         expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(4, {
-            topic: KAFKA_SCHEDULED_TASKS,
-            messages: [
-                {
-                    key: '4',
-                    value: JSON.stringify({
-                        taskType: 'runEveryHour',
-                        pluginConfigId: 4,
-                    }),
-                },
-            ],
+            kafkaMessage: {
+                topic: KAFKA_SCHEDULED_TASKS,
+                messages: [
+                    {
+                        key: '4',
+                        value: JSON.stringify({
+                            taskType: 'runEveryHour',
+                            pluginConfigId: 4,
+                        }),
+                    },
+                ],
+            },
+            waitForAck: true,
         })
         expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(5, {
-            topic: KAFKA_SCHEDULED_TASKS,
-            messages: [
-                {
-                    key: '5',
-                    value: JSON.stringify({
-                        taskType: 'runEveryHour',
-                        pluginConfigId: 5,
-                    }),
-                },
-            ],
+            kafkaMessage: {
+                topic: KAFKA_SCHEDULED_TASKS,
+                messages: [
+                    {
+                        key: '5',
+                        value: JSON.stringify({
+                            taskType: 'runEveryHour',
+                            pluginConfigId: 5,
+                        }),
+                    },
+                ],
+            },
+            waitForAck: true,
         })
         expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(6, {
-            topic: KAFKA_SCHEDULED_TASKS,
-            messages: [
-                {
-                    key: '6',
-                    value: JSON.stringify({
-                        taskType: 'runEveryHour',
-                        pluginConfigId: 6,
-                    }),
-                },
-            ],
+            kafkaMessage: {
+                topic: KAFKA_SCHEDULED_TASKS,
+                messages: [
+                    {
+                        key: '6',
+                        value: JSON.stringify({
+                            taskType: 'runEveryHour',
+                            pluginConfigId: 6,
+                        }),
+                    },
+                ],
+            },
+            waitForAck: true,
         })
 
         await runScheduledTasks(mockHubWithPluginSchedule, mockPiscina as any, 'runEveryDay', {
             job: { run_at: new Date() },
         } as any)
         expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(7, {
-            topic: KAFKA_SCHEDULED_TASKS,
-            messages: [
-                {
-                    key: '7',
-                    value: JSON.stringify({
-                        taskType: 'runEveryDay',
-                        pluginConfigId: 7,
-                    }),
-                },
-            ],
+            kafkaMessage: {
+                topic: KAFKA_SCHEDULED_TASKS,
+                messages: [
+                    {
+                        key: '7',
+                        value: JSON.stringify({
+                            taskType: 'runEveryDay',
+                            pluginConfigId: 7,
+                        }),
+                    },
+                ],
+            },
+            waitForAck: true,
         })
         expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(8, {
-            topic: KAFKA_SCHEDULED_TASKS,
-            messages: [
-                {
-                    key: '8',
-                    value: JSON.stringify({
-                        taskType: 'runEveryDay',
-                        pluginConfigId: 8,
-                    }),
-                },
-            ],
+            kafkaMessage: {
+                topic: KAFKA_SCHEDULED_TASKS,
+                messages: [
+                    {
+                        key: '8',
+                        value: JSON.stringify({
+                            taskType: 'runEveryDay',
+                            pluginConfigId: 8,
+                        }),
+                    },
+                ],
+            },
+            waitForAck: true,
         })
         expect(mockHubWithPluginSchedule.kafkaProducer.queueMessage).toHaveBeenNthCalledWith(9, {
-            topic: KAFKA_SCHEDULED_TASKS,
-            messages: [
-                {
-                    key: '9',
-                    value: JSON.stringify({
-                        taskType: 'runEveryDay',
-                        pluginConfigId: 9,
-                    }),
-                },
-            ],
+            kafkaMessage: {
+                topic: KAFKA_SCHEDULED_TASKS,
+                messages: [
+                    {
+                        key: '9',
+                        value: JSON.stringify({
+                            taskType: 'runEveryDay',
+                            pluginConfigId: 9,
+                        }),
+                    },
+                ],
+            },
+            waitForAck: true,
         })
     })
 })

--- a/plugin-server/tests/worker/console.test.ts
+++ b/plugin-server/tests/worker/console.test.ts
@@ -42,10 +42,10 @@ describe('console extension', () => {
                     await (console[typeMethod](...args) as unknown as Promise<void>)
 
                     expect(queueSingleJsonMessageSpy).toHaveBeenCalledTimes(1)
-                    expect(queueSingleJsonMessageSpy).toHaveBeenCalledWith(
-                        KAFKA_PLUGIN_LOG_ENTRIES,
-                        expect.any(String),
-                        {
+                    expect(queueSingleJsonMessageSpy).toHaveBeenCalledWith({
+                        topic: KAFKA_PLUGIN_LOG_ENTRIES,
+                        key: expect.any(String),
+                        object: {
                             source: PluginLogEntrySource.Console,
                             type,
                             id: expect.any(String),
@@ -56,8 +56,8 @@ describe('console extension', () => {
                             message: expectedFinalMessage,
                             instance_id: hub.instanceId.toString(),
                         },
-                        false
-                    )
+                        waitForAck: false,
+                    })
                 })
             })
         })

--- a/plugin-server/tests/worker/ingestion/__snapshots__/app-metrics.test.ts.snap
+++ b/plugin-server/tests/worker/ingestion/__snapshots__/app-metrics.test.ts.snap
@@ -4,12 +4,15 @@ exports[`AppMetrics() flush() flushes queued messages 1`] = `
 Array [
   Array [
     Object {
-      "messages": Array [
-        Object {
-          "value": "{\\"timestamp\\":\\"1970-01-01 00:16:40.000\\",\\"team_id\\":2,\\"plugin_config_id\\":2,\\"job_id\\":\\"000-000\\",\\"category\\":\\"processEvent\\",\\"successes\\":1,\\"successes_on_retry\\":0,\\"failures\\":0}",
-        },
-      ],
-      "topic": "clickhouse_app_metrics_test",
+      "kafkaMessage": Object {
+        "messages": Array [
+          Object {
+            "value": "{\\"timestamp\\":\\"1970-01-01 00:16:40.000\\",\\"team_id\\":2,\\"plugin_config_id\\":2,\\"job_id\\":\\"000-000\\",\\"category\\":\\"processEvent\\",\\"successes\\":1,\\"successes_on_retry\\":0,\\"failures\\":0}",
+          },
+        ],
+        "topic": "clickhouse_app_metrics_test",
+      },
+      "waitForAck": true,
     },
   ],
 ]

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -219,7 +219,9 @@ describe('EventPipelineRunner', () => {
                 await runner.runEventPipeline(pipelineEvent)
 
                 expect(hub.db.kafkaProducer.queueMessage).toHaveBeenCalledTimes(1)
-                expect(JSON.parse(hub.db.kafkaProducer.queueMessage.mock.calls[0][0].messages[0].value)).toMatchObject({
+                expect(
+                    JSON.parse(hub.db.kafkaProducer.queueMessage.mock.calls[0][0].kafkaMessage.messages[0].value)
+                ).toMatchObject({
                     team_id: 2,
                     distinct_id: 'my_id',
                     error: 'Event ingestion failed. Error: testError',

--- a/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
+++ b/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
@@ -339,7 +339,7 @@ describe('postgres parity', () => {
         // move distinct ids from person to to anotherPerson
 
         const kafkaMessages = await hub.db.moveDistinctIds(person, anotherPerson)
-        await hub.db!.kafkaProducer!.queueMessages(kafkaMessages)
+        await hub.db!.kafkaProducer!.queueMessages({ kafkaMessages, waitForAck: true })
         await delayUntilEventIngested(() => hub.db.fetchDistinctIdValues(anotherPerson, Database.ClickHouse), 2)
 
         // it got added
@@ -395,7 +395,7 @@ describe('postgres parity', () => {
         // delete person
         await hub.db.postgres.transaction(PostgresUse.COMMON_WRITE, '', async (client) => {
             const deletePersonMessage = await hub.db.deletePerson(person, client)
-            await hub.db!.kafkaProducer!.queueMessage(deletePersonMessage[0])
+            await hub.db!.kafkaProducer!.queueMessage({ kafkaMessage: deletePersonMessage[0], waitForAck: true })
         })
 
         await delayUntilEventIngested(async () =>

--- a/plugin-server/tests/worker/vm.test.ts
+++ b/plugin-server/tests/worker/vm.test.ts
@@ -689,10 +689,10 @@ describe('vm tests', () => {
         await vm.methods.processEvent!(event)
 
         expect(queueSingleJsonMessageSpy).toHaveBeenCalledTimes(1)
-        expect(queueSingleJsonMessageSpy).toHaveBeenCalledWith(
-            KAFKA_PLUGIN_LOG_ENTRIES,
-            expect.any(String),
-            {
+        expect(queueSingleJsonMessageSpy).toHaveBeenCalledWith({
+            topic: KAFKA_PLUGIN_LOG_ENTRIES,
+            key: expect.any(String),
+            object: {
                 id: expect.any(String),
                 instance_id: hub.instanceId.toString(),
                 message: 'logged event',
@@ -703,8 +703,8 @@ describe('vm tests', () => {
                 timestamp: expect.any(String),
                 type: PluginLogEntryType.Log,
             },
-            false
-        )
+            waitForAck: false,
+        })
     })
 
     test('fetch', async () => {
@@ -969,8 +969,8 @@ describe('vm tests', () => {
 
         expect(response).toBe('haha')
         expect(queueMessageSpy).toHaveBeenCalledTimes(1)
-        expect(queueMessageSpy.mock.calls[0][0].topic).toEqual(KAFKA_EVENTS_PLUGIN_INGESTION)
-        const parsedMessage = JSON.parse(queueMessageSpy.mock.calls[0][0].messages[0].value!.toString())
+        expect(queueMessageSpy.mock.calls[0][0].kafkaMessage.topic).toEqual(KAFKA_EVENTS_PLUGIN_INGESTION)
+        const parsedMessage = JSON.parse(queueMessageSpy.mock.calls[0][0].kafkaMessage.messages[0].value!.toString())
         expect(JSON.parse(parsedMessage.data)).toMatchObject({
             distinct_id: 'plugin-id-60',
             event: 'my-new-event',
@@ -998,8 +998,8 @@ describe('vm tests', () => {
 
         expect(response).toBe('haha')
         expect(queueMessageSpy).toHaveBeenCalledTimes(1)
-        expect(queueMessageSpy.mock.calls[0][0].topic).toEqual(KAFKA_EVENTS_PLUGIN_INGESTION)
-        const parsedMessage = JSON.parse(queueMessageSpy.mock.calls[0][0].messages[0].value!.toString())
+        expect(queueMessageSpy.mock.calls[0][0].kafkaMessage.topic).toEqual(KAFKA_EVENTS_PLUGIN_INGESTION)
+        const parsedMessage = JSON.parse(queueMessageSpy.mock.calls[0][0].kafkaMessage.messages[0].value!.toString())
         expect(JSON.parse(parsedMessage.data)).toMatchObject({
             timestamp: '2020-02-23T02:15:00Z', // taken out of the properties
             distinct_id: 'plugin-id-60',
@@ -1025,8 +1025,8 @@ describe('vm tests', () => {
         expect(response).toBe('haha')
         expect(response).toBe('haha')
         expect(queueMessageSpy).toHaveBeenCalledTimes(1)
-        expect(queueMessageSpy.mock.calls[0][0].topic).toEqual(KAFKA_EVENTS_PLUGIN_INGESTION)
-        const parsedMessage = JSON.parse(queueMessageSpy.mock.calls[0][0].messages[0].value!.toString())
+        expect(queueMessageSpy.mock.calls[0][0].kafkaMessage.topic).toEqual(KAFKA_EVENTS_PLUGIN_INGESTION)
+        const parsedMessage = JSON.parse(queueMessageSpy.mock.calls[0][0].kafkaMessage.messages[0].value!.toString())
         expect(JSON.parse(parsedMessage.data)).toMatchObject({
             distinct_id: 'custom id',
             event: 'my-new-event',


### PR DESCRIPTION
## Problem

We want some observability around how long we're waiting on Kafka produces (where we await the ACKs, which is the vast majority of them).

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add some metrics.

Additionally did some cleanup and made `waitForAck` a required argument so that it's abundantly clear at the callsite. I considered just making it always await, but we do have 1 use for `waitForAcks: false` (plugin logs) and I think we want to make some other places (ingestion warnings, maybe even console logs?) _not_ await in the future.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes.

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
Existing tests updated, no functional change.