### PR TITLE
chore(blobby): log sessions IDs that we add to redis overflow zset

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/overflow-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/overflow-manager.ts
@@ -2,6 +2,7 @@ import { Redis } from 'ioredis'
 import LRUCache from 'lru-cache'
 import { Gauge } from 'prom-client'
 
+import { status } from '../../../../utils/status'
 import { Limiter } from '../../../../utils/token-bucket'
 
 export const overflowTriggeredGauge = new Gauge({
@@ -31,6 +32,11 @@ export class OverflowManager {
     ) {
         this.limiter = new Limiter(burstCapacity, replenishRate)
         this.triggered = new LRUCache({ max: 1_000_000, maxAge: cooldownSeconds * 1000 })
+        status.info('🚛 ', '[overflow-manager] manager stated', {
+            redis_key: this.redisKey,
+            burstCapacity,
+            replenishRate,
+        })
     }
 
     public async observe(key: string, quantity: number, now?: number): Promise<void> {
@@ -50,6 +56,11 @@ export class OverflowManager {
         // The zset value is a timestamp in seconds.
         const expiration = (now ?? Date.now()) / 1000 + this.cooldownSeconds
         await this.redisClient.zadd(this.redisKey, 'NX', expiration, key)
+        status.info('🚛 ', '[overflow-manager] added new overflow record', {
+            redis_key: this.redisKey,
+            key,
+            expiration,
+        })
 
         // Cleanup old entries with values expired more than one hour ago.
         // We run the cleanup here because we assume this will only run a dozen times per day per region.


### PR DESCRIPTION
Add some info status log when we insert overflow records. Happens < 100 times/day, so we can be verbose.

```
[11:34:40.987] INFO (41232): [MAIN] 🚛  [overflow-manager] added new overflow record
    redis_key: "@posthog/capture-overflow/replay"
    key: "018ebd03-ec60-7ac3-b3c1-25388e55f855"
    expiration: 1712654538.031
```
