### PR TITLE
fix(insights): Fix timezone issue when selecting fixed dates

### DIFF
--- a/frontend/src/lib/components/DateFilter/dateFilterLogic.ts
+++ b/frontend/src/lib/components/DateFilter/dateFilterLogic.ts
@@ -130,7 +130,8 @@ export const dateFilterLogic = kea<dateFilterLogicType>([
             if (values.rangeDateFrom) {
                 actions.setDate(
                     dayjs(values.rangeDateFrom).format('YYYY-MM-DD'),
-                    values.rangeDateTo ? dayjs(values.rangeDateTo).format() : null
+                    // Treat as naive time. Project timezone will be applied on backend.
+                    values.rangeDateTo ? dayjs(values.rangeDateTo).format('YYYY-MM-DDTHH:mm:ss') : null
                 )
             }
         },


### PR DESCRIPTION
## Problem

When selecting a fixed date range for an insight e.g. "7th April", the generated dates are off when the users' timezone doesn't match the project timezone. 

Improvement to #20154

## Changes

- format such that we drop the timezone info
- backend will apply project timezone via HogQL

## Does this work well for both Cloud and self-hosted?

it doesn't have an impact

## How did you test this code?

- made queries, checked resulting SQL