### PR TITLE
fix(debug): Restore order to CH query debug modal list

### DIFF
--- a/ee/api/debug_ch_queries.py
+++ b/ee/api/debug_ch_queries.py
@@ -31,8 +31,12 @@ class DebugCHQueries(viewsets.ViewSet):
         response = sync_execute(
             """
             SELECT
-                query_id, argMax(query, type), argMax(query_start_time, type), argMax(exception, type),
-                argMax(query_duration_ms, type), max(type) AS status
+                query_id,
+                argMax(query, type) AS query,
+                argMax(query_start_time, type) AS query_start_time,
+                argMax(exception, type) AS exception,
+                argMax(query_duration_ms, type) AS query_duration_ms,
+                max(type) AS status
             FROM (
                 SELECT
                     query_id, query, query_start_time, exception, query_duration_ms, toInt8(type) AS type

--- a/ee/api/debug_ch_queries.py
+++ b/ee/api/debug_ch_queries.py
@@ -41,10 +41,11 @@ class DebugCHQueries(viewsets.ViewSet):
                     query LIKE %(query)s AND
                     query NOT LIKE %(not_query)s AND
                     query_start_time > %(start_time)s
-                ORDER BY query_start_time desc
+                ORDER BY query_start_time DESC
                 LIMIT 100
             )
-            GROUP BY query_id""",
+            GROUP BY query_id
+            ORDER BY query_start_time DESC""",
             {
                 "query": f"/* user_id:{request.user.pk} %",
                 "start_time": (now() - relativedelta(minutes=10)).timestamp(),


### PR DESCRIPTION
## Problem

Ordering guarantees got broken in #21160, resulting in the debug modal being confusing.

## Changes

Restored order.