### PR TITLE
chore: test new migrations to see if an existing migration already exists with that index for CH

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -231,6 +231,8 @@ jobs:
                   # initial migrations (0001_*) as these are guaranteed to be
                   # run on initial setup where there is no data.
                   git diff --name-status origin/master..HEAD | grep "A\sposthog/migrations/" | awk '{print $2}' | grep -v migrations/0001_ | python manage.py test_migrations_are_safe
+                  # Same as above, except now for CH looking at files that were added in posthog/clickhouse/migrations/
+                  git diff --name-status origin/master..HEAD | grep "A\sposthog/migrations/" | awk '{print $2}' | grep -v migrations/0001_ | python manage.py test_migrations_are_safe
 
     django:
         needs: changes

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -173,7 +173,7 @@ jobs:
         if: needs.changes.outputs.backend == 'true'
         timeout-minutes: 10
 
-        name: Validate Django migrations
+        name: Validate Django and CH migrations
         runs-on: depot-ubuntu-latest-4
 
         steps:
@@ -231,6 +231,9 @@ jobs:
                   # initial migrations (0001_*) as these are guaranteed to be
                   # run on initial setup where there is no data.
                   git diff --name-status origin/master..HEAD | grep "A\sposthog/migrations/" | awk '{print $2}' | grep -v migrations/0001_ | python manage.py test_migrations_are_safe
+
+            - name: Check CH migrations
+              run: |
                   # Same as above, except now for CH looking at files that were added in posthog/clickhouse/migrations/
                   git diff --name-status origin/master..HEAD | grep "A\sposthog/clickhouse/migrations/" | awk '{print $2}' |  python manage.py test_ch_migrations_are_safe
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -232,7 +232,7 @@ jobs:
                   # run on initial setup where there is no data.
                   git diff --name-status origin/master..HEAD | grep "A\sposthog/migrations/" | awk '{print $2}' | grep -v migrations/0001_ | python manage.py test_migrations_are_safe
                   # Same as above, except now for CH looking at files that were added in posthog/clickhouse/migrations/
-                  git diff --name-status origin/master..HEAD | grep "A\sposthog/migrations/" | awk '{print $2}' | grep -v migrations/0001_ | python manage.py test_migrations_are_safe
+                  git diff --name-status origin/master..HEAD | grep "A\sposthog/clickhouse/migrations/" | awk '{print $2}' |  python manage.py test_migrations_are_safe
 
     django:
         needs: changes

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -232,7 +232,7 @@ jobs:
                   # run on initial setup where there is no data.
                   git diff --name-status origin/master..HEAD | grep "A\sposthog/migrations/" | awk '{print $2}' | grep -v migrations/0001_ | python manage.py test_migrations_are_safe
                   # Same as above, except now for CH looking at files that were added in posthog/clickhouse/migrations/
-                  git diff --name-status origin/master..HEAD | grep "A\sposthog/clickhouse/migrations/" | awk '{print $2}' |  python manage.py test_migrations_are_safe
+                  git diff --name-status origin/master..HEAD | grep "A\sposthog/clickhouse/migrations/" | awk '{print $2}' |  python manage.py test_ch_migrations_are_safe
 
     django:
         needs: changes

--- a/posthog/management/commands/test_ch_migrations_are_safe.py
+++ b/posthog/management/commands/test_ch_migrations_are_safe.py
@@ -33,14 +33,14 @@ class Command(BaseCommand):
             old_migrations.sort()
 
             for index, name in old_migrations:
-                logger.warn(f"old ClickHouse migration with index {index} and name {name} found")
+                logger.info(f"old ClickHouse migration with index {index} and name {name} found")
 
             try:
                 should_fail = False
                 app, index, name = re.findall(
                     r"([a-z]+)\/clickhouse\/migrations\/([0-9]+)_([a-zA-Z_0-9]+)\.py", new_migration
                 )[0]
-                logger.warn(f"new ClickHouse migration for app {app} with index {index} and name {name} found")
+                logger.info(f"new ClickHouse migration for app {app} with index {index} and name {name} found")
 
                 matching_migration_indexes = []
                 for old_index, old_name in old_migrations:
@@ -52,6 +52,7 @@ class Command(BaseCommand):
                     logger.error("Colliding migrations are:")
                     for old_index, old_name in matching_migration_indexes:
                         logger.error(f"  - {old_index}_{old_name}")
+                    logger.error(f"  - {index}_{name}")
                     logger.error(
                         "Please manually resolve this conflict and ensure all migrations are monotonically increasing"
                     )

--- a/posthog/management/commands/test_ch_migrations_are_safe.py
+++ b/posthog/management/commands/test_ch_migrations_are_safe.py
@@ -23,11 +23,14 @@ class Command(BaseCommand):
 
             try:
                 original_state = repo.active_branch.name
+                logger.warn(f"Original branch found: {original_state}.")
             except TypeError:
                 # This means we're in a detached HEAD state
-                was_detached = True
                 original_state = repo.head.commit.hexsha
