### PR TITLE
fix(experiment): UI fixes

### DIFF
--- a/frontend/src/lib/components/SeriesGlyph.tsx
+++ b/frontend/src/lib/components/SeriesGlyph.tsx
@@ -58,16 +58,17 @@ interface ExperimentVariantNumberProps {
     index: number
 }
 export function ExperimentVariantNumber({ className, index }: ExperimentVariantNumberProps): JSX.Element {
-    const color = getSeriesColor(index + 1)
     const { isDarkModeOn } = useValues(themeLogic)
 
     return (
         <SeriesGlyph
             className={className}
             style={{
-                borderColor: color,
-                color: color,
-                backgroundColor: isDarkModeOn ? RGBToRGBA(lightenDarkenColor(color, -20), 0.3) : hexToRGBA(color, 0.2),
+                borderColor: 'var(--muted)',
+                color: 'var(--muted)',
+                backgroundColor: isDarkModeOn
+                    ? RGBToRGBA(lightenDarkenColor('var(--muted)', -20), 0.3)
+                    : hexToRGBA('var(--muted)', 0.2),
             }}
         >
             {index}

--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -2,6 +2,7 @@ import '../Experiment.scss'
 
 import { LemonTable, LemonTableColumns, Link } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
+import { capitalizeFirstLetter } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
 import { MultivariateFlagVariant } from '~/types'
@@ -10,7 +11,7 @@ import { experimentLogic } from '../experimentLogic'
 import { VariantTag } from './components'
 
 export function DistributionTable(): JSX.Element {
-    const { experiment } = useValues(experimentLogic)
+    const { experiment, experimentResults } = useValues(experimentLogic)
 
     const columns: LemonTableColumns<MultivariateFlagVariant> = [
         {
@@ -18,6 +19,9 @@ export function DistributionTable(): JSX.Element {
             key: 'key',
             title: 'Variant',
             render: function Key(_, item): JSX.Element {
+                if (!experimentResults || !experimentResults.insight) {
+                    return <span className="font-semibold">{capitalizeFirstLetter(item.key)}</span>
+                }
                 return <VariantTag variantKey={item.key} />
             },
         },

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -2,8 +2,9 @@ import '../Experiment.scss'
 
 import { IconWarning } from '@posthog/icons'
 import { Link, ProfilePicture, Tooltip } from '@posthog/lemon-ui'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
+import { EditableField } from 'lib/components/EditableField/EditableField'
 import { TZLabel } from 'lib/components/TZLabel'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { urls } from 'scenes/urls'
@@ -17,6 +18,8 @@ import { ResultsTag } from './components'
 
 export function Info(): JSX.Element {
     const { experiment } = useValues(experimentLogic)
+    const { updateExperiment } = useActions(experimentLogic)
+
     const { created_by, created_at } = experiment
 
     if (!experiment.feature_flag) {
@@ -24,63 +27,80 @@ export function Info(): JSX.Element {
     }
 
     return (
-        <div className="flex">
-            <div className="w-1/2 inline-flex space-x-8">
-                <div className="block">
-                    <div className="text-xs font-semibold uppercase tracking-wide">Status</div>
-                    <StatusTag experiment={experiment} />
-                </div>
-                <div className="block">
-                    <div className="text-xs font-semibold uppercase tracking-wide">Significance</div>
-                    <ResultsTag />
-                </div>
-                {experiment.feature_flag && (
+        <div>
+            <div className="flex">
+                <div className="w-1/2 inline-flex space-x-8">
                     <div className="block">
-                        <div className="text-xs font-semibold uppercase tracking-wide">
-                            <span>Feature flag</span>
+                        <div className="text-xs font-semibold uppercase tracking-wide">Status</div>
+                        <StatusTag experiment={experiment} />
+                    </div>
+                    <div className="block">
+                        <div className="text-xs font-semibold uppercase tracking-wide">Significance</div>
+                        <ResultsTag />
+                    </div>
+                    {experiment.feature_flag && (
+                        <div className="block">
+                            <div className="text-xs font-semibold uppercase tracking-wide">
+                                <span>Feature flag</span>
+                            </div>
+                            {getExperimentStatus(experiment) === ProgressStatus.Running &&
+                                !experiment.feature_flag.active && (
+                                    <Tooltip
+                                        placement="bottom"
+                                        title="Your experiment is running, but the linked flag is disabled. No data is being collected."
+                                    >
+                                        <IconWarning
+                                            style={{ transform: 'translateY(2px)' }}
+                                            className="mr-1 text-danger"
+                                            fontSize="18px"
+                                        />
+                                    </Tooltip>
+                                )}
+                            <CopyToClipboardInline
+                                iconStyle={{ color: 'var(--lemon-button-icon-opacity)' }}
+                                className="font-normal text-sm"
+                                description="feature flag key"
+                            >
+                                {experiment.feature_flag.key}
+                            </CopyToClipboardInline>
+                            <Link
+                                target="_blank"
+                                className="font-semibold"
+                                to={experiment.feature_flag ? urls.featureFlag(experiment.feature_flag.id) : undefined}
+                            >
+                                <IconOpenInNew fontSize="18" />
+                            </Link>
                         </div>
-                        {getExperimentStatus(experiment) === ProgressStatus.Running &&
-                            !experiment.feature_flag.active && (
-                                <Tooltip
-                                    placement="bottom"
-                                    title="Your experiment is running, but the linked flag is disabled. No data is being collected."
-                                >
-                                    <IconWarning
-                                        style={{ transform: 'translateY(2px)' }}
-                                        className="mr-1 text-danger"
-                                        fontSize="18px"
-                                    />
-                                </Tooltip>
-                            )}
-                        <CopyToClipboardInline
-                            iconStyle={{ color: 'var(--lemon-button-icon-opacity)' }}
-                            className="font-normal text-sm"
-                            description="feature flag key"
-                        >
-                            {experiment.feature_flag.key}
-                        </CopyToClipboardInline>
-                        <Link
-                            target="_blank"
-                            className="font-semibold"
-                            to={experiment.feature_flag ? urls.featureFlag(experiment.feature_flag.id) : undefined}
-                        >
-                            <IconOpenInNew fontSize="18" />
-                        </Link>
-                    </div>
-                )}
-            </div>
+                    )}
+                </div>
 
-            <div className="w-1/2 flex flex-col justify-end">
-                <div className="ml-auto inline-flex space-x-8">
-                    <div className="block">
-                        <div className="text-xs font-semibold uppercase tracking-wide">Created at</div>
-                        {created_at && <TZLabel time={created_at} />}
-                    </div>
-                    <div className="block">
-                        <div className="text-xs font-semibold uppercase tracking-wide">Created by</div>
-                        {created_by && <ProfilePicture user={created_by} size="md" showName />}
+                <div className="w-1/2 flex flex-col justify-end">
+                    <div className="ml-auto inline-flex space-x-8">
+                        <div className="block">
+                            <div className="text-xs font-semibold uppercase tracking-wide">Created at</div>
+                            {created_at && <TZLabel time={created_at} />}
+                        </div>
+                        <div className="block">
+                            <div className="text-xs font-semibold uppercase tracking-wide">Created by</div>
+                            {created_by && <ProfilePicture user={created_by} size="md" showName />}
+                        </div>
                     </div>
                 </div>
+            </div>
+            <div className="block mt-4">
+                <div className="text-xs font-semibold uppercase tracking-wide">Description</div>
+                <EditableField
+                    className="py-2"
+                    multiline
+                    markdown
+                    name="description"
+                    value={experiment.description || ''}
+                    placeholder="Add your hypothesis for this test (optional)"
+                    onSave={(value) => updateExperiment({ description: value })}
+                    maxLength={400}
+                    data-attr="experiment-description"
+                    compactButtons
+                />
             </div>
         </div>
     )

--- a/frontend/src/scenes/experiments/ExperimentView/Overview.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Overview.tsx
@@ -20,10 +20,20 @@ export function Overview(): JSX.Element {
     function WinningVariantText(): JSX.Element {
         if (experimentInsightType === InsightType.FUNNELS) {
             const winningVariant = sortedConversionRates[0]
-            const secondBestVariant = sortedConversionRates[1]
-            const difference = winningVariant.conversionRate - secondBestVariant.conversionRate
 
-            if (winningVariant.conversionRate === secondBestVariant.conversionRate) {
+            let comparisonVariant
+            if (winningVariant.key === 'control') {
+                comparisonVariant = sortedConversionRates[1]
+            } else {
+                comparisonVariant = sortedConversionRates.find(({ key }) => key === 'control')
+            }
+
+            if (!comparisonVariant) {
+                return <></>
+            }
+
+            const difference = winningVariant.conversionRate - comparisonVariant.conversionRate
+            if (winningVariant.conversionRate === comparisonVariant.conversionRate) {
                 return (
                     <span>
                         <b>No variant is winning</b> at this moment.&nbsp;
@@ -39,7 +49,7 @@ export function Overview(): JSX.Element {
                         increase of {`${difference.toFixed(2)}%`}
                     </span>
                     <span>&nbsp;percentage points (vs&nbsp;</span>
-                    <VariantTag variantKey={secondBestVariant.key} />
+                    <VariantTag variantKey={comparisonVariant.key} />
                     <span>).&nbsp;</span>
                 </div>
             )

--- a/frontend/src/scenes/experiments/ExperimentView/SecondaryMetricsTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SecondaryMetricsTable.tsx
@@ -125,6 +125,7 @@ export function SecondaryMetricsTable({
     const { openModalToCreateSecondaryMetric, openModalToEditSecondaryMetric } = useActions(logic)
 
     const {
+        experimentResults,
         secondaryMetricResultsLoading,
         isExperimentRunning,
         experiment,
@@ -143,6 +144,9 @@ export function SecondaryMetricsTable({
                 {
                     title: <div className="py-2">Variant</div>,
                     render: function Key(_, item: TabularSecondaryMetricResults): JSX.Element {
+                        if (!experimentResults || !experimentResults.insight) {
+                            return <span className="font-semibold">{capitalizeFirstLetter(item.variant)}</span>
+                        }
                         return (
                             <div className="flex items-center py-2">
                                 <VariantTag variantKey={item.variant} />


### PR DESCRIPTION
## Changes
1. Currently, the colors only work if experiment results are ready. This is because for funnels, `getExperimentVariants` method sorts variants based on the results - this is so that the colors of the variants will respect the colors in the visualization. I've opted not to show any colors for variants in the form & draft view. A good future solution might be for the Query component to respect variant colors, based on their creation order.

<img width="659" alt="image" src="https://github.com/PostHog/posthog/assets/22996112/7c5110ba-9156-4902-9dde-0c41da566aea">

<img width="204" alt="image" src="https://github.com/PostHog/posthog/assets/22996112/7069e394-a86a-4343-a780-04383d908b05">


2. Variant comparisons - if a test variant is winning, compare it with the control. Otherwise, compare it with the second best variant.

<img width="860" alt="image" src="https://github.com/PostHog/posthog/assets/22996112/a86bef67-c26c-4b7f-9a00-b3d39c18e65d">


3. Add an editable description field.

<img width="769" alt="image" src="https://github.com/PostHog/posthog/assets/22996112/c0b71ba1-2bea-4883-9d40-4ea9f69e5d11">

## How did you test this code?
👀 