### PR TITLE
fix(batch-exports): drop internal inserted_at column from s3 exports

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -409,8 +409,6 @@ def s3_default_fields() -> list[BatchExportField]:
     batch_export_fields.append({"expression": "elements_chain", "alias": "elements_chain"})
     batch_export_fields.append({"expression": "nullIf(person_properties, '')", "alias": "person_properties"})
     batch_export_fields.append({"expression": "toString(person_id)", "alias": "person_id"})
-    # In contrast to other destinations, we do export this field.
-    batch_export_fields.append({"expression": "COALESCE(inserted_at, _timestamp)", "alias": "inserted_at"})
 
     # Again, in contrast to other destinations, and for historical reasons, we do not include these fields.
     not_exported_by_default = {"team_id", "set", "set_once"}

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -308,7 +308,6 @@ TEST_S3_SCHEMAS: list[BatchExportSchema | None] = [
     {
         "fields": [
             {"expression": "event", "alias": "my_event_name"},
-            {"expression": "inserted_at", "alias": "inserted_at"},
             {"expression": "1 + 1", "alias": "two"},
         ],
         "values": {},


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
This is an internal column, and some users don't want accurate timestamps (plus it's just confusing).

## Changes

Drop it from S3 exports.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Existing.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
