### PR TITLE
chore: disable upgrade button when the upgrade plan is missing

### DIFF
--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -164,6 +164,11 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
                                 type="primary"
                                 icon={<IconPlus />}
                                 size="small"
+                                disabledReason={
+                                    !currentAndUpgradePlans?.upgradePlan
+                                        ? "You don't have a plan to upgrade to"
+                                        : undefined
+                                }
                                 to={`/api/billing-v2/activation?products=${addon.type}:${
                                     currentAndUpgradePlans?.upgradePlan?.plan_key
                                 }${redirectPath && `&redirect_path=${redirectPath}`}`}


### PR DESCRIPTION
## Problem

There is a race condition - when a user deactivates an add-on, there is a lag before the UI is updated and the `upgradePlan` is available. There was a case when the user tried to re-click deactivate, and when it didn't happen right away, they clicked again, and it caused a call to activate without a plan because `upgradePlan` was null.

Here is the Sentry error that was triggered: https://posthog.sentry.io/issues/4995931287/?environment=production&project=4504038670008320&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=4

## Changes

This changes makes sure you can't activate an add-on unless the `upgradePlan` is available. This shouldn't really be shown to users as it's more of an intermediary while things load. 

There is an opportunity here for a more significant improvement around making sure we have proper loading states for billing changes. Some of them are trickier, like the activation calls, since they are redirects and not buttons, so we don't have a state or onclick handler for them.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
