### PR TITLE
feat(web-analytics): Sessions backfill: add settings to increase execution time

### DIFF
--- a/posthog/management/commands/backfill_sessions_table.py
+++ b/posthog/management/commands/backfill_sessions_table.py
@@ -16,6 +16,10 @@ logger = structlog.get_logger(__name__)
 
 TARGET_TABLE = "sessions"
 
+SETTINGS = {
+    "max_execution_time": 3600  # 1 hour
+}
+
 
 @dataclass
 class BackfillQuery:
@@ -109,12 +113,12 @@ WHERE `$session_id` IS NOT NULL AND `$session_id` != '' AND {where}
 
         # print the count of entries in the main sessions table
         count_query = f"SELECT count(), uniq(session_id) FROM {TARGET_TABLE}"
-        [(sessions_row_count, sessions_event_count)] = sync_execute(count_query)
+        [(sessions_row_count, sessions_event_count)] = sync_execute(count_query, settings=SETTINGS)
         logger.info(f"{sessions_row_count} rows and {sessions_event_count} unique session_ids in sessions table")
 
         if dry_run:
             count_query = f"SELECT count(), uniq(session_id) FROM ({select_query()})"
-            [(events_count, sessions_count)] = sync_execute(count_query)
+            [(events_count, sessions_count)] = sync_execute(count_query, settings=SETTINGS)
             logger.info(f"{events_count} events and {sessions_count} sessions to backfill for")
             logger.info(f"The first select query would be:\n{select_query(self.start_date)}")
             return
@@ -125,11 +129,12 @@ WHERE `$session_id` IS NOT NULL AND `$session_id` != '' AND {where}
             sync_execute(
                 query=f"""INSERT INTO writable_sessions {select_query(select_date=date)} SETTINGS max_execution_time=3600""",
                 workload=Workload.OFFLINE if self.use_offline_workload else Workload.DEFAULT,
+                settings=SETTINGS,
             )
 
         # print the count of entries in the main sessions table
         count_query = f"SELECT count(), uniq(session_id) FROM {TARGET_TABLE}"
-        [(sessions_row_count, sessions_event_count)] = sync_execute(count_query)
+        [(sessions_row_count, sessions_event_count)] = sync_execute(count_query, settings=SETTINGS)
         logger.info(f"{sessions_row_count} rows and {sessions_event_count} unique session_ids in sessions table")
 
 


### PR DESCRIPTION
## Problem
The insert query is timing out, looks like including settings in the sql doesn't work

## Changes

Pass a settings argument to execute

## Does this work well for both Cloud and self-hosted?

Yes but unlikely to be relevant

## How did you test this code?

Ran locally
