### PR TITLE
feat: Pass PR labels through to deploy action

### DIFF
--- a/.github/actions/get-pr-labels/action.yml
+++ b/.github/actions/get-pr-labels/action.yml
@@ -1,0 +1,47 @@
+name: "Get merged pull request labels"
+shell: bash
+description: "Get the labels of the PR that was merged to create this push event"
+inputs:
+  token:
+    description: "GH token"
+    required: true
+outputs:
+  labels:
+    description: "JSON array labels of the PR that was merged (if any)"
+    value: ${{ steps.labels.outputs.labels }}
+runs:
+  using: "composite"
+  steps:
+    - name: Get PR associated with the last commit
+      id: pr-info
+      uses: octokit/request-action@v2.x
+      with:
+        route: GET /repos/${{ github.repository }}/commits/${{ github.sha }}/pulls
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+
+    - name: Extract PR number
+      shell: bash
+      if: steps.pr-info.outputs.data
+      id: extract-pr
+      run: |
+        echo "PR_NUMBER=$(cat | jq -r '.[-1].number' <<EOF
+          ${{ steps.pr-info.outputs.data }}
+        EOF
+        )" >> $GITHUB_OUTPUT
+
+    - name: Fetch PR Labels
+      shell: bash
+      if: steps.extract-pr.outputs.PR_NUMBER
+      id: labels
+      run: |
+        PR_NUMBER=${{ steps.extract-pr.outputs.PR_NUMBER }}
+        LABELS=$(curl \
+          -H "Authorization: Bearer ${{ inputs.token }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/labels | jq -rc '[.[].name]')
+        echo "Labels of PR #$PR_NUMBER: $LABELS"
+
+        echo labels="$LABELS" >> $GITHUB_OUTPUT
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -76,6 +76,12 @@ jobs:
                   app_id: ${{ secrets.DEPLOYER_APP_ID }}
                   private_key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
 
+            - name: get PR labels
+              id: labels
+              uses: ./.github/actions/get-pr-labels
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Trigger PostHog Cloud deployment from Charts
               uses: mvasigh/dispatch-action@main
               with:
@@ -86,7 +92,8 @@ jobs:
                   message: |
                       {
                         "image_tag": "${{ steps.build.outputs.digest }}",
-                        "context": ${{ toJson(github) }}
+                        "context": ${{ toJson(github) }},
+                        "github_labels": ${{ toJson(steps.labels.outputs.labels }}
                       }
 
             - name: Check for changes in plugins directory

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -93,7 +93,7 @@ jobs:
                       {
                         "image_tag": "${{ steps.build.outputs.digest }}",
                         "context": ${{ toJson(github) }},
-                        "github_labels": ${{ toJson(steps.labels.outputs.labels }}
+                        "github_labels": ${{ toJson(steps.labels.outputs.labels) }}
                       }
 
             - name: Check for changes in plugins directory


### PR DESCRIPTION
## Problem

We want to be able to control aspects of deploys (e.g. canarying) depending on the pull request that triggered it (e.g. high risk change)

Pass through the PR labels to the deploy action so we can change the deployment based on them

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
