### PR TITLE
fix: error title parsing

### DIFF
--- a/frontend/src/scenes/session-recordings/errors/SessionRecordingErrors.tsx
+++ b/frontend/src/scenes/session-recordings/errors/SessionRecordingErrors.tsx
@@ -1,5 +1,5 @@
 import { IconFeatures } from '@posthog/icons'
-import { LemonButton, LemonTable, LemonTabs, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, LemonTable, LemonTabs } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { JSONViewer } from 'lib/components/JSONViewer'
 import { Sparkline } from 'lib/lemon-ui/Sparkline'
@@ -17,11 +17,7 @@ export function SessionRecordingErrors(): JSX.Element {
     const { errors, errorsLoading } = useValues(sessionRecordingErrorsLogic)
     const { loadErrorClusters, createPlaylist } = useActions(sessionRecordingErrorsLogic)
 
-    if (errorsLoading) {
-        return <Spinner />
-    }
-
-    if (!errors) {
+    if (!errors && !errorsLoading) {
         return (
             <LemonButton size="large" type="primary" icon={<IconFeatures />} onClick={() => loadErrorClusters()}>
                 Automagically find errors
@@ -110,7 +106,8 @@ export function SessionRecordingErrors(): JSX.Element {
                         },
                     },
                 ]}
-                dataSource={errors}
+                loading={errorsLoading}
+                dataSource={errors || []}
                 expandable={{
                     expandedRowRender: (cluster) => <ExpandedError error={cluster.sample} />,
                 }}
@@ -165,5 +162,5 @@ function parseTitle(error: string): string {
         input = error
     }
 
-    return input.split('\n')[0].trim().substring(0, MAX_TITLE_LENGTH)
+    return input?.split('\n')[0].trim().substring(0, MAX_TITLE_LENGTH) || error
 }


### PR DESCRIPTION
## Problem

Some unexpected input in prod means this page is exploding

![Screenshot 2024-03-25 at 11 19 21](https://github.com/PostHog/posthog/assets/984817/d920aefa-8b44-4162-b1e6-236b7f9ec01f)

* safely split the error title or return the unmodified item
* fly-by: since it's a `LemonTable` now we may as well use built in loading 
