### PR TITLE
revert: "fix: element stats API is only returning rage clicks"

### DIFF
--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -119,14 +119,12 @@ export const heatmapLogic = kea<heatmapLogicType>([
                         )}${includeEventsParams}`
                     }
 
-                    // toolbar fetch collapses URL query params to an object
-                    // but this URL has multiple with the same name,
-                    // so we must pass it through only-add-token
+                    // toolbar fetch collapses queryparams but this URL has multiple with the same name
                     const response = await toolbarFetch(
                         url || defaultUrl,
                         'GET',
                         undefined,
-                        url ? 'use-as-provided' : 'only-add-token'
+                        url ? 'use-as-provided' : 'full'
                     )
 
                     if (response.status === 403) {

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -103,14 +103,10 @@ export async function toolbarFetch(
     /*
      allows caller to control how the provided URL is altered before use
      if "full" then the payload and URL are taken apart and reconstructed
-     if "only-add-token" the URL is unchanged, but the temporary token is added to the URL
-     if "use-as-provided" then the URL is used as-is, the token is not added
-
+     if "use-as-provided" then the URL is used as-is, and the payload is not used
      this is because the heatmapLogic needs more control over how the query parameters are constructed
-     the call to elementStats allows multiple query parameter with the same name
-     passing it through url construction loses information
     */
-    urlConstruction: 'full' | 'only-add-token' | 'use-as-provided' = 'full'
+    urlConstruction: 'full' | 'use-as-provided' = 'full'
 ): Promise<Response> {
     const temporaryToken = toolbarConfigLogic.findMounted()?.values.temporaryToken
     const apiURL = toolbarConfigLogic.findMounted()?.values.apiURL
@@ -118,8 +114,6 @@ export async function toolbarFetch(
     let fullUrl: string
     if (urlConstruction === 'use-as-provided') {
         fullUrl = url
-    } else if (urlConstruction === 'only-add-token') {
-        fullUrl = `${url}&temporary_token=${temporaryToken}`
     } else {
         const { pathname, searchParams } = combineUrl(url)
         const params = { ...searchParams, temporary_token: temporaryToken }


### PR DESCRIPTION
Reverts PostHog/posthog#21178

ok, we need both things... the fix to the API host and the ability to add two include parameters

this was only tested on localhost where the app and api host are the same 🫠