### PR TITLE
fix: Offline queries don't need to verify the cluster url

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -38,7 +38,7 @@ def get_pool(workload: Workload, team_id=None, readonly=False):
     if (
         workload == Workload.OFFLINE or workload == Workload.DEFAULT and _default_workload == Workload.OFFLINE
     ) and settings.CLICKHOUSE_OFFLINE_CLUSTER_HOST is not None:
-        return make_ch_pool(host=settings.CLICKHOUSE_OFFLINE_CLUSTER_HOST)
+        return make_ch_pool(host=settings.CLICKHOUSE_OFFLINE_CLUSTER_HOST, verify=False)
 
     return make_ch_pool()
 


### PR DESCRIPTION
## Problem

New CH driver is more strict verifying hostnames of certs. Offline cluster hostname does not match cert issued.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
