### PR TITLE
chore: syphar is deprecated. fangle python actions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,8 +59,8 @@ jobs:
                   cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            - uses: syphar/restore-virtualenv@v1
-              id: cache-benchmark-tests
+            # uv is a fast pip alternative: https://github.com/astral-sh/uv/
+            - run: pip install uv
 
             - name: Install SAML (python3-saml) dependencies
               shell: bash
@@ -69,13 +69,12 @@ jobs:
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install python dependencies
-              if: steps.cache-benchmark-tests.outputs.cache-hit != 'true'
               run: |
-                  python -m pip install -r requirements-dev.txt
-                  python -m pip install -r requirements.txt
+                  uv pip install --system -r requirements-dev.txt
+                  uv pip install --system -r requirements.txt
 
             - name: Install asv
-              run: python -m pip install asv==0.5.1 virtualenv
+              run: uv pip install --system asv==0.5.1 virtualenv
 
             - name: Set up PostHog
               run: |

--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -84,8 +84,11 @@ jobs:
               if: matrix.os == 'ubuntu-22.04' # Only build the sdist once
               run: cd hogql_parser && python setup.py sdist
 
+            # uv is a fast pip alternative: https://github.com/astral-sh/uv/
+            - run: pip install uv
+
             - name: Install cibuildwheel
-              run: python -m pip install cibuildwheel==2.16.*
+              run: uv pip install --system cibuildwheel==2.16.*
 
             - name: Build wheels
               run: cd hogql_parser && python -m cibuildwheel --output-dir dist

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -112,10 +112,8 @@ jobs:
                   cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            - uses: syphar/restore-virtualenv@v1
-              id: cache-backend-tests
-              with:
-                  custom_cache_key_element: v2-
+            # uv is a fast pip alternative: https://github.com/astral-sh/uv/
+            - run: pip install uv
 
             - name: Install SAML (python3-saml) dependencies
               run: |
@@ -123,9 +121,8 @@ jobs:
                   sudo apt-get install libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install Python dependencies
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
               run: |
-                  python -m pip install -r requirements.txt -r requirements-dev.txt
+                  uv pip install --system -r requirements.txt -r requirements-dev.txt
 
             - name: Check for syntax errors, import sort, and code style violations
               run: |
@@ -192,10 +189,8 @@ jobs:
                   cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            - uses: syphar/restore-virtualenv@v1
-              id: cache-backend-tests
-              with:
-                  custom_cache_key_element: v1-
+            # uv is a fast pip alternative: https://github.com/astral-sh/uv/
+            - run: pip install uv
 
             - name: Install SAML (python3-saml) dependencies
               run: |
@@ -203,9 +198,8 @@ jobs:
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install python dependencies
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
               run: |
-                  python -m pip install -r requirements.txt -r requirements-dev.txt
+                  uv pip install --system -r requirements.txt -r requirements-dev.txt
 
             - uses: actions/checkout@v3
               with:
@@ -215,7 +209,7 @@ jobs:
               run: |
                   # We need to ensure we have requirements for the master branch
                   # now also, so we can run migrations up to master.
-                  python -m pip install -r requirements.txt -r requirements-dev.txt
+                  uv pip install --system -r requirements.txt -r requirements-dev.txt
                   python manage.py migrate
 
             - uses: actions/checkout@v3
@@ -344,10 +338,8 @@ jobs:
                   cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            - uses: syphar/restore-virtualenv@v1
-              id: cache-backend-tests
-              with:
-                  custom_cache_key_element: v2-
+            # uv is a fast pip alternative: https://github.com/astral-sh/uv/
+            - run: pip install uv
 
             - name: Install SAML (python3-saml) dependencies
               run: |
@@ -355,10 +347,9 @@ jobs:
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install python dependencies
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
               shell: bash
               run: |
-                  python -m pip install -r requirements.txt -r requirements-dev.txt
+                  uv pip install --system -r requirements.txt -r requirements-dev.txt
 
             - name: Add kafka host to /etc/hosts for kafka connectivity
               run: sudo echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -122,11 +122,8 @@ jobs:
                   cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            - uses: syphar/restore-virtualenv@v1
-              if: needs.changes.outputs.plugin-server == 'true'
-              id: cache-backend-tests
-              with:
-                  custom_cache_key_element: v1-
+            # uv is a fast pip alternative: https://github.com/astral-sh/uv/
+            - run: pip install uv
 
             - name: Install SAML (python3-saml) dependencies
               if: needs.changes.outputs.plugin-server == 'true'
@@ -135,10 +132,10 @@ jobs:
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install python dependencies
-              if: needs.changes.outputs.plugin-server == 'true' && steps.cache-backend-tests.outputs.cache-hit != 'true'
+              if: needs.changes.outputs.plugin-server == 'true'
               run: |
-                  python -m pip install -r requirements-dev.txt
-                  python -m pip install -r requirements.txt
+                  uv pip install --system -r requirements-dev.txt
+                  uv pip install --system -r requirements.txt
 
             - name: Install pnpm
               if: needs.changes.outputs.plugin-server == 'true'
@@ -219,22 +216,18 @@ jobs:
                   cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            - uses: syphar/restore-virtualenv@v1
-              id: cache-backend-tests
-              with:
-                  custom_cache_key_element: v1-
+            # uv is a fast pip alternative: https://github.com/astral-sh/uv/
+            - run: pip install uv
 
             - name: Install SAML (python3-saml) dependencies
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
 
             - name: Install python dependencies
-              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
               run: |
-                  python -m pip install -r requirements-dev.txt
-                  python -m pip install -r requirements.txt
+                  uv pip install --system -r requirements-dev.txt
+                  uv pip install --system -r requirements.txt
 
             - name: Install pnpm
               uses: pnpm/action-setup@v2


### PR DESCRIPTION
We use https://github.com/syphar/restore-virtualenv

but it's been marked as in maintenance mode for 10 months, (most of) its functionality has been included in the setup-python action we use

(we're using that action's cache functionality already anyway)

## when uncached 

<img width="538" alt="23m29s-uncached" src="https://github.com/PostHog/posthog/assets/984817/b1642f5e-660b-4d89-855d-fc02e910e865">

## next run shows pip is cached

this run was about 3 minutes faster than uncached

<img width="1107" alt="20m25s-cachd" src="https://github.com/PostHog/posthog/assets/984817/3714161e-5628-4711-9b31-1fc61053eca9">

That made me realise that pip is horribly slow... it takes over a minute to pip install the cached packages

I've been using UV locally for months https://github.com/astral-sh/uv/

UV is `An extremely fast Python package installer and resolver, written in Rust. Designed as a drop-in replacement for common pip and pip-tools workflows.` testing on a fork the 1 minute pip install takes 13 seconds with uv

## obscenely fast with UV

<img width="1134" alt="Screenshot 2024-03-31 at 20 46 01" src="https://github.com/PostHog/posthog/assets/984817/8ad805f5-8e3c-4c8c-884c-33d8d2d1a85d">




