### PR TITLE
chore(blobby): fix gaugeLagMilliseconds reporting, take 2

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -599,12 +599,12 @@ export class SessionRecordingIngester {
 
                 if (highOffset && metrics.lastMessageOffset) {
                     // High watermark is reported as highest message offset plus one
-                    metrics.offsetLag = highOffset - 1 - metrics.lastMessageOffset
+                    metrics.offsetLag = Math.max(0, highOffset - 1 - metrics.lastMessageOffset)
                     // NOTE: This is an important metric used by the autoscaler
-                    gaugeLag.set({ partition }, Math.max(0, metrics.offsetLag))
+                    gaugeLag.set({ partition }, metrics.offsetLag)
                 }
 
-                if (metrics.offsetLag && metrics.offsetLag < 1) {
+                if (metrics.offsetLag === 0) {
                     // Consumer caught up, let's not report lag.
                     // Code path active on overflow when sessions end and the partition is empty.
                     gaugeLagMilliseconds.labels({ partition }).set(0)


### PR DESCRIPTION
## Problem

`recording_blob_ingestion_lag_in_milliseconds` is still incremented when the consumer is caught up on an empty partition.

## Changes

- Fix the `if` condition to trigger if offsetLag is zero

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
