### PR TITLE
chore(data-warehouse): Have a more responsive warehouse settings table

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1912,8 +1912,8 @@ const api = {
     },
 
     externalDataSources: {
-        async list(): Promise<PaginatedResponse<ExternalDataStripeSource>> {
-            return await new ApiRequest().externalDataSources().get()
+        async list(options?: ApiMethodOptions | undefined): Promise<PaginatedResponse<ExternalDataStripeSource>> {
+            return await new ApiRequest().externalDataSources().get(options)
         },
         async create(data: Partial<ExternalDataSourceCreatePayload>): Promise<ExternalDataSourceCreatePayload> {
             return await new ApiRequest().externalDataSources().create({ data })

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -55,6 +55,8 @@ export interface LemonTableProps<T extends Record<string, any>> {
     /** Whether to hide the table background and inner borders. **/
     stealth?: boolean
     loading?: boolean
+    /** Whether the table is still interactable while `loading` is `true`. Defaults to `true`. **/
+    disableTableWhileLoading?: boolean
     pagination?: PaginationAuto | PaginationManual
     expandable?: ExpandableConfig<T>
     /** Whether the header should be shown. The default value is `true`. */
@@ -102,6 +104,7 @@ export function LemonTable<T extends Record<string, any>>({
     embedded = false,
     stealth = false,
     loading,
+    disableTableWhileLoading = true,
     pagination,
     expandable,
     showHeader = true,
@@ -217,7 +220,7 @@ export function LemonTable<T extends Record<string, any>>({
                 'LemonTable',
                 size && size !== 'middle' && `LemonTable--${size}`,
                 inset && 'LemonTable--inset',
-                loading && 'LemonTable--loading',
+                loading && disableTableWhileLoading && 'LemonTable--loading',
                 embedded && 'LemonTable--embedded',
                 rowRibbonColor !== undefined && `LemonTable--with-ribbon`,
                 stealth && 'LemonTable--stealth',

--- a/frontend/src/scenes/data-warehouse/external/forms/sourceFormLogic.ts
+++ b/frontend/src/scenes/data-warehouse/external/forms/sourceFormLogic.ts
@@ -102,7 +102,7 @@ export const sourceFormLogic = kea<sourceFormLogicType>([
             lemonToast.success('New Data Resource Created')
             actions.toggleSourceModal(false)
             actions.resetExternalDataSource()
-            actions.loadSources()
+            actions.loadSources(null)
             router.actions.push(urls.dataWarehouseSettings())
         },
         submitDatabaseSchemaFormSuccess: () => {

--- a/frontend/src/scenes/data-warehouse/settings/DataWarehouseSettingsScene.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/DataWarehouseSettingsScene.tsx
@@ -63,6 +63,7 @@ export function DataWarehouseSettingsScene(): JSX.Element {
             <LemonTable
                 dataSource={dataWarehouseSources?.results ?? []}
                 loading={dataWarehouseSourcesLoading}
+                disableTableWhileLoading={false}
                 columns={[
                     {
                         title: 'Source Type',

--- a/frontend/src/scenes/data-warehouse/settings/dataWarehouseSettingsLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/dataWarehouseSettingsLogic.ts
@@ -1,6 +1,6 @@
 import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import api, { PaginatedResponse } from 'lib/api'
+import api, { ApiMethodOptions, PaginatedResponse } from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -20,18 +20,40 @@ export const dataWarehouseSettingsLogic = kea<dataWarehouseSettingsLogicType>([
         reloadSource: (source: ExternalDataStripeSource) => ({ source }),
         loadingFinished: (source: ExternalDataStripeSource) => ({ source }),
         updateSchema: (schema: ExternalDataSourceSchema) => ({ schema }),
+        abortAnyRunningQuery: true,
     }),
-    loaders({
+    loaders(({ cache, actions }) => ({
         dataWarehouseSources: [
             null as PaginatedResponse<ExternalDataStripeSource> | null,
             {
-                loadSources: async () => {
-                    return api.externalDataSources.list()
+                loadSources: async (_, breakpoint) => {
+                    await breakpoint(300)
+                    actions.abortAnyRunningQuery()
+
+                    cache.abortController = new AbortController()
+                    const methodOptions: ApiMethodOptions = {
+                        signal: cache.abortController.signal,
+                    }
+
+                    const res = await api.externalDataSources.list(methodOptions)
+                    breakpoint()
+
+                    cache.abortController = null
+
+                    return res
                 },
             },
         ],
-    }),
-    reducers({
+    })),
+    reducers(({ cache }) => ({
+        dataWarehouseSourcesLoading: [
+            false as boolean,
+            {
+                loadSources: () => true,
+                loadSourcesFailure: () => cache.abortController !== null,
+                loadSourcesSuccess: () => cache.abortController !== null,
+            },
+        ],
         sourceReloadingById: [
             {} as Record<string, boolean>,
             {
@@ -49,7 +71,7 @@ export const dataWarehouseSettingsLogic = kea<dataWarehouseSettingsLogicType>([
                 }),
             },
         ],
-    }),
+    })),
     selectors({
         breadcrumbs: [
             () => [],
@@ -67,23 +89,23 @@ export const dataWarehouseSettingsLogic = kea<dataWarehouseSettingsLogicType>([
             ],
         ],
     }),
-    listeners(({ actions, cache }) => ({
+    listeners(({ actions, values, cache }) => ({
         loadSourcesSuccess: () => {
             clearTimeout(cache.refreshTimeout)
 
             cache.refreshTimeout = setTimeout(() => {
-                actions.loadSources()
+                actions.loadSources(null)
             }, REFRESH_INTERVAL)
         },
         deleteSource: async ({ source }) => {
             await api.externalDataSources.delete(source.id)
-            actions.loadSources()
+            actions.loadSources(null)
             actions.loadingFinished(source)
         },
         reloadSource: async ({ source }) => {
             try {
                 await api.externalDataSources.reload(source.id)
-                actions.loadSources()
+                actions.loadSources(null)
             } catch (e: any) {
                 if (e.message) {
                     lemonToast.error(e.message)
@@ -94,11 +116,30 @@ export const dataWarehouseSettingsLogic = kea<dataWarehouseSettingsLogicType>([
             actions.loadingFinished(source)
         },
         updateSchema: async ({ schema }) => {
+            // Optimistic UI updates before sending updates to the backend
+            const clonedSources = JSON.parse(
+                JSON.stringify(values.dataWarehouseSources?.results ?? [])
+            ) as ExternalDataStripeSource[]
+            const sourceIndex = clonedSources.findIndex((n) => n.schemas.find((m) => m.id === schema.id))
+            const schemaIndex = clonedSources[sourceIndex].schemas.findIndex((n) => n.id === schema.id)
+            clonedSources[sourceIndex].schemas[schemaIndex] = schema
+
+            actions.loadSourcesSuccess({
+                ...values.dataWarehouseSources,
+                results: clonedSources,
+            })
+
             await api.externalDataSchemas.update(schema.id, schema)
-            actions.loadSources()
+            actions.loadSources(null)
+        },
+        abortAnyRunningQuery: () => {
+            if (cache.abortController) {
+                cache.abortController.abort()
+                cache.abortController = null
+            }
         },
     })),
     afterMount(({ actions }) => {
-        actions.loadSources()
+        actions.loadSources(null)
     }),
 ])


### PR DESCRIPTION
## Problem
- We have polling enabled on the warehouse settings table, meaning when the poll kicks off, the whole table becomes disabled for a short while until the request completes
- And, when I want to turn on/off the sync status for multiple tables at once, I have to wait a few secs between each toggle switch before I can switch the next one

## Changes
- Allow the LemonTable to still be interactive during `loading`. (defaults to the normal behavior, but you can toggle this using a prop for the table now)
- Changes any schema updates to have optimistic updates. Meaning that the UI will update before the request in the background is completed, allowing for a more intuitive UI when toggling multiple tables sync status at once

**Old:**

https://github.com/PostHog/posthog/assets/1459269/bc3f88fe-4c01-4f91-b35a-506d6040e1de


**New:**

https://github.com/PostHog/posthog/assets/1459269/245c0e43-efa6-48a5-9e37-65d1dbddde71

## Does this work well for both Cloud and self-hosted?
- Yes

## How did you test this code?
Browser testing