### PR TITLE
feat(admin): allow to filter pluginconfigs on is_global from the plugin

### DIFF
--- a/posthog/admin/admins/plugin_config_admin.py
+++ b/posthog/admin/admins/plugin_config_admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.utils.html import format_html
-from posthog.admin.inlines.plugin_attachment_inline import PluginAttachmentInline
 
+from posthog.admin.inlines.plugin_attachment_inline import PluginAttachmentInline
 from posthog.models import PluginConfig
 
 
@@ -14,6 +14,7 @@ class PluginConfigAdmin(admin.ModelAdmin):
         ("deleted", admin.BooleanFieldListFilter),
         ("updated_at", admin.DateFieldListFilter),
         ("plugin", admin.RelatedOnlyFieldListFilter),
+        "plugin__is_global",
     )
     list_select_related = ("team", "plugin")
     search_fields = ("team__name", "team__organization__name", "plugin__name")


### PR DESCRIPTION
Allow to filter out plugin configs by the plugin's `is_global` value in the admin.

<img width="298" alt="image" src="https://github.com/PostHog/posthog/assets/6241083/0320a282-4492-4207-ad97-f73234eb2f3d">