### PR TITLE
feat(plugin-server): Preserve distinct ID locality on overflow rerouting

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -74,6 +74,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         TASKS_PER_WORKER: 10,
         INGESTION_CONCURRENCY: 10,
         INGESTION_BATCH_SIZE: 500,
+        INGESTION_OVERFLOW_ENABLED: false,
+        INGESTION_OVERFLOW_PRESERVE_PARTITION_LOCALITY: false,
         PLUGINS_DEFAULT_LOG_LEVEL: isTestEnv() ? PluginLogLevel.Full : PluginLogLevel.Log,
         LOG_LEVEL: isTestEnv() ? LogLevel.Warn : LogLevel.Info,
         SENTRY_DSN: null,

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -267,7 +267,10 @@ async function emitToOverflow(queue: IngestionConsumer, kafkaMessages: Message[]
             queue.pluginsServer.kafkaProducer.produce({
                 topic: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
                 value: message.value,
-                key: useRandomPartitioner ? null : message.key,
+                // ``message.key`` should not be undefined here, but in the
+                // (extremely) unlikely event that it is, set it to ``null``
+                // instead as that behavior is safer.
+                key: useRandomPartitioner ? null : message.key ?? null,
                 headers: message.headers,
                 waitForAck: true,
             })

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -28,7 +28,8 @@ require('@sentry/tracing')
 
 export enum IngestionOverflowMode {
     Disabled,
-    Reroute,
+    Reroute, // preserves partition locality
+    RerouteRandomly, // discards partition locality
     ConsumeSplitByDistinctId,
     ConsumeSplitEvenly,
 }
@@ -217,7 +218,9 @@ export async function eachBatchParallelIngestion(
                 op: 'emitToOverflow',
                 data: { eventCount: splitBatch.toOverflow.length },
             })
-            processingPromises.push(emitToOverflow(queue, splitBatch.toOverflow))
+            processingPromises.push(
+                emitToOverflow(queue, splitBatch.toOverflow, overflowMode === IngestionOverflowMode.RerouteRandomly)
+            )
             overflowSpan.finish()
         }
 
@@ -257,14 +260,14 @@ export function computeKey(pluginEvent: PipelineEvent): string {
     return `${pluginEvent.team_id ?? pluginEvent.token}:${pluginEvent.distinct_id}`
 }
 
