### PR TITLE
feat: Switch to asgi over wsgi

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -59,7 +59,6 @@ jobs:
         timeout-minutes: 5
         outputs:
             chunks: ${{ steps.chunk.outputs.chunks }}
-
         steps:
             - name: Check out
               uses: actions/checkout@v3

--- a/posthog/asgi.py
+++ b/posthog/asgi.py
@@ -1,0 +1,7 @@
+import os
+
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
+
+application = get_asgi_application()

--- a/unit.json
+++ b/unit.json
@@ -43,7 +43,8 @@
             "processes": 4,
             "working_directory": "/code",
             "path": ".",
-            "module": "posthog.wsgi",
+            "module": "posthog.asgi",
+            "protocol": "asgi",
             "user": "nobody",
             "limits": {
                 "requests": 50000


### PR DESCRIPTION
## Problem

With wsgi each pod can only handle 4 simultaneous requests, even if all of those requests are simply blocked on IO (e.g. waiting for posthog/clickhouse)

With asgi requests are handled async which means while those requests are blocked the threads can be reused for other requests.

This should mean we can handle spikes of slow requests without outages

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Ran on dev with a test endpoint that just did `time.sleep(10)`. then ran `rewrk` benchmarking against them with 60 parallel requests:

With WSGI
```
$ rewrk --duration 120s -c 60 --host https://app.i.dev.posthog.dev/_sleepz
Beginning round 1...
Benchmarking 60 connections @ https://app.i.dev.posthog.dev/_sleepz for 2 minute(s)
  Latencies:
    Avg      Stdev    Min      Max
    164.72ms  2114.97ms  76.44ms  60094.84ms
  Requests:
    Total:  43552  Req/Sec: 362.95
  Transfer:
    Total: 8.88 MB Transfer Rate: 75.76 KB/Sec
```

Note that the majority of requests are very short (160ms average) which means they are 503 errors. All 200 requests should be ~10 seconds. The max duration is 60 seconds

With ASGI
```
$ rewrk --duration 120s -c 60 --host https://app.i.dev.posthog.dev/_sleepz
Beginning round 1...
Benchmarking 60 connections @ https://app.i.dev.posthog.dev/_sleepz for 2 minute(s)
  Latencies:
    Avg      Stdev    Min      Max
    10101.04ms  8.37ms   10085.22ms  10145.01ms
  Requests:
    Total:   660   Req/Sec:  5.50
  Transfer:
    Total: 579.67 KB Transfer Rate: 4.83 KB/Sec
```

Every request is between 10085ms and 10145ms, which means every request successfully ran the time.sleep(10)


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
