### PR TITLE
feat(hogql): no_persons poe mode

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2571,7 +2571,7 @@
                     "type": "string"
                 },
                 "personsOnEventsMode": {
-                    "enum": ["disabled", "v1_enabled", "v1_mixed", "v2_enabled", "v3_enabled"],
+                    "enum": ["disabled", "v1_enabled", "v1_mixed", "v2_enabled", "v3_enabled", "no_persons"],
                     "type": "string"
                 }
             },

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -179,7 +179,7 @@ export interface DataNode extends Node {
 
 /** HogQL Query Options are automatically set per team. However, they can be overriden in the query. */
 export interface HogQLQueryModifiers {
-    personsOnEventsMode?: 'disabled' | 'v1_enabled' | 'v1_mixed' | 'v2_enabled' | 'v3_enabled'
+    personsOnEventsMode?: 'disabled' | 'v1_enabled' | 'v1_mixed' | 'v2_enabled' | 'v3_enabled' | 'no_persons'
     personsArgMaxVersion?: 'auto' | 'v1' | 'v2'
     inCohortVia?: 'auto' | 'leftjoin' | 'subquery' | 'leftjoin_conjoined'
     materializationMode?: 'auto' | 'legacy_null_as_string' | 'legacy_null_as_null' | 'disabled'

--- a/frontend/src/scenes/debug/HogQLDebug.tsx
+++ b/frontend/src/scenes/debug/HogQLDebug.tsx
@@ -72,6 +72,7 @@ export function HogQLDebug({ query, setQuery, queryKey }: HogQLDebugProps): JSX.
                                 { value: 'v1_mixed', label: 'V1 Mixed' },
                                 { value: 'v2_enabled', label: 'V2 Enabled' },
                                 { value: 'v3_enabled', label: 'V3 Enabled (Join)' },
+                                { value: 'no_persons', label: 'No persons (all NULL)' },
                             ]}
                             onChange={(value) =>
                                 setQuery({

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -210,6 +210,17 @@ def create_hogql_database(
         database.events.fields["poe"].fields["id"] = database.events.fields["person_id"]
         database.events.fields["person"] = FieldTraverser(chain=["poe"])
 
+    elif modifiers.personsOnEventsMode == PersonsOnEventsMode.no_persons:
+        database.events.fields["person_id"] = ExpressionField(
+            name="person_id", expr=parse_expr("toUUID('00000000-0000-0000-0000-000000000000')")
+        )
+        database.events.fields["person"] = FieldTraverser(chain=["poe"])
+        database.events.fields["poe"].fields["id"] = ExpressionField(
+            name="person_id", expr=parse_expr("toUUID('00000000-0000-0000-0000-000000000000')")
+        )
+        database.events.fields["poe"].fields["properties"] = ExpressionField(name="properties", expr=parse_expr("null"))
+        database.events.fields["poe"].fields["created_at"] = ExpressionField(name="created_at", expr=parse_expr("null"))
+
     database.persons.fields["$virt_initial_referring_domain_type"] = create_initial_domain_type(
         "$virt_initial_referring_domain_type"
     )

--- a/posthog/hogql/test/test_modifiers.py
+++ b/posthog/hogql/test/test_modifiers.py
@@ -88,6 +88,13 @@ class TestModifiers(BaseTest):
                 "events.person_properties AS properties",
                 "toTimeZone(events.person_created_at, %(hogql_val_0)s) AS created_at",
             ),
+            (
+                PersonsOnEventsMode.no_persons,
+                "events.event AS event",
+                "toUUIDOrNull(%(hogql_val_0)s) AS id",
+                "NULL AS properties",
+                "NULL AS created_at",
+            ),
         ]
 
         for mode, *expected in test_cases:

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -423,6 +423,7 @@ class PersonsOnEventsMode(str, Enum):
     v1_mixed = "v1_mixed"
     v2_enabled = "v2_enabled"
     v3_enabled = "v3_enabled"
+    no_persons = "no_persons"
 
 
 class HogQLQueryModifiers(BaseModel):


### PR DESCRIPTION
## Problem

We want to support personless events.

## Changes

Adds a new PoE mode `no_persons` that just blanks out all person properties and IDs. This doesn't make them `null` completely, but gives a zero UUID value. So you will see 1 user when any user was active, and 0 users when no users were active.

To enable it locally, modify these lines: https://github.com/PostHog/posthog/blob/205376b86e1e523461ee494099fe92f084850dee/posthog/hogql/modifiers.py#L23-L27

We might want an empty `'{}'` for properties instead of the null to not have everything fail, but it's a start.

## How did you test this code?

Just locally in the `/debug` page for now.