### PR TITLE
refactor: Make capture overflow partitioning code a bit more straightforward

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -602,11 +602,6 @@ def capture_internal(
         token=token,
     )
 
-    # We aim to always partition by {team_id}:{distinct_id} but allow
-    # overriding this to deal with hot partitions in specific cases.
-    # Setting the partition key to None means using random partitioning.
-    kafka_partition_key = None
-
     if event["event"] in SESSION_RECORDING_EVENT_NAMES:
         session_id = event["properties"]["$session_id"]
         headers = [
@@ -623,14 +618,16 @@ def capture_internal(
             parsed_event, event["event"], partition_key=session_id, headers=headers, overflowing=overflowing
         )
 
+    # We aim to always partition by {team_id}:{distinct_id} but allow
+    # overriding this to deal with hot partitions in specific cases.
+    # Setting the partition key to None means using random partitioning.
     candidate_partition_key = f"{token}:{distinct_id}"
-
     if (
-        distinct_id.lower() not in LIKELY_ANONYMOUS_IDS
-        and not is_randomly_partitioned(candidate_partition_key)
-        or historical
-    ):
+        distinct_id.lower() not in LIKELY_ANONYMOUS_IDS and not is_randomly_partitioned(candidate_partition_key)
+    ) or historical:
         kafka_partition_key = hashlib.sha256(candidate_partition_key.encode()).hexdigest()
+    else:
+        kafka_partition_key = None
 
     return log_event(parsed_event, event["event"], partition_key=kafka_partition_key, historical=historical)
 


### PR DESCRIPTION
## Problem

These might be personal problems, but:

1. I've been writing Python for nearly two decades and still have to look up the precedence rules for logical operator chaining like this
2. I misread the `candidate_partition_key`/`kafka_partition_key` assignments earlier (in part because my brain glossed over the complex conditional expression)

## Changes

1. Made the operator precedence explicit
2. Tried to make it clearer there are two separate potential assignments for `kafka_partition_key` by keeping them closer together makes it glaringly obvious for the next unsuspecting reader.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Hopefully already covered, maybe?