### PR TITLE
fix(flags): Handle is not set operator correctly for not-seen persons…

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -347,7 +347,7 @@ dependencies:
 optionalDependencies:
   fsevents:
     specifier: ^2.3.2
-    version: 2.3.2
+    version: 2.3.3
 
 devDependencies:
   '@babel/core':
@@ -12822,6 +12822,7 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /fsevents@2.3.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -347,7 +347,7 @@ dependencies:
 optionalDependencies:
   fsevents:
     specifier: ^2.3.2
-    version: 2.3.3
+    version: 2.3.2
 
 devDependencies:
   '@babel/core':
@@ -12822,7 +12822,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /fsevents@2.3.3:

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -514,6 +514,39 @@
          AND "posthog_person"."team_id" = 2)
   '''
 # ---
+# name: TestFeatureFlagMatcher.test_numeric_operator_with_cohorts_and_nested_cohorts.2
+  '''
+  SELECT (((("posthog_person"."properties" -> 'number') > '"100"'
+            AND JSONB_TYPEOF(("posthog_person"."properties" -> 'number')) = ('string'))
+           OR (("posthog_person"."properties" -> 'number') > '100.0'
+               AND JSONB_TYPEOF(("posthog_person"."properties" -> 'number')) = ('number')))
+          AND "posthog_person"."properties" ? 'number'
+          AND NOT (("posthog_person"."properties" -> 'number') = 'null')) AS "flag_X_condition_0",
+         (((("posthog_person"."properties" -> 'version') > '"1.05"'
+            AND JSONB_TYPEOF(("posthog_person"."properties" -> 'version')) = ('string'))
+           OR (("posthog_person"."properties" -> 'version') > '1.05'
+               AND JSONB_TYPEOF(("posthog_person"."properties" -> 'version')) = ('number')))
+          AND "posthog_person"."properties" ? 'version'
+          AND NOT (("posthog_person"."properties" -> 'version') = 'null')) AS "flag_X_condition_0",
+         (((("posthog_person"."properties" -> 'number') < '"31"'
+            AND JSONB_TYPEOF(("posthog_person"."properties" -> 'number')) = ('string'))
+           OR (("posthog_person"."properties" -> 'number') < '31.0'
+               AND JSONB_TYPEOF(("posthog_person"."properties" -> 'number')) = ('number')))
+          AND "posthog_person"."properties" ? 'number'
+          AND NOT (("posthog_person"."properties" -> 'number') = 'null')
+          AND ((("posthog_person"."properties" -> 'nested_prop') > '"20"'
+                AND JSONB_TYPEOF(("posthog_person"."properties" -> 'nested_prop')) = ('string'))
+               OR (("posthog_person"."properties" -> 'nested_prop') > '20.0'
+                   AND JSONB_TYPEOF(("posthog_person"."properties" -> 'nested_prop')) = ('number')))
+          AND "posthog_person"."properties" ? 'nested_prop'
+          AND NOT (("posthog_person"."properties" -> 'nested_prop') = 'null')) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = '307'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '''
+# ---
 # name: TestFeatureFlagMatcher.test_numeric_operator_with_groups_and_person_flags
   '''
   SELECT "posthog_grouptypemapping"."id",
