### PR TITLE
fix: Make session where clause extractor handle comparison functions

### DIFF
--- a/posthog/hogql/database/schema/util/session_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/session_where_clause_extractor.py
@@ -154,6 +154,26 @@ class SessionMinTimestampWhereClauseExtractor(CloningVisitor):
             return self.visit_and(ast.And(exprs=node.args))
         elif node.name == "or":
             return self.visit_or(ast.Or(exprs=node.args))
+        elif node.name == "greaterOrEquals":
+            return self.visit_compare_operation(
+                ast.CompareOperation(op=CompareOperationOp.GtEq, left=node.args[0], right=node.args[1])
+            )
+        elif node.name == "greater":
+            return self.visit_compare_operation(
+                ast.CompareOperation(op=CompareOperationOp.Gt, left=node.args[0], right=node.args[1])
+            )
+        elif node.name == "lessOrEquals":
+            return self.visit_compare_operation(
+                ast.CompareOperation(op=CompareOperationOp.LtEq, left=node.args[0], right=node.args[1])
+            )
+        elif node.name == "less":
+            return self.visit_compare_operation(
+                ast.CompareOperation(op=CompareOperationOp.Lt, left=node.args[0], right=node.args[1])
+            )
+        elif node.name == "equals":
+            return self.visit_compare_operation(
+                ast.CompareOperation(op=CompareOperationOp.Eq, left=node.args[0], right=node.args[1])
+            )
         return ast.Constant(value=True)
 
     def visit_field(self, node: ast.Field) -> ast.Expr:

--- a/posthog/hogql/database/schema/util/test/test_session_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_session_where_clause_extractor.py
@@ -190,6 +190,16 @@ class TestSessionTimestampInliner(ClickhouseTestMixin, APIBaseTest):
         expected = f("((raw_sessions.min_timestamp + toIntervalDay(3)) >= minus(today(), 2))")
         assert expected == actual
 
+    def test_less_function(self):
+        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE less(min_timestamp, today())")))
+        expected = f("((raw_sessions.min_timestamp - toIntervalDay(3)) <= today())")
+        assert expected == actual
+
+    def test_less_function_second_arg(self):
+        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE less(today(), min_timestamp)")))
+        expected = f("((raw_sessions.min_timestamp + toIntervalDay(3)) >= today())")
+        assert expected == actual
+
     def test_real_example(self):
         actual = f(
             self.inliner.get_inner_where(


### PR DESCRIPTION
## Problem

Internal slack thread: https://posthog.slack.com/archives/C04BU5FS2Q7/p1712863319392779

## Changes

Add support for these comparison functions

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added some new tests