### PR TITLE
feat(data-warehouse): resume imports after stop/retry

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline.py
@@ -11,6 +11,7 @@ from posthog.settings.base_variables import TEST
 from structlog.typing import FilteringBoundLogger
 from dlt.sources import DltSource
 from posthog.temporal.data_imports.pipelines.stripe.helpers import StripeSourceInput, stripe_get_data
+from temporalio import activity
 
 BLOCK_SIZE = 10_000
 
@@ -110,6 +111,8 @@ class DataImportPipeline:
                         break
 
                 pipeline.run(data_to_push, loader_file_format=self.loader_file_format, table_name=endpoint)
+
+                activity.heartbeat(cursor=starting_after, endpoint=endpoint)
                 data_to_push = []
 
         row_counts = pipeline.last_trace.last_normalize_info.row_counts

--- a/posthog/temporal/data_imports/pipelines/stripe/helpers.py
+++ b/posthog/temporal/data_imports/pipelines/stripe/helpers.py
@@ -10,6 +10,8 @@ from pendulum import DateTime
 from asgiref.sync import sync_to_async
 from posthog.temporal.data_imports.pipelines.helpers import check_limit
 from posthog.warehouse.models import ExternalDataJob
+import dataclasses
+
 
 stripe.api_version = "2022-11-15"
 
@@ -114,3 +116,12 @@ def stripe_source(
             job_id=job_id,
             starting_after=starting_after,
         )
+
+
+@dataclasses.dataclass
+class StripeSourceInput:
+    api_key: str
+    account_id: str
+    endpoints: Tuple[str, ...]
+    team_id: int
+    run_id: str


### PR DESCRIPTION
## Problem

- if a long running sync fails, it has to start from scratch

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- batch run the pipeline. Send a block of data every so often and record state so that the job can be resumed upon being started again

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
