### PR TITLE
feat: Add command to recreate a month in the sessions table

### DIFF
--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -1720,7 +1720,7 @@
   sumIf(1, event='$autocapture') as autocapture_count
   
   FROM posthog_test.sharded_events
-  WHERE `$session_id` IS NOT NULL AND `$session_id` != ''
+  WHERE (`$session_id` IS NOT NULL AND `$session_id` != '') AND (TRUE)
   GROUP BY `$session_id`, team_id
   
   

--- a/posthog/management/commands/backfill_sessions_table.py
+++ b/posthog/management/commands/backfill_sessions_table.py
@@ -9,8 +9,9 @@ from django.core.management.base import BaseCommand
 
 from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.client.execute import sync_execute
-from posthog.models.property.util import get_property_string_expr
 from datetime import datetime, timedelta
+
+from posthog.models.sessions.sql import get_session_table_mv_select_sql
 
 logger = structlog.get_logger(__name__)
 
@@ -32,37 +33,11 @@ class BackfillQuery:
         dry_run: bool = True,
         print_counts: bool = True,
     ) -> None:
-        def source_column(column_name: str) -> str:
-            return get_property_string_expr(
-                "events", property_name=column_name, var=f"'{column_name}'", column="properties"
-            )[0]
-
         num_days = (self.end_date - self.start_date).days + 1
 
         logger.info(
             f"Backfilling sessions table from {self.start_date.strftime('%Y-%m-%d')} to {self.end_date.strftime('%Y-%m-%d')}, total numbers of days to insert: {num_days}"
         )
-
-        current_url_property = source_column("$current_url")
-        referring_domain_property = source_column("$referring_domain")
-        utm_source_property = source_column("utm_source")
-        utm_campaign_property = source_column("utm_campaign")
-        utm_medium_property = source_column("utm_medium")
-        utm_term_property = source_column("utm_term")
-        utm_content_property = source_column("utm_content")
-        gclid_property = source_column("gclid")
-        gad_source_property = source_column("gad_source")
-        gclsrc_property = source_column("gclsrc")
-        dclid_property = source_column("dclid")
-        gbraid_property = source_column("gbraid")
-        wbraid_property = source_column("wbraid")
-        fbclid_property = source_column("fbclid")
-        msclkid_property = source_column("msclkid")
-        twclid_property = source_column("twclid")
-        li_fat_id_property = source_column("li_fat_id")
-        mc_cid_property = source_column("mc_cid")
-        igshid_property = source_column("igshid")
-        ttclid_property = source_column("ttclid")
 
         def select_query(select_date: Optional[datetime] = None) -> str:
             if select_date:
@@ -70,47 +45,7 @@ class BackfillQuery:
             else:
                 where = "true"
 
-            return f"""
-SELECT
-    `$session_id` as session_id,
-    team_id,
-
-    distinct_id,
-
-    timestamp AS min_first_timestamp,
-    timestamp AS max_last_timestamp,
-
-    [{current_url_property}] AS urls,
-    initializeAggregation('argMinState', {current_url_property}, timestamp) as entry_url,
-    initializeAggregation('argMaxState', {current_url_property}, timestamp) as exit_url,
-
-    initializeAggregation('argMinState', {referring_domain_property}, timestamp) as initial_referring_domain,
-    initializeAggregation('argMinState', {utm_source_property}, timestamp) as initial_utm_source,
-    initializeAggregation('argMinState', {utm_campaign_property}, timestamp) as initial_utm_campaign,
-    initializeAggregation('argMinState', {utm_medium_property}, timestamp) as initial_utm_medium,
-    initializeAggregation('argMinState', {utm_term_property}, timestamp) as initial_utm_term,
-    initializeAggregation('argMinState', {utm_content_property}, timestamp) as initial_utm_content,
-    initializeAggregation('argMinState', {gclid_property}, timestamp) as initial_gclid,
-    initializeAggregation('argMinState', {gad_source_property}, timestamp) as initial_gad_source,
-    initializeAggregation('argMinState', {gclsrc_property}, timestamp) as initial_gclsrc,
-    initializeAggregation('argMinState', {dclid_property}, timestamp) as initial_dclid,
-    initializeAggregation('argMinState', {gbraid_property}, timestamp) as initial_gbraid,
-    initializeAggregation('argMinState', {wbraid_property}, timestamp) as initial_wbraid,
-    initializeAggregation('argMinState', {fbclid_property}, timestamp) as initial_fbclid,
-    initializeAggregation('argMinState', {msclkid_property}, timestamp) as initial_msclkid,
-    initializeAggregation('argMinState', {twclid_property}, timestamp) as initial_twclid,
-    initializeAggregation('argMinState', {li_fat_id_property}, timestamp) as initial_li_fat_id,
-    initializeAggregation('argMinState', {mc_cid_property}, timestamp) as initial_mc_cid,
-    initializeAggregation('argMinState', {igshid_property}, timestamp) as initial_igshid,
-    initializeAggregation('argMinState', {ttclid_property}, timestamp) as initial_ttclid,
-
-    CAST(([event], [1]), 'Map(String, UInt64)') as event_count_map,
-    if(event='$pageview', 1, NULL) as pageview_count,
-    if(event='$autocapture', 1, NULL) as autocapture_count
-
-FROM events
-WHERE `$session_id` IS NOT NULL AND `$session_id` != '' AND {where}
-        """
+            return get_session_table_mv_select_sql(source_column_mode="json_or_mat", extra_where=where)
 
         # print the count of entries in the main sessions table
         if print_counts:

