### PR TITLE
chore(data-warehouse): don't cancel just skip next workflow

### DIFF
--- a/posthog/warehouse/data_load/service.py
+++ b/posthog/warehouse/data_load/service.py
@@ -58,7 +58,7 @@ def sync_external_data_job_workflow(
             jitter=timedelta(hours=2),
         ),
         state=ScheduleState(note=f"Schedule for external data source: {external_data_source.pk}"),
-        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.CANCEL_OTHER),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
     )
 
     if create:


### PR DESCRIPTION
## Problem

- daily workflows will cancel any in progress

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- just skip the upcoming one and allow the previous one to finish

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
