### PR TITLE
fix: personless mode to retry get person for races

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -111,7 +111,7 @@ export class PersonState {
             // In the future, we won't even get or create a real Person for these events, and so
             // the `processPerson` boolean can be removed from this class altogether, as this class
             // shouldn't even need to be invoked.
-            const [person, _] = await this.createOrGetPerson()
+            const [person, _] = await promiseRetry(() => this.createOrGetPerson(), 'get_person_personless')
 
             // Ensure person properties don't propagate elsewhere, such as onto the event itself.
             person.properties = {}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We saw some stuff in DLQ, we retry everywhere else, but not here ... yet.
Related thread: https://posthog.slack.com/archives/C04R8HGPACX/p1712621792119379 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
