### PR TITLE
chore(CI): revert "chore: syphar is deprecated. fangle python actions"

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,8 +59,8 @@ jobs:
                   cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            # uv is a fast pip alternative: https://github.com/astral-sh/uv/
-            - run: pip install uv
+            - uses: syphar/restore-virtualenv@v1
+              id: cache-benchmark-tests
 
             - name: Install SAML (python3-saml) dependencies
               shell: bash
@@ -69,12 +69,13 @@ jobs:
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install python dependencies
+              if: steps.cache-benchmark-tests.outputs.cache-hit != 'true'
               run: |
-                  uv pip install --system -r requirements-dev.txt
-                  uv pip install --system -r requirements.txt
+                  python -m pip install -r requirements-dev.txt
+                  python -m pip install -r requirements.txt
 
             - name: Install asv
-              run: uv pip install --system asv==0.5.1 virtualenv
+              run: python -m pip install asv==0.5.1 virtualenv
 
             - name: Set up PostHog
               run: |

--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -84,11 +84,8 @@ jobs:
               if: matrix.os == 'ubuntu-22.04' # Only build the sdist once
               run: cd hogql_parser && python setup.py sdist
 
-            # uv is a fast pip alternative: https://github.com/astral-sh/uv/
-            - run: pip install uv
-
             - name: Install cibuildwheel
-              run: uv pip install --system cibuildwheel==2.16.*
+              run: python -m pip install cibuildwheel==2.16.*
 
             - name: Build wheels
               run: cd hogql_parser && python -m cibuildwheel --output-dir dist

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -112,8 +112,10 @@ jobs:
                   cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            # uv is a fast pip alternative: https://github.com/astral-sh/uv/
-            - run: pip install uv
+            - uses: syphar/restore-virtualenv@v1
+              id: cache-backend-tests
+              with:
+                  custom_cache_key_element: v2-
 
             - name: Install SAML (python3-saml) dependencies
               run: |
@@ -121,8 +123,9 @@ jobs:
                   sudo apt-get install libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install Python dependencies
+              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
               run: |
-                  uv pip install --system -r requirements.txt -r requirements-dev.txt
+                  python -m pip install -r requirements.txt -r requirements-dev.txt
 
             - name: Check for syntax errors, import sort, and code style violations
               run: |
@@ -189,8 +192,10 @@ jobs:
                   cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            # uv is a fast pip alternative: https://github.com/astral-sh/uv/
-            - run: pip install uv
+            - uses: syphar/restore-virtualenv@v1
+              id: cache-backend-tests
+              with:
+                  custom_cache_key_element: v1-
 
             - name: Install SAML (python3-saml) dependencies
               run: |
@@ -198,8 +203,9 @@ jobs:
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install python dependencies
+              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
               run: |
-                  uv pip install --system -r requirements.txt -r requirements-dev.txt
+                  python -m pip install -r requirements.txt -r requirements-dev.txt
 
             - uses: actions/checkout@v3
               with:
@@ -209,7 +215,7 @@ jobs:
               run: |
                   # We need to ensure we have requirements for the master branch
                   # now also, so we can run migrations up to master.
-                  uv pip install --system -r requirements.txt -r requirements-dev.txt
+                  python -m pip install -r requirements.txt -r requirements-dev.txt
                   python manage.py migrate
 
             - uses: actions/checkout@v3
@@ -338,8 +344,10 @@ jobs:
                   cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            # uv is a fast pip alternative: https://github.com/astral-sh/uv/
-            - run: pip install uv
+            - uses: syphar/restore-virtualenv@v1
+              id: cache-backend-tests
+              with:
+                  custom_cache_key_element: v2-
 
             - name: Install SAML (python3-saml) dependencies
               run: |
@@ -347,9 +355,10 @@ jobs:
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install python dependencies
+              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
               shell: bash
               run: |
-                  uv pip install --system -r requirements.txt -r requirements-dev.txt
+                  python -m pip install -r requirements.txt -r requirements-dev.txt
 
             - name: Add kafka host to /etc/hosts for kafka connectivity
               run: sudo echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -122,8 +122,11 @@ jobs:
                   cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            # uv is a fast pip alternative: https://github.com/astral-sh/uv/
-            - run: pip install uv
+            - uses: syphar/restore-virtualenv@v1
+              if: needs.changes.outputs.plugin-server == 'true'
+              id: cache-backend-tests
+              with:
+                  custom_cache_key_element: v1-
 
             - name: Install SAML (python3-saml) dependencies
               if: needs.changes.outputs.plugin-server == 'true'
@@ -132,10 +135,10 @@ jobs:
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install python dependencies
-              if: needs.changes.outputs.plugin-server == 'true'
+              if: needs.changes.outputs.plugin-server == 'true' && steps.cache-backend-tests.outputs.cache-hit != 'true'
               run: |
-                  uv pip install --system -r requirements-dev.txt
-                  uv pip install --system -r requirements.txt
+                  python -m pip install -r requirements-dev.txt
+                  python -m pip install -r requirements.txt
 
             - name: Install pnpm
               if: needs.changes.outputs.plugin-server == 'true'
@@ -216,18 +219,22 @@ jobs:
                   cache-dependency-path: '**/requirements*.txt'
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            # uv is a fast pip alternative: https://github.com/astral-sh/uv/
-            - run: pip install uv
+            - uses: syphar/restore-virtualenv@v1
+              id: cache-backend-tests
+              with:
+                  custom_cache_key_element: v1-
 
             - name: Install SAML (python3-saml) dependencies
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
 
             - name: Install python dependencies
+              if: steps.cache-backend-tests.outputs.cache-hit != 'true'
               run: |
-                  uv pip install --system -r requirements-dev.txt
-                  uv pip install --system -r requirements.txt
+                  python -m pip install -r requirements-dev.txt
+                  python -m pip install -r requirements.txt
 
             - name: Install pnpm
               uses: pnpm/action-setup@v2


### PR DESCRIPTION
Reverts PostHog/posthog#21249 because CI on branches is failing with:
> thread 'main' panicked at crates/uv/src/commands/pip_install.rs:670:18:
> Resolution should contain all packages

The CI on that PR was green, I suspect caching shenanigans.

https://github.com/PostHog/posthog/pull/21266 is https://github.com/PostHog/posthog/pull/21161 with that commit reverted, to confirm whether it'll help.