### PR TITLE
feat(hogql): move default execution time to 120sec

### DIFF
--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -12,7 +12,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -29,7 +29,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -46,7 +46,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -63,7 +63,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -80,7 +80,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -97,7 +97,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -110,7 +110,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -123,7 +123,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -136,7 +136,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -151,7 +151,7 @@
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -191,7 +191,7 @@
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -206,7 +206,7 @@
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -225,7 +225,7 @@
      ORDER BY toTimeZone(events.timestamp, 'UTC') ASC) AS event_view
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -242,7 +242,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -259,7 +259,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -276,7 +276,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -293,7 +293,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -310,7 +310,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -327,7 +327,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -344,7 +344,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -361,7 +361,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -396,7 +396,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -431,7 +431,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -446,7 +446,7 @@
   ORDER BY count() DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -462,7 +462,7 @@
   ORDER BY count() DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -477,7 +477,7 @@
   ORDER BY count() DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -493,7 +493,7 @@
   ORDER BY count() DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -508,7 +508,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -524,7 +524,7 @@
   ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -538,7 +538,7 @@
   ORDER BY tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -553,7 +553,7 @@
   ORDER BY count() DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -568,7 +568,7 @@
   ORDER BY count() DESC, events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -77,5 +77,5 @@ class HogQLQuerySettings(BaseModel):
 class HogQLGlobalSettings(HogQLQuerySettings):
     model_config = ConfigDict(extra="forbid")
     readonly: Optional[int] = 2
-    max_execution_time: Optional[int] = 60
+    max_execution_time: Optional[int] = 120
     allow_experimental_object_type: Optional[bool] = True

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -89,7 +89,7 @@ class TestDatabase(BaseTest):
 
         self.assertEqual(
             response.clickhouse,
-            f"SELECT whatever.id AS id FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s, %(hogql_val_1)s, %(hogql_val_2)s) AS whatever LIMIT 100 SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1",
+            f"SELECT whatever.id AS id FROM s3(%(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s, %(hogql_val_1)s, %(hogql_val_2)s) AS whatever LIMIT 100 SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1",
         )
 
     def test_database_group_type_mappings(self):

--- a/posthog/hogql/functions/test/__snapshots__/test_cohort.ambr
+++ b/posthog/hogql/functions/test/__snapshots__/test_cohort.ambr
@@ -12,7 +12,7 @@
   GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, cohortpeople.version 
   HAVING ifNull(greater(sum(cohortpeople.sign), 0), 0))), equals(events.event, %(hogql_val_0)s)) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -38,7 +38,7 @@
   FROM person_static_cohort 
   WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, XX))))) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -62,7 +62,7 @@
   FROM person_static_cohort 
   WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, XX))))) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   

