### PR TITLE
refactor: Preventing mouse wheel from altering value in number fields

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
@@ -64,6 +64,8 @@ export interface LemonInputPropsNumber
     value?: number
     defaultValue?: number
     onChange?: (newValue: number | undefined) => void
+    onWheel?: (event: React.WheelEvent<HTMLInputElement>) => void
+    onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void
 }
 
 export type LemonInputProps = LemonInputPropsText | LemonInputPropsNumber
@@ -82,6 +84,8 @@ export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(fu
         suffix,
         type,
         value,
+        onWheel,
+        onKeyDown,
         transparentBackground = false,
         size = 'medium',
         stopPropagation = false,
@@ -99,6 +103,21 @@ export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(fu
             inputRef.current?.focus()
         }
         setFocused(true)
+    }
+    // Prevent mouse wheel from changing the value of the number input fields
+    const handleNumberWheel = (event: React.WheelEvent<HTMLInputElement>) => {
+        event.currentTarget.blur()
+        onWheel?.(event)
+    }
+    // Prevent up arrow and down arrow from changing the value of the number input fields
+    const handleNumberKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (stopPropagation) {
+            event.stopPropagation()
+        }
+        if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+            event.preventDefault()
+        }
+        onKeyDown?.(event)
     }
 
     if (type === 'search') {
@@ -196,6 +215,8 @@ export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(fu
                         onPressEnter(event)
                     }
                 }}
+                onWheel={type === 'number' ? handleNumberWheel : onWheel}
+                onKeyDown={type === 'number' ? handleNumberKeyDown : onKeyDown}
                 {...textProps}
             />
             {suffix}


### PR DESCRIPTION
## Problem
A user pointed out (in ZenDesk ticket 11999) that the value in the port number field, in the batch export config screen, can be changed unintentionally by scrolling with the mouse wheel (after entering a value, he scrolled with his mouse wheel before clicking outside of the number field.  This gif is from my repro):

![2024-03-22_11h46_27](https://github.com/PostHog/posthog/assets/227448/cddc7928-01c1-400e-b2bc-87f9f42dfcc9)

## Changes

- added `onWheel` and `onKeyDown` to `LemonInputPropsNumber`
-  created separate handler functions `handleNumberWheel` and `handleNumberKeyDown` specifically for type `number`
- set `handleNumberWheel` to `blur` the number field to prevent the value from being changed if the user scrolls the mouse wheel while the cursor is in a `number` type field
- set `handleNumberKeyDown` to `stopPropagation` to prevent up and down arrows changes from changing the value (since the user most likely intends to scroll with up or down arrow, and the field already has buttons to increase/decrease the value)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

**Caution:** I haven't tested this yet. 😳 Please feel free to ignore this until I have (I'll add a comment when done.)  My laptop won't arrive until 3/26/2024, so I don't have PH running on a local machine yet.  