### PR TITLE
fix(insights): Remove insight reuse on dashboard and insights

### DIFF
--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -62,7 +62,7 @@ describe('Dashboard', () => {
         }
     })
 
-    it.only('Dashboard filter updates are correctly isolated for one insight on multiple dashboards', () => {
+    it('Dashboard filter updates are correctly isolated for one insight on multiple dashboards', () => {
         const dashboardAName = randomString('Dashboard with insight A')
         const dashboardBName = randomString('Dashboard with insight B')
         const insightName = randomString('insight to add to dashboard')

--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -31,6 +31,29 @@ describe('Dashboard', () => {
         insight.addInsightToDashboard(dashboardName, { visitAfterAdding: true })
 
         cy.get('.CardMeta h4').should('have.text', insightName)
+
+        dashboard.addPropertyFilter()
+        cy.get('main').contains('There are no matching events for this query').should('not.exist')
+
+        cy.clickNavMenu('dashboards')
+        const dashboardNameB = randomString('Dashboard with insight B')
+        dashboards.createAndGoToEmptyDashboard(dashboardNameB)
+
+        insight.visitInsight(insightName)
+        insight.addInsightToDashboard(dashboardNameB, { visitAfterAdding: true })
+
+        dashboard.addPropertyFilter('Browser', 'Hogbrowser')
+
+        // Go back and forth to make sure the filters are correctly applied
+        for (let i = 0; i < 3; i++) {
+            cy.clickNavMenu('dashboards')
+            dashboards.visitDashboard(dashboardName)
+            cy.get('main').contains('There are no matching events for this query').should('not.exist')
+
+            cy.clickNavMenu('dashboards')
+            dashboards.visitDashboard(dashboardNameB)
+            cy.get('main').contains('There are no matching events for this query').should('exist')
+        }
     })
 
     it('Adding new insight to dashboard does not clear filters', () => {

--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -20,7 +20,7 @@ describe('Dashboard', () => {
     })
 
     it('Adding new insight to dashboard works', () => {
-        const dashboardName = randomString('Dashboard with insight A')
+        const dashboardName = randomString('Dashboard with matching filter')
         const insightName = randomString('insight to add to dashboard')
 
         // create and visit a dashboard to get it into turbomode cache
@@ -36,22 +36,27 @@ describe('Dashboard', () => {
         cy.get('main').contains('There are no matching events for this query').should('not.exist')
 
         cy.clickNavMenu('dashboards')
-        const dashboardNameB = randomString('Dashboard with insight B')
-        dashboards.createAndGoToEmptyDashboard(dashboardNameB)
+        const dashboardNonMatching = randomString('Dashboard with non-matching filter')
+        dashboards.createAndGoToEmptyDashboard(dashboardNonMatching)
 
         insight.visitInsight(insightName)
-        insight.addInsightToDashboard(dashboardNameB, { visitAfterAdding: true })
+        insight.addInsightToDashboard(dashboardNonMatching, { visitAfterAdding: true })
 
         dashboard.addPropertyFilter('Browser', 'Hogbrowser')
+        cy.get('main').contains('There are no matching events for this query').should('exist')
 
         // Go back and forth to make sure the filters are correctly applied
         for (let i = 0; i < 3; i++) {
             cy.clickNavMenu('dashboards')
             dashboards.visitDashboard(dashboardName)
+            cy.get('.CardMeta h4').should('have.text', insightName)
+            cy.get('h4').contains('Refreshing').should('not.exist')
             cy.get('main').contains('There are no matching events for this query').should('not.exist')
 
             cy.clickNavMenu('dashboards')
-            dashboards.visitDashboard(dashboardNameB)
+            dashboards.visitDashboard(dashboardNonMatching)
+            cy.get('.CardMeta h4').should('have.text', insightName)
+            cy.get('h4').contains('Refreshing').should('not.exist')
             cy.get('main').contains('There are no matching events for this query').should('exist')
         }
     })

--- a/cypress/productAnalytics/index.ts
+++ b/cypress/productAnalytics/index.ts
@@ -67,7 +67,7 @@ export const insight = {
     },
     visitInsight: (insightName: string): void => {
         cy.clickNavMenu('savedinsights')
-        cy.contains('.row-name > .Link', insightName).click()
+        cy.contains('.Link', insightName).click()
     },
     create: (insightName: string, insightType: string = 'TRENDS'): void => {
         cy.clickNavMenu('savedinsights')
@@ -174,8 +174,8 @@ export const dashboard = {
         cy.get('[data-attr="property-filter-0"]').click()
         cy.get('[data-attr="taxonomic-filter-searchfield"]').click().type('Browser').wait(1000)
         cy.get('[data-attr="prop-filter-event_properties-0"]').click({ force: true })
-        cy.get('.ant-select-selector').type(value)
-        cy.get('.ant-select-item-option-content').click({ force: true })
+        cy.get('.LemonInput').type(value)
+        cy.contains('.LemonButton__content', value).click({ force: true })
     },
     addAnyFilter(): void {
         cy.get('.PropertyFilterButton').should('have.length', 0)

--- a/cypress/productAnalytics/index.ts
+++ b/cypress/productAnalytics/index.ts
@@ -169,6 +169,14 @@ export const dashboard = {
         cy.get('[data-attr=insight-save-button]').contains('Save & add to dashboard').click()
         cy.wait('@postInsight')
     },
+    addPropertyFilter(type: string = 'Browser', value: string = 'Chrome'): void {
+        cy.get('.PropertyFilterButton').should('have.length', 0)
+        cy.get('[data-attr="property-filter-0"]').click()
+        cy.get('[data-attr="taxonomic-filter-searchfield"]').click().type('Browser').wait(1000)
+        cy.get('[data-attr="prop-filter-event_properties-0"]').click({ force: true })
+        cy.get('.ant-select-selector').type(value)
+        cy.get('.ant-select-item-option-content').click({ force: true })
+    },
     addAnyFilter(): void {
         cy.get('.PropertyFilterButton').should('have.length', 0)
         cy.get('[data-attr="property-filter-0"]').click()

--- a/frontend/src/lib/components/AddToDashboard/AddToDashboardModal.tsx
+++ b/frontend/src/lib/components/AddToDashboard/AddToDashboardModal.tsx
@@ -128,7 +128,10 @@ export function AddToDashboardModal({
 
     return (
         <LemonModal
-            onClose={closeModal}
+            onClose={() => {
+                closeModal()
+                setSearchQuery('')
+            }}
             isOpen={isOpen}
             title="Add to dashboard"
             footer={
@@ -139,7 +142,7 @@ export function AddToDashboardModal({
                             onClick={addNewDashboard}
                             disabledReason={
                                 !canEditInsight
-                                    ? 'You do not have permission to add this Insight to dashboards'
+                                    ? 'You do not have permission to add this insight to dashboards'
                                     : undefined
                             }
                         >
@@ -162,9 +165,8 @@ export function AddToDashboardModal({
                     onChange={(newValue) => setSearchQuery(newValue)}
                 />
                 <div className="text-muted-alt">
-                    This insight is referenced on{' '}
-                    <strong className="text-default">{insight.dashboard_tiles?.length}</strong>{' '}
-                    {pluralize(insight.dashboard_tiles?.length || 0, 'dashboard', 'dashboards', false)}
+                    This insight is referenced on <strong className="text-default">{currentDashboards.length}</strong>{' '}
+                    {pluralize(currentDashboards.length, 'dashboard', 'dashboards', false)}
                 </div>
                 {/* eslint-disable-next-line react/forbid-dom-props */}
                 <div style={{ minHeight: 420 }}>

--- a/frontend/src/lib/components/AddToDashboard/AddToDashboardModal.tsx
+++ b/frontend/src/lib/components/AddToDashboard/AddToDashboardModal.tsx
@@ -42,7 +42,6 @@ const DashboardRelationRow = ({
 }: DashboardRelationRowProps): JSX.Element => {
     const logic = addToDashboardModalLogic({
         insight: insight,
-        fromDashboard: insight.dashboards?.[0] || undefined,
     })
     const { addToDashboard, removeFromDashboard } = useActions(logic)
     const { dashboardWithActiveAPICall } = useValues(logic)
@@ -104,7 +103,6 @@ export function AddToDashboardModal({
 }: SaveToDashboardModalProps): JSX.Element {
     const logic = addToDashboardModalLogic({
         insight: insight,
-        fromDashboard: insight.dashboards?.[0] || undefined,
     })
 
     const { searchQuery, currentDashboards, orderedDashboards, scrollIndex } = useValues(logic)

--- a/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
@@ -30,16 +30,28 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>([
         return insight.short_id
     }),
     path(['lib', 'components', 'AddToDashboard', 'saveToDashboardModalLogic']),
-    connect((props: AddToDashboardModalLogicProps) => ({
-        actions: [
-            insightLogic({ dashboardItemId: props.insight.short_id, cachedInsight: props.insight }),
-            ['updateInsight', 'updateInsightSuccess', 'updateInsightFailure'],
-            eventUsageLogic,
-            ['reportSavedInsightToDashboard', 'reportRemovedInsightFromDashboard', 'reportCreatedDashboardFromModal'],
-            newDashboardLogic,
-            ['showNewDashboardModal'],
-        ],
-    })),
+    connect((props: AddToDashboardModalLogicProps) => {
+        const builtInsightLogic = insightLogic({
+            dashboardItemId: props.insight.short_id,
+            dashboardId: props.fromDashboard,
+            cachedInsight: props.insight,
+        })
+        return {
+            values: [builtInsightLogic, ['insight']],
+            actions: [
+                builtInsightLogic,
+                ['updateInsight', 'updateInsightSuccess', 'updateInsightFailure'],
+                eventUsageLogic,
+                [
+                    'reportSavedInsightToDashboard',
+                    'reportRemovedInsightFromDashboard',
+                    'reportCreatedDashboardFromModal',
+                ],
+                newDashboardLogic,
+                ['showNewDashboardModal'],
+            ],
+        }
+    }),
     actions({
         addNewDashboard: true,
         setSearchQuery: (query: string) => ({ query }),
@@ -79,8 +91,8 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>([
                     : nameSortedDashboards,
         ],
         currentDashboards: [
-            (s, p) => [s.filteredDashboards, p.insight],
-            (filteredDashboards, insight: InsightModel): DashboardBasicType[] =>
+            (s) => [s.filteredDashboards, s.insight],
+            (filteredDashboards, insight): DashboardBasicType[] =>
                 filteredDashboards.filter((d) => insight.dashboard_tiles?.map((dt) => dt.dashboard_id)?.includes(d.id)),
         ],
         availableDashboards: [

--- a/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
@@ -14,7 +14,6 @@ import type { addToDashboardModalLogicType } from './addToDashboardModalLogicTyp
 
 export interface AddToDashboardModalLogicProps {
     insight: Partial<InsightModel>
-    fromDashboard?: number
 }
 
 // Helping kea-typegen navigate the exported default class for Fuse
@@ -33,7 +32,6 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>([
     connect((props: AddToDashboardModalLogicProps) => {
         const builtInsightLogic = insightLogic({
             dashboardItemId: props.insight.short_id,
-            dashboardId: props.fromDashboard,
             cachedInsight: props.insight,
         })
         return {

--- a/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
@@ -133,7 +133,7 @@ export function TextCardInternal(
                                         fullWidth
                                         data-attr="remove-text-tile-from-dashboard"
                                     >
-                                        Remove from dashboard
+                                        Delete
                                     </LemonButton>
                                 )}
                             </>

--- a/frontend/src/mocks/fixtures/api/projects/team_id/insights/stickiness.json
+++ b/frontend/src/mocks/fixtures/api/projects/team_id/insights/stickiness.json
@@ -1,6 +1,6 @@
 {
     "id": 51,
-    "short_id": "jEAIVJnI",
+    "short_id": "xEAIVJnI",
     "name": "",
     "derived_name": "User stickiness based on Pageview",
     "filters": {

--- a/frontend/src/mocks/fixtures/api/projects/team_id/insights/trendsBarBreakdown.json
+++ b/frontend/src/mocks/fixtures/api/projects/team_id/insights/trendsBarBreakdown.json
@@ -1,6 +1,6 @@
 {
     "id": 51,
-    "short_id": "jEAIVJnK",
+    "short_id": "xEAIVJnK",
     "name": "",
     "derived_name": "Pageview count by event's Library Version",
     "filters": {

--- a/frontend/src/mocks/fixtures/api/projects/team_id/insights/trendsCumulativeBreakdown.json
+++ b/frontend/src/mocks/fixtures/api/projects/team_id/insights/trendsCumulativeBreakdown.json
@@ -1,6 +1,6 @@
 {
     "id": 51,
-    "short_id": "jEAIVJnM",
+    "short_id": "xEAIVJnM",
     "name": "",
     "derived_name": "Pageview count by event's Browser Version",
     "filters": {

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -113,15 +113,16 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
         if (oldProps.query && props.query.kind !== oldProps.query.kind) {
             actions.clearResponse()
         }
-        if (!queryEqual(props.query, oldProps.query)) {
-            if (
-                !props.cachedResults ||
-                (isInsightQueryNode(props.query) && !props.cachedResults['result'] && !props.cachedResults['results'])
-            ) {
-                actions.loadData()
-            } else {
-                actions.setResponse(props.cachedResults)
-            }
+        if (
+            !queryEqual(props.query, oldProps.query) &&
+            (!props.cachedResults ||
+                (isInsightQueryNode(props.query) && !props.cachedResults['result'] && !props.cachedResults['results']))
+        ) {
+            actions.loadData()
+        }
+        if (props.cachedResults) {
+            // Use cached results if available, otherwise this logic will load the data again
+            actions.setResponse(props.cachedResults)
         }
     }),
     actions({
@@ -624,7 +625,9 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
         },
     })),
     afterMount(({ actions, props }) => {
-        if (Object.keys(props.query || {}).length > 0) {
+        if (Object.keys(props.query || {}).length > 0 && !props.key.includes('dashboard')) {
+            // Attention: When on dashboard we don't want to load data on mount
+            // as it will have be loaded by some other logic
             actions.loadData()
         }
 

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -114,13 +114,13 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
             actions.clearResponse()
         }
         if (
+            !(props.cachedResults && props.key.includes('dashboard')) && // Don't load data on dashboard if cached results are available
             !queryEqual(props.query, oldProps.query) &&
             (!props.cachedResults ||
                 (isInsightQueryNode(props.query) && !props.cachedResults['result'] && !props.cachedResults['results']))
         ) {
             actions.loadData()
-        }
-        if (props.cachedResults) {
+        } else if (props.cachedResults) {
             // Use cached results if available, otherwise this logic will load the data again
             actions.setResponse(props.cachedResults)
         }

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -861,7 +861,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
             let refreshesFinished = 0
             let totalResponseBytes = 0
 
-            const hardRefreshWithoutCache = ['refresh', 'load_missing'].includes(action)
+            const hardRefreshWithoutCache = ['refresh', 'load_missing', 'refresh_insights_on_filters_updated'].includes(
+                action
+            )
 
             // array of functions that reload each item
             const fetchItemFunctions = insights.map((insight) => async () => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -340,10 +340,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         const newTiles = state.tiles.slice()
 
                         if (tileIndex >= 0) {
-                            if (insight.dashboards?.includes(props.id)) {
-                                newTiles[tileIndex] = { ...newTiles[tileIndex], insight: insight }
-                                if (updateTileOnDashboards?.includes(props.id)) {
-                                    newTiles[tileIndex].last_refresh = insight.last_refresh
+                            if (insight.dashboards?.includes(props.id) && updateTileOnDashboards?.includes(props.id)) {
+                                newTiles[tileIndex] = {
+                                    ...newTiles[tileIndex],
+                                    insight: insight,
+                                    last_refresh: insight.last_refresh,
                                 }
                             } else {
                                 newTiles.splice(tileIndex, 1)

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -660,7 +660,7 @@ describe('insightLogic', () => {
             await verifyItLoadsFromTheAPI(logic)
         })
 
-        it('loads from the savedInsightLogic when not in a dashboard context', async () => {
+        it.skip('loads from the savedInsightLogic when not in a dashboard context', async () => {
             // 1. open saved insights
             router.actions.push(urls.savedInsights(), {}, {})
             savedInsightsLogic.mount()

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -609,17 +609,6 @@ describe('insightLogic', () => {
     })
 
     describe('takes data from other logics if available', () => {
-        const verifyItLoadsFromALogic = async (
-            logicUnderTest: ReturnType<typeof insightLogic.build>,
-            partialExpectedInsight: Partial<InsightModel>
-        ): Promise<void> =>
-            expectLogic(logicUnderTest)
-                .toDispatchActions(['setInsight'])
-                .toNotHaveDispatchedActions(['setFilters', 'loadResults', 'loadInsight', 'updateInsight'])
-                .toMatchValues({
-                    insight: partial(partialExpectedInsight),
-                })
-
         const verifyItLoadsFromTheAPI = async (logicUnderTest: ReturnType<typeof insightLogic.build>): Promise<void> =>
             expectLogic(logicUnderTest)
                 .toDispatchActions(['loadInsight'])
@@ -629,7 +618,7 @@ describe('insightLogic', () => {
                     }),
                 })
 
-        it.skip('loads from the dashboardLogic when in dashboard context', async () => {
+        it('loads from the api when coming from dashboard context', async () => {
             // 1. the dashboard is mounted
             const dashLogic = dashboardLogic({ id: 33 })
             dashLogic.mount()
@@ -639,12 +628,7 @@ describe('insightLogic', () => {
             logic = insightLogic({ dashboardItemId: Insight42, dashboardId: 33 })
             logic.mount()
 
-            // 3. verify it didn't make any API calls
-            await verifyItLoadsFromALogic(logic, {
-                id: 42,
-                result: 'result!',
-                filters: { insight: InsightType.TRENDS, interval: 'month' },
-            })
+            await verifyItLoadsFromTheAPI(logic)
         })
 
         it('does not load from the dashboardLogic when not in that dashboard context', async () => {
@@ -658,23 +642,6 @@ describe('insightLogic', () => {
             logic.mount()
 
             await verifyItLoadsFromTheAPI(logic)
-        })
-
-        it.skip('loads from the savedInsightLogic when not in a dashboard context', async () => {
-            // 1. open saved insights
-            router.actions.push(urls.savedInsights(), {}, {})
-            savedInsightsLogic.mount()
-
-            // 2. the insights are loaded
-            await expectLogic(savedInsightsLogic).toDispatchActions(['loadInsights', 'loadInsightsSuccess'])
-
-            // 3. mount the insight
-            logic = insightLogic({ dashboardItemId: Insight42 })
-            logic.mount()
-
-            await verifyItLoadsFromALogic(logic, {
-                short_id: '42' as InsightShortId,
-            })
         })
 
         it('does not load from the savedInsightLogic when in a dashboard context', async () => {

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -629,7 +629,7 @@ describe('insightLogic', () => {
                     }),
                 })
 
-        it('loads from the dashboardLogic when in dashboard context', async () => {
+        it.skip('loads from the dashboardLogic when in dashboard context', async () => {
             // 1. the dashboard is mounted
             const dashLogic = dashboardLogic({ id: 33 })
             dashLogic.mount()

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -52,7 +52,7 @@ import {
 import { teamLogic } from '../teamLogic'
 import { toLocalFilters } from './filters/ActionFilter/entityFilterLogic'
 import type { insightLogicType } from './insightLogicType'
-import { extractObjectDiffKeys, findInsightFromMountedLogic, getInsightId } from './utils'
+import { extractObjectDiffKeys, getInsightId } from './utils'
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 export const UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES = 3
@@ -707,18 +707,6 @@ export const insightLogic = kea<insightLogicType>([
     events(({ props, actions }) => ({
         afterMount: () => {
             if (!props.dashboardItemId || props.dashboardItemId === 'new' || props.dashboardItemId.startsWith('new-')) {
-                return
-            }
-
-            const insight = findInsightFromMountedLogic(
-                props.dashboardItemId as string | InsightShortId,
-                props.dashboardId
-            )
-            if (insight) {
-                actions.setInsight(insight, { overrideFilter: true, fromPersistentApi: true })
-                if (insight?.result) {
-                    actions.reportInsightViewed(insight, insight.filters || {})
-                }
                 return
             }
 

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -711,7 +711,7 @@ export const insightLogic = kea<insightLogicType>([
             }
 
             if (!props.doNotLoad) {
-                actions.loadInsight(props.dashboardItemId as InsightShortId)
+                //actions.loadInsight(props.dashboardItemId as InsightShortId)
             }
         },
     })),

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -710,7 +710,7 @@ export const insightLogic = kea<insightLogicType>([
                 return
             }
 
-            if (!props.doNotLoad) {
+            if (!props.doNotLoad && !props.cachedInsight) {
                 actions.loadInsight(props.dashboardItemId as InsightShortId)
             }
         },

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -711,7 +711,7 @@ export const insightLogic = kea<insightLogicType>([
             }
 
             if (!props.doNotLoad) {
-                //actions.loadInsight(props.dashboardItemId as InsightShortId)
+                actions.loadInsight(props.dashboardItemId as InsightShortId)
             }
         },
     })),

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -4,11 +4,8 @@ import { CORE_FILTER_DEFINITIONS_BY_GROUP } from 'lib/taxonomy'
 import { ensureStringIsNotBlank, humanFriendlyNumber, objectsEqual } from 'lib/utils'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
 import { ReactNode } from 'react'
-import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
-import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { urls } from 'scenes/urls'
 
-import { dashboardsModel } from '~/models/dashboardsModel'
 import { FormatPropertyValueForDisplayFunction } from '~/models/propertyDefinitionsModel'
 import { examples } from '~/queries/examples'
 import { ActionsNode, BreakdownFilter, DataWarehouseNode, EventsNode, PathsFilter } from '~/queries/schema'
@@ -23,7 +20,6 @@ import {
     EntityFilter,
     EntityTypes,
     EventType,
-    InsightModel,
     InsightShortId,
     InsightType,
     PathType,
@@ -124,35 +120,6 @@ export function extractObjectDiffKeys(
     }
 
     return changedKeys
-}
-
-export function findInsightFromMountedLogic(
-    insightShortId: InsightShortId | string,
-    dashboardId: number | undefined
-): Partial<InsightModel> | null {
-    if (dashboardId) {
-        const insightOnDashboard = dashboardLogic
-            .findMounted({ id: dashboardId })
-            ?.values.insightTiles?.find((tile) => tile.insight?.short_id === insightShortId)?.insight
-        if (insightOnDashboard) {
-            return insightOnDashboard
-        } else {
-            const dashboards = dashboardsModel.findMounted()?.values.rawDashboards
-            let foundOnModel: Partial<InsightModel> | undefined
-            for (const dashModelId of Object.keys(dashboards || {})) {
-                foundOnModel = dashboardLogic
-                    .findMounted({ id: parseInt(dashModelId) })
-                    ?.values.insightTiles?.find((tile) => tile.insight?.short_id === insightShortId)?.insight
-            }
-            return foundOnModel || null
-        }
-    } else {
-        return (
-            savedInsightsLogic
-                .findMounted()
-                ?.values.insights?.results?.find((item) => item.short_id === insightShortId) || null
-        )
-    }
 }
 
 export async function getInsightId(shortId: InsightShortId): Promise<number | undefined> {

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -75,9 +75,13 @@ export function ActionsLineGraph({
         isInsightVizNode(query) &&
         isTrendsQuery(query.source)
 
-    return indexedResults &&
-        indexedResults[0]?.data &&
-        indexedResults.filter((result) => result.count !== 0).length > 0 ? (
+    if (
+        !(indexedResults && indexedResults[0]?.data && indexedResults.filter((result) => result.count !== 0).length > 0)
+    ) {
+        return <InsightEmptyState heading={context?.emptyStateHeading} detail={context?.emptyStateDetail} />
+    }
+
+    return (
         <LineGraph
             data-attr="trend-line-graph"
             type={display === ChartDisplayType.ActionsBar || isLifecycle ? GraphType.Bar : GraphType.Line}
@@ -169,7 +173,5 @@ export function ActionsLineGraph({
                       }
             }
         />
-    ) : (
-        <InsightEmptyState heading={context?.emptyStateHeading} detail={context?.emptyStateDetail} />
     )
 }


### PR DESCRIPTION
## Problem

Another try for #20371 and #20508

How to reproduce:

- create two dashboards with separate filters
  - e.g. dashboard A filters for "browser = Firefox" an dashboard B for "browser = Hogbrowser"
- add an insight, e.g. pageviews per day and add it to both dashboards
- when switching between dashboards it will first show correct data depending on where you go first, but then start to show wrong data, for example no data when you previously already saw the Firefox filtered data
- on top of that, when going to view or edit the insight, you will also still see wrong data and when editing, you will also the filters from the dashboard that are not really stored on the insight

## Changes

- remove any reuse of logics and cached insights accross dashboards and/or insight scene.
- cleaned up when `insightLogic` and `dataNodeLogic` should load stuff
  - it's important they don't load `onMount` as we already have insights from the main dashboard call
    - which is nice since we get all data in one call from cache

## Does this work well for both Cloud and self-hosted?

it doesn't have an impact

## How did you test this code?

- tested creating insights, filters, dashboards
- see extended Crypress tests... got them to pass 🤞🏻 