--- a/posthog/hogql/functions/test/test_sparkline.py
+++ b/posthog/hogql/functions/test/test_sparkline.py
@@ -8,7 +8,7 @@ class TestSparkline(BaseTest):
         response = execute_hogql_query("select sparkline([1,2,3])", self.team, pretty=False)
         self.assertEqual(
             response.clickhouse,
-            f"SELECT tuple(%(hogql_val_0)s, %(hogql_val_1)s, %(hogql_val_2)s, [1, 2, 3]) LIMIT 100 SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1",
+            f"SELECT tuple(%(hogql_val_0)s, %(hogql_val_1)s, %(hogql_val_2)s, [1, 2, 3]) LIMIT 100 SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1",
         )
         self.assertEqual(
             response.hogql,

--- a/posthog/hogql/test/__snapshots__/test_query.ambr
+++ b/posthog/hogql/test/__snapshots__/test_query.ambr
@@ -5,7 +5,7 @@
   
   SELECT [1, 2, 3], [10, 11, 12][1] 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -19,7 +19,7 @@
   
   SELECT arrayMap(x -> multiply(x, 2), [1, 2, 3]), 1 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -35,7 +35,7 @@
   FROM events 
   WHERE and(equals(events.team_id, 420), equals(events.distinct_id, %(hogql_val_0)s), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_1)s), ''), 'null'), '^"|"$', ''), %(hogql_val_2)s), 0)) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -62,7 +62,7 @@
   FROM events 
   WHERE and(equals(events.team_id, 420), equals(events.distinct_id, %(hogql_val_0)s), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_1)s), ''), 'null'), '^"|"$', ''), %(hogql_val_2)s), 0), less(toTimeZone(events.timestamp, %(hogql_val_3)s), toDateTime64('2020-01-02 00:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_4)s), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')))) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -89,7 +89,7 @@
   FROM events AS e 
   WHERE and(equals(e.team_id, 420), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), %(hogql_val_1)s), 0)) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -111,7 +111,7 @@
   FROM events 
   WHERE equals(events.team_id, 420) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -135,7 +135,7 @@
   GROUP BY session_replay_events.session_id) AS s ON equals(s.session_id, nullIf(nullIf(e.`$session_id`, ''), 'null')) 
   WHERE and(equals(e.team_id, 420), isNotNull(nullIf(nullIf(e.`$session_id`, ''), 'null'))) 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -166,7 +166,7 @@
   GROUP BY session_replay_events.session_id) AS s LEFT JOIN events AS e ON equals(nullIf(nullIf(e.`$session_id`, ''), 'null'), s.session_id) 
   WHERE and(equals(e.team_id, 420), isNotNull(nullIf(nullIf(e.`$session_id`, ''), 'null'))) 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -197,7 +197,7 @@
   GROUP BY session_replay_events.session_id) AS s ON equals(s.session_id, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '')) 
   WHERE and(equals(e.team_id, 420), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_1)s), ''), 'null'), '^"|"$', ''))) 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -228,7 +228,7 @@
   GROUP BY session_replay_events.session_id) AS s LEFT JOIN events AS e ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), s.session_id) 
   WHERE and(equals(e.team_id, 420), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, %(hogql_val_1)s), ''), 'null'), '^"|"$', ''))) 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -266,7 +266,7 @@
   HAVING ifNull(greater(sum(cohortpeople.sign), 0), 0))), 0)) 
   GROUP BY events.event 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -296,7 +296,7 @@
   HAVING ifNull(greater(sum(cohortpeople.sign), 0), 0)))) 
   GROUP BY events.event 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -329,7 +329,7 @@
   WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, XX)))), 0)) 
   GROUP BY events.event 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -355,7 +355,7 @@
   WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, XX))))) 
   GROUP BY events.event 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -378,7 +378,7 @@
   WHERE and(equals(events.team_id, 420), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), %(hogql_val_1)s), 0)) 
   GROUP BY events.event 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -406,7 +406,7 @@
   SETTINGS optimize_aggregation_in_order=1) AS persons 
   WHERE ifNull(equals(persons.properties___random_uuid, %(hogql_val_2)s), 0) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -429,7 +429,7 @@
   HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id) 
   WHERE equals(e.team_id, 420) 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -451,7 +451,7 @@
   HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id) 
   WHERE equals(events.team_id, 420) 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -482,7 +482,7 @@
   SETTINGS optimize_aggregation_in_order=1) AS e__pdi__person ON equals(e__pdi.e__pdi___person_id, e__pdi__person.id) 
   WHERE equals(e.team_id, 420) 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -510,7 +510,7 @@
   SETTINGS optimize_aggregation_in_order=1) AS events__pdi__person ON equals(events__pdi.events__pdi___person_id, events__pdi__person.id) 
   WHERE equals(events.team_id, 420) 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -541,7 +541,7 @@
   SETTINGS optimize_aggregation_in_order=1) AS events__pdi__person ON equals(events__pdi.events__pdi___person_id, events__pdi__person.id) 
   WHERE equals(events.team_id, 420) 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -572,7 +572,7 @@
   SETTINGS optimize_aggregation_in_order=1) AS e__pdi__person ON equals(e__pdi.e__pdi___person_id, e__pdi__person.id) 
   WHERE equals(e.team_id, 420) 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -604,7 +604,7 @@
   WHERE equals(s.team_id, 420) 
   GROUP BY s__pdi__person.properties___sneaky_mail 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -627,7 +627,7 @@
   HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS pdi ON equals(e.distinct_id, pdi.distinct_id) 
   WHERE equals(e.team_id, 420) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -661,7 +661,7 @@
   HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0))), 0)) 
   SETTINGS optimize_aggregation_in_order=1) AS pdi__person ON equals(pdi.pdi___person_id, pdi__person.id) 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -688,7 +688,7 @@
   HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0) 
   SETTINGS optimize_aggregation_in_order=1) AS pdi__person ON equals(pdi.pdi___person_id, pdi__person.id) 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -719,7 +719,7 @@
   SETTINGS optimize_aggregation_in_order=1) AS p ON equals(p.id, pdi.person_id) 
   WHERE equals(e.team_id, 420) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -740,7 +740,7 @@
   GROUP BY person_distinct_id2.distinct_id 
   HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS person_distinct_ids 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -771,7 +771,7 @@
   SETTINGS optimize_aggregation_in_order=1) AS events__pdi__person ON equals(events__pdi.events__pdi___person_id, events__pdi__person.id) 
   WHERE equals(events.team_id, 420) 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -788,7 +788,7 @@
   FROM events 
   WHERE equals(events.team_id, 420) 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -806,7 +806,7 @@
   WHERE equals(s.team_id, 420) 
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(s.person_properties, %(hogql_val_1)s), ''), 'null'), '^"|"$', '') 
   LIMIT 10 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -828,7 +828,7 @@
   GROUP BY events.event) 
   GROUP BY count, event 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -854,7 +854,7 @@
   GROUP BY events.event) AS c 
   GROUP BY c.count, c.event 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -883,7 +883,7 @@
   GROUP BY col_a) 
   GROUP BY col_a ORDER BY col_a ASC 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -916,7 +916,7 @@
   GROUP BY PIVOT_TABLE_COL_ABC.col_a) AS PIVOT_FUNCTION_1 
   GROUP BY PIVOT_FUNCTION_1.col_a) AS PIVOT_FUNCTION_2 ORDER BY PIVOT_FUNCTION_2.col_a ASC 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -953,7 +953,7 @@
   GROUP BY PIVOT_TABLE_COL_ABC.col_a) AS PIVOT_FUNCTION_1 
   GROUP BY PIVOT_FUNCTION_1.col_a) AS PIVOT_FUNCTION_2) AS final ORDER BY final.col_a ASC 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -1012,7 +1012,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 f"FROM events "
                 f"WHERE and(equals(events.team_id, {self.team.pk}), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_46)s), ''), 'null'), '^\"|\"$', ''), %(hogql_val_47)s), 0)) "
                 f"LIMIT 100 "
