### PR TITLE
fix(insights): Don't reset new insight when recording opened 2.0

### DIFF
--- a/frontend/src/scenes/session-recordings/player/modal/sessionPlayerModalLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/modal/sessionPlayerModalLogic.ts
@@ -42,9 +42,7 @@ export const sessionPlayerModalLogic = kea<sessionPlayerModalLogicType>([
         ],
     }),
     actionToUrl(({ values }) => {
-        const buildURL = (
-            replace: boolean
-        ): [
+        const buildURL = (): [
             string,
             Record<string, any>,
             Record<string, any>,
@@ -71,12 +69,12 @@ export const sessionPlayerModalLogic = kea<sessionPlayerModalLogicType>([
                 searchParams.timestamp = values.initialTimestamp
             }
 
-            return [router.values.location.pathname, searchParams, hashParams, { replace }]
+            return [router.values.location.pathname, searchParams, hashParams, { replace: true }]
         }
 
         return {
-            openSessionPlayer: () => buildURL(false),
-            closeSessionPlayer: () => buildURL(false),
+            openSessionPlayer: () => buildURL(),
+            closeSessionPlayer: () => buildURL(),
         }
     }),
     urlToAction(({ actions, values }) => {


### PR DESCRIPTION
## Problem

Second attempt at #21424 (CC @webjunkie):

https://github.com/PostHog/posthog/assets/4550621/ff0baee2-83bc-4bd1-9927-1601dcc4694a

Reported in ZEN-12286 (issue #1).

## Changes

Previously I tried to fix this by updating `insightSceneLogic` URL handling, but in principle the existing handling is so much more correct than not, that I don't that's what needs to change. It's `sessionPlayerModalLogic.ts` that really is the offender. It pushes the `sessionRecordingId` change as a new browsing history item, and I think it shouldn't be doing that.

The problem from the recording above no longer occurs.