### PR TITLE
fix: Fix property definitions table page problems

### DIFF
--- a/frontend/src/scenes/data-management/properties/propertyDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/properties/propertyDefinitionsTableLogic.ts
@@ -155,11 +155,13 @@ export const propertyDefinitionsTableLogic = kea<propertyDefinitionsTableLogicTy
         ],
     })),
     listeners(({ actions, values, cache }) => ({
-        setFilters: () => {
+        setFilters: async (_, breakpoint) => {
+            await breakpoint(500)
             actions.loadPropertyDefinitions(
                 normalizePropertyDefinitionEndpointUrl(
                     values.propertyDefinitions.current,
                     {
+                        offset: 0,
                         search: values.filters.property,
                         type: values.filters.type,
                         group_type_index: values.filters.group_type_index,
@@ -200,9 +202,12 @@ export const propertyDefinitionsTableLogic = kea<propertyDefinitionsTableLogicTy
     })),
     urlToAction(({ actions, values }) => ({
         [urls.propertyDefinitions()]: (_, searchParams) => {
+            if (values.propertyDefinitionsLoading) {
+                return
+            }
             if (!objectsEqual(cleanFilters(values.filters), cleanFilters(router.values.searchParams))) {
                 actions.setFilters(searchParams as Filters)
-            } else if (!values.propertyDefinitions.results.length && !values.propertyDefinitionsLoading) {
+            } else if (!values.propertyDefinitions.results.length) {
                 actions.loadPropertyDefinitions()
             }
         },


### PR DESCRIPTION
## Problem

pagination often takes 2 clicks because it's using a previous offset value
searching when on a page > 1 doesn't reset the offset so the search might show no results even if there are results

## Changes

- turns out we use the `next` URL for the loading, but at the very same time the pagination updates the URL, causing `setFilter` to trigger, which loads with the current URL -> this is caught by a breakpoint hence the current URL is ultimately used again
  - mitigated by checking for loading state and not applying filter changes
- set offset to 0 when filters are set

## Does this work well for both Cloud and self-hosted?

it doesn't have an impact

## How did you test this code?

- clicked and checked
