### PR TITLE
feat(web-analytics): Add popover to learn more about channel types

### DIFF
--- a/frontend/src/lib/lemon-ui/Link/Link.tsx
+++ b/frontend/src/lib/lemon-ui/Link/Link.tsx
@@ -61,9 +61,11 @@ const isDirectLink = (url: string): boolean => {
     return /^(mailto:|https?:\/\/|:\/\/)/.test(url)
 }
 
-const isPostHogComDocs = (url: string): boolean => {
+const isPostHogComDocs = (url: string): url is PostHogComDocsURL => {
     return /^https:\/\/(www\.)?posthog\.com\/docs/.test(url)
 }
+
+export type PostHogComDocsURL = `https://${'www.' | ''}posthog.com/docs/${string}`
 
 /**
  * Link

--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -166,13 +166,13 @@ const labelFromKey = (key: string): string => {
         case 'visitors':
             return 'Visitors'
         case 'views':
-            return 'Views'
+            return 'Page views'
         case 'sessions':
             return 'Sessions'
         case 'session duration':
-            return 'Session Duration'
+            return 'Session duration'
         case 'bounce rate':
-            return 'Bounce Rate'
+            return 'Bounce rate'
         default:
             return key
                 .split(' ')

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -118,13 +118,7 @@ const QueryTileItem = ({ tile }: { tile: QueryTile }): JSX.Element => {
             )}
         >
             {title && <h2 className="m-0 mb-3">{title}</h2>}
-            {docs && (
-                <LearnMorePopover
-                    docsURL="https://posthog.com/docs/data/channel-type"
-                    title="Channel Type"
-                    description="Channel type tells what kind of acquisition channel this traffic comes from, e.g. Paid Search or Organic Social"
-                />
-            )}
+            {docs && <LearnMorePopover docsURL={docs.docsUrl} title={docs.title} description={docs.description} />}
             <WebQuery
                 query={query}
                 insightProps={insightProps}
@@ -306,7 +300,7 @@ export const LearnMorePopover = ({ docsURL, title, description }: LearnMorePopov
                             to={docsURL}
                             onClick={() => setIsOpen(false)}
                             targetBlank={true}
-                            sideIcon={<IconOpenSidebar className="w-4 h-4" />}
+                            sideIcon={<IconOpenSidebar />}
                         >
                             Learn more
                         </LemonButton>
@@ -314,11 +308,7 @@ export const LearnMorePopover = ({ docsURL, title, description }: LearnMorePopov
                 </div>
             }
         >
-            <LemonButton
-                onClick={() => setIsOpen(!isOpen)}
-                size="small"
-                icon={<IconInfo />}
-            />
+            <LemonButton onClick={() => setIsOpen(!isOpen)} size="small" icon={<IconInfo />} />
         </Popover>
     )
 }

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -1,4 +1,4 @@
-import { IconExpand45 } from '@posthog/icons'
+import { IconExpand45, IconInfo, IconOpenSidebar, IconX } from '@posthog/icons'
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
@@ -6,8 +6,10 @@ import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { PostHogComDocsURL } from 'lib/lemon-ui/Link/Link'
+import { Popover } from 'lib/lemon-ui/Popover'
 import { isNotNil } from 'lib/utils'
-import React from 'react'
+import React, { useState } from 'react'
 import { WebAnalyticsHealthCheck } from 'scenes/web-analytics/WebAnalyticsHealthCheck'
 import {
     QueryTile,
@@ -75,7 +77,7 @@ const Tiles = (): JSX.Element => {
 }
 
 const QueryTileItem = ({ tile }: { tile: QueryTile }): JSX.Element => {
-    const { query, title, layout, insightProps, showPathCleaningControls, showIntervalSelect } = tile
+    const { query, title, layout, insightProps, showPathCleaningControls, showIntervalSelect, docs } = tile
 
     const { openModal } = useActions(webAnalyticsLogic)
     const { getNewInsightUrl } = useValues(webAnalyticsLogic)
@@ -116,6 +118,13 @@ const QueryTileItem = ({ tile }: { tile: QueryTile }): JSX.Element => {
             )}
         >
             {title && <h2 className="m-0 mb-3">{title}</h2>}
+            {docs && (
+                <LearnMorePopover
+                    docsURL="https://posthog.com/docs/data/channel-type"
+                    title="Channel Type"
+                    description="Channel type tells what kind of acquisition channel this traffic comes from, e.g. Paid Search or Organic Social"
+                />
+            )}
             <WebQuery
                 query={query}
                 insightProps={insightProps}
@@ -160,6 +169,7 @@ const TabsTileItem = ({ tile }: { tile: TabsTile }): JSX.Element => {
                 canOpenModal: !!tab.canOpenModal,
                 canOpenInsight: !!tab.canOpenInsight,
                 query: tab.query,
+                docs: tab.docs,
             }))}
             tileId={tile.tileId}
             openModal={openModal}
@@ -183,10 +193,18 @@ export const WebTabs = ({
         id: string
         title: string
         linkText: string
+        docsUrl?: string
         content: React.ReactNode
         canOpenModal: boolean
         canOpenInsight: boolean
         query: QuerySchema
+        docs:
+            | {
+                  docsUrl: PostHogComDocsURL
+                  title: string
+                  description: string
+              }
+            | undefined
     }[]
     setActiveTabId: (id: string) => void
     openModal: (tileId: TileId, tabId: string) => void
@@ -223,7 +241,16 @@ export const WebTabs = ({
     return (
         <div className={clsx(className, 'flex flex-col')}>
             <div className="flex flex-row items-center self-stretch mb-3">
-                <h2 className="flex-1 m-0">{activeTab?.title}</h2>
+                <h2 className="flex-1 m-0 flex flex-row">
+                    {activeTab?.title}
+                    {activeTab?.docs && (
+                        <LearnMorePopover
+                            docsURL={activeTab.docs.docsUrl}
+                            title={activeTab.docs.title}
+                            description={activeTab.docs.description}
+                        />
+                    )}
+                </h2>
 
                 {tabs.length > 3 ? (
                     <LemonSelect
@@ -246,6 +273,57 @@ export const WebTabs = ({
             <div className="flex-1 flex flex-col">{activeTab?.content}</div>
             {buttonsRow.length > 0 ? <div className="flex justify-end my-2 space-x-2">{buttonsRow}</div> : null}
         </div>
+    )
+}
+
+export interface LearnMorePopoverProps {
+    docsURL: PostHogComDocsURL
+    title: string
+    description: string
+}
+
+export const LearnMorePopover = ({ docsURL, title, description }: LearnMorePopoverProps): JSX.Element => {
+    const [isOpen, setIsOpen] = useState(false)
+
+    return (
+        <Popover
+            visible={isOpen}
+            onClickOutside={() => setIsOpen(false)}
+            overlay={
+                <div className="p-4">
+                    <div className="flex flex-row w-full">
+                        <h2 className="flex-1 text-lg font-bold">{title}</h2>
+                        <LemonButton
+                            targetBlank={true}
+                            type="tertiary"
+                            onClick={() => setIsOpen(false)}
+                            size="xsmall"
+                            icon={<IconX />}
+                        />
+                    </div>
+                    <p className="text-sm text-gray-700">{description}</p>
+                    <div className="flex justify-end mt-4">
+                        <LemonButton
+                            to={docsURL}
+                            onClick={() => setIsOpen(false)}
+                            targetBlank={true}
+                            sideIcon={<IconOpenSidebar className="w-4 h-4" />}
+                            type="tertiary"
+                        >
+                            Learn more
+                        </LemonButton>
+                    </div>
+                </div>
+            }
+        >
+            <LemonButton
+                targetBlank={true}
+                type="tertiary"
+                onClick={() => setIsOpen(!isOpen)}
+                size="small"
+                icon={<IconInfo />}
+            />
+        </Popover>
     )
 }
 

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -315,7 +315,6 @@ export const LearnMorePopover = ({ docsURL, title, description }: LearnMorePopov
             }
         >
             <LemonButton
-                targetBlank={true}
                 type="tertiary"
                 onClick={() => setIsOpen(!isOpen)}
                 size="small"

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -293,7 +293,7 @@ export const LearnMorePopover = ({ docsURL, title, description }: LearnMorePopov
                     <div className="flex flex-row w-full">
                         <h2 className="flex-1 text-lg font-bold">{title}</h2>
                         <LemonButton
-                            targetBlank={true}
+                            targetBlank
                             type="tertiary"
                             onClick={() => setIsOpen(false)}
                             size="xsmall"

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -193,7 +193,6 @@ export const WebTabs = ({
         id: string
         title: string
         linkText: string
-        docsUrl?: string
         content: React.ReactNode
         canOpenModal: boolean
         canOpenInsight: boolean

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -285,7 +285,7 @@ export const LearnMorePopover = ({ docsURL, title, description }: LearnMorePopov
             overlay={
                 <div className="p-4">
                     <div className="flex flex-row w-full">
-                        <h2 className="flex-1 text-lg font-bold">{title}</h2>
+                        <h2 className="flex-1">{title}</h2>
                         <LemonButton
                             targetBlank
                             type="tertiary"

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -315,7 +315,6 @@ export const LearnMorePopover = ({ docsURL, title, description }: LearnMorePopov
             }
         >
             <LemonButton
-                type="tertiary"
                 onClick={() => setIsOpen(!isOpen)}
                 size="small"
                 icon={<IconInfo />}

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -307,7 +307,6 @@ export const LearnMorePopover = ({ docsURL, title, description }: LearnMorePopov
                             onClick={() => setIsOpen(false)}
                             targetBlank={true}
                             sideIcon={<IconOpenSidebar className="w-4 h-4" />}
-                            type="tertiary"
                         >
                             Learn more
                         </LemonButton>

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -5,6 +5,7 @@ import { windowValues } from 'kea-window-values'
 import api from 'lib/api'
 import { FEATURE_FLAGS, RETENTION_FIRST_TIME, STALE_EVENT_SECONDS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
+import { PostHogComDocsURL } from 'lib/lemon-ui/Link/Link'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getDefaultInterval, isNotNil, updateDatesWithInterval } from 'lib/utils'
 import { urls } from 'scenes/urls'
@@ -70,6 +71,11 @@ interface BaseTile {
     layout: WebTileLayout
 }
 
+export interface Docs {
+    docsUrl: PostHogComDocsURL
+    title: string
+    description: string
+}
 export interface QueryTile extends BaseTile {
     title?: string
     query: QuerySchema
@@ -78,6 +84,7 @@ export interface QueryTile extends BaseTile {
     insightProps: InsightLogicProps
     canOpenModal: boolean
     canOpenInsight?: boolean
+    docs?: Docs
 }
 
 export interface TabsTile extends BaseTile {
@@ -87,12 +94,14 @@ export interface TabsTile extends BaseTile {
         id: string
         title: string
         linkText: string
+        docsLink?: string
         query: QuerySchema
         showIntervalSelect?: boolean
         showPathCleaningControls?: boolean
         insightProps: InsightLogicProps
         canOpenModal?: boolean
         canOpenInsight?: boolean
+        docs?: Docs
     }[]
 }
 
@@ -116,8 +125,8 @@ export enum GraphsTab {
 }
 
 export enum SourceTab {
-    REFERRING_DOMAIN = 'REFERRING_DOMAIN',
     CHANNEL = 'CHANNEL',
+    REFERRING_DOMAIN = 'REFERRING_DOMAIN',
     UTM_SOURCE = 'UTM_SOURCE',
     UTM_MEDIUM = 'UTM_MEDIUM',
     UTM_CAMPAIGN = 'UTM_CAMPAIGN',
@@ -371,7 +380,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
     }),
     selectors(({ actions, values }) => ({
         graphsTab: [(s) => [s._graphsTab], (graphsTab: string | null) => graphsTab || GraphsTab.UNIQUE_USERS],
-        sourceTab: [(s) => [s._sourceTab], (sourceTab: string | null) => sourceTab || SourceTab.REFERRING_DOMAIN],
+        sourceTab: [(s) => [s._sourceTab], (sourceTab: string | null) => sourceTab || SourceTab.CHANNEL],
         deviceTab: [(s) => [s._deviceTab], (deviceTab: string | null) => deviceTab || DeviceTab.DEVICE_TYPE],
         pathTab: [(s) => [s._pathTab], (pathTab: string | null) => pathTab || PathTab.PATH],
         geographyTab: [(s) => [s._geographyTab], (geographyTab: string | null) => geographyTab || GeographyTab.MAP],
@@ -585,7 +594,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             {
                                 id: PathTab.INITIAL_PATH,
                                 title: 'Top entry paths',
-                                linkText: 'Entry Path',
+                                linkText: 'Entry path',
                                 query: {
                                     full: true,
                                     kind: NodeKind.DataTableNode,
@@ -617,6 +626,31 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         setTabId: actions.setSourceTab,
                         tabs: [
                             {
+                                id: SourceTab.CHANNEL,
+                                title: 'Top channels',
+                                linkText: 'Channel',
+                                query: {
+                                    full: true,
+                                    kind: NodeKind.DataTableNode,
+                                    source: {
+                                        kind: NodeKind.WebStatsTableQuery,
+                                        properties: webAnalyticsFilters,
+                                        breakdownBy: WebStatsBreakdown.InitialChannelType,
+                                        dateRange,
+                                        sampling,
+                                        limit: 10,
+                                    },
+                                },
+                                insightProps: createInsightProps(TileId.SOURCES, SourceTab.CHANNEL),
+                                canOpenModal: true,
+                                docs: {
+                                    docsUrl: 'https://posthog.com/docs/data/channel-type',
+                                    title: 'Channels',
+                                    description:
+                                        'Channels are the different sources that bring traffic to your website, e.g. Paid Search, Organic Social, Direct, etc.',
+                                },
+                            },
+                            {
                                 id: SourceTab.REFERRING_DOMAIN,
                                 title: 'Top referrers',
                                 linkText: 'Referring domain',
@@ -635,25 +669,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 insightProps: createInsightProps(TileId.SOURCES, SourceTab.REFERRING_DOMAIN),
                                 canOpenModal: true,
                             },
-                            {
-                                id: SourceTab.CHANNEL,
-                                title: 'Top channels',
-                                linkText: 'Channel',
-                                query: {
-                                    full: true,
-                                    kind: NodeKind.DataTableNode,
-                                    source: {
-                                        kind: NodeKind.WebStatsTableQuery,
-                                        properties: webAnalyticsFilters,
-                                        breakdownBy: WebStatsBreakdown.InitialChannelType,
-                                        dateRange,
-                                        sampling,
-                                        limit: 10,
-                                    },
-                                },
-                                insightProps: createInsightProps(TileId.SOURCES, SourceTab.CHANNEL),
-                                canOpenModal: true,
-                            },
+
                             {
                                 id: SourceTab.UTM_SOURCE,
                                 title: 'Top sources',

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -94,7 +94,6 @@ export interface TabsTile extends BaseTile {
         id: string
         title: string
         linkText: string
-        docsLink?: string
         query: QuerySchema
         showIntervalSelect?: boolean
         showPathCleaningControls?: boolean


### PR DESCRIPTION
## Problem

Channel type is super valuable, but not very prominent and could do with some explanation of how it is calculated.

## Changes

Make channel the default option in the sources tile. Add a popover explaining what it is.

Video: https://github.com/PostHog/posthog/assets/2056078/f6bfd095-a16a-4245-b993-aac80fa314ec
<img width="861" alt="Screenshot 2024-04-12 at 15 16 09" src="https://github.com/PostHog/posthog/assets/2056078/18972305-6af9-4f9c-a0b9-16f8ded1195c">


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually
