### PR TITLE
fix(hogql): Only expose HogQL exceptions relevant to users

### DIFF
--- a/hogql_parser/CONTRIBUTING.md
+++ b/hogql_parser/CONTRIBUTING.md
@@ -58,6 +58,11 @@ The three pages below are must-reads though. They're key to writing production-r
     pip install ./hogql_parser
     ```
 
+   > If you're getting compilation errors like this on macOS Sonoma:  
+   > `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/cstring:66:5: error: <cstring> tried including <string.h> but didn't find libc++'s <string.h> header.`  
+   > Then you may need to remove Xcode Command Line Tools:  
+   > `sudo rm -rf /Library/Developer/CommandLineTools`
+
 1. If you now run tests, the locally-built version of `hogql_parser` will be used:
 
     ```bash

--- a/hogql_parser/error.cpp
+++ b/hogql_parser/error.cpp
@@ -2,16 +2,16 @@
 
 using namespace std;
 
-#define EXCEPTION_CLASS_IMPLEMENTATION(NAME, BASE)                                                       \
+#define ERROR_CLASS_IMPLEMENTATION(NAME, BASE)                                                           \
   NAME::NAME(const string& message, size_t start, size_t end) : BASE(message), start(start), end(end) {} \
   NAME::NAME(const char* message, size_t start, size_t end) : BASE(message), start(start), end(end) {}   \
   NAME::NAME(const string& message) : BASE(message), start(0), end(0) {}                                 \
   NAME::NAME(const char* message) : BASE(message), start(0), end(0) {}
 
-EXCEPTION_CLASS_IMPLEMENTATION(HogQLException, runtime_error)
+ERROR_CLASS_IMPLEMENTATION(HogQLError, runtime_error)
 
-EXCEPTION_CLASS_IMPLEMENTATION(SyntaxException, HogQLException)
-EXCEPTION_CLASS_IMPLEMENTATION(NotImplementedException, HogQLException)
-EXCEPTION_CLASS_IMPLEMENTATION(ParsingException, HogQLException)
+ERROR_CLASS_IMPLEMENTATION(SyntaxError, HogQLError)
+ERROR_CLASS_IMPLEMENTATION(NotImplementedError, HogQLError)
+ERROR_CLASS_IMPLEMENTATION(ParsingError, HogQLError)
 
-PyInternalException::PyInternalException() : exception() {}
+PyInternalError::PyInternalError() : exception() {}

--- a/hogql_parser/error.h
+++ b/hogql_parser/error.h
@@ -3,7 +3,7 @@
 #include <stdexcept>
 #include <string>
 
-#define EXCEPTION_CLASS_DEFINITION(NAME, BASE)                           \
+#define ERROR_CLASS_DEFINITION(NAME, BASE)                               \
   class NAME : public BASE {                                             \
    public:                                                               \
     size_t start;                                                        \
@@ -14,19 +14,19 @@
     explicit NAME(const char* message);                                  \
   };
 
-EXCEPTION_CLASS_DEFINITION(HogQLException, std::runtime_error)
+ERROR_CLASS_DEFINITION(HogQLError, std::runtime_error)
 
 // The input does not conform to HogQL syntax.
-EXCEPTION_CLASS_DEFINITION(SyntaxException, HogQLException)
+ERROR_CLASS_DEFINITION(SyntaxError, HogQLError)
 
 // This feature isn't implemented in HogQL (yet).
-EXCEPTION_CLASS_DEFINITION(NotImplementedException, HogQLException)
+ERROR_CLASS_DEFINITION(NotImplementedError, HogQLError)
 
 // An internal problem in the parser layer.
-EXCEPTION_CLASS_DEFINITION(ParsingException, HogQLException)
+ERROR_CLASS_DEFINITION(ParsingError, HogQLError)
 
 // Python runtime errored out somewhere - this means we must use the error it's already raised.