-                f"SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1",
+                f"SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1",
             )
             self.assertEqual(response.results[0], tuple(map(lambda x: random_uuid, alternatives)))
 

--- a/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
@@ -10,7 +10,7 @@
   WHERE and(equals(cohortpeople.team_id, 420), equals(cohortpeople.cohort_id, XX), equals(cohortpeople.version, 0))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
   WHERE and(equals(events.team_id, 420), and(1, equals(events.event, %(hogql_val_0)s)), ifNull(equals(__in_cohort.matched, 1), 0)) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -34,7 +34,7 @@
   WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [11]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
   WHERE and(equals(events.team_id, 420), 1, ifNull(equals(__in_cohort.matched, 1), 0)) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -58,7 +58,7 @@
   WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [12]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
   WHERE and(equals(events.team_id, 420), 1, ifNull(equals(__in_cohort.matched, 1), 0)) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -84,7 +84,7 @@
   HAVING ifNull(greater(sum(cohortpeople.sign), 0), 0)) AS in_cohort__XX ON equals(in_cohort__XX.person_id, events.person_id) 
   WHERE and(equals(events.team_id, 420), ifNull(equals(in_cohort__XX.matched, 1), 0), equals(events.event, %(hogql_val_0)s)) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -110,7 +110,7 @@
   WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, XX))) AS in_cohort__XX ON equals(in_cohort__XX.person_id, events.person_id) 
   WHERE and(equals(events.team_id, 420), ifNull(equals(in_cohort__XX.matched, 1), 0)) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   
