### PR TITLE
fix(web-analytics): Add logic to handle empty strings in channel type

### DIFF
--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -62,6 +62,9 @@ def create_channel_type_expr(
     gclid: ast.Expr,
     gad_source: ast.Expr,
 ) -> ast.Expr:
+    def wrap_with_null_if_empty(expr: ast.Expr) -> ast.Expr:
+        return ast.Call(name="nullIf", args=[expr, ast.Constant(value="")])
+
     return parse_expr(
         """
 multiIf(
@@ -95,8 +98,8 @@ multiIf(
 
     (
         {referring_domain} = '$direct'
-        AND ({medium} IS NULL OR {medium} = '')
-        AND ({source} IS NULL OR {source} IN ('', '(direct)', 'direct'))
+        AND ({medium} IS NULL)
+        AND ({source} IS NULL OR {source} IN ('(direct)', 'direct'))
     ),
     'Direct',
 
@@ -122,11 +125,11 @@ multiIf(
 )""",
         start=None,
         placeholders={
-            "campaign": campaign,
-            "medium": medium,
-            "source": source,
+            "campaign": wrap_with_null_if_empty(campaign),
+            "medium": wrap_with_null_if_empty(medium),
+            "source": wrap_with_null_if_empty(source),
             "referring_domain": referring_domain,
-            "gclid": gclid,
-            "gad_source": gad_source,
+            "gclid": wrap_with_null_if_empty(gclid),
+            "gad_source": wrap_with_null_if_empty(gad_source),
         },
     )

--- a/posthog/hogql/database/schema/test/test_channel_type.py
+++ b/posthog/hogql/database/schema/test/test_channel_type.py
@@ -106,6 +106,21 @@ class TestChannelType(ClickhouseTestMixin, APIBaseTest):
             ),
         )
 
+    def test_direct_empty_string(self):
+        self.assertEqual(
+            "Direct",
+            self._get_initial_channel_type(
+                {
+                    "$initial_referring_domain": "$direct",
+                    "$initial_utm_source": "",
+                    "$initial_utm_medium": "",
+                    "$initial_utm_campaign": "",
+                    "$initial_gclid": "",
+                    "$initial_gad_source": "",
+                }
+            ),
+        )
+
     def test_cross_network(self):
         self.assertEqual(
             "Cross Network",


### PR DESCRIPTION
## Problem

Currently the session table has a channel type of Paid Other for organic traffic

## Changes

This is a null handling bug

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
The new test fails on the old code, passes on the new code