### PR TITLE
chore(blobby): fix reporting of recording_blob_ingestion_lag* metrics 

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -595,20 +595,22 @@ export class SessionRecordingIngester {
         for (let partition = 0; partition < this.totalNumPartitions; partition++) {
             if (assignedPartitions.includes(partition)) {
                 const metrics = this.partitionMetrics[partition] || {}
-                if (metrics.lastMessageTimestamp) {
-                    gaugeLagMilliseconds
-                        .labels({
-                            partition: partition.toString(),
-                        })
-                        .set(now() - metrics.lastMessageTimestamp)
-                }
-
                 const highOffset = offsetsByPartition[partition]
 
                 if (highOffset && metrics.lastMessageOffset) {
-                    metrics.offsetLag = highOffset - metrics.lastMessageOffset
+                    // High watermark is highest offset plus one
+                    metrics.offsetLag = highOffset - 1 - metrics.lastMessageOffset
                     // NOTE: This is an important metric used by the autoscaler
                     gaugeLag.set({ partition }, Math.max(0, metrics.offsetLag))
+                }
+
+                if (metrics.offsetLag && metrics.offsetLag < 1) {
+                    // Consumer caught up, let's not report lag.
+                    // Code path active on overflow when sessions end and the partition is empty.
+                    gaugeLagMilliseconds.labels({ partition }).set(0)
+                } else if (metrics.lastMessageTimestamp) {
+                    // Not caught up, compute the processing lag based on the latest message we read.
+                    gaugeLagMilliseconds.labels({ partition }).set(now() - metrics.lastMessageTimestamp)
                 }
             } else {
                 delete this.partitionMetrics[partition]

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -598,7 +598,7 @@ export class SessionRecordingIngester {
                 const highOffset = offsetsByPartition[partition]
 
                 if (highOffset && metrics.lastMessageOffset) {
-                    // High watermark is highest offset plus one
+                    // High watermark is reported as highest message offset plus one
                     metrics.offsetLag = highOffset - 1 - metrics.lastMessageOffset
                     // NOTE: This is an important metric used by the autoscaler
                     gaugeLag.set({ partition }, Math.max(0, metrics.offsetLag))


### PR DESCRIPTION
## Problem

Blobby overflow consumer is reporting wonky values for these metrics: when the partition is empty (the sessions directed to overflow ends), `recording_blob_ingestion_lag` is stuck at 1 and `recording_blob_ingestion_lag_in_milliseconds` continues to increase while kafka metrics reports that there's zero lag on the partition.

## Changes

- Substract one from `metrics.offsetLag`, as the high watermark [is documented to report](https://docs.confluent.io/platform/current/clients/confluent-kafka-dotnet/_site/api/Confluent.Kafka.WatermarkOffsets.html) "the offset of the latest message in the topic/partition available for consumption + 1". Fixes `recording_blob_ingestion_lag` being stuck at one when the partition is empty
- Report `recording_blob_ingestion_lag_in_milliseconds` to zero when the consumer is caught up. The current behavior is to report the latest read message, and this gauge continuing to increase when the consumer is caught up and the partition empty.


## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
