### PR TITLE
test(plugin-server): Improve the robustness of overflow handling tests

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -253,7 +253,7 @@ export async function eachBatchParallelIngestion(
     }
 }
 
-function computeKey(pluginEvent: PipelineEvent): string {
+export function computeKey(pluginEvent: PipelineEvent): string {
     return `${pluginEvent.team_id ?? pluginEvent.token}:${pluginEvent.distinct_id}`
 }
 

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
@@ -1,3 +1,5 @@
+import { Message } from 'node-rdkafka'
+
 import { buildStringMatcher } from '../../../src/config/config'
 import { KAFKA_EVENTS_PLUGIN_INGESTION, KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW } from '../../../src/config/kafka-topics'
 import {
@@ -53,14 +55,19 @@ describe('eachBatchParallelIngestion with overflow reroute', () => {
     let closeServer: () => Promise<void>
     let queue: any
 
-    function createBatchWithMultipleEventsWithKeys(events: any[], timestamp?: any): any {
-        return events.map((event) => ({
+    function makeMessageKey(event: any): string {
+        return event.token + ':' + event.distinct_id
+    }
+
+    function createBatchWithMultipleEvents(events: any[], timestamp?: any, withKey: boolean = true): Message[] {
+        return events.map((event, i) => ({
             partition: 0,
             topic: KAFKA_EVENTS_PLUGIN_INGESTION,
-            value: JSON.stringify(event),
+            value: Buffer.from(JSON.stringify(event)),
             timestamp,
-            offset: event.offset,
-            key: event.team_id + ':' + event.distinct_id,
+            offset: i,
+            key: withKey ? makeMessageKey(event) : null,
+            size: 0, // irrelevant, but needed for type checking
         }))
     }
 
@@ -79,30 +86,24 @@ describe('eachBatchParallelIngestion with overflow reroute', () => {
     })
 
     it('reroutes events with no key to OVERFLOW topic', async () => {
-        const batch = [
-            {
-                partition: 0,
-                topic: KAFKA_EVENTS_PLUGIN_INGESTION,
-                value: JSON.stringify(captureEndpointEvent1),
-                timestamp: captureEndpointEvent1['timestamp'],
-                offset: captureEndpointEvent1['offset'],
-                key: null,
-                token: 'ok',
-            },
-        ]
+        const now = Date.now()
+        const [message] = createBatchWithMultipleEvents(
+            [captureEndpointEvent1],
+            now,
+            false // act as if this message was intended to be routed to overflow by capture
+        )
+
         const consume = jest.spyOn(ConfiguredLimiter, 'consume').mockImplementation(() => false)
         const produce = jest.spyOn(queue.pluginsServer.kafkaProducer, 'produce')
 
         const tokenBlockList = buildStringMatcher('another_token,more_token', false)
-        await eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Reroute)
+        await eachBatchParallelIngestion(tokenBlockList, [message], queue, IngestionOverflowMode.Reroute)
 
         expect(consume).not.toHaveBeenCalled()
         expect(captureIngestionWarning).not.toHaveBeenCalled()
         expect(produce).toHaveBeenCalledWith({
             topic: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
-            value: JSON.stringify(captureEndpointEvent1),
-            timestamp: captureEndpointEvent1['timestamp'],
-            offset: captureEndpointEvent1['offset'],
+            value: message.value,
             key: null,
             waitForAck: true,
         })
@@ -113,24 +114,23 @@ describe('eachBatchParallelIngestion with overflow reroute', () => {
 
     it('reroutes excess events to OVERFLOW topic', async () => {
         const now = Date.now()
-        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent1], now)
+        const event = captureEndpointEvent1
+        const [message] = createBatchWithMultipleEvents([event], now)
         const consume = jest.spyOn(ConfiguredLimiter, 'consume').mockImplementation(() => false)
         const produce = jest.spyOn(queue.pluginsServer.kafkaProducer, 'produce')
 
         const tokenBlockList = buildStringMatcher('another_token,more_token', false)
-        await eachBatchParallelIngestion(tokenBlockList, batch, queue, IngestionOverflowMode.Reroute)
+        await eachBatchParallelIngestion(tokenBlockList, [message], queue, IngestionOverflowMode.Reroute)
 
         expect(consume).toHaveBeenCalledWith(
-            captureEndpointEvent1['token'] + ':' + captureEndpointEvent1['distinct_id'],
+            makeMessageKey(event), // NOTE: can't use ``message.key`` here as it will already have been mutated
             1,
             now
         )
         expect(captureIngestionWarning).not.toHaveBeenCalled()
         expect(produce).toHaveBeenCalledWith({
             topic: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
-            value: JSON.stringify(captureEndpointEvent1),
-            timestamp: captureEndpointEvent1['timestamp'],
-            offset: captureEndpointEvent1['offset'],
+            value: message.value,
             key: null,
             waitForAck: true,
         })
@@ -141,7 +141,7 @@ describe('eachBatchParallelIngestion with overflow reroute', () => {
 
     it('does not reroute if not over capacity limit', async () => {
         const now = Date.now()
-        const batch = createBatchWithMultipleEventsWithKeys([captureEndpointEvent1, captureEndpointEvent2], now)
+        const batch = createBatchWithMultipleEvents([captureEndpointEvent1, captureEndpointEvent2], now)
         const consume = jest.spyOn(ConfiguredLimiter, 'consume').mockImplementation(() => true)
         const produce = jest.spyOn(queue.pluginsServer.kafkaProducer, 'produce')
 
@@ -166,7 +166,7 @@ describe('eachBatchParallelIngestion with overflow reroute', () => {
 
     it('does drop events from blocked tokens', async () => {
         const now = Date.now()
-        const batch = createBatchWithMultipleEventsWithKeys(
+        const batch = createBatchWithMultipleEvents(
             [captureEndpointEvent1, captureEndpointEvent2, captureEndpointEvent1],
             now
         )


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/20945#discussion_r1548779396 seems like it should have been caught by tests but wasn't.

## Changes

- Replaces use of mocked producer with actual Kafka producer usage to make these tests more of an integration test.
- Fixes some of the types and assertions so that they are more reflective of the code being tested

## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

(This one is hopefully obvious.)