### PR TITLE
fix: Make timeouts variable according to interval

### DIFF
--- a/posthog/api/test/__snapshots__/test_annotation.ambr
+++ b/posthog/api/test/__snapshots__/test_annotation.ambr
@@ -201,91 +201,23 @@
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
   '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
+  '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_annotation"
   WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
            AND "posthog_annotation"."scope" = 'organization')
           OR "posthog_annotation"."team_id" = 2)
          AND NOT "posthog_annotation"."deleted")
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
-  '''
-  SELECT "posthog_annotation"."id",
-         "posthog_annotation"."content",
-         "posthog_annotation"."created_at",
-         "posthog_annotation"."updated_at",
-         "posthog_annotation"."dashboard_item_id",
-         "posthog_annotation"."team_id",
-         "posthog_annotation"."organization_id",
-         "posthog_annotation"."created_by_id",
-         "posthog_annotation"."scope",
-         "posthog_annotation"."creation_type",
-         "posthog_annotation"."date_marker",
-         "posthog_annotation"."deleted",
-         "posthog_annotation"."apply_all",
-         "posthog_dashboarditem"."id",
-         "posthog_dashboarditem"."name",
-         "posthog_dashboarditem"."derived_name",
-         "posthog_dashboarditem"."description",
-         "posthog_dashboarditem"."team_id",
-         "posthog_dashboarditem"."filters",
-         "posthog_dashboarditem"."filters_hash",
-         "posthog_dashboarditem"."query",
-         "posthog_dashboarditem"."order",
-         "posthog_dashboarditem"."deleted",
-         "posthog_dashboarditem"."saved",
-         "posthog_dashboarditem"."created_at",
-         "posthog_dashboarditem"."last_refresh",
-         "posthog_dashboarditem"."refreshing",
-         "posthog_dashboarditem"."created_by_id",
-         "posthog_dashboarditem"."is_sample",
-         "posthog_dashboarditem"."short_id",
-         "posthog_dashboarditem"."favorited",
-         "posthog_dashboarditem"."refresh_attempt",
-         "posthog_dashboarditem"."last_modified_at",
-         "posthog_dashboarditem"."last_modified_by_id",
-         "posthog_dashboarditem"."dashboard_id",
-         "posthog_dashboarditem"."layouts",
-         "posthog_dashboarditem"."color",
-         "posthog_dashboarditem"."dive_dashboard_id",
-         "posthog_dashboarditem"."updated_at",
-         "posthog_dashboarditem"."deprecated_tags",
-         "posthog_dashboarditem"."tags",
-         "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."pending_email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."is_email_verified",
-         "posthog_user"."requested_password_reset_at",
-         "posthog_user"."has_seen_product_intro_for",
-         "posthog_user"."strapi_id",
-         "posthog_user"."email_opt_in",
-         "posthog_user"."theme_mode",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."events_column_config"
-  FROM "posthog_annotation"
-  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
-  LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
-  WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-           AND "posthog_annotation"."scope" = 'organization')
-          OR "posthog_annotation"."team_id" = 2)
-         AND NOT "posthog_annotation"."deleted")
-  ORDER BY "posthog_annotation"."date_marker" DESC
-  LIMIT 1000
   '''
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.15

--- a/posthog/api/test/__snapshots__/test_annotation.ambr
+++ b/posthog/api/test/__snapshots__/test_annotation.ambr
@@ -85,6 +85,132 @@
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.10
   '''
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."strapi_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 2
+  LIMIT 21
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.11
+  '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."extra_settings",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.12
+  '''
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."available_features"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE "posthog_organizationmembership"."user_id" = 2
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_annotation"
+  WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+           AND "posthog_annotation"."scope" = 'organization')
+          OR "posthog_annotation"."team_id" = 2)
+         AND NOT "posthog_annotation"."deleted")
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
+  '''
   SELECT "posthog_annotation"."id",
          "posthog_annotation"."content",
          "posthog_annotation"."created_at",
@@ -160,132 +286,6 @@
          AND NOT "posthog_annotation"."deleted")
   ORDER BY "posthog_annotation"."date_marker" DESC
   LIMIT 1000
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.11
-  '''
-  SELECT "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."pending_email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."is_email_verified",
-         "posthog_user"."has_seen_product_intro_for",
-         "posthog_user"."strapi_id",
-         "posthog_user"."email_opt_in",
-         "posthog_user"."theme_mode",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."events_column_config"
-  FROM "posthog_user"
-  WHERE "posthog_user"."id" = 2
-  LIMIT 21
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.12
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."extra_settings",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 2
-  LIMIT 21
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
-  '''
-  SELECT "posthog_organizationmembership"."id",
-         "posthog_organizationmembership"."organization_id",
-         "posthog_organizationmembership"."user_id",
-         "posthog_organizationmembership"."level",
-         "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist",
-         "posthog_organization"."available_features"
-  FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE "posthog_organizationmembership"."user_id" = 2
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
-  '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_annotation"
-  WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-           AND "posthog_annotation"."scope" = 'organization')
-          OR "posthog_annotation"."team_id" = 2)
-         AND NOT "posthog_annotation"."deleted")
   '''
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.15
@@ -538,22 +538,90 @@
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.8
   '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.9
