### PR TITLE
feat(experiments): get breakdown for every possible flag value

### DIFF
--- a/ee/clickhouse/queries/experiments/funnel_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/funnel_experiment_result.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import List, Optional, Tuple, Type
@@ -69,6 +70,8 @@ class ClickhouseFunnelExperimentResult:
                 experiment_end_date.astimezone(ZoneInfo(team.timezone)) if experiment_end_date else None
             )
 
+        # ruff: disable=T201
+        print("BREAKDOWN_KEY", breakdown_key)  # noqa: T201
         query_filter = filter.shallow_clone(
             {
                 "date_from": start_date_in_project_timezone,
@@ -89,8 +92,12 @@ class ClickhouseFunnelExperimentResult:
     def get_results(self, validate: bool = True):
         funnel_results = self.funnel.run()
 
+        # This only shows breakdown for control and test variants, not other values such as None
+        print("RAW_FUNNEL_RESULT", json.dumps(funnel_results, indent=2))  # noqa: T201
+
         basic_result_props = {
             # TODO: check if this can error out or not?, i.e. results don't have 0 index?
+            # I was expecting this part to filter out events with the experiment variants only
             "insight": [result for result in funnel_results if result[0]["breakdown_value"][0] in self.variants],
             "filters": self.funnel._filter.to_dict(),
         }

--- a/posthog/queries/funnels/base.py
+++ b/posthog/queries/funnels/base.py
@@ -272,6 +272,8 @@ class ClickhouseFunnelBase(ABC):
     def _exec_query(self) -> List[Tuple]:
         self._filter.team = self._team
         query = self.get_query()
+        print("QUERY", query)  # noqa: T201
+        print("FILTER", self._filter)  # noqa: T201
         return insight_sync_execute(
             query,
             {**self.params, **self._filter.hogql_context.values},


### PR DESCRIPTION
## Problem
This is related to the sprint goal: _no results empty state: show checklist for what events are missing_. Part of this sprint goal is also detecting when events are missing flag information.

To detect this, the funnel query needs return events with all possible breakdown values. To test this, I’ve created a funnel experiment with steps `funnel step 1` and `funnel step 2`.

I’ve populated some events with the following values for `$feature/exp-1 field`: `control`, `test`, `some_other_value`, `false` and `null`. I expected the funnel query to return events with breakdown for all of the above values, especially since after returning the query, we're filtering raw results to include only those with the experiment variants:

```
"insight": [result for result in funnel_results if result[0]["breakdown_value"][0] in self.variants],
```

However, the funnel query only returns the events with `control` and `test` in the breakdown_value:

```
  [
    {
      "action_id": "funnel step 1",
	…
      "breakdown_value": [
        "test"
      ],
	…
    },
    {
      "action_id": "funnel step 2",
	…
      "breakdown_value": [
        "test"
      ],
	…
    }
  ],
  [
    {
      "action_id": "funnel step 1",
	…
      "breakdown_value": [
        "control"
      ],
	…
    },
    {
      "action_id": "funnel step 2",
	…
      "breakdown_value": [
        "control"
      ],
	…
    }
  ]
]
```

I looked at the query but couldn't figure out how it filters out the events with the experiment variants only.

How can we get events with all breakdown values from the funnel query?
Alternatively, is there a better way to detect when events are missing flag values?