### PR TITLE
feat(hogql): make some aggregations case insensitive

### DIFF
--- a/posthog/hogql/functions/__init__.py
+++ b/posthog/hogql/functions/__init__.py
@@ -1,9 +1,9 @@
 from .mapping import (
-    find_clickhouse_function,
+    find_hogql_function,
     validate_function_args,
     HogQLFunctionMeta,
-    HOGQL_AGGREGATIONS,
-    HOGQL_POSTHOG_FUNCTIONS,
+    find_hogql_aggregation,
+    find_hogql_posthog_function,
     ADD_OR_NULL_DATETIME_FUNCTIONS,
     FIRST_ARG_DATETIME_FUNCTIONS,
 )
@@ -11,11 +11,11 @@ from .cohort import cohort
 from .sparkline import sparkline
 
 __all__ = [
-    "find_clickhouse_function",
+    "find_hogql_function",
     "validate_function_args",
     "HogQLFunctionMeta",
-    "HOGQL_AGGREGATIONS",
-    "HOGQL_POSTHOG_FUNCTIONS",
+    "find_hogql_aggregation",
+    "find_hogql_posthog_function",
     "ADD_OR_NULL_DATETIME_FUNCTIONS",
     "FIRST_ARG_DATETIME_FUNCTIONS",
     "cohort",

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -577,17 +577,16 @@ HOGQL_CLICKHOUSE_FUNCTIONS: Dict[str, HogQLFunctionMeta] = {
 # Permitted HogQL aggregations
 HOGQL_AGGREGATIONS: Dict[str, HogQLFunctionMeta] = {
     # Standard aggregate functions
-    "count": HogQLFunctionMeta("count", 0, 1, aggregate=True),
-    "COUNT": HogQLFunctionMeta("count", 0, 1, aggregate=True),
+    "count": HogQLFunctionMeta("count", 0, 1, aggregate=True, case_sensitive=False),
     "countIf": HogQLFunctionMeta("countIf", 1, 2, aggregate=True),
     "countDistinctIf": HogQLFunctionMeta("countIf", 1, 2, aggregate=True),
-    "min": HogQLFunctionMeta("min", 1, 1, aggregate=True),
+    "min": HogQLFunctionMeta("min", 1, 1, aggregate=True, case_sensitive=False),
     "minIf": HogQLFunctionMeta("minIf", 2, 2, aggregate=True),
-    "max": HogQLFunctionMeta("max", 1, 1, aggregate=True),
+    "max": HogQLFunctionMeta("max", 1, 1, aggregate=True, case_sensitive=False),
     "maxIf": HogQLFunctionMeta("maxIf", 2, 2, aggregate=True),
-    "sum": HogQLFunctionMeta("sum", 1, 1, aggregate=True),
+    "sum": HogQLFunctionMeta("sum", 1, 1, aggregate=True, case_sensitive=False),
     "sumIf": HogQLFunctionMeta("sumIf", 2, 2, aggregate=True),
-    "avg": HogQLFunctionMeta("avg", 1, 1, aggregate=True),
+    "avg": HogQLFunctionMeta("avg", 1, 1, aggregate=True, case_sensitive=False),
     "avgIf": HogQLFunctionMeta("avgIf", 2, 2, aggregate=True),
     "any": HogQLFunctionMeta("any", 1, 1, aggregate=True),
     "anyIf": HogQLFunctionMeta("anyIf", 2, 2, aggregate=True),
@@ -781,12 +780,12 @@ FIRST_ARG_DATETIME_FUNCTIONS = (
 )
 
 
-def find_clickhouse_function(name: str) -> Optional[HogQLFunctionMeta]:
-    func = HOGQL_CLICKHOUSE_FUNCTIONS.get(name)
+def _find_function(name: str, functions: Dict[str, HogQLFunctionMeta]) -> Optional[HogQLFunctionMeta]:
+    func = functions.get(name)
     if func is not None:
         return func
 
-    func = HOGQL_CLICKHOUSE_FUNCTIONS.get(name.lower())
+    func = functions.get(name.lower())
     if func is None:
         return None
     # If we haven't found a function with the case preserved, but we have found it in lowercase,
@@ -795,3 +794,15 @@ def find_clickhouse_function(name: str) -> Optional[HogQLFunctionMeta]:
         return None
 
     return func
+
+
+def find_hogql_aggregation(name: str) -> Optional[HogQLFunctionMeta]:
+    return _find_function(name, HOGQL_AGGREGATIONS)
+
+
+def find_hogql_function(name: str) -> Optional[HogQLFunctionMeta]:
+    return _find_function(name, HOGQL_CLICKHOUSE_FUNCTIONS)
+
+
+def find_hogql_posthog_function(name: str) -> Optional[HogQLFunctionMeta]:
+    return _find_function(name, HOGQL_POSTHOG_FUNCTIONS)

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -12,7 +12,7 @@ from posthog.constants import (
 )
 from posthog.hogql import ast
 from posthog.hogql.base import AST
-from posthog.hogql.functions import HOGQL_AGGREGATIONS
+from posthog.hogql.functions import find_hogql_aggregation
 from posthog.hogql.errors import NotImplementedError
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.visitor import TraversingVisitor, clone_expr
@@ -59,7 +59,7 @@ class AggregationFinder(TraversingVisitor):
         pass
 
     def visit_call(self, node: ast.Call):
-        if node.name in HOGQL_AGGREGATIONS:
+        if find_hogql_aggregation(node.name):
             self.has_aggregation = True
         else:
             for arg in node.args:

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from posthog.hogql import ast
 from posthog.hogql.ast import FieldTraverserType, ConstantType
-from posthog.hogql.functions import HOGQL_POSTHOG_FUNCTIONS
+from posthog.hogql.functions import find_hogql_posthog_function
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import (
     StringJSONDatabaseField,
@@ -384,7 +384,7 @@ class Resolver(CloningVisitor):
     def visit_call(self, node: ast.Call):
         """Visit function calls."""
 
-        if func_meta := HOGQL_POSTHOG_FUNCTIONS.get(node.name):
+        if func_meta := find_hogql_posthog_function(node.name):
             validate_function_args(node.args, func_meta.min_args, func_meta.max_args, node.name)
             if node.name == "sparkline":
                 return self.visit(sparkline(node=node, args=node.args))

--- a/posthog/hogql/test/test_mapping.py
+++ b/posthog/hogql/test/test_mapping.py
@@ -1,21 +1,21 @@
 from posthog.test.base import BaseTest
-from posthog.hogql.functions.mapping import find_clickhouse_function, HogQLFunctionMeta
+from posthog.hogql.functions.mapping import find_hogql_function, HogQLFunctionMeta
 
 
 class TestMappings(BaseTest):
     def _get_clickhouse_function(self, name: str) -> HogQLFunctionMeta:
-        result = find_clickhouse_function(name)
+        result = find_hogql_function(name)
         assert result is not None
         return result
 
     def test_find_case_sensitive_function(self):
         self.assertEquals(self._get_clickhouse_function("toString").clickhouse_name, "toString")
-        self.assertEquals(find_clickhouse_function("TOString"), None)
-        self.assertEquals(find_clickhouse_function("PlUs"), None)
+        self.assertEquals(find_hogql_function("TOString"), None)
+        self.assertEquals(find_hogql_function("PlUs"), None)
 
     def test_find_case_insensitive_function(self):
         self.assertEquals(self._get_clickhouse_function("coalesce").clickhouse_name, "coalesce")
         self.assertEquals(self._get_clickhouse_function("CoAlesce").clickhouse_name, "coalesce")
 
     def test_find_non_existent_function(self):
-        self.assertEquals(find_clickhouse_function("functionThatDoesntExist"), None)
+        self.assertEquals(find_hogql_function("functionThatDoesntExist"), None)

--- a/posthog/hogql/test/test_mapping.py
+++ b/posthog/hogql/test/test_mapping.py
@@ -25,6 +25,7 @@ class TestMappings(BaseTest):
     def test_find_case_sensitive_function(self):
         self.assertEquals(self._get_hogql_function("toString").clickhouse_name, "toString")
         self.assertEquals(find_hogql_function("TOString"), None)
+        self.assertEquals(find_hogql_function("PlUs"), None)
 
         self.assertEquals(self._get_hogql_aggregation("countIf").clickhouse_name, "countIf")
         self.assertEquals(find_hogql_aggregation("COUNTIF"), None)

--- a/posthog/hogql/test/test_mapping.py
+++ b/posthog/hogql/test/test_mapping.py
@@ -1,21 +1,43 @@
 from posthog.test.base import BaseTest
-from posthog.hogql.functions.mapping import find_hogql_function, HogQLFunctionMeta
+from typing import Optional
+from posthog.hogql.functions.mapping import (
+    find_hogql_function,
+    find_hogql_aggregation,
+    find_hogql_posthog_function,
+    HogQLFunctionMeta,
+)
 
 
 class TestMappings(BaseTest):
-    def _get_clickhouse_function(self, name: str) -> HogQLFunctionMeta:
-        result = find_hogql_function(name)
-        assert result is not None
-        return result
+    def _return_present_function(self, function: Optional[HogQLFunctionMeta]) -> HogQLFunctionMeta:
+        assert function is not None
+        return function
+
+    def _get_hogql_function(self, name: str) -> HogQLFunctionMeta:
+        return self._return_present_function(find_hogql_function(name))
+
+    def _get_hogql_aggregation(self, name: str) -> HogQLFunctionMeta:
+        return self._return_present_function(find_hogql_aggregation(name))
+
+    def _get_hogql_posthog_function(self, name: str) -> HogQLFunctionMeta:
+        return self._return_present_function(find_hogql_posthog_function(name))
 
     def test_find_case_sensitive_function(self):
-        self.assertEquals(self._get_clickhouse_function("toString").clickhouse_name, "toString")
+        self.assertEquals(self._get_hogql_function("toString").clickhouse_name, "toString")
         self.assertEquals(find_hogql_function("TOString"), None)
-        self.assertEquals(find_hogql_function("PlUs"), None)
+
+        self.assertEquals(self._get_hogql_aggregation("countIf").clickhouse_name, "countIf")
+        self.assertEquals(find_hogql_aggregation("COUNTIF"), None)
+
+        self.assertEquals(self._get_hogql_posthog_function("sparkline").clickhouse_name, "sparkline")
+        self.assertEquals(find_hogql_posthog_function("SPARKLINE"), None)
 
     def test_find_case_insensitive_function(self):
-        self.assertEquals(self._get_clickhouse_function("coalesce").clickhouse_name, "coalesce")
-        self.assertEquals(self._get_clickhouse_function("CoAlesce").clickhouse_name, "coalesce")
+        self.assertEquals(self._get_hogql_function("CoAlesce").clickhouse_name, "coalesce")
+
+        self.assertEquals(self._get_hogql_aggregation("SuM").clickhouse_name, "sum")
 
     def test_find_non_existent_function(self):
         self.assertEquals(find_hogql_function("functionThatDoesntExist"), None)
+        self.assertEquals(find_hogql_aggregation("functionThatDoesntExist"), None)
+        self.assertEquals(find_hogql_posthog_function("functionThatDoesntExist"), None)

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -1590,3 +1590,7 @@ class TestPrinter(BaseTest):
             self._expr("CoALESce(1)", context),
             "coalesce(1)",
         )
+        self.assertEqual(
+            self._expr("SuM(1)", context),
+            "sum(1)",
+        )


### PR DESCRIPTION
## Problem

Fix https://github.com/PostHog/posthog/issues/21469

## Changes

It allows to use aggregations without case sensitivity

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Automated tests