-  '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_annotation"
   WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
            AND "posthog_annotation"."scope" = 'organization')
           OR "posthog_annotation"."team_id" = 2)
          AND NOT "posthog_annotation"."deleted")
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.9
+  '''
+  SELECT "posthog_annotation"."id",
+         "posthog_annotation"."content",
+         "posthog_annotation"."created_at",
+         "posthog_annotation"."updated_at",
+         "posthog_annotation"."dashboard_item_id",
+         "posthog_annotation"."team_id",
+         "posthog_annotation"."organization_id",
+         "posthog_annotation"."created_by_id",
+         "posthog_annotation"."scope",
+         "posthog_annotation"."creation_type",
+         "posthog_annotation"."date_marker",
+         "posthog_annotation"."deleted",
+         "posthog_annotation"."apply_all",
+         "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."derived_name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."query",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt",
+         "posthog_dashboarditem"."last_modified_at",
+         "posthog_dashboarditem"."last_modified_by_id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."updated_at",
+         "posthog_dashboarditem"."deprecated_tags",
+         "posthog_dashboarditem"."tags",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."requested_password_reset_at",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."strapi_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_annotation"
+  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
+  WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+           AND "posthog_annotation"."scope" = 'organization')
+          OR "posthog_annotation"."team_id" = 2)
+         AND NOT "posthog_annotation"."deleted")
+  ORDER BY "posthog_annotation"."date_marker" DESC
+  LIMIT 1000
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_annotation.ambr
+++ b/posthog/api/test/__snapshots__/test_annotation.ambr
@@ -85,6 +85,85 @@
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.10
   '''
+  SELECT "posthog_annotation"."id",
+         "posthog_annotation"."content",
+         "posthog_annotation"."created_at",
+         "posthog_annotation"."updated_at",
+         "posthog_annotation"."dashboard_item_id",
+         "posthog_annotation"."team_id",
+         "posthog_annotation"."organization_id",
+         "posthog_annotation"."created_by_id",
+         "posthog_annotation"."scope",
+         "posthog_annotation"."creation_type",
+         "posthog_annotation"."date_marker",
+         "posthog_annotation"."deleted",
+         "posthog_annotation"."apply_all",
+         "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."derived_name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."query",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt",
+         "posthog_dashboarditem"."last_modified_at",
+         "posthog_dashboarditem"."last_modified_by_id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."updated_at",
+         "posthog_dashboarditem"."deprecated_tags",
+         "posthog_dashboarditem"."tags",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."requested_password_reset_at",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."strapi_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_annotation"
+  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
+  WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+           AND "posthog_annotation"."scope" = 'organization')
+          OR "posthog_annotation"."team_id" = 2)
+         AND NOT "posthog_annotation"."deleted")
+  ORDER BY "posthog_annotation"."date_marker" DESC
+  LIMIT 1000
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.11
+  '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
          "posthog_user"."last_login",
@@ -114,7 +193,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.11
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.12
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -167,7 +246,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.12
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
   '''
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -197,17 +276,6 @@
   FROM "posthog_organizationmembership"
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
   WHERE "posthog_organizationmembership"."user_id" = 2
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
-  '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1
   '''
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
@@ -470,90 +538,22 @@
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.8
   '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.9
