### PR TITLE
fix: flaky dashboard e2e test

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
@@ -44,8 +44,7 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>([
 
     listeners(({ actions, props, values }) => ({
         // Only send update if value is set to something
-        setFilter: async ({ property }, breakpoint) => {
-            await breakpoint(300)
+        setFilter: async ({ property }) => {
             if (props.sendAllKeyUpdates || property?.value || (property?.key && property.type === 'hogql')) {
                 actions.update()
             }


### PR DESCRIPTION
## Problem

The "Adding new insight to dashboard does not clear filters" test is flaky, see [this run](https://github.com/PostHog/posthog/actions/runs/8471528949/job/23211744774) as an example.

## Changes

IIUC this is caused by the debouncer in the [propertyFilterLogic](https://github.com/PostHog/posthog/blob/7d61de5724bf9e37e6a1e32017871682073da781/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts#L48). It was introduced in https://github.com/PostHog/posthog/pull/20572 and I'm not sure it's needed in this place. See a [video](https://github.com/PostHog/posthog/assets/6707908/a7d9e4a3-ac5c-45bc-8aa7-202098a4aae7) - the `setFilter` listener is called only on pressing "Enter", not after writing anything, so I don't think debouncing is necessary anymore.

## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

I ran the test ~5 times, it hasn't failed. It was failing locally without the change almost all the time.