### PR TITLE
feat(insights): Make async queries ack late

### DIFF
--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -87,6 +87,10 @@ def execute_process_query(
     team = Team.objects.get(pk=team_id)
 
     query_status = manager.get_query_status()
+
+    if query_status.complete or query_status.error:
+        return
+
     query_status.error = True  # Assume error in case nothing below ends up working
 
     pickup_time = datetime.datetime.now(datetime.timezone.utc)

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -32,7 +32,7 @@ def redis_heartbeat() -> None:
     get_client().set("POSTHOG_HEARTBEAT", int(time.time()))
 
 
-@shared_task(ignore_result=True, queue=CeleryQueue.ANALYTICS_QUERIES.value)
+@shared_task(ignore_result=True, queue=CeleryQueue.ANALYTICS_QUERIES.value, acks_late=True)
 def process_query_task(
     team_id: int,
     user_id: int,


### PR DESCRIPTION
## Problem

As async queries might be long running, we want 0 prefetched tasks.
See
https://docs.celeryq.dev/en/stable/userguide/optimizing.html#reserve-one-task-at-a-time

## Changes

- add acks late

## Does this work well for both Cloud and self-hosted?

it doesn't have an impact

## How did you test this code?

n/a