### PR TITLE
fix: update upgrade copy logic

### DIFF
--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -613,7 +613,7 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                             {additionalFeaturesOnUpgradedPlan?.length > 0 ? (
                                 <>
                                     <p className="ml-0 max-w-200">
-                                        {product.subscribed
+                                        {!upgradePlan && product.subscribed
                                             ? 'You now'
                                             : featureFlags[FEATURE_FLAGS.BILLING_UPGRADE_LANGUAGE] === 'subscribe'
                                             ? 'Subscribe to'


### PR DESCRIPTION
## Problem

There's an issue with the upgrade logic, if a user is currently on a plan then it defaults to "You get" when the list below is the upgrade list:

| before | after |
| ------- | ------- |
|  <img width="441" alt="Screenshot 2024-04-04 at 9 28 57 AM" src="https://github.com/PostHog/posthog/assets/6392501/608d344e-1236-4296-8e82-249cb266d783"> |  <img width="419" alt="Screenshot 2024-04-04 at 9 28 18 AM" src="https://github.com/PostHog/posthog/assets/6392501/b9269f88-fd02-4aea-ad21-524ae0ac5be2"> |

## Changes

This change will only show "You get" when there is no `upgradePlan` and they are currently subscribed to the product. 

There is room for improvement here because `additionalFeaturesOnUpgradedPlan` is confusing since it could be the difference between your current plan and the next plan if there is an upgrade option or the previous plan and your plan if there is not. We should split this out; there is too much room for logic regression because a developer can't quickly understand it.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
