### PR TITLE
feat: Support client side ingestion warnings

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -162,7 +162,7 @@ export class EventPipelineRunner {
                 { alwaysSend: true }
             )
 
-            return this.registerLastStep('clientIngestionWarning', [], [warningAck])
+            return this.registerLastStep('clientIngestionWarning', [event], [warningAck])
         }
 
         const processedEvent = await this.runStep(pluginsProcessEventStep, [this, event], event.team_id)

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -148,6 +148,23 @@ export class EventPipelineRunner {
             event = normalizeProcessPerson(event, processPerson)
         }
 
+        if (event.event === '$$client_ingestion_warning') {
+            const warningAck = captureIngestionWarning(
+                this.hub.db.kafkaProducer,
+                event.team_id,
+                'client_ingestion_warning',
+                {
+                    eventUuid: event.uuid,
+                    event: event.event,
+                    distinctId: event.distinct_id,
+                    message: event.properties?.$$client_ingestion_warning_message,
+                },
+                { alwaysSend: true }
+            )
+
+            return this.registerLastStep('clientIngestionWarning', [], [warningAck])
+        }
+
         const processedEvent = await this.runStep(pluginsProcessEventStep, [this, event], event.team_id)
         if (processedEvent == null) {
             // A plugin dropped the event.


### PR DESCRIPTION
## Problem

Related to https://github.com/PostHog/posthog-js/pull/1051 

We want to send client ingestion warnings but we don't want them to be billable events.

## Changes

* Adds a check for a special `$$client_ingestion_warning` event that will trigger an ingestion warning but drop the event

@PostHog/team-pipeline open to renaming / any changes really - just went for PRs over issues 👍 

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Tests