+                was_detached = True
+                logger.warn(f"Detached HEAD state found at commit {original_state}.")
 
+            logger.warn("Checking out master branch to check for existing migrations")
             repo.git.checkout("master")
             old_migration_files = os.listdir("posthog/clickhouse/migrations")
             old_migrations = []

--- a/posthog/management/commands/test_ch_migrations_are_safe.py
+++ b/posthog/management/commands/test_ch_migrations_are_safe.py
@@ -33,21 +33,21 @@ class Command(BaseCommand):
             old_migrations.sort()
 
             for index, name in old_migrations:
-                logger.info(f"old ClickHouse migration with index {index} and name {name} found")
+                logger.warn(f"old ClickHouse migration with index {index} and name {name} found")
 
             try:
                 should_fail = False
                 app, index, name = re.findall(
                     r"([a-z]+)\/clickhouse\/migrations\/([0-9]+)_([a-zA-Z_0-9]+)\.py", new_migration
                 )[0]
-                logger.info(f"new ClickHouse migration for app {app} with index {index} and name {name} found")
+                logger.warn(f"new ClickHouse migration for app {app} with index {index} and name {name} found")
 
                 matching_migration_indexes = []
                 for old_index, old_name in old_migrations:
                     if old_index == index:
                         matching_migration_indexes.append((old_index, old_name))
 
-                if len(matching_migration_indexes) > 1:
+                if len(matching_migration_indexes) > 0:
                     logger.error(f"Found an existing matching migrations with index {index} - PaNiC!")
                     logger.error("Colliding migrations are:")
                     for old_index, old_name in matching_migration_indexes:

--- a/posthog/management/commands/test_ch_migrations_are_safe.py
+++ b/posthog/management/commands/test_ch_migrations_are_safe.py
@@ -45,6 +45,8 @@ class Command(BaseCommand):
                     logger.error(
                         "Please manually resolve this conflict and ensure all migrations are monotonically increasing"
                     )
+                    should_fail = True
+
                 if should_fail:
                     sys.exit(1)
 
@@ -54,7 +56,7 @@ class Command(BaseCommand):
         migrations = sys.stdin.readlines()
 
         if len(migrations) > 1:
-            logger.info(
+            logger.error(
                 f"\n\n\033[91mFound multiple migrations. Please scope PRs to one migration to promote easy debugging and revertability"
             )
             sys.exit(1)

--- a/posthog/management/commands/test_ch_migrations_are_safe.py
+++ b/posthog/management/commands/test_ch_migrations_are_safe.py
@@ -3,10 +3,15 @@ import re
 import sys
 import logging
 
+from git import Repo
+
 from django.core.management.base import BaseCommand, CommandError
 
 
 logger = logging.getLogger(__name__)
+repo_path = os.getcwd()
+repo = Repo(repo_path)
+current_branch = repo.active_branch.name
 
 
 class Command(BaseCommand):
@@ -14,8 +19,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         def run_and_check_migration(new_migration):
+            repo.git.checkout("master")
             old_migration_files = os.listdir("posthog/clickhouse/migrations")
             old_migrations = []
+            repo.git.checkout(current_branch)
 
             for migration in old_migration_files:
                 match = re.findall(r"([0-9]+)_([a-zA-Z_0-9]+)\.py", migration)

--- a/posthog/management/commands/test_ch_migrations_are_safe.py
+++ b/posthog/management/commands/test_ch_migrations_are_safe.py
@@ -42,6 +42,9 @@ class Command(BaseCommand):
 
                 if len(matching_migration_indexes) > 1:
                     logger.error(f"Found an existing matching migrations with index {index} - PaNiC!")
+                    logger.error("Colliding migrations are:")
+                    for old_index, old_name in matching_migration_indexes:
+                        logger.error(f"  - {old_index}_{old_name}")
                     logger.error(
                         "Please manually resolve this conflict and ensure all migrations are monotonically increasing"
                     )

--- a/posthog/management/commands/test_ch_migrations_are_safe.py
+++ b/posthog/management/commands/test_ch_migrations_are_safe.py
@@ -11,7 +11,7 @@ from django.core.management.base import BaseCommand, CommandError
 logger = logging.getLogger(__name__)
 repo_path = os.getcwd()
 repo = Repo(repo_path)
-current_branch = repo.active_branch.name
+current_sha = repo.head.object.hexsha
 
 
 class Command(BaseCommand):
@@ -22,7 +22,7 @@ class Command(BaseCommand):
             repo.git.checkout("master")
             old_migration_files = os.listdir("posthog/clickhouse/migrations")
             old_migrations = []
-            repo.git.checkout(current_branch)
+            repo.git.checkout(current_sha)
 
             for migration in old_migration_files:
                 match = re.findall(r"([0-9]+)_([a-zA-Z_0-9]+)\.py", migration)


### PR DESCRIPTION
- **chore: catch bad indexes for CH migrations**

## Problem

We have had a few commits where the same CH migration index has been committed to our repo. This keeps things sane by checking these before they are landed

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
