### PR TITLE
fix: Continue squash on no more total mutations

### DIFF
--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -569,12 +569,12 @@ async def wait_for_mutation(inputs: MutationActivityInputs) -> None:
                         query_parameters={"query": query_command, "table": mutation.table},
                     )
 
-                    mutations_in_progress, total_mutations = parse_mutation_counts(response)
+                    mutations_in_progress, _ = parse_mutation_counts(response)
 
-                    if mutations_in_progress == 0 and total_mutations > 0:
+                    if mutations_in_progress == 0:
                         break
 
-                    activity.logger.info("Still waiting for mutatio %s", inputs.name)
+                    activity.logger.info("Still waiting for mutation %s", inputs.name)
 
                     await asyncio.sleep(5)
 


### PR DESCRIPTION
## Problem

It would seem that ClickHouse frequently purges data from `system.mutations`, so we can't expect `total_mutations` to be > 0. This can cause us to get stuck waiting even if there's nothing more to wait for.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Ignore `total_mutations` while waiting for mutations in squash.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