--- a/posthog/management/commands/recreate_sessions_table.py
+++ b/posthog/management/commands/recreate_sessions_table.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import structlog
+from django.core.management.base import BaseCommand
+
+from posthog.clickhouse.client.connection import Workload
+from posthog.clickhouse.client.execute import sync_execute
+from datetime import datetime
+
+from posthog.models.sessions.sql import get_session_table_mv_select_sql
+
+logger = structlog.get_logger(__name__)
+
+
+SETTINGS = {
+    "max_execution_time": 3600  # 1 hour
+}
+
+
+@dataclass
+class RecreateSessionsTable:
+    date: datetime
+    use_offline_workload: bool
+
+    def execute(
+        self,
+    ) -> None:
+        logger.info(f"Recreating sessions table for {self.date.strftime('%Y-%m-%d')}")
+
+        events_where = f"toStartOfDay(timestamp) = '{self.date.strftime('%Y-%m-%d')}'"
+        sessions_where = f"toStartOfDay(min_timestamp) = '{self.date.strftime('%Y-%m-%d')}'"
+        select_query = get_session_table_mv_select_sql(source_column_mode="json_or_mat", extra_where=events_where)
+
+        logging.info("Deleting the existing sessions for day %s", self.date.strftime("%Y-%m-%d"))
+        sync_execute(
+            query=f"""DELETE FROM sharded_sessions WHERE {sessions_where}""",
+            workload=Workload.OFFLINE if self.use_offline_workload else Workload.DEFAULT,
+            settings=SETTINGS,
+        )
+
+        logging.info("Writing the new sessions for day %s", self.date.strftime("%Y-%m-%d"))
+        sync_execute(
+            query=f"""INSERT INTO writable_sessions {select_query}""",
+            workload=Workload.OFFLINE if self.use_offline_workload else Workload.DEFAULT,
+            settings=SETTINGS,
+        )
+
+
+class Command(BaseCommand):
+    help = "Backfill person_distinct_id_overrides records."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--date", required=True, type=str, help="Day to replace (format YYYY-MM-DD)")
+        parser.add_argument(
+            "--use-offline-workload", action="store_true", help="actually execute INSERT queries (default is dry-run)"
+        )
+
+    def handle(
+        self,
+        *,
+        date: str,
+        use_offline_workload: bool,
+        **options,
+    ):
+        logger.setLevel(logging.INFO)
+
+        date_datetime = datetime.strptime(date, "%Y-%m-%d")
+
+        RecreateSessionsTable(date_datetime, use_offline_workload).execute()

--- a/posthog/models/sessions/sql.py
+++ b/posthog/models/sessions/sql.py
@@ -103,7 +103,7 @@ SETTINGS index_granularity=512
 
 
 def json_source_column(column_name: str) -> str:
-    return trim_quotes_expr(f"nullIf(JSONExtractRaw(properties, '{column_name}'), 'null'")
+    return trim_quotes_expr(f"JSONExtractRaw(properties, '{column_name}')")
 
 
 def json_or_mat_source_column(column_name: str) -> str:


### PR DESCRIPTION
## Problem

We had a day where we didn't ingest some data properly into the sessions table. See internal thread https://posthog.slack.com/archives/C0113360FFV/p1712165323602909

This isn't really data loss, as this data can be fully recreated from the events table, but we'd need a command to do this. 

## Changes

Add a management command to delete and recreate the sessions table for a given month.

It does it for one month at a time, as that is what one parition is (has `toYYYYMM(min_timestamp)` in the index).

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran it with demo data
