### PR TITLE
chore(data-warehouse): fix long table names

### DIFF
--- a/frontend/src/lib/components/DatabaseTableTree/TreeRow.scss
+++ b/frontend/src/lib/components/DatabaseTableTree/TreeRow.scss
@@ -1,4 +1,7 @@
 .TreeRow {
+    display: flex;
+    flex-direction: row;
+
     &:hover {
         cursor: pointer;
         background-color: var(--primary-bg-hover);

--- a/frontend/src/lib/components/DatabaseTableTree/TreeRow.tsx
+++ b/frontend/src/lib/components/DatabaseTableTree/TreeRow.tsx
@@ -23,9 +23,9 @@ export function TreeRow({ item, onClick, selected }: TreeRowProps): JSX.Element 
 
     return (
         <li>
-            <div className={clsx('TreeRow', selected ? 'TreeRow__selected' : '')} onClick={_onClick}>
+            <div className={clsx('TreeRow text-ellipsis', selected ? 'TreeRow__selected' : '')} onClick={_onClick}>
                 <span className="mr-2">{item.icon}</span>
-                {item.table.name}
+                <div className="overflow-hidden text-ellipsis whitespace-nowrap">{item.table.name}</div>
             </div>
         </li>
     )

--- a/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
+++ b/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
@@ -73,20 +73,22 @@ export function ViewLinkForm(): JSX.Element {
         <Form logic={viewLinkLogic} formKey="viewLink" enableFormOnSubmit>
             <div className="flex flex-col w-full justify-between items-center">
                 <div className="flex flex-row w-full justify-between">
-                    <div className={isNewJoin ? 'w-60' : 'flex flex-col'}>
+                    <div className="w-60">
                         <span className="l4">Source Table</span>
-                        {isNewJoin ? (
-                            <Field name="source_table_name">
-                                <LemonSelect
-                                    fullWidth
-                                    options={tableOptions}
-                                    onSelect={selectSourceTable}
-                                    placeholder="Select a table"
-                                />
-                            </Field>
-                        ) : (
-                            selectedSourceTableName ?? ''
-                        )}
+                        <div className="text-wrap break-all">
+                            {isNewJoin ? (
+                                <Field name="source_table_name">
+                                    <LemonSelect
+                                        fullWidth
+                                        options={tableOptions}
+                                        onSelect={selectSourceTable}
+                                        placeholder="Select a table"
+                                    />
+                                </Field>
+                            ) : (
+                                selectedSourceTableName ?? ''
+                            )}
+                        </div>
                     </div>
                     <div className="w-60">
                         <span className="l4">Joining Table</span>

--- a/frontend/src/scenes/data-warehouse/external/DataWarehouseJoins.tsx
+++ b/frontend/src/scenes/data-warehouse/external/DataWarehouseJoins.tsx
@@ -29,6 +29,7 @@ export const DataWarehouseJoins = (): JSX.Element => {
                                 Joining {join.joining_table_name} onto {join.source_table_name}
                             </>
                         }
+                        onClick={() => void toggleEditJoinModal(join)}
                     />
                 )
             },

--- a/frontend/src/scenes/data-warehouse/external/TableData.tsx
+++ b/frontend/src/scenes/data-warehouse/external/TableData.tsx
@@ -77,7 +77,7 @@ export function TableData(): JSX.Element {
     return table ? (
         <div className="px-4 py-3 col-span-2">
             <div className="flex flex-row justify-between items-center">
-                <h3>{table.name}</h3>
+                <h3 className="w-3/4 text-wrap break-all">{table.name}</h3>
                 {isEditingSavedQuery ? (
                     <LemonButton type="secondary" onClick={() => setIsEditingSavedQuery(false)}>
                         Cancel


### PR DESCRIPTION
## Problem

- long table names were ugly

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- have proper wrapping on the table names
- add functionality when clicking on a join
<img width="1239" alt="Screenshot 2024-04-03 at 11 27 08 AM" src="https://github.com/PostHog/posthog/assets/13127476/b8140005-674c-4f82-a628-221778971c18">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
