### PR TITLE
fix(insights): Don't allow annotations overlay to crash insight

### DIFF
--- a/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
@@ -25,9 +25,9 @@ export function ErrorBoundary({ children }: { children: React.ReactElement }): J
                                 )}
                             </code>
                         </pre>
-                        {isSentryInitialized
+                        {isSentryInitialized && eventId?.match(/[^0]/)
                             ? `We've registered this event for analysis (ID ${eventId}), but feel free to contact us directly too.`
-                            : 'Please send over a screenshot of this message, so that we can resolve the issue.'}
+                            : 'Please help us resolve the issue by sending a screenshot of this message.'}
                         <HelpButton
                             customComponent={
                                 <LemonButton type="primary" sideIcon={<IconChevronDown />}>

--- a/frontend/src/lib/components/AnnotationsOverlay/useAnnotationsPositioning.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/useAnnotationsPositioning.ts
@@ -24,8 +24,9 @@ export function useAnnotationsPositioning(
             const points = chart._metasets[0].data as Point[]
             const firstTickPointIndex = chart.scales.x.ticks[0].value
             const lastTickPointIndex = chart.scales.x.ticks[tickCount - 1].value
-            const firstTickLeftPx = points[firstTickPointIndex].x
-            const lastTickLeftPx = points[lastTickPointIndex].x
+            // Fall back to zero for resiliency against temporary chart inconsistencies during loading
+            const firstTickLeftPx = points[firstTickPointIndex]?.x ?? 0
+            const lastTickLeftPx = points[lastTickPointIndex]?.x ?? 0
             return {
                 tickIntervalPx: (lastTickLeftPx - firstTickLeftPx) / (tickCount - 1),
                 firstTickLeftPx,


### PR DESCRIPTION
## Changes

Fix for:

<img width="859" alt="Screenshot 2024-03-28 at 16 20 25" src="https://github.com/PostHog/posthog/assets/4550621/c40ce7da-44d3-4485-bfec-256ce6f8220a">

Seen on [this insight](https://posthog.slack.com/archives/C05LEB8PB33/p1709231918947839?thread_ts=1709230675.026009&cid=C05LEB8PB33) when toggling series visibility.