### PR TITLE
fix(dashboards): Prevent insight card interaction when editing layout

### DIFF
--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -36,7 +36,7 @@
 
 .CardMeta {
     position: relative;
-    z-index: 101; // Elevate above viz
+    z-index: var(--z-raised); // Elevate above viz
     display: flex;
     flex-direction: column;
     flex-shrink: 0;

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
@@ -16,10 +16,12 @@
         outline: 1px solid var(--primary-3000);
     }
 
-    .ant-alert {
-        width: 100%;
-        margin: 1rem;
-        overflow: auto;
+    &.react-draggable::after {
+        // During dashboard layout editing, we need an overlay to prevent accidental interaction with card content
+        position: absolute;
+        inset: 0;
+        z-index: var(--z-content-overlay);
+        content: '';
     }
 }
 


### PR DESCRIPTION
## Problem

When editing a dashboard's layout, it was easy to accidentally interact with insight card elements and e.g. click into the insight. Such misclicks can be frustrating. See point 3 in ZEN-12286.

## Changes

Misclicks now won't be possible, as insights card content becomes non-interactive in dashboard edit mode.