### PR TITLE
feat(data-warehouse): Updated the source sync flow to allow users to select the synced tables

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -33,9 +33,10 @@ import {
     EventType,
     Experiment,
     ExportedAssetType,
-    ExternalDataPostgresSchema,
     ExternalDataSourceCreatePayload,
     ExternalDataSourceSchema,
+    ExternalDataSourceSyncSchema,
+    ExternalDataSourceType,
     ExternalDataStripeSource,
     FeatureFlagAssociatedRoleType,
     FeatureFlagType,
@@ -1924,17 +1925,18 @@ const api = {
             await new ApiRequest().externalDataSource(sourceId).withAction('reload').create()
         },
         async database_schema(
-            host: string,
-            port: string,
-            dbname: string,
-            user: string,
-            password: string,
-            schema: string
-        ): Promise<ExternalDataPostgresSchema[]> {
+            source_type: ExternalDataSourceType,
+            host?: string,
+            port?: string,
+            dbname?: string,
+            user?: string,
+            password?: string,
+            schema?: string
+        ): Promise<ExternalDataSourceSyncSchema[]> {
             return await new ApiRequest()
                 .externalDataSources()
                 .withAction('database_schema')
-                .create({ data: { host, port, dbname, user, password, schema } })
+                .create({ data: { source_type, host, port, dbname, user, password, schema } })
         },
     },
 

--- a/frontend/src/scenes/data-warehouse/external/forms/SourceForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SourceForm.tsx
@@ -16,7 +16,7 @@ export default function SourceForm({ sourceType }: SourceFormProps): JSX.Element
         <Form
             logic={sourceFormLogic}
             props={{ sourceType }}
-            formKey={sourceType == 'Postgres' ? 'databaseSchemaForm' : 'externalDataSource'}
+            formKey="sourceConnectionDetails"
             className="space-y-4"
             enableFormOnSubmit
         >

--- a/frontend/src/scenes/data-warehouse/external/forms/sourceFormLogic.ts
+++ b/frontend/src/scenes/data-warehouse/external/forms/sourceFormLogic.ts
@@ -46,6 +46,33 @@ const getErrorsDefaults = (sourceType: string): ((args: Record<string, any>) => 
                     ? null
                     : "Please enter a valid prefix (only letters, numbers, and '_' or '-').",
             })
+        case 'Postgres':
+            return ({ prefix, payload }) => ({
+                prefix: /^[a-zA-Z0-9_-]*$/.test(prefix)
+                    ? null
+                    : "Please enter a valid prefix (only letters, numbers, and '_' or '-').",
+                payload: {
+                    host: !payload.host && 'Please enter a host.',
+                    port: !payload.port && 'Please enter a port.',
+                    dbname: !payload.dbname && 'Please enter a dbname.',
+                    user: !payload.user && 'Please enter a user.',
+                    password: !payload.password && 'Please enter a password.',
+                    schema: !payload.schema && 'Please enter a schema.',
+                },
+            })
+        case 'Zendesk':
+            return ({ prefix, payload }) => {
+                return {
+                    prefix: /^[a-zA-Z0-9_-]*$/.test(prefix)
+                        ? null
+                        : "Please enter a valid prefix (only letters, numbers, and '_' or '-').",
+                    payload: {
+                        subdomain: !payload.subdomain && 'Please enter a subdomain.',
+                        api_key: !payload.api_key && 'Please enter an API key.',
+                        email_address: !payload.email_address && 'Please enter an email address.',
+                    },
+                }
+            }
         default:
             return () => ({})
     }
