### PR TITLE
chore: allow a user to go to billing page before onboarding

### DIFF
--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -202,7 +202,8 @@ export const sceneLogic = kea<sceneLogicType>([
                         !teamLogic.values.currentTeam.is_demo &&
                         !removeProjectIdIfPresent(location.pathname).startsWith(urls.onboarding('')) &&
                         !removeProjectIdIfPresent(location.pathname).startsWith(urls.products()) &&
-                        !removeProjectIdIfPresent(location.pathname).startsWith('/settings')
+                        !removeProjectIdIfPresent(location.pathname).startsWith('/settings') &&
+                        !removeProjectIdIfPresent(location.pathname).startsWith(urls.organizationBilling())
                     ) {
                         const allProductUrls = Object.values(productUrlMapping).flat()
                         if (


### PR DESCRIPTION
## Problem

Sometimes users need to visit billing right away. This will allow them to do it before completing onboarding.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

it doesn't have an impact