### PR TITLE
fix(lemon-ui): Fix tab bar animation

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTabs/LemonTabs.scss
+++ b/frontend/src/lib/lemon-ui/LemonTabs/LemonTabs.scss
@@ -12,80 +12,80 @@
     .Navigation3000__scene > :first-child > &:first-child {
         margin-top: -0.75rem;
     }
+}
 
-    .LemonTabs__bar {
-        position: relative;
-        display: flex;
-        flex-direction: row;
-        flex-shrink: 0;
-        gap: var(--lemon-tabs-gap);
-        align-items: stretch;
-        margin-bottom: var(--lemon-tabs-margin-bottom);
-        overflow-x: auto;
-        list-style: none;
+.LemonTabs__bar {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    flex-shrink: 0;
+    gap: var(--lemon-tabs-gap);
+    align-items: stretch;
+    margin-bottom: var(--lemon-tabs-margin-bottom);
+    overflow-x: auto;
+    list-style: none;
 
-        &::before {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            height: 1px;
+    &::before {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 1px;
 
-            // The bottom border
-            content: '';
-            background: var(--border);
+        // The bottom border
+        content: '';
+        background: var(--border);
+    }
+
+    &::after {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: var(--lemon-tabs-slider-width);
+        height: 0.125rem;
+
+        // The active tab slider
+        content: '';
+        background: var(--link);
+        transform: translateX(var(--lemon-tabs-slider-offset));
+
+        .LemonTabs--transitioning & {
+            transition: width 150ms ease, transform 150ms ease;
+        }
+    }
+
+    .LemonTabs__tab {
+        .LemonTabs--transitioning & {
+            transition: color 150ms ease;
         }
 
-        &::after {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            width: var(--lemon-tabs-slider-width);
-            height: 0.125rem;
-
-            // The active tab slider
-            content: '';
-            background: var(--link);
-            transform: translateX(var(--lemon-tabs-slider-offset));
-
-            .LemonTabs--transitioning & {
-                transition: width 200ms ease, transform 200ms ease;
-            }
+        &:hover {
+            color: var(--link);
         }
 
-        .LemonTabs__tab {
-            .LemonTabs--transitioning & {
-                transition: color 200ms ease;
-            }
+        &:active {
+            color: var(--primary-3000-active);
+        }
 
-            &:hover {
-                color: var(--link);
-            }
+        &.LemonTabs__tab--active {
+            color: var(--link);
+            text-shadow: 0 0 0.25px currentColor; // Simulate increased weight without affecting width
+        }
 
-            &:active {
-                color: var(--primary-3000-active);
-            }
+        a {
+            color: inherit;
 
-            &.LemonTabs__tab--active {
-                color: var(--link);
-                text-shadow: 0 0 0.25px currentColor; // Simulate increased weight without affecting width
-            }
+            // Make tab labels that are links the same colors as regular tab labels
+            text-decoration: none;
+            transition: none;
+        }
 
-            a {
-                color: inherit;
-
-                // Make tab labels that are links the same colors as regular tab labels
-                text-decoration: none;
-                transition: none;
-            }
-
-            .LemonTabs__tab-content {
-                display: flex;
-                align-items: center;
-                padding: var(--lemon-tabs-content-padding);
-                white-space: nowrap;
-                cursor: pointer;
-            }
+        .LemonTabs__tab-content {
+            display: flex;
+            align-items: center;
+            padding: var(--lemon-tabs-content-padding);
+            white-space: nowrap;
+            cursor: pointer;
         }
     }
 }


### PR DESCRIPTION
## Problem

Had this on my list of tiny to-dos for a long time: the tab underline transition was broken.

![2024-04-02 21 14 23](https://github.com/PostHog/posthog/assets/4550621/8dfc497e-ab21-4e2a-a054-43b4e934496c)

## Changes

Now works smoothly:

![2024-04-02 21 14 08](https://github.com/PostHog/posthog/assets/4550621/0d02e496-f97d-481a-9e29-c209da4bc63e)
