### PR TITLE
chore: add groups to billing limit events

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -75,7 +75,9 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                         distinct_id,
                         "billing limits updated",
                         properties={**custom_limits_usd},
-                        groups=groups(org, self.request.user.team),
+                        groups=groups(org, self.request.user.team)
+                        if hasattr(self.request.user, "team")
+                        else groups(org),
                     )
                     posthoganalytics.group_identify(
                         "organization",

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -18,7 +18,7 @@ from ee.settings import BILLING_SERVICE_URL
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.models import Organization
-from posthog.settings import SITE_URL
+from posthog.event_usage import groups
 
 logger = structlog.get_logger(__name__)
 
@@ -75,11 +75,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                         distinct_id,
                         "billing limits updated",
                         properties={**custom_limits_usd},
-                        groups={
-                            "instance": SITE_URL,
-                            "organization": str(org.pk),
-                            "project": str(self.request.user.team.uuid) if self.request.user.team else None,
-                        },
+                        groups=groups(org, self.request.user.team),
                     )
                     posthoganalytics.group_identify(
                         "organization",

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -18,6 +18,7 @@ from ee.settings import BILLING_SERVICE_URL
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.models import Organization
+from posthog.settings import SITE_URL
 
 logger = structlog.get_logger(__name__)
 
@@ -74,6 +75,11 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                         distinct_id,
                         "billing limits updated",
                         properties={**custom_limits_usd},
+                        groups={
+                            "instance": SITE_URL,
+                            "organization": str(org.pk),
+                            "project": str(self.request.user.team.uuid) if self.request.user.team else None,
+                        },
                     )
                     posthoganalytics.group_identify(
                         "organization",


### PR DESCRIPTION
## Changes

Billing limit update events are missing groups, this adds them.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