@@ -134,7 +134,7 @@
   WHERE and(equals(person_static_cohort.team_id, 420), equals(person_static_cohort.cohort_id, XX))) AS in_cohort__XX ON equals(in_cohort__XX.person_id, events.person_id) 
   WHERE and(equals(events.team_id, 420), ifNull(equals(in_cohort__XX.matched, 1), 0)) 
   LIMIT 100 
-  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
+  SETTINGS readonly=2, max_execution_time=120, allow_experimental_object_type=1
   
   -- HogQL
   

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
@@ -87,7 +87,7 @@
      HAVING ifNull(equals(steps, max_steps), isNull(steps)
                    and isNull(max_steps)))
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -189,7 +189,7 @@
   ORDER BY toTimeZone(persons.created_at, 'UTC') DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -294,7 +294,7 @@
      HAVING ifNull(equals(steps, max_steps), isNull(steps)
                    and isNull(max_steps)))
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -378,7 +378,7 @@
      HAVING ifNull(equals(steps, max_steps), isNull(steps)
                    and isNull(max_steps)))
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -482,7 +482,7 @@
      HAVING ifNull(equals(steps, max_steps), isNull(steps)
                    and isNull(max_steps)))
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -596,7 +596,7 @@
   ORDER BY toTimeZone(persons.created_at, 'UTC') DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -710,7 +710,7 @@
   ORDER BY toTimeZone(persons.created_at, 'UTC') DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -824,7 +824,7 @@
   ORDER BY toTimeZone(persons.created_at, 'UTC') DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -895,7 +895,7 @@
      HAVING ifNull(equals(steps, max_steps), isNull(steps)
                    and isNull(max_steps)))
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -954,7 +954,7 @@
      HAVING ifNull(equals(steps, max_steps), isNull(steps)
                    and isNull(max_steps)))
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -975,7 +975,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -1060,7 +1060,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -1081,7 +1081,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -1173,7 +1173,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -1194,7 +1194,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -1279,7 +1279,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -1301,7 +1301,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -1426,7 +1426,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -1454,7 +1454,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -1579,7 +1579,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -1608,7 +1608,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -1740,7 +1740,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_breakdowns_by_current_url.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_breakdowns_by_current_url.ambr
@@ -16,7 +16,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -101,7 +101,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -122,7 +122,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -207,7 +207,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -144,7 +144,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -302,7 +302,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -431,7 +431,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -445,7 +445,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -574,7 +574,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -588,7 +588,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -717,7 +717,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -731,7 +731,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -860,7 +860,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -874,7 +874,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -1008,7 +1008,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -1142,7 +1142,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -1270,7 +1270,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -1381,7 +1381,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -1492,7 +1492,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -1603,7 +1603,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -1714,7 +1714,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -1858,7 +1858,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -1969,7 +1969,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -2080,7 +2080,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -2208,7 +2208,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -2319,7 +2319,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -2430,7 +2430,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -2541,7 +2541,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -2652,7 +2652,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -2796,7 +2796,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -2907,7 +2907,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3018,7 +3018,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3161,7 +3161,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -3279,7 +3279,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3397,7 +3397,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3515,7 +3515,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3633,7 +3633,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3776,7 +3776,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -3919,7 +3919,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -4037,7 +4037,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -4155,7 +4155,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -4273,7 +4273,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -4391,7 +4391,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -4534,7 +4534,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -4677,7 +4677,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -4795,7 +4795,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -4913,7 +4913,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -5031,7 +5031,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -5149,7 +5149,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -5292,7 +5292,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -5435,7 +5435,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -5553,7 +5553,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -5671,7 +5671,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -5789,7 +5789,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -5907,7 +5907,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -6050,7 +6050,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -6193,7 +6193,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -6311,7 +6311,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -6429,7 +6429,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -6547,7 +6547,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -6665,7 +6665,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -6808,7 +6808,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -121,7 +121,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -135,7 +135,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -327,7 +327,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -341,7 +341,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -470,7 +470,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -484,7 +484,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -613,7 +613,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -627,7 +627,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -756,7 +756,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -770,7 +770,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s3']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_persons.ambr
@@ -163,7 +163,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -177,7 +177,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s1']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -345,7 +345,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -359,7 +359,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -527,7 +527,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -541,7 +541,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -16,7 +16,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -100,7 +100,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -121,7 +121,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -212,7 +212,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -233,7 +233,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -317,7 +317,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -339,7 +339,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -464,7 +464,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -492,7 +492,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -617,7 +617,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -646,7 +646,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -778,7 +778,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
@@ -123,7 +123,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -137,7 +137,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s1']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -265,7 +265,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -279,7 +279,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -407,7 +407,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -421,7 +421,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
@@ -410,7 +410,7 @@
                                     WHERE isNotNull(step_runs.step_1_average_conversion_time_inner)) AS histogram_params), 0), 1)) AS numbers) AS fill ON equals(results.bin_from_seconds, fill.bin_from_seconds)
   ORDER BY fill.bin_from_seconds ASC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -752,7 +752,7 @@
                                     WHERE isNotNull(step_runs.step_1_average_conversion_time_inner)) AS histogram_params), 0), 1)) AS numbers) AS fill ON equals(results.bin_from_seconds, fill.bin_from_seconds)
   ORDER BY fill.bin_from_seconds ASC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -1494,7 +1494,7 @@
                                     WHERE isNotNull(step_runs.step_1_average_conversion_time_inner)) AS histogram_params), 0), 1)) AS numbers) AS fill ON equals(results.bin_from_seconds, fill.bin_from_seconds)
   ORDER BY fill.bin_from_seconds ASC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends.ambr
