### PR TITLE
fix(insights): Fix breakdown limit saving in trends

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.test.ts
@@ -1004,7 +1004,6 @@ describe('filtersToQueryNode', () => {
                 ],
                 actions: [],
                 display: ChartDisplayType.ActionsTable,
-                breakdown: '$current_url',
                 date_from: '-6m',
                 new_entity: [],
                 properties: {
@@ -1023,8 +1022,11 @@ describe('filtersToQueryNode', () => {
                         },
                     ],
                 },
+                breakdown: '$current_url',
                 breakdown_type: 'event',
                 breakdown_normalize_url: true,
+                breakdown_hide_other_aggregation: true,
+                breakdown_limit: 1,
             }
 
             const result = filtersToQueryNode(filters)
@@ -1045,6 +1047,8 @@ describe('filtersToQueryNode', () => {
                     breakdown: '$current_url',
                     breakdown_type: 'event',
                     breakdown_normalize_url: true,
+                    breakdown_hide_other_aggregation: true,
+                    breakdown_limit: 1,
                 },
                 dateRange: {
                     date_from: '-6m',

--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -427,6 +427,7 @@ export const breakdownFilterToQuery = (filters: Record<string, any>, isTrends: b
         breakdown_normalize_url: filters.breakdown_normalize_url,
         breakdowns: filters.breakdowns,
         breakdown_group_type_index: filters.breakdown_group_type_index,
+        breakdown_limit: filters.breakdown_limit,
         ...(isTrends
             ? {
                   breakdown_histogram_bin_count: filters.breakdown_histogram_bin_count,

--- a/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.test.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.test.ts
@@ -65,6 +65,12 @@ describe('queryNodeToFilter', () => {
         const query: TrendsQuery = {
             kind: NodeKind.TrendsQuery,
             series: [],
+            breakdownFilter: {
+                breakdown: '$browser',
+                breakdown_hide_other_aggregation: true,
+                breakdown_limit: 1,
+                breakdown_type: 'event',
+            },
             trendsFilter: {
                 smoothingIntervals: 3,
                 compare: true,
@@ -98,6 +104,10 @@ describe('queryNodeToFilter', () => {
             aggregation_axis_format: 'numeric',
             aggregation_axis_prefix: 'M',
             aggregation_axis_postfix: '$',
+            breakdown: '$browser',
+            breakdown_hide_other_aggregation: true,
+            breakdown_limit: 1,
+            breakdown_type: 'event',
             show_labels_on_series: true,
             show_percent_stack_view: true,
             show_legend: true,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1528,6 +1528,9 @@
                 "breakdown_hide_other_aggregation": {
                     "type": ["boolean", "null"]
                 },
+                "breakdown_limit": {
+                    "type": "integer"
+                },
                 "breakdown_normalize_url": {
                     "type": "boolean"
                 },

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -65,9 +65,9 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
             },
         ],
         localBreakdownLimit: [
-            25 as number | undefined,
+            undefined as number | undefined,
             {
-                setBreakdownLimit: (_, { value }) => value ?? 25,
+                setBreakdownLimit: (_, { value }) => value,
             },
         ],
     }),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1946,6 +1946,8 @@ export interface FilterType {
     breakdowns?: Breakdown[]
     breakdown_group_type_index?: number | null
     breakdown_hide_other_aggregation?: boolean | null
+    /** @asType integer */
+    breakdown_limit?: number | null
     aggregation_group_type_index?: number // Groups aggregation
 }
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2568,6 +2568,7 @@ class FilterType(BaseModel):
     breakdown: Optional[Union[str, float, List[Union[str, float]]]] = None
     breakdown_group_type_index: Optional[float] = None
     breakdown_hide_other_aggregation: Optional[bool] = None
+    breakdown_limit: Optional[int] = None
     breakdown_normalize_url: Optional[bool] = None
     breakdown_type: Optional[BreakdownType] = None
     breakdowns: Optional[List[Breakdown]] = None


### PR DESCRIPTION
## Problem

Fixes #21311

## Changes

- a local default of `25` was used in logic before the value in filter 🤦🏻 
- but even after fixing this, turns out filter conversion did not include the limit 🙃 

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

- UI and tests