### PR TITLE
fix: Wait longer for temporal

### DIFF
--- a/bin/check_temporal_up
+++ b/bin/check_temporal_up
@@ -4,11 +4,11 @@ set -e
 
 # Wait for Temporal to be ready
 SECONDS=0
-TIMEOUT=360
+TIMEOUT=180
 
 # Check Temporal by just checking that the port is open
 while true; do
-    if nc -z localhost 7233; then
+    if nc -vz localhost 7233; then
         echo "Temporal is up!"
         exit 0
     fi

--- a/bin/check_temporal_up
+++ b/bin/check_temporal_up
@@ -8,16 +8,16 @@ TIMEOUT=180
 
 # Check Temporal by just checking that the port is open
 while true; do
-    if nc -z localhost 7233; then
+    if nc -vz localhost 7233; then
         echo "Temporal is up!"
         exit 0
     fi
-    
+
     if [ $SECONDS -ge $TIMEOUT ]; then
         echo "Timed out waiting for Temporal to be ready"
         exit 1
     fi
-    
+
     echo "Waiting for Temporal to be ready"
     sleep 1
 done

--- a/bin/check_temporal_up
+++ b/bin/check_temporal_up
@@ -4,11 +4,11 @@ set -e
 
 # Wait for Temporal to be ready
 SECONDS=0
-TIMEOUT=180
+TIMEOUT=360
 
 # Check Temporal by just checking that the port is open
 while true; do
-    if nc -vz localhost 7233; then
+    if nc -z localhost 7233; then
         echo "Temporal is up!"
         exit 0
     fi

--- a/bin/check_temporal_up
+++ b/bin/check_temporal_up
@@ -19,5 +19,6 @@ while true; do
     fi
 
     echo "Waiting for Temporal to be ready"
+    docker-compose -f docker-compose.dev.yml logs temporal
     sleep 1
 done


### PR DESCRIPTION
## Problem

Investigating why temporal is timing out in CI.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

There doesn't seem to be anything going on, temporal is just not up. So, let's try waiting longer.

Could be the new depot runners are taking longer to start our stack for some reason.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