@@ -109,13 +136,20 @@ export const sourceFormLogic = kea<sourceFormLogicType>([
         },
     })),
     forms(({ props, actions }) => ({
-        externalDataSource: {
+        sourceConnectionDetails: {
             defaults: {
                 prefix: '',
                 source_type: props.sourceType,
                 payload: getPayloadDefaults(props.sourceType),
             } as ExternalDataSourceCreatePayload,
             errors: getErrorsDefaults(props.sourceType),
+        },
+        externalDataSource: {
+            defaults: {
+                prefix: '',
+                source_type: props.sourceType,
+                payload: getPayloadDefaults(props.sourceType),
+            } as ExternalDataSourceCreatePayload,
             submit: async (payload: ExternalDataSourceCreatePayload) => {
                 const newResource = await api.externalDataSources.create(payload)
                 return newResource
@@ -133,21 +167,9 @@ export const sourceFormLogic = kea<sourceFormLogicType>([
                     schema: '',
                 },
             },
-            errors: ({ prefix, payload: { host, port, dbname, user, password, schema } }) => ({
-                prefix: /^[a-zA-Z0-9_-]*$/.test(prefix)
-                    ? null
-                    : "Please enter a valid prefix (only letters, numbers, and '_' or '-').",
-                payload: {
-                    host: !host && 'Please enter a host.',
-                    port: !port && 'Please enter a port.',
-                    dbname: !dbname && 'Please enter a dbname.',
-                    user: !user && 'Please enter a user.',
-                    password: !password && 'Please enter a password.',
-                    schema: !schema && 'Please enter a schema.',
-                },
-            }),
             submit: async ({ payload: { host, port, dbname, user, password, schema }, prefix }) => {
                 const schemas = await api.externalDataSources.database_schema(
+                    props.sourceType,
                     host,
                     port,
                     dbname,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3576,7 +3576,7 @@ export interface SimpleExternalDataSourceSchema {
     last_synced_at?: Dayjs
 }
 
-export interface ExternalDataPostgresSchema {
+export interface ExternalDataSourceSyncSchema {
     table: string
     should_sync: boolean
 }

--- a/posthog/warehouse/api/test/test_external_data_source.py
+++ b/posthog/warehouse/api/test/test_external_data_source.py
@@ -1,3 +1,4 @@
+from posthog.temporal.data_imports.pipelines.stripe.settings import ENDPOINTS
 from posthog.test.base import APIBaseTest
 from posthog.warehouse.models import ExternalDataSource, ExternalDataSchema
 import uuid
@@ -164,6 +165,7 @@ class TestSavedQuery(APIBaseTest):
         response = self.client.post(
             f"/api/projects/{self.team.id}/external_data_sources/database_schema/",
             data={
+                "source_type": "Postgres",
                 "host": settings.PG_HOST,
                 "port": int(settings.PG_PORT),
                 "dbname": settings.PG_DATABASE,
@@ -189,6 +191,21 @@ class TestSavedQuery(APIBaseTest):
 
         postgres_connection.close()
 
+    def test_database_schema_non_postgres_source(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/external_data_sources/database_schema/",
+            data={
+                "source_type": "Stripe",
+            },
+        )
+        results = response.json()
+
+        self.assertEqual(response.status_code, 200)
+
+        table_names = [table["table"] for table in results]
+        for table in ENDPOINTS:
+            assert table in table_names
+
     @patch("posthog.warehouse.api.external_data_source.get_postgres_schemas")
     def test_internal_postgres(self, patch_get_postgres_schemas):
         patch_get_postgres_schemas.return_value = ["table_1"]
@@ -198,6 +215,7 @@ class TestSavedQuery(APIBaseTest):
             response = self.client.post(
                 f"/api/projects/{team_2.id}/external_data_sources/database_schema/",
                 data={
+                    "source_type": "Postgres",
                     "host": "172.16.0.0",
                     "port": int(settings.PG_PORT),
                     "dbname": settings.PG_DATABASE,
@@ -214,6 +232,7 @@ class TestSavedQuery(APIBaseTest):
             response = self.client.post(
                 f"/api/projects/{new_team.id}/external_data_sources/database_schema/",
                 data={
+                    "source_type": "Postgres",
                     "host": "172.16.0.0",
                     "port": int(settings.PG_PORT),
                     "dbname": settings.PG_DATABASE,
@@ -230,6 +249,7 @@ class TestSavedQuery(APIBaseTest):
             response = self.client.post(
                 f"/api/projects/{team_1.id}/external_data_sources/database_schema/",
                 data={
+                    "source_type": "Postgres",
                     "host": "172.16.0.0",
                     "port": int(settings.PG_PORT),
                     "dbname": settings.PG_DATABASE,
@@ -246,6 +266,7 @@ class TestSavedQuery(APIBaseTest):
             response = self.client.post(
                 f"/api/projects/{new_team.id}/external_data_sources/database_schema/",
                 data={
+                    "source_type": "Postgres",
                     "host": "172.16.0.0",
                     "port": int(settings.PG_PORT),
                     "dbname": settings.PG_DATABASE,

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -1,3 +1,4 @@
+from typing import Any, List
 from django.db import models
 
 from posthog.models.team import Team
@@ -64,7 +65,7 @@ def sync_old_schemas_with_new_schemas(new_schemas: list, source_id: uuid.UUID, t
         ExternalDataSchema.objects.create(name=schema, team_id=team_id, source_id=source_id, should_sync=False)
 
 
-def get_postgres_schemas(host: str, port: str, database: str, user: str, password: str, schema: str):
+def get_postgres_schemas(host: str, port: str, database: str, user: str, password: str, schema: str) -> List[Any]:
     connection = psycopg.Connection.connect(
         host=host,
         port=int(port),


### PR DESCRIPTION
## Problem
- We want to allow users to select what tables they sync when connecting an integration, currently it syncs _everything_ automatically 

## Changes
- Reuse the postgres connection flow to show all the available endpoints for all integrations
- Updates the `/external_data_sources/database_schema` endpoint to take any source type and return the endpoints/tables for it
- At a later point, we should clean up the `form` logic within `sourceFormLogic` - its getting a bit messy right now with us having a "wizard" like flow with multiple forms

https://github.com/PostHog/posthog/assets/1459269/d9ea783a-c5c8-4501-a217-0398a58106d0

<img width="865" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/e101d343-2307-4ab8-b7d3-2a7da22c801d">


## Does this work well for both Cloud and self-hosted?
Yes?

## How did you test this code?
- Updated unit tests