-async function emitToOverflow(queue: IngestionConsumer, kafkaMessages: Message[]) {
+async function emitToOverflow(queue: IngestionConsumer, kafkaMessages: Message[], useRandomPartitioner: boolean) {
     ingestionOverflowingMessagesTotal.inc(kafkaMessages.length)
     await Promise.all(
         kafkaMessages.map((message) =>
             queue.pluginsServer.kafkaProducer.produce({
                 topic: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
                 value: message.value,
-                key: null, // No locality guarantees in overflow
+                key: useRandomPartitioner ? null : message.key,
                 headers: message.headers,
                 waitForAck: true,
             })
@@ -286,6 +289,9 @@ export function splitIngestionBatch(
         toProcess: [],
         toOverflow: [],
     }
+    const shouldRerouteToOverflow = [IngestionOverflowMode.Reroute, IngestionOverflowMode.RerouteRandomly].includes(
+        overflowMode
+    )
 
     if (overflowMode === IngestionOverflowMode.ConsumeSplitEvenly) {
         /**
@@ -314,7 +320,7 @@ export function splitIngestionBatch(
 
     const batches: Map<string, { message: Message; pluginEvent: PipelineEvent }[]> = new Map()
     for (const message of kafkaMessages) {
-        if (overflowMode === IngestionOverflowMode.Reroute && message.key == null) {
+        if (shouldRerouteToOverflow && message.key == null) {
             // Overflow detected by capture, reroute to overflow topic
             // Not applying tokenBlockList to save CPU. TODO: do so once token is in the message headers
             output.toOverflow.push(message)
@@ -334,12 +340,8 @@ export function splitIngestionBatch(
         }
 
         const eventKey = computeKey(pluginEvent)
-        if (
-            overflowMode === IngestionOverflowMode.Reroute &&
-            !ConfiguredLimiter.consume(eventKey, 1, message.timestamp)
-        ) {
+        if (shouldRerouteToOverflow && !ConfiguredLimiter.consume(eventKey, 1, message.timestamp)) {
             // Local overflow detection triggering, reroute to overflow topic too
-            message.key = null
             ingestionPartitionKeyOverflowed.labels(`${pluginEvent.team_id ?? pluginEvent.token}`).inc()
             if (LoggingLimiter.consume(eventKey, 1)) {
                 status.warn('🪣', `Local overflow detection triggered on key ${eventKey}`)

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -94,6 +94,8 @@ export interface PluginsServerConfig {
     TASKS_PER_WORKER: number // number of parallel tasks per worker thread
     INGESTION_CONCURRENCY: number // number of parallel event ingestion queues per batch
     INGESTION_BATCH_SIZE: number // kafka consumer batch size
+    INGESTION_OVERFLOW_ENABLED: boolean // whether or not overflow rerouting is enabled (only used by analytics-ingestion)
+    INGESTION_OVERFLOW_PRESERVE_PARTITION_LOCALITY: boolean // whether or not Kafka message keys should be preserved or discarded when messages are rerouted to overflow
     TASK_TIMEOUT: number // how many seconds until tasks are timed out
     DATABASE_URL: string // Postgres database URL
     DATABASE_READONLY_URL: string // Optional read-only replica to the main Postgres database

--- a/plugin-server/src/utils/env-utils.ts
+++ b/plugin-server/src/utils/env-utils.ts
@@ -42,11 +42,6 @@ export const isProdEnv = (): boolean => determineNodeEnv() === NodeEnv.Productio
 
 export const isCloud = (): boolean => !!process.env.CLOUD_DEPLOYMENT
 
-export function isIngestionOverflowEnabled(): boolean {
-    const ingestionOverflowEnabled = process.env.INGESTION_OVERFLOW_ENABLED
-    return stringToBoolean(ingestionOverflowEnabled)
-}
-
 export function isOverflowBatchByDistinctId(): boolean {
     const overflowBatchByDistinctId = process.env.INGESTION_OVERFLOW_BATCH_BY_DISTINCT_ID
     return stringToBoolean(overflowBatchByDistinctId)

--- a/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/analytics-events-ingestion-consumer.test.ts
@@ -109,32 +109,30 @@ describe('eachBatchParallelIngestion with overflow reroute', () => {
         expect(runEventPipeline).not.toHaveBeenCalled()
     })
 
-    it('reroutes excess events to OVERFLOW topic', async () => {
-        const now = Date.now()
-        const event = captureEndpointEvent1
-        const [message] = createBatchWithMultipleEvents([event], now)
-        const consume = jest.spyOn(ConfiguredLimiter, 'consume').mockImplementation(() => false)
-        const produce = jest.spyOn(queue.pluginsServer.kafkaProducer, 'produce')
+    it.each([IngestionOverflowMode.Reroute, IngestionOverflowMode.RerouteRandomly])(
+        'reroutes excess events to OVERFLOW topic (mode=%p)',
+        async (overflowMode) => {
+            const now = Date.now()
+            const event = captureEndpointEvent1
+            const [message] = createBatchWithMultipleEvents([event], now)
+            const originalKey = message.key
+            const consume = jest.spyOn(ConfiguredLimiter, 'consume').mockImplementation(() => false)
+            const produce = jest.spyOn(queue.pluginsServer.kafkaProducer, 'produce')
 
-        const tokenBlockList = buildStringMatcher('another_token,more_token', false)
-        await eachBatchParallelIngestion(tokenBlockList, [message], queue, IngestionOverflowMode.Reroute)
+            const tokenBlockList = buildStringMatcher('another_token,more_token', false)
+            await eachBatchParallelIngestion(tokenBlockList, [message], queue, overflowMode)
 
-        expect(consume).toHaveBeenCalledWith(
-            computeKey(event), // NOTE: can't use ``message.key`` here as it will already have been mutated
-            1,
-            now
-        )
-        expect(captureIngestionWarning).not.toHaveBeenCalled()
-        expect(produce).toHaveBeenCalledWith({
-            topic: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
-            value: message.value,
-            key: null,
-            waitForAck: true,
-        })
-
-        // Event is not processed here
-        expect(runEventPipeline).not.toHaveBeenCalled()
-    })
+            // NOTE: can't use ``message.key`` below as it will already have been mutated
+            expect(consume).toHaveBeenCalledWith(originalKey, 1, now)
+            expect(captureIngestionWarning).not.toHaveBeenCalled()
+            expect(produce).toHaveBeenCalledWith({
+                topic: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
+                value: message.value,
+                key: overflowMode === IngestionOverflowMode.Reroute ? originalKey : null,
+                waitForAck: true,
+            })
+        }
+    )
 
     it('does not reroute if not over capacity limit', async () => {
         const now = Date.now()


### PR DESCRIPTION
## Problem

See #20945 for details.

## Changes

See #20945 for details. This change fixes the (known) issue with that implementation.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Updated existing tests, as before.

This also is based on a couple of changes that prevent the issue we saw earlier, making this change itself safer:

- #21289 protects against the problematic `undefined` message key value by preventing its use when type checking
- #21315 improved the existing tests so that they call the producer rather than mocking it, which would have identified the issue where promises associated with producing messages with `undefined` keys never settled, blocking the consumer loop indefinitely

This patch can be applied to this PR to demonstrate the bad behavior when running tests:

```diff
diff --git a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
index 313e0cf083..e659c5fa1c 100644
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -269,7 +269,7 @@ async function emitToOverflow(queue: IngestionConsumer, kafkaMessages: Message[]
                 // ``message.key`` should not be undefined here, but in the
                 // (extremely) unlikely event that it is, set it to ``null``
                 // instead as that behavior is safer.
-                key: useRandomPartitioning ? null : message.key ?? null,
+                key: undefined,
                 headers: message.headers,
                 waitForAck: true,
             })
```