### PR TITLE
feat: Heartbeat while running all the time in S3 batch exports

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -714,7 +714,6 @@ posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py:0: 
 posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py:0: error: List item 0 has incompatible type "tuple[str, str, int, int, int, int, str, int]"; expected "tuple[str, str, int, int, str, str, str, str]"  [list-item]
 posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py:0: error: "tuple[Any, ...]" has no attribute "last_uploaded_part_timestamp"  [attr-defined]
 posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py:0: error: "tuple[Any, ...]" has no attribute "upload_state"  [attr-defined]
-posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py:0: error: "tuple[Any, ...]" has no attribute "upload_state"  [attr-defined]
 posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py:0: error: Incompatible types in assignment (expression has type "str | int", variable has type "int")  [assignment]
 posthog/api/test/batch_exports/conftest.py:0: error: Argument "activities" to "ThreadedWorker" has incompatible type "list[function]"; expected "Sequence[Callable[..., Any]]"  [arg-type]
 posthog/management/commands/test/test_create_batch_export_from_app.py:0: error: Incompatible return value type (got "dict[str, Collection[str]]", expected "dict[str, str]")  [return-value]

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -1,4 +1,3 @@
-import asyncio
 import collections.abc
 import contextlib
 import datetime as dt
@@ -47,7 +46,7 @@ from posthog.temporal.batch_exports.temporary_file import (
 )
 from posthog.temporal.batch_exports.utils import peek_first_and_rewind, try_set_batch_export_run_to_running
 from posthog.temporal.common.clickhouse import get_client
-from posthog.temporal.common.heartbeat import heartbeat_every
+from posthog.temporal.common.heartbeat import Heartbeatter
 from posthog.temporal.common.logger import bind_temporal_worker_logger
 
 
@@ -463,76 +462,51 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
             extra_query_parameters=query_parameters,
         )
 
-        last_uploaded_part_timestamp: str | None = None
+        async with Heartbeatter() as heartbeatter:
+            async with s3_upload as s3_upload:
 
-        async def worker_shutdown_handler() -> None:
-            """Handle the Worker shutting down by heart-beating our latest status."""
-            await activity.wait_for_worker_shutdown()
-            logger.warn(
-                f"Worker shutting down! Reporting back latest exported part {last_uploaded_part_timestamp}",
-            )
-            if last_uploaded_part_timestamp is None:
-                # Don't heartbeat if worker shuts down before we could even send anything
-                # Just start from the beginning again.
-                return
+                async def flush_to_s3(
+                    local_results_file,
+                    records_since_last_flush: int,
+                    bytes_since_last_flush: int,
+                    last_inserted_at: dt.datetime,
+                    last: bool,
+                ):
+                    logger.debug(
+                        "Uploading %s part %s containing %s records with size %s bytes",
+                        "last " if last else "",
+                        s3_upload.part_number + 1,
+                        records_since_last_flush,
+                        bytes_since_last_flush,
+                    )
 
-            activity.heartbeat(last_uploaded_part_timestamp, s3_upload.to_state())
+                    await s3_upload.upload_part(local_results_file)
+                    rows_exported.add(records_since_last_flush)
+                    bytes_exported.add(bytes_since_last_flush)
 
-        asyncio.create_task(worker_shutdown_handler())
+                    heartbeatter.details = (str(last_inserted_at), s3_upload.to_state())
 
-        async with s3_upload as s3_upload:
+                first_record_batch, record_iterator = peek_first_and_rewind(record_iterator)
+                first_record_batch = cast_record_batch_json_columns(first_record_batch)
+                column_names = first_record_batch.column_names
+                column_names.pop(column_names.index("_inserted_at"))
 
