### PR TITLE
feat(celery): Add prefetch multiplier to flags

### DIFF
--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -76,6 +76,8 @@ FLAGS+=("-n node@%h")
 # Restart worker process after it exceeds this much memory usage (to mitigate memory leaks)
 [[ -n "${CELERY_MAX_MEMORY_PER_CHILD}" ]]    && FLAGS+=" --max-memory-per-child $CELERY_MAX_MEMORY_PER_CHILD"
 
+[[ -n "${CELERY_WORKER_PREFETCH_MULTIPLIER}" ]] && FLAGS+=" --prefetch-multiplier $CELERY_WORKER_PREFETCH_MULTIPLIER"
+
 if [[ -z "${CELERY_WORKER_QUEUES}" ]]; then
   source ./bin/celery-queues.env
 fi


### PR DESCRIPTION
## Problem

Since the env var doesn't make it to the subprocess, set it as flag.

## Changes

- adds prefetch multiplier

## Does this work well for both Cloud and self-hosted?

n/a
