### PR TITLE
fix: Fix subscription deliveries happening multiple times

### DIFF
--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -117,7 +117,7 @@ def _deliver_subscription_report(
         raise NotImplementedError(f"{subscription.target_type} is not supported")
 
     if not is_new_subscription_target:
-        subscription.set_next_delivery_date(subscription.next_delivery_date)
+        subscription.set_next_delivery_date()
         subscription.save()
 
 


### PR DESCRIPTION
## Problem

#21416 - we were sending subscriptions way more frequently than we should
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

I'm not sure exactly what happened here, but I _think_ it's because we're probably falling behind so some subscriptions hadn't been updated in a while. We would then use the next_delivery_date to set the _next_ delivery date, but that date was still in the past, so next time around we would update it again.

Now we just use the current date to set the next delivery date, so at least it's always 1 hour/day removed from whenever the last one was set.

The downside is if we fall behind we could end up not sending _enough_ of these, but probably worth it.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
