### PR TITLE
fix: Update `PersonDistinctIdOverridesTable` to be consistent with updated `LazyTable` interface

### DIFF
--- a/posthog/hogql/database/schema/person_distinct_id_overrides.py
+++ b/posthog/hogql/database/schema/person_distinct_id_overrides.py
@@ -14,7 +14,6 @@ from posthog.hogql.database.models import (
 )
 from posthog.hogql.database.schema.persons import join_with_persons_table
 from posthog.hogql.errors import HogQLException
-from posthog.schema import HogQLQueryModifiers
 
 PERSON_DISTINCT_ID_OVERRIDES_FIELDS = {
     "team_id": IntegerDatabaseField(name="team_id"),
@@ -82,7 +81,7 @@ class RawPersonDistinctIdOverridesTable(Table):
 class PersonDistinctIdOverridesTable(LazyTable):
     fields: Dict[str, FieldOrTable] = PERSON_DISTINCT_ID_OVERRIDES_FIELDS
 
-    def lazy_select(self, requested_fields: Dict[str, List[str | int]], modifiers: HogQLQueryModifiers):
+    def lazy_select(self, requested_fields: Dict[str, List[str | int]], context: HogQLContext, node: SelectQuery):
         return select_from_person_distinct_id_overrides_table(requested_fields)
 
     def to_printed_clickhouse(self, context):


### PR DESCRIPTION
## Problem

The `LazyTable` interface was updated in #20986 which was merged before #21059 was, causing test failures and type checking errors when #21059 was merged.

## Changes

Non functional change, adapted `PersonDistinctIdOverridesTable` to use superclass interface.

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

Fixed the broken ones.