+  '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_annotation"
   WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
            AND "posthog_annotation"."scope" = 'organization')
           OR "posthog_annotation"."team_id" = 2)
          AND NOT "posthog_annotation"."deleted")
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.9
-  '''
-  SELECT "posthog_annotation"."id",
-         "posthog_annotation"."content",
-         "posthog_annotation"."created_at",
-         "posthog_annotation"."updated_at",
-         "posthog_annotation"."dashboard_item_id",
-         "posthog_annotation"."team_id",
-         "posthog_annotation"."organization_id",
-         "posthog_annotation"."created_by_id",
-         "posthog_annotation"."scope",
-         "posthog_annotation"."creation_type",
-         "posthog_annotation"."date_marker",
-         "posthog_annotation"."deleted",
-         "posthog_annotation"."apply_all",
-         "posthog_dashboarditem"."id",
-         "posthog_dashboarditem"."name",
-         "posthog_dashboarditem"."derived_name",
-         "posthog_dashboarditem"."description",
-         "posthog_dashboarditem"."team_id",
-         "posthog_dashboarditem"."filters",
-         "posthog_dashboarditem"."filters_hash",
-         "posthog_dashboarditem"."query",
-         "posthog_dashboarditem"."order",
-         "posthog_dashboarditem"."deleted",
-         "posthog_dashboarditem"."saved",
-         "posthog_dashboarditem"."created_at",
-         "posthog_dashboarditem"."last_refresh",
-         "posthog_dashboarditem"."refreshing",
-         "posthog_dashboarditem"."created_by_id",
-         "posthog_dashboarditem"."is_sample",
-         "posthog_dashboarditem"."short_id",
-         "posthog_dashboarditem"."favorited",
-         "posthog_dashboarditem"."refresh_attempt",
-         "posthog_dashboarditem"."last_modified_at",
-         "posthog_dashboarditem"."last_modified_by_id",
-         "posthog_dashboarditem"."dashboard_id",
-         "posthog_dashboarditem"."layouts",
-         "posthog_dashboarditem"."color",
-         "posthog_dashboarditem"."dive_dashboard_id",
-         "posthog_dashboarditem"."updated_at",
-         "posthog_dashboarditem"."deprecated_tags",
-         "posthog_dashboarditem"."tags",
-         "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."pending_email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."is_email_verified",
-         "posthog_user"."requested_password_reset_at",
-         "posthog_user"."has_seen_product_intro_for",
-         "posthog_user"."strapi_id",
-         "posthog_user"."email_opt_in",
-         "posthog_user"."theme_mode",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."events_column_config"
-  FROM "posthog_annotation"
-  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
-  LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
-  WHERE ((("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-           AND "posthog_annotation"."scope" = 'organization')
-          OR "posthog_annotation"."team_id" = 2)
-         AND NOT "posthog_annotation"."deleted")
-  ORDER BY "posthog_annotation"."date_marker" DESC
-  LIMIT 1000
   '''
 # ---

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -596,8 +596,8 @@ async def execute_batch_export_insert_activity(
     interval: str,
     start_to_close_timeout_multiplier: int = 2,
     heartbeat_timeout_seconds: int | None = 120,
-    maximum_attempts: int = 10,
-    initial_retry_interval_seconds: int = 10,
+    maximum_attempts: int = 15,
+    initial_retry_interval_seconds: int = 30,
     maximum_retry_interval_seconds: int = 120,
 ) -> None:
     """Execute the main insert activity of a batch export handling any errors.

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -594,7 +594,6 @@ async def execute_batch_export_insert_activity(
     non_retryable_error_types: list[str],
     finish_inputs: FinishBatchExportRunInputs,
     interval: str,
-    start_to_close_timeout_multiplier: int = 2,
     heartbeat_timeout_seconds: int | None = 120,
     maximum_attempts: int = 15,
     initial_retry_interval_seconds: int = 30,
@@ -612,8 +611,6 @@ async def execute_batch_export_insert_activity(
         non_retryable_error_types: A list of errors to not retry on when executing the activity.
         finish_inputs: Inputs to the 'finish_batch_export_run' to run at the end.
         interval: The interval of the batch export used to set the start to close timeout.
-        start_to_close_timeout_multiplier: Multiply computed timeout by this multiplier. Used to add
-            some extra buffer to the timeout.
         maximum_attempts: Maximum number of retries for the 'insert_into_*' activity function.
             Assuming the error that triggered the retry is not in non_retryable_error_types.
         initial_retry_interval_seconds: When retrying, seconds until the first retry.
@@ -628,13 +625,13 @@ async def execute_batch_export_insert_activity(
     )
 
     if interval == "hour":
-        start_to_close_timeout = dt.timedelta(hours=1) * start_to_close_timeout_multiplier
+        start_to_close_timeout = dt.timedelta(hours=1)
     elif interval == "day":
-        start_to_close_timeout = dt.timedelta(days=1) * start_to_close_timeout_multiplier
+        start_to_close_timeout = dt.timedelta(days=1)
     elif interval.startswith("every"):
         _, value, unit = interval.split(" ")
         kwargs = {unit: int(value)}
-        start_to_close_timeout = dt.timedelta(**kwargs) * start_to_close_timeout_multiplier
+        start_to_close_timeout = dt.timedelta(**kwargs)
     else:
         raise ValueError(f"Unsupported interval: '{interval}'")
 

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -631,7 +631,8 @@ async def execute_batch_export_insert_activity(
     elif interval.startswith("every"):
         _, value, unit = interval.split(" ")
         kwargs = {unit: int(value)}
-        start_to_close_timeout = dt.timedelta(**kwargs)
+        # TODO: Consider removing this 10 minute minimum once we are more confident about hitting 5 minute or lower SLAs.
+        start_to_close_timeout = max(dt.timedelta(minutes=10), dt.timedelta(**kwargs))
     else:
         raise ValueError(f"Unsupported interval: '{interval}'")
 

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -432,6 +432,7 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
         await execute_batch_export_insert_activity(
             insert_into_bigquery_activity,
             insert_inputs,
+            interval=inputs.interval,
             non_retryable_error_types=[
                 # Raised on missing permissions.
                 "Forbidden",

--- a/posthog/temporal/batch_exports/http_batch_export.py
+++ b/posthog/temporal/batch_exports/http_batch_export.py
@@ -373,6 +373,7 @@ class HttpBatchExportWorkflow(PostHogWorkflow):
         await execute_batch_export_insert_activity(
             insert_into_http_activity,
             insert_inputs,
+            interval=inputs.interval,
             non_retryable_error_types=[
                 "NonRetryableResponseError",
             ],

--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -439,6 +439,7 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
         await execute_batch_export_insert_activity(
             insert_into_postgres_activity,
             insert_inputs,
+            interval=inputs.interval,
             non_retryable_error_types=[
                 # Raised on errors that are related to database operation.
                 # For example: unexpected disconnect, database or other object not found.

--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -469,6 +469,7 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
         await execute_batch_export_insert_activity(
             insert_into_redshift_activity,
             insert_inputs,
+            interval=inputs.interval,
             non_retryable_error_types=[
                 # Raised on errors that are related to database operation.
                 # For example: unexpected disconnect, database or other object not found.

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -687,6 +687,7 @@ class S3BatchExportWorkflow(PostHogWorkflow):
         await execute_batch_export_insert_activity(
             insert_into_s3_activity,
             insert_inputs,
+            interval=inputs.interval,
             non_retryable_error_types=[
                 # S3 parameter validation failed.
                 "ParamValidationError",

--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -631,6 +631,7 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
         await execute_batch_export_insert_activity(
             insert_into_snowflake_activity,
             insert_inputs,
+            interval=inputs.interval,
             non_retryable_error_types=[
                 # Raised when we cannot connect to Snowflake.
                 "DatabaseError",

--- a/posthog/temporal/tests/utils/events.py
+++ b/posthog/temporal/tests/utils/events.py
@@ -170,7 +170,7 @@ async def generate_test_events_in_clickhouse(
     events: list[EventValues] = []
     while len(events) < count:
         events_to_insert = generate_test_events(
-            count=min(count, batch_size),
+            count=min(count - len(events), batch_size),
             team_id=team_id,
             possible_datetimes=possible_datetimes,
             event_name=event_name,

--- a/posthog/temporal/tests/utils/events.py
+++ b/posthog/temporal/tests/utils/events.py
@@ -166,7 +166,7 @@ async def generate_test_events_in_clickhouse(
     possible_datetimes = list(date_range(start_time, end_time, dt.timedelta(minutes=1)))
 
     # Base events
-    events = []
+    events: list[EventValues] = []
     while len(events) < count:
         events_to_insert = generate_test_events(
             count=min(count, batch_size),

--- a/posthog/temporal/tests/utils/events.py
+++ b/posthog/temporal/tests/utils/events.py
@@ -139,7 +139,7 @@ async def generate_test_events_in_clickhouse(
     person_properties: dict | None = None,
     inserted_at: str | dt.datetime | None = "_timestamp",
     duplicate: bool = False,
-    batch_size: int = 1000,
+    batch_size: int = 10000,
 ) -> tuple[list[EventValues], list[EventValues], list[EventValues]]:
     """Insert test events into the sharded_events table.
 

