### PR TITLE
revert: "chore(clickhouse): Capture final SQL in Sentry errors"

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -197,29 +197,22 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
-            # First running migrations from master, to simulate the real-world scenario
+            - name: Install python dependencies
+              run: |
+                  uv pip install --system -r requirements.txt -r requirements-dev.txt
 
-            - name: Checkout master
-              uses: actions/checkout@v3
+            - uses: actions/checkout@v3
               with:
                   ref: master
 
-            - name: Install python dependencies for master
-              run: |
-                  uv pip install --system -r requirements.txt -r requirements-dev.txt
-
             - name: Run migrations up to master
               run: |
+                  # We need to ensure we have requirements for the master branch
+                  # now also, so we can run migrations up to master.
+                  uv pip install --system -r requirements.txt -r requirements-dev.txt
                   python manage.py migrate
 
-            # Now we can consider this PR's migrations
-
-            - name: Checkout this PR
-              uses: actions/checkout@v3
-
-            - name: Install python dependencies for this PR
-              run: |
-                  uv pip install --system -r requirements.txt -r requirements-dev.txt
+            - uses: actions/checkout@v3
 
             - name: Check migrations
               run: |

--- a/posthog/clickhouse/client/escape.py
+++ b/posthog/clickhouse/client/escape.py
@@ -89,7 +89,6 @@ def escape_param_for_clickhouse(param: Any) -> str:
         version_patch="placeholder server_info value",
         revision="placeholder server_info value",
         display_name="placeholder server_info value",
-        used_revision="placeholder server_info value",
         timezone="UTC",
     )
     return escape_param(param, context=context)

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ boto3-stubs[s3]
 brotli==1.1.0
 celery==5.3.4
 celery-redbeat==2.1.1
-clickhouse-driver==0.2.7
+clickhouse-driver==0.2.4
 clickhouse-pool==0.5.3
 cryptography==37.0.2
 defusedxml==0.6.0
@@ -79,7 +79,7 @@ requests-oauthlib==1.3.0
 s3fs==2023.10.0
 stripe==7.4.0
 selenium==4.1.5
-sentry-sdk[clickhouse-driver,celery,openai,django]~=1.44.1
+sentry-sdk==1.14.0
 semantic_version==2.8.5
 scikit-learn==1.4.0
 slack_sdk==3.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,6 @@ celery==5.3.4
     # via
     #   -r requirements.in
     #   celery-redbeat
-    #   sentry-sdk
 celery-redbeat==2.1.1
     # via -r requirements.in
 certifi==2019.11.28
@@ -115,11 +114,10 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
-clickhouse-driver==0.2.7
+clickhouse-driver==0.2.4
     # via
     #   -r requirements.in
     #   clickhouse-pool
-    #   sentry-sdk
 clickhouse-pool==0.5.3
     # via -r requirements.in
 cryptography==37.0.2
@@ -166,7 +164,6 @@ django==4.1.13
     #   djangorestframework
     #   djangorestframework-dataclasses
     #   drf-spectacular
-    #   sentry-sdk
 django-axes==5.9.0
     # via -r requirements.in
 django-cors-headers==3.5.0
@@ -390,9 +387,7 @@ oauthlib==3.1.0
     #   requests-oauthlib
     #   social-auth-core
 openai==1.10.0
-    # via
-    #   -r requirements.in
-    #   sentry-sdk
+    # via -r requirements.in
 openapi-schema-validator==0.6.2
     # via openapi-spec-validator
 openapi-spec-validator==0.7.1
@@ -591,7 +586,7 @@ semantic-version==2.8.5
     # via -r requirements.in
 semver==3.0.2
     # via dlt
-sentry-sdk[celery,clickhouse-driver,django,openai]==1.44.1
+sentry-sdk==1.14.0
     # via -r requirements.in
 simplejson==3.19.2
     # via dlt
@@ -650,9 +645,7 @@ tenacity==8.2.3
 threadpoolctl==3.3.0
     # via scikit-learn
 tiktoken==0.6.0
-    # via
-    #   -r requirements.in
-    #   sentry-sdk
+    # via -r requirements.in
 token-bucket==0.3.0
     # via -r requirements.in
 tomlkit==0.12.3


### PR DESCRIPTION
Reverts PostHog/posthog#21436

see https://posthog.slack.com/archives/C0185UNBSJZ/p1712779189666039

We've seen multiple thousands of errors in Celery that appear to start when this PR deployed