### PR TITLE
chore(plugin-server): warn about invalid $process_person, add normali…

### DIFF
--- a/plugin-server/functional_tests/analytics-ingestion/happy-path.test.ts
+++ b/plugin-server/functional_tests/analytics-ingestion/happy-path.test.ts
@@ -251,7 +251,7 @@ test.concurrent(
             expect(event).toEqual(
                 expect.objectContaining({
                     person_properties: {},
-                    properties: { uuid: properylessUuid, $sent_at: expect.any(String) },
+                    properties: { uuid: properylessUuid, $sent_at: expect.any(String), $process_person: false },
                     person_mode: 'propertyless',
                 })
             )

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -130,11 +130,14 @@ export function normalizeProcessPerson(event: PluginEvent, processPerson: boolea
         delete properties.$set
         delete properties.$set_once
         delete properties.$unset
+        // Recorded for clarity and so that the property exists if it is ever sent elsewhere,
+        // e.g. for migrations.
+        properties.$process_person = false
+    } else {
+        // Removed as it is the default, note that we have record the `person_mode` column
+        // in ClickHouse for all events.
+        delete properties.$process_person
     }
-
-    // We store the `person_mode` column if people want to see how an event was processed after
-    // the fact.
-    delete properties.$process_person
 
     event.properties = properties
     return event

--- a/plugin-server/tests/worker/ingestion/event-pipeline/normalizeEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/normalizeEventStep.test.ts
@@ -94,6 +94,7 @@ describe('normalizeEventStep()', () => {
             ...event,
             properties: {
                 $browser: 'Chrome',
+                $process_person: false,
             },
         })
 


### PR DESCRIPTION
…zed field to properties

## Problem

1. We are being deliberately strict about what is accepted in this field, but we need to warn if someone sends us something invalid.
2. We should leave the property when it is not the default, for visibility and migrations.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Fix the two things above.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->


## Does this work well for both Cloud and self-hosted?

Yes.

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Updated existing.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
