### PR TITLE
fix: element stats API is only returning rage clicks

### DIFF
--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -119,12 +119,14 @@ export const heatmapLogic = kea<heatmapLogicType>([
                         )}${includeEventsParams}`
                     }
 
-                    // toolbar fetch collapses queryparams but this URL has multiple with the same name
+                    // toolbar fetch collapses URL query params to an object
+                    // but this URL has multiple with the same name,
+                    // so we must pass it through only-add-token
                     const response = await toolbarFetch(
                         url || defaultUrl,
                         'GET',
                         undefined,
-                        url ? 'use-as-provided' : 'full'
+                        url ? 'use-as-provided' : 'only-add-token'
                     )
 
                     if (response.status === 403) {

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -103,10 +103,14 @@ export async function toolbarFetch(
     /*
      allows caller to control how the provided URL is altered before use
      if "full" then the payload and URL are taken apart and reconstructed
-     if "use-as-provided" then the URL is used as-is, and the payload is not used
+     if "only-add-token" the URL is unchanged, but the temporary token is added to the URL
+     if "use-as-provided" then the URL is used as-is, the token is not added
+
      this is because the heatmapLogic needs more control over how the query parameters are constructed
+     the call to elementStats allows multiple query parameter with the same name
+     passing it through url construction loses information
     */
-    urlConstruction: 'full' | 'use-as-provided' = 'full'
+    urlConstruction: 'full' | 'only-add-token' | 'use-as-provided' = 'full'
 ): Promise<Response> {
     const temporaryToken = toolbarConfigLogic.findMounted()?.values.temporaryToken
     const apiURL = toolbarConfigLogic.findMounted()?.values.apiURL
@@ -114,6 +118,8 @@ export async function toolbarFetch(
     let fullUrl: string
     if (urlConstruction === 'use-as-provided') {
         fullUrl = url
+    } else if (urlConstruction === 'only-add-token') {
+        fullUrl = `${url}&temporary_token=${temporaryToken}`
     } else {
         const { pathname, searchParams } = combineUrl(url)
         const params = { ...searchParams, temporary_token: temporaryToken }


### PR DESCRIPTION
follow-up to #21097 
see: https://posthoghelp.zendesk.com/agent/tickets/12054 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/14719)

that removed the `only-add-token` mechanism of URL construction which is needed for the heatmap to work

* we pass in a string `https://my-api/stats/?include=a&include=b`
* toolbar fetch - unless you tell it not to converts the query parameters to an object
* so we end up with `{ include: b }` since objects can't have two identical keys and kea doesn't handle converting it to an array of values
* rageclicks is the second `include` so becomes the only type of event we put in the heatmap
