### PR TITLE
feat: Allow setting --max-tasks-per-child on celery worker

### DIFF
--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -71,6 +71,10 @@ FLAGS+=("-n node@%h")
 # On Heroku $WEB_CONCURRENCY contains suggested number of forks per dyno type
 # https://github.com/heroku/heroku-buildpack-python/blob/main/vendor/WEB_CONCURRENCY.sh
 [[ -n "${WEB_CONCURRENCY}" ]]    && FLAGS+=" --concurrency $WEB_CONCURRENCY"
+# Restart worker process after it processes this many tasks (to mitigate memory leaks)
+[[ -n "${CELERY_MAX_TASKS_PER_CHILD}" ]]    && FLAGS+=" --max-tasks-per-child $CELERY_MAX_TASKS_PER_CHILD"
+# Restart worker process after it exceeds this much memory usage (to mitigate memory leaks)
+[[ -n "${CELERY_MAX_MEMORY_PER_CHILD}" ]]    && FLAGS+=" --max-memory-per-child $CELERY_MAX_MEMORY_PER_CHILD"
 
 if [[ -z "${CELERY_WORKER_QUEUES}" ]]; then
   source ./bin/celery-queues.env


### PR DESCRIPTION

## Problem
This is so we can try to stop worker memory usage growing over time

<img width="294" alt="image" src="https://github.com/PostHog/posthog/assets/2088870/181482e7-c8fb-4205-a6b9-bc1929769fb4">
📈 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
