### PR TITLE
fix: audio improvements

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -724,6 +724,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         },
         seekToTimestamp: ({ timestamp, forcePlay }, breakpoint) => {
             actions.stopAnimation()
+            cache.pausedMediaElements = []
             actions.setCurrentTimestamp(timestamp)
 
             // Check if we're seeking to a new segment

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -904,7 +904,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             const playingElements = mediaElements.filter(isMediaElementPlaying)
 
             playingElements.forEach((el) => el.pause())
-            cache.pausedMediaElements = playingElements
+            cache.pausedMediaElements = values.endReached ? [] : playingElements
         },
         restartIframePlayback: () => {
             cache.pausedMediaElements.forEach((el: HTMLMediaElement) => el.play())


### PR DESCRIPTION
## Problem

Solves https://posthoghelp.zendesk.com/agent/tickets/11870 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15045)

Addresses two problems:

1. Clicking the seekbar and playing from a new position sees paused elements continue playing. Even though they may no longer exist on the page and will certainly be at a new position
2. Reaching the end of a video with media playing pauses the media but restarts it when you click play again (which loops the video back to the beginning)

## Changes

- Clear cache when seeking timestamp
- Clear cache when pausing because the end of the video has been reached

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Locally