### PR TITLE
feat(hogql): Add modifiers to query tags

### DIFF
--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -148,6 +148,7 @@ def execute_hogql_query(
             has_joins="JOIN" in clickhouse_sql,
             has_json_operations="JSONExtract" in clickhouse_sql or "JSONHas" in clickhouse_sql,
             timings=timings_dict,
+            modifiers={k: v for k, v in modifiers.model_dump().items() if v is not None} if modifiers else {},
         )
 
         error = None


### PR DESCRIPTION
## Problem

We're going to want to test some additional variations of v3 overrides (#21059) with various modifiers, as well as comparing the performance of v3 against other PoE and non-PoE variations of similar queries. Having these values logged to the query log will make it easier to look at performance impacts over a larger sample than just single spot-checked queries.

## Changes

Adds modifiers to query tags so that they are avaiable in the `system.query_log.log_comment` field.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

These paths are already generally covered.

I don't think this is important enough to really need a test, but I did verify manually that it works:

```
ted@revuelto posthog % docker-compose -f docker-compose.dev.yml exec -it clickhouse clickhouse-client -q "select JSONExtractRaw(log_comment, 'modifiers') as modifiers from system.query_log where not empty(modifiers) order by event_time desc limit 10"
{"materializationMode":"auto"}
{"materializationMode":"disabled"}
{"materializationMode":"legacy_null_as_null"}
{"materializationMode":"legacy_null_as_null"}
{"materializationMode":"legacy_null_as_null"}
{"materializationMode":"legacy_null_as_null"}
{"materializationMode":"auto"}
{"materializationMode":"legacy_null_as_string"}
{"materializationMode":"legacy_null_as_string"}
{"materializationMode":"disabled"}
```