--- a/posthog/temporal/tests/utils/events.py
+++ b/posthog/temporal/tests/utils/events.py
@@ -44,6 +44,7 @@ def generate_test_events(
     site_url: str | None = "",
     set_field: dict | None = None,
     set_once: dict | None = None,
+    start: int = 0,
 ):
     """Generate a list of events for testing."""
     _timestamp = random.choice(possible_datetimes)
@@ -77,7 +78,7 @@ def generate_test_events(
             "set": set_field,
             "set_once": set_once,
         }
-        for i in range(count)
+        for i in range(start, count + start)
     ]
 
     return events
@@ -176,6 +177,7 @@ async def generate_test_events_in_clickhouse(
             properties=properties,
             person_properties=person_properties,
             inserted_at=inserted_at,
+            start=len(events),
         )
 
         # Add duplicates if required


### PR DESCRIPTION
## Problem

Our start-to-close timeout is fixed at 3600 seconds, which doesn't work very well for larger daily exports.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Start-to-close timeout is now computed based on the batch export interval. So, by default, daily exports get one day, hourly exports get one hour, other frequencies get whatever 1 x their frequency is (there is a 10 minute minimum to be removed later once we are more confident about faster SLAs).
* Bump number of maximum attempts to allow more chances of recovery.
* Bump `initial_retry_interval_seconds` to wait slightly longer before attempting first recovery.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