-            async def flush_to_s3(
-                local_results_file,
-                records_since_last_flush: int,
-                bytes_since_last_flush: int,
-                last_inserted_at: dt.datetime,
-                last: bool,
-            ):
-                nonlocal last_uploaded_part_timestamp
-
-                logger.debug(
-                    "Uploading %s part %s containing %s records with size %s bytes",
-                    "last " if last else "",
-                    s3_upload.part_number + 1,
-                    records_since_last_flush,
-                    bytes_since_last_flush,
+                schema = pa.schema(
+                    # NOTE: For some reason, some batches set non-nullable fields as non-nullable, whereas other
+                    # record batches have them as nullable.
+                    # Until we figure it out, we set all fields to nullable. There are some fields we know
+                    # are not nullable, but I'm opting for the more flexible option until we out why schemas differ
+                    # between batches.
+                    [field.with_nullable(True) for field in first_record_batch.select(column_names).schema]
                 )
 
-                await s3_upload.upload_part(local_results_file)
-                rows_exported.add(records_since_last_flush)
-                bytes_exported.add(bytes_since_last_flush)
+                writer = get_batch_export_writer(
+                    inputs,
+                    flush_callable=flush_to_s3,
+                    max_bytes=settings.BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES,
+                    schema=schema,
+                )
 
-                last_uploaded_part_timestamp = str(last_inserted_at)
-
-            first_record_batch, record_iterator = peek_first_and_rewind(record_iterator)
-            first_record_batch = cast_record_batch_json_columns(first_record_batch)
-            column_names = first_record_batch.column_names
-            column_names.pop(column_names.index("_inserted_at"))
-
-            schema = pa.schema(
-                # NOTE: For some reason, some batches set non-nullable fields as non-nullable, whereas other
-                # record batches have them as nullable.
-                # Until we figure it out, we set all fields to nullable. There are some fields we know
-                # are not nullable, but I'm opting for the more flexible option until we out why schemas differ
-                # between batches.
-                [field.with_nullable(True) for field in first_record_batch.select(column_names).schema]
-            )
-
-            writer = get_batch_export_writer(
-                inputs,
-                flush_callable=flush_to_s3,
-                max_bytes=settings.BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES,
-                schema=schema,
-            )
-
-            def s3_heartbeat_details() -> tuple | tuple[str, S3MultiPartUploadState]:
-                """Return S3 heartbeat details if set."""
-                if last_uploaded_part_timestamp is None:
-                    return ()
-                return (last_uploaded_part_timestamp, s3_upload.to_state())
-
-            async with heartbeat_every(details_callable=s3_heartbeat_details):
                 async with writer.open_temporary_file():
                     rows_exported = get_rows_exported_metric()
                     bytes_exported = get_bytes_exported_metric()
@@ -542,7 +516,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
 
                         await writer.write_record_batch(record_batch)
 
-            await s3_upload.complete()
+                await s3_upload.complete()
 
         return writer.records_total
 

--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -12,7 +12,7 @@ from temporalio.common import RetryPolicy
 
 from posthog.temporal.batch_exports.base import PostHogWorkflow
 from posthog.temporal.common.clickhouse import get_client
-from posthog.temporal.common.heartbeat import heartbeat_every
+from posthog.temporal.common.heartbeat import Heartbeatter
 
 EPOCH = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
 
@@ -243,7 +243,7 @@ async def optimize_person_distinct_id_overrides(dry_run: bool) -> None:
         activity.logger.debug("Optimize query: %s", optimize_query)
         return
 
-    async with heartbeat_every():
+    async with Heartbeatter():
         async with get_client(mutations_sync=2) as clickhouse_client:
             await clickhouse_client.execute_query(
                 optimize_query.format(database=settings.CLICKHOUSE_DATABASE, cluster=settings.CLICKHOUSE_CLUSTER)
@@ -292,7 +292,7 @@ async def create_table(inputs: TableActivityInputs) -> None:
         activity.logger.debug("Query: %s", create_table_query)
         return
 
-    async with heartbeat_every():
+    async with Heartbeatter():
         async with get_client() as clickhouse_client:
             await clickhouse_client.execute_query(create_table_query, query_parameters=inputs.query_parameters)
 
@@ -321,7 +321,7 @@ async def drop_table(inputs: TableActivityInputs) -> None:
         activity.logger.debug("Query: %s", drop_table_query)
         return
 
-    async with heartbeat_every():
+    async with Heartbeatter():
         async with get_client() as clickhouse_client:
             await clickhouse_client.execute_query(drop_table_query)
 

--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -12,6 +12,7 @@ from temporalio.common import RetryPolicy
 
 from posthog.temporal.batch_exports.base import PostHogWorkflow
 from posthog.temporal.common.clickhouse import get_client
+from posthog.temporal.common.heartbeat import heartbeat_every
 
 EPOCH = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
 
@@ -225,37 +226,6 @@ def parse_mutation_command(mutation_query: str) -> str:
         raise ValueError("Provided query does not appear to be an 'ALTER TABLE ... ON CLUSTER' mutation")
 
     return query_command
-
-
-def no_details() -> tuple:
-    """No heartbeat details."""
-    return ()
-
-
-@contextlib.asynccontextmanager
-async def heartbeat_every(
-    factor: int = 2,
-    details_callable: collections.abc.Callable[[], tuple[typing.Any]] = no_details,
-) -> collections.abc.AsyncIterator[None]:
-    """Heartbeat every Activity heartbeat timeout / factor seconds while in context."""
-    heartbeat_timeout = activity.info().heartbeat_timeout
-    heartbeat_task = None
-
-    async def heartbeat_forever(delay: float) -> None:
-        """Heartbeat forever every delay seconds."""
-        while True:
-            await asyncio.sleep(delay)
-            activity.heartbeat(*details_callable())
-
-    if heartbeat_timeout:
-        heartbeat_task = asyncio.create_task(heartbeat_forever(heartbeat_timeout.total_seconds() / factor))
-
-    try:
-        yield
-    finally:
-        if heartbeat_task:
-            heartbeat_task.cancel()
-            await asyncio.wait([heartbeat_task])
 
 
 @activity.defn

--- a/posthog/temporal/batch_exports/utils.py
+++ b/posthog/temporal/batch_exports/utils.py
@@ -2,7 +2,6 @@ import asyncio
 import collections.abc
 import typing
 import uuid
-
 from posthog.batch_exports.models import BatchExportRun
 from posthog.batch_exports.service import update_batch_export_run
 

--- a/posthog/temporal/common/heartbeat.py
+++ b/posthog/temporal/common/heartbeat.py
@@ -1,37 +1,63 @@
 import asyncio
-import collections.abc
-import contextlib
 import typing
 
 from temporalio import activity
 
 
-def no_details() -> tuple:
-    """No heartbeat details."""
-    return ()
+class Heartbeatter:
+    def __init__(self, details: None | tuple[typing.Any, ...] = None, factor: int = 2):
+        self._details: None | tuple[typing.Any, ...] = details
+        self.factor = factor
+        self.heartbeat_task: asyncio.Task | None = None
+        self.heartbeat_on_shutdown_task: asyncio.Task | None = None
 
+    @property
+    def details(self) -> tuple[typing.Any, ...]:
+        if self._details is None:
+            return ()
+        return self._details
 
-@contextlib.asynccontextmanager
-async def heartbeat_every(
-    factor: int = 2,
-    details_callable: collections.abc.Callable[[], tuple[typing.Any, ...]] = no_details,
-) -> collections.abc.AsyncIterator[None]:
-    """Heartbeat every Activity heartbeat timeout / factor seconds while in context."""
-    heartbeat_timeout = activity.info().heartbeat_timeout
-    heartbeat_task = None
+    @details.setter
+    def details(self, details: tuple[typing.Any, ...]) -> None:
+        self._details = details
 
-    async def heartbeat_forever(delay: float) -> None:
-        """Heartbeat forever every delay seconds."""
-        while True:
-            await asyncio.sleep(delay)
-            activity.heartbeat(*details_callable())
+    async def __aenter__(self):
+        async def heartbeat_forever(delay: float) -> None:
+            """Heartbeat forever every delay seconds."""
+            while True:
+                await asyncio.sleep(delay)
+                activity.heartbeat(*self.details)
 
-    if heartbeat_timeout:
-        heartbeat_task = asyncio.create_task(heartbeat_forever(heartbeat_timeout.total_seconds() / factor))
+        heartbeat_timeout = activity.info().heartbeat_timeout
 
-    try:
-        yield
-    finally:
-        if heartbeat_task:
-            heartbeat_task.cancel()
-            await asyncio.wait([heartbeat_task])
+        if heartbeat_timeout:
+            self.heartbeat_task = asyncio.create_task(
+                heartbeat_forever(heartbeat_timeout.total_seconds() / self.factor)
+            )
+
+        async def heartbeat_on_shutdown() -> None:
+            """Handle the Worker shutting down by heart-beating our latest status."""
+            await activity.wait_for_worker_shutdown()
+            if not self.details:
+                return
+
+            activity.heartbeat(*self.details)
+
+        self.heartbeat_on_shutdown_task = asyncio.create_task(heartbeat_on_shutdown())
+
+        return self
+
+    async def __aexit__(self, *args, **kwargs):
+        if self.heartbeat_task:
+            self.heartbeat_task.cancel()
+
+            await asyncio.wait([self.heartbeat_task])
+
+            self.heartbeat_task = None
+
+        if self.heartbeat_on_shutdown_task:
+            self.heartbeat_on_shutdown_task.cancel()
+
+            await asyncio.wait([self.heartbeat_on_shutdown_task])
+
+            self.heartbeat_task = None

--- a/posthog/temporal/common/heartbeat.py
+++ b/posthog/temporal/common/heartbeat.py
@@ -1,0 +1,37 @@
+import asyncio
+import collections.abc
+import contextlib
+import typing
+
+from temporalio import activity
+
+
+def no_details() -> tuple:
+    """No heartbeat details."""
+    return ()
+
+
+@contextlib.asynccontextmanager
+async def heartbeat_every(
+    factor: int = 2,
+    details_callable: collections.abc.Callable[[], tuple[typing.Any, ...]] = no_details,
+) -> collections.abc.AsyncIterator[None]:
+    """Heartbeat every Activity heartbeat timeout / factor seconds while in context."""
+    heartbeat_timeout = activity.info().heartbeat_timeout
+    heartbeat_task = None
+
+    async def heartbeat_forever(delay: float) -> None:
+        """Heartbeat forever every delay seconds."""
+        while True:
+            await asyncio.sleep(delay)
+            activity.heartbeat(*details_callable())
+
+    if heartbeat_timeout:
+        heartbeat_task = asyncio.create_task(heartbeat_forever(heartbeat_timeout.total_seconds() / factor))
+
+    try:
+        yield
+    finally:
+        if heartbeat_task:
+            heartbeat_task.cancel()
+            await asyncio.wait([heartbeat_task])

--- a/posthog/temporal/common/heartbeat.py
+++ b/posthog/temporal/common/heartbeat.py
@@ -78,5 +78,7 @@ class Heartbeatter:
         if tasks_to_wait:
             await asyncio.wait(tasks_to_wait)
 
+        activity.heartbeat(*self.details)
+
         self.heartbeat_task = None
         self.heartbeat_on_shutdown_task = None

--- a/posthog/temporal/common/heartbeat.py
+++ b/posthog/temporal/common/heartbeat.py
@@ -5,23 +5,40 @@ from temporalio import activity
 
 
 class Heartbeatter:
-    def __init__(self, details: None | tuple[typing.Any, ...] = None, factor: int = 2):
-        self._details: None | tuple[typing.Any, ...] = details
+    """Regular heartbeatting during Temporal activity execution.
+
+    This class manages two heartbeat tasks via a context manager:
+    * A task that hearbeats regularly every 'heartbeat_timeout' / 'factor'.
+    * A task that heartbeats after worker shutdown is detected.
+
+    Attributes:
+        details: Set this attribute to a tuple to send as heartbeat details.
+        factor: Used to determine interval between regular heartbeatting.
+        heartbeat_task: A reference to regular heartbeatting task maintained while in the
+            context manager to avoid garbage collection.
+        heartbeat_on_shutdown_task: A reference to task that heartbeats on shutdown
+            maintained while in the context manager to avoid garbage collection.
+    """
+
+    def __init__(self, details: tuple[typing.Any, ...] = (), factor: int = 2):
+        self._details: tuple[typing.Any, ...] = details
         self.factor = factor
         self.heartbeat_task: asyncio.Task | None = None
         self.heartbeat_on_shutdown_task: asyncio.Task | None = None
 
     @property
     def details(self) -> tuple[typing.Any, ...]:
-        if self._details is None:
-            return ()
+        """Return details if available, otherwise an empty tuple."""
         return self._details
 
     @details.setter
     def details(self, details: tuple[typing.Any, ...]) -> None:
+        """Set tuple to be passed as heartbeat details."""
         self._details = details
 
     async def __aenter__(self):
+        """Enter managed heartbeatting context."""
+
         async def heartbeat_forever(delay: float) -> None:
             """Heartbeat forever every delay seconds."""
             while True:
@@ -48,16 +65,18 @@ class Heartbeatter:
         return self
 
     async def __aexit__(self, *args, **kwargs):
-        if self.heartbeat_task:
+        """Cancel heartbeatting tasks on exit."""
+        tasks_to_wait = []
+        if self.heartbeat_task is not None:
             self.heartbeat_task.cancel()
+            tasks_to_wait.append(self.heartbeat_task)
 
-            await asyncio.wait([self.heartbeat_task])
-
-            self.heartbeat_task = None
-
-        if self.heartbeat_on_shutdown_task:
+        if self.heartbeat_on_shutdown_task is not None:
             self.heartbeat_on_shutdown_task.cancel()
+            tasks_to_wait.append(self.heartbeat_on_shutdown_task)
 
-            await asyncio.wait([self.heartbeat_on_shutdown_task])
+        if tasks_to_wait:
+            await asyncio.wait(tasks_to_wait)
 
-            self.heartbeat_task = None
+        self.heartbeat_task = None
+        self.heartbeat_on_shutdown_task = None

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -1363,21 +1363,16 @@ async def test_insert_into_s3_activity_heartbeats(
             inserted_at=part_inserted_at,
         )
 
-    current_part_number = 1
+    heartbeat_details = []
 
-    def assert_heartbeat_details(*details):
-        """A function to track and assert we are heartbeating."""
-        nonlocal current_part_number
+    def track_hearbeat_details(*details):
+        """Record heartbeat details received."""
+        nonlocal heartbeat_details
 
         details = HeartbeatDetails.from_activity_details(details)
+        heartbeat_details.append(details)
 
-        last_uploaded_part_dt = dt.datetime.fromisoformat(details.last_uploaded_part_timestamp)
-        assert last_uploaded_part_dt == data_interval_end - s3_batch_export.interval_time_delta / current_part_number
-
-        assert len(details.upload_state.parts) == current_part_number
-        current_part_number = len(details.upload_state.parts) + 1
-
-    activity_environment.on_heartbeat = assert_heartbeat_details
+    activity_environment.on_heartbeat = track_hearbeat_details
 
     insert_inputs = S3InsertInputs(
         bucket_name=bucket_name,
@@ -1394,9 +1389,13 @@ async def test_insert_into_s3_activity_heartbeats(
     with override_settings(BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES=1, CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT=1):
         await activity_environment.run(insert_into_s3_activity, insert_inputs)
 
-    # This checks that the assert_heartbeat_details function was actually called.
-    # The '+ 1' is because we increment current_part_number one last time after we are done.
-    assert current_part_number == n_expected_parts + 1
+    assert len(heartbeat_details) > 0
+
+    for detail in heartbeat_details:
+        last_uploaded_part_dt = dt.datetime.fromisoformat(detail.last_uploaded_part_timestamp)
+        assert last_uploaded_part_dt == data_interval_end - s3_batch_export.interval_time_delta / len(
+            detail.upload_state.parts
+        )
 
     await assert_clickhouse_records_in_s3(
         s3_compatible_client=minio_client,

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@
 # - `pip-compile --rebuild requirements.in`
 # - `pip-compile --rebuild requirements-dev.in`
 #
+
 aiohttp>=3.9.0
 aioboto3==12.0.0
 aiokafka>=0.8


### PR DESCRIPTION
## Problem

We are not heartbeatting while the upload to s3 is happening, which can cause timeouts to fireoff.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Move the `heartbeat_every` function used in squash to a common module.
Use it in s3 to wrap the entire flow.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
