### PR TITLE
fix(insights): Fix timezone config popover issue

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -35,6 +35,7 @@ export type LemonInputSelectProps = Pick<
     onBlur?: () => void
     onInputChange?: (newValue: string) => void
     'data-attr'?: string
+    popoverClassName?: string
 }
 
 export function LemonInputSelect({
@@ -50,6 +51,7 @@ export function LemonInputSelect({
     disableFiltering = false,
     allowCustomValues = false,
     autoFocus = false,
+    popoverClassName,
     ...props
 }: LemonInputSelectProps): JSX.Element {
     const [showPopover, setShowPopover] = useState(false)
@@ -269,6 +271,7 @@ export function LemonInputSelect({
                 popoverFocusRef.current = true
                 e.stopPropagation()
             }}
+            className={popoverClassName}
             overlay={
                 <div className="space-y-px overflow-y-auto">
                     {visibleOptions.length ? (

--- a/frontend/src/scenes/settings/project/TimezoneConfig.tsx
+++ b/frontend/src/scenes/settings/project/TimezoneConfig.tsx
@@ -31,6 +31,7 @@ export function TimezoneConfig(): JSX.Element {
                 loading={currentTeamLoading}
                 disabled={currentTeamLoading}
                 value={[currentTeam.timezone]}
+                popoverClassName="z-[1000]"
                 onChange={([newTimezone]): void => {
                     // This is a string for a single-mode select, but typing is poor
                     if (!preflight?.available_timezones) {


### PR DESCRIPTION
## Problem

Timezone changing opens a modal that shows below the dropdown popover

## Changes

Use z-index class and pass it through to popover.

Quick fix. Ultimately we should make the dropdown close after selecting a single value.
See https://posthog.slack.com/archives/C045L1VEG87/p1712582962858839

<img width="888" alt="image" src="https://github.com/PostHog/posthog/assets/59713/47369533-39ec-42b9-877c-9ec606175cb5">


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

- 👀 