### PR TITLE
chore(plugin-server): add  property for anonymized created_at

### DIFF
--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -213,6 +213,14 @@ export class EventsProcessor {
         })
         // TODO: Remove Redis caching for person that's not used anymore
 
+        let createdAt = DateTime.utc()
+        let personCreatedAt = person.created_at
+        if (properties['$truncate_created_at']) {
+            // Some customers don't want accurate timestamps around their events for privacy reasons.
+            createdAt = createdAt.startOf('day')
+            personCreatedAt = personCreatedAt.startOf('day')
+        }
+
         const rawEvent: RawClickHouseEvent = {
             uuid,
             event: safeClickhouseString(event),
@@ -221,10 +229,10 @@ export class EventsProcessor {
             team_id: teamId,
             distinct_id: safeClickhouseString(distinctId),
             elements_chain: safeClickhouseString(elementsChain),
-            created_at: castTimestampOrNow(null, TimestampFormat.ClickHouse),
+            created_at: castTimestampOrNow(createdAt, TimestampFormat.ClickHouse),
             person_id: person.uuid,
             person_properties: eventPersonProperties ?? undefined,
-            person_created_at: castTimestampOrNow(person.created_at, TimestampFormat.ClickHouseSecondPrecision),
+            person_created_at: castTimestampOrNow(personCreatedAt, TimestampFormat.ClickHouseSecondPrecision),
             ...groupsColumns,
         }
 

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1997,6 +1997,21 @@ test('team event_properties', async () => {
     ])
 })
 
+test('$truncate_created_at', async () => {
+    await processEvent(
+        'xxx',
+        '',
+        '',
+        { event: 'event name', properties: { $truncate_created_at: true } } as any as PluginEvent,
+        team.id,
+        now,
+        new UUIDT().toString()
+    )
+    const [event] = await hub.db.fetchEvents()
+    expect(event.created_at).toEqual(DateTime.utc().startOf('day'))
+    expect(event.person_created_at).toEqual(DateTime.utc().startOf('day'))
+})
+
 test('event name object json', async () => {
     await processEvent(
         'xxx',


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Some customers really don't want accurate timestamps in their data, and these `created_at` ones were totally out of their control.

## Changes

Add `$truncate_created_at` property which truncates to the day.

I'm actually not in love with adding this based on a single customer request. Magical properties easily become long-term maintenance burdens. Should the customer write a plugin for this, and then we check for a `created_at` field on the event instead of hardcoding `now()`?

Is it safe to give users control over that field? I actually don't know if there is product fallout from "breaking" `created_at`, I'm assuming it's just a debug column... but if it's a debug column for us, then giving them control will make it very confusing.

## Does this work well for both Cloud and self-hosted?

Yes.

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Unit test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
