### PR TITLE
fix(data-warehouse): use account id for stripe integration

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -176,10 +176,12 @@ async def run_external_data_job(inputs: ExternalDataJobInputs) -> TSchemaTables:
         from posthog.temporal.data_imports.pipelines.stripe.helpers import stripe_source
 
         stripe_secret_key = model.pipeline.job_inputs.get("stripe_secret_key", None)
+        account_id = model.pipeline.job_inputs.get("stripe_account_id", None)
         if not stripe_secret_key:
             raise ValueError(f"Stripe secret key not found for job {model.id}")
         source = stripe_source(
             api_key=stripe_secret_key,
+            account_id=account_id,
             endpoints=tuple(endpoints),
             team_id=inputs.team_id,
             job_id=inputs.run_id,

--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -177,6 +177,8 @@ async def run_external_data_job(inputs: ExternalDataJobInputs) -> TSchemaTables:
 
         stripe_secret_key = model.pipeline.job_inputs.get("stripe_secret_key", None)
         account_id = model.pipeline.job_inputs.get("stripe_account_id", None)
+        # Cludge: account_id should be checked here too but can deal with nulls
+        # until we require re update of account_ids in stripe so they're all store
         if not stripe_secret_key:
             raise ValueError(f"Stripe secret key not found for job {model.id}")
         source = stripe_source(

--- a/posthog/temporal/data_imports/pipelines/stripe/helpers.py
+++ b/posthog/temporal/data_imports/pipelines/stripe/helpers.py
@@ -25,6 +25,7 @@ def transform_date(date: Union[str, DateTime, int]) -> int:
 
 async def stripe_get_data(
     api_key: str,
+    account_id: str,
     resource: str,
     start_date: Optional[Any] = None,
     end_date: Optional[Any] = None,
@@ -42,6 +43,7 @@ async def stripe_get_data(
 
     resource_dict = await sync_to_async(_resource.list)(
         api_key=api_key,
+        stripe_account=account_id,
         created={"gte": start_date, "lt": end_date},
         limit=100,
         **kwargs,
@@ -53,6 +55,7 @@ async def stripe_get_data(
 
 async def stripe_pagination(
     api_key: str,
+    account_id: str,
     endpoint: str,
     team_id: int,
     job_id: str,
@@ -75,6 +78,7 @@ async def stripe_pagination(
 
         response = await stripe_get_data(
             api_key,
+            account_id,
             endpoint,
             starting_after=starting_after,
         )
@@ -97,7 +101,7 @@ async def stripe_pagination(
 
 @dlt.source(max_table_nesting=0)
 def stripe_source(
-    api_key: str, endpoints: Tuple[str, ...], team_id, job_id, starting_after: Optional[str] = None
+    api_key: str, account_id: str, endpoints: Tuple[str, ...], team_id, job_id, starting_after: Optional[str] = None
 ) -> Iterable[DltResource]:
     for endpoint in endpoints:
         yield dlt.resource(
@@ -106,6 +110,7 @@ def stripe_source(
             write_disposition="append",
         )(
             api_key=api_key,
+            account_id=account_id,
             endpoint=endpoint,
             team_id=team_id,
             job_id=job_id,

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -173,6 +173,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def _handle_stripe_source(self, request: Request, *args: Any, **kwargs: Any) -> ExternalDataSource:
         payload = request.data["payload"]
         client_secret = payload.get("client_secret")
+        account_id = payload.get("account_id")
         prefix = request.data.get("prefix", None)
         source_type = request.data["source_type"]
 
@@ -184,9 +185,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             team=self.team,
             status="Running",
             source_type=source_type,
-            job_inputs={
-                "stripe_secret_key": client_secret,
-            },
+            job_inputs={"stripe_secret_key": client_secret, "stripe_account_id": account_id},
             prefix=prefix,
         )
 


### PR DESCRIPTION
## Problem

- stripe integration wasn't using account id

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- use account id

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