@@ -567,6 +600,26 @@
   '''
 # ---
 # name: TestFeatureFlagMatcher.test_super_condition_matches_string
+  '''
+  SELECT ((("posthog_person"."properties" -> 'is_enabled') = 'true'
+           OR ("posthog_person"."properties" -> 'is_enabled') = '"true"')
+          AND "posthog_person"."properties" ? 'is_enabled'
+          AND NOT (("posthog_person"."properties" -> 'is_enabled') = 'null')) AS "flag_X_super_condition", ("posthog_person"."properties" -> 'is_enabled') IS NOT NULL AS "flag_X_super_condition_is_set",
+                                                                                                                                                                          (("posthog_person"."properties" -> 'email') = '"fake@posthog.com"'
+                                                                                                                                                                           AND "posthog_person"."properties" ? 'email'
+                                                                                                                                                                           AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_0",
+                                                                                                                                                                          (("posthog_person"."properties" -> 'email') = '"test@posthog.com"'
+                                                                                                                                                                           AND "posthog_person"."properties" ? 'email'
+                                                                                                                                                                           AND NOT (("posthog_person"."properties" -> 'email') = 'null')) AS "flag_X_condition_1",
+                                                                                                                                                                          (true) AS "flag_X_condition_2"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'test_id'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '''
+# ---
+# name: TestFeatureFlagMatcher.test_super_condition_matches_string.1
   '''
   SELECT ((("posthog_person"."properties" -> 'is_enabled') = 'true'
            OR ("posthog_person"."properties" -> 'is_enabled') = '"true"')
@@ -694,6 +747,43 @@
   '''
 # ---
 # name: TestFeatureFlagMatcher.test_with_sql_injection_properties_and_other_aliases.3
+  '''
+  SELECT (((("posthog_person"."properties" -> 'number space') > '"100"'
+            AND JSONB_TYPEOF(("posthog_person"."properties" -> 'number space')) = ('string'))
+           OR (("posthog_person"."properties" -> 'number space') > '100.0'
+               AND JSONB_TYPEOF(("posthog_person"."properties" -> 'number space')) = ('number')))
+          AND "posthog_person"."properties" ? 'number space'
+          AND NOT (("posthog_person"."properties" -> 'number space') = 'null')
+          AND ((JSONB_TYPEOF(("posthog_person"."properties" -> ';''" SELECT 1; DROP TABLE posthog_featureflag;')) = ('string')
+                AND ("posthog_person"."properties" -> ';''" SELECT 1; DROP TABLE posthog_featureflag;') > '"100"')
+               OR (JSONB_TYPEOF(("posthog_person"."properties" -> ';''" SELECT 1; DROP TABLE posthog_featureflag;')) = ('number')
+                   AND ("posthog_person"."properties" -> ';''" SELECT 1; DROP TABLE posthog_featureflag;') > '100.0'))
+          AND "posthog_person"."properties" ? ';''" SELECT 1; DROP TABLE posthog_featureflag;'
+          AND NOT (("posthog_person"."properties" -> ';''" SELECT 1; DROP TABLE posthog_featureflag;') = 'null')) AS "flag_X_condition_0",
+         (((JSONB_TYPEOF(("posthog_person"."properties" -> ';''" SELECT 1; DROP TABLE posthog_featureflag;')) = ('string')
+            AND ("posthog_person"."properties" -> ';''" SELECT 1; DROP TABLE posthog_featureflag;') > '"100"')
+           OR (JSONB_TYPEOF(("posthog_person"."properties" -> ';''" SELECT 1; DROP TABLE posthog_featureflag;')) = ('number')
+               AND ("posthog_person"."properties" -> ';''" SELECT 1; DROP TABLE posthog_featureflag;') > '100.0'))
+          AND "posthog_person"."properties" ? ';''" SELECT 1; DROP TABLE posthog_featureflag;'
+          AND NOT (("posthog_person"."properties" -> ';''" SELECT 1; DROP TABLE posthog_featureflag;') = 'null')) AS "flag_X_condition_1",
+         (((("posthog_person"."properties" -> 'version!!!') > '"1.05"'
+            AND JSONB_TYPEOF(("posthog_person"."properties" -> 'version!!!')) = ('string'))
+           OR (("posthog_person"."properties" -> 'version!!!') > '1.05'
+               AND JSONB_TYPEOF(("posthog_person"."properties" -> 'version!!!')) = ('number')))
+          AND "posthog_person"."properties" ? 'version!!!'
+          AND NOT (("posthog_person"."properties" -> 'version!!!') = 'null')) AS "flag_X_condition_2",
+         ((("posthog_person"."properties" -> 'nested_prop --random #comment //test') = '"21"'
+           OR ("posthog_person"."properties" -> 'nested_prop --random #comment //test') = '21')
+          AND "posthog_person"."properties" ? 'nested_prop --random #comment //test'
+          AND NOT (("posthog_person"."properties" -> 'nested_prop --random #comment //test') = 'null')) AS "flag_X_condition_3"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = '307'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '''
+# ---
+# name: TestFeatureFlagMatcher.test_with_sql_injection_properties_and_other_aliases.4
   '''
   SELECT (((("posthog_person"."properties" -> 'number space') > '"100"'
             AND JSONB_TYPEOF(("posthog_person"."properties" -> 'number space')) = ('string'))

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -3272,11 +3272,12 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
         feature_flag = self.create_feature_flag(
             filters={"groups": [{"properties": [{"key": "email", "operator": "is_not_set"}]}]}
         )
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(5):
             self.assertEqual(
                 FeatureFlagMatcher([feature_flag], "example_id", property_value_overrides={}).get_match(feature_flag),
                 FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
             )
+        with self.assertNumQueries(0):
             self.assertEqual(
                 FeatureFlagMatcher(
                     [feature_flag],
@@ -3286,16 +3287,399 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
             )
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(5):
             self.assertEqual(
                 FeatureFlagMatcher([feature_flag], "random_id").get_match(feature_flag),
                 FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
             )
+        with self.assertNumQueries(0):
             self.assertEqual(
                 FeatureFlagMatcher(
                     [feature_flag],
                     "random_id",
                     property_value_overrides={"email": "example@example.com"},
+                ).get_match(feature_flag),
+                FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+            )
+
+    def test_non_existing_person_with_is_not_set(self):
+        feature_flag = self.create_feature_flag(
+            filters={"groups": [{"properties": [{"key": "email", "operator": "is_not_set"}]}]}
+        )
+
+        # one extra query to check existence
+        with self.assertNumQueries(5):
+            self.assertEqual(
+                FeatureFlagMatcher([feature_flag], "not-seen-person").get_match(feature_flag),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag],
+                    "not-seen-person",
+                    property_value_overrides={"email": "example@example.com"},
+                ).get_match(feature_flag),
+                FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+            )
+
+    def test_is_not_set_operator_with_overrides(self):
+        Person.objects.create(
+            team=self.team,
+            distinct_ids=["another_id"],
+            properties={"company": "example.com"},
+        )
+        feature_flag1 = self.create_feature_flag(
+            key="x1",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": "email", "operator": "is_not_set"},
+                            {"key": "company", "operator": "is_set"},
+                        ]
+                    }
+                ]
+            },
+        )
+
+        # no extra query to check existence because it doesn't matter - since not a pure condition
+        with self.assertNumQueries(4):
+            self.assertEqual(
+                FeatureFlagMatcher([feature_flag1], "not-seen-person").get_match(feature_flag1),
+                FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+            )
+        # still goes to DB because no company override, and then fails because person doesn't exist
+        with self.assertNumQueries(4):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag1],
+                    "not-seen-person",
+                    property_value_overrides={"email": "example@example.com"},
+                ).get_match(feature_flag1),
+                FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+            )
+        # :TRICKY: For optimising queries, we're not supporting this case yet - because it should be pretty
+        # rare in practice: One property is overridden, another property doesn't exist, and the person doesn't exist yet either
+        # This will get sorted in the rewrite.
+        #
+        # goes to DB because no email override, and then FAILS because person doesn't exist (should pass ideally)
+        with self.assertNumQueries(4):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag1],
+                    "not-seen-person",
+                    property_value_overrides={"company": "x.com"},
+                ).get_match(feature_flag1),
+                FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+            )
+        # doesn't go to DB
+        with self.assertNumQueries(0):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag1],
+                    "not-seen-person",
+                    property_value_overrides={"company": "x.com", "email": "k"},
+                ).get_match(feature_flag1),
+                FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+            )
+
+        # now dealing with existing person
+        with self.assertNumQueries(4):
+            self.assertEqual(
+                FeatureFlagMatcher([feature_flag1], "another_id").get_match(feature_flag1),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+        # since not all conditions are available in overrides, goes to DB, but then correctly matches is_not_set condition
+        # using the given override
+        with self.assertNumQueries(4):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag1],
+                    "another_id",
+                    property_value_overrides={"email": "example@example.com"},
+                ).get_match(feature_flag1),
+                FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+            )
+
+    def test_is_not_set_operator_with_pure_multiple_conditions(self):
+        Person.objects.create(
+            team=self.team,
+            distinct_ids=["another_id"],
+            properties={"email": "example@example.com"},
+        )
+        Person.objects.create(
+            team=self.team,
+            distinct_ids=["another_id_without_email"],
+            properties={},
+        )
+        feature_flag1 = self.create_feature_flag(
+            key="x2",
+            filters={
+                "groups": [
+                    {"properties": [{"key": "email", "operator": "is_not_set"}]},
+                    {"properties": [{"key": "email", "operator": "icontains", "type": "person", "value": "example"}]},
+                ]
+            },
+        )
+
+        # 1 extra query to get existence clause
+        with self.assertNumQueries(5):
+            self.assertEqual(
+                FeatureFlagMatcher([feature_flag1], "not-seen-person").get_match(feature_flag1),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+
+        with self.assertNumQueries(0):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag1],
+                    "not-seen-person",
+                    property_value_overrides={"email": "x"},
+                ).get_match(feature_flag1),
+                FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 1),
+            )
+
+        with self.assertNumQueries(0):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag1],
+                    "not-seen-person",
+                    property_value_overrides={"email": "example.com"},
+                ).get_match(feature_flag1),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 1),
+            )
+
+        # now dealing with existing person
+        # one extra query to check existence
+        with self.assertNumQueries(5):
+            self.assertEqual(
+                FeatureFlagMatcher([feature_flag1], "another_id").get_match(feature_flag1),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 1),
+            )
+
+        with self.assertNumQueries(0):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag1],
+                    "another_id",
+                    property_value_overrides={"email": "x"},
+                ).get_match(feature_flag1),
+                FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 1),
+            )
+
+        # without email, person exists though, should thus return True
+        with self.assertNumQueries(5):
+            self.assertEqual(
+                FeatureFlagMatcher([feature_flag1], "another_id_without_email").get_match(feature_flag1),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+
+    def test_is_not_set_operator_with_groups(self):
+        self.create_groups()
+        Group.objects.create(
+            team=self.team,
+            group_type_index=0,
+            group_key="target_group",
+            group_properties={},
+            version=1,
+        )
+        feature_flag = self.create_feature_flag(
+            filters={
+                "aggregation_group_type_index": 0,
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "name",
+                                "operator": "is_not_set",
+                                "type": "group",
+                                "group_type_index": 0,
+                            }
+                        ]
+                    }
+                ],
+            }
+        )
+        feature_flag_different_group = self.create_feature_flag(
+            key="x1_group2",
+            filters={
+                "aggregation_group_type_index": 1,
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "name",
+                                "operator": "is_not_set",
+                                "type": "group",
+                                "group_type_index": 1,
+                            }
+                        ]
+                    }
+                ],
+            },
+        )
+        feature_flag_unknown_group_type = self.create_feature_flag(
+            key="x_unkown",
+            filters={
+                "aggregation_group_type_index": 5,
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "name",
+                                "operator": "is_not_set",
+                                "type": "group",
+                                "group_type_index": 5,
+                            }
+                        ]
+                    }
+                ],
+            },
+        )
+        feature_flag_with_no_person_is_not_set = self.create_feature_flag(
+            key="x1",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "name",
+                                "operator": "is_set",
+                                "type": "person",
+                            }
+                        ]
+                    }
+                ],
+            },
+        )
+        feature_flag_with_person_is_not_set = self.create_feature_flag(
+            key="x2",
+            filters={
+                "groups": [
+                    {"properties": [{"key": "email", "operator": "is_not_set"}]},
+                    {"properties": [{"key": "email", "operator": "icontains", "type": "person", "value": "example"}]},
+                ]
+            },
+        )
+
+        # one extra query for existence clause
+        with self.assertNumQueries(9):
+            self.assertEqual(
+                FeatureFlagMatcher([feature_flag], "", {"organization": "target_group"}).get_match(feature_flag),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+
+        with self.assertNumQueries(9):
+            self.assertEqual(
+                FeatureFlagMatcher([feature_flag], "", {"organization": "foo"}).get_match(feature_flag),
+                FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+            )
+        with self.assertNumQueries(9):
+            self.assertEqual(
+                FeatureFlagMatcher([feature_flag], "", {"organization": "unknown-new-org"}).get_match(feature_flag),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+
+        # now with overrides - only query to get group type mappings
+        with self.assertNumQueries(4):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag],
+                    "",
+                    {"organization": "target_group"},
+                    group_property_value_overrides={"organization": {"name": "x"}},
+                ).get_match(feature_flag),
+                FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+            )
+        with self.assertNumQueries(4):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag],
+                    "",
+                    {"organization": "unknown-new-org"},
+                    group_property_value_overrides={"organization": {"name": "x"}},
+                ).get_match(feature_flag),
+                FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+            )
+
+        # now queries with additional flags - check if existence queries are made for different group types / persons
+
+        # no extra query for second group type because groups not passed in
+        with self.assertNumQueries(9):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag, feature_flag_different_group], "", {"organization": "target_group"}
+                ).get_match(feature_flag),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+
+        # no extra query for second group type because unknown group not passed in
+        with self.assertNumQueries(9):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag, feature_flag_unknown_group_type], "", {"organization": "target_group"}
+                ).get_match(feature_flag),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+        # one extra query to query group
+        # second extra query to check existence
+        with self.assertNumQueries(11):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag, feature_flag_different_group],
+                    "",
+                    {"organization": "target_group", "project": "shazam"},
+                ).get_match(feature_flag),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+
+        # override means one less query to fetch group property values
+        # TODO: We still make a query for existence check, but this is unnecessary. Consider optimising.
+        with self.assertNumQueries(10):
+            matcher = FeatureFlagMatcher(
+                [feature_flag, feature_flag_different_group],
+                "",
+                {"organization": "target_group", "project": "shazam"},
+                group_property_value_overrides={"project": {"name": "x"}},
+            )
+            self.assertEqual(
+                matcher.get_match(feature_flag),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+            self.assertEqual(
+                matcher.get_match(feature_flag_different_group),
+                FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+            )
+
+        # 9 queries same as before for groups, 1 extra for person existence check, 1 extra for person query
+        with self.assertNumQueries(11):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag, feature_flag_with_person_is_not_set], "random_id", {"organization": "target_group"}
+                ).get_match(feature_flag),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+
+        # 9 queries same as before for groups, 1 extra for person existence check, no person query because overrides
+        # TODO: We still make a query for existence check, but this is unnecessary. Consider optimising.
+        with self.assertNumQueries(10):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag, feature_flag_with_person_is_not_set],
+                    "random_id",
+                    {"organization": "target_group"},
+                    property_value_overrides={"email": "x"},
+                ).get_match(feature_flag),
+                FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+
+        # no existence check for person because flag has not is_not_set condition
+        with self.assertNumQueries(10):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag, feature_flag_with_no_person_is_not_set],
+                    "random_id",
+                    {"organization": "target_group"},
                 ).get_match(feature_flag),
                 FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
             )


### PR DESCRIPTION
… and local eval

## Problem

Ugh, it's becoming painful to work with the ORM here, but not going to refactor right now, the rewrite will take care of all this mess.

The problem is that we don't treat 'is not set' operator correctly for not-ingested persons. Since when the person doesn't exist, is not set should return true, because technically the property doesn't exist.

This handles the above^ by checking whether the person exists or not, which makes an extra query, and then spends 10x the time to make sure we don't unnecessarily make this query always. There is one more optimisation here remaining, but I've added a TODO, doesnt seem worth it to do it now as its rare + will go away with the rewrite anyway.

Then, adds lots of tests for these cases, and fixes some small other things found during testing (like unnecessary group queries, and errors on querying flags for unknown groups)


The local evaluation handling for 'is not set' operator should be added to SDKs as well, but not worth blocking I think, since right now it just goes to the servers instead of giving a wrong response, which is ok.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
