### PR TITLE
fix(plugin-server): fix ordering of utm properties so ,  from the eve…

### DIFF
--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -108,10 +108,10 @@ export function personInitialAndUTMProperties(properties: Properties): Propertie
     const maybeSet: [string, any][] = propertiesForPerson
 
     if (maybeSet.length > 0) {
-        propertiesCopy.$set = { ...(properties.$set || {}), ...Object.fromEntries(maybeSet) }
+        propertiesCopy.$set = { ...Object.fromEntries(maybeSet), ...(properties.$set || {}) }
     }
     if (maybeSetOnce.length > 0) {
-        propertiesCopy.$set_once = { ...(properties.$set_once || {}), ...Object.fromEntries(maybeSetOnce) }
+        propertiesCopy.$set_once = { ...Object.fromEntries(maybeSetOnce), ...(properties.$set_once || {}) }
     }
     return propertiesCopy
 }

--- a/plugin-server/tests/utils/db/utils.test.ts
+++ b/plugin-server/tests/utils/db/utils.test.ts
@@ -22,6 +22,12 @@ describe('personInitialAndUTMProperties()', () => {
             $app_name: 'my app',
             $app_namespace: 'com.posthog.myapp',
             $app_version: '1.2.3',
+            $set: {
+                $browser_version: 'manually $set value wins',
+            },
+            $set_once: {
+                $initial_os_version: 'manually $set_once value wins',
+            },
         }
 
         expect(personInitialAndUTMProperties(properties)).toMatchInlineSnapshot(`
@@ -57,7 +63,7 @@ describe('personInitialAndUTMProperties()', () => {
                 "$app_namespace": "com.posthog.myapp",
                 "$app_version": "1.2.3",
                 "$browser": "Chrome",
-                "$browser_version": "95",
+                "$browser_version": "manually $set value wins",
                 "$current_url": "https://test.com",
                 "$os": "Mac OS X",
                 "$os_version": "10.15.7",
@@ -78,7 +84,7 @@ describe('personInitialAndUTMProperties()', () => {
                 "$initial_gclid": "GOOGLE ADS ID",
                 "$initial_msclkid": "BING ADS ID",
                 "$initial_os": "Mac OS X",
-                "$initial_os_version": "10.15.7",
+                "$initial_os_version": "manually $set_once value wins",
                 "$initial_referrer": "https://google.com/?q=posthog",
                 "$initial_referring_domain": "https://google.com",
                 "$initial_utm_medium": "twitter",


### PR DESCRIPTION
…nt win

## Problem

We override what the event sent with our UTM props.

https://posthog.slack.com/archives/C0374DA782U/p1712163503605649

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Fix order.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes.
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Updated existing.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