-class PyInternalException : public std::exception {
+class PyInternalError : public std::exception {
  public:
-  PyInternalException();
+  PyInternalError();
 };

--- a/hogql_parser/parser.cpp
+++ b/hogql_parser/parser.cpp
@@ -14,10 +14,10 @@
 #define VISIT(RULE) any visit##RULE(HogQLParser::RULE##Context* ctx) override
 #define VISIT_UNSUPPORTED(RULE)                                \
   VISIT(RULE) {                                                \
-    throw NotImplementedException("Unsupported rule: " #RULE); \
+    throw NotImplementedError("Unsupported rule: " #RULE); \
   }
 
-#define HANDLE_HOGQL_EXCEPTION(TYPE, OTHER_CLEANUP)                                                     \
+#define HANDLE_HOGQL_ERROR(TYPE, OTHER_CLEANUP)                                                     \
   (const TYPE& e) {                                                                                     \
     string err_what = e.what();                                                                         \
     PyObject *error_type = NULL, *py_err_args = NULL, *py_err = NULL, *py_start = NULL, *py_end = NULL; \
@@ -50,7 +50,7 @@
   PyObject* ret = build_ast_node(TYPE_NAME, KWARGS_FORMAT, __VA_ARGS__);                                      \
   /* Fortunately we don't need to care about decrementing Py_BuildValue/Py_VaBuildValue args, */              \
   /* so just throw is enough: https://github.com/python/cpython/blob/a254120f/Python/modsupport.c#L147-L148*/ \
-  if (!ret) throw PyInternalException();                                                                      \
+  if (!ret) throw PyInternalError();                                                                      \
   return ret
 
 using namespace std;
@@ -166,7 +166,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     } else {
       auto ctx = dynamic_cast<antlr4::ParserRuleContext*>(tree);
       if (!ctx) {
-        throw ParsingException("Parse tree node is neither a Token nor a ParserRuleContext");
+        throw ParsingError("Parse tree node is neither a Token nor a ParserRuleContext");
       }
       start = ctx->getStart()->getStartIndex();
       stop = ctx->getStop()->getStopIndex();
@@ -175,10 +175,10 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     any node;
     try {
       node = tree->accept(this);
-    } catch (const SyntaxException& e) {
+    } catch (const SyntaxError& e) {
       // If start and end are unset, rethrow with the current start and stop
       if (!is_internal && e.start == 0 && e.end == 0) {
-        throw SyntaxException(e.what(), start, stop + 1);
+        throw SyntaxError(e.what(), start, stop + 1);
       }
       throw;
     }
@@ -188,7 +188,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
         int is_ast = is_ast_node_instance(py_node);
         if (is_ast == -1) {
           Py_DECREF(py_node);
-          throw PyInternalException();
+          throw PyInternalError();
         }
         if (is_ast) {
           PyObject *py_start = NULL, *py_end = NULL;
@@ -206,7 +206,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
           Py_XDECREF(py_start);
           Py_XDECREF(py_end);
           Py_DECREF(py_node);
-          throw PyInternalException();
+          throw PyInternalError();
         success:
           Py_XDECREF(py_start);
           Py_XDECREF(py_end);
@@ -221,12 +221,12 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   PyObject* visitAsPyObjectFinal(antlr4::tree::ParseTree* tree) {
     try {
       return visitAsPyObject(tree);
-    } catch HANDLE_HOGQL_EXCEPTION(SyntaxException, ) catch HANDLE_HOGQL_EXCEPTION(
-        NotImplementedException,
-    ) catch HANDLE_HOGQL_EXCEPTION(ParsingException, ) catch (const PyInternalException& e) {
+    } catch HANDLE_HOGQL_ERROR(SyntaxError, ) catch HANDLE_HOGQL_ERROR(
+        NotImplementedError,
+    ) catch HANDLE_HOGQL_ERROR(ParsingError, ) catch (const PyInternalError& e) {
       return NULL;
     } catch (const bad_any_cast& e) {
-      PyObject* error_type = PyObject_GetAttrString(state->errors_module, "ParsingException");
+      PyObject* error_type = PyObject_GetAttrString(state->errors_module, "ParsingError");
       if (error_type) {
         PyErr_SetString(error_type, "Parsing failed due to bad type casting");
       }
@@ -237,8 +237,8 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   PyObject* visitAsPyObject(antlr4::tree::ParseTree* tree) {
     PyObject* ret = any_cast<PyObject*>(visit(tree));
     if (!ret) {
-      throw ParsingException(
-          "Rule resulted in a null PyObject pointer. A PyInternalException should have been raised instead."
+      throw ParsingError(
+          "Rule resulted in a null PyObject pointer. A PyInternalError should have been raised instead."
       );
     }
     return ret;
@@ -254,7 +254,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   PyObject* visitAsPyObjectOrEmptyList(antlr4::tree::ParseTree* tree) {
     if (tree == NULL) {
       PyObject* list = PyList_New(0);
-      if (!list) throw PyInternalException();
+      if (!list) throw PyInternalError();
       return list;
     }
     return visitAsPyObject(tree);
@@ -266,7 +266,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   PyObject* visitPyListOfObjects(vector<T> tree) {
     PyObject* ret = PyList_New(tree.size());
     if (!ret) {
-      throw PyInternalException();
+      throw PyInternalError();
     }
     for (size_t i = 0; i < tree.size(); i++) {
       try {
@@ -315,7 +315,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     if (placeholder_ctx) {
       return visitAsPyObject(placeholder_ctx);
     }
-    
+
     return visit(ctx->selectUnionStmt());
   }
 
@@ -335,7 +335,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     PyObject* flattened_queries = PyList_New(0);
     if (!flattened_queries) {
       X_Py_DECREF_ALL(select_queries);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     for (auto query : select_queries) {
       int is_select_query = is_ast_node_instance(query, "SelectQuery");
@@ -356,20 +356,20 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       } else {
         Py_DECREF(flattened_queries);
         X_Py_DECREF_ALL(select_queries);
-        throw ParsingException("Unexpected query node type: " + string(Py_TYPE(query)->tp_name));
+        throw ParsingError("Unexpected query node type: " + string(Py_TYPE(query)->tp_name));
       }
     }
     goto select_queries_loop_success;
   select_queries_loop_py_error:
     X_Py_DECREF_ALL(select_queries);
     Py_DECREF(flattened_queries);
-    throw PyInternalException();
+    throw PyInternalError();
   select_queries_loop_success:
     X_Py_DECREF_ALL(select_queries);
     Py_ssize_t flattened_queries_size = PyList_Size(flattened_queries);
     if (flattened_queries_size == -1) {
       Py_DECREF(flattened_queries);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     if (flattened_queries_size == 1) {
       PyObject* query = PyList_GET_ITEM(flattened_queries, 0);
@@ -412,7 +412,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
         prewhere, "having", having, "group_by", group_by, "order_by", order_by
     );
     if (!select_query) {
-      throw PyInternalException();
+      throw PyInternalError();
     }
 
     int err_indicator = 0;
@@ -423,12 +423,12 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       auto identifier_ctxs = window_clause_ctx->identifier();
       if (window_expr_ctxs.size() != identifier_ctxs.size()) {
         Py_DECREF(select_query);
-        throw ParsingException("WindowClause must have a matching number of window exprs and identifiers");
+        throw ParsingError("WindowClause must have a matching number of window exprs and identifiers");
       }
       PyObject* window_exprs = PyDict_New();
       if (!window_exprs) {
         Py_DECREF(select_query);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       for (size_t i = 0; i < window_expr_ctxs.size(); i++) {
         string identifier;
@@ -446,14 +446,14 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
         if (err_indicator == -1) {
           Py_DECREF(window_exprs);
           Py_DECREF(select_query);
-          throw PyInternalException();
+          throw PyInternalError();
         }
       }
       err_indicator = PyObject_SetAttrString(select_query, "window_exprs", window_exprs);
       Py_DECREF(window_exprs);
       if (err_indicator == -1) {
         Py_DECREF(select_query);
-        throw PyInternalException();
+        throw PyInternalError();
       }
     }
 
@@ -470,7 +470,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       Py_DECREF(limit);
       if (err_indicator == -1) {
         Py_DECREF(select_query);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       auto offset_ctx = limit_and_offset_clause_ctx->columnExpr(1);
       if (offset_ctx) {
@@ -485,7 +485,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
         Py_DECREF(offset);
         if (err_indicator == -1) {
           Py_DECREF(select_query);
-          throw PyInternalException();
+          throw PyInternalError();
         }
       }
       auto limit_by_exprs_ctx = limit_and_offset_clause_ctx->columnExprList();
@@ -501,14 +501,14 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
         Py_DECREF(limit_by_exprs);
         if (err_indicator == -1) {
           Py_DECREF(select_query);
-          throw PyInternalException();
+          throw PyInternalError();
         }
       }
       if (limit_and_offset_clause_ctx->WITH() && limit_and_offset_clause_ctx->TIES()) {
         err_indicator = PyObject_SetAttrString(select_query, "limit_with_ties", Py_True);
         if (err_indicator == -1) {
           Py_DECREF(select_query);
-          throw PyInternalException();
+          throw PyInternalError();
         }
       }
     } else {
@@ -525,7 +525,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
         Py_DECREF(offset_only_clause);
         if (err_indicator == -1) {
           Py_DECREF(select_query);
-          throw PyInternalException();
+          throw PyInternalError();
         }
       }
     }
@@ -534,7 +534,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     if (array_join_clause_ctx) {
       if (Py_IsNone(select_from)) {
         Py_DECREF(select_query);
-        throw SyntaxException("Using ARRAY JOIN without a FROM clause is not permitted");
+        throw SyntaxError("Using ARRAY JOIN without a FROM clause is not permitted");
       }
       PyObject* join_op = PyUnicode_FromString(
           array_join_clause_ctx->LEFT()    ? "LEFT ARRAY JOIN"
@@ -543,13 +543,13 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       );
       if (!join_op) {
         Py_DECREF(select_query);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       err_indicator = PyObject_SetAttrString(select_query, "array_join_op", join_op);
       Py_DECREF(join_op);
       if (err_indicator == -1) {
         Py_DECREF(select_query);
-        throw PyInternalException();
+        throw PyInternalError();
       }
 
       auto array_join_arrays_ctx = array_join_clause_ctx->columnExprList();
@@ -564,7 +564,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       if (array_join_list_size == -1) {
         Py_DECREF(select_query);
         Py_DECREF(array_join_list);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       for (Py_ssize_t i = 0; i < array_join_list_size; i++) {
         PyObject* expr = PyList_GET_ITEM(array_join_list, i);
@@ -572,13 +572,13 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
         if (is_alias == -1) {
           Py_DECREF(array_join_list);
           Py_DECREF(select_query);
-          throw PyInternalException();
+          throw PyInternalError();
         }
         if (!is_alias) {
           Py_DECREF(array_join_list);
           Py_DECREF(select_query);
           auto relevant_column_expr_ctx = array_join_arrays_ctx->columnExpr(i);
-          throw SyntaxException(
+          throw SyntaxError(
               "ARRAY JOIN arrays must have an alias", relevant_column_expr_ctx->getStart()->getStartIndex(),
               relevant_column_expr_ctx->getStop()->getStopIndex() + 1
           );
@@ -588,17 +588,17 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       Py_DECREF(array_join_list);
       if (err_indicator == -1) {
         Py_DECREF(select_query);
-        throw PyInternalException();
+        throw PyInternalError();
       }
     }
 
     if (ctx->topClause()) {
       Py_DECREF(select_query);
-      throw NotImplementedException("Unsupported: SelectStmt.topClause()");
+      throw NotImplementedError("Unsupported: SelectStmt.topClause()");
     }
     if (ctx->settingsClause()) {
       Py_DECREF(select_query);
-      throw NotImplementedException("Unsupported: SelectStmt.settingsClause()");
+      throw NotImplementedError("Unsupported: SelectStmt.settingsClause()");
     }
 
     return select_query;
@@ -639,20 +639,20 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     if (!next_join) {                                                                                            \
       Py_DECREF(join1);                                                                                          \
       Py_DECREF(join2);                                                                                          \
-      throw PyInternalException();                                                                               \
+      throw PyInternalError();                                                                               \
     }                                                                                                            \
     int reached_end_of_chain = Py_IsNone(next_join);                                                             \
     if (reached_end_of_chain == -1) {                                                                            \
       Py_DECREF(join1);                                                                                          \
       Py_DECREF(join2);                                                                                          \
-      throw PyInternalException();                                                                               \
+      throw PyInternalError();                                                                               \
     }                                                                                                            \
     if (reached_end_of_chain) {                                                                                  \
       int err_indicator = PyObject_SetAttrString(last_join, "next_join", join2);                                 \
       if (err_indicator == -1) {                                                                                 \
         Py_DECREF(join1);                                                                                        \
         Py_DECREF(join2);                                                                                        \
-        throw PyInternalException();                                                                             \
+        throw PyInternalError();                                                                             \
       }                                                                                                          \
       Py_DECREF(join2);                                                                                          \
       return join1;                                                                                              \
@@ -663,7 +663,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   Py_DECREF(join1);                                                                                              \
   Py_DECREF(join2);                                                                                              \
   PyErr_SetString(PyExc_RecursionError, "maximum recursion depth exceeded during JOIN parsing");                 \
-  throw PyInternalException(); /* This should never be reached, but `while (true)`s are scary, so better to be safe */
+  throw PyInternalError(); /* This should never be reached, but `while (true)`s are scary, so better to be safe */
 
   VISIT(JoinExprOp) {
     auto join_op_ctx = ctx->joinOp();
@@ -675,7 +675,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     } else {
       py_join_op = PyUnicode_FromString("JOIN");
     }
-    if (!py_join_op) throw PyInternalException();
+    if (!py_join_op) throw PyInternalError();
 
     int err_indicator = 0;
 
@@ -690,7 +690,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     Py_DECREF(py_join_op);
     if (err_indicator == -1) {
       Py_DECREF(join2);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     PyObject* constraint;
     try {
@@ -703,7 +703,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     Py_DECREF(constraint);
     if (err_indicator == -1) {
       Py_DECREF(join2);
-      throw PyInternalException();
+      throw PyInternalError();
     }
 
     PyObject* join1;
@@ -722,7 +722,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     int is_table_join_expr = is_ast_node_instance(table, "JoinExpr");
     if (is_table_join_expr == -1) {
       Py_DECREF(table);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     PyObject* sample;
     try {
@@ -738,12 +738,12 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       Py_DECREF(sample);
       if (err_indicator == -1) {
         Py_DECREF(table);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       err_indicator = PyObject_SetAttrString(table, "table_final", table_final);
       if (err_indicator == -1) {
         Py_DECREF(table);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       return table;
     } else {
@@ -752,7 +752,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       if (!ret) {
         Py_DECREF(table);
         Py_DECREF(sample);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       return ret;
     }
@@ -763,7 +763,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   VISIT(JoinExprCrossOp) {
     PyObject* join_type = PyUnicode_FromString("CROSS JOIN");
     if (!join_type) {
-      throw PyInternalException();
+      throw PyInternalError();
     }
 
     PyObject* join2;
@@ -776,7 +776,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     int err_indicator = PyObject_SetAttrString(join2, "join_type", join_type);
     if (err_indicator == -1) {
       Py_DECREF(join2);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     Py_DECREF(join_type);
 
@@ -858,17 +858,17 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   VISIT(JoinConstraintClause) {
     if (ctx->USING()) {
-      throw NotImplementedException("Unsupported: JOIN ... USING");
+      throw NotImplementedError("Unsupported: JOIN ... USING");
     }
     PyObject* column_expr_list = visitAsPyObject(ctx->columnExprList());
     Py_ssize_t column_expr_list_size = PyList_Size(column_expr_list);
     if (column_expr_list_size == -1) {
       Py_DECREF(column_expr_list);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     if (column_expr_list_size > 1) {
       Py_DECREF(column_expr_list);
-      throw NotImplementedException("Unsupported: JOIN ... ON with multiple expressions");
+      throw NotImplementedError("Unsupported: JOIN ... ON with multiple expressions");
     }
     PyObject* expr = Py_NewRef(PyList_GET_ITEM(column_expr_list, 0));
     Py_DECREF(column_expr_list);
@@ -905,9 +905,9 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     auto number_literal_ctxs = ctx->numberLiteral();
 
     if (number_literal_ctxs.size() > 2) {
-      throw ParsingException("RatioExpr must have at most two number literals");
+      throw ParsingError("RatioExpr must have at most two number literals");
     } else if (number_literal_ctxs.size() == 0) {
-      throw ParsingException("RatioExpr must have at least one number literal");
+      throw ParsingError("RatioExpr must have at least one number literal");
     }
 
     auto left_ctx = number_literal_ctxs[0];
@@ -935,17 +935,17 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     int is_frame_a_tuple = PyTuple_Check(frame);
     if (is_frame_a_tuple == -1) {
       Py_DECREF(frame);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     if (is_frame_a_tuple) {
       Py_ssize_t frame_tuple_size = PyTuple_Size(frame);
       if (frame_tuple_size == -1) {
         Py_DECREF(frame);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       if (frame_tuple_size != 2) {
         Py_DECREF(frame);
-        throw ParsingException("WindowExpr frame must be a tuple of size 2");
+        throw ParsingError("WindowExpr frame must be a tuple of size 2");
       }
     }
     PyObject* frame_start = Py_NewRef(is_frame_a_tuple ? PyTuple_GET_ITEM(frame, 0) : frame);
@@ -957,7 +957,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     if (!frame_method) {
       Py_DECREF(frame_start);
       Py_DECREF(frame_end);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     PyObject* partition_by;
     try {
@@ -1013,7 +1013,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
         PyObject* constant = visitAsPyObject(ctx->numberLiteral());
         number = PyObject_GetAttrString(constant, "value");
         Py_DECREF(constant);
-        if (!number) throw PyInternalException();
+        if (!number) throw PyInternalError();
       } else {
         number = Py_NewRef(Py_None);
       }
@@ -1069,14 +1069,14 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     } else if (ctx->STRING_LITERAL()) {
       alias = unquote_string_terminal(ctx->STRING_LITERAL());
     } else {
-      throw ParsingException("A ColumnExprAlias must have the alias in some form");
+      throw ParsingError("A ColumnExprAlias must have the alias in some form");
     }
     PyObject* expr = visitAsPyObject(ctx->columnExpr());
 
     if (find(RESERVED_KEYWORDS.begin(), RESERVED_KEYWORDS.end(), boost::algorithm::to_lower_copy(alias)) !=
         RESERVED_KEYWORDS.end()) {
       Py_DECREF(expr);
-      throw SyntaxException("\"" + alias + "\" cannot be an alias or identifier, as it's a reserved keyword");
+      throw SyntaxError("\"" + alias + "\" cannot be an alias or identifier, as it's a reserved keyword");
     }
 
     RETURN_NEW_AST_NODE("Alias", "{s:N,s:s#}", "expr", expr, "alias", alias.data(), alias.size());
@@ -1084,11 +1084,11 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   VISIT(ColumnExprNegate) {
     PyObject* left = build_ast_node("Constant", "{s:i}", "value", 0);
-    if (!left) throw PyInternalException();
+    if (!left) throw PyInternalError();
     PyObject* op = get_ast_enum_member("ArithmeticOperationOp", "Sub");
     if (!op) {
       Py_DECREF(left);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     PyObject* right;
     try {
@@ -1121,9 +1121,9 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     } else if (ctx->PERCENT()) {
       op = get_ast_enum_member("ArithmeticOperationOp", "Mod");
     } else {
-      throw ParsingException("Unsupported value of rule ColumnExprPrecedence1");
+      throw ParsingError("Unsupported value of rule ColumnExprPrecedence1");
     }
-    if (!op) throw PyInternalException();
+    if (!op) throw PyInternalError();
     PyObject* left;
     try {
       left = visitAsPyObject(ctx->columnExpr(0));
@@ -1157,7 +1157,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       if (!op) {
         Py_DECREF(left);
         Py_DECREF(right);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       RETURN_NEW_AST_NODE("ArithmeticOperation", "{s:N,s:N,s:N}", "left", left, "right", right, "op", op);
     } else if (ctx->DASH()) {
@@ -1165,7 +1165,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       if (!op) {
         Py_DECREF(left);
         Py_DECREF(right);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       RETURN_NEW_AST_NODE("ArithmeticOperation", "{s:N,s:N,s:N}", "left", left, "right", right, "op", op);
     } else if (ctx->CONCAT()) {
@@ -1175,7 +1175,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   if (is_##VAR##_a_call == -1) {                                                                          \
     Py_DECREF(left);                                                                                      \
     Py_DECREF(right);                                                                                     \
-    throw PyInternalException();                                                                          \
+    throw PyInternalError();                                                                          \
   }                                                                                                       \
   if (is_##VAR##_a_call) {                                                                                \
     PyObject* VAR##_name = PyObject_GetAttrString(VAR, "name");                                           \
@@ -1183,7 +1183,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       Py_DECREF(left);                                                                                    \
       Py_DECREF(right);                                                                                   \
       Py_DECREF(concat_as_str);                                                                           \
-      throw PyInternalException();                                                                        \
+      throw PyInternalError();                                                                        \
     }                                                                                                     \
     PyObject* VAR##_name_lower = PyObject_CallMethod(VAR##_name, "lower", NULL);                          \
     Py_DECREF(VAR##_name);                                                                                \
@@ -1191,7 +1191,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       Py_DECREF(left);                                                                                    \
       Py_DECREF(right);                                                                                   \
       Py_DECREF(concat_as_str);                                                                           \
-      throw PyInternalException();                                                                        \
+      throw PyInternalError();                                                                        \
     }                                                                                                     \
     is_##VAR##_a_concat_call = PyObject_RichCompareBool(VAR##_name_lower, concat_as_str, Py_EQ);          \
     Py_DECREF(VAR##_name_lower);                                                                          \
@@ -1199,7 +1199,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       Py_DECREF(left);                                                                                    \
       Py_DECREF(right);                                                                                   \
       Py_DECREF(concat_as_str);                                                                           \
-      throw PyInternalException();                                                                        \
+      throw PyInternalError();                                                                        \
     }                                                                                                     \
   }
 
@@ -1207,7 +1207,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       if (!concat_as_str) {
         Py_DECREF(left);
         Py_DECREF(right);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       IS_NODE_A_CONCAT_CALL(left);
       IS_NODE_A_CONCAT_CALL(right);
@@ -1219,7 +1219,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       if (!args) {
         Py_DECREF(left);
         Py_DECREF(right);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       if (is_right_a_concat_call) {
         PyObject* right_args = PyObject_GetAttrString(right, "args");
@@ -1227,7 +1227,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
           Py_DECREF(args);
           Py_DECREF(left);
           Py_DECREF(right);
-          throw PyInternalException();
+          throw PyInternalError();
         }
         int err_indicator = X_PyList_Extend(args, right_args);
         Py_DECREF(right_args);
@@ -1235,7 +1235,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
           Py_DECREF(args);
           Py_DECREF(left);
           Py_DECREF(right);
-          throw PyInternalException();
+          throw PyInternalError();
         }
       } else {
         int err_indicator = PyList_Append(args, right);
@@ -1243,7 +1243,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
           Py_DECREF(args);
           Py_DECREF(left);
           Py_DECREF(right);
-          throw PyInternalException();
+          throw PyInternalError();
         }
       }
       Py_DECREF(right);
@@ -1252,7 +1252,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     } else {
       Py_DECREF(right);
       Py_DECREF(left);
-      throw ParsingException("Unsupported value of rule ColumnExprPrecedence2");
+      throw ParsingError("Unsupported value of rule ColumnExprPrecedence2");
     }
   }
 
@@ -1305,9 +1305,9 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
         }
       }
     } else {
-      throw ParsingException("Unsupported value of rule ColumnExprPrecedence3");
+      throw ParsingError("Unsupported value of rule ColumnExprPrecedence3");
     }
-    if (!op) throw PyInternalException();
+    if (!op) throw PyInternalError();
 
     PyObject* left;
     try {
@@ -1348,7 +1348,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     } else if (interval_ctx->YEAR()) {
       name = "toIntervalYear";
     } else {
-      throw ParsingException("Unsupported value of rule ColumnExprInterval");
+      throw ParsingError("Unsupported value of rule ColumnExprInterval");
     }
 
     RETURN_NEW_AST_NODE("Call", "{s:s,s:[N]}", "name", name, "args", visitAsPyObject(ctx->columnExpr()));
@@ -1356,11 +1356,11 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   VISIT(ColumnExprIsNull) {
     PyObject* null_constant = build_ast_node("Constant", "{s:O}", "value", Py_None);
-    if (!null_constant) throw PyInternalException();
+    if (!null_constant) throw PyInternalError();
     PyObject* op = get_ast_enum_member("CompareOperationOp", ctx->NOT() ? "NotEq" : "Eq");
     if (!op) {
       Py_DECREF(null_constant);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     PyObject* left;
     try {
@@ -1382,12 +1382,12 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     } else if (ctx->BOTH()) {
       name = "trim";
     } else {
-      throw ParsingException("Unsupported value of rule ColumnExprTrim");
+      throw ParsingError("Unsupported value of rule ColumnExprTrim");
     }
     string text = unquote_string_terminal(ctx->STRING_LITERAL());
     PyObject* expr = visitAsPyObject(ctx->columnExpr());
     PyObject* value = build_ast_node("Constant", "{s:s#}", "value", text.data(), text.size());
-    if (!value) throw PyInternalException();
+    if (!value) throw PyInternalError();
     RETURN_NEW_AST_NODE("Call", "{s:s,s:[NN]}", "name", name, "args", expr, value);
   }
 
@@ -1400,30 +1400,30 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     int is_property_a_constant = is_ast_node_instance(property, "Constant");
     if (is_property_a_constant == -1) {
       Py_DECREF(property);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     if (is_property_a_constant) {
       PyObject* property_value = PyObject_GetAttrString(property, "value");
       if (!property_value) {
         Py_DECREF(property);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       PyObject* zero = PyLong_FromLong(0);
       if (!zero) {
         Py_DECREF(property_value);
         Py_DECREF(property);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       int is_property_zero = PyObject_RichCompareBool(property_value, zero, Py_EQ);
       Py_DECREF(zero);
       Py_DECREF(property_value);
       if (is_property_zero == -1) {
         Py_DECREF(property);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       if (is_property_zero) {
         Py_DECREF(property);
-        throw SyntaxException("SQL indexes start from one, not from zero. E.g: array[1]");
+        throw SyntaxError("SQL indexes start from one, not from zero. E.g: array[1]");
       }
     }
     PyObject* object;
@@ -1440,7 +1440,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     string identifier = visitAsString(ctx->identifier());
     PyObject* property = build_ast_node("Constant", "{s:s#}", "value", identifier.data(), identifier.size());
     if (!property) {
-      throw PyInternalException();
+      throw PyInternalError();
     }
     PyObject* object;
     try {
@@ -1472,7 +1472,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     if (is_left_an_and == -1) {
       Py_DECREF(left);
       Py_DECREF(right);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     PyObject* exprs = is_left_an_and ? PyObject_GetAttrString(left, "exprs") : Py_BuildValue("[O]", left);
 
@@ -1493,7 +1493,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     Py_DECREF(exprs);
     Py_DECREF(left);
     Py_DECREF(right);
-    throw PyInternalException();
+    throw PyInternalError();
   right_check_success:
     Py_DECREF(right);
     Py_DECREF(left);
@@ -1515,7 +1515,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     if (is_left_an_or == -1) {
       Py_DECREF(left);
       Py_DECREF(right);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     PyObject* exprs = is_left_an_or ? PyObject_GetAttrString(left, "exprs") : Py_BuildValue("[O]", left);
 
@@ -1536,7 +1536,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     Py_DECREF(exprs);
     Py_DECREF(left);
     Py_DECREF(right);
-    throw PyInternalException();
+    throw PyInternalError();
   right_check_success:
     Py_DECREF(right);
     Py_DECREF(left);
@@ -1546,21 +1546,21 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   VISIT(ColumnExprTupleAccess) {
     PyObject* index = PyLong_FromString(ctx->DECIMAL_LITERAL()->getText().c_str(), NULL, 10);
-    if (!index) throw PyInternalException();
+    if (!index) throw PyInternalError();
     PyObject* zero = PyLong_FromLong(0);
     if (!zero) {
       Py_DECREF(index);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     int is_index_zero = PyObject_RichCompareBool(index, zero, Py_EQ);
     Py_DECREF(zero);
     if (is_index_zero == -1) {
       Py_DECREF(index);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     if (is_index_zero) {
       Py_DECREF(index);
-      throw SyntaxException("SQL indexes start from one, not from zero. E.g: array[1]");
+      throw SyntaxError("SQL indexes start from one, not from zero. E.g: array[1]");
     }
     PyObject* tuple;
     try {
@@ -1608,7 +1608,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       Py_XDECREF(arg_2);
       Py_XDECREF(arg_1);
       Py_XDECREF(columns);
-      throw PyInternalException();
+      throw PyInternalError();
     success:
       RETURN_NEW_AST_NODE("Call", "{s:s,s:N}", "name", "transform", "args", args);
     } else {
@@ -1694,7 +1694,7 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   VISIT(WithExprList) {
     PyObject* ctes = PyDict_New();
-    if (!ctes) throw PyInternalException();
+    if (!ctes) throw PyInternalError();
     for (auto with_expr_ctx : ctx->withExpr()) {
       PyObject* cte;
       try {
@@ -1707,14 +1707,14 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       if (!name) {
         Py_DECREF(cte);
         Py_DECREF(ctes);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       int err_indicator = PyDict_SetItem(ctes, name, cte);
       if (err_indicator == -1) {
         Py_DECREF(name);
         Py_DECREF(cte);
         Py_DECREF(ctes);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       Py_DECREF(name);
       Py_DECREF(cte);
@@ -1780,10 +1780,10 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     string alias = any_cast<string>(alias_ctx ? visit(alias_ctx) : visit(ctx->identifier()));
     if (find(RESERVED_KEYWORDS.begin(), RESERVED_KEYWORDS.end(), boost::algorithm::to_lower_copy(alias)) !=
         RESERVED_KEYWORDS.end()) {
-      throw SyntaxException("ALIAS is a reserved keyword");
+      throw SyntaxError("ALIAS is a reserved keyword");
     }
     PyObject* py_alias = PyUnicode_FromStringAndSize(alias.data(), alias.size());
-    if (!py_alias) throw PyInternalException();
+    if (!py_alias) throw PyInternalError();
     PyObject* table;
     try {
       table = visitAsPyObject(ctx->tableExpr());
@@ -1795,14 +1795,14 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     int is_table_a_join_expr = is_ast_node_instance(table, "JoinExpr");
     if (is_table_a_join_expr == -1) {
       Py_DECREF(py_alias);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     if (is_table_a_join_expr) {
       int err_indicator = PyObject_SetAttrString(table, "alias", py_alias);
       Py_DECREF(py_alias);
       if (err_indicator == -1) {
         Py_DECREF(table);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       return table;
     }
@@ -1817,11 +1817,11 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     string table_name = visitAsString(ctx->identifier());
     auto table_args_ctx = ctx->tableArgList();
     PyObject* table_args = table_args_ctx ? visitAsPyObject(table_args_ctx) : PyList_New(0);
-    if (!table_args) throw PyInternalException();
+    if (!table_args) throw PyInternalError();
     PyObject* table = build_ast_node("Field", "{s:[s#]}", "chain", table_name.data(), table_name.size());
     if (!table) {
       Py_DECREF(table_args);
-      throw PyInternalException();
+      throw PyInternalError();
     }
     RETURN_NEW_AST_NODE("JoinExpr", "{s:N,s:N}", "table", table, "table_args", table_args);
   }
@@ -1847,14 +1847,14 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     if (text.find(".") != string::npos || text.find("e") != string::npos || !text.compare("-inf") ||
         !text.compare("inf") || !text.compare("nan")) {
       PyObject* py_text = PyUnicode_FromStringAndSize(text.data(), text.size());
-      if (!py_text) throw PyInternalException();
+      if (!py_text) throw PyInternalError();
       PyObject* value = PyFloat_FromString(py_text);
       Py_DECREF(py_text);
-      if (!value) throw PyInternalException();
+      if (!value) throw PyInternalError();
       RETURN_NEW_AST_NODE("Constant", "{s:N}", "value", value);
     } else {
       PyObject* value = PyLong_FromString(text.c_str(), NULL, 10);
-      if (!value) throw PyInternalException();
+      if (!value) throw PyInternalError();
       RETURN_NEW_AST_NODE("Constant", "{s:N}", "value", value);
     }
   }
@@ -1915,12 +1915,12 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     if (string_literal_ctx) {
       string text = unquote_string_terminal(string_literal_ctx);
       PyObject* value = build_ast_node("Constant", "{s:s#}", "value", text.data(), text.size());
-      if (!value) throw PyInternalException();
+      if (!value) throw PyInternalError();
       RETURN_NEW_AST_NODE("HogQLXAttribute", "{s:s#,s:N}", "name", name.data(), name.size(), "value", value);
     }
 
     PyObject* value = build_ast_node("Constant", "{s:O}", "value", Py_True);
-    if (!value) throw PyInternalException();
+    if (!value) throw PyInternalError();
     RETURN_NEW_AST_NODE("HogQLXAttribute", "{s:s#,s:N}", "name", name.data(), name.size(), "value", value);
   }
 
@@ -1936,13 +1936,13 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     string opening = visitAsString(ctx->identifier(0));
     string closing = visitAsString(ctx->identifier(1));
     if (opening != closing) {
-      throw SyntaxException("Opening and closing HogQLX tags must match. Got " + opening + " and " + closing);
+      throw SyntaxError("Opening and closing HogQLX tags must match. Got " + opening + " and " + closing);
     }
 
     auto tag_element_ctx = ctx->hogqlxTagElement();
     auto tag_attribute_ctx = ctx->hogqlxTagAttribute();
     PyObject* attributes = PyList_New(tag_attribute_ctx.size() + (tag_element_ctx ? 1 : 0));
-    if (!attributes) throw PyInternalException();
+    if (!attributes) throw PyInternalError();
     bool found_source = false;
     for (size_t i = 0; i < tag_attribute_ctx.size(); i++) {
       PyObject* object;
@@ -1957,20 +1957,20 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
       PyObject* name = PyObject_GetAttrString(object, "name");
       if (!name) {
         Py_DECREF(attributes);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       PyObject* source_as_str = PyUnicode_FromString("source");
       if (!source_as_str) {
         Py_DECREF(name);
         Py_DECREF(attributes);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       int tentative_found_source = PyObject_RichCompareBool(name, source_as_str, Py_EQ);
       Py_DECREF(source_as_str);
       Py_DECREF(name);
       if (tentative_found_source == -1) {
         Py_DECREF(attributes);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       if (tentative_found_source) {
         found_source = true;
@@ -1980,14 +1980,14 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
     if (tag_element_ctx) {
       if (found_source) {
         Py_DECREF(attributes);
-        throw SyntaxException("Nested HogQLX tags cannot have a source attribute");
+        throw SyntaxError("Nested HogQLX tags cannot have a source attribute");
       }
       PyObject* source_attribute = build_ast_node(
           "HogQLXAttribute", "{s:s#,s:N}", "name", "source", 6, "value", visitAsPyObject(ctx->hogqlxTagElement())
       );
       if (!source_attribute) {
         Py_DECREF(attributes);
-        throw PyInternalException();
+        throw PyInternalError();
       }
       PyList_SET_ITEM(attributes, tag_attribute_ctx.size(), source_attribute);
     }
@@ -2033,7 +2033,7 @@ class HogQLErrorListener : public antlr4::BaseErrorListener {
     if (start == string::npos) {
       start = 0;
     }
-    throw SyntaxException(msg, start, input.size());
+    throw SyntaxError(msg, start, input.size());
   }
 
  private:
@@ -2077,7 +2077,7 @@ parser_state* get_module_state(PyObject* module) {
     HogQLParser::PASCAL_CASE##Context* parse_tree;                                                                     \
     try {                                                                                                              \
       parse_tree = parser->CAMEL_CASE();                                                                               \
-    } catch HANDLE_HOGQL_EXCEPTION(SyntaxException, delete error_listener; delete parser; delete stream; delete lexer; \
+    } catch HANDLE_HOGQL_ERROR(SyntaxError, delete error_listener; delete parser; delete stream; delete lexer; \
                                    delete input_stream;);                                                              \
     HogQLParseTreeConverter converter = HogQLParseTreeConverter(state, internal == 1);                                 \
     PyObject* result_node = converter.visitAsPyObjectFinal(parse_tree);                                                \
@@ -2104,7 +2104,7 @@ static PyObject* method_unquote_string(PyObject* self, PyObject* args) {
   string unquoted_string;
   try {
     unquoted_string = unquote_string(str);
-  } catch HANDLE_HOGQL_EXCEPTION(SyntaxException, );
+  } catch HANDLE_HOGQL_ERROR(SyntaxError, );
   return PyUnicode_FromStringAndSize(unquoted_string.data(), unquoted_string.size());
 }
 

--- a/hogql_parser/setup.py
+++ b/hogql_parser/setup.py
@@ -32,7 +32,7 @@ module = Extension(
 
 setup(
     name="hogql_parser",
-    version="1.0.6",
+    version="1.0.7",
     url="https://github.com/PostHog/posthog/tree/master/hogql_parser",
     author="PostHog Inc.",
     author_email="hey@posthog.com",

--- a/hogql_parser/string.cpp
+++ b/hogql_parser/string.cpp
@@ -8,7 +8,7 @@ using namespace std;
 string unquote_string(string text) {
   size_t original_text_size = text.size();
   if (original_text_size == 0) {
-    throw ParsingException("Encountered an unexpected empty string input");
+    throw ParsingError("Encountered an unexpected empty string input");
   }
   const char first_char = text.front();
   const char last_char = text.back();
@@ -29,7 +29,7 @@ string unquote_string(string text) {
     boost::replace_all(text, "{{", "{");
     boost::replace_all(text, "\\{", "{");
   } else {
-    throw SyntaxException("Invalid string literal, must start and end with the same quote type: " + text);
+    throw SyntaxError("Invalid string literal, must start and end with the same quote type: " + text);
   }
 
   // Copied from clickhouse_driver/util/escape.py
@@ -50,9 +50,9 @@ string unquote_string_terminal(antlr4::tree::TerminalNode* node) {
   string text = node->getText();
   try {
     return unquote_string(text);
-  } catch (SyntaxException& e) {
-    throw SyntaxException(e.what(), node->getSymbol()->getStartIndex(), node->getSymbol()->getStopIndex() + 1);
-  } catch (ParsingException& e) {
-    throw ParsingException(e.what(), node->getSymbol()->getStartIndex(), node->getSymbol()->getStopIndex() + 1);
+  } catch (SyntaxError& e) {
+    throw SyntaxError(e.what(), node->getSymbol()->getStartIndex(), node->getSymbol()->getStopIndex() + 1);
+  } catch (ParsingError& e) {
+    throw ParsingError(e.what(), node->getSymbol()->getStartIndex(), node->getSymbol()->getStopIndex() + 1);
   }
 }

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -55,7 +55,7 @@ from posthog.decorators import cached_by_filters
 from posthog.helpers.multi_property_breakdown import (
     protect_old_clients_from_multi_property_default,
 )
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ExposedHogQLException
 from posthog.hogql.timings import HogQLTimings
 from posthog.hogql_queries.legacy_compatibility.feature_flag import hogql_insights_enabled
 from posthog.hogql_queries.legacy_compatibility.process_insight import is_insight_with_hogql_support, process_insight
@@ -804,7 +804,7 @@ Using the correct cache and enriching the response with dashboard specific confi
         try:
             with timings.measure("calculate"):
                 result = self.calculate_trends(request)
-        except HogQLException as e:
+        except ExposedHogQLException as e:
             raise ValidationError(str(e))
         filter = Filter(request=request, team=self.team)
 
@@ -890,7 +890,7 @@ Using the correct cache and enriching the response with dashboard specific confi
         try:
             with timings.measure("calculate"):
                 funnel = self.calculate_funnel(request)
-        except HogQLException as e:
+        except ExposedHogQLException as e:
             raise ValidationError(str(e))
 
         funnel["result"] = protect_old_clients_from_multi_property_default(request.data, funnel["result"])
@@ -932,7 +932,7 @@ Using the correct cache and enriching the response with dashboard specific confi
         try:
             with timings.measure("calculate"):
                 result = self.calculate_retention(request)
-        except HogQLException as e:
+        except ExposedHogQLException as e:
             raise ValidationError(str(e))
 
         result["timings"] = [val.model_dump() for val in timings.to_list()]
@@ -962,7 +962,7 @@ Using the correct cache and enriching the response with dashboard specific confi
         try:
             with timings.measure("calculate"):
                 result = self.calculate_path(request)
-        except HogQLException as e:
+        except ExposedHogQLException as e:
             raise ValidationError(str(e))
 
         result["timings"] = [val.model_dump() for val in timings.to_list()]

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -55,7 +55,7 @@ from posthog.decorators import cached_by_filters
 from posthog.helpers.multi_property_breakdown import (
     protect_old_clients_from_multi_property_default,
 )
-from posthog.hogql.errors import ExposedHogQLException
+from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.timings import HogQLTimings
 from posthog.hogql_queries.legacy_compatibility.feature_flag import hogql_insights_enabled
 from posthog.hogql_queries.legacy_compatibility.process_insight import is_insight_with_hogql_support, process_insight
@@ -804,7 +804,7 @@ Using the correct cache and enriching the response with dashboard specific confi
         try:
             with timings.measure("calculate"):
                 result = self.calculate_trends(request)
-        except ExposedHogQLException as e:
+        except ExposedHogQLError as e:
             raise ValidationError(str(e))
         filter = Filter(request=request, team=self.team)
 
@@ -890,7 +890,7 @@ Using the correct cache and enriching the response with dashboard specific confi
         try:
             with timings.measure("calculate"):
                 funnel = self.calculate_funnel(request)
-        except ExposedHogQLException as e:
+        except ExposedHogQLError as e:
             raise ValidationError(str(e))
 
         funnel["result"] = protect_old_clients_from_multi_property_default(request.data, funnel["result"])
@@ -932,7 +932,7 @@ Using the correct cache and enriching the response with dashboard specific confi
         try:
             with timings.measure("calculate"):
                 result = self.calculate_retention(request)
-        except ExposedHogQLException as e:
+        except ExposedHogQLError as e:
             raise ValidationError(str(e))
 
         result["timings"] = [val.model_dump() for val in timings.to_list()]
@@ -962,7 +962,7 @@ Using the correct cache and enriching the response with dashboard specific confi
         try:
             with timings.measure("calculate"):
                 result = self.calculate_path(request)
-        except ExposedHogQLException as e:
+        except ExposedHogQLError as e:
             raise ValidationError(str(e))
 
         result["timings"] = [val.model_dump() for val in timings.to_list()]

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -24,7 +24,7 @@ from posthog.clickhouse.client.execute_async import (
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.errors import ExposedCHQueryError
 from posthog.hogql.ai import PromptUnclear, write_sql_from_prompt
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ExposedHogQLException
 from posthog.models.user import User
 from posthog.rate_limit import (
     AIBurstRateThrottle,
@@ -78,7 +78,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         try:
             result = process_query_model(self.team, data.query, refresh_requested=data.refresh)
             return Response(result)
-        except (HogQLException, ExposedCHQueryError) as e:
+        except (ExposedHogQLException, ExposedCHQueryError) as e:
             raise ValidationError(str(e), getattr(e, "code_name", None))
         except Exception as e:
             self.handle_column_ch_error(e)

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -24,7 +24,7 @@ from posthog.clickhouse.client.execute_async import (
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.errors import ExposedCHQueryError
 from posthog.hogql.ai import PromptUnclear, write_sql_from_prompt
-from posthog.hogql.errors import ExposedHogQLException
+from posthog.hogql.errors import ExposedHogQLError
 from posthog.models.user import User
 from posthog.rate_limit import (
     AIBurstRateThrottle,
@@ -78,7 +78,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         try:
             result = process_query_model(self.team, data.query, refresh_requested=data.refresh)
             return Response(result)
-        except (ExposedHogQLException, ExposedCHQueryError) as e:
+        except (ExposedHogQLError, ExposedCHQueryError) as e:
             raise ValidationError(str(e), getattr(e, "code_name", None))
         except Exception as e:
             self.handle_column_ch_error(e)

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -163,7 +163,7 @@ class HogQLSelectQueryField(serializers.Field):
                     dialect="hogql",
                 ),
             )
-        except errors.ResolverException:
+        except errors.ResolutionException:
             raise serializers.ValidationError("Invalid HogQL query")
 
         return prepared_select_query

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -163,8 +163,8 @@ class HogQLSelectQueryField(serializers.Field):
                     dialect="hogql",
                 ),
             )
-        except errors.ResolutionException:
-            raise serializers.ValidationError("Invalid HogQL query")
+        except errors.ExposedHogQLException as e:
+            raise serializers.ValidationError(f"Invalid HogQL query: {e}")
 
         return prepared_select_query
 

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -163,7 +163,7 @@ class HogQLSelectQueryField(serializers.Field):
                     dialect="hogql",
                 ),
             )
-        except errors.ExposedHogQLException as e:
+        except errors.ExposedHogQLError as e:
             raise serializers.ValidationError(f"Invalid HogQL query: {e}")
 
         return prepared_select_query
@@ -259,7 +259,7 @@ class BatchExportSerializer(serializers.ModelSerializer):
                 "values": {},
                 "hogql_query": print_prepared_ast(hogql_query, context=context, dialect="hogql"),
             }
-        except errors.ExposedHogQLException:
+        except errors.ExposedHogQLError:
             raise serializers.ValidationError("Unsupported HogQL query")
 
         for field in hogql_query.select:

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -259,7 +259,7 @@ class BatchExportSerializer(serializers.ModelSerializer):
                 "values": {},
                 "hogql_query": print_prepared_ast(hogql_query, context=context, dialect="hogql"),
             }
-        except errors.HogQLException:
+        except errors.ExposedHogQLException:
             raise serializers.ValidationError("Unsupported HogQL query")
 
         for field in hogql_query.select:

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -11,7 +11,7 @@ from posthog import celery, redis
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.errors import ExposedCHQueryError
 from posthog.hogql.constants import LimitContext
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ExposedHogQLException
 from posthog.renderers import SafeJSONRenderer
 from posthog.schema import QueryStatus
 from posthog.tasks.tasks import process_query_task
@@ -107,7 +107,7 @@ def execute_process_query(
         query_status.expiration_time = query_status.end_time + datetime.timedelta(seconds=manager.STATUS_TTL_SECONDS)
         process_duration = (query_status.end_time - pickup_time) / datetime.timedelta(seconds=1)
         QUERY_PROCESS_TIME.observe(process_duration)
-    except (HogQLException, ExposedCHQueryError) as err:  # We can expose the error to the user
+    except (ExposedHogQLException, ExposedCHQueryError) as err:  # We can expose the error to the user
         query_status.results = None  # Clear results in case they are faulty
         query_status.error_message = str(err)
         logger.error("Error processing query for team %s query %s: %s", team_id, query_id, err)

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -11,7 +11,7 @@ from posthog import celery, redis
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.errors import ExposedCHQueryError
 from posthog.hogql.constants import LimitContext
-from posthog.hogql.errors import ExposedHogQLException
+from posthog.hogql.errors import ExposedHogQLError
 from posthog.renderers import SafeJSONRenderer
 from posthog.schema import QueryStatus
 from posthog.tasks.tasks import process_query_task
@@ -107,7 +107,7 @@ def execute_process_query(
         query_status.expiration_time = query_status.end_time + datetime.timedelta(seconds=manager.STATUS_TTL_SECONDS)
         process_duration = (query_status.end_time - pickup_time) / datetime.timedelta(seconds=1)
         QUERY_PROCESS_TIME.observe(process_duration)
-    except (ExposedHogQLException, ExposedCHQueryError) as err:  # We can expose the error to the user
+    except (ExposedHogQLError, ExposedCHQueryError) as err:  # We can expose the error to the user
         query_status.results = None  # Clear results in case they are faulty
         query_status.error_message = str(err)
         logger.error("Error processing query for team %s query %s: %s", team_id, query_id, err)

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 
 from posthog.clickhouse.client import execute_async as client
 from posthog.client import sync_execute
-from posthog.hogql.errors import ExposedHogQLException
+from posthog.hogql.errors import ExposedHogQLError
 from posthog.models import Organization, Team
 from posthog.test.base import ClickhouseTestMixin, snapshot_clickhouse_queries
 from unittest.mock import patch, MagicMock
@@ -77,7 +77,7 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
     def test_async_query_client_errors(self):
         query = build_query("SELECT WOW SUCH DATA FROM NOWHERE THIS WILL CERTAINLY WORK")
         self.assertRaises(
-            ExposedHogQLException,
+            ExposedHogQLError,
             client.enqueue_process_query_task,
             **{"team_id": self.team_id, "user_id": self.user_id, "query_json": query, "_test_only_bypass_celery": True},
         )

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 
 from posthog.clickhouse.client import execute_async as client
 from posthog.client import sync_execute
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ExposedHogQLException
 from posthog.models import Organization, Team
 from posthog.test.base import ClickhouseTestMixin, snapshot_clickhouse_queries
 from unittest.mock import patch, MagicMock
@@ -77,7 +77,7 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
     def test_async_query_client_errors(self):
         query = build_query("SELECT WOW SUCH DATA FROM NOWHERE THIS WILL CERTAINLY WORK")
         self.assertRaises(
-            HogQLException,
+            ExposedHogQLException,
             client.enqueue_process_query_task,
             **{"team_id": self.team_id, "user_id": self.user_id, "query_json": query, "_test_only_bypass_celery": True},
         )

--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Optional
 import openai
 from posthog.event_usage import report_user_action
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ExposedHogQLException
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import print_ast
 from .database.database import create_hogql_database, serialize_database
@@ -119,7 +119,7 @@ def write_sql_from_prompt(prompt: str, *, current_query: Optional[str] = None, t
         candidate_sql = content
         try:
             print_ast(parse_select(candidate_sql), context=context, dialect="clickhouse")
-        except HogQLException as e:
+        except ExposedHogQLException as e:
             messages.append({"role": "assistant", "content": candidate_sql})
             messages.append(
                 {

--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Optional
 import openai
 from posthog.event_usage import report_user_action
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.errors import ExposedHogQLException
+from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import print_ast
 from .database.database import create_hogql_database, serialize_database
@@ -119,7 +119,7 @@ def write_sql_from_prompt(prompt: str, *, current_query: Optional[str] = None, t
         candidate_sql = content
         try:
             print_ast(parse_select(candidate_sql), context=context, dialect="clickhouse")
-        except ExposedHogQLException as e:
+        except ExposedHogQLError as e:
             messages.append({"role": "assistant", "content": candidate_sql})
             messages.append(
                 {

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -23,7 +23,7 @@ from posthog.hogql.database.models import (
     StringArrayDatabaseField,
     ExpressionField,
 )
-from posthog.hogql.errors import HogQLException, NotImplementedException
+from posthog.hogql.errors import NotImplementedException, QueryException, ResolutionException
 
 # :NOTE: when you add new AST fields or nodes, add them to CloningVisitor and TraversingVisitor in visitor.py as well.
 # :NOTE2: also search for ":TRICKY:" in "resolver.py" when modifying SelectQuery or JoinExpr
@@ -82,7 +82,7 @@ class BaseTableType(Type):
             if isinstance(field, ExpressionField):
                 return ExpressionFieldType(table_type=self, name=name, expr=field.expr)
             return FieldType(name=name, table_type=self)
-        raise HogQLException(f"Field not found: {name}")
+        raise QueryException(f"Field not found: {name}")
 
 
 TableOrSelectType = Union[
@@ -165,7 +165,7 @@ class SelectQueryType(Type):
             return AsteriskType(table_type=self)
         if name in self.columns:
             return FieldType(name=name, table_type=self)
-        raise HogQLException(f"Column not found: {name}")
+        raise QueryException(f"Column not found: {name}")
 
     def has_child(self, name: str, context: HogQLContext) -> bool:
         return name in self.columns
@@ -198,7 +198,7 @@ class SelectViewType(Type):
             return FieldType(name=name, table_type=self)
         if self.view_name:
             if context.database is None:
-                raise HogQLException("Database must be set for queries with views")
+                raise ResolutionException("Database must be set for queries with views")
 
             field = context.database.get_table(self.view_name).get_field(name)
 
@@ -213,12 +213,12 @@ class SelectViewType(Type):
             if isinstance(field, ExpressionField):
                 return ExpressionFieldType(table_type=self, name=name, expr=field.expr)
             return FieldType(name=name, table_type=self)
-        raise HogQLException(f"Field {name} not found on view query with name {self.view_name}")
+        raise ResolutionException(f"Field {name} not found on view query with name {self.view_name}")
 
     def has_child(self, name: str, context: HogQLContext) -> bool:
         if self.view_name:
             if context.database is None:
-                raise HogQLException("Database must be set for queries with views")
+                raise ResolutionException("Database must be set for queries with views")
             try:
                 context.database.get_table(self.view_name).get_field(name)
                 return True
@@ -239,7 +239,7 @@ class SelectQueryAliasType(Type):
         if self.select_query_type.has_child(name, context):
             return FieldType(name=name, table_type=self)
 
-        raise HogQLException(f"Field {name} not found on query with alias {self.alias}")
+        raise ResolutionException(f"Field {name} not found on query with alias {self.alias}")
 
     def has_child(self, name: str, context: HogQLContext) -> bool:
         return self.select_query_type.has_child(name, context)
@@ -385,12 +385,12 @@ class FieldType(Type):
     def get_child(self, name: str | int, context: HogQLContext) -> Type:
         database_field = self.resolve_database_field(context)
         if database_field is None:
-            raise HogQLException(f'Can not access property "{name}" on field "{self.name}".')
+            raise ResolutionException(f'Can not access property "{name}" on field "{self.name}".')
         if isinstance(database_field, StringJSONDatabaseField):
             return PropertyType(chain=[name], field_type=self)
         if isinstance(database_field, StringArrayDatabaseField):
             return PropertyType(chain=[name], field_type=self)
-        raise HogQLException(
+        raise ResolutionException(
             f'Can not access property "{name}" on field "{self.name}" of type: {type(database_field).__name__}'
         )
 

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -23,7 +23,7 @@ from posthog.hogql.database.models import (
     StringArrayDatabaseField,
     ExpressionField,
 )
-from posthog.hogql.errors import NotImplementedException, QueryException, ResolutionException
+from posthog.hogql.errors import NotImplementedError, QueryError, ResolutionError
 
 # :NOTE: when you add new AST fields or nodes, add them to CloningVisitor and TraversingVisitor in visitor.py as well.
 # :NOTE2: also search for ":TRICKY:" in "resolver.py" when modifying SelectQuery or JoinExpr
@@ -48,20 +48,20 @@ class FieldAliasType(Type):
             return self.type.resolve_database_field(context)
         if isinstance(self.type, PropertyType):
             return self.type.field_type.resolve_database_field(context)
-        raise NotImplementedException("FieldAliasType.resolve_database_field not implemented")
+        raise NotImplementedError("FieldAliasType.resolve_database_field not implemented")
 
     def resolve_table_type(self, context: HogQLContext):
         if isinstance(self.type, FieldType):
             return self.type.table_type
         if isinstance(self.type, PropertyType):
             return self.type.field_type.table_type
-        raise NotImplementedException("FieldAliasType.resolve_table_type not implemented")
+        raise NotImplementedError("FieldAliasType.resolve_table_type not implemented")
 
 
 @dataclass(kw_only=True)
 class BaseTableType(Type):
     def resolve_database_table(self, context: HogQLContext) -> Table:
-        raise NotImplementedException("BaseTableType.resolve_database_table not overridden")
+        raise NotImplementedError("BaseTableType.resolve_database_table not overridden")
 
     def has_child(self, name: str, context: HogQLContext) -> bool:
         return self.resolve_database_table(context).has_field(name)
@@ -82,7 +82,7 @@ class BaseTableType(Type):
             if isinstance(field, ExpressionField):
                 return ExpressionFieldType(table_type=self, name=name, expr=field.expr)
             return FieldType(name=name, table_type=self)
-        raise QueryException(f"Field not found: {name}")
+        raise QueryError(f"Field not found: {name}")
 
 
 TableOrSelectType = Union[
@@ -165,7 +165,7 @@ class SelectQueryType(Type):
             return AsteriskType(table_type=self)
         if name in self.columns:
             return FieldType(name=name, table_type=self)
-        raise QueryException(f"Column not found: {name}")
+        raise QueryError(f"Column not found: {name}")
 
     def has_child(self, name: str, context: HogQLContext) -> bool:
         return name in self.columns
@@ -198,7 +198,7 @@ class SelectViewType(Type):
             return FieldType(name=name, table_type=self)
         if self.view_name:
             if context.database is None:
-                raise ResolutionException("Database must be set for queries with views")
+                raise ResolutionError("Database must be set for queries with views")
 
             field = context.database.get_table(self.view_name).get_field(name)
 
@@ -213,12 +213,12 @@ class SelectViewType(Type):
             if isinstance(field, ExpressionField):
                 return ExpressionFieldType(table_type=self, name=name, expr=field.expr)
             return FieldType(name=name, table_type=self)
-        raise ResolutionException(f"Field {name} not found on view query with name {self.view_name}")
+        raise ResolutionError(f"Field {name} not found on view query with name {self.view_name}")
 
     def has_child(self, name: str, context: HogQLContext) -> bool:
         if self.view_name:
             if context.database is None:
-                raise ResolutionException("Database must be set for queries with views")
+                raise ResolutionError("Database must be set for queries with views")
             try:
                 context.database.get_table(self.view_name).get_field(name)
                 return True
@@ -239,7 +239,7 @@ class SelectQueryAliasType(Type):
         if self.select_query_type.has_child(name, context):
             return FieldType(name=name, table_type=self)
 
-        raise ResolutionException(f"Field {name} not found on query with alias {self.alias}")
+        raise ResolutionError(f"Field {name} not found on query with alias {self.alias}")
 
     def has_child(self, name: str, context: HogQLContext) -> bool:
         return self.select_query_type.has_child(name, context)
@@ -385,12 +385,12 @@ class FieldType(Type):
     def get_child(self, name: str | int, context: HogQLContext) -> Type:
         database_field = self.resolve_database_field(context)
         if database_field is None:
-            raise ResolutionException(f'Can not access property "{name}" on field "{self.name}".')
+            raise ResolutionError(f'Can not access property "{name}" on field "{self.name}".')
         if isinstance(database_field, StringJSONDatabaseField):
             return PropertyType(chain=[name], field_type=self)
         if isinstance(database_field, StringArrayDatabaseField):
             return PropertyType(chain=[name], field_type=self)
-        raise ResolutionException(
+        raise ResolutionError(
             f'Can not access property "{name}" on field "{self.name}" of type: {type(database_field).__name__}'
         )
 

--- a/posthog/hogql/base.py
+++ b/posthog/hogql/base.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal, Optional
 
 from posthog.hogql.constants import ConstantDataType
-from posthog.hogql.errors import NotImplementedException
+from posthog.hogql.errors import NotImplementedError
 
 if TYPE_CHECKING:
     from posthog.hogql.context import HogQLContext
@@ -32,13 +32,13 @@ class AST:
             return visit(self)
         if hasattr(visitor, "visit_unknown"):
             return visitor.visit_unknown(self)
-        raise NotImplementedException(f"{visitor.__class__.__name__} has no method {method_name}")
+        raise NotImplementedError(f"{visitor.__class__.__name__} has no method {method_name}")
 
 
 @dataclass(kw_only=True)
 class Type(AST):
     def get_child(self, name: str, context: "HogQLContext") -> "Type":
-        raise NotImplementedException("Type.get_child not overridden")
+        raise NotImplementedError("Type.get_child not overridden")
 
     def has_child(self, name: str, context: "HogQLContext") -> bool:
         return self.get_child(name, context) is not None
@@ -70,7 +70,7 @@ class ConstantType(Type):
         return self
 
     def print_type(self) -> str:
-        raise NotImplementedException("ConstantType.print_type not implemented")
+        raise NotImplementedError("ConstantType.print_type not implemented")
 
 
 @dataclass(kw_only=True)

--- a/posthog/hogql/bytecode.py
+++ b/posthog/hogql/bytecode.py
@@ -1,7 +1,7 @@
 from typing import List, Any
 
 from posthog.hogql import ast
-from posthog.hogql.errors import NotImplementedException
+from posthog.hogql.errors import NotImplementedError
 from posthog.hogql.visitor import Visitor
 from hogvm.python.operation import (
     Operation,
@@ -74,7 +74,7 @@ class BytecodeBuilder(Visitor):
     def visit_compare_operation(self, node: ast.CompareOperation):
         operation = COMPARE_OPERATIONS[node.op]
         if operation in [Operation.IN_COHORT, Operation.NOT_IN_COHORT]:
-            raise NotImplementedException("Cohort operations are not supported")
+            raise NotImplementedError("Cohort operations are not supported")
         return [*self.visit(node.right), *self.visit(node.left), operation]
 
     def visit_arithmetic_operation(self, node: ast.ArithmeticOperation):
@@ -110,7 +110,7 @@ class BytecodeBuilder(Visitor):
         elif isinstance(node.value, str):
             return [Operation.STRING, node.value]
         else:
-            raise NotImplementedException(f"Constant type `{type(node.value)}` is not supported")
+            raise NotImplementedError(f"Constant type `{type(node.value)}` is not supported")
 
     def visit_call(self, node: ast.Call):
         if node.name == "not" and len(node.args) == 1:
@@ -126,7 +126,7 @@ class BytecodeBuilder(Visitor):
                 args.extend(self.visit(arg))
             return [*args, Operation.OR, len(node.args)]
         if node.name not in SUPPORTED_FUNCTIONS:
-            raise NotImplementedException(f"HogQL function `{node.name}` is not supported")
+            raise NotImplementedError(f"HogQL function `{node.name}` is not supported")
         response = []
         for expr in reversed(node.args):
             response.extend(self.visit(expr))

--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -4,8 +4,6 @@ from typing import Optional, Literal, TypeAlias, Tuple, List
 from uuid import UUID
 from pydantic import ConfigDict, BaseModel
 
-from posthog.hogql.errors import HogQLException
-
 ConstantDataType: TypeAlias = Literal[
     "int",
     "float",
@@ -52,7 +50,7 @@ def get_max_limit_for_context(limit_context: LimitContext) -> int:
     elif limit_context == LimitContext.COHORT_CALCULATION:
         return MAX_SELECT_COHORT_CALCULATION_LIMIT  # 1b
     else:
-        raise HogQLException(f"Unexpected LimitContext value: {limit_context}")
+        raise ValueError(f"Unexpected LimitContext value: {limit_context}")
 
 
 def get_default_limit_for_context(limit_context: LimitContext) -> int:
@@ -64,7 +62,7 @@ def get_default_limit_for_context(limit_context: LimitContext) -> int:
     elif limit_context == LimitContext.COHORT_CALCULATION:
         return MAX_SELECT_COHORT_CALCULATION_LIMIT  # 1b
     else:
-        raise HogQLException(f"Unexpected LimitContext value: {limit_context}")
+        raise ValueError(f"Unexpected LimitContext value: {limit_context}")
 
 
 # Settings applied at the SELECT level

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -52,7 +52,7 @@ from posthog.hogql.database.schema.session_replay_events import (
 )
 from posthog.hogql.database.schema.sessions import RawSessionsTable, SessionsTable
 from posthog.hogql.database.schema.static_cohort_people import StaticCohortPeople
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import QueryException, ResolutionException
 from posthog.hogql.parser import parse_expr
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.team.team import WeekStartDay
@@ -117,7 +117,7 @@ class Database(BaseModel):
         try:
             self._timezone = str(ZoneInfo(timezone)) if timezone else None
         except ZoneInfoNotFoundError:
-            raise HogQLException(f"Unknown timezone: '{str(timezone)}'")
+            raise ValueError(f"Unknown timezone: '{str(timezone)}'")
         self._week_start_day = week_start_day
 
     def get_timezone(self) -> str:
@@ -132,7 +132,7 @@ class Database(BaseModel):
     def get_table(self, table_name: str) -> Table:
         if self.has_table(table_name):
             return getattr(self, table_name)
-        raise HogQLException(f'Table "{table_name}" not found in database')
+        raise QueryException(f'Table "{table_name}" not found in database')
 
     def get_all_tables(self) -> List[str]:
         return self._table_names + self._warehouse_table_names
@@ -275,12 +275,12 @@ def create_hogql_database(
 
             field = parse_expr(join.source_table_key)
             if not isinstance(field, ast.Field):
-                raise HogQLException("Data Warehouse Join HogQL expression should be a Field node")
+                raise ResolutionException("Data Warehouse Join HogQL expression should be a Field node")
             from_field = field.chain
 
             field = parse_expr(join.joining_table_key)
             if not isinstance(field, ast.Field):
-                raise HogQLException("Data Warehouse Join HogQL expression should be a Field node")
+                raise ResolutionException("Data Warehouse Join HogQL expression should be a Field node")
             to_field = field.chain
 
             source_table.fields[join.field_name] = LazyJoin(
@@ -359,7 +359,7 @@ def serialize_database(context: HogQLContext) -> Dict[str, List[SerializedField]
     tables: Dict[str, List[SerializedField]] = {}
 
     if context.database is None:
-        raise HogQLException("Must provide database to serialize_database")
+        raise ResolutionException("Must provide database to serialize_database")
 
     for table_key in context.database.model_fields.keys():
         field_input: Dict[str, Any] = {}

--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 from pydantic import ConfigDict, BaseModel
 
 from posthog.hogql.base import Expr
-from posthog.hogql.errors import ResolutionException, NotImplementedException
+from posthog.hogql.errors import ResolutionError, NotImplementedError
 
 if TYPE_CHECKING:
     from posthog.hogql.context import HogQLContext
@@ -82,10 +82,10 @@ class Table(FieldOrTable):
         raise Exception(f'Field "{name}" not found on table {self.__class__.__name__}')
 
     def to_printed_clickhouse(self, context: "HogQLContext") -> str:
-        raise NotImplementedException("Table.to_printed_clickhouse not overridden")
+        raise NotImplementedError("Table.to_printed_clickhouse not overridden")
 
     def to_printed_hogql(self) -> str:
-        raise NotImplementedException("Table.to_printed_hogql not overridden")
+        raise NotImplementedError("Table.to_printed_hogql not overridden")
 
     def avoid_asterisk_fields(self) -> List[str]:
         return []
@@ -102,7 +102,7 @@ class Table(FieldOrTable):
                 if not field.hidden:  # Skip over hidden fields
                     asterisk[key] = field
             else:
-                raise ResolutionException(f"Unknown field type {type(field).__name__} for asterisk")
+                raise ResolutionError(f"Unknown field type {type(field).__name__} for asterisk")
         return asterisk
 
 
@@ -119,7 +119,7 @@ class LazyJoin(FieldOrTable):
             return self.join_table
 
         if context.database is None:
-            raise ResolutionException("Database is not set")
+            raise ResolutionError("Database is not set")
 
         return context.database.get_table(self.join_table)
 
@@ -134,7 +134,7 @@ class LazyTable(Table):
     def lazy_select(
         self, requested_fields: Dict[str, List[str | int]], context: "HogQLContext", node: "SelectQuery"
     ) -> Any:
-        raise NotImplementedException("LazyTable.lazy_select not overridden")
+        raise NotImplementedError("LazyTable.lazy_select not overridden")
 
 
 class VirtualTable(Table):

--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 from pydantic import ConfigDict, BaseModel
 
 from posthog.hogql.base import Expr
-from posthog.hogql.errors import HogQLException, NotImplementedException
+from posthog.hogql.errors import ResolutionException, NotImplementedException
 
 if TYPE_CHECKING:
     from posthog.hogql.context import HogQLContext
@@ -102,7 +102,7 @@ class Table(FieldOrTable):
                 if not field.hidden:  # Skip over hidden fields
                     asterisk[key] = field
             else:
-                raise HogQLException(f"Unknown field type {type(field).__name__} for asterisk")
+                raise ResolutionException(f"Unknown field type {type(field).__name__} for asterisk")
         return asterisk
 
 
@@ -119,7 +119,7 @@ class LazyJoin(FieldOrTable):
             return self.join_table
 
         if context.database is None:
-            raise HogQLException("Database is not set")
+            raise ResolutionException("Database is not set")
 
         return context.database.get_table(self.join_table)
 

--- a/posthog/hogql/database/schema/groups.py
+++ b/posthog/hogql/database/schema/groups.py
@@ -12,7 +12,7 @@ from posthog.hogql.database.models import (
     Table,
     FieldOrTable,
 )
-from posthog.hogql.errors import ResolutionException
+from posthog.hogql.errors import ResolutionError
 
 GROUPS_TABLE_FIELDS = {
     "index": IntegerDatabaseField(name="group_type_index"),
@@ -44,7 +44,7 @@ def join_with_group_n_table(group_index: int):
         from posthog.hogql import ast
 
         if not requested_fields:
-            raise ResolutionException("No fields requested from person_distinct_ids")
+            raise ResolutionError("No fields requested from person_distinct_ids")
 
         select_query = select_from_groups_table(requested_fields)
         select_query.where = ast.CompareOperation(

--- a/posthog/hogql/database/schema/groups.py
+++ b/posthog/hogql/database/schema/groups.py
@@ -12,7 +12,7 @@ from posthog.hogql.database.models import (
     Table,
     FieldOrTable,
 )
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ResolutionException
 
 GROUPS_TABLE_FIELDS = {
     "index": IntegerDatabaseField(name="group_type_index"),
@@ -44,7 +44,7 @@ def join_with_group_n_table(group_index: int):
         from posthog.hogql import ast
 
         if not requested_fields:
-            raise HogQLException("No fields requested from person_distinct_ids")
+            raise ResolutionException("No fields requested from person_distinct_ids")
 
         select_query = select_from_groups_table(requested_fields)
         select_query.where = ast.CompareOperation(

--- a/posthog/hogql/database/schema/person_distinct_id_overrides.py
+++ b/posthog/hogql/database/schema/person_distinct_id_overrides.py
@@ -13,7 +13,7 @@ from posthog.hogql.database.models import (
     FieldOrTable,
 )
 from posthog.hogql.database.schema.persons import join_with_persons_table
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ResolutionException
 
 PERSON_DISTINCT_ID_OVERRIDES_FIELDS = {
     "team_id": IntegerDatabaseField(name="team_id"),
@@ -50,7 +50,7 @@ def join_with_person_distinct_id_overrides_table(
     from posthog.hogql import ast
 
     if not requested_fields:
-        raise HogQLException("No fields requested from person_distinct_id_overrides")
+        raise ResolutionException("No fields requested from person_distinct_id_overrides")
     join_expr = ast.JoinExpr(table=select_from_person_distinct_id_overrides_table(requested_fields))
     join_expr.join_type = "LEFT OUTER JOIN"
     join_expr.alias = to_table

--- a/posthog/hogql/database/schema/person_distinct_id_overrides.py
+++ b/posthog/hogql/database/schema/person_distinct_id_overrides.py
@@ -13,7 +13,7 @@ from posthog.hogql.database.models import (
     FieldOrTable,
 )
 from posthog.hogql.database.schema.persons import join_with_persons_table
-from posthog.hogql.errors import ResolutionException
+from posthog.hogql.errors import ResolutionError
 
 PERSON_DISTINCT_ID_OVERRIDES_FIELDS = {
     "team_id": IntegerDatabaseField(name="team_id"),
@@ -50,7 +50,7 @@ def join_with_person_distinct_id_overrides_table(
     from posthog.hogql import ast
 
     if not requested_fields:
-        raise ResolutionException("No fields requested from person_distinct_id_overrides")
+        raise ResolutionError("No fields requested from person_distinct_id_overrides")
     join_expr = ast.JoinExpr(table=select_from_person_distinct_id_overrides_table(requested_fields))
     join_expr.join_type = "LEFT OUTER JOIN"
     join_expr.alias = to_table

--- a/posthog/hogql/database/schema/person_distinct_ids.py
+++ b/posthog/hogql/database/schema/person_distinct_ids.py
@@ -13,7 +13,7 @@ from posthog.hogql.database.models import (
     FieldOrTable,
 )
 from posthog.hogql.database.schema.persons import join_with_persons_table
-from posthog.hogql.errors import ResolutionException
+from posthog.hogql.errors import ResolutionError
 
 PERSON_DISTINCT_IDS_FIELDS = {
     "team_id": IntegerDatabaseField(name="team_id"),
@@ -50,7 +50,7 @@ def join_with_person_distinct_ids_table(
     from posthog.hogql import ast
 
     if not requested_fields:
-        raise ResolutionException("No fields requested from person_distinct_ids")
+        raise ResolutionError("No fields requested from person_distinct_ids")
     join_expr = ast.JoinExpr(table=select_from_person_distinct_ids_table(requested_fields))
     join_expr.join_type = "INNER JOIN"
     join_expr.alias = to_table

--- a/posthog/hogql/database/schema/person_distinct_ids.py
+++ b/posthog/hogql/database/schema/person_distinct_ids.py
@@ -13,7 +13,7 @@ from posthog.hogql.database.models import (
     FieldOrTable,
 )
 from posthog.hogql.database.schema.persons import join_with_persons_table
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ResolutionException
 
 PERSON_DISTINCT_IDS_FIELDS = {
     "team_id": IntegerDatabaseField(name="team_id"),
@@ -50,7 +50,7 @@ def join_with_person_distinct_ids_table(
     from posthog.hogql import ast
 
     if not requested_fields:
-        raise HogQLException("No fields requested from person_distinct_ids")
+        raise ResolutionException("No fields requested from person_distinct_ids")
     join_expr = ast.JoinExpr(table=select_from_person_distinct_ids_table(requested_fields))
     join_expr.join_type = "INNER JOIN"
     join_expr.alias = to_table

--- a/posthog/hogql/database/schema/person_overrides.py
+++ b/posthog/hogql/database/schema/person_overrides.py
@@ -11,7 +11,7 @@ from posthog.hogql.database.models import (
     FieldOrTable,
 )
 
-from posthog.hogql.errors import ResolutionException
+from posthog.hogql.errors import ResolutionError
 from posthog.schema import HogQLQueryModifiers
 
 PERSON_OVERRIDES_FIELDS: Dict[str, FieldOrTable] = {
@@ -43,7 +43,7 @@ def join_with_person_overrides_table(
     from posthog.hogql import ast
 
     if not requested_fields:
-        raise ResolutionException("No fields requested from person_distinct_ids")
+        raise ResolutionError("No fields requested from person_distinct_ids")
 
     join_expr = ast.JoinExpr(table=select_from_person_overrides_table(requested_fields))
     join_expr.join_type = "LEFT OUTER JOIN"

--- a/posthog/hogql/database/schema/person_overrides.py
+++ b/posthog/hogql/database/schema/person_overrides.py
@@ -11,7 +11,7 @@ from posthog.hogql.database.models import (
     FieldOrTable,
 )
 
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ResolutionException
 from posthog.schema import HogQLQueryModifiers
 
 PERSON_OVERRIDES_FIELDS: Dict[str, FieldOrTable] = {
@@ -43,7 +43,7 @@ def join_with_person_overrides_table(
     from posthog.hogql import ast
 
     if not requested_fields:
-        raise HogQLException("No fields requested from person_distinct_ids")
+        raise ResolutionException("No fields requested from person_distinct_ids")
 
     join_expr = ast.JoinExpr(table=select_from_person_overrides_table(requested_fields))
     join_expr.join_type = "LEFT OUTER JOIN"

--- a/posthog/hogql/database/schema/persons.py
+++ b/posthog/hogql/database/schema/persons.py
@@ -15,7 +15,7 @@ from posthog.hogql.database.models import (
     LazyJoin,
     FieldOrTable,
 )
-from posthog.hogql.errors import ResolutionException
+from posthog.hogql.errors import ResolutionError
 from posthog.hogql.database.schema.persons_pdi import PersonsPDITable, persons_pdi_join
 from posthog.schema import HogQLQueryModifiers, PersonsArgMaxVersion
 
@@ -92,7 +92,7 @@ def join_with_persons_table(
     from posthog.hogql import ast
 
     if not requested_fields:
-        raise ResolutionException("No fields requested from persons table")
+        raise ResolutionError("No fields requested from persons table")
     join_expr = ast.JoinExpr(table=select_from_persons_table(requested_fields, context.modifiers))
     join_expr.join_type = "INNER JOIN"
     join_expr.alias = to_table

--- a/posthog/hogql/database/schema/persons.py
+++ b/posthog/hogql/database/schema/persons.py
@@ -15,7 +15,7 @@ from posthog.hogql.database.models import (
     LazyJoin,
     FieldOrTable,
 )
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ResolutionException
 from posthog.hogql.database.schema.persons_pdi import PersonsPDITable, persons_pdi_join
 from posthog.schema import HogQLQueryModifiers, PersonsArgMaxVersion
 
@@ -92,7 +92,7 @@ def join_with_persons_table(
     from posthog.hogql import ast
 
     if not requested_fields:
-        raise HogQLException("No fields requested from persons table")
+        raise ResolutionException("No fields requested from persons table")
     join_expr = ast.JoinExpr(table=select_from_persons_table(requested_fields, context.modifiers))
     join_expr.join_type = "INNER JOIN"
     join_expr.alias = to_table

--- a/posthog/hogql/database/schema/persons_pdi.py
+++ b/posthog/hogql/database/schema/persons_pdi.py
@@ -9,7 +9,7 @@ from posthog.hogql.database.models import (
     LazyTable,
     FieldOrTable,
 )
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ResolutionException
 
 
 # :NOTE: We already have person_distinct_ids.py, which most tables link to. This persons_pdi.py is a hack to
@@ -39,7 +39,7 @@ def persons_pdi_join(
     from posthog.hogql import ast
 
     if not requested_fields:
-        raise HogQLException("No fields requested from person_distinct_ids")
+        raise ResolutionException("No fields requested from person_distinct_ids")
     join_expr = ast.JoinExpr(table=persons_pdi_select(requested_fields))
     join_expr.join_type = "INNER JOIN"
     join_expr.alias = to_table

--- a/posthog/hogql/database/schema/persons_pdi.py
+++ b/posthog/hogql/database/schema/persons_pdi.py
@@ -9,7 +9,7 @@ from posthog.hogql.database.models import (
     LazyTable,
     FieldOrTable,
 )
-from posthog.hogql.errors import ResolutionException
+from posthog.hogql.errors import ResolutionError
 
 
 # :NOTE: We already have person_distinct_ids.py, which most tables link to. This persons_pdi.py is a hack to
@@ -39,7 +39,7 @@ def persons_pdi_join(
     from posthog.hogql import ast
 
     if not requested_fields:
-        raise ResolutionException("No fields requested from person_distinct_ids")
+        raise ResolutionError("No fields requested from person_distinct_ids")
     join_expr = ast.JoinExpr(table=persons_pdi_select(requested_fields))
     join_expr.join_type = "INNER JOIN"
     join_expr.alias = to_table

--- a/posthog/hogql/database/schema/sessions.py
+++ b/posthog/hogql/database/schema/sessions.py
@@ -14,7 +14,7 @@ from posthog.hogql.database.models import (
 )
 from posthog.hogql.database.schema.channel_type import create_channel_type_expr
 from posthog.hogql.database.schema.util.session_where_clause_extractor import SessionMinTimestampWhereClauseExtractor
-from posthog.hogql.errors import ResolutionException
+from posthog.hogql.errors import ResolutionError
 
 SESSIONS_COMMON_FIELDS: Dict[str, FieldOrTable] = {
     "id": StringDatabaseField(
@@ -178,7 +178,7 @@ def join_events_table_to_sessions_table(
     from posthog.hogql import ast
 
     if not requested_fields:
-        raise ResolutionException("No fields requested from events")
+        raise ResolutionError("No fields requested from events")
 
     join_expr = ast.JoinExpr(table=select_from_sessions_table(requested_fields, node, context))
     join_expr.join_type = "LEFT JOIN"

--- a/posthog/hogql/database/schema/sessions.py
+++ b/posthog/hogql/database/schema/sessions.py
@@ -14,7 +14,7 @@ from posthog.hogql.database.models import (
 )
 from posthog.hogql.database.schema.channel_type import create_channel_type_expr
 from posthog.hogql.database.schema.util.session_where_clause_extractor import SessionMinTimestampWhereClauseExtractor
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ResolutionException
 
 SESSIONS_COMMON_FIELDS: Dict[str, FieldOrTable] = {
     "id": StringDatabaseField(
@@ -178,7 +178,7 @@ def join_events_table_to_sessions_table(
     from posthog.hogql import ast
 
     if not requested_fields:
-        raise HogQLException("No fields requested from events")
+        raise ResolutionException("No fields requested from events")
 
     join_expr = ast.JoinExpr(table=select_from_sessions_table(requested_fields, node, context))
     join_expr.join_type = "LEFT JOIN"

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -8,7 +8,7 @@ from parameterized import parameterized
 
 from posthog.hogql.database.database import create_hogql_database, serialize_database
 from posthog.hogql.database.models import FieldTraverser, LazyJoin, StringDatabaseField, ExpressionField, Table
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ExposedHogQLException
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import print_ast
@@ -176,7 +176,7 @@ class TestDatabase(BaseTest):
         )
 
         sql = "select some_field.key from events"
-        with pytest.raises(HogQLException):
+        with pytest.raises(ExposedHogQLException):
             print_ast(parse_select(sql), context, dialect="clickhouse")
 
     def test_database_warehouse_joins_other_team(self):
@@ -200,7 +200,7 @@ class TestDatabase(BaseTest):
         )
 
         sql = "select some_field.key from events"
-        with pytest.raises(HogQLException):
+        with pytest.raises(ExposedHogQLException):
             print_ast(parse_select(sql), context, dialect="clickhouse")
 
     def test_database_warehouse_joins_bad_key_expression(self):

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -8,7 +8,7 @@ from parameterized import parameterized
 
 from posthog.hogql.database.database import create_hogql_database, serialize_database
 from posthog.hogql.database.models import FieldTraverser, LazyJoin, StringDatabaseField, ExpressionField, Table
-from posthog.hogql.errors import ExposedHogQLException
+from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import print_ast
@@ -176,7 +176,7 @@ class TestDatabase(BaseTest):
         )
 
         sql = "select some_field.key from events"
-        with pytest.raises(ExposedHogQLException):
+        with pytest.raises(ExposedHogQLError):
             print_ast(parse_select(sql), context, dialect="clickhouse")
 
     def test_database_warehouse_joins_other_team(self):
@@ -200,7 +200,7 @@ class TestDatabase(BaseTest):
         )
 
         sql = "select some_field.key from events"
-        with pytest.raises(ExposedHogQLException):
+        with pytest.raises(ExposedHogQLError):
             print_ast(parse_select(sql), context, dialect="clickhouse")
 
     def test_database_warehouse_joins_bad_key_expression(self):

--- a/posthog/hogql/database/test/test_s3_table.py
+++ b/posthog/hogql/database/test/test_s3_table.py
@@ -5,7 +5,7 @@ from posthog.hogql.printer import print_ast
 from posthog.hogql.query import create_default_modifiers_for_team
 from posthog.test.base import BaseTest
 from posthog.hogql.database.test.tables import create_aapl_stock_s3_table
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ExposedHogQLException
 
 
 class TestS3Table(BaseTest):
@@ -176,7 +176,7 @@ class TestS3Table(BaseTest):
         escaped_table = create_aapl_stock_s3_table(name="some%(asd)sname")
         self.database.add_warehouse_tables(**{"some%(asd)sname": escaped_table})
 
-        with self.assertRaises(HogQLException) as context:
+        with self.assertRaises(ExposedHogQLException) as context:
             self._select(query='SELECT * FROM "some%(asd)sname" LIMIT 10', dialect="clickhouse")
             self.assertTrue("Alias \"some%(asd)sname\" contains unsupported character '%'" in str(context.exception))
 

--- a/posthog/hogql/database/test/test_s3_table.py
+++ b/posthog/hogql/database/test/test_s3_table.py
@@ -5,7 +5,7 @@ from posthog.hogql.printer import print_ast
 from posthog.hogql.query import create_default_modifiers_for_team
 from posthog.test.base import BaseTest
 from posthog.hogql.database.test.tables import create_aapl_stock_s3_table
-from posthog.hogql.errors import ExposedHogQLException
+from posthog.hogql.errors import ExposedHogQLError
 
 
 class TestS3Table(BaseTest):
@@ -176,7 +176,7 @@ class TestS3Table(BaseTest):
         escaped_table = create_aapl_stock_s3_table(name="some%(asd)sname")
         self.database.add_warehouse_tables(**{"some%(asd)sname": escaped_table})
 
-        with self.assertRaises(ExposedHogQLException) as context:
+        with self.assertRaises(ExposedHogQLError) as context:
             self._select(query='SELECT * FROM "some%(asd)sname" LIMIT 10', dialect="clickhouse")
             self.assertTrue("Alias \"some%(asd)sname\" contains unsupported character '%'" in str(context.exception))
 

--- a/posthog/hogql/errors.py
+++ b/posthog/hogql/errors.py
@@ -3,8 +3,10 @@ from typing import Optional, TYPE_CHECKING
 if TYPE_CHECKING:
     from .ast import Expr
 
+# Base
 
-class HogQLException(Exception):
+
+class BaseHogQLException(Exception):
     """Base exception for HogQL. These are exposed to the user."""
 
     start: Optional[int]
@@ -27,31 +29,55 @@ class HogQLException(Exception):
             self.end = end
 
 
-class SyntaxException(HogQLException):
+# Exposed vs. internal
+
+
+class ExposedHogQLException(BaseHogQLException):
+    """An exception that can be exposed to the user."""
+
+    pass
+
+
+class InternalHogQLException(BaseHogQLException):
+    """An internal exception in the HogQL engine."""
+
+    pass
+
+
+# Specific exceptions
+
+
+class SyntaxException(ExposedHogQLException):
     """The input does not conform to HogQL syntax."""
 
     pass
 
 
-class QueryException(HogQLException):
-    """The query invalid (though correct syntactically)."""
+class QueryException(ExposedHogQLException):
+    """The query is invalid, though correct syntactically."""
 
     pass
 
 
-class NotImplementedException(HogQLException):
+class NotImplementedException(ExposedHogQLException):
     """This feature isn't implemented in HogQL (yet)."""
 
     pass
 
 
-class ParsingException(HogQLException):
-    """An internal problem in the parser layer."""
+class ParsingException(InternalHogQLException):
+    """Parsing failed."""
 
     pass
 
 
-class ResolverException(HogQLException):
-    """An internal problem in the resolver layer."""
+class ImpossibleASTException(InternalHogQLException):
+    """Parsing or resolution resulted in an impossible AST."""
+
+    pass
+
+
+class ResolutionException(InternalHogQLException):
+    """Resolution of a table/field/expression failed."""
 
     pass

--- a/posthog/hogql/errors.py
+++ b/posthog/hogql/errors.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
 # Base
 
 
-class BaseHogQLException(Exception):
+class BaseHogQLError(Exception):
     """Base exception for HogQL. These are exposed to the user."""
 
     start: Optional[int]
@@ -32,13 +32,13 @@ class BaseHogQLException(Exception):
 # Exposed vs. internal
 
 
-class ExposedHogQLException(BaseHogQLException):
+class ExposedHogQLError(BaseHogQLError):
     """An exception that can be exposed to the user."""
 
     pass
 
 
-class InternalHogQLException(BaseHogQLException):
+class InternalHogQLError(BaseHogQLError):
     """An internal exception in the HogQL engine."""
 
     pass
@@ -47,37 +47,37 @@ class InternalHogQLException(BaseHogQLException):
 # Specific exceptions
 
 
-class SyntaxException(ExposedHogQLException):
+class SyntaxError(ExposedHogQLError):
     """The input does not conform to HogQL syntax."""
 
     pass
 
 
-class QueryException(ExposedHogQLException):
+class QueryError(ExposedHogQLError):
     """The query is invalid, though correct syntactically."""
 
     pass
 
 
-class NotImplementedException(InternalHogQLException):
+class NotImplementedError(InternalHogQLError):
     """This feature isn't implemented in HogQL (yet)."""
 
     pass
 
 
-class ParsingException(InternalHogQLException):
+class ParsingError(InternalHogQLError):
     """Parsing failed."""
 
     pass
 
 
-class ImpossibleASTException(InternalHogQLException):
+class ImpossibleASTError(InternalHogQLError):
     """Parsing or resolution resulted in an impossible AST."""
 
     pass
 
 
-class ResolutionException(InternalHogQLException):
+class ResolutionError(InternalHogQLError):
     """Resolution of a table/field/expression failed."""
 
     pass

--- a/posthog/hogql/errors.py
+++ b/posthog/hogql/errors.py
@@ -59,7 +59,7 @@ class QueryException(ExposedHogQLException):
     pass
 
 
-class NotImplementedException(ExposedHogQLException):
+class NotImplementedException(InternalHogQLException):
     """This feature isn't implemented in HogQL (yet)."""
 
     pass

--- a/posthog/hogql/escape_sql.py
+++ b/posthog/hogql/escape_sql.py
@@ -6,7 +6,7 @@ from zoneinfo import ZoneInfo
 
 import math
 
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import QueryException, ResolutionException
 from posthog.models.utils import UUIDT
 
 # Copied from clickhouse_driver.util.escape, adapted only from single quotes to backquotes.
@@ -35,7 +35,7 @@ def escape_hogql_identifier(identifier: str | int) -> str:
     if isinstance(identifier, int):  # In HogQL we allow integers as identifiers to access array elements
         return str(identifier)
     if "%" in identifier:
-        raise HogQLException(f'The HogQL identifier "{identifier}" is not permitted as it contains the "%" character')
+        raise QueryException(f'The HogQL identifier "{identifier}" is not permitted as it contains the "%" character')
     # HogQL allows dollars in the identifier.
     if re.match(
         r"^[A-Za-z_$][A-Za-z0-9_$]*$", identifier
@@ -47,7 +47,7 @@ def escape_hogql_identifier(identifier: str | int) -> str:
 # Copied from clickhouse_driver.util.escape, adapted from single quotes to backquotes.
 def escape_clickhouse_identifier(identifier: str) -> str:
     if "%" in identifier:
-        raise HogQLException(f'The HogQL identifier "{identifier}" is not permitted as it contains the "%" character')
+        raise QueryException(f'The HogQL identifier "{identifier}" is not permitted as it contains the "%" character')
     if re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", identifier):
         return identifier
     return "`%s`" % "".join(backquote_escape_chars_map.get(c, c) for c in identifier)
@@ -81,7 +81,7 @@ class SQLValueEscaper:
         method_name = f"visit_{node.__class__.__name__.lower()}"
         if hasattr(self, method_name):
             return getattr(self, method_name)(node)
-        raise HogQLException(f"SQLValueEscaper has no method {method_name}")
+        raise ResolutionException(f"SQLValueEscaper has no method {method_name}")
 
     def visit_nonetype(self, value: None):
         return "NULL"

--- a/posthog/hogql/escape_sql.py
+++ b/posthog/hogql/escape_sql.py
@@ -6,7 +6,7 @@ from zoneinfo import ZoneInfo
 
 import math
 
-from posthog.hogql.errors import QueryException, ResolutionException
+from posthog.hogql.errors import QueryError, ResolutionError
 from posthog.models.utils import UUIDT
 
 # Copied from clickhouse_driver.util.escape, adapted only from single quotes to backquotes.
@@ -35,7 +35,7 @@ def escape_hogql_identifier(identifier: str | int) -> str:
     if isinstance(identifier, int):  # In HogQL we allow integers as identifiers to access array elements
         return str(identifier)
     if "%" in identifier:
-        raise QueryException(f'The HogQL identifier "{identifier}" is not permitted as it contains the "%" character')
+        raise QueryError(f'The HogQL identifier "{identifier}" is not permitted as it contains the "%" character')
     # HogQL allows dollars in the identifier.
     if re.match(
         r"^[A-Za-z_$][A-Za-z0-9_$]*$", identifier
@@ -47,7 +47,7 @@ def escape_hogql_identifier(identifier: str | int) -> str:
 # Copied from clickhouse_driver.util.escape, adapted from single quotes to backquotes.
 def escape_clickhouse_identifier(identifier: str) -> str:
     if "%" in identifier:
-        raise QueryException(f'The HogQL identifier "{identifier}" is not permitted as it contains the "%" character')
+        raise QueryError(f'The HogQL identifier "{identifier}" is not permitted as it contains the "%" character')
     if re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", identifier):
         return identifier
     return "`%s`" % "".join(backquote_escape_chars_map.get(c, c) for c in identifier)
@@ -81,7 +81,7 @@ class SQLValueEscaper:
         method_name = f"visit_{node.__class__.__name__.lower()}"
         if hasattr(self, method_name):
             return getattr(self, method_name)(node)
-        raise ResolutionException(f"SQLValueEscaper has no method {method_name}")
+        raise ResolutionError(f"SQLValueEscaper has no method {method_name}")
 
     def visit_nonetype(self, value: None):
         return "NULL"

--- a/posthog/hogql/filters.py
+++ b/posthog/hogql/filters.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from dateutil.parser import isoparse
 
 from posthog.hogql import ast
-from posthog.hogql.errors import QueryException
+from posthog.hogql.errors import QueryError
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.visitor import CloningVisitor
@@ -45,7 +45,7 @@ class ReplaceFilters(CloningVisitor):
                 last_join = last_join.next_join
 
             if not found_events:
-                raise QueryException(
+                raise QueryError(
                     "Cannot use 'filters' placeholder in a SELECT clause that does not select from the events table."
                 )
 

--- a/posthog/hogql/filters.py
+++ b/posthog/hogql/filters.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from dateutil.parser import isoparse
 
 from posthog.hogql import ast
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import QueryException
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.visitor import CloningVisitor
@@ -45,7 +45,7 @@ class ReplaceFilters(CloningVisitor):
                 last_join = last_join.next_join
 
             if not found_events:
-                raise HogQLException(
+                raise QueryException(
                     "Cannot use 'filters' placeholder in a SELECT clause that does not select from the events table."
                 )
 

--- a/posthog/hogql/functions/cohort.py
+++ b/posthog/hogql/functions/cohort.py
@@ -2,7 +2,7 @@ from typing import List
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import QueryException
 from posthog.hogql.escape_sql import escape_clickhouse_string
 from posthog.hogql.parser import parse_expr
 
@@ -22,7 +22,7 @@ def cohort_query_node(node: ast.Expr, context: HogQLContext) -> ast.Expr:
 def cohort(node: ast.Expr, args: List[ast.Expr], context: HogQLContext) -> ast.Expr:
     arg = args[0]
     if not isinstance(arg, ast.Constant):
-        raise HogQLException("cohort() takes only constant arguments", node=arg)
+        raise QueryException("cohort() takes only constant arguments", node=arg)
 
     from posthog.models import Cohort
 
@@ -38,7 +38,7 @@ def cohort(node: ast.Expr, args: List[ast.Expr], context: HogQLContext) -> ast.E
                 fix=escape_clickhouse_string(cohorts[0][2]),
             )
             return cohort_subquery(cohorts[0][0], cohorts[0][1])
-        raise HogQLException(f"Could not find cohort with id {arg.value}", node=arg)
+        raise QueryException(f"Could not find cohort with ID {arg.value}", node=arg)
 
     if isinstance(arg.value, str):
         cohorts = Cohort.objects.filter(name=arg.value, team_id=context.team_id).values_list("id", "is_static")
@@ -51,7 +51,7 @@ def cohort(node: ast.Expr, args: List[ast.Expr], context: HogQLContext) -> ast.E
             )
             return cohort_subquery(cohorts[0][0], cohorts[0][1])
         elif len(cohorts) > 1:
-            raise HogQLException(f"Found multiple cohorts with name '{arg.value}'", node=arg)
-        raise HogQLException(f"Could not find a cohort with the name '{arg.value}'", node=arg)
+            raise QueryException(f"Found multiple cohorts with name '{arg.value}'", node=arg)
+        raise QueryException(f"Could not find a cohort with the name '{arg.value}'", node=arg)
 
-    raise HogQLException("cohort() takes exactly one string or integer argument", node=arg)
+    raise QueryException("cohort() takes exactly one string or integer argument", node=arg)

--- a/posthog/hogql/functions/cohort.py
+++ b/posthog/hogql/functions/cohort.py
@@ -2,7 +2,7 @@ from typing import List
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.errors import QueryException
+from posthog.hogql.errors import QueryError
 from posthog.hogql.escape_sql import escape_clickhouse_string
 from posthog.hogql.parser import parse_expr
 
@@ -22,7 +22,7 @@ def cohort_query_node(node: ast.Expr, context: HogQLContext) -> ast.Expr:
 def cohort(node: ast.Expr, args: List[ast.Expr], context: HogQLContext) -> ast.Expr:
     arg = args[0]
     if not isinstance(arg, ast.Constant):
-        raise QueryException("cohort() takes only constant arguments", node=arg)
+        raise QueryError("cohort() takes only constant arguments", node=arg)
 
     from posthog.models import Cohort
 
@@ -38,7 +38,7 @@ def cohort(node: ast.Expr, args: List[ast.Expr], context: HogQLContext) -> ast.E
                 fix=escape_clickhouse_string(cohorts[0][2]),
             )
             return cohort_subquery(cohorts[0][0], cohorts[0][1])
-        raise QueryException(f"Could not find cohort with ID {arg.value}", node=arg)
+        raise QueryError(f"Could not find cohort with ID {arg.value}", node=arg)
 
     if isinstance(arg.value, str):
         cohorts = Cohort.objects.filter(name=arg.value, team_id=context.team_id).values_list("id", "is_static")
@@ -51,7 +51,7 @@ def cohort(node: ast.Expr, args: List[ast.Expr], context: HogQLContext) -> ast.E
             )
             return cohort_subquery(cohorts[0][0], cohorts[0][1])
         elif len(cohorts) > 1:
-            raise QueryException(f"Found multiple cohorts with name '{arg.value}'", node=arg)
-        raise QueryException(f"Could not find a cohort with the name '{arg.value}'", node=arg)
+            raise QueryError(f"Found multiple cohorts with name '{arg.value}'", node=arg)
+        raise QueryError(f"Could not find a cohort with the name '{arg.value}'", node=arg)
 
-    raise QueryException("cohort() takes exactly one string or integer argument", node=arg)
+    raise QueryError("cohort() takes exactly one string or integer argument", node=arg)

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -3,7 +3,7 @@ from itertools import chain
 from typing import List, Optional, Dict, Tuple, Type
 from posthog.hogql import ast
 from posthog.hogql.base import ConstantType
-from posthog.hogql.errors import QueryException
+from posthog.hogql.errors import QueryError
 
 
 def validate_function_args(
@@ -18,15 +18,15 @@ def validate_function_args(
     too_few = len(args) < min_args
     too_many = max_args is not None and len(args) > max_args
     if min_args == max_args and (too_few or too_many):
-        raise QueryException(
+        raise QueryError(
             f"{function_term.capitalize()} '{function_name}' expects {min_args} {argument_term}{'s' if min_args != 1 else ''}, found {len(args)}"
         )
     if too_few:
-        raise QueryException(
+        raise QueryError(
             f"{function_term.capitalize()} '{function_name}' expects at least {min_args} {argument_term}{'s' if min_args != 1 else ''}, found {len(args)}"
         )
     if too_many:
-        raise QueryException(
+        raise QueryError(
             f"{function_term.capitalize()} '{function_name}' expects at most {max_args} {argument_term}{'s' if max_args != 1 else ''}, found {len(args)}"
         )
 

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -3,7 +3,7 @@ from itertools import chain
 from typing import List, Optional, Dict, Tuple, Type
 from posthog.hogql import ast
 from posthog.hogql.base import ConstantType
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import QueryException
 
 
 def validate_function_args(
@@ -18,15 +18,15 @@ def validate_function_args(
     too_few = len(args) < min_args
     too_many = max_args is not None and len(args) > max_args
     if min_args == max_args and (too_few or too_many):
-        raise HogQLException(
+        raise QueryException(
             f"{function_term.capitalize()} '{function_name}' expects {min_args} {argument_term}{'s' if min_args != 1 else ''}, found {len(args)}"
         )
     if too_few:
-        raise HogQLException(
+        raise QueryException(
             f"{function_term.capitalize()} '{function_name}' expects at least {min_args} {argument_term}{'s' if min_args != 1 else ''}, found {len(args)}"
         )
     if too_many:
-        raise HogQLException(
+        raise QueryException(
             f"{function_term.capitalize()} '{function_name}' expects at most {max_args} {argument_term}{'s' if max_args != 1 else ''}, found {len(args)}"
         )
 

--- a/posthog/hogql/functions/test/test_cohort.py
+++ b/posthog/hogql/functions/test/test_cohort.py
@@ -2,7 +2,7 @@ import pytest
 from django.test import override_settings
 
 from posthog.hogql import ast
-from posthog.hogql.errors import QueryException
+from posthog.hogql.errors import QueryError
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.test.utils import pretty_print_response_in_tests
@@ -88,11 +88,11 @@ class TestCohort(BaseTest):
 
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=True, PERSON_ON_EVENTS_V2_OVERRIDE=True)
     def test_in_cohort_error(self):
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             execute_hogql_query(f"SELECT event FROM events WHERE person_id IN COHORT true", self.team)
         self.assertEqual(str(e.exception), "cohort() takes exactly one string or integer argument")
 
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             execute_hogql_query(
                 f"SELECT event FROM events WHERE person_id IN COHORT 'blabla'",
                 self.team,

--- a/posthog/hogql/functions/test/test_cohort.py
+++ b/posthog/hogql/functions/test/test_cohort.py
@@ -2,7 +2,7 @@ import pytest
 from django.test import override_settings
 
 from posthog.hogql import ast
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import QueryException
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.test.utils import pretty_print_response_in_tests
@@ -88,11 +88,11 @@ class TestCohort(BaseTest):
 
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=True, PERSON_ON_EVENTS_V2_OVERRIDE=True)
     def test_in_cohort_error(self):
-        with self.assertRaises(HogQLException) as e:
+        with self.assertRaises(QueryException) as e:
             execute_hogql_query(f"SELECT event FROM events WHERE person_id IN COHORT true", self.team)
         self.assertEqual(str(e.exception), "cohort() takes exactly one string or integer argument")
 
-        with self.assertRaises(HogQLException) as e:
+        with self.assertRaises(QueryException) as e:
             execute_hogql_query(
                 f"SELECT event FROM events WHERE person_id IN COHORT 'blabla'",
                 self.team,

--- a/posthog/hogql/functions/test/test_sparkline.py
+++ b/posthog/hogql/functions/test/test_sparkline.py
@@ -1,4 +1,4 @@
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import QueryException
 from posthog.hogql.query import execute_hogql_query
 from posthog.test.base import BaseTest
 
@@ -20,6 +20,6 @@ class TestSparkline(BaseTest):
         )
 
     def test_sparkline_error(self):
-        with self.assertRaises(HogQLException) as e:
+        with self.assertRaises(QueryException) as e:
             execute_hogql_query(f"SELECT sparkline()", self.team)
         self.assertEqual(str(e.exception), "Function 'sparkline' expects 1 argument, found 0")

--- a/posthog/hogql/functions/test/test_sparkline.py
+++ b/posthog/hogql/functions/test/test_sparkline.py
@@ -1,4 +1,4 @@
-from posthog.hogql.errors import QueryException
+from posthog.hogql.errors import QueryError
 from posthog.hogql.query import execute_hogql_query
 from posthog.test.base import BaseTest
 
@@ -20,6 +20,6 @@ class TestSparkline(BaseTest):
         )
 
     def test_sparkline_error(self):
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             execute_hogql_query(f"SELECT sparkline()", self.team)
         self.assertEqual(str(e.exception), "Function 'sparkline' expects 1 argument, found 0")

--- a/posthog/hogql/hogql.py
+++ b/posthog/hogql/hogql.py
@@ -3,7 +3,7 @@ from typing import Dict, Literal, cast, Optional
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import create_hogql_database
-from posthog.hogql.errors import NotImplementedException, QueryException, SyntaxException
+from posthog.hogql.errors import NotImplementedError, QueryError, SyntaxError
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
 from posthog.hogql.visitor import clone_expr
@@ -22,7 +22,7 @@ def translate_hogql(
 ) -> str:
     """Translate a HogQL expression into a ClickHouse expression."""
     if query == "":
-        raise QueryException("Empty query")
+        raise QueryError("Empty query")
 
     try:
         # Create a fake query that selects from "events" to have fields to select from.
@@ -50,5 +50,5 @@ def translate_hogql(
             dialect=dialect,
             stack=[prepared_select_query],
         )
-    except (NotImplementedException, SyntaxException):
+    except (NotImplementedError, SyntaxError):
         raise

--- a/posthog/hogql/hogql.py
+++ b/posthog/hogql/hogql.py
@@ -3,11 +3,7 @@ from typing import Dict, Literal, cast, Optional
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import create_hogql_database
-from posthog.hogql.errors import (
-    HogQLException,
-    NotImplementedException,
-    SyntaxException,
-)
+from posthog.hogql.errors import NotImplementedException, QueryException, SyntaxException
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
 from posthog.hogql.visitor import clone_expr
@@ -26,7 +22,7 @@ def translate_hogql(
 ) -> str:
     """Translate a HogQL expression into a ClickHouse expression."""
     if query == "":
-        raise HogQLException("Empty query")
+        raise QueryException("Empty query")
 
     try:
         # Create a fake query that selects from "events" to have fields to select from.

--- a/posthog/hogql/metadata.py
+++ b/posthog/hogql/metadata.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ExposedHogQLException
 from posthog.hogql.filters import replace_filters
 from posthog.hogql.hogql import translate_hogql
 from posthog.hogql.parser import parse_select
@@ -60,9 +60,7 @@ def get_hogql_metadata(
         response.notices = context.notices
     except Exception as e:
         response.isValid = False
-        if isinstance(e, ValueError):
-            response.errors.append(HogQLNotice(message=str(e)))
-        elif isinstance(e, HogQLException):
+        if isinstance(e, ExposedHogQLException):
             error = str(e)
             if "mismatched input '<EOF>' expecting" in error:
                 error = "Unexpected end of query"

--- a/posthog/hogql/metadata.py
+++ b/posthog/hogql/metadata.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.errors import ExposedHogQLException
+from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.filters import replace_filters
 from posthog.hogql.hogql import translate_hogql
 from posthog.hogql.parser import parse_select
@@ -60,7 +60,7 @@ def get_hogql_metadata(
         response.notices = context.notices
     except Exception as e:
         response.isValid = False
-        if isinstance(e, ExposedHogQLException):
+        if isinstance(e, ExposedHogQLError):
             error = str(e)
             if "mismatched input '<EOF>' expecting" in error:
                 error = "Unexpected end of query"

--- a/posthog/hogql/parse_string.py
+++ b/posthog/hogql/parse_string.py
@@ -1,6 +1,6 @@
 from antlr4 import ParserRuleContext
 
-from posthog.hogql.errors import SyntaxException
+from posthog.hogql.errors import SyntaxError
 
 
 def parse_string(text: str) -> str:
@@ -22,7 +22,7 @@ def parse_string(text: str) -> str:
         text = text.replace("{{", "{")
         text = text.replace("\\{", "{")
     else:
-        raise SyntaxException(f"Invalid string literal, must start and end with the same quote type: {text}")
+        raise SyntaxError(f"Invalid string literal, must start and end with the same quote type: {text}")
 
     # copied from clickhouse_driver/util/escape.py
     text = text.replace("\\b", "\b")

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -7,11 +7,7 @@ from prometheus_client import Histogram
 from posthog.hogql import ast
 from posthog.hogql.base import AST
 from posthog.hogql.constants import RESERVED_KEYWORDS
-from posthog.hogql.errors import (
-    NotImplementedException,
-    HogQLException,
-    SyntaxException,
-)
+from posthog.hogql.errors import BaseHogQLException, NotImplementedException, SyntaxException
 from posthog.hogql.grammar.HogQLLexer import HogQLLexer
 from posthog.hogql.grammar.HogQLParser import HogQLParser
 from posthog.hogql.parse_string import parse_string, parse_string_literal
@@ -153,7 +149,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
                 node.start = start
                 node.end = end
             return node
-        except HogQLException as e:
+        except BaseHogQLException as e:
             if start is not None and end is not None and e.start is None or e.end is None:
                 e.start = start
                 e.end = end

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -7,7 +7,7 @@ from prometheus_client import Histogram
 from posthog.hogql import ast
 from posthog.hogql.base import AST
 from posthog.hogql.constants import RESERVED_KEYWORDS
-from posthog.hogql.errors import BaseHogQLException, NotImplementedException, SyntaxException
+from posthog.hogql.errors import BaseHogQLError, NotImplementedError, SyntaxError
 from posthog.hogql.grammar.HogQLLexer import HogQLLexer
 from posthog.hogql.grammar.HogQLParser import HogQLParser
 from posthog.hogql.parse_string import parse_string, parse_string_literal
@@ -132,7 +132,7 @@ class HogQLErrorListener(ErrorListener):
 
     def syntaxError(self, recognizer, offendingType, line, column, msg, e):
         start = max(self.get_position(line, column), 0)
-        raise SyntaxException(msg, start=start, end=len(self.query))
+        raise SyntaxError(msg, start=start, end=len(self.query))
 
 
 class HogQLParseTreeConverter(ParseTreeVisitor):
@@ -149,7 +149,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
                 node.start = start
                 node.end = end
             return node
-        except BaseHogQLException as e:
+        except BaseHogQLError as e:
             if start is not None and end is not None and e.start is None or e.end is None:
                 e.start = start
                 e.end = end
@@ -212,7 +212,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         if ctx.arrayJoinClause():
             array_join_clause = ctx.arrayJoinClause()
             if select_query.select_from is None:
-                raise SyntaxException("Using ARRAY JOIN without a FROM clause is not permitted")
+                raise SyntaxError("Using ARRAY JOIN without a FROM clause is not permitted")
             if array_join_clause.LEFT():
                 select_query.array_join_op = "LEFT ARRAY JOIN"
             elif array_join_clause.INNER():
@@ -222,16 +222,16 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
             select_query.array_join_list = self.visit(array_join_clause.columnExprList())
             for expr in select_query.array_join_list:
                 if not isinstance(expr, ast.Alias):
-                    raise SyntaxException(
+                    raise SyntaxError(
                         "ARRAY JOIN arrays must have an alias",
                         start=expr.start,
                         end=expr.end,
                     )
 
         if ctx.topClause():
-            raise NotImplementedException(f"Unsupported: SelectStmt.topClause()")
+            raise NotImplementedError(f"Unsupported: SelectStmt.topClause()")
         if ctx.settingsClause():
-            raise NotImplementedException(f"Unsupported: SelectStmt.settingsClause()")
+            raise NotImplementedError(f"Unsupported: SelectStmt.settingsClause()")
 
         return select_query
 
@@ -239,16 +239,16 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return self.visit(ctx.withExprList())
 
     def visitTopClause(self, ctx: HogQLParser.TopClauseContext):
-        raise NotImplementedException(f"Unsupported node: TopClause")
+        raise NotImplementedError(f"Unsupported node: TopClause")
 
     def visitFromClause(self, ctx: HogQLParser.FromClauseContext):
         return self.visit(ctx.joinExpr())
 
     def visitArrayJoinClause(self, ctx: HogQLParser.ArrayJoinClauseContext):
-        raise NotImplementedException(f"Unsupported node: ArrayJoinClause")
+        raise NotImplementedError(f"Unsupported node: ArrayJoinClause")
 
     def visitWindowClause(self, ctx: HogQLParser.WindowClauseContext):
-        raise NotImplementedException(f"Unsupported node: WindowClause")
+        raise NotImplementedError(f"Unsupported node: WindowClause")
 
     def visitPrewhereClause(self, ctx: HogQLParser.PrewhereClauseContext):
         return self.visit(ctx.columnExpr())
@@ -266,13 +266,13 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return self.visit(ctx.orderExprList())
 
     def visitProjectionOrderByClause(self, ctx: HogQLParser.ProjectionOrderByClauseContext):
-        raise NotImplementedException(f"Unsupported node: ProjectionOrderByClause")
+        raise NotImplementedError(f"Unsupported node: ProjectionOrderByClause")
 
     def visitLimitAndOffsetClauseClause(self, ctx: HogQLParser.LimitAndOffsetClauseContext):
         raise Exception(f"Parsed as part of SelectStmt, can't parse directly")
 
     def visitSettingsClause(self, ctx: HogQLParser.SettingsClauseContext):
-        raise NotImplementedException(f"Unsupported node: SettingsClause")
+        raise NotImplementedError(f"Unsupported node: SettingsClause")
 
     def visitJoinExprOp(self, ctx: HogQLParser.JoinExprOpContext):
         join1: ast.JoinExpr = self.visit(ctx.joinExpr(0))
@@ -362,14 +362,14 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return " ".join(tokens)
 
     def visitJoinOpCross(self, ctx: HogQLParser.JoinOpCrossContext):
-        raise NotImplementedException(f"Unsupported node: JoinOpCross")
+        raise NotImplementedError(f"Unsupported node: JoinOpCross")
 
     def visitJoinConstraintClause(self, ctx: HogQLParser.JoinConstraintClauseContext):
         if ctx.USING():
-            raise NotImplementedException(f"Unsupported: JOIN ... USING")
+            raise NotImplementedError(f"Unsupported: JOIN ... USING")
         column_expr_list = self.visit(ctx.columnExprList())
         if len(column_expr_list) != 1:
-            raise NotImplementedException(f"Unsupported: JOIN ... ON with multiple expressions")
+            raise NotImplementedError(f"Unsupported: JOIN ... ON with multiple expressions")
         return ast.JoinConstraint(expr=column_expr_list[0])
 
     def visitSampleClause(self, ctx: HogQLParser.SampleClauseContext):
@@ -402,10 +402,10 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         )
 
     def visitSettingExprList(self, ctx: HogQLParser.SettingExprListContext):
-        raise NotImplementedException(f"Unsupported node: SettingExprList")
+        raise NotImplementedError(f"Unsupported node: SettingExprList")
 
     def visitSettingExpr(self, ctx: HogQLParser.SettingExprContext):
-        raise NotImplementedException(f"Unsupported node: SettingExpr")
+        raise NotImplementedError(f"Unsupported node: SettingExpr")
 
     def visitWindowExpr(self, ctx: HogQLParser.WindowExprContext):
         frame = ctx.winFrameClause()
@@ -451,19 +451,19 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return self.visit(ctx.columnExpr())
 
     def visitColumnTypeExprSimple(self, ctx: HogQLParser.ColumnTypeExprSimpleContext):
-        raise NotImplementedException(f"Unsupported node: ColumnTypeExprSimple")
+        raise NotImplementedError(f"Unsupported node: ColumnTypeExprSimple")
 
     def visitColumnTypeExprNested(self, ctx: HogQLParser.ColumnTypeExprNestedContext):
-        raise NotImplementedException(f"Unsupported node: ColumnTypeExprNested")
+        raise NotImplementedError(f"Unsupported node: ColumnTypeExprNested")
 
     def visitColumnTypeExprEnum(self, ctx: HogQLParser.ColumnTypeExprEnumContext):
-        raise NotImplementedException(f"Unsupported node: ColumnTypeExprEnum")
+        raise NotImplementedError(f"Unsupported node: ColumnTypeExprEnum")
 
     def visitColumnTypeExprComplex(self, ctx: HogQLParser.ColumnTypeExprComplexContext):
-        raise NotImplementedException(f"Unsupported node: ColumnTypeExprComplex")
+        raise NotImplementedError(f"Unsupported node: ColumnTypeExprComplex")
 
     def visitColumnTypeExprParam(self, ctx: HogQLParser.ColumnTypeExprParamContext):
-        raise NotImplementedException(f"Unsupported node: ColumnTypeExprParam")
+        raise NotImplementedError(f"Unsupported node: ColumnTypeExprParam")
 
     def visitColumnExprList(self, ctx: HogQLParser.ColumnExprListContext):
         return [self.visit(c) for c in ctx.columnExpr()]
@@ -487,11 +487,11 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         elif ctx.STRING_LITERAL():
             alias = parse_string_literal(ctx.STRING_LITERAL())
         else:
-            raise NotImplementedException(f"Must specify an alias")
+            raise NotImplementedError(f"Must specify an alias")
         expr = self.visit(ctx.columnExpr())
 
         if alias.lower() in RESERVED_KEYWORDS:
-            raise SyntaxException(f'"{alias}" cannot be an alias or identifier, as it\'s a reserved keyword')
+            raise SyntaxError(f'"{alias}" cannot be an alias or identifier, as it\'s a reserved keyword')
 
         return ast.Alias(expr=expr, alias=alias)
 
@@ -512,10 +512,10 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return ast.Array(exprs=self.visit(ctx.columnExprList()) if ctx.columnExprList() else [])
 
     def visitColumnExprSubstring(self, ctx: HogQLParser.ColumnExprSubstringContext):
-        raise NotImplementedException(f"Unsupported node: ColumnExprSubstring")
+        raise NotImplementedError(f"Unsupported node: ColumnExprSubstring")
 
     def visitColumnExprCast(self, ctx: HogQLParser.ColumnExprCastContext):
-        raise NotImplementedException(f"Unsupported node: ColumnExprCast")
+        raise NotImplementedError(f"Unsupported node: ColumnExprCast")
 
     def visitColumnExprPrecedence1(self, ctx: HogQLParser.ColumnExprPrecedence1Context):
         if ctx.SLASH():
@@ -525,7 +525,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         elif ctx.PERCENT():
             op = ast.ArithmeticOperationOp.Mod
         else:
-            raise NotImplementedException(f"Unsupported ColumnExprPrecedence1: {ctx.operator.text}")
+            raise NotImplementedError(f"Unsupported ColumnExprPrecedence1: {ctx.operator.text}")
         left = self.visit(ctx.left)
         right = self.visit(ctx.right)
         return ast.ArithmeticOperation(left=left, right=right, op=op)
@@ -552,7 +552,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
 
             return ast.Call(name="concat", args=args)
         else:
-            raise NotImplementedException(f"Unsupported ColumnExprPrecedence2: {ctx.operator.text}")
+            raise NotImplementedError(f"Unsupported ColumnExprPrecedence2: {ctx.operator.text}")
 
     def visitColumnExprPrecedence3(self, ctx: HogQLParser.ColumnExprPrecedence3Context):
         left = self.visit(ctx.left)
@@ -600,7 +600,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
                 else:
                     op = ast.CompareOperationOp.In
         else:
-            raise NotImplementedException(f"Unsupported ColumnExprPrecedence3: {ctx.getText()}")
+            raise NotImplementedError(f"Unsupported ColumnExprPrecedence3: {ctx.getText()}")
 
         return ast.CompareOperation(left=left, right=right, op=op)
 
@@ -622,7 +622,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         elif ctx.interval().YEAR():
             name = "toIntervalYear"
         else:
-            raise NotImplementedException(f"Unsupported interval type: {ctx.interval().getText()}")
+            raise NotImplementedError(f"Unsupported interval type: {ctx.interval().getText()}")
 
         return ast.Call(name=name, args=[self.visit(ctx.columnExpr())])
 
@@ -641,7 +641,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
             return ast.Call(name="trimRight", args=args)
         if ctx.BOTH():
             return ast.Call(name="trim", args=args)
-        raise NotImplementedException(f"Unsupported modifier for ColumnExprTrim, must be LEADING, TRAILING or BOTH")
+        raise NotImplementedError(f"Unsupported modifier for ColumnExprTrim, must be LEADING, TRAILING or BOTH")
 
     def visitColumnExprTuple(self, ctx: HogQLParser.ColumnExprTupleContext):
         return ast.Tuple(exprs=self.visit(ctx.columnExprList()) if ctx.columnExprList() else [])
@@ -650,7 +650,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         object: ast.Expr = self.visit(ctx.columnExpr(0))
         property: ast.Expr = self.visit(ctx.columnExpr(1))
         if isinstance(property, ast.Constant) and property.value == 0:
-            raise SyntaxException("SQL indexes start from one, not from zero. E.g: array[1]")
+            raise SyntaxError("SQL indexes start from one, not from zero. E.g: array[1]")
         return ast.ArrayAccess(array=object, property=property)
 
     def visitColumnExprPropertyAccess(self, ctx: HogQLParser.ColumnExprPropertyAccessContext):
@@ -659,13 +659,13 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return ast.ArrayAccess(array=object, property=property)
 
     def visitColumnExprBetween(self, ctx: HogQLParser.ColumnExprBetweenContext):
-        raise NotImplementedException(f"Unsupported node: ColumnExprBetween")
+        raise NotImplementedError(f"Unsupported node: ColumnExprBetween")
 
     def visitColumnExprParens(self, ctx: HogQLParser.ColumnExprParensContext):
         return self.visit(ctx.columnExpr())
 
     def visitColumnExprTimestamp(self, ctx: HogQLParser.ColumnExprTimestampContext):
-        raise NotImplementedException(f"Unsupported node: ColumnExprTimestamp")
+        raise NotImplementedError(f"Unsupported node: ColumnExprTimestamp")
 
     def visitColumnExprAnd(self, ctx: HogQLParser.ColumnExprAndContext):
         left = self.visit(ctx.columnExpr(0))
@@ -701,7 +701,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         tuple = self.visit(ctx.columnExpr())
         index = int(ctx.DECIMAL_LITERAL().getText())
         if index == 0:
-            raise SyntaxException("SQL indexes start from one, not from zero. E.g: array[1]")
+            raise SyntaxError("SQL indexes start from one, not from zero. E.g: array[1]")
         return ast.TupleAccess(tuple=tuple, index=index)
 
     def visitColumnExprCase(self, ctx: HogQLParser.ColumnExprCaseContext):
@@ -718,7 +718,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
             return ast.Call(name="multiIf", args=columns)
 
     def visitColumnExprDate(self, ctx: HogQLParser.ColumnExprDateContext):
-        raise NotImplementedException(f"Unsupported node: ColumnExprDate")
+        raise NotImplementedError(f"Unsupported node: ColumnExprDate")
 
     def visitColumnExprNot(self, ctx: HogQLParser.ColumnExprNotContext):
         return ast.Not(expr=self.visit(ctx.columnExpr()))
@@ -820,7 +820,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
     def visitTableExprAlias(self, ctx: HogQLParser.TableExprAliasContext):
         alias: str = self.visit(ctx.alias() or ctx.identifier())
         if alias.lower() in RESERVED_KEYWORDS:
-            raise SyntaxException(f'"{alias}" cannot be an alias or identifier, as it\'s a reserved keyword')
+            raise SyntaxError(f'"{alias}" cannot be an alias or identifier, as it\'s a reserved keyword')
         table = self.visit(ctx.tableExpr())
         if isinstance(table, ast.JoinExpr):
             table.alias = alias
@@ -851,7 +851,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return self.visit(ctx.identifier())
 
     def visitFloatingLiteral(self, ctx: HogQLParser.FloatingLiteralContext):
-        raise NotImplementedException(f"Unsupported node: visitFloatingLiteral")
+        raise NotImplementedError(f"Unsupported node: visitFloatingLiteral")
 
     def visitNumberLiteral(self, ctx: HogQLParser.NumberLiteralContext):
         text = ctx.getText().lower()
@@ -868,13 +868,13 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return self.visitChildren(ctx)
 
     def visitInterval(self, ctx: HogQLParser.IntervalContext):
-        raise NotImplementedException(f"Unsupported node: Interval")
+        raise NotImplementedError(f"Unsupported node: Interval")
 
     def visitKeyword(self, ctx: HogQLParser.KeywordContext):
-        raise NotImplementedException(f"Unsupported node: Keyword")
+        raise NotImplementedError(f"Unsupported node: Keyword")
 
     def visitKeywordForAlias(self, ctx: HogQLParser.KeywordForAliasContext):
-        raise NotImplementedException(f"Unsupported node: KeywordForAlias")
+        raise NotImplementedError(f"Unsupported node: KeywordForAlias")
 
     def visitAlias(self, ctx: HogQLParser.AliasContext):
         text = ctx.getText()
@@ -893,7 +893,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         return text
 
     def visitEnumValue(self, ctx: HogQLParser.EnumValueContext):
-        raise NotImplementedException(f"Unsupported node: EnumValue")
+        raise NotImplementedError(f"Unsupported node: EnumValue")
 
     def visitColumnExprNullish(self, ctx: HogQLParser.ColumnExprNullishContext):
         return ast.Call(
@@ -910,14 +910,14 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
         opening = self.visit(ctx.identifier(0))
         closing = self.visit(ctx.identifier(1))
         if opening != closing:
-            raise SyntaxException(f"Opening and closing HogQLX tags must match. Got {opening} and {closing}")
+            raise SyntaxError(f"Opening and closing HogQLX tags must match. Got {opening} and {closing}")
 
         attributes = [self.visit(a) for a in ctx.hogqlxTagAttribute()] if ctx.hogqlxTagAttribute() else []
         if ctx.hogqlxTagElement():
             source = self.visit(ctx.hogqlxTagElement())
             for a in attributes:
                 if a.name == "source":
-                    raise SyntaxException(f"Nested HogQLX tags cannot have a source attribute")
+                    raise SyntaxError(f"Nested HogQLX tags cannot have a source attribute")
             attributes.append(ast.HogQLXAttribute(name="source", value=source))
         return ast.HogQLXTag(kind=opening, attributes=attributes)
 

--- a/posthog/hogql/placeholders.py
+++ b/posthog/hogql/placeholders.py
@@ -1,7 +1,7 @@
 from typing import Dict, Optional, List
 
 from posthog.hogql import ast
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import QueryException
 from posthog.hogql.visitor import CloningVisitor, TraversingVisitor
 
 
@@ -34,13 +34,13 @@ class ReplacePlaceholders(CloningVisitor):
 
     def visit_placeholder(self, node):
         if not self.placeholders:
-            raise HogQLException(f"Placeholders, such as {{{node.field}}}, are not supported in this context")
+            raise QueryException(f"Placeholders, such as {{{node.field}}}, are not supported in this context")
         if node.field in self.placeholders and self.placeholders[node.field] is not None:
             new_node = self.placeholders[node.field]
             new_node.start = node.start
             new_node.end = node.end
             return new_node
-        raise HogQLException(
+        raise QueryException(
             f"Placeholder {{{node.field}}} is not available in this context. You can use the following: "
             + ", ".join((f"{placeholder}" for placeholder in self.placeholders))
         )

--- a/posthog/hogql/placeholders.py
+++ b/posthog/hogql/placeholders.py
@@ -1,7 +1,7 @@
 from typing import Dict, Optional, List
 
 from posthog.hogql import ast
-from posthog.hogql.errors import QueryException
+from posthog.hogql.errors import QueryError
 from posthog.hogql.visitor import CloningVisitor, TraversingVisitor
 
 
@@ -34,13 +34,13 @@ class ReplacePlaceholders(CloningVisitor):
 
     def visit_placeholder(self, node):
         if not self.placeholders:
-            raise QueryException(f"Placeholders, such as {{{node.field}}}, are not supported in this context")
+            raise QueryError(f"Placeholders, such as {{{node.field}}}, are not supported in this context")
         if node.field in self.placeholders and self.placeholders[node.field] is not None:
             new_node = self.placeholders[node.field]
             new_node.start = node.start
             new_node.end = node.end
             return new_node
-        raise QueryException(
+        raise QueryError(
             f"Placeholder {{{node.field}}} is not available in this context. You can use the following: "
             + ", ".join((f"{placeholder}" for placeholder in self.placeholders))
         )

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -22,7 +22,7 @@ from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import Table, FunctionCallTable, SavedQuery
 from posthog.hogql.database.database import create_hogql_database
 from posthog.hogql.database.s3_table import S3Table
-from posthog.hogql.errors import ImpossibleASTException, InternalHogQLException, QueryException, ResolutionException
+from posthog.hogql.errors import ImpossibleASTError, InternalHogQLError, QueryError, ResolutionError
 from posthog.hogql.escape_sql import (
     escape_clickhouse_identifier,
     escape_clickhouse_string,
@@ -48,7 +48,7 @@ from posthog.utils import PersonOnEventsMode
 def team_id_guard_for_table(table_type: Union[ast.TableType, ast.TableAliasType], context: HogQLContext) -> ast.Expr:
     """Add a mandatory "and(team_id, ...)" filter around the expression."""
     if not context.team_id:
-        raise InternalHogQLException("context.team_id not found")
+        raise InternalHogQLError("context.team_id not found")
 
     return ast.CompareOperation(
         op=ast.CompareOperationOp.Eq,
@@ -183,7 +183,7 @@ class _Printer(Visitor):
 
         if len(self.stack) == 0 and self.dialect == "clickhouse" and self.settings:
             if not isinstance(node, ast.SelectQuery) and not isinstance(node, ast.SelectUnionQuery):
-                raise QueryException("Settings can only be applied to SELECT queries")
+                raise QueryError("Settings can only be applied to SELECT queries")
             settings = self._print_settings(self.settings)
             if settings is not None:
                 response += " " + settings
@@ -205,11 +205,9 @@ class _Printer(Visitor):
     def visit_select_query(self, node: ast.SelectQuery):
         if self.dialect == "clickhouse":
             if not self.context.enable_select_queries:
-                raise InternalHogQLException(
-                    "Full SELECT queries are disabled if context.enable_select_queries is False"
-                )
+                raise InternalHogQLError("Full SELECT queries are disabled if context.enable_select_queries is False")
             if not self.context.team_id:
-                raise InternalHogQLException("Full SELECT queries are disabled if context.team_id is not set")
+                raise InternalHogQLError("Full SELECT queries are disabled if context.team_id is not set")
 
         # if we are the first parsed node in the tree, or a child of a SelectUnionQuery, mark us as a top level query
         part_of_select_union = len(self.stack) >= 2 and isinstance(self.stack[-2], ast.SelectUnionQuery)
@@ -223,7 +221,7 @@ class _Printer(Visitor):
         while isinstance(next_join, ast.JoinExpr):
             if next_join.type is None:
                 if self.dialect == "clickhouse":
-                    raise InternalHogQLException(
+                    raise InternalHogQLError(
                         "Printing queries with a FROM clause is not permitted before type resolution"
                     )
 
@@ -242,7 +240,7 @@ class _Printer(Visitor):
                 else:
                     where = ast.And(exprs=[extra_where, where])
             else:
-                raise ImpossibleASTException(
+                raise ImpossibleASTError(
                     f"Invalid where of type {type(extra_where).__name__} returned by join_expr", node=visited_join.where
                 )
 
@@ -297,10 +295,10 @@ class _Printer(Visitor):
                 "LEFT ARRAY JOIN",
                 "INNER ARRAY JOIN",
             ):
-                raise ImpossibleASTException(f"Invalid ARRAY JOIN operation: {node.array_join_op}")
+                raise ImpossibleASTError(f"Invalid ARRAY JOIN operation: {node.array_join_op}")
             array_join = node.array_join_op
             if len(node.array_join_list) == 0:
-                raise ImpossibleASTException(f"Invalid ARRAY JOIN without an array")
+                raise ImpossibleASTError(f"Invalid ARRAY JOIN without an array")
             array_join += f" {', '.join(self.visit(expr) for expr in node.array_join_list)}"
 
         space = f"\n{self.indent(1)}" if self.pretty else " "
@@ -374,7 +372,7 @@ class _Printer(Visitor):
                 table_type = table_type.table_type
 
             if not isinstance(table_type, ast.TableType) and not isinstance(table_type, ast.LazyTableType):
-                raise ImpossibleASTException(f"Invalid table type {type(table_type).__name__} in join_expr")
+                raise ImpossibleASTError(f"Invalid table type {type(table_type).__name__} in join_expr")
 
             # :IMPORTANT: This assures a "team_id" where clause is present on every selected table.
             # Skip function call tables like numbers(), s3(), etc.
@@ -398,24 +396,24 @@ class _Printer(Visitor):
 
             if isinstance(table_type.table, FunctionCallTable) and not isinstance(table_type.table, S3Table):
                 if node.table_args is None:
-                    raise QueryException(f"Table function '{table_type.table.name}' requires arguments")
+                    raise QueryError(f"Table function '{table_type.table.name}' requires arguments")
 
                 if table_type.table.min_args is not None and (
                     node.table_args is None or len(node.table_args) < table_type.table.min_args
                 ):
-                    raise QueryException(
+                    raise QueryError(
                         f"Table function '{table_type.table.name}' requires at least {table_type.table.min_args} argument{'s' if table_type.table.min_args > 1 else ''}"
                     )
                 if table_type.table.max_args is not None and (
                     node.table_args is None or len(node.table_args) > table_type.table.max_args
                 ):
-                    raise QueryException(
+                    raise QueryError(
                         f"Table function '{table_type.table.name}' requires at most {table_type.table.max_args} argument{'s' if table_type.table.max_args > 1 else ''}"
                     )
                 if node.table_args is not None and len(node.table_args) > 0:
                     sql = f"{sql}({', '.join([self.visit(arg) for arg in node.table_args])})"
             elif node.table_args is not None:
-                raise QueryException(f"Table '{table_type.table.to_printed_hogql()}' does not accept arguments")
+                raise QueryError(f"Table '{table_type.table.to_printed_hogql()}' does not accept arguments")
 
             join_strings.append(sql)
 
@@ -440,9 +438,9 @@ class _Printer(Visitor):
             if self.dialect == "hogql":
                 join_strings.append(self._print_identifier(node.type.table.to_printed_hogql()))
             else:
-                raise ImpossibleASTException(f"Unexpected LazyTableType for: {node.type.table.to_printed_hogql()}")
+                raise ImpossibleASTError(f"Unexpected LazyTableType for: {node.type.table.to_printed_hogql()}")
         else:
-            raise QueryException(
+            raise QueryError(
                 f"Only selecting from a table or a subquery is supported. Unexpected type: {node.type.__class__.__name__}"
             )
 
@@ -474,7 +472,7 @@ class _Printer(Visitor):
         elif node.op == ast.ArithmeticOperationOp.Mod:
             return f"modulo({self.visit(node.left)}, {self.visit(node.right)})"
         else:
-            raise ImpossibleASTException(f"Unknown ArithmeticOperationOp {node.op}")
+            raise ImpossibleASTError(f"Unknown ArithmeticOperationOp {node.op}")
 
     def visit_and(self, node: ast.And):
         if len(node.exprs) == 1:
@@ -595,7 +593,7 @@ class _Printer(Visitor):
                 lambda left_op, right_op: left_op <= right_op if left_op is not None and right_op is not None else False
             )
         else:
-            raise ImpossibleASTException(f"Unknown CompareOperationOp: {node.op.name}")
+            raise ImpossibleASTError(f"Unknown CompareOperationOp: {node.op.name}")
 
         # Try to see if we can take shortcuts
 
@@ -668,7 +666,7 @@ class _Printer(Visitor):
         elif value_if_one_side_is_null is False and value_if_both_sides_are_null is False:
             return f"ifNull({op}, 0)"
         else:
-            raise ImpossibleASTException("Impossible")
+            raise ImpossibleASTError("Impossible")
 
     def visit_constant(self, node: ast.Constant):
         if self.dialect == "hogql":
@@ -689,7 +687,7 @@ class _Printer(Visitor):
             if "%" in value:
                 # We don't know if this will be passed on as part of a legacy ClickHouse query or not.
                 # Ban % to be on the safe side. Who knows how it can end up in a UUID or datetime for example.
-                raise QueryException(f"Invalid character '%' in constant: {value}")
+                raise QueryError(f"Invalid character '%' in constant: {value}")
             return value
         else:
             # Strings, lists, tuples, and any other random datatype printed in ClickHouse.
@@ -698,7 +696,7 @@ class _Printer(Visitor):
     def visit_field(self, node: ast.Field):
         if node.type is None:
             field = ".".join([self._print_hogql_identifier_or_index(identifier) for identifier in node.chain])
-            raise ImpossibleASTException(f"Field {field} has no type")
+            raise ImpossibleASTError(f"Field {field} has no type")
 
         if self.dialect == "hogql":
             if node.chain == ["*"]:
@@ -708,17 +706,17 @@ class _Printer(Visitor):
 
         if node.type is not None:
             if isinstance(node.type, ast.LazyJoinType) or isinstance(node.type, ast.VirtualTableType):
-                raise QueryException(f"Can't select a table when a column is expected: {'.'.join(node.chain)}")
+                raise QueryError(f"Can't select a table when a column is expected: {'.'.join(node.chain)}")
 
             return self.visit(node.type)
         else:
-            raise ImpossibleASTException(f"Unknown Type, can not print {type(node.type).__name__}")
+            raise ImpossibleASTError(f"Unknown Type, can not print {type(node.type).__name__}")
 
     def visit_call(self, node: ast.Call):
         if node.name in HOGQL_COMPARISON_MAPPING:
             op = HOGQL_COMPARISON_MAPPING[node.name]
             if len(node.args) != 2:
-                raise QueryException(f"Comparison '{node.name}' requires exactly two arguments")
+                raise QueryError(f"Comparison '{node.name}' requires exactly two arguments")
             # We do "cleverer" logic with nullable types in visit_compare_operation
             return self.visit_compare_operation(
                 ast.CompareOperation(
@@ -739,7 +737,7 @@ class _Printer(Visitor):
             )
             if func_meta.min_params:
                 if node.params is None:
-                    raise QueryException(f"Aggregation '{node.name}' requires parameters in addition to arguments")
+                    raise QueryError(f"Aggregation '{node.name}' requires parameters in addition to arguments")
                 validate_function_args(
                     node.params,
                     func_meta.min_params,
@@ -752,7 +750,7 @@ class _Printer(Visitor):
             # check that we're not running inside another aggregate
             for stack_node in self.stack:
                 if stack_node != node and isinstance(stack_node, ast.Call) and stack_node.name in HOGQL_AGGREGATIONS:
-                    raise QueryException(
+                    raise QueryError(
                         f"Aggregation '{node.name}' cannot be nested inside another aggregation '{stack_node.name}'."
                     )
 
@@ -769,7 +767,7 @@ class _Printer(Visitor):
             validate_function_args(node.args, func_meta.min_args, func_meta.max_args, node.name)
             if func_meta.min_params:
                 if node.params is None:
-                    raise QueryException(f"Function '{node.name}' requires parameters in addition to arguments")
+                    raise QueryError(f"Function '{node.name}' requires parameters in addition to arguments")
                 validate_function_args(
                     node.params,
                     func_meta.min_params,
@@ -887,17 +885,17 @@ class _Printer(Visitor):
                     return f"dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce({args[0]}, ''), 'source'))"
                 elif node.name == "hogql_lookupOrganicMediumType":
                     return f"dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce({args[0]}, ''), 'medium'))"
-            raise QueryException(f"Unexpected unresolved HogQL function '{node.name}(...)'")
+            raise QueryError(f"Unexpected unresolved HogQL function '{node.name}(...)'")
         else:
             close_matches = get_close_matches(node.name, ALL_EXPOSED_FUNCTION_NAMES, 1)
             if len(close_matches) > 0:
-                raise QueryException(
+                raise QueryError(
                     f"Unsupported function call '{node.name}(...)'. Perhaps you meant '{close_matches[0]}(...)'?"
                 )
-            raise QueryException(f"Unsupported function call '{node.name}(...)'")
+            raise QueryError(f"Unsupported function call '{node.name}(...)'")
 
     def visit_placeholder(self, node: ast.Placeholder):
-        raise QueryException(f"Placeholders, such as {{{node.field}}}, are not supported in this context")
+        raise QueryError(f"Placeholders, such as {{{node.field}}}, are not supported in this context")
 
     def visit_alias(self, node: ast.Alias):
         # Skip hidden aliases completely.
@@ -930,7 +928,7 @@ class _Printer(Visitor):
             type_with_name_in_scope = (
                 lookup_field_by_name(last_select.type, type.name, self.context) if last_select else None
             )
-        except ResolutionException:
+        except ResolutionError:
             type_with_name_in_scope = None
 
         if (
@@ -940,7 +938,7 @@ class _Printer(Visitor):
         ):
             resolved_field = type.resolve_database_field(self.context)
             if resolved_field is None:
-                raise QueryException(f'Can\'t resolve field "{type.name}" on table.')
+                raise QueryError(f'Can\'t resolve field "{type.name}" on table.')
             if isinstance(resolved_field, Table):
                 if isinstance(type.table_type, ast.VirtualTableType):
                     return self.visit(ast.AsteriskType(table_type=ast.TableType(table=resolved_field)))
@@ -994,7 +992,7 @@ class _Printer(Visitor):
             error = f"Can't access field '{type.name}' on a table with type '{type.table_type.__class__.__name__}'."
             if isinstance(type.table_type, ast.LazyJoinType):
                 error += f" Lazy joins should have all been replaced in the resolver."
-            raise ImpossibleASTException(error)
+            raise ImpossibleASTError(error)
 
         return field_sql
 
@@ -1021,7 +1019,7 @@ class _Printer(Visitor):
                 else:
                     table_name = table.table.to_printed_hogql()
                 if field is None:
-                    raise QueryException(f"Can't resolve field {field_type.name} on table {table_name}")
+                    raise QueryError(f"Can't resolve field {field_type.name} on table {table_name}")
                 field_name = cast(Union[Literal["properties"], Literal["person_properties"]], field.name)
 
                 materialized_column = self._get_materialized_column(table_name, type.chain[0], field_name)
@@ -1088,22 +1086,22 @@ class _Printer(Visitor):
         return "*"
 
     def visit_lazy_join_type(self, type: ast.LazyJoinType):
-        raise ImpossibleASTException("Unexpected ast.LazyJoinType. Make sure LazyJoinResolver has run on the AST.")
+        raise ImpossibleASTError("Unexpected ast.LazyJoinType. Make sure LazyJoinResolver has run on the AST.")
 
     def visit_lazy_table_type(self, type: ast.LazyJoinType):
-        raise ImpossibleASTException("Unexpected ast.LazyTableType. Make sure LazyJoinResolver has run on the AST.")
+        raise ImpossibleASTError("Unexpected ast.LazyTableType. Make sure LazyJoinResolver has run on the AST.")
 
     def visit_field_traverser_type(self, type: ast.FieldTraverserType):
-        raise ImpossibleASTException("Unexpected ast.FieldTraverserType. This should have been resolved.")
+        raise ImpossibleASTError("Unexpected ast.FieldTraverserType. This should have been resolved.")
 
     def visit_unknown(self, node: AST):
-        raise ImpossibleASTException(f"Unknown AST node {type(node).__name__}")
+        raise ImpossibleASTError(f"Unknown AST node {type(node).__name__}")
 
     def visit_window_expr(self, node: ast.WindowExpr):
         strings: List[str] = []
         if node.partition_by is not None:
             if len(node.partition_by) == 0:
-                raise ImpossibleASTException("PARTITION BY must have at least one argument")
+                raise ImpossibleASTError("PARTITION BY must have at least one argument")
             strings.append("PARTITION BY")
             columns = []
             for expr in node.partition_by:
@@ -1112,7 +1110,7 @@ class _Printer(Visitor):
 
         if node.order_by is not None:
             if len(node.order_by) == 0:
-                raise ImpossibleASTException("ORDER BY must have at least one argument")
+                raise ImpossibleASTError("ORDER BY must have at least one argument")
             strings.append("ORDER BY")
             for expr in node.order_by:
                 strings.append(self.visit(expr))
@@ -1123,7 +1121,7 @@ class _Printer(Visitor):
             elif node.frame_method == "RANGE":
                 strings.append("RANGE")
             else:
-                raise ImpossibleASTException(f"Invalid frame method {node.frame_method}")
+                raise ImpossibleASTError(f"Invalid frame method {node.frame_method}")
             if node.frame_start and node.frame_end is None:
                 strings.append(self.visit(node.frame_start))
 
@@ -1134,7 +1132,7 @@ class _Printer(Visitor):
                 strings.append(self.visit(node.frame_end))
 
             else:
-                raise ImpossibleASTException("Frame start and end must be specified together")
+                raise ImpossibleASTError("Frame start and end must be specified together")
         return " ".join(strings)
 
     def visit_window_function(self, node: ast.WindowFunction):
@@ -1149,7 +1147,7 @@ class _Printer(Visitor):
         elif node.frame_type == "CURRENT ROW":
             return "CURRENT ROW"
         else:
-            raise ImpossibleASTException(f"Invalid frame type {node.frame_type}")
+            raise ImpossibleASTError(f"Invalid frame type {node.frame_type}")
 
     def _last_select(self) -> Optional[ast.SelectQuery]:
         """Find the last SELECT query in the stack."""
@@ -1216,9 +1214,9 @@ class _Printer(Visitor):
             if value is None:
                 continue
             if not isinstance(value, (int, float, str)):
-                raise QueryException(f"Setting {key} must be a string, int, or float")
+                raise QueryError(f"Setting {key} must be a string, int, or float")
             if not re.match(r"^[a-zA-Z0-9_]+$", key):
-                raise QueryException(f"Setting {key} is not supported")
+                raise QueryError(f"Setting {key} is not supported")
             if isinstance(value, bool):
                 pairs.append(f"{key}={1 if value else 0}")
             elif isinstance(value, int) or isinstance(value, float):

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -22,7 +22,7 @@ from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import Table, FunctionCallTable, SavedQuery
 from posthog.hogql.database.database import create_hogql_database
 from posthog.hogql.database.s3_table import S3Table
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ImpossibleASTException, InternalHogQLException, QueryException, ResolutionException
 from posthog.hogql.escape_sql import (
     escape_clickhouse_identifier,
     escape_clickhouse_string,
@@ -31,7 +31,7 @@ from posthog.hogql.escape_sql import (
 )
 from posthog.hogql.functions.mapping import ALL_EXPOSED_FUNCTION_NAMES, validate_function_args, HOGQL_COMPARISON_MAPPING
 from posthog.hogql.modifiers import create_default_modifiers_for_team, set_default_in_cohort_via
-from posthog.hogql.resolver import ResolverException, resolve_types
+from posthog.hogql.resolver import resolve_types
 from posthog.hogql.resolver_utils import lookup_field_by_name
 from posthog.hogql.transforms.in_cohort import resolve_in_cohorts, resolve_in_cohorts_conjoined
 from posthog.hogql.transforms.lazy_tables import resolve_lazy_tables
@@ -48,7 +48,7 @@ from posthog.utils import PersonOnEventsMode
 def team_id_guard_for_table(table_type: Union[ast.TableType, ast.TableAliasType], context: HogQLContext) -> ast.Expr:
     """Add a mandatory "and(team_id, ...)" filter around the expression."""
     if not context.team_id:
-        raise HogQLException("context.team_id not found")
+        raise InternalHogQLException("context.team_id not found")
 
     return ast.CompareOperation(
         op=ast.CompareOperationOp.Eq,
@@ -183,7 +183,7 @@ class _Printer(Visitor):
 
         if len(self.stack) == 0 and self.dialect == "clickhouse" and self.settings:
             if not isinstance(node, ast.SelectQuery) and not isinstance(node, ast.SelectUnionQuery):
-                raise HogQLException("Settings can only be applied to SELECT queries")
+                raise QueryException("Settings can only be applied to SELECT queries")
             settings = self._print_settings(self.settings)
             if settings is not None:
                 response += " " + settings
@@ -205,9 +205,11 @@ class _Printer(Visitor):
     def visit_select_query(self, node: ast.SelectQuery):
         if self.dialect == "clickhouse":
             if not self.context.enable_select_queries:
-                raise HogQLException("Full SELECT queries are disabled if context.enable_select_queries is False")
+                raise InternalHogQLException(
+                    "Full SELECT queries are disabled if context.enable_select_queries is False"
+                )
             if not self.context.team_id:
-                raise HogQLException("Full SELECT queries are disabled if context.team_id is not set")
+                raise InternalHogQLException("Full SELECT queries are disabled if context.team_id is not set")
 
         # if we are the first parsed node in the tree, or a child of a SelectUnionQuery, mark us as a top level query
         part_of_select_union = len(self.stack) >= 2 and isinstance(self.stack[-2], ast.SelectUnionQuery)
@@ -221,7 +223,9 @@ class _Printer(Visitor):
         while isinstance(next_join, ast.JoinExpr):
             if next_join.type is None:
                 if self.dialect == "clickhouse":
-                    raise HogQLException("Printing queries with a FROM clause is not permitted before type resolution")
+                    raise InternalHogQLException(
+                        "Printing queries with a FROM clause is not permitted before type resolution"
+                    )
 
             visited_join = self.visit_join_expr(next_join)
             joined_tables.append(visited_join.printed_sql)
@@ -238,7 +242,7 @@ class _Printer(Visitor):
                 else:
                     where = ast.And(exprs=[extra_where, where])
             else:
-                raise HogQLException(
+                raise ImpossibleASTException(
                     f"Invalid where of type {type(extra_where).__name__} returned by join_expr", node=visited_join.where
                 )
 
@@ -293,10 +297,10 @@ class _Printer(Visitor):
                 "LEFT ARRAY JOIN",
                 "INNER ARRAY JOIN",
             ):
-                raise HogQLException(f"Invalid ARRAY JOIN operation: {node.array_join_op}")
+                raise ImpossibleASTException(f"Invalid ARRAY JOIN operation: {node.array_join_op}")
             array_join = node.array_join_op
             if len(node.array_join_list) == 0:
-                raise HogQLException(f"Invalid ARRAY JOIN without an array")
+                raise ImpossibleASTException(f"Invalid ARRAY JOIN without an array")
             array_join += f" {', '.join(self.visit(expr) for expr in node.array_join_list)}"
 
         space = f"\n{self.indent(1)}" if self.pretty else " "
@@ -370,7 +374,7 @@ class _Printer(Visitor):
                 table_type = table_type.table_type
 
             if not isinstance(table_type, ast.TableType) and not isinstance(table_type, ast.LazyTableType):
-                raise HogQLException(f"Invalid table type {type(table_type).__name__} in join_expr")
+                raise ImpossibleASTException(f"Invalid table type {type(table_type).__name__} in join_expr")
 
             # :IMPORTANT: This assures a "team_id" where clause is present on every selected table.
             # Skip function call tables like numbers(), s3(), etc.
@@ -394,24 +398,24 @@ class _Printer(Visitor):
 
             if isinstance(table_type.table, FunctionCallTable) and not isinstance(table_type.table, S3Table):
                 if node.table_args is None:
-                    raise HogQLException(f"Table function '{table_type.table.name}' requires arguments")
+                    raise QueryException(f"Table function '{table_type.table.name}' requires arguments")
 
                 if table_type.table.min_args is not None and (
                     node.table_args is None or len(node.table_args) < table_type.table.min_args
                 ):
-                    raise HogQLException(
+                    raise QueryException(
                         f"Table function '{table_type.table.name}' requires at least {table_type.table.min_args} argument{'s' if table_type.table.min_args > 1 else ''}"
                     )
                 if table_type.table.max_args is not None and (
                     node.table_args is None or len(node.table_args) > table_type.table.max_args
                 ):
-                    raise HogQLException(
+                    raise QueryException(
                         f"Table function '{table_type.table.name}' requires at most {table_type.table.max_args} argument{'s' if table_type.table.max_args > 1 else ''}"
                     )
                 if node.table_args is not None and len(node.table_args) > 0:
                     sql = f"{sql}({', '.join([self.visit(arg) for arg in node.table_args])})"
             elif node.table_args is not None:
-                raise HogQLException(f"Table '{table_type.table.to_printed_hogql()}' does not accept arguments")
+                raise QueryException(f"Table '{table_type.table.to_printed_hogql()}' does not accept arguments")
 
             join_strings.append(sql)
 
@@ -436,9 +440,9 @@ class _Printer(Visitor):
             if self.dialect == "hogql":
                 join_strings.append(self._print_identifier(node.type.table.to_printed_hogql()))
             else:
-                raise HogQLException(f"Unexpected LazyTableType for: {node.type.table.to_printed_hogql()}")
+                raise ImpossibleASTException(f"Unexpected LazyTableType for: {node.type.table.to_printed_hogql()}")
         else:
-            raise HogQLException(
+            raise QueryException(
                 f"Only selecting from a table or a subquery is supported. Unexpected type: {node.type.__class__.__name__}"
             )
 
@@ -470,7 +474,7 @@ class _Printer(Visitor):
         elif node.op == ast.ArithmeticOperationOp.Mod:
             return f"modulo({self.visit(node.left)}, {self.visit(node.right)})"
         else:
-            raise HogQLException(f"Unknown ArithmeticOperationOp {node.op}")
+            raise ImpossibleASTException(f"Unknown ArithmeticOperationOp {node.op}")
 
     def visit_and(self, node: ast.And):
         if len(node.exprs) == 1:
@@ -591,7 +595,7 @@ class _Printer(Visitor):
                 lambda left_op, right_op: left_op <= right_op if left_op is not None and right_op is not None else False
             )
         else:
-            raise HogQLException(f"Unknown CompareOperationOp: {node.op.name}")
+            raise ImpossibleASTException(f"Unknown CompareOperationOp: {node.op.name}")
 
         # Try to see if we can take shortcuts
 
@@ -664,7 +668,7 @@ class _Printer(Visitor):
         elif value_if_one_side_is_null is False and value_if_both_sides_are_null is False:
             return f"ifNull({op}, 0)"
         else:
-            raise HogQLException("Impossible")
+            raise ImpossibleASTException("Impossible")
 
     def visit_constant(self, node: ast.Constant):
         if self.dialect == "hogql":
@@ -685,7 +689,7 @@ class _Printer(Visitor):
             if "%" in value:
                 # We don't know if this will be passed on as part of a legacy ClickHouse query or not.
                 # Ban % to be on the safe side. Who knows how it can end up in a UUID or datetime for example.
-                raise HogQLException(f"Invalid character '%' in constant: {value}")
+                raise QueryException(f"Invalid character '%' in constant: {value}")
             return value
         else:
             # Strings, lists, tuples, and any other random datatype printed in ClickHouse.
@@ -694,7 +698,7 @@ class _Printer(Visitor):
     def visit_field(self, node: ast.Field):
         if node.type is None:
             field = ".".join([self._print_hogql_identifier_or_index(identifier) for identifier in node.chain])
-            raise HogQLException(f"Field {field} has no type")
+            raise ImpossibleASTException(f"Field {field} has no type")
 
         if self.dialect == "hogql":
             if node.chain == ["*"]:
@@ -704,17 +708,17 @@ class _Printer(Visitor):
 
         if node.type is not None:
             if isinstance(node.type, ast.LazyJoinType) or isinstance(node.type, ast.VirtualTableType):
-                raise HogQLException(f"Can't select a table when a column is expected: {'.'.join(node.chain)}")
+                raise QueryException(f"Can't select a table when a column is expected: {'.'.join(node.chain)}")
 
             return self.visit(node.type)
         else:
-            raise HogQLException(f"Unknown Type, can not print {type(node.type).__name__}")
+            raise ImpossibleASTException(f"Unknown Type, can not print {type(node.type).__name__}")
 
     def visit_call(self, node: ast.Call):
         if node.name in HOGQL_COMPARISON_MAPPING:
             op = HOGQL_COMPARISON_MAPPING[node.name]
             if len(node.args) != 2:
-                raise HogQLException(f"Comparison '{node.name}' requires exactly two arguments")
+                raise QueryException(f"Comparison '{node.name}' requires exactly two arguments")
             # We do "cleverer" logic with nullable types in visit_compare_operation
             return self.visit_compare_operation(
                 ast.CompareOperation(
@@ -735,7 +739,7 @@ class _Printer(Visitor):
             )
             if func_meta.min_params:
                 if node.params is None:
-                    raise HogQLException(f"Aggregation '{node.name}' requires parameters in addition to arguments")
+                    raise QueryException(f"Aggregation '{node.name}' requires parameters in addition to arguments")
                 validate_function_args(
                     node.params,
                     func_meta.min_params,
@@ -748,7 +752,7 @@ class _Printer(Visitor):
             # check that we're not running inside another aggregate
             for stack_node in self.stack:
                 if stack_node != node and isinstance(stack_node, ast.Call) and stack_node.name in HOGQL_AGGREGATIONS:
-                    raise HogQLException(
+                    raise QueryException(
                         f"Aggregation '{node.name}' cannot be nested inside another aggregation '{stack_node.name}'."
                     )
 
@@ -765,7 +769,7 @@ class _Printer(Visitor):
             validate_function_args(node.args, func_meta.min_args, func_meta.max_args, node.name)
             if func_meta.min_params:
                 if node.params is None:
-                    raise HogQLException(f"Function '{node.name}' requires parameters in addition to arguments")
+                    raise QueryException(f"Function '{node.name}' requires parameters in addition to arguments")
                 validate_function_args(
                     node.params,
                     func_meta.min_params,
@@ -883,17 +887,17 @@ class _Printer(Visitor):
                     return f"dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce({args[0]}, ''), 'source'))"
                 elif node.name == "hogql_lookupOrganicMediumType":
                     return f"dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce({args[0]}, ''), 'medium'))"
-            raise HogQLException(f"Unexpected unresolved HogQL function '{node.name}(...)'")
+            raise QueryException(f"Unexpected unresolved HogQL function '{node.name}(...)'")
         else:
             close_matches = get_close_matches(node.name, ALL_EXPOSED_FUNCTION_NAMES, 1)
             if len(close_matches) > 0:
-                raise HogQLException(
+                raise QueryException(
                     f"Unsupported function call '{node.name}(...)'. Perhaps you meant '{close_matches[0]}(...)'?"
                 )
-            raise HogQLException(f"Unsupported function call '{node.name}(...)'")
+            raise QueryException(f"Unsupported function call '{node.name}(...)'")
 
     def visit_placeholder(self, node: ast.Placeholder):
-        raise HogQLException(f"Placeholders, such as {{{node.field}}}, are not supported in this context")
+        raise QueryException(f"Placeholders, such as {{{node.field}}}, are not supported in this context")
 
     def visit_alias(self, node: ast.Alias):
         # Skip hidden aliases completely.
@@ -926,7 +930,7 @@ class _Printer(Visitor):
             type_with_name_in_scope = (
                 lookup_field_by_name(last_select.type, type.name, self.context) if last_select else None
             )
-        except ResolverException:
+        except ResolutionException:
             type_with_name_in_scope = None
 
         if (
@@ -936,7 +940,7 @@ class _Printer(Visitor):
         ):
             resolved_field = type.resolve_database_field(self.context)
             if resolved_field is None:
-                raise HogQLException(f'Can\'t resolve field "{type.name}" on table.')
+                raise QueryException(f'Can\'t resolve field "{type.name}" on table.')
             if isinstance(resolved_field, Table):
                 if isinstance(type.table_type, ast.VirtualTableType):
                     return self.visit(ast.AsteriskType(table_type=ast.TableType(table=resolved_field)))
@@ -990,7 +994,7 @@ class _Printer(Visitor):
             error = f"Can't access field '{type.name}' on a table with type '{type.table_type.__class__.__name__}'."
             if isinstance(type.table_type, ast.LazyJoinType):
                 error += f" Lazy joins should have all been replaced in the resolver."
-            raise HogQLException(error)
+            raise ImpossibleASTException(error)
 
         return field_sql
 
@@ -1017,7 +1021,7 @@ class _Printer(Visitor):
                 else:
                     table_name = table.table.to_printed_hogql()
                 if field is None:
-                    raise HogQLException(f"Can't resolve field {field_type.name} on table {table_name}")
+                    raise QueryException(f"Can't resolve field {field_type.name} on table {table_name}")
                 field_name = cast(Union[Literal["properties"], Literal["person_properties"]], field.name)
 
                 materialized_column = self._get_materialized_column(table_name, type.chain[0], field_name)
@@ -1084,22 +1088,22 @@ class _Printer(Visitor):
         return "*"
 
     def visit_lazy_join_type(self, type: ast.LazyJoinType):
-        raise HogQLException("Unexpected ast.LazyJoinType. Make sure LazyJoinResolver has run on the AST.")
+        raise ImpossibleASTException("Unexpected ast.LazyJoinType. Make sure LazyJoinResolver has run on the AST.")
 
     def visit_lazy_table_type(self, type: ast.LazyJoinType):
-        raise HogQLException("Unexpected ast.LazyTableType. Make sure LazyJoinResolver has run on the AST.")
+        raise ImpossibleASTException("Unexpected ast.LazyTableType. Make sure LazyJoinResolver has run on the AST.")
 
     def visit_field_traverser_type(self, type: ast.FieldTraverserType):
-        raise HogQLException("Unexpected ast.FieldTraverserType. This should have been resolved.")
+        raise ImpossibleASTException("Unexpected ast.FieldTraverserType. This should have been resolved.")
 
     def visit_unknown(self, node: AST):
-        raise HogQLException(f"Unknown AST node {type(node).__name__}")
+        raise ImpossibleASTException(f"Unknown AST node {type(node).__name__}")
 
     def visit_window_expr(self, node: ast.WindowExpr):
         strings: List[str] = []
         if node.partition_by is not None:
             if len(node.partition_by) == 0:
-                raise HogQLException("PARTITION BY must have at least one argument")
+                raise ImpossibleASTException("PARTITION BY must have at least one argument")
             strings.append("PARTITION BY")
             columns = []
             for expr in node.partition_by:
@@ -1108,7 +1112,7 @@ class _Printer(Visitor):
 
         if node.order_by is not None:
             if len(node.order_by) == 0:
-                raise HogQLException("ORDER BY must have at least one argument")
+                raise ImpossibleASTException("ORDER BY must have at least one argument")
             strings.append("ORDER BY")
             for expr in node.order_by:
                 strings.append(self.visit(expr))
@@ -1119,7 +1123,7 @@ class _Printer(Visitor):
             elif node.frame_method == "RANGE":
                 strings.append("RANGE")
             else:
-                raise HogQLException(f"Invalid frame method {node.frame_method}")
+                raise ImpossibleASTException(f"Invalid frame method {node.frame_method}")
             if node.frame_start and node.frame_end is None:
                 strings.append(self.visit(node.frame_start))
 
@@ -1130,7 +1134,7 @@ class _Printer(Visitor):
                 strings.append(self.visit(node.frame_end))
 
             else:
-                raise HogQLException("Frame start and end must be specified together")
+                raise ImpossibleASTException("Frame start and end must be specified together")
         return " ".join(strings)
 
     def visit_window_function(self, node: ast.WindowFunction):
@@ -1145,7 +1149,7 @@ class _Printer(Visitor):
         elif node.frame_type == "CURRENT ROW":
             return "CURRENT ROW"
         else:
-            raise HogQLException(f"Invalid frame type {node.frame_type}")
+            raise ImpossibleASTException(f"Invalid frame type {node.frame_type}")
 
     def _last_select(self) -> Optional[ast.SelectQuery]:
         """Find the last SELECT query in the stack."""
@@ -1212,9 +1216,9 @@ class _Printer(Visitor):
             if value is None:
                 continue
             if not isinstance(value, (int, float, str)):
-                raise HogQLException(f"Setting {key} must be a string, int, or float")
+                raise QueryException(f"Setting {key} must be a string, int, or float")
             if not re.match(r"^[a-zA-Z0-9_]+$", key):
-                raise HogQLException(f"Setting {key} is not supported")
+                raise QueryException(f"Setting {key} is not supported")
             if isinstance(value, bool):
                 pairs.append(f"{key}={1 if value else 0}")
             elif isinstance(value, int) or isinstance(value, float):

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -4,7 +4,7 @@ from posthog.clickhouse.client.connection import Workload
 from posthog.errors import ExposedCHQueryError
 from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings, LimitContext, get_default_limit_for_context
-from posthog.hogql.errors import ExposedHogQLException
+from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.hogql import HogQLContext
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_select
@@ -164,7 +164,7 @@ def execute_hogql_query(
         except Exception as e:
             if explain:
                 results, types = None, None
-                if isinstance(e, (ExposedCHQueryError, ExposedHogQLException)):
+                if isinstance(e, (ExposedCHQueryError, ExposedHogQLError)):
                     error = str(e)
                 else:
                     error = "Unknown error"

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -4,7 +4,7 @@ from posthog.clickhouse.client.connection import Workload
 from posthog.errors import ExposedCHQueryError
 from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings, LimitContext, get_default_limit_for_context
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ExposedHogQLException
 from posthog.hogql.hogql import HogQLContext
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_select
@@ -57,7 +57,7 @@ def execute_hogql_query(
         placeholders = placeholders or {}
 
         if "filters" in placeholders and filters is not None:
-            raise HogQLException(
+            raise ValueError(
                 f"Query contains 'filters' placeholder, yet filters are also provided as a standalone query parameter."
             )
         if "filters" in placeholders_in_query:
@@ -66,7 +66,7 @@ def execute_hogql_query(
 
         if len(placeholders_in_query) > 0:
             if len(placeholders) == 0:
-                raise HogQLException(
+                raise ValueError(
                     f"Query contains placeholders, but none were provided. Placeholders in query: {', '.join(placeholders_in_query)}"
                 )
             select_query = replace_placeholders(select_query, placeholders)
@@ -164,7 +164,7 @@ def execute_hogql_query(
         except Exception as e:
             if explain:
                 results, types = None, None
-                if isinstance(e, (ExposedCHQueryError, HogQLException)):
+                if isinstance(e, (ExposedCHQueryError, ExposedHogQLException)):
                     error = str(e)
                 else:
                     error = "Unknown error"

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -12,7 +12,7 @@ from posthog.hogql.database.models import (
     LazyTable,
     SavedQuery,
 )
-from posthog.hogql.errors import ImpossibleASTException, QueryException, ResolutionException
+from posthog.hogql.errors import ImpossibleASTError, QueryError, ResolutionError
 from posthog.hogql.functions.cohort import cohort_query_node
 from posthog.hogql.functions.mapping import validate_function_args
 from posthog.hogql.functions.sparkline import sparkline
@@ -50,7 +50,7 @@ def resolve_constant_data_type(constant: Any) -> ConstantType:
         return ast.DateType()
     if isinstance(constant, UUID) or isinstance(constant, UUIDT):
         return ast.UUIDType()
-    raise ImpossibleASTException(f"Unsupported constant type: {type(constant)}")
+    raise ImpossibleASTError(f"Unsupported constant type: {type(constant)}")
 
 
 def resolve_types(
@@ -92,11 +92,11 @@ class Resolver(CloningVisitor):
 
     def visit(self, node: ast.Expr) -> ast.Expr:
         if isinstance(node, ast.Expr) and node.type is not None:
-            raise ResolutionException(
+            raise ResolutionError(
                 f"Type already resolved for {type(node).__name__} ({type(node.type).__name__}). Can't run again."
             )
         if self.cte_counter > 50:
-            raise QueryException("Too many CTE expansions (50+). Probably a CTE loop.")
+            raise QueryError("Too many CTE expansions (50+). Probably a CTE loop.")
         return super().visit(node)
 
     def visit_select_union_query(self, node: ast.SelectUnionQuery):
@@ -142,7 +142,7 @@ class Resolver(CloningVisitor):
             array_join_aliases = ac.aliases
             for key in array_join_aliases:
                 if key in node_type.aliases:
-                    raise QueryException(f"Cannot redefine an alias with the name: {key}")
+                    raise QueryError(f"Cannot redefine an alias with the name: {key}")
                 node_type.aliases[key] = ast.FieldAliasType(alias=key, type=ast.UnknownType())
 
         # Visit all the "SELECT a,b,c" columns. Mark each for export in "columns".
@@ -233,15 +233,15 @@ class Resolver(CloningVisitor):
             if isinstance(select, ast.SelectQueryType):
                 return [ast.Field(chain=[key]) for key in select.columns.keys()]
             else:
-                raise QueryException("Can't expand asterisk (*) on subquery")
+                raise QueryError("Can't expand asterisk (*) on subquery")
         else:
-            raise QueryException(f"Can't expand asterisk (*) on a type of type {type(asterisk.table_type).__name__}")
+            raise QueryError(f"Can't expand asterisk (*) on a type of type {type(asterisk.table_type).__name__}")
 
     def visit_join_expr(self, node: ast.JoinExpr):
         """Visit each FROM and JOIN table or subquery."""
 
         if len(self.scopes) == 0:
-            raise ImpossibleASTException("Unexpected JoinExpr outside a SELECT query")
+            raise ImpossibleASTError("Unexpected JoinExpr outside a SELECT query")
 
         scope = self.scopes[-1]
 
@@ -266,7 +266,7 @@ class Resolver(CloningVisitor):
             table_name = node.table.chain[0]
             table_alias = node.alias or table_name
             if table_alias in scope.tables:
-                raise QueryException(f'Already have joined a table called "{table_alias}". Can\'t redefine.')
+                raise QueryError(f'Already have joined a table called "{table_alias}". Can\'t redefine.')
 
             if self.database.has_table(table_name):
                 database_table = self.database.get_table(table_name)
@@ -275,7 +275,7 @@ class Resolver(CloningVisitor):
                     self.current_view_depth += 1
 
                     if self.current_view_depth > self.context.max_view_depth:
-                        raise QueryException("Nested views are not supported")
+                        raise QueryError("Nested views are not supported")
 
                     node.table = parse_select(str(database_table.query))
 
@@ -328,7 +328,7 @@ class Resolver(CloningVisitor):
 
                 return node
             else:
-                raise QueryException(f'Unknown table "{table_name}".')
+                raise QueryError(f'Unknown table "{table_name}".')
 
         elif isinstance(node.table, ast.SelectQuery) or isinstance(node.table, ast.SelectUnionQuery):
             node = cast(ast.JoinExpr, clone_expr(node))
@@ -336,7 +336,7 @@ class Resolver(CloningVisitor):
             node.table = super().visit(node.table)
             if isinstance(node.table, ast.SelectQuery) and node.table.view_name is not None and node.alias is not None:
                 if node.alias in scope.tables:
-                    raise QueryException(
+                    raise QueryError(
                         f'Already have joined a table called "{node.alias}". Can\'t join another one with the same name.'
                     )
                 node.type = ast.SelectViewType(
@@ -345,7 +345,7 @@ class Resolver(CloningVisitor):
                 scope.tables[node.alias] = node.type
             elif node.alias is not None:
                 if node.alias in scope.tables:
-                    raise QueryException(
+                    raise QueryError(
                         f'Already have joined a table called "{node.alias}". Can\'t join another one with the same name.'
                     )
                 node.type = ast.SelectQueryAliasType(alias=node.alias, select_query_type=node.table.type)
@@ -361,7 +361,7 @@ class Resolver(CloningVisitor):
 
             return node
         else:
-            raise QueryException(f"A {type(node.table).__name__} cannot be used as a SELECT source")
+            raise QueryError(f"A {type(node.table).__name__} cannot be used as a SELECT source")
 
     def visit_hogqlx_tag(self, node: ast.HogQLXTag):
         return self.visit(convert_hogqlx_tag(node, self.context.team_id))
@@ -369,13 +369,13 @@ class Resolver(CloningVisitor):
     def visit_alias(self, node: ast.Alias):
         """Visit column aliases. SELECT 1, (select 3 as y) as x."""
         if len(self.scopes) == 0:
-            raise QueryException("Aliases are allowed only within SELECT queries")
+            raise QueryError("Aliases are allowed only within SELECT queries")
 
         scope = self.scopes[-1]
         if node.alias in scope.aliases and not node.hidden:
-            raise QueryException(f"Cannot redefine an alias with the name: {node.alias}")
+            raise QueryError(f"Cannot redefine an alias with the name: {node.alias}")
         if node.alias == "":
-            raise ImpossibleASTException("Alias cannot be empty")
+            raise ImpossibleASTError("Alias cannot be empty")
 
         node = super().visit_alias(node)
         node.type = ast.FieldAliasType(alias=node.alias, type=node.expr.type or ast.UnknownType())
@@ -437,7 +437,7 @@ class Resolver(CloningVisitor):
     def visit_field(self, node: ast.Field):
         """Visit a field such as ast.Field(chain=["e", "properties", "$browser"])"""
         if len(node.chain) == 0:
-            raise ResolutionException("Invalid field access with empty chain")
+            raise ResolutionError("Invalid field access with empty chain")
 
         node = super().visit_field(node)
 
@@ -459,9 +459,9 @@ class Resolver(CloningVisitor):
         if name == "*" and len(node.chain) == 1:
             table_count = len(scope.anonymous_tables) + len(scope.tables)
             if table_count == 0:
-                raise QueryException("Cannot use '*' when there are no tables in the query")
+                raise QueryError("Cannot use '*' when there are no tables in the query")
             if table_count > 1:
-                raise QueryException("Cannot use '*' without table name when there are multiple tables in the query")
+                raise QueryError("Cannot use '*' without table name when there are multiple tables in the query")
             table_type = (
                 scope.anonymous_tables[0] if len(scope.anonymous_tables) > 0 else list(scope.tables.values())[0]
             )
@@ -475,7 +475,7 @@ class Resolver(CloningVisitor):
             cte = lookup_cte_by_name(self.scopes, name)
             if cte:
                 if len(node.chain) > 1:
-                    raise QueryException(f"Cannot access fields on CTE {cte.name} yet")
+                    raise QueryError(f"Cannot access fields on CTE {cte.name} yet")
                 # SubQuery CTEs ("WITH a AS (SELECT 1)") can only be used in the "FROM table" part of a select query,
                 # which is handled in visit_join_expr. Referring to it here means we want to access its value.
                 if cte.cte_type == "subquery":
@@ -486,7 +486,7 @@ class Resolver(CloningVisitor):
                 return response
 
         if not type:
-            raise QueryException(f"Unable to resolve field: {name}")
+            raise QueryError(f"Unable to resolve field: {name}")
 
         # Recursively resolve the rest of the chain until we can point to the deepest node.
         field_name = node.chain[-1]
@@ -510,9 +510,7 @@ class Resolver(CloningVisitor):
 
             loop_type = loop_type.get_child(next_chain, self.context)
             if loop_type is None:
-                raise ResolutionException(
-                    f"Cannot resolve type {'.'.join(node.chain)}. Unable to resolve {next_chain}."
-                )
+                raise ResolutionError(f"Cannot resolve type {'.'.join(node.chain)}. Unable to resolve {next_chain}.")
         node.type = loop_type
 
         if isinstance(node.type, ast.ExpressionFieldType):

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -12,7 +12,7 @@ from posthog.hogql.database.models import (
     LazyTable,
     SavedQuery,
 )
-from posthog.hogql.errors import ResolverException
+from posthog.hogql.errors import ResolutionException
 from posthog.hogql.functions.cohort import cohort_query_node
 from posthog.hogql.functions.mapping import validate_function_args
 from posthog.hogql.functions.sparkline import sparkline
@@ -50,7 +50,7 @@ def resolve_constant_data_type(constant: Any) -> ConstantType:
         return ast.DateType()
     if isinstance(constant, UUID) or isinstance(constant, UUIDT):
         return ast.UUIDType()
-    raise ResolverException(f"Unsupported constant type: {type(constant)}")
+    raise ResolutionException(f"Unsupported constant type: {type(constant)}")
 
 
 def resolve_types(
@@ -92,11 +92,11 @@ class Resolver(CloningVisitor):
 
     def visit(self, node: ast.Expr) -> ast.Expr:
         if isinstance(node, ast.Expr) and node.type is not None:
-            raise ResolverException(
+            raise ResolutionException(
                 f"Type already resolved for {type(node).__name__} ({type(node.type).__name__}). Can't run again."
             )
         if self.cte_counter > 50:
-            raise ResolverException("Too many CTE expansions (50+). Probably a CTE loop.")
+            raise ResolutionException("Too many CTE expansions (50+). Probably a CTE loop.")
         return super().visit(node)
 
     def visit_select_union_query(self, node: ast.SelectUnionQuery):
@@ -142,7 +142,7 @@ class Resolver(CloningVisitor):
             array_join_aliases = ac.aliases
             for key in array_join_aliases:
                 if key in node_type.aliases:
-                    raise ResolverException(f"Cannot redefine an alias with the name: {key}")
+                    raise ResolutionException(f"Cannot redefine an alias with the name: {key}")
                 node_type.aliases[key] = ast.FieldAliasType(alias=key, type=ast.UnknownType())
 
         # Visit all the "SELECT a,b,c" columns. Mark each for export in "columns".
@@ -233,15 +233,17 @@ class Resolver(CloningVisitor):
             if isinstance(select, ast.SelectQueryType):
                 return [ast.Field(chain=[key]) for key in select.columns.keys()]
             else:
-                raise ResolverException("Can't expand asterisk (*) on subquery")
+                raise ResolutionException("Can't expand asterisk (*) on subquery")
         else:
-            raise ResolverException(f"Can't expand asterisk (*) on a type of type {type(asterisk.table_type).__name__}")
+            raise ResolutionException(
+                f"Can't expand asterisk (*) on a type of type {type(asterisk.table_type).__name__}"
+            )
 
     def visit_join_expr(self, node: ast.JoinExpr):
         """Visit each FROM and JOIN table or subquery."""
 
         if len(self.scopes) == 0:
-            raise ResolverException("Unexpected JoinExpr outside a SELECT query")
+            raise ResolutionException("Unexpected JoinExpr outside a SELECT query")
 
         scope = self.scopes[-1]
 
@@ -266,7 +268,7 @@ class Resolver(CloningVisitor):
             table_name = node.table.chain[0]
             table_alias = node.alias or table_name
             if table_alias in scope.tables:
-                raise ResolverException(f'Already have joined a table called "{table_alias}". Can\'t redefine.')
+                raise ResolutionException(f'Already have joined a table called "{table_alias}". Can\'t redefine.')
 
             if self.database.has_table(table_name):
                 database_table = self.database.get_table(table_name)
@@ -275,7 +277,7 @@ class Resolver(CloningVisitor):
                     self.current_view_depth += 1
 
                     if self.current_view_depth > self.context.max_view_depth:
-                        raise ResolverException("Nested views are not supported")
+                        raise ResolutionException("Nested views are not supported")
 
                     node.table = parse_select(str(database_table.query))
 
@@ -328,7 +330,7 @@ class Resolver(CloningVisitor):
 
                 return node
             else:
-                raise ResolverException(f'Unknown table "{table_name}".')
+                raise ResolutionException(f'Unknown table "{table_name}".')
 
         elif isinstance(node.table, ast.SelectQuery) or isinstance(node.table, ast.SelectUnionQuery):
             node = cast(ast.JoinExpr, clone_expr(node))
@@ -336,7 +338,7 @@ class Resolver(CloningVisitor):
             node.table = super().visit(node.table)
             if isinstance(node.table, ast.SelectQuery) and node.table.view_name is not None and node.alias is not None:
                 if node.alias in scope.tables:
-                    raise ResolverException(
+                    raise ResolutionException(
                         f'Already have joined a table called "{node.alias}". Can\'t join another one with the same name.'
                     )
                 node.type = ast.SelectViewType(
@@ -345,7 +347,7 @@ class Resolver(CloningVisitor):
                 scope.tables[node.alias] = node.type
             elif node.alias is not None:
                 if node.alias in scope.tables:
-                    raise ResolverException(
+                    raise ResolutionException(
                         f'Already have joined a table called "{node.alias}". Can\'t join another one with the same name.'
                     )
                 node.type = ast.SelectQueryAliasType(alias=node.alias, select_query_type=node.table.type)
@@ -361,7 +363,7 @@ class Resolver(CloningVisitor):
 
             return node
         else:
-            raise ResolverException(f"JoinExpr with table of type {type(node.table).__name__} not supported")
+            raise ResolutionException(f"JoinExpr with table of type {type(node.table).__name__} not supported")
 
     def visit_hogqlx_tag(self, node: ast.HogQLXTag):
         return self.visit(convert_hogqlx_tag(node, self.context.team_id))
@@ -369,13 +371,13 @@ class Resolver(CloningVisitor):
     def visit_alias(self, node: ast.Alias):
         """Visit column aliases. SELECT 1, (select 3 as y) as x."""
         if len(self.scopes) == 0:
-            raise ResolverException("Aliases are allowed only within SELECT queries")
+            raise ResolutionException("Aliases are allowed only within SELECT queries")
 
         scope = self.scopes[-1]
         if node.alias in scope.aliases and not node.hidden:
-            raise ResolverException(f"Cannot redefine an alias with the name: {node.alias}")
+            raise ResolutionException(f"Cannot redefine an alias with the name: {node.alias}")
         if node.alias == "":
-            raise ResolverException("Alias cannot be empty")
+            raise ResolutionException("Alias cannot be empty")
 
         node = super().visit_alias(node)
         node.type = ast.FieldAliasType(alias=node.alias, type=node.expr.type or ast.UnknownType())
@@ -437,7 +439,7 @@ class Resolver(CloningVisitor):
     def visit_field(self, node: ast.Field):
         """Visit a field such as ast.Field(chain=["e", "properties", "$browser"])"""
         if len(node.chain) == 0:
-            raise ResolverException("Invalid field access with empty chain")
+            raise ResolutionException("Invalid field access with empty chain")
 
         node = super().visit_field(node)
 
@@ -459,9 +461,11 @@ class Resolver(CloningVisitor):
         if name == "*" and len(node.chain) == 1:
             table_count = len(scope.anonymous_tables) + len(scope.tables)
             if table_count == 0:
-                raise ResolverException("Cannot use '*' when there are no tables in the query")
+                raise ResolutionException("Cannot use '*' when there are no tables in the query")
             if table_count > 1:
-                raise ResolverException("Cannot use '*' without table name when there are multiple tables in the query")
+                raise ResolutionException(
+                    "Cannot use '*' without table name when there are multiple tables in the query"
+                )
             table_type = (
                 scope.anonymous_tables[0] if len(scope.anonymous_tables) > 0 else list(scope.tables.values())[0]
             )
@@ -475,7 +479,7 @@ class Resolver(CloningVisitor):
             cte = lookup_cte_by_name(self.scopes, name)
             if cte:
                 if len(node.chain) > 1:
-                    raise ResolverException(f"Cannot access fields on CTE {cte.name} yet")
+                    raise ResolutionException(f"Cannot access fields on CTE {cte.name} yet")
                 # SubQuery CTEs ("WITH a AS (SELECT 1)") can only be used in the "FROM table" part of a select query,
                 # which is handled in visit_join_expr. Referring to it here means we want to access its value.
                 if cte.cte_type == "subquery":
@@ -486,7 +490,7 @@ class Resolver(CloningVisitor):
                 return response
 
         if not type:
-            raise ResolverException(f"Unable to resolve field: {name}")
+            raise ResolutionException(f"Unable to resolve field: {name}")
 
         # Recursively resolve the rest of the chain until we can point to the deepest node.
         field_name = node.chain[-1]
@@ -510,7 +514,9 @@ class Resolver(CloningVisitor):
 
             loop_type = loop_type.get_child(next_chain, self.context)
             if loop_type is None:
-                raise ResolverException(f"Cannot resolve type {'.'.join(node.chain)}. Unable to resolve {next_chain}.")
+                raise ResolutionException(
+                    f"Cannot resolve type {'.'.join(node.chain)}. Unable to resolve {next_chain}."
+                )
         node.type = loop_type
 
         if isinstance(node.type, ast.ExpressionFieldType):

--- a/posthog/hogql/resolver_utils.py
+++ b/posthog/hogql/resolver_utils.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from posthog import schema
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.errors import HogQLException, ResolverException, SyntaxException
+from posthog.hogql.errors import ResolutionException, SyntaxException
 from posthog.hogql.visitor import clone_expr
 
 
@@ -17,7 +17,7 @@ def lookup_field_by_name(scope: ast.SelectQueryType, name: str, context: HogQLCo
         tables_with_field = named_tables + anonymous_tables
 
         if len(tables_with_field) > 1:
-            raise ResolverException(f"Ambiguous query. Found multiple sources for field: {name}")
+            raise ResolutionException(f"Ambiguous query. Found multiple sources for field: {name}")
         elif len(tables_with_field) == 1:
             return tables_with_field[0].get_child(name, context)
 
@@ -50,7 +50,7 @@ def get_long_table_name(select: ast.SelectQueryType, type: ast.Type) -> str:
     elif isinstance(type, ast.VirtualTableType):
         return f"{get_long_table_name(select, type.table_type)}__{type.field}"
     else:
-        raise HogQLException(f"Unknown table type in LazyTableResolver: {type.__class__.__name__}")
+        raise ResolutionException(f"Unknown table type in LazyTableResolver: {type.__class__.__name__}")
 
 
 def ast_to_query_node(expr: ast.Expr | ast.HogQLXTag):
@@ -82,4 +82,4 @@ def convert_hogqlx_tag(node: ast.HogQLXTag, team_id: int):
         query = clone_expr(runner.to_query(), clear_locations=True)
         return query
     except Exception as e:
-        raise ResolverException(f"Error parsing query tag: {e}", start=node.start, end=node.end)
+        raise ResolutionException(f"Error parsing query tag: {e}", start=node.start, end=node.end)

--- a/posthog/hogql/resolver_utils.py
+++ b/posthog/hogql/resolver_utils.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from posthog import schema
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.errors import ResolutionException, SyntaxException
+from posthog.hogql.errors import ResolutionError, SyntaxError
 from posthog.hogql.visitor import clone_expr
 
 
@@ -17,7 +17,7 @@ def lookup_field_by_name(scope: ast.SelectQueryType, name: str, context: HogQLCo
         tables_with_field = named_tables + anonymous_tables
 
         if len(tables_with_field) > 1:
-            raise ResolutionException(f"Ambiguous query. Found multiple sources for field: {name}")
+            raise ResolutionError(f"Ambiguous query. Found multiple sources for field: {name}")
         elif len(tables_with_field) == 1:
             return tables_with_field[0].get_child(name, context)
 
@@ -50,7 +50,7 @@ def get_long_table_name(select: ast.SelectQueryType, type: ast.Type) -> str:
     elif isinstance(type, ast.VirtualTableType):
         return f"{get_long_table_name(select, type.table_type)}__{type.field}"
     else:
-        raise ResolutionException(f"Unknown table type in LazyTableResolver: {type.__class__.__name__}")
+        raise ResolutionError(f"Unknown table type in LazyTableResolver: {type.__class__.__name__}")
 
 
 def ast_to_query_node(expr: ast.Expr | ast.HogQLXTag):
@@ -67,9 +67,9 @@ def ast_to_query_node(expr: ast.Expr | ast.HogQLXTag):
                 attributes.pop("kind")
                 attributes = {key: ast_to_query_node(value) for key, value in attributes.items()}
                 return klass(**attributes)
-        raise SyntaxException(f'Tag of kind "{expr.kind}" not found in schema.')
+        raise SyntaxError(f'Tag of kind "{expr.kind}" not found in schema.')
     else:
-        raise SyntaxException(f'Expression of type "{type(expr).__name__}". Can\'t convert to constant.')
+        raise SyntaxError(f'Expression of type "{type(expr).__name__}". Can\'t convert to constant.')
 
 
 def convert_hogqlx_tag(node: ast.HogQLXTag, team_id: int):
@@ -82,4 +82,4 @@ def convert_hogqlx_tag(node: ast.HogQLXTag, team_id: int):
         query = clone_expr(runner.to_query(), clear_locations=True)
         return query
     except Exception as e:
-        raise ResolutionException(f"Error parsing query tag: {e}", start=node.start, end=node.end)
+        raise ResolutionError(f"Error parsing query tag: {e}", start=node.start, end=node.end)

--- a/posthog/hogql/test/_test_parse_string.py
+++ b/posthog/hogql/test/_test_parse_string.py
@@ -1,5 +1,5 @@
 from typing import Literal
-from posthog.hogql.errors import SyntaxException
+from posthog.hogql.errors import SyntaxError
 from posthog.hogql.parse_string import parse_string as parse_string_py
 from hogql_parser import unquote_string as unquote_string_cpp
 from posthog.test.base import BaseTest
@@ -52,7 +52,7 @@ def parse_string_test_factory(backend: Literal["python", "cpp"]):
 
         def test_raises_on_mismatched_quotes(self):
             self.assertRaisesMessage(
-                SyntaxException,
+                SyntaxError,
                 "Invalid string literal, must start and end with the same quote type: `asd'",
                 parse_string,
                 "`asd'",

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -3,7 +3,7 @@ from typing import Literal, cast, Optional, Dict
 import math
 
 from posthog.hogql import ast
-from posthog.hogql.errors import InternalHogQLException, SyntaxException
+from posthog.hogql.errors import ExposedHogQLException, SyntaxException
 from posthog.hogql.parser import parse_expr, parse_order_expr, parse_select
 from posthog.hogql.visitor import clear_locations
 from posthog.test.base import BaseTest, MemoryLeakTestMixin
@@ -1004,13 +1004,13 @@ def parser_test_factory(backend: Literal["python", "cpp"]):
             )
 
         def test_select_array_join_errors(self):
-            with self.assertRaises(InternalHogQLException) as e:
+            with self.assertRaises(ExposedHogQLException) as e:
                 self._select("select a from events ARRAY JOIN [1,2,3]")
             self.assertEqual(str(e.exception), "ARRAY JOIN arrays must have an alias")
             self.assertEqual(e.exception.start, 32)
             self.assertEqual(e.exception.end, 39)
 
-            with self.assertRaises(InternalHogQLException) as e:
+            with self.assertRaises(ExposedHogQLException) as e:
                 self._select("select a ARRAY JOIN [1,2,3]")
             self.assertEqual(
                 str(e.exception),
@@ -1532,14 +1532,14 @@ def parser_test_factory(backend: Literal["python", "cpp"]):
             )
 
             # With mismatched closing tag
-            with self.assertRaises(InternalHogQLException) as e:
+            with self.assertRaises(ExposedHogQLException) as e:
                 self._select(
                     "select event from <OuterQuery q='b'><HogQLQuery query='select event from events' /></HogQLQuery>"
                 )
             assert str(e.exception) == "Opening and closing HogQLX tags must match. Got OuterQuery and HogQLQuery"
 
             # With mismatched closing tag
-            with self.assertRaises(InternalHogQLException) as e:
+            with self.assertRaises(ExposedHogQLException) as e:
                 self._select(
                     "select event from <OuterQuery source='b'><HogQLQuery query='select event from events' /></OuterQuery>"
                 )

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -3,7 +3,7 @@ from typing import Literal, cast, Optional, Dict
 import math
 
 from posthog.hogql import ast
-from posthog.hogql.errors import HogQLException, SyntaxException
+from posthog.hogql.errors import InternalHogQLException, SyntaxException
 from posthog.hogql.parser import parse_expr, parse_order_expr, parse_select
 from posthog.hogql.visitor import clear_locations
 from posthog.test.base import BaseTest, MemoryLeakTestMixin
@@ -1004,13 +1004,13 @@ def parser_test_factory(backend: Literal["python", "cpp"]):
             )
 
         def test_select_array_join_errors(self):
-            with self.assertRaises(HogQLException) as e:
+            with self.assertRaises(InternalHogQLException) as e:
                 self._select("select a from events ARRAY JOIN [1,2,3]")
             self.assertEqual(str(e.exception), "ARRAY JOIN arrays must have an alias")
             self.assertEqual(e.exception.start, 32)
             self.assertEqual(e.exception.end, 39)
 
-            with self.assertRaises(HogQLException) as e:
+            with self.assertRaises(InternalHogQLException) as e:
                 self._select("select a ARRAY JOIN [1,2,3]")
             self.assertEqual(
                 str(e.exception),
@@ -1532,14 +1532,14 @@ def parser_test_factory(backend: Literal["python", "cpp"]):
             )
 
             # With mismatched closing tag
-            with self.assertRaises(HogQLException) as e:
+            with self.assertRaises(InternalHogQLException) as e:
                 self._select(
                     "select event from <OuterQuery q='b'><HogQLQuery query='select event from events' /></HogQLQuery>"
                 )
             assert str(e.exception) == "Opening and closing HogQLX tags must match. Got OuterQuery and HogQLQuery"
 
             # With mismatched closing tag
-            with self.assertRaises(HogQLException) as e:
+            with self.assertRaises(InternalHogQLException) as e:
                 self._select(
                     "select event from <OuterQuery source='b'><HogQLQuery query='select event from events' /></OuterQuery>"
                 )

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -3,7 +3,7 @@ from typing import Literal, cast, Optional, Dict
 import math
 
 from posthog.hogql import ast
-from posthog.hogql.errors import ExposedHogQLException, SyntaxException
+from posthog.hogql.errors import ExposedHogQLError, SyntaxError
 from posthog.hogql.parser import parse_expr, parse_order_expr, parse_select
 from posthog.hogql.visitor import clear_locations
 from posthog.test.base import BaseTest, MemoryLeakTestMixin
@@ -1004,13 +1004,13 @@ def parser_test_factory(backend: Literal["python", "cpp"]):
             )
 
         def test_select_array_join_errors(self):
-            with self.assertRaises(ExposedHogQLException) as e:
+            with self.assertRaises(ExposedHogQLError) as e:
                 self._select("select a from events ARRAY JOIN [1,2,3]")
             self.assertEqual(str(e.exception), "ARRAY JOIN arrays must have an alias")
             self.assertEqual(e.exception.start, 32)
             self.assertEqual(e.exception.end, 39)
 
-            with self.assertRaises(ExposedHogQLException) as e:
+            with self.assertRaises(ExposedHogQLError) as e:
                 self._select("select a ARRAY JOIN [1,2,3]")
             self.assertEqual(
                 str(e.exception),
@@ -1436,7 +1436,7 @@ def parser_test_factory(backend: Literal["python", "cpp"]):
         def test_property_access_with_arrays_zero_index_error(self):
             query = f"SELECT properties.something[0] FROM events"
             with self.assertRaisesMessage(
-                SyntaxException,
+                SyntaxError,
                 "SQL indexes start from one, not from zero. E.g: array[1]",
             ) as e:
                 self._select(query)
@@ -1446,7 +1446,7 @@ def parser_test_factory(backend: Literal["python", "cpp"]):
         def test_property_access_with_tuples_zero_index_error(self):
             query = f"SELECT properties.something.0 FROM events"
             with self.assertRaisesMessage(
-                SyntaxException,
+                SyntaxError,
                 "SQL indexes start from one, not from zero. E.g: array[1]",
             ) as e:
                 self._select(query)
@@ -1456,7 +1456,7 @@ def parser_test_factory(backend: Literal["python", "cpp"]):
         def test_reserved_keyword_alias_error(self):
             query = f"SELECT 0 AS trUE FROM events"
             with self.assertRaisesMessage(
-                SyntaxException,
+                SyntaxError,
                 '"trUE" cannot be an alias or identifier, as it\'s a reserved keyword',
             ) as e:
                 self._select(query)
@@ -1466,7 +1466,7 @@ def parser_test_factory(backend: Literal["python", "cpp"]):
         def test_malformed_sql(self):
             query = "SELEC 2"
             with self.assertRaisesMessage(
-                SyntaxException,
+                SyntaxError,
                 "mismatched input 'SELEC' expecting {SELECT, WITH, '{', '(', '<'}",
             ) as e:
                 self._select(query)
@@ -1532,14 +1532,14 @@ def parser_test_factory(backend: Literal["python", "cpp"]):
             )
 
             # With mismatched closing tag
-            with self.assertRaises(ExposedHogQLException) as e:
+            with self.assertRaises(ExposedHogQLError) as e:
                 self._select(
                     "select event from <OuterQuery q='b'><HogQLQuery query='select event from events' /></HogQLQuery>"
                 )
             assert str(e.exception) == "Opening and closing HogQLX tags must match. Got OuterQuery and HogQLQuery"
 
             # With mismatched closing tag
-            with self.assertRaises(ExposedHogQLException) as e:
+            with self.assertRaises(ExposedHogQLError) as e:
                 self._select(
                     "select event from <OuterQuery source='b'><HogQLQuery query='select event from events' /></OuterQuery>"
                 )

--- a/posthog/hogql/test/test_bytecode.py
+++ b/posthog/hogql/test/test_bytecode.py
@@ -1,6 +1,6 @@
 from posthog.hogql.bytecode import to_bytecode
 from hogvm.python.operation import Operation as op, HOGQL_BYTECODE_IDENTIFIER as _H
-from posthog.hogql.errors import NotImplementedException
+from posthog.hogql.errors import NotImplementedError
 from posthog.test.base import BaseTest
 
 
@@ -128,10 +128,10 @@ class TestBytecode(BaseTest):
         )
 
     def test_bytecode_create_error(self):
-        with self.assertRaises(NotImplementedException) as e:
+        with self.assertRaises(NotImplementedError) as e:
             to_bytecode("(select 1)")
         self.assertEqual(str(e.exception), "BytecodeBuilder has no method visit_select_query")
 
-        with self.assertRaises(NotImplementedException) as e:
+        with self.assertRaises(NotImplementedError) as e:
             to_bytecode("1 in cohort 2")
         self.assertEqual(str(e.exception), "Cohort operations are not supported")

--- a/posthog/hogql/test/test_escape_sql.py
+++ b/posthog/hogql/test/test_escape_sql.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import QueryException
 from posthog.hogql.escape_sql import (
     escape_hogql_identifier,
     escape_clickhouse_string,
@@ -126,7 +126,7 @@ class TestPrintString(BaseTest):
         )
 
     def test_escape_hogql_identifier_errors(self):
-        with self.assertRaises(HogQLException) as context:
+        with self.assertRaises(QueryException) as context:
             escape_hogql_identifier("with % percent")
         self.assertTrue(
             'The HogQL identifier "with % percent" is not permitted as it contains the "%" character'
@@ -134,7 +134,7 @@ class TestPrintString(BaseTest):
         )
 
     def test_escape_clickhouse_identifier_errors(self):
-        with self.assertRaises(HogQLException) as context:
+        with self.assertRaises(QueryException) as context:
             escape_clickhouse_identifier("with % percent")
         self.assertTrue(
             'The HogQL identifier "with % percent" is not permitted as it contains the "%" character'
@@ -144,6 +144,6 @@ class TestPrintString(BaseTest):
     def test_escape_clickhouse_string_errors(self):
         # This test is a stopgap. Think long and hard before adding support for printing dicts or objects.
         # Make sure string escaping happens at the right level, and % is tested through and through.
-        with self.assertRaises(HogQLException) as context:
+        with self.assertRaises(QueryException) as context:
             escape_clickhouse_string({"a": 1, "b": 2})  # type: ignore
         self.assertTrue("SQLValueEscaper has no method visit_dict" in str(context.exception))

--- a/posthog/hogql/test/test_escape_sql.py
+++ b/posthog/hogql/test/test_escape_sql.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from posthog.hogql.errors import QueryException
+from posthog.hogql.errors import QueryException, ResolutionException
 from posthog.hogql.escape_sql import (
     escape_hogql_identifier,
     escape_clickhouse_string,
@@ -144,6 +144,6 @@ class TestPrintString(BaseTest):
     def test_escape_clickhouse_string_errors(self):
         # This test is a stopgap. Think long and hard before adding support for printing dicts or objects.
         # Make sure string escaping happens at the right level, and % is tested through and through.
-        with self.assertRaises(QueryException) as context:
+        with self.assertRaises(ResolutionException) as context:
             escape_clickhouse_string({"a": 1, "b": 2})  # type: ignore
         self.assertTrue("SQLValueEscaper has no method visit_dict" in str(context.exception))

--- a/posthog/hogql/test/test_escape_sql.py
+++ b/posthog/hogql/test/test_escape_sql.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from posthog.hogql.errors import QueryException, ResolutionException
+from posthog.hogql.errors import QueryError, ResolutionError
 from posthog.hogql.escape_sql import (
     escape_hogql_identifier,
     escape_clickhouse_string,
@@ -126,7 +126,7 @@ class TestPrintString(BaseTest):
         )
 
     def test_escape_hogql_identifier_errors(self):
-        with self.assertRaises(QueryException) as context:
+        with self.assertRaises(QueryError) as context:
             escape_hogql_identifier("with % percent")
         self.assertTrue(
             'The HogQL identifier "with % percent" is not permitted as it contains the "%" character'
@@ -134,7 +134,7 @@ class TestPrintString(BaseTest):
         )
 
     def test_escape_clickhouse_identifier_errors(self):
-        with self.assertRaises(QueryException) as context:
+        with self.assertRaises(QueryError) as context:
             escape_clickhouse_identifier("with % percent")
         self.assertTrue(
             'The HogQL identifier "with % percent" is not permitted as it contains the "%" character'
@@ -144,6 +144,6 @@ class TestPrintString(BaseTest):
     def test_escape_clickhouse_string_errors(self):
         # This test is a stopgap. Think long and hard before adding support for printing dicts or objects.
         # Make sure string escaping happens at the right level, and % is tested through and through.
-        with self.assertRaises(ResolutionException) as context:
+        with self.assertRaises(ResolutionError) as context:
             escape_clickhouse_string({"a": 1, "b": 2})  # type: ignore
         self.assertTrue("SQLValueEscaper has no method visit_dict" in str(context.exception))

--- a/posthog/hogql/test/test_placeholders.py
+++ b/posthog/hogql/test/test_placeholders.py
@@ -1,6 +1,6 @@
 from typing import cast
 from posthog.hogql import ast
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import QueryException
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.placeholders import replace_placeholders, find_placeholders
 from posthog.test.base import BaseTest
@@ -25,13 +25,13 @@ class TestParser(BaseTest):
 
     def test_replace_placeholders_error(self):
         expr = ast.Placeholder(field="foo")
-        with self.assertRaises(HogQLException) as context:
+        with self.assertRaises(QueryException) as context:
             replace_placeholders(expr, {})
         self.assertEqual(
             "Placeholders, such as {foo}, are not supported in this context",
             str(context.exception),
         )
-        with self.assertRaises(HogQLException) as context:
+        with self.assertRaises(QueryException) as context:
             replace_placeholders(expr, {"bar": ast.Constant(value=123)})
         self.assertEqual(
             "Placeholder {foo} is not available in this context. You can use the following: bar",
@@ -64,7 +64,7 @@ class TestParser(BaseTest):
 
     def test_assert_no_placeholders(self):
         expr = ast.Placeholder(field="foo")
-        with self.assertRaises(HogQLException) as context:
+        with self.assertRaises(QueryException) as context:
             replace_placeholders(expr, None)
         self.assertEqual(
             "Placeholders, such as {foo}, are not supported in this context",

--- a/posthog/hogql/test/test_placeholders.py
+++ b/posthog/hogql/test/test_placeholders.py
@@ -1,6 +1,6 @@
 from typing import cast
 from posthog.hogql import ast
-from posthog.hogql.errors import QueryException
+from posthog.hogql.errors import QueryError
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.placeholders import replace_placeholders, find_placeholders
 from posthog.test.base import BaseTest
@@ -25,13 +25,13 @@ class TestParser(BaseTest):
 
     def test_replace_placeholders_error(self):
         expr = ast.Placeholder(field="foo")
-        with self.assertRaises(QueryException) as context:
+        with self.assertRaises(QueryError) as context:
             replace_placeholders(expr, {})
         self.assertEqual(
             "Placeholders, such as {foo}, are not supported in this context",
             str(context.exception),
         )
-        with self.assertRaises(QueryException) as context:
+        with self.assertRaises(QueryError) as context:
             replace_placeholders(expr, {"bar": ast.Constant(value=123)})
         self.assertEqual(
             "Placeholder {foo} is not available in this context. You can use the following: bar",
@@ -64,7 +64,7 @@ class TestParser(BaseTest):
 
     def test_assert_no_placeholders(self):
         expr = ast.Placeholder(field="foo")
-        with self.assertRaises(QueryException) as context:
+        with self.assertRaises(QueryError) as context:
             replace_placeholders(expr, None)
         self.assertEqual(
             "Placeholders, such as {foo}, are not supported in this context",

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -8,7 +8,7 @@ from posthog.hogql.constants import HogQLQuerySettings, HogQLGlobalSettings
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import DateDatabaseField, StringDatabaseField
-from posthog.hogql.errors import ExposedHogQLException, QueryException
+from posthog.hogql.errors import ExposedHogQLError, QueryError
 from posthog.hogql.hogql import translate_hogql
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import print_ast, to_printed_hogql
@@ -50,14 +50,14 @@ class TestPrinter(BaseTest):
         expected_error,
         dialect: Literal["hogql", "clickhouse"] = "clickhouse",
     ):
-        with self.assertRaises(ExposedHogQLException) as context:
+        with self.assertRaises(ExposedHogQLError) as context:
             self._expr(expr, None, dialect)
         if expected_error not in str(context.exception):
             raise AssertionError(f"Expected '{expected_error}' in '{str(context.exception)}'")
         self.assertTrue(expected_error in str(context.exception))
 
     def _assert_select_error(self, statement, expected_error):
-        with self.assertRaises(ExposedHogQLException) as context:
+        with self.assertRaises(ExposedHogQLError) as context:
             self._select(statement, None)
         if expected_error not in str(context.exception):
             raise AssertionError(f"Expected '{expected_error}' in '{str(context.exception)}'")
@@ -547,7 +547,7 @@ class TestPrinter(BaseTest):
             ),
             f"SELECT 1 FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 10000",
         )
-        with self.assertRaises(QueryException) as error_context:
+        with self.assertRaises(QueryError) as error_context:
             (
                 self._select(
                     "select 1 from {placeholder}",

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -8,7 +8,7 @@ from posthog.hogql.constants import HogQLQuerySettings, HogQLGlobalSettings
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import DateDatabaseField, StringDatabaseField
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import BaseHogQLException
 from posthog.hogql.hogql import translate_hogql
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import print_ast, to_printed_hogql
@@ -50,14 +50,14 @@ class TestPrinter(BaseTest):
         expected_error,
         dialect: Literal["hogql", "clickhouse"] = "clickhouse",
     ):
-        with self.assertRaises(HogQLException) as context:
+        with self.assertRaises(BaseHogQLException) as context:
             self._expr(expr, None, dialect)
         if expected_error not in str(context.exception):
             raise AssertionError(f"Expected '{expected_error}' in '{str(context.exception)}'")
         self.assertTrue(expected_error in str(context.exception))
 
     def _assert_select_error(self, statement, expected_error):
-        with self.assertRaises(HogQLException) as context:
+        with self.assertRaises(BaseHogQLException) as context:
             self._select(statement, None)
         if expected_error not in str(context.exception):
             raise AssertionError(f"Expected '{expected_error}' in '{str(context.exception)}'")
@@ -547,7 +547,7 @@ class TestPrinter(BaseTest):
             ),
             f"SELECT 1 FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 10000",
         )
-        with self.assertRaises(HogQLException) as error_context:
+        with self.assertRaises(BaseHogQLException) as error_context:
             (
                 self._select(
                     "select 1 from {placeholder}",
@@ -888,7 +888,7 @@ class TestPrinter(BaseTest):
         self.team.save()
 
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
-        with self.assertRaises(HogQLException) as error_context:
+        with self.assertRaises(BaseHogQLException) as error_context:
             self._select(
                 "SELECT now(), toDateTime(timestamp), toDateTime('2020-02-02') FROM events",
                 context,

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -8,7 +8,7 @@ from posthog.hogql.constants import HogQLQuerySettings, HogQLGlobalSettings
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 from posthog.hogql.database.models import DateDatabaseField, StringDatabaseField
-from posthog.hogql.errors import BaseHogQLException
+from posthog.hogql.errors import ExposedHogQLException, QueryException
 from posthog.hogql.hogql import translate_hogql
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import print_ast, to_printed_hogql
@@ -50,14 +50,14 @@ class TestPrinter(BaseTest):
         expected_error,
         dialect: Literal["hogql", "clickhouse"] = "clickhouse",
     ):
-        with self.assertRaises(BaseHogQLException) as context:
+        with self.assertRaises(ExposedHogQLException) as context:
             self._expr(expr, None, dialect)
         if expected_error not in str(context.exception):
             raise AssertionError(f"Expected '{expected_error}' in '{str(context.exception)}'")
         self.assertTrue(expected_error in str(context.exception))
 
     def _assert_select_error(self, statement, expected_error):
-        with self.assertRaises(BaseHogQLException) as context:
+        with self.assertRaises(ExposedHogQLException) as context:
             self._select(statement, None)
         if expected_error not in str(context.exception):
             raise AssertionError(f"Expected '{expected_error}' in '{str(context.exception)}'")
@@ -547,7 +547,7 @@ class TestPrinter(BaseTest):
             ),
             f"SELECT 1 FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 10000",
         )
-        with self.assertRaises(BaseHogQLException) as error_context:
+        with self.assertRaises(QueryException) as error_context:
             (
                 self._select(
                     "select 1 from {placeholder}",
@@ -562,7 +562,7 @@ class TestPrinter(BaseTest):
             )
         self.assertEqual(
             str(error_context.exception),
-            "JoinExpr with table of type CompareOperation not supported",
+            "A CompareOperation cannot be used as a SELECT source",
         )
 
     def test_select_cross_join(self):
@@ -888,7 +888,7 @@ class TestPrinter(BaseTest):
         self.team.save()
 
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
-        with self.assertRaises(BaseHogQLException) as error_context:
+        with self.assertRaises(ValueError) as error_context:
             self._select(
                 "SELECT now(), toDateTime(timestamp), toDateTime('2020-02-02') FROM events",
                 context,

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 
 from posthog import datetime
 from posthog.hogql import ast
-from posthog.hogql.errors import SyntaxException, HogQLException
+from posthog.hogql.errors import SyntaxException, QueryException
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.test.utils import pretty_print_in_tests, pretty_print_response_in_tests
@@ -1272,17 +1272,17 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         )
 
         query = f"SELECT number from numbers"
-        with self.assertRaises(HogQLException) as e:
+        with self.assertRaises(QueryException) as e:
             execute_hogql_query(query, team=self.team)
         self.assertEqual(str(e.exception), "Table function 'numbers' requires arguments")
 
         query = f"SELECT number from numbers()"
-        with self.assertRaises(HogQLException) as e:
+        with self.assertRaises(QueryException) as e:
             execute_hogql_query(query, team=self.team)
         self.assertEqual(str(e.exception), "Table function 'numbers' requires at least 1 argument")
 
         query = f"SELECT number from numbers(1,2,3)"
-        with self.assertRaises(HogQLException) as e:
+        with self.assertRaises(QueryException) as e:
             execute_hogql_query(query, team=self.team)
         self.assertEqual(str(e.exception), "Table function 'numbers' requires at most 2 arguments")
 
@@ -1322,7 +1322,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_events_table_error_if_function(self):
         query = "SELECT * from events(1, 4)"
-        with self.assertRaises(HogQLException) as e:
+        with self.assertRaises(QueryException) as e:
             execute_hogql_query(query, team=self.team)
         self.assertEqual(str(e.exception), "Table 'events' does not accept arguments")
 
@@ -1380,7 +1380,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_hogql_query_filters_double_error(self):
         query = "SELECT event from events where {filters}"
-        with self.assertRaises(HogQLException) as e:
+        with self.assertRaises(QueryException) as e:
             execute_hogql_query(
                 query,
                 team=self.team,

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -1380,7 +1380,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_hogql_query_filters_double_error(self):
         query = "SELECT event from events where {filters}"
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(ValueError) as e:
             execute_hogql_query(
                 query,
                 team=self.team,

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 
 from posthog import datetime
 from posthog.hogql import ast
-from posthog.hogql.errors import SyntaxException, QueryException
+from posthog.hogql.errors import SyntaxError, QueryError
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.test.utils import pretty_print_in_tests, pretty_print_response_in_tests
@@ -1018,12 +1018,12 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_property_access_with_arrays_zero_index_error(self):
         query = f"SELECT properties.something[0] FROM events"
-        with self.assertRaises(SyntaxException) as e:
+        with self.assertRaises(SyntaxError) as e:
             execute_hogql_query(query, team=self.team)
         self.assertEqual(str(e.exception), "SQL indexes start from one, not from zero. E.g: array[1]")
 
         query = f"SELECT properties.something.0 FROM events"
-        with self.assertRaises(SyntaxException) as e:
+        with self.assertRaises(SyntaxError) as e:
             execute_hogql_query(query, team=self.team)
         self.assertEqual(str(e.exception), "SQL indexes start from one, not from zero. E.g: array[1]")
 
@@ -1272,17 +1272,17 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         )
 
         query = f"SELECT number from numbers"
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             execute_hogql_query(query, team=self.team)
         self.assertEqual(str(e.exception), "Table function 'numbers' requires arguments")
 
         query = f"SELECT number from numbers()"
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             execute_hogql_query(query, team=self.team)
         self.assertEqual(str(e.exception), "Table function 'numbers' requires at least 1 argument")
 
         query = f"SELECT number from numbers(1,2,3)"
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             execute_hogql_query(query, team=self.team)
         self.assertEqual(str(e.exception), "Table function 'numbers' requires at most 2 arguments")
 
@@ -1322,7 +1322,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_events_table_error_if_function(self):
         query = "SELECT * from events(1, 4)"
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             execute_hogql_query(query, team=self.team)
         self.assertEqual(str(e.exception), "Table 'events' does not accept arguments")
 

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -16,12 +16,12 @@ from posthog.hogql.database.models import (
     StringDatabaseField,
     DateTimeDatabaseField,
 )
-from posthog.hogql.errors import QueryException
+from posthog.hogql.errors import QueryError
 from posthog.hogql.test.utils import pretty_dataclasses
 from posthog.hogql.visitor import clone_expr
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import print_ast, print_prepared_ast
-from posthog.hogql.resolver import ResolutionException, resolve_types
+from posthog.hogql.resolver import ResolutionError, resolve_types
 from posthog.test.base import BaseTest
 
 
@@ -55,7 +55,7 @@ class TestResolver(BaseTest):
     def test_will_not_run_twice(self):
         expr = self._select("SELECT event, events.timestamp FROM events WHERE events.event = 'test'")
         expr = resolve_types(expr, self.context, dialect="clickhouse")
-        with self.assertRaises(ResolutionException) as context:
+        with self.assertRaises(ResolutionError) as context:
             expr = resolve_types(expr, self.context, dialect="clickhouse")
         self.assertEqual(
             str(context.exception),
@@ -85,7 +85,7 @@ class TestResolver(BaseTest):
         expr = self._select(
             "SELECT event, (select count() from events where event = e.event) as c FROM events e where event = '$pageview'"
         )
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             expr = resolve_types(expr, self.context, dialect="clickhouse")
         self.assertEqual(str(e.exception), "Unable to resolve field: e")
 
@@ -121,7 +121,7 @@ class TestResolver(BaseTest):
             "SELECT x.y FROM (SELECT event as y FROM events AS x) AS t",
         ]
         for query in queries:
-            with self.assertRaises(QueryException) as e:
+            with self.assertRaises(QueryError) as e:
                 resolve_types(self._select(query), self.context, dialect="clickhouse")
             self.assertIn("Unable to resolve field:", str(e.exception))
 
@@ -174,7 +174,7 @@ class TestResolver(BaseTest):
         assert pretty_dataclasses(node) == self.snapshot
 
     def test_ctes_loop(self):
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             self._print_hogql("with cte as (select * from cte) select * from cte")
         self.assertIn("Too many CTE expansions (50+). Probably a CTE loop.", str(e.exception))
 
@@ -190,7 +190,7 @@ class TestResolver(BaseTest):
         )
 
     def test_ctes_field_access(self):
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             self._print_hogql("with properties as cte select cte.$browser from events")
         self.assertIn("Cannot access fields on CTE cte yet", str(e.exception))
 
@@ -279,7 +279,7 @@ class TestResolver(BaseTest):
 
     def test_asterisk_expander_multiple_table_error(self):
         node = self._select("select * from (select 1 as a, 2 as b) x left join (select 1 as a, 2 as b) y on x.a = y.a")
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             resolve_types(node, self.context, dialect="clickhouse")
         self.assertEqual(
             str(e.exception),

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -20,7 +20,7 @@ from posthog.hogql.test.utils import pretty_dataclasses
 from posthog.hogql.visitor import clone_expr
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import print_ast, print_prepared_ast
-from posthog.hogql.resolver import ResolverException, resolve_types
+from posthog.hogql.resolver import ResolutionException, resolve_types
 from posthog.test.base import BaseTest
 
 
@@ -54,7 +54,7 @@ class TestResolver(BaseTest):
     def test_will_not_run_twice(self):
         expr = self._select("SELECT event, events.timestamp FROM events WHERE events.event = 'test'")
         expr = resolve_types(expr, self.context, dialect="clickhouse")
-        with self.assertRaises(ResolverException) as context:
+        with self.assertRaises(ResolutionException) as context:
             expr = resolve_types(expr, self.context, dialect="clickhouse")
         self.assertEqual(
             str(context.exception),
@@ -84,7 +84,7 @@ class TestResolver(BaseTest):
         expr = self._select(
             "SELECT event, (select count() from events where event = e.event) as c FROM events e where event = '$pageview'"
         )
-        with self.assertRaises(ResolverException) as e:
+        with self.assertRaises(ResolutionException) as e:
             expr = resolve_types(expr, self.context, dialect="clickhouse")
         self.assertEqual(str(e.exception), "Unable to resolve field: e")
 
@@ -120,7 +120,7 @@ class TestResolver(BaseTest):
             "SELECT x.y FROM (SELECT event as y FROM events AS x) AS t",
         ]
         for query in queries:
-            with self.assertRaises(ResolverException) as e:
+            with self.assertRaises(ResolutionException) as e:
                 resolve_types(self._select(query), self.context, dialect="clickhouse")
             self.assertIn("Unable to resolve field:", str(e.exception))
 
@@ -173,7 +173,7 @@ class TestResolver(BaseTest):
         assert pretty_dataclasses(node) == self.snapshot
 
     def test_ctes_loop(self):
-        with self.assertRaises(ResolverException) as e:
+        with self.assertRaises(ResolutionException) as e:
             self._print_hogql("with cte as (select * from cte) select * from cte")
         self.assertIn("Too many CTE expansions (50+). Probably a CTE loop.", str(e.exception))
 
@@ -189,7 +189,7 @@ class TestResolver(BaseTest):
         )
 
     def test_ctes_field_access(self):
-        with self.assertRaises(ResolverException) as e:
+        with self.assertRaises(ResolutionException) as e:
             self._print_hogql("with properties as cte select cte.$browser from events")
         self.assertIn("Cannot access fields on CTE cte yet", str(e.exception))
 
@@ -278,7 +278,7 @@ class TestResolver(BaseTest):
 
     def test_asterisk_expander_multiple_table_error(self):
         node = self._select("select * from (select 1 as a, 2 as b) x left join (select 1 as a, 2 as b) y on x.a = y.a")
-        with self.assertRaises(ResolverException) as e:
+        with self.assertRaises(ResolutionException) as e:
             resolve_types(node, self.context, dialect="clickhouse")
         self.assertEqual(
             str(e.exception),

--- a/posthog/hogql/test/test_visitor.py
+++ b/posthog/hogql/test/test_visitor.py
@@ -1,6 +1,6 @@
 from posthog.hogql import ast
 from posthog.hogql.ast import UUIDType, HogQLXTag, HogQLXAttribute
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import InternalHogQLException
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.visitor import CloningVisitor, Visitor, TraversingVisitor
 from posthog.test.base import BaseTest
@@ -123,7 +123,7 @@ class TestVisitor(BaseTest):
             def visit_arithmetic_operation(self, node: ast.ArithmeticOperation):
                 return self.visit(node.left) + node.op + self.visit(node.right)
 
-        with self.assertRaises(HogQLException) as e:
+        with self.assertRaises(InternalHogQLException) as e:
             UnknownNotDefinedVisitor().visit(parse_expr("1 + 3 / 'asd2'"))
         self.assertEqual(str(e.exception), "UnknownNotDefinedVisitor has no method visit_constant")
 
@@ -131,9 +131,9 @@ class TestVisitor(BaseTest):
         class EternalVisitor(TraversingVisitor):
             def visit_constant(self, node: ast.Constant):
                 if node.value == 616:
-                    raise HogQLException("You tried accessing a forbidden number, perish!")
+                    raise InternalHogQLException("You tried accessing a forbidden number, perish!")
 
-        with self.assertRaises(HogQLException) as e:
+        with self.assertRaises(InternalHogQLException) as e:
             EternalVisitor().visit(parse_expr("1 + 616 / 'asd2'"))
         self.assertEqual(str(e.exception), "You tried accessing a forbidden number, perish!")
         self.assertEqual(e.exception.start, 4)

--- a/posthog/hogql/test/test_visitor.py
+++ b/posthog/hogql/test/test_visitor.py
@@ -1,6 +1,6 @@
 from posthog.hogql import ast
 from posthog.hogql.ast import UUIDType, HogQLXTag, HogQLXAttribute
-from posthog.hogql.errors import InternalHogQLException
+from posthog.hogql.errors import InternalHogQLError
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.visitor import CloningVisitor, Visitor, TraversingVisitor
 from posthog.test.base import BaseTest
@@ -123,7 +123,7 @@ class TestVisitor(BaseTest):
             def visit_arithmetic_operation(self, node: ast.ArithmeticOperation):
                 return self.visit(node.left) + node.op + self.visit(node.right)
 
-        with self.assertRaises(InternalHogQLException) as e:
+        with self.assertRaises(InternalHogQLError) as e:
             UnknownNotDefinedVisitor().visit(parse_expr("1 + 3 / 'asd2'"))
         self.assertEqual(str(e.exception), "UnknownNotDefinedVisitor has no method visit_constant")
 
@@ -131,9 +131,9 @@ class TestVisitor(BaseTest):
         class EternalVisitor(TraversingVisitor):
             def visit_constant(self, node: ast.Constant):
                 if node.value == 616:
-                    raise InternalHogQLException("You tried accessing a forbidden number, perish!")
+                    raise InternalHogQLError("You tried accessing a forbidden number, perish!")
 
-        with self.assertRaises(InternalHogQLException) as e:
+        with self.assertRaises(InternalHogQLError) as e:
             EternalVisitor().visit(parse_expr("1 + 616 / 'asd2'"))
         self.assertEqual(str(e.exception), "You tried accessing a forbidden number, perish!")
         self.assertEqual(e.exception.start, 4)

--- a/posthog/hogql/transforms/in_cohort.py
+++ b/posthog/hogql/transforms/in_cohort.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple, cast, Literal
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.errors import ResolutionException
+from posthog.hogql.errors import QueryException
 from posthog.hogql.escape_sql import escape_clickhouse_string
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.resolver import resolve_types
@@ -90,7 +90,7 @@ class MultipleInCohortResolver(TraversingVisitor):
         for node in compare_operations:
             arg = node.right
             if not isinstance(arg, ast.Constant):
-                raise ResolutionException("IN COHORT only works with constant arguments", node=arg)
+                raise QueryException("IN COHORT only works with constant arguments", node=arg)
 
             if (isinstance(arg.value, int) or isinstance(arg.value, float)) and not isinstance(arg.value, bool):
                 int_cohorts = Cohort.objects.filter(id=int(arg.value), team_id=self.context.team_id).values_list(
@@ -98,7 +98,7 @@ class MultipleInCohortResolver(TraversingVisitor):
                 )
                 if len(int_cohorts) == 1:
                     if node.op == ast.CompareOperationOp.NotInCohort:
-                        raise ResolutionException("NOT IN COHORT is not supported by this cohort mode")
+                        raise QueryException("NOT IN COHORT is not supported by this cohort mode")
 
                     id = int_cohorts[0][0]
                     is_static = int_cohorts[0][1]
@@ -106,7 +106,7 @@ class MultipleInCohortResolver(TraversingVisitor):
 
                     cohorts.append((id, "static" if is_static else "dynamic", version))
                     continue
-                raise ResolutionException(f"Could not find cohort with id {arg.value}", node=arg)
+                raise QueryException(f"Could not find cohort with ID {arg.value}", node=arg)
 
             if isinstance(arg.value, str):
                 str_cohorts = Cohort.objects.filter(name=arg.value, team_id=self.context.team_id).values_list(
@@ -114,7 +114,7 @@ class MultipleInCohortResolver(TraversingVisitor):
                 )
                 if len(str_cohorts) == 1:
                     if node.op == ast.CompareOperationOp.NotInCohort:
-                        raise ResolutionException("NOT IN COHORT is not supported by this cohort mode")
+                        raise QueryException("NOT IN COHORT is not supported by this cohort mode")
 
                     id = str_cohorts[0][0]
                     is_static = str_cohorts[0][1]
@@ -123,10 +123,10 @@ class MultipleInCohortResolver(TraversingVisitor):
                     cohorts.append((id, "static" if is_static else "dynamic", version))
                     continue
                 elif len(str_cohorts) > 1:
-                    raise ResolutionException(f"Found multiple cohorts with name '{arg.value}'", node=arg)
-                raise ResolutionException(f"Could not find a cohort with the name '{arg.value}'", node=arg)
+                    raise QueryException(f"Found multiple cohorts with name '{arg.value}'", node=arg)
+                raise QueryException(f"Could not find a cohort with the name '{arg.value}'", node=arg)
 
-            raise ResolutionException("cohort() takes exactly one string or integer argument", node=arg)
+            raise QueryException("cohort() takes exactly one string or integer argument", node=arg)
 
         return cohorts
 
@@ -281,7 +281,7 @@ class InCohortResolver(TraversingVisitor):
         if node.op == ast.CompareOperationOp.InCohort or node.op == ast.CompareOperationOp.NotInCohort:
             arg = node.right
             if not isinstance(arg, ast.Constant):
-                raise ResolutionException("IN COHORT only works with constant arguments", node=arg)
+                raise QueryException("IN COHORT only works with constant arguments", node=arg)
 
             from posthog.models import Cohort
 
@@ -304,7 +304,7 @@ class InCohortResolver(TraversingVisitor):
                         negative=node.op == ast.CompareOperationOp.NotInCohort,
                     )
                     return
-                raise ResolutionException(f"Could not find cohort with id {arg.value}", node=arg)
+                raise QueryException(f"Could not find cohort with ID {arg.value}", node=arg)
 
             if isinstance(arg.value, str):
                 cohorts = Cohort.objects.filter(name=arg.value, team_id=self.context.team_id).values_list(
@@ -326,8 +326,8 @@ class InCohortResolver(TraversingVisitor):
                     )
                     return
                 elif len(cohorts) > 1:
-                    raise ResolutionException(f"Found multiple cohorts with name '{arg.value}'", node=arg)
-                raise ResolutionException(f"Could not find a cohort with the name '{arg.value}'", node=arg)
+                    raise QueryException(f"Found multiple cohorts with name '{arg.value}'", node=arg)
+                raise QueryException(f"Could not find a cohort with the name '{arg.value}'", node=arg)
         else:
             self.visit(node.left)
             self.visit(node.right)

--- a/posthog/hogql/transforms/in_cohort.py
+++ b/posthog/hogql/transforms/in_cohort.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple, cast, Literal
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.errors import QueryException
+from posthog.hogql.errors import QueryError
 from posthog.hogql.escape_sql import escape_clickhouse_string
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.resolver import resolve_types
@@ -90,7 +90,7 @@ class MultipleInCohortResolver(TraversingVisitor):
         for node in compare_operations:
             arg = node.right
             if not isinstance(arg, ast.Constant):
-                raise QueryException("IN COHORT only works with constant arguments", node=arg)
+                raise QueryError("IN COHORT only works with constant arguments", node=arg)
 
             if (isinstance(arg.value, int) or isinstance(arg.value, float)) and not isinstance(arg.value, bool):
                 int_cohorts = Cohort.objects.filter(id=int(arg.value), team_id=self.context.team_id).values_list(
@@ -98,7 +98,7 @@ class MultipleInCohortResolver(TraversingVisitor):
                 )
                 if len(int_cohorts) == 1:
                     if node.op == ast.CompareOperationOp.NotInCohort:
-                        raise QueryException("NOT IN COHORT is not supported by this cohort mode")
+                        raise QueryError("NOT IN COHORT is not supported by this cohort mode")
 
                     id = int_cohorts[0][0]
                     is_static = int_cohorts[0][1]
@@ -106,7 +106,7 @@ class MultipleInCohortResolver(TraversingVisitor):
 
                     cohorts.append((id, "static" if is_static else "dynamic", version))
                     continue
-                raise QueryException(f"Could not find cohort with ID {arg.value}", node=arg)
+                raise QueryError(f"Could not find cohort with ID {arg.value}", node=arg)
 
             if isinstance(arg.value, str):
                 str_cohorts = Cohort.objects.filter(name=arg.value, team_id=self.context.team_id).values_list(
@@ -114,7 +114,7 @@ class MultipleInCohortResolver(TraversingVisitor):
                 )
                 if len(str_cohorts) == 1:
                     if node.op == ast.CompareOperationOp.NotInCohort:
-                        raise QueryException("NOT IN COHORT is not supported by this cohort mode")
+                        raise QueryError("NOT IN COHORT is not supported by this cohort mode")
 
                     id = str_cohorts[0][0]
                     is_static = str_cohorts[0][1]
@@ -123,10 +123,10 @@ class MultipleInCohortResolver(TraversingVisitor):
                     cohorts.append((id, "static" if is_static else "dynamic", version))
                     continue
                 elif len(str_cohorts) > 1:
-                    raise QueryException(f"Found multiple cohorts with name '{arg.value}'", node=arg)
-                raise QueryException(f"Could not find a cohort with the name '{arg.value}'", node=arg)
+                    raise QueryError(f"Found multiple cohorts with name '{arg.value}'", node=arg)
+                raise QueryError(f"Could not find a cohort with the name '{arg.value}'", node=arg)
 
-            raise QueryException("cohort() takes exactly one string or integer argument", node=arg)
+            raise QueryError("cohort() takes exactly one string or integer argument", node=arg)
 
         return cohorts
 
@@ -281,7 +281,7 @@ class InCohortResolver(TraversingVisitor):
         if node.op == ast.CompareOperationOp.InCohort or node.op == ast.CompareOperationOp.NotInCohort:
             arg = node.right
             if not isinstance(arg, ast.Constant):
-                raise QueryException("IN COHORT only works with constant arguments", node=arg)
+                raise QueryError("IN COHORT only works with constant arguments", node=arg)
 
             from posthog.models import Cohort
 
@@ -304,7 +304,7 @@ class InCohortResolver(TraversingVisitor):
                         negative=node.op == ast.CompareOperationOp.NotInCohort,
                     )
                     return
-                raise QueryException(f"Could not find cohort with ID {arg.value}", node=arg)
+                raise QueryError(f"Could not find cohort with ID {arg.value}", node=arg)
 
             if isinstance(arg.value, str):
                 cohorts = Cohort.objects.filter(name=arg.value, team_id=self.context.team_id).values_list(
@@ -326,8 +326,8 @@ class InCohortResolver(TraversingVisitor):
                     )
                     return
                 elif len(cohorts) > 1:
-                    raise QueryException(f"Found multiple cohorts with name '{arg.value}'", node=arg)
-                raise QueryException(f"Could not find a cohort with the name '{arg.value}'", node=arg)
+                    raise QueryError(f"Found multiple cohorts with name '{arg.value}'", node=arg)
+                raise QueryError(f"Could not find a cohort with the name '{arg.value}'", node=arg)
         else:
             self.visit(node.left)
             self.visit(node.right)

--- a/posthog/hogql/transforms/in_cohort.py
+++ b/posthog/hogql/transforms/in_cohort.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple, cast, Literal
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ResolutionException
 from posthog.hogql.escape_sql import escape_clickhouse_string
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.resolver import resolve_types
@@ -90,7 +90,7 @@ class MultipleInCohortResolver(TraversingVisitor):
         for node in compare_operations:
             arg = node.right
             if not isinstance(arg, ast.Constant):
-                raise HogQLException("IN COHORT only works with constant arguments", node=arg)
+                raise ResolutionException("IN COHORT only works with constant arguments", node=arg)
 
             if (isinstance(arg.value, int) or isinstance(arg.value, float)) and not isinstance(arg.value, bool):
                 int_cohorts = Cohort.objects.filter(id=int(arg.value), team_id=self.context.team_id).values_list(
@@ -98,7 +98,7 @@ class MultipleInCohortResolver(TraversingVisitor):
                 )
                 if len(int_cohorts) == 1:
                     if node.op == ast.CompareOperationOp.NotInCohort:
-                        raise HogQLException("NOT IN COHORT is not supported by this cohort mode")
+                        raise ResolutionException("NOT IN COHORT is not supported by this cohort mode")
 
                     id = int_cohorts[0][0]
                     is_static = int_cohorts[0][1]
@@ -106,7 +106,7 @@ class MultipleInCohortResolver(TraversingVisitor):
 
                     cohorts.append((id, "static" if is_static else "dynamic", version))
                     continue
-                raise HogQLException(f"Could not find cohort with id {arg.value}", node=arg)
+                raise ResolutionException(f"Could not find cohort with id {arg.value}", node=arg)
 
             if isinstance(arg.value, str):
                 str_cohorts = Cohort.objects.filter(name=arg.value, team_id=self.context.team_id).values_list(
@@ -114,7 +114,7 @@ class MultipleInCohortResolver(TraversingVisitor):
                 )
                 if len(str_cohorts) == 1:
                     if node.op == ast.CompareOperationOp.NotInCohort:
-                        raise HogQLException("NOT IN COHORT is not supported by this cohort mode")
+                        raise ResolutionException("NOT IN COHORT is not supported by this cohort mode")
 
                     id = str_cohorts[0][0]
                     is_static = str_cohorts[0][1]
@@ -123,10 +123,10 @@ class MultipleInCohortResolver(TraversingVisitor):
                     cohorts.append((id, "static" if is_static else "dynamic", version))
                     continue
                 elif len(str_cohorts) > 1:
-                    raise HogQLException(f"Found multiple cohorts with name '{arg.value}'", node=arg)
-                raise HogQLException(f"Could not find a cohort with the name '{arg.value}'", node=arg)
+                    raise ResolutionException(f"Found multiple cohorts with name '{arg.value}'", node=arg)
+                raise ResolutionException(f"Could not find a cohort with the name '{arg.value}'", node=arg)
 
-            raise HogQLException("cohort() takes exactly one string or integer argument", node=arg)
+            raise ResolutionException("cohort() takes exactly one string or integer argument", node=arg)
 
         return cohorts
 
@@ -281,7 +281,7 @@ class InCohortResolver(TraversingVisitor):
         if node.op == ast.CompareOperationOp.InCohort or node.op == ast.CompareOperationOp.NotInCohort:
             arg = node.right
             if not isinstance(arg, ast.Constant):
-                raise HogQLException("IN COHORT only works with constant arguments", node=arg)
+                raise ResolutionException("IN COHORT only works with constant arguments", node=arg)
 
             from posthog.models import Cohort
 
@@ -304,7 +304,7 @@ class InCohortResolver(TraversingVisitor):
                         negative=node.op == ast.CompareOperationOp.NotInCohort,
                     )
                     return
-                raise HogQLException(f"Could not find cohort with id {arg.value}", node=arg)
+                raise ResolutionException(f"Could not find cohort with id {arg.value}", node=arg)
 
             if isinstance(arg.value, str):
                 cohorts = Cohort.objects.filter(name=arg.value, team_id=self.context.team_id).values_list(
@@ -326,8 +326,8 @@ class InCohortResolver(TraversingVisitor):
                     )
                     return
                 elif len(cohorts) > 1:
-                    raise HogQLException(f"Found multiple cohorts with name '{arg.value}'", node=arg)
-                raise HogQLException(f"Could not find a cohort with the name '{arg.value}'", node=arg)
+                    raise ResolutionException(f"Found multiple cohorts with name '{arg.value}'", node=arg)
+                raise ResolutionException(f"Could not find a cohort with the name '{arg.value}'", node=arg)
         else:
             self.visit(node.left)
             self.visit(node.right)

--- a/posthog/hogql/transforms/lazy_tables.py
+++ b/posthog/hogql/transforms/lazy_tables.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, cast, Literal
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import LazyJoin, LazyTable
-from posthog.hogql.errors import ResolutionException
+from posthog.hogql.errors import ResolutionError
 from posthog.hogql.resolver import resolve_types
 from posthog.hogql.resolver_utils import get_long_table_name
 from posthog.hogql.visitor import TraversingVisitor, clone_expr
@@ -94,7 +94,7 @@ class LazyTableResolver(TraversingVisitor):
             else:
                 # Place the property in a list for processing in "visit_select_query"
                 if len(self.stack_of_fields) == 0:
-                    raise ResolutionException("Can't access a lazy field when not in a SelectQuery context")
+                    raise ResolutionError("Can't access a lazy field when not in a SelectQuery context")
                 self.stack_of_fields[-1].append(node)
 
     def visit_field_type(self, node: ast.FieldType):
@@ -106,13 +106,13 @@ class LazyTableResolver(TraversingVisitor):
         if isinstance(table_type, ast.LazyJoinType) or isinstance(table_type, ast.LazyTableType):
             # Each time we find a field, we place it in a list for processing in "visit_select_query"
             if len(self.stack_of_fields) == 0:
-                raise ResolutionException("Can't access a lazy field when not in a SelectQuery context")
+                raise ResolutionError("Can't access a lazy field when not in a SelectQuery context")
             self.stack_of_fields[-1].append(node)
 
     def visit_select_query(self, node: ast.SelectQuery):
         select_type = node.type
         if not select_type:
-            raise ResolutionException("Select query must have a type")
+            raise ResolutionError("Select query must have a type")
 
         assert node.type is not None
         assert select_type is not None
@@ -170,7 +170,7 @@ class LazyTableResolver(TraversingVisitor):
                 property = field_or_property
                 field = property.field_type
             else:
-                raise ResolutionException("Should not be reachable")
+                raise ResolutionError("Should not be reachable")
             table_type = field.table_type
 
             # Traverse the lazy tables until we reach a real table, collecting them in a list.
@@ -382,7 +382,7 @@ class LazyTableResolver(TraversingVisitor):
             elif isinstance(field_or_property, ast.PropertyType):
                 table_type = field_or_property.field_type.table_type
             else:
-                raise ResolutionException("Should not be reachable")
+                raise ResolutionError("Should not be reachable")
 
             table_name = get_long_table_name(select_type, table_type)
             table_type = select_type.tables[table_name]

--- a/posthog/hogql/transforms/lazy_tables.py
+++ b/posthog/hogql/transforms/lazy_tables.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, cast, Literal
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import LazyJoin, LazyTable
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ResolutionException
 from posthog.hogql.resolver import resolve_types
 from posthog.hogql.resolver_utils import get_long_table_name
 from posthog.hogql.visitor import TraversingVisitor, clone_expr
@@ -94,7 +94,7 @@ class LazyTableResolver(TraversingVisitor):
             else:
                 # Place the property in a list for processing in "visit_select_query"
                 if len(self.stack_of_fields) == 0:
-                    raise HogQLException("Can't access a lazy field when not in a SelectQuery context")
+                    raise ResolutionException("Can't access a lazy field when not in a SelectQuery context")
                 self.stack_of_fields[-1].append(node)
 
     def visit_field_type(self, node: ast.FieldType):
@@ -106,13 +106,13 @@ class LazyTableResolver(TraversingVisitor):
         if isinstance(table_type, ast.LazyJoinType) or isinstance(table_type, ast.LazyTableType):
             # Each time we find a field, we place it in a list for processing in "visit_select_query"
             if len(self.stack_of_fields) == 0:
-                raise HogQLException("Can't access a lazy field when not in a SelectQuery context")
+                raise ResolutionException("Can't access a lazy field when not in a SelectQuery context")
             self.stack_of_fields[-1].append(node)
 
     def visit_select_query(self, node: ast.SelectQuery):
         select_type = node.type
         if not select_type:
-            raise HogQLException("Select query must have a type")
+            raise ResolutionException("Select query must have a type")
 
         assert node.type is not None
         assert select_type is not None
@@ -170,7 +170,7 @@ class LazyTableResolver(TraversingVisitor):
                 property = field_or_property
                 field = property.field_type
             else:
-                raise HogQLException("Should not be reachable")
+                raise ResolutionException("Should not be reachable")
             table_type = field.table_type
 
             # Traverse the lazy tables until we reach a real table, collecting them in a list.
@@ -382,7 +382,7 @@ class LazyTableResolver(TraversingVisitor):
             elif isinstance(field_or_property, ast.PropertyType):
                 table_type = field_or_property.field_type.table_type
             else:
-                raise HogQLException("Should not be reachable")
+                raise ResolutionException("Should not be reachable")
 
             table_name = get_long_table_name(select_type, table_type)
             table_type = select_type.tables[table_name]

--- a/posthog/hogql/transforms/test/test_in_cohort.py
+++ b/posthog/hogql/transforms/test/test_in_cohort.py
@@ -2,7 +2,7 @@ import pytest
 from django.test import override_settings
 
 from posthog.hogql import ast
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import QueryException
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.test.utils import pretty_print_response_in_tests
@@ -89,7 +89,7 @@ class TestInCohort(BaseTest):
     @pytest.mark.usefixtures("unittest_snapshot")
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=True, PERSON_ON_EVENTS_V2_OVERRIDE=True)
     def test_in_cohort_error(self):
-        with self.assertRaises(HogQLException) as e:
+        with self.assertRaises(QueryException) as e:
             execute_hogql_query(
                 f"SELECT event FROM events WHERE person_id IN COHORT true",
                 self.team,
@@ -98,7 +98,7 @@ class TestInCohort(BaseTest):
             )
         self.assertEqual(str(e.exception), "cohort() takes exactly one string or integer argument")
 
-        with self.assertRaises(HogQLException) as e:
+        with self.assertRaises(QueryException) as e:
             execute_hogql_query(
                 f"SELECT event FROM events WHERE person_id IN COHORT 'blabla'",
                 self.team,
@@ -160,7 +160,7 @@ class TestInCohort(BaseTest):
     @pytest.mark.usefixtures("unittest_snapshot")
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=True, PERSON_ON_EVENTS_V2_OVERRIDE=True)
     def test_in_cohort_conjoined_error(self):
-        with self.assertRaises(HogQLException) as e:
+        with self.assertRaises(QueryException) as e:
             execute_hogql_query(
                 f"SELECT event FROM events WHERE person_id IN COHORT true",
                 self.team,
@@ -169,7 +169,7 @@ class TestInCohort(BaseTest):
             )
         self.assertEqual(str(e.exception), "cohort() takes exactly one string or integer argument")
 
-        with self.assertRaises(HogQLException) as e:
+        with self.assertRaises(QueryException) as e:
             execute_hogql_query(
                 f"SELECT event FROM events WHERE person_id IN COHORT 'blabla'",
                 self.team,

--- a/posthog/hogql/transforms/test/test_in_cohort.py
+++ b/posthog/hogql/transforms/test/test_in_cohort.py
@@ -2,7 +2,7 @@ import pytest
 from django.test import override_settings
 
 from posthog.hogql import ast
-from posthog.hogql.errors import QueryException
+from posthog.hogql.errors import QueryError
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.test.utils import pretty_print_response_in_tests
@@ -89,7 +89,7 @@ class TestInCohort(BaseTest):
     @pytest.mark.usefixtures("unittest_snapshot")
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=True, PERSON_ON_EVENTS_V2_OVERRIDE=True)
     def test_in_cohort_error(self):
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             execute_hogql_query(
                 f"SELECT event FROM events WHERE person_id IN COHORT true",
                 self.team,
@@ -98,7 +98,7 @@ class TestInCohort(BaseTest):
             )
         self.assertEqual(str(e.exception), "cohort() takes exactly one string or integer argument")
 
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             execute_hogql_query(
                 f"SELECT event FROM events WHERE person_id IN COHORT 'blabla'",
                 self.team,
@@ -160,7 +160,7 @@ class TestInCohort(BaseTest):
     @pytest.mark.usefixtures("unittest_snapshot")
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=True, PERSON_ON_EVENTS_V2_OVERRIDE=True)
     def test_in_cohort_conjoined_error(self):
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             execute_hogql_query(
                 f"SELECT event FROM events WHERE person_id IN COHORT true",
                 self.team,
@@ -169,7 +169,7 @@ class TestInCohort(BaseTest):
             )
         self.assertEqual(str(e.exception), "cohort() takes exactly one string or integer argument")
 
-        with self.assertRaises(QueryException) as e:
+        with self.assertRaises(QueryError) as e:
             execute_hogql_query(
                 f"SELECT event FROM events WHERE person_id IN COHORT 'blabla'",
                 self.team,

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -2,7 +2,7 @@ from typing import Optional, TypeVar, Generic, Any
 
 from posthog.hogql import ast
 from posthog.hogql.base import AST, Expr
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import BaseHogQLException
 
 
 def clone_expr(expr: Expr, clear_types=False, clear_locations=False) -> Expr:
@@ -24,7 +24,7 @@ class Visitor(Generic[T]):
 
         try:
             return node.accept(self)
-        except HogQLException as e:
+        except BaseHogQLException as e:
             if e.start is None or e.end is None:
                 e.start = node.start
                 e.end = node.end
@@ -33,9 +33,6 @@ class Visitor(Generic[T]):
 
 class TraversingVisitor(Visitor[None]):
     """Visitor that traverses the AST tree without returning anything"""
-
-    def visit_expr(self, node: Expr):
-        raise HogQLException("Can not visit generic Expr node")
 
     def visit_cte(self, node: ast.CTE):
         pass
@@ -274,9 +271,6 @@ class CloningVisitor(Visitor[Any]):
     ):
         self.clear_types = clear_types
         self.clear_locations = clear_locations
-
-    def visit_expr(self, node: Expr):
-        raise HogQLException("Can not visit generic Expr node")
 
     def visit_cte(self, node: ast.CTE):
         return ast.CTE(

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -2,7 +2,7 @@ from typing import Optional, TypeVar, Generic, Any
 
 from posthog.hogql import ast
 from posthog.hogql.base import AST, Expr
-from posthog.hogql.errors import BaseHogQLException
+from posthog.hogql.errors import BaseHogQLError
 
 
 def clone_expr(expr: Expr, clear_types=False, clear_locations=False) -> Expr:
@@ -24,7 +24,7 @@ class Visitor(Generic[T]):
 
         try:
             return node.accept(self)
-        except BaseHogQLException as e:
+        except BaseHogQLError as e:
             if e.start is None or e.end is None:
                 e.start = node.start
                 e.end = node.end

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ImpossibleASTException
 from posthog.hogql.parser import ast
 from posthog.models.team import Team, WeekStartDay
 from posthog.queries.util import get_earliest_timestamp, get_trunc_func_ch
@@ -232,7 +232,7 @@ class QueryDateRange:
             case "month":
                 return ast.Call(name="toStartOfMonth", args=[date])
             case _:
-                raise HogQLException(message="Unknown interval name")
+                raise ImpossibleASTException(message="Unknown interval name")
 
     def date_from_to_start_of_interval_hogql(self) -> ast.Call:
         return self.date_to_start_of_interval_hogql(self.date_from_as_hogql())

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 
-from posthog.hogql.errors import ImpossibleASTException
+from posthog.hogql.errors import ImpossibleASTError
 from posthog.hogql.parser import ast
 from posthog.models.team import Team, WeekStartDay
 from posthog.queries.util import get_earliest_timestamp, get_trunc_func_ch
@@ -232,7 +232,7 @@ class QueryDateRange:
             case "month":
                 return ast.Call(name="toStartOfMonth", args=[date])
             case _:
-                raise ImpossibleASTException(message="Unknown interval name")
+                raise ImpossibleASTError(message="Unknown interval name")
 
     def date_from_to_start_of_interval_hogql(self) -> ast.Call:
         return self.date_to_start_of_interval_hogql(self.date_from_as_hogql())

--- a/posthog/models/action/action.py
+++ b/posthog/models/action/action.py
@@ -7,7 +7,7 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch.dispatcher import receiver
 from django.utils import timezone
 
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ExposedHogQLException
 from posthog.models.signals import mutable_receiver
 from posthog.redis import get_client
 
@@ -67,7 +67,7 @@ class Action(models.Model):
                 self.bytecode = new_bytecode
                 self.bytecode_error = None
                 self.save(update_fields=["bytecode", "bytecode_error"])
-        except HogQLException as e:
+        except ExposedHogQLException as e:
             # There are several known cases when bytecode generation can fail. Instead of spamming
             # Sentry with errors, ignore those cases for now.
             if self.bytecode is not None or self.bytecode_error != str(e):

--- a/posthog/models/action/action.py
+++ b/posthog/models/action/action.py
@@ -7,7 +7,7 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch.dispatcher import receiver
 from django.utils import timezone
 
-from posthog.hogql.errors import BaseHogQLException
+from posthog.hogql.errors import BaseHogQLError
 from posthog.models.signals import mutable_receiver
 from posthog.redis import get_client
 
@@ -67,7 +67,7 @@ class Action(models.Model):
                 self.bytecode = new_bytecode
                 self.bytecode_error = None
                 self.save(update_fields=["bytecode", "bytecode_error"])
-        except BaseHogQLException as e:
+        except BaseHogQLError as e:
             # There are several known cases when bytecode generation can fail. Instead of spamming
             # Sentry with errors, ignore those cases for now.
             if self.bytecode is not None or self.bytecode_error != str(e):

--- a/posthog/models/action/action.py
+++ b/posthog/models/action/action.py
@@ -7,7 +7,7 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch.dispatcher import receiver
 from django.utils import timezone
 
-from posthog.hogql.errors import ExposedHogQLException
+from posthog.hogql.errors import BaseHogQLException
 from posthog.models.signals import mutable_receiver
 from posthog.redis import get_client
 
@@ -67,7 +67,7 @@ class Action(models.Model):
                 self.bytecode = new_bytecode
                 self.bytecode_error = None
                 self.save(update_fields=["bytecode", "bytecode_error"])
-        except ExposedHogQLException as e:
+        except BaseHogQLException as e:
             # There are several known cases when bytecode generation can fail. Instead of spamming
             # Sentry with errors, ignore those cases for now.
             if self.bytecode is not None or self.bytecode_error != str(e):

--- a/posthog/warehouse/api/saved_query.py
+++ b/posthog/warehouse/api/saved_query.py
@@ -8,7 +8,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import SerializedField, create_hogql_database, serialize_fields
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ExposedHogQLException
 from posthog.hogql.metadata import is_valid_view
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import print_ast
@@ -84,7 +84,7 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
                 settings=None,
             )
         except Exception as err:
-            if isinstance(err, ValueError) or isinstance(err, HogQLException):
+            if isinstance(err, ExposedHogQLException):
                 error = str(err)
                 raise exceptions.ValidationError(detail=f"Invalid query: {error}")
             elif not settings.DEBUG:

--- a/posthog/warehouse/api/saved_query.py
+++ b/posthog/warehouse/api/saved_query.py
@@ -8,7 +8,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import SerializedField, create_hogql_database, serialize_fields
-from posthog.hogql.errors import ExposedHogQLException
+from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.metadata import is_valid_view
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import print_ast
@@ -84,7 +84,7 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
                 settings=None,
             )
         except Exception as err:
-            if isinstance(err, ExposedHogQLException):
+            if isinstance(err, ExposedHogQLError):
                 error = str(err)
                 raise exceptions.ValidationError(detail=f"Invalid query: {error}")
             elif not settings.DEBUG:

--- a/posthog/warehouse/models/join.py
+++ b/posthog/warehouse/models/join.py
@@ -5,7 +5,7 @@ from django.db import models
 
 from posthog.hogql.ast import SelectQuery
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.errors import ResolutionException
+from posthog.hogql.errors import ResolutionError
 from posthog.hogql.parser import parse_expr
 from posthog.models.team import Team
 from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UUIDModel
@@ -52,16 +52,16 @@ class DataWarehouseJoin(CreatedMetaFields, UUIDModel, DeletedMetaFields):
             from posthog.hogql import ast
 
             if not requested_fields:
-                raise ResolutionException(f"No fields requested from {to_table}")
+                raise ResolutionError(f"No fields requested from {to_table}")
 
             left = parse_expr(self.source_table_key)
             if not isinstance(left, ast.Field):
-                raise ResolutionException("Data Warehouse Join HogQL expression should be a Field node")
+                raise ResolutionError("Data Warehouse Join HogQL expression should be a Field node")
             left.chain = [from_table, *left.chain]
 
             right = parse_expr(self.joining_table_key)
             if not isinstance(right, ast.Field):
-                raise ResolutionException("Data Warehouse Join HogQL expression should be a Field node")
+                raise ResolutionError("Data Warehouse Join HogQL expression should be a Field node")
             right.chain = [to_table, *right.chain]
 
             join_expr = ast.JoinExpr(

--- a/posthog/warehouse/models/join.py
+++ b/posthog/warehouse/models/join.py
@@ -5,7 +5,7 @@ from django.db import models
 
 from posthog.hogql.ast import SelectQuery
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.errors import HogQLException
+from posthog.hogql.errors import ResolutionException
 from posthog.hogql.parser import parse_expr
 from posthog.models.team import Team
 from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UUIDModel
@@ -52,16 +52,16 @@ class DataWarehouseJoin(CreatedMetaFields, UUIDModel, DeletedMetaFields):
             from posthog.hogql import ast
 
             if not requested_fields:
-                raise HogQLException(f"No fields requested from {to_table}")
+                raise ResolutionException(f"No fields requested from {to_table}")
 
             left = parse_expr(self.source_table_key)
             if not isinstance(left, ast.Field):
-                raise HogQLException("Data Warehouse Join HogQL expression should be a Field node")
+                raise ResolutionException("Data Warehouse Join HogQL expression should be a Field node")
             left.chain = [from_table, *left.chain]
 
             right = parse_expr(self.joining_table_key)
             if not isinstance(right, ast.Field):
-                raise HogQLException("Data Warehouse Join HogQL expression should be a Field node")
+                raise ResolutionException("Data Warehouse Join HogQL expression should be a Field node")
             right.chain = [to_table, *right.chain]
 
             join_expr = ast.JoinExpr(

--- a/requirements.in
+++ b/requirements.in
@@ -102,5 +102,5 @@ phonenumberslite==8.13.6
 openai==1.10.0
 tiktoken==0.6.0
 nh3==0.2.14
-hogql-parser==1.0.6
+hogql-parser==1.0.7
 urllib3[secure,socks]==1.26.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -291,7 +291,7 @@ h11==0.13.0
     #   wsproto
 hexbytes==1.0.0
     # via dlt
-hogql-parser==1.0.6
+hogql-parser==1.0.7
     # via -r requirements.in
 httpcore==1.0.2
     # via httpx


### PR DESCRIPTION
## Problem

Up until now, we've been handling all `HogQLException`s equally – that is, they were exposed to users regardless whether that was fully safe or useful, resulting in users seeing unhelpful errors like the one below (which would in turn NOT show up in Sentry for us):

<img width="544" alt="Screenshot 2024-04-04 at 13 49 26" src="https://github.com/PostHog/posthog/assets/4550621/6e369712-609d-46a1-979a-fe0b4d531a52">

There was no distinction between HogQL exceptions which should be internal, and those we can expose.

## Changes

Split `HogQLException` into `InternalHogQLException` and `ExposedHogQLException`. Renamed `ResolverException` to `ResolutionException`, to be applicable in a wider range of resolution situations, not only in `resolver.py`. Added `ImpossibleASTException` as a new internal error.

Finally, made is to that only `ExposedHogQLException`s are ever passed on to users. `InternalHogQLException`s are now just for our internal use, which means we'll get to actually see them in error tracking.

## How did you test this code?

Updated a lot of tests.