@@ -82,7 +82,7 @@
      FROM numbers(plus(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull(('2021-04-30 00:00:00'), 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull(('2021-05-07 23:59:59'), 6, 'UTC')))), 1)) AS period_offsets) AS fill ON equals(data.entrance_period_start, fill.entrance_period_start)
   ORDER BY fill.entrance_period_start ASC
   LIMIT 1000 SETTINGS readonly=2,
-                      max_execution_time=60,
+                      max_execution_time=120,
                       allow_experimental_object_type=1
   '''
 # ---
@@ -169,7 +169,7 @@
      FROM numbers(plus(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull(('2021-04-30 00:00:00'), 6, 'US/Pacific'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull(('2021-05-07 23:59:59'), 6, 'US/Pacific')))), 1)) AS period_offsets) AS fill ON equals(data.entrance_period_start, fill.entrance_period_start)
   ORDER BY fill.entrance_period_start ASC
   LIMIT 1000 SETTINGS readonly=2,
-                      max_execution_time=60,
+                      max_execution_time=120,
                       allow_experimental_object_type=1
   '''
 # ---
@@ -256,7 +256,7 @@
      FROM numbers(plus(dateDiff('week', toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull(('2021-05-01 00:00:00'), 6, 'UTC')), 0), toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull(('2021-05-07 23:59:59'), 6, 'UTC')), 0)), 1)) AS period_offsets) AS fill ON equals(data.entrance_period_start, fill.entrance_period_start)
   ORDER BY fill.entrance_period_start ASC
   LIMIT 1000 SETTINGS readonly=2,
-                      max_execution_time=60,
+                      max_execution_time=120,
                       allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
@@ -149,7 +149,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -163,7 +163,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s1b']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -317,7 +317,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -331,7 +331,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s1a']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -485,7 +485,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -499,7 +499,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s1c']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -16,7 +16,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -152,7 +152,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -173,7 +173,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -323,7 +323,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -344,7 +344,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -480,7 +480,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -502,7 +502,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -627,7 +627,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -655,7 +655,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -780,7 +780,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -809,7 +809,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -941,7 +941,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
@@ -267,7 +267,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -281,7 +281,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, []), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_lifecycle_query_runner.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_lifecycle_query_runner.ambr
@@ -92,7 +92,7 @@
      ORDER BY start_of_period ASC)
   GROUP BY status
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -164,7 +164,7 @@
      ORDER BY start_of_period ASC)
   GROUP BY status
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -236,7 +236,7 @@
      ORDER BY start_of_period ASC)
   GROUP BY status
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -308,7 +308,7 @@
      ORDER BY start_of_period ASC)
   GROUP BY status
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_retention_query_runner.ambr
@@ -41,7 +41,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -103,7 +103,7 @@
   ORDER BY length(source.appearances) DESC, source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -149,7 +149,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -195,7 +195,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -257,7 +257,7 @@
   ORDER BY length(source.appearances) DESC, source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -303,7 +303,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -370,7 +370,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -448,7 +448,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -515,7 +515,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -604,7 +604,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -671,7 +671,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -738,7 +738,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -805,7 +805,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -872,7 +872,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -94,7 +94,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -181,7 +181,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -202,7 +202,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -250,7 +250,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -302,7 +302,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -350,7 +350,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -363,7 +363,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -403,7 +403,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -416,7 +416,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -456,7 +456,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -476,7 +476,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -514,7 +514,7 @@
   WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-11 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-11 23:59:59', 6, 'UTC'))), 0))
   GROUP BY breakdown_value
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -534,7 +534,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -572,7 +572,7 @@
   WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-11 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-11 23:59:59', 6, 'UTC'))), 0))
   GROUP BY breakdown_value
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -628,7 +628,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -707,7 +707,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -728,7 +728,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -776,7 +776,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -811,7 +811,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -865,7 +865,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -878,7 +878,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -925,7 +925,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -938,7 +938,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -985,7 +985,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1069,7 +1069,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1135,7 +1135,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1177,7 +1177,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1250,7 +1250,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1282,7 +1282,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -1357,7 +1357,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1376,7 +1376,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -1438,7 +1438,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1464,7 +1464,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1509,7 +1509,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -1561,7 +1561,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1605,7 +1605,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -1656,7 +1656,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1700,7 +1700,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1744,7 +1744,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1770,7 +1770,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1814,7 +1814,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1840,7 +1840,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1884,7 +1884,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1924,7 +1924,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -1956,7 +1956,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2002,7 +2002,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2048,7 +2048,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2094,7 +2094,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2120,7 +2120,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2153,7 +2153,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2199,7 +2199,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2225,7 +2225,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2238,7 +2238,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -2285,7 +2285,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2311,7 +2311,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2344,7 +2344,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2390,7 +2390,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2416,7 +2416,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2429,7 +2429,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -2476,7 +2476,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2502,7 +2502,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2535,7 +2535,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2581,7 +2581,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2607,7 +2607,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2620,7 +2620,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -2667,7 +2667,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2700,7 +2700,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2726,7 +2726,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2759,7 +2759,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2785,7 +2785,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2818,7 +2818,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2844,7 +2844,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2870,7 +2870,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2896,7 +2896,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2922,7 +2922,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2948,7 +2948,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -2974,7 +2974,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3000,7 +3000,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3033,7 +3033,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3093,7 +3093,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3126,7 +3126,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3186,7 +3186,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3212,7 +3212,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3256,7 +3256,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3287,7 +3287,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3345,7 +3345,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3384,7 +3384,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3423,7 +3423,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3436,7 +3436,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3476,7 +3476,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3502,7 +3502,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3528,7 +3528,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3541,7 +3541,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3594,7 +3594,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3607,7 +3607,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3659,7 +3659,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3678,7 +3678,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3701,7 +3701,7 @@
               breakdown_value)
   GROUP BY breakdown_value
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3720,7 +3720,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3743,7 +3743,7 @@
               breakdown_value)
   GROUP BY breakdown_value
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3769,7 +3769,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3795,7 +3795,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3821,7 +3821,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3843,7 +3843,7 @@
         WHERE and(equals(e.team_id, 2), equals(e.event, 'viewed video'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), minus(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-01 00:00:00', 6, 'UTC')), toIntervalDay(0))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-07 23:59:59', 6, 'UTC'))))
         GROUP BY e__pdi.person_id))
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3864,7 +3864,7 @@
         WHERE and(equals(e.team_id, 2), equals(e.event, 'viewed video'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), minus(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-01 00:00:00', 6, 'UTC')), toIntervalDay(0))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-07 23:59:59', 6, 'UTC'))))
         GROUP BY ifNull(nullIf(e__override.override_person_id, '00000000-0000-0000-0000-000000000000'), e.person_id)))
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3877,7 +3877,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -3904,7 +3904,7 @@
                  breakdown_value)
      GROUP BY breakdown_value)
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3945,7 +3945,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -3985,7 +3985,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4011,7 +4011,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4042,7 +4042,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4073,7 +4073,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4111,7 +4111,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4148,7 +4148,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -4189,7 +4189,7 @@
               breakdown_value)
   GROUP BY breakdown_value
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4215,7 +4215,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4234,7 +4234,7 @@
      WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')), 0)), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
      GROUP BY e__session.id)
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4253,7 +4253,7 @@
      WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
      GROUP BY e__session.id)
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4291,7 +4291,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4329,7 +4329,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4348,7 +4348,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -4402,7 +4402,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4421,7 +4421,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -4475,7 +4475,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4507,7 +4507,7 @@
      ORDER BY d.timestamp ASC)
   WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-11 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 23:59:59', 6, 'UTC'))), 0))
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4539,7 +4539,7 @@
      ORDER BY d.timestamp ASC)
   WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-01 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-08 23:59:59', 6, 'UTC'))), 0))
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4571,7 +4571,7 @@
      ORDER BY d.timestamp ASC)
   WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-01 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-08 23:59:59', 6, 'UTC'))), 0))
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4617,7 +4617,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4663,7 +4663,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4709,7 +4709,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4766,7 +4766,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4823,7 +4823,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4869,7 +4869,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4915,7 +4915,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -4961,7 +4961,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---
@@ -5007,7 +5007,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=120,
                        allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends_data_warehouse_query.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends_data_warehouse_query.ambr
@@ -8,7 +8,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -48,7 +48,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -61,7 +61,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=120,
                     allow_experimental_object_type=1
   '''
 # ---
@@ -101,7 +101,7 @@
   GROUP BY breakdown_value
   ORDER BY sum(count) DESC, breakdown_value ASC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -127,7 +127,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -153,7 +153,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -179,7 +179,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---

--- a/posthog/hogql_queries/test/__snapshots__/test_sessions_timeline_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_sessions_timeline_query_runner.ambr
@@ -59,7 +59,7 @@
         GROUP BY session_replay_events.session_id) AS session_replay_events) AS sre ON equals(e.session_id, sre.session_id)
   ORDER BY e.timestamp DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -123,7 +123,7 @@
         GROUP BY session_replay_events.session_id) AS session_replay_events) AS sre ON equals(e.session_id, sre.session_id)
   ORDER BY e.timestamp DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -187,7 +187,7 @@
         GROUP BY session_replay_events.session_id) AS session_replay_events) AS sre ON equals(e.session_id, sre.session_id)
   ORDER BY e.timestamp DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -251,7 +251,7 @@
         GROUP BY session_replay_events.session_id) AS session_replay_events) AS sre ON equals(e.session_id, sre.session_id)
   ORDER BY e.timestamp DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -315,7 +315,7 @@
         GROUP BY session_replay_events.session_id) AS session_replay_events) AS sre ON equals(e.session_id, sre.session_id)
   ORDER BY e.timestamp DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -379,7 +379,7 @@
         GROUP BY session_replay_events.session_id) AS session_replay_events) AS sre ON equals(e.session_id, sre.session_id)
   ORDER BY e.timestamp DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---
@@ -443,7 +443,7 @@
         GROUP BY session_replay_events.session_id) AS session_replay_events) AS sre ON equals(e.session_id, sre.session_id)
   ORDER BY e.timestamp DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=120,
                      allow_experimental_object_type=1
   '''
 # ---


### PR DESCRIPTION
## Problem

The legacy trends have a 120sec timeout. Several HogQL queries for our team time out at 60 seconds, but they pass for the old ones.

## Changes

Equalise timeouts, hopefully equalise test results.

## How did you test this code?

CI