### PR TITLE
feat: filter enhanced_events query by person_mode

### DIFF
--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -1,7 +1,7 @@
 import datetime as dt
 import json
 import uuid
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Literal, Optional, Set, Union
 from zoneinfo import ZoneInfo
 
 from dateutil.parser import isoparse
@@ -46,7 +46,7 @@ def create_event(
     group2_created_at: Optional[Union[timezone.datetime, str]] = None,
     group3_created_at: Optional[Union[timezone.datetime, str]] = None,
     group4_created_at: Optional[Union[timezone.datetime, str]] = None,
-    person_mode: str = "full",
+    person_mode: Literal["full", "propertyless"] = "full",
 ) -> str:
     if not timestamp:
         timestamp = timezone.now()
@@ -102,7 +102,11 @@ def format_clickhouse_timestamp(
     return parsed_datetime.strftime("%Y-%m-%d %H:%M:%S.%f")
 
 
-def bulk_create_events(events: List[Dict[str, Any]], person_mapping: Optional[Dict[str, Person]] = None) -> None:
+def bulk_create_events(
+    events: List[Dict[str, Any]],
+    person_mapping: Optional[Dict[str, Person]] = None,
+    person_mode: Literal["full", "propertyless"] = "full",
+) -> None:
     """
     TEST ONLY
     Insert events in bulk. List of dicts:
@@ -252,7 +256,7 @@ def bulk_create_events(events: List[Dict[str, Any]], person_mapping: Optional[Di
             "group4_created_at": (
                 event["group4_created_at"] if event.get("group4_created_at") else datetime64_default_timestamp
             ),
-            "person_mode": "full",
+            "person_mode": person_mode,
         }
 
         params = {

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -105,7 +105,6 @@ def format_clickhouse_timestamp(
 def bulk_create_events(
     events: List[Dict[str, Any]],
     person_mapping: Optional[Dict[str, Person]] = None,
-    person_mode: Literal["full", "propertyless"] = "full",
 ) -> None:
     """
     TEST ONLY
@@ -168,6 +167,7 @@ def bulk_create_events(
 
         #  use person properties mapping to populate person properties in given event
         team_id = event["team"].pk
+        person_mode = event.get("person_mode", "full")
         if person_mapping and person_mapping.get(event["distinct_id"]):
             person = person_mapping[event["distinct_id"]]
             person_properties = person.properties

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -2,8 +2,8 @@ import datetime as dt
 import json
 import uuid
 from typing import Any, Dict, List, Optional, Set, Union
-
 from zoneinfo import ZoneInfo
+
 from dateutil.parser import isoparse
 from django.utils import timezone
 from rest_framework import serializers
@@ -46,6 +46,7 @@ def create_event(
     group2_created_at: Optional[Union[timezone.datetime, str]] = None,
     group3_created_at: Optional[Union[timezone.datetime, str]] = None,
     group4_created_at: Optional[Union[timezone.datetime, str]] = None,
+    person_mode: str = "full",
 ) -> str:
     if not timestamp:
         timestamp = timezone.now()
@@ -79,7 +80,7 @@ def create_event(
         "group2_created_at": format_clickhouse_timestamp(group2_created_at, ZERO_DATE),
         "group3_created_at": format_clickhouse_timestamp(group3_created_at, ZERO_DATE),
         "group4_created_at": format_clickhouse_timestamp(group4_created_at, ZERO_DATE),
-        "person_mode": "full",
+        "person_mode": person_mode,
     }
     p = ClickhouseProducer()
     p.produce(topic=KAFKA_EVENTS_JSON, sql=INSERT_EVENT_SQL(), data=data)
@@ -228,29 +229,29 @@ def bulk_create_events(events: List[Dict[str, Any]], person_mapping: Optional[Di
             "created_at": timestamp,
             "person_id": event["person_id"] if event.get("person_id") else str(uuid.uuid4()),
             "person_properties": json.dumps(event["person_properties"]) if event.get("person_properties") else "{}",
-            "person_created_at": event["person_created_at"]
-            if event.get("person_created_at")
-            else datetime64_default_timestamp,
+            "person_created_at": (
+                event["person_created_at"] if event.get("person_created_at") else datetime64_default_timestamp
+            ),
             "group0_properties": json.dumps(event["group0_properties"]) if event.get("group0_properties") else "{}",
             "group1_properties": json.dumps(event["group1_properties"]) if event.get("group1_properties") else "{}",
             "group2_properties": json.dumps(event["group2_properties"]) if event.get("group2_properties") else "{}",
             "group3_properties": json.dumps(event["group3_properties"]) if event.get("group3_properties") else "{}",
             "group4_properties": json.dumps(event["group4_properties"]) if event.get("group4_properties") else "{}",
-            "group0_created_at": event["group0_created_at"]
-            if event.get("group0_created_at")
-            else datetime64_default_timestamp,
-            "group1_created_at": event["group1_created_at"]
-            if event.get("group1_created_at")
-            else datetime64_default_timestamp,
-            "group2_created_at": event["group2_created_at"]
-            if event.get("group2_created_at")
-            else datetime64_default_timestamp,
-            "group3_created_at": event["group3_created_at"]
-            if event.get("group3_created_at")
-            else datetime64_default_timestamp,
-            "group4_created_at": event["group4_created_at"]
-            if event.get("group4_created_at")
-            else datetime64_default_timestamp,
+            "group0_created_at": (
+                event["group0_created_at"] if event.get("group0_created_at") else datetime64_default_timestamp
+            ),
+            "group1_created_at": (
+                event["group1_created_at"] if event.get("group1_created_at") else datetime64_default_timestamp
+            ),
+            "group2_created_at": (
+                event["group2_created_at"] if event.get("group2_created_at") else datetime64_default_timestamp
+            ),
+            "group3_created_at": (
+                event["group3_created_at"] if event.get("group3_created_at") else datetime64_default_timestamp
+            ),
+            "group4_created_at": (
+                event["group4_created_at"] if event.get("group4_created_at") else datetime64_default_timestamp
+            ),
             "person_mode": "full",
         }
 

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -199,6 +199,7 @@
     AND event NOT IN ('survey sent',
                       'survey shown',
                       'survey dismissed')
+    AND person_mode = 'full'
   GROUP BY team_id
   '''
 # ---

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -147,16 +147,6 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     team=self.org_1_team_1,
                 )
 
-            _create_event(
-                event_uuid=uuid4(),
-                distinct_id=distinct_id,
-                event="$personfull_event",
-                properties={"$lib": "$web"},
-                timestamp=now() - relativedelta(hours=12),
-                team=self.org_1_team_1,
-                person_mode="propertyless",
-            )
-
             # create duplicate events
             for uuid in uuids:
                 _create_event(
@@ -322,6 +312,15 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                 timestamp=now() - relativedelta(hours=12),
                 team=self.org_2_team_3,
             )
+            _create_event(
+                event_uuid=uuid4(),
+                distinct_id=distinct_id,
+                event="$propertyless_event",
+                properties={"$lib": "$web"},
+                timestamp=now() - relativedelta(hours=12),
+                team=self.org_1_team_1,
+                person_mode="propertyless",
+            )
 
             flush_persons_and_events()
 
@@ -377,10 +376,10 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     },
                     "plugins_enabled": {"Installed and enabled": 1},
                     "instance_tag": "none",
-                    "event_count_lifetime": 55,
+                    "event_count_lifetime": 56,
                     "event_count_in_period": 23,
                     "enhanced_persons_event_count_in_period": 22,
-                    "event_count_in_month": 42,
+                    "event_count_in_month": 43,
                     "event_count_with_groups_in_period": 2,
                     "recording_count_in_period": 5,
                     "recording_count_total": 16,
@@ -420,10 +419,10 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "team_count": 2,
                     "teams": {
                         str(self.org_1_team_1.id): {
-                            "event_count_lifetime": 44,
+                            "event_count_lifetime": 45,
                             "event_count_in_period": 13,
                             "enhanced_persons_event_count_in_period": 12,
-                            "event_count_in_month": 32,
+                            "event_count_in_month": 33,
                             "event_count_with_groups_in_period": 2,
                             "recording_count_in_period": 0,
                             "recording_count_total": 0,

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -147,6 +147,16 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     team=self.org_1_team_1,
                 )
 
+            _create_event(
+                event_uuid=uuid4(),
+                distinct_id=distinct_id,
+                event="$personfull_event",
+                properties={"$lib": "$web"},
+                timestamp=now() - relativedelta(hours=12),
+                team=self.org_1_team_1,
+                person_mode="propertyless",
+            )
+
             # create duplicate events
             for uuid in uuids:
                 _create_event(
@@ -368,8 +378,7 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "plugins_enabled": {"Installed and enabled": 1},
                     "instance_tag": "none",
                     "event_count_lifetime": 55,
-                    "event_count_in_period": 22,
-                    # TODO: enhanced_persons: modify this test so that there are fewer of these events than the base
+                    "event_count_in_period": 23,
                     "enhanced_persons_event_count_in_period": 22,
                     "event_count_in_month": 42,
                     "event_count_with_groups_in_period": 2,
@@ -412,7 +421,7 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "teams": {
                         str(self.org_1_team_1.id): {
                             "event_count_lifetime": 44,
-                            "event_count_in_period": 12,
+                            "event_count_in_period": 13,
                             "enhanced_persons_event_count_in_period": 12,
                             "event_count_in_month": 32,
                             "event_count_with_groups_in_period": 2,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -432,12 +432,11 @@ def get_teams_with_billable_enhanced_persons_event_count_in_period(
     else:
         distinct_expression = "1"
 
-    # TODO: enhanced_persons: update this query to filter on enhanced_persons column
     result = sync_execute(
         f"""
         SELECT team_id, count({distinct_expression}) as count
         FROM events
-        WHERE timestamp between %(begin)s AND %(end)s AND event != '$feature_flag_called' AND event NOT IN ('survey sent', 'survey shown', 'survey dismissed')
+        WHERE timestamp between %(begin)s AND %(end)s AND event != '$feature_flag_called' AND event NOT IN ('survey sent', 'survey shown', 'survey dismissed') and person_mode = 'full'
         GROUP BY team_id
     """,
         {"begin": begin, "end": end},

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -436,7 +436,7 @@ def get_teams_with_billable_enhanced_persons_event_count_in_period(
         f"""
         SELECT team_id, count({distinct_expression}) as count
         FROM events
-        WHERE timestamp between %(begin)s AND %(end)s AND event != '$feature_flag_called' AND event NOT IN ('survey sent', 'survey shown', 'survey dismissed') and person_mode = 'full'
+        WHERE timestamp between %(begin)s AND %(end)s AND event != '$feature_flag_called' AND event NOT IN ('survey sent', 'survey shown', 'survey dismissed') AND person_mode = 'full'
         GROUP BY team_id
     """,
         {"begin": begin, "end": end},


### PR DESCRIPTION
## Problem

We need to know how many events are personfull.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds the person_mode filter to the enhanced_persons query.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

I'm struggling with tests for this code. If I include `person_mode` on `create_event` or `_create_event` it doesn't do anything. I'm not sure why it's not being included in the event column. The query does work in metabase. @tiina303 maybe you know why it's not working?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
