### PR TITLE
fix(batch-exports): replace invalid unicode with ?

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_temporary_file.py
+++ b/posthog/temporal/tests/batch_exports/test_temporary_file.py
@@ -88,6 +88,15 @@ def test_batch_export_temporary_file_write_records_to_jsonl(records):
         assert be_file.records_since_last_reset == 0
 
 
+def test_batch_export_temporary_file_write_records_to_jsonl_invalid_unicode():
+    with BatchExportTemporaryFile() as be_file:
+        be_file.write_records_to_jsonl(["hello\ud83dworld"])
+
+        be_file.seek(0)
+        # Invalid single surrogate is replaced with a question mark.
+        assert json.loads(be_file.readlines()[0]) == "hello?world"
+
+
 @pytest.mark.parametrize(
     "records",
     TEST_RECORDS,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
`orjson` is very strict about Unicode (but doesn't seem to provide a way to do error replacement on its own). Users have hit this in prod.

## Changes

Catch rare errors, do Unicode error replacement, then use `orjson.dumps` again.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes.

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Unit.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
