### PR TITLE
fix(lemon-ui): limit number of entries displayed in lemon input select at once

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -91,7 +91,11 @@ export function LemonInputSelect({
                 res.unshift({ key: value, label: value })
             })
         }
-        return res
+
+        // :HACKY: This is a quick fix to make the select dropdown work for large values,
+        // as it was getting slow when we'd load more than ~10k entries. Ideally we'd
+        // make this a virtualized list.
+        return res.slice(0, 100)
     }, [options, inputValue, values])
 
     // Reset the selected index when the visible options change


### PR DESCRIPTION
## Problem

The taxonomic filter was getting slow for properties with a large amount of values, see here: https://posthog.slack.com/archives/C0368RPHLQH/p1712172874857719. 

This can easily be reproduced locally by adding a large number of groups and trying to filter them:
```javascript
for (let i = 1; i <= 12000; i++) {
  let customerId = "id:" + i;
  let customerName = "Awesome customer " + i;
  posthog.group("customer", customerId, { name: customerName });
}
```

![2024-04-04 10 08 03](https://github.com/PostHog/posthog/assets/1851359/e36e37bd-4b79-4fa0-ae54-0a8f260256ae)


## Changes

This PR limits the number of displayed results to a flat 100. Virtualizing the list would be a better option, but I'd like to focus on the HogQL rollout and revisit this later.

![2024-04-04 10 05 51](https://github.com/PostHog/posthog/assets/1851359/37698157-dd5d-4fc3-9f4b-ad49c4db738b)

## How did you test this code?

See above.