### PR TITLE
fix: nested css selector splitting

### DIFF
--- a/patches/rrweb@2.0.0-alpha.12.patch
+++ b/patches/rrweb@2.0.0-alpha.12.patch
@@ -520,3 +520,51 @@ index e9a8ab2ba94093198f3dc42c9f6c4915f99cbc1d..182662fff8cca2eb4c63d956f0fce946
          }
      }
      applyMutation(d, isSync) {
+diff --git a/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js b/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
+index 342e1df171368d312dc0372dace0c6b5a1eb9c61..e98368347aab6f22902e691e1909aa0333232140 100644
+--- a/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
++++ b/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
+@@ -1254,16 +1254,40 @@ function parse(css, options = {}) {
+         if (!m) {
+             return;
+         }
+-        return trim(m[0])
++        return splitRootSelectors(trim(m[0])
+             .replace(/\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*\/+/g, '')
+             .replace(/"(?:\\"|[^"])*"|'(?:\\'|[^'])*'/g, (m) => {
+             return m.replace(/,/g, '\u200C');
+-        })
+-            .split(/\s*(?![^(]*\)),\s*/)
++        }))
+             .map((s) => {
+             return s.replace(/\u200C/g, ',');
+         });
+     }
++    function splitRootSelectors(input) {
++        let parts = [];
++        let nestedLevel = 0;
++        let currentPart = '';
++
++        for (let i = 0; i < input.length; i++) {
++            const char = input[i];
++            currentPart += char;
++
++            if (char === '(') {
++                nestedLevel++;
++            } else if (char === ')') {
++                nestedLevel--;
++            } else if (char === ',' && nestedLevel === 0) {
++                parts.push(currentPart.slice(0, -1).trim());
++                currentPart = '';
++            }
++        }
++
++        if (currentPart.trim() !== '') {
++            parts.push(currentPart.trim());
++        }
++
++        return parts;
++    }
+     function declaration() {
+         const pos = position();
+         const propMatch = match(/^(\*?[-#\/\*\\\w]+(\[[0-9a-z_-]+\])?)\s*/);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -9,7 +9,7 @@ overrides:
 
 patchedDependencies:
   rrweb@2.0.0-alpha.12:
-    hash: 2rbzexnjhaf34oglgkdlfbhwde
+    hash: t3xxecww6aodjl4qopwv6jdxmq
     path: patches/rrweb@2.0.0-alpha.12.patch
 
 dependencies:
@@ -327,7 +327,7 @@ dependencies:
     version: 1.5.1
   rrweb:
     specifier: 2.0.0-alpha.12
-    version: 2.0.0-alpha.12(patch_hash=2rbzexnjhaf34oglgkdlfbhwde)
+    version: 2.0.0-alpha.12(patch_hash=t3xxecww6aodjl4qopwv6jdxmq)
   sass:
     specifier: ^1.26.2
     version: 1.56.0
@@ -347,7 +347,7 @@ dependencies:
 optionalDependencies:
   fsevents:
     specifier: ^2.3.2
-    version: 2.3.2
+    version: 2.3.3
 
 devDependencies:
   '@babel/core':
@@ -12822,6 +12822,7 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /fsevents@2.3.3:
@@ -19156,7 +19157,7 @@ packages:
     resolution: {integrity: sha512-i4sz9469dbsEGFiBzCkq+7I7M+imPeC3NrKgrrdJ2tXu9H+/eegNe4SrQgCsLBeSZHZDHU0o9L5rxTAiapWbGg==}
     dev: false
 
-  /rrweb@2.0.0-alpha.12(patch_hash=2rbzexnjhaf34oglgkdlfbhwde):
+  /rrweb@2.0.0-alpha.12(patch_hash=t3xxecww6aodjl4qopwv6jdxmq):
     resolution: {integrity: sha512-lUGwBV7gmbwz1dIgzo9EEayIVyxoTIF6NBF6+Jctqs4Uy45QkyARtikpQlCUfxVCGTCQ0FOee9jeVYsG39oq1g==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.12


### PR DESCRIPTION
## Problem

Ticket https://posthoghelp.zendesk.com/agent/tickets/11767 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/14269)

Customers website was not rendering correctly due to a CSS rule of the form

```
body > ul :is(li:not(:first-of-type) a:hover, li:not(:first-of-type).active a) {
    background: 'red';
}
```

The CSS parser included in RRWeb attempts to find the [selector for a given rule](https://github.com/rrweb-io/rrweb/blob/3d1877cff83d9a018630674fb6e730050ceef812/packages/rrweb-snapshot/src/css.ts#L427-L443). It uses these selectors to [generate hover classes necessary during playback](https://github.com/rrweb-io/rrweb/blob/3d1877cff83d9a018630674fb6e730050ceef812/packages/rrweb-snapshot/src/rebuild.ts#L73-L136).

However the parser was misinterpreting the `,` in the above rule and splitting it into two separate selectors e.g. `body > ul :is(li:not(:first-of-type) a:hover` and `li:not(:first-of-type).active a)`. Both of which were malformed. This broke the rest of the stylesheet and meant that the rules were not being loaded.

## Changes

The problem arises from the [split regex](https://github.com/rrweb-io/rrweb/blob/3d1877cff83d9a018630674fb6e730050ceef812/packages/rrweb-snapshot/src/css.ts#L439)
```
.split(/\s*(?![^(]*\)),\s*/)
```

It does not account for nesting. An arbitrary level of nesting cannot be handled in CSS so I opted to create a new JS function in the parser called `splitRootSelectors`

The customers website playback now looks perfect!

## Does this work well for both Cloud and self-hosted?

Yes