### PR TITLE
feat: product plan support response times

### DIFF
--- a/cypress/fixtures/api/billing-v2/billing-v2-subscribed-all.json
+++ b/cypress/fixtures/api/billing-v2/billing-v2-subscribed-all.json
@@ -3544,14 +3544,6 @@
                     "images": null,
                     "icon_key": null,
                     "type": null
-                },
-                {
-                    "key": "support_slas",
-                    "name": "Support SLAs",
-                    "description": "Support SLAs",
-                    "images": null,
-                    "icon_key": null,
-                    "type": null
                 }
             ]
         }

--- a/cypress/fixtures/api/billing-v2/billing-v2-subscribed-all.json
+++ b/cypress/fixtures/api/billing-v2/billing-v2-subscribed-all.json
@@ -3544,6 +3544,14 @@
                     "images": null,
                     "icon_key": null,
                     "type": null
+                },
+                {
+                    "key": "support_response_time",
+                    "name": "Support response time",
+                    "description": "Get help from our team!",
+                    "images": null,
+                    "icon_key": null,
+                    "type": null
                 }
             ]
         }

--- a/cypress/fixtures/api/billing-v2/billing-v2-unsubscribed.json
+++ b/cypress/fixtures/api/billing-v2/billing-v2-unsubscribed.json
@@ -3648,6 +3648,14 @@
                     "type": null
                 },
                 {
+                    "key": "support_response_time",
+                    "name": "Support response time",
+                    "description": "Get help from our team!",
+                    "images": null,
+                    "icon_key": null,
+                    "type": null
+                },
+                {
                     "key": "audit_logs",
                     "name": "Audit logs",
                     "description": "See who in your organization has accessed or modified entities within PostHog.",

--- a/cypress/fixtures/api/billing-v2/billing-v2-unsubscribed.json
+++ b/cypress/fixtures/api/billing-v2/billing-v2-unsubscribed.json
@@ -2945,7 +2945,7 @@
                 {
                     "plan_key": "paid-20240208",
                     "product_key": "platform_and_support",
-                    "name": "With subscription",
+                    "name": "Pay-per-use",
                     "description": "SSO, permission management, and support.",
                     "image_url": "https://posthog.com/images/product/product-icons/platform.svg",
                     "docs_url": "https://posthog.com/docs",

--- a/cypress/fixtures/api/billing-v2/billing-v2-unsubscribed.json
+++ b/cypress/fixtures/api/billing-v2/billing-v2-unsubscribed.json
@@ -3648,14 +3648,6 @@
                     "type": null
                 },
                 {
-                    "key": "support_slas",
-                    "name": "Support SLAs",
-                    "description": "Support SLAs",
-                    "images": null,
-                    "icon_key": null,
-                    "type": null
-                },
-                {
                     "key": "audit_logs",
                     "name": "Audit logs",
                     "description": "See who in your organization has accessed or modified entities within PostHog.",

--- a/cypress/fixtures/api/billing-v2/billing-v2.json
+++ b/cypress/fixtures/api/billing-v2/billing-v2.json
@@ -3775,6 +3775,14 @@
                     "type": null
                 },
                 {
+                    "key": "support_response_time",
+                    "name": "Support response time",
+                    "description": "Get help from our team!",
+                    "images": null,
+                    "icon_key": null,
+                    "type": null
+                },
+                {
                     "key": "audit_logs",
                     "name": "Audit logs",
                     "description": "See who in your organization has accessed or modified entities within PostHog.",

--- a/cypress/fixtures/api/billing-v2/billing-v2.json
+++ b/cypress/fixtures/api/billing-v2/billing-v2.json
@@ -3072,7 +3072,7 @@
                 {
                     "plan_key": "paid-20240208",
                     "product_key": "platform_and_support",
-                    "name": "With subscription",
+                    "name": "Pay-per-use",
                     "description": "SSO, permission management, and support.",
                     "image_url": "https://posthog.com/images/product/product-icons/platform.svg",
                     "docs_url": "https://posthog.com/docs",

--- a/cypress/fixtures/api/billing-v2/billing-v2.json
+++ b/cypress/fixtures/api/billing-v2/billing-v2.json
@@ -3775,14 +3775,6 @@
                     "type": null
                 },
                 {
-                    "key": "support_slas",
-                    "name": "Support SLAs",
-                    "description": "Support SLAs",
-                    "images": null,
-                    "icon_key": null,
-                    "type": null
-                },
-                {
                     "key": "audit_logs",
                     "name": "Audit logs",
                     "description": "See who in your organization has accessed or modified entities within PostHog.",

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -71,6 +71,8 @@ const Section = ({ title, children }: { title: string; children: React.ReactNode
 
 const SupportFormBlock = ({ onCancel }: { onCancel: () => void }): JSX.Element => {
     const { billing } = useValues(billingLogic)
+
+    // TODO(@zach): remove after updated plans w/ support levels are shipped
     const supportResponseTimes = {
         [AvailableFeature.EMAIL_SUPPORT]: '2-3 days',
         [AvailableFeature.PRIORITY_SUPPORT]: '4-6 hours',
@@ -89,10 +91,10 @@ const SupportFormBlock = ({ onCancel }: { onCancel: () => void }): JSX.Element =
                 </div>
                 {billing?.products
                     ?.find((product) => product.type == ProductKey.PLATFORM_AND_SUPPORT)
-                    ?.plans?.map((plan, i) => (
+                    ?.plans?.map((plan) => (
                         <React.Fragment key={`support-panel-${plan.plan_key}`}>
                             <div className={plan.current_plan ? 'font-bold' : undefined}>
-                                {i == 1 ? 'Pay-per-use' : plan.name}
+                                {plan.name}
                                 {plan.current_plan && (
                                     <>
                                         {' '}
@@ -101,7 +103,10 @@ const SupportFormBlock = ({ onCancel }: { onCancel: () => void }): JSX.Element =
                                 )}
                             </div>
                             <div className={plan.current_plan ? 'font-bold' : undefined}>
-                                {plan.features.some((f) => f.key == AvailableFeature.PRIORITY_SUPPORT)
+                                {/* TODO(@zach): remove fallback after updated plans w/ support levels are shipped */}
+                                {plan.support_level
+                                    ? plan.support_level.response_time
+                                    : plan.features.some((f) => f.key == AvailableFeature.PRIORITY_SUPPORT)
                                     ? supportResponseTimes[AvailableFeature.PRIORITY_SUPPORT]
                                     : plan.features.some((f) => f.key == AvailableFeature.EMAIL_SUPPORT)
                                     ? supportResponseTimes[AvailableFeature.EMAIL_SUPPORT]

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -104,13 +104,12 @@ const SupportFormBlock = ({ onCancel }: { onCancel: () => void }): JSX.Element =
                             </div>
                             <div className={plan.current_plan ? 'font-bold' : undefined}>
                                 {/* TODO(@zach): remove fallback after updated plans w/ support levels are shipped */}
-                                {plan.support_level
-                                    ? plan.support_level.response_time
-                                    : plan.features.some((f) => f.key == AvailableFeature.PRIORITY_SUPPORT)
-                                    ? supportResponseTimes[AvailableFeature.PRIORITY_SUPPORT]
-                                    : plan.features.some((f) => f.key == AvailableFeature.EMAIL_SUPPORT)
-                                    ? supportResponseTimes[AvailableFeature.EMAIL_SUPPORT]
-                                    : 'Community support only'}
+                                {plan.features.find((f) => f.key == AvailableFeature.SUPPORT_RESPONSE_TIME)?.note ??
+                                    (plan.features.some((f) => f.key == AvailableFeature.PRIORITY_SUPPORT)
+                                        ? supportResponseTimes[AvailableFeature.PRIORITY_SUPPORT]
+                                        : plan.features.some((f) => f.key == AvailableFeature.EMAIL_SUPPORT)
+                                        ? supportResponseTimes[AvailableFeature.EMAIL_SUPPORT]
+                                        : 'Community support only')}
                             </div>
                         </React.Fragment>
                     ))}

--- a/frontend/src/mocks/fixtures/_billing_v2.tsx
+++ b/frontend/src/mocks/fixtures/_billing_v2.tsx
@@ -3429,14 +3429,6 @@ export const billingJson: BillingV2Type = {
                     type: null,
                 },
                 {
-                    key: 'support_slas',
-                    name: 'Support SLAs',
-                    description: 'Support SLAs',
-                    images: null,
-                    icon_key: null,
-                    type: null,
-                },
-                {
                     key: 'audit_logs',
                     name: 'Audit logs',
                     description: 'See who in your organization has accessed or modified entities within PostHog.',

--- a/frontend/src/mocks/fixtures/_billing_v2.tsx
+++ b/frontend/src/mocks/fixtures/_billing_v2.tsx
@@ -3429,6 +3429,14 @@ export const billingJson: BillingV2Type = {
                     type: null,
                 },
                 {
+                    key: 'support_response_time',
+                    name: 'Support response time',
+                    description: 'Get help from our team!',
+                    images: null,
+                    icon_key: null,
+                    type: null,
+                },
+                {
                     key: 'audit_logs',
                     name: 'Audit logs',
                     description: 'See who in your organization has accessed or modified entities within PostHog.',

--- a/frontend/src/mocks/fixtures/_billing_v2.tsx
+++ b/frontend/src/mocks/fixtures/_billing_v2.tsx
@@ -2693,7 +2693,7 @@ export const billingJson: BillingV2Type = {
                 {
                     plan_key: 'paid-20240208',
                     product_key: 'platform_and_support',
-                    name: 'With subscription',
+                    name: 'With Pay-per-use',
                     description: 'SSO, permission management, and support.',
                     image_url: 'https://posthog.com/images/product/product-icons/platform.svg',
                     docs_url: 'https://posthog.com/docs',

--- a/frontend/src/mocks/fixtures/_billing_v2_with_100_percent_discount.json
+++ b/frontend/src/mocks/fixtures/_billing_v2_with_100_percent_discount.json
@@ -2823,15 +2823,6 @@
                                     "limit": null,
                                     "note": null,
                                     "group": "support"
-                                },
-                                {
-                                    "key": "support_slas",
-                                    "name": "Support SLAs",
-                                    "description": "Support SLAs",
-                                    "unit": null,
-                                    "limit": null,
-                                    "note": null,
-                                    "group": "support"
                                 }
                             ]
                         }

--- a/frontend/src/mocks/fixtures/_billing_v2_with_100_percent_discount.json
+++ b/frontend/src/mocks/fixtures/_billing_v2_with_100_percent_discount.json
@@ -2823,6 +2823,14 @@
                                     "limit": null,
                                     "note": null,
                                     "group": "support"
+                                },
+                                {
+                                    "key": "support_response_time",
+                                    "name": "Support response time",
+                                    "description": "Get help from our team!",
+                                    "images": null,
+                                    "icon_key": null,
+                                    "type": null
                                 }
                             ]
                         }

--- a/frontend/src/mocks/fixtures/_billing_v2_with_100_percent_discount.json
+++ b/frontend/src/mocks/fixtures/_billing_v2_with_100_percent_discount.json
@@ -2828,9 +2828,10 @@
                                     "key": "support_response_time",
                                     "name": "Support response time",
                                     "description": "Get help from our team!",
-                                    "images": null,
-                                    "icon_key": null,
-                                    "type": null
+                                    "unit": null,
+                                    "limit": null,
+                                    "note": null,
+                                    "group": "support"
                                 }
                             ]
                         }

--- a/frontend/src/mocks/fixtures/_billing_v2_with_discount.json
+++ b/frontend/src/mocks/fixtures/_billing_v2_with_discount.json
@@ -2821,6 +2821,14 @@
                                     "limit": null,
                                     "note": null,
                                     "group": "support"
+                                },
+                                {
+                                    "key": "support_response_time",
+                                    "name": "Support response time",
+                                    "description": "Get help from our team!",
+                                    "images": null,
+                                    "icon_key": null,
+                                    "type": null
                                 }
                             ]
                         }

--- a/frontend/src/mocks/fixtures/_billing_v2_with_discount.json
+++ b/frontend/src/mocks/fixtures/_billing_v2_with_discount.json
@@ -2821,15 +2821,6 @@
                                     "limit": null,
                                     "note": null,
                                     "group": "support"
-                                },
-                                {
-                                    "key": "support_slas",
-                                    "name": "Support SLAs",
-                                    "description": "Support SLAs",
-                                    "unit": null,
-                                    "limit": null,
-                                    "note": null,
-                                    "group": "support"
                                 }
                             ]
                         }

--- a/frontend/src/mocks/fixtures/_billing_v2_with_discount.json
+++ b/frontend/src/mocks/fixtures/_billing_v2_with_discount.json
@@ -2826,9 +2826,10 @@
                                     "key": "support_response_time",
                                     "name": "Support response time",
                                     "description": "Get help from our team!",
-                                    "images": null,
-                                    "icon_key": null,
-                                    "type": null
+                                    "unit": null,
+                                    "limit": null,
+                                    "note": null,
+                                    "group": "support"
                                 }
                             ]
                         }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -104,7 +104,6 @@ export enum AvailableFeature {
     SECURITY_ASSESSMENT = 'security_assessment',
     BESPOKE_PRICING = 'bespoke_pricing',
     INVOICE_PAYMENTS = 'invoice_payments',
-    SUPPORT_SLAS = 'support_slas',
     BOOLEAN_FLAGS = 'boolean_flags',
     FEATURE_FLAGS_DATA_RETENTION = 'feature_flags_data_retention',
     MULTIVARIATE_FLAGS = 'multivariate_flags',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1474,6 +1474,11 @@ export interface BillingV2Type {
     amount_off_expires_at?: Dayjs
 }
 
+export interface BillingV2SupportLevelType {
+    type: string
+    response_time: string
+}
+
 export interface BillingV2PlanType {
     free_allocation?: number | null
     features: BillingV2FeatureType[]
@@ -1492,6 +1497,7 @@ export interface BillingV2PlanType {
     included_if?: 'no_active_subscription' | 'has_subscription' | null
     initial_billing_limit?: number
     contact_support: boolean | null
+    support_level?: BillingV2SupportLevelType
 }
 
 export interface PlanInterface {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -147,6 +147,7 @@ export enum AvailableFeature {
     CUSTOMM_MSA = 'custom_msa',
     TWOFA = '2fa',
     PRIORITY_SUPPORT = 'priority_support',
+    SUPPORT_RESPONSE_TIME = 'support_response_time',
 }
 
 type AvailableFeatureUnion = `${AvailableFeature}`
@@ -1473,11 +1474,6 @@ export interface BillingV2Type {
     amount_off_expires_at?: Dayjs
 }
 
-export interface BillingV2SupportLevelType {
-    type: string
-    response_time: string
-}
-
 export interface BillingV2PlanType {
     free_allocation?: number | null
     features: BillingV2FeatureType[]
@@ -1496,7 +1492,6 @@ export interface BillingV2PlanType {
     included_if?: 'no_active_subscription' | 'has_subscription' | null
     initial_billing_limit?: number
     contact_support: boolean | null
-    support_level?: BillingV2SupportLevelType
 }
 
 export interface PlanInterface {


### PR DESCRIPTION
## Changes

- updates the plan structures to support the new `support_response_time` from billing. See https://github.com/PostHog/billing/pull/507 for more information.
- updates the sidebar support panel to show the new support response times
- renames 'with subscription' to 'pay-per-use' so we are consistent across the entire stack.
- removes old usage of `support_slas`



👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
