### PR TITLE
fix(plugin-server): Better limit Kafka message key types to avoid problematic values

### DIFF
--- a/plugin-server/src/kafka/producer.ts
+++ b/plugin-server/src/kafka/producer.ts
@@ -2,7 +2,7 @@ import {
     ClientMetrics,
     HighLevelProducer as RdKafkaProducer,
     MessageHeader,
-    MessageKey,
+    MessageKey as RdKafkaMessageKey,
     MessageValue,
     NumberNullUndefined,
     ProducerGlobalConfig,
@@ -17,6 +17,11 @@ export type KafkaProducerConfig = {
     KAFKA_PRODUCER_BATCH_SIZE: number
     KAFKA_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES: number
 }
+
+// Disallow use of ``undefined`` with ``HighLevelProducer`` since it will result
+// in messages that are never produced, and the corresponding callback is never
+// called, causing the promise returned to never settle.
+export type MessageKey = Exclude<RdKafkaMessageKey, undefined>
 
 export const ingestEventKafkaProduceLatency = new Summary({
     name: 'ingest_event_kafka_produce_latency',

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -75,7 +75,7 @@ async function handleProcessingError(
             await queue.pluginsServer.kafkaProducer.produce({
                 topic: KAFKA_EVENTS_PLUGIN_INGESTION_DLQ,
                 value: message.value,
-                key: message.key,
+                key: message.key ?? null, // avoid undefined, just to be safe
                 headers: headers,
                 waitForAck: true,
             })

--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -1,8 +1,8 @@
 import { Message, ProducerRecord } from 'kafkajs'
-import { HighLevelProducer, LibrdKafkaError, MessageHeader, MessageKey, MessageValue } from 'node-rdkafka'
+import { HighLevelProducer, LibrdKafkaError, MessageHeader, MessageValue } from 'node-rdkafka'
 import { Counter } from 'prom-client'
 
-import { disconnectProducer, flushProducer, produce } from '../../kafka/producer'
+import { disconnectProducer, flushProducer, MessageKey, produce } from '../../kafka/producer'
 import { status } from '../../utils/status'
 import { DependencyUnavailableError, MessageSizeTooLarge } from './error'
 


### PR DESCRIPTION
## Problem

[`undefined` can cause problems with `HighLevelProducer`](https://github.com/PostHog/posthog/pull/20945/files/057597d853a61c45fff5706c0dc26d79c365bd67#r1548779396), so let's disallow it.

## Changes

Excludes `undefined` from the set of valid types for a message key when type checking. I figured it's not a common enough problem to add a runtime check.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

See [this comment](https://github.com/PostHog/posthog/pull/20945/files/057597d853a61c45fff5706c0dc26d79c365bd67#r1548779396) explaining the rationale for why this should be avoided. Depending on the type checker instead of tests here to ensure this doesn't happen elsewhere now or in the future.

Cherry picking 85ef23745934cf91cdb3e5ea18d366eba2a5d764 and running `pnpm typescript:check` also fails.