### PR TITLE
chore: add ios sdk as exception for permitted recording domain

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -49,11 +49,11 @@ def on_permitted_recording_domain(team: Team, request: HttpRequest) -> bool:
     ) or hostname_in_allowed_url_list(team.recording_domains, referer)
     # TODO this is a short term fix for beta testers
     # TODO we will match on the app identifier in the origin instead and allow users to auth those
-    is_authorized_android_client: bool = user_agent is not None and any(
+    is_authorized_mobile_client: bool = user_agent is not None and any(
         keyword in user_agent for keyword in ["posthog-android", "posthog-ios"]
     )
 
-    return is_authorized_web_client or is_authorized_android_client
+    return is_authorized_web_client or is_authorized_mobile_client
 
 
 def hostname_in_allowed_url_list(allowed_url_list: Optional[List[str]], hostname: Optional[str]) -> bool:

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -49,7 +49,9 @@ def on_permitted_recording_domain(team: Team, request: HttpRequest) -> bool:
     ) or hostname_in_allowed_url_list(team.recording_domains, referer)
     # TODO this is a short term fix for beta testers
     # TODO we will match on the app identifier in the origin instead and allow users to auth those
-    is_authorized_android_client: bool = user_agent is not None and "posthog-android" in user_agent
+    is_authorized_android_client: bool = user_agent is not None and any(
+        keyword in user_agent for keyword in ["posthog-android", "posthog-ios"]
+    )
 
     return is_authorized_web_client or is_authorized_android_client
 

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -482,6 +482,20 @@ class TestDecide(BaseTest, QueryMatchingTest):
             "networkPayloadCapture": None,
         }
 
+    def test_user_session_recording_allowed_for_ios(self, *args) -> None:
+        self._update_team({"session_recording_opt_in": True, "recording_domains": ["https://my-website.io"]})
+
+        response = self._post_decide(origin="any.site.com", user_agent="posthog-ios/3.1.0").json()
+        assert response["sessionRecording"] == {
+            "endpoint": "/s/",
+            "recorderVersion": "v2",
+            "consoleLogRecordingEnabled": False,
+            "sampleRate": None,
+            "linkedFlag": None,
+            "minimumDurationMilliseconds": None,
+            "networkPayloadCapture": None,
+        }
+
     def test_user_session_recording_allowed_when_permitted_domains_are_not_http_based(self, *args):
         self._update_team(
             {


### PR DESCRIPTION
## Problem

iOS recording won't work if authorized domains is disabled.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
