### PR TITLE
fix(settings): Get rid of overkill `overflow-hidden`

### DIFF
--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -84,7 +84,7 @@ export function Settings({
                 </>
             )}
 
-            <div className="flex-1 w-full space-y-2 overflow-hidden">
+            <div className="flex-1 w-full space-y-2 min-w-0">
                 {!hideSections && selectedLevel === 'project' && (
                     <LemonBanner type="info">
                         These settings only apply to the current project{' '}


### PR DESCRIPTION
## Problem

There's some occasional button clipping in settings:

<img width="268" alt="image" src="https://github.com/PostHog/posthog/assets/4550621/23137e54-de1f-4397-b3d7-1cbbb16fb251">

## Changes


`overflow: hidden` is overkill, we just need `min-width: 0`.