### PR TITLE
revert: "fix: Fix geoip not containing postal_code for UK"

### DIFF
--- a/posthog/api/test/test_geoip.py
+++ b/posthog/api/test/test_geoip.py
@@ -16,16 +16,15 @@ local_ip = "127.0.0.1"
 @pytest.mark.parametrize(
     "test_input,expected",
     [
-        (australia_ip, ("Australia", 6)),
-        (uk_ip, ("United Kingdom", 5)),
-        (us_ip_v6, ("United States", 6)),
+        (australia_ip, "Australia"),
+        (uk_ip, "United Kingdom"),
+        (us_ip_v6, "United States"),
     ],
 )
 def test_geoip_results(test_input, expected):
     properties = get_geoip_properties(test_input)
-    name, length = expected
-    assert properties["$geoip_country_name"] == name
-    assert len(properties) == length
+    assert properties["$geoip_country_name"] == expected
+    assert len(properties) == 6
 
 
 class TestGeoIPDBError(TestCase):


### PR DESCRIPTION
Looks like the new geoIP version has this back? 😳☺️