### PR TITLE
fix: use psycopg-binary for bundled version of libpq

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -65,7 +65,7 @@ Pillow==10.2.0
 posthoganalytics==3.5.0
 prance==23.06.21.0
 psycopg2-binary==2.9.7
-psycopg-binary==3.1.13
+psycopg[binary]==3.1.13
 pyarrow==15.0.0
 pydantic==2.5.3
 pyjwt==2.4.0

--- a/requirements.in
+++ b/requirements.in
@@ -65,7 +65,7 @@ Pillow==10.2.0
 posthoganalytics==3.5.0
 prance==23.06.21.0
 psycopg2-binary==2.9.7
-psycopg==3.1.13
+psycopg-binary==3.1.13
 pyarrow==15.0.0
 pydantic==2.5.3
 pyjwt==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -448,7 +448,7 @@ protobuf==4.22.1
     #   grpcio-status
     #   proto-plus
     #   temporalio
-psycopg==3.1.13
+psycopg-binary==3.1.13
     # via -r requirements.in
 psycopg2-binary==2.9.7
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -448,8 +448,12 @@ protobuf==4.22.1
     #   grpcio-status
     #   proto-plus
     #   temporalio
+psycopg[binary]==3.1.13
+    # via
+    #   -r requirements.in
+    #   psycopg
 psycopg-binary==3.1.13
-    # via -r requirements.in
+    # via psycopg
 psycopg2-binary==2.9.7
     # via -r requirements.in
 ptyprocess==0.6.0


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/21475

## Changes

Updates `psycopg` to use the other version that includes bundled system dependencies. This allows to ensure the versions have the latest features, instead of accidentally using old version of libpq.

psycopg: https://github.com/psycopg/psycopg?tab=readme-ov-file#installation

## Does this work well for both Cloud and self-hosted?

`psycopg-binary` is a drop-in version of `psycopg`, the imports and everything else works exactly the same, but it just doesn't depend on libpq on the system.

## How did you test this code?

Described in the issue
