### PR TITLE
fix: versions are not numbers, when will I ever learn

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
@@ -238,7 +238,7 @@ export const parseKafkaMessage = async (
                     libVersion,
                     parsedVersion,
                 },
-                { key: libVersion || parsedVersion.toString() }
+                { key: libVersion || 'unknown' }
             )
         }
     }

--- a/plugin-server/tests/main/ingestion-queues/session-recording/utils.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/utils.test.ts
@@ -203,7 +203,7 @@ describe('session-recording utils', () => {
             ],
             [
                 'three-part lib version that is recent enough means no call to capture ingestion warning',
-                [{ lib_version: '1.75.0' }],
+                [{ lib_version: '1.116.0' }],
                 [],
             ],
             [
@@ -216,7 +216,7 @@ describe('session-recording utils', () => {
                                 messages: [
                                     expectedIngestionWarningMessage({
                                         libVersion: '1.74.0',
-                                        parsedVersion: 1.74,
+                                        parsedVersion: { major: 1, minor: 74 },
                                     }),
                                 ],
                                 topic: 'clickhouse_ingestion_warnings_test',
@@ -236,7 +236,7 @@ describe('session-recording utils', () => {
                                 messages: [
                                     expectedIngestionWarningMessage({
                                         libVersion: '1.32.0',
-                                        parsedVersion: 1.32,
+                                        parsedVersion: { major: 1, minor: 32 },
                                     }),
                                 ],
                                 topic: 'clickhouse_ingestion_warnings_test',


### PR DESCRIPTION
We parsed a semantic version major and minor to a number and then compared to see if it was "less" than a reference value

That worked in the tests I ran but doesn't work in practice because (at some point I will learn this) versions are not numbers

1.116 is not > 1.75 when treated as a number even though it obviously is to a human