### PR TITLE
fix: revert depot runners until we figure out cache issue

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -39,7 +39,7 @@ jobs:
     # Job to decide if we should run backend ci
     # See https://github.com/dorny/paths-filter#conditional-execution for more details
     changes:
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
         timeout-minutes: 5
         if: github.repository == 'PostHog/posthog'
         name: Determine need to run backend checks
@@ -90,7 +90,7 @@ jobs:
         timeout-minutes: 30
 
         name: Python code quality checks
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
 
         steps:
             # If this run wasn't initiated by the bot (meaning: snapshot update) and we've determined
@@ -171,7 +171,7 @@ jobs:
         timeout-minutes: 10
 
         name: Validate Django and CH migrations
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
 
         steps:
             - uses: actions/checkout@v3
@@ -236,7 +236,7 @@ jobs:
         timeout-minutes: 30
 
         name: Django tests – ${{ matrix.segment }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
 
         strategy:
             fail-fast: false
@@ -319,7 +319,7 @@ jobs:
                 clickhouse-server-image:
                     ['clickhouse/clickhouse-server:23.11.2.11-alpine', 'clickhouse/clickhouse-server:23.12.5.81-alpine']
         if: needs.changes.outputs.backend == 'true'
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
         steps:
             - name: 'Checkout repo'
               uses: actions/checkout@v3
@@ -373,7 +373,7 @@ jobs:
     calculate-running-time:
         name: Calculate running time
         needs: [django, async-migrations]
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
         if: needs.changes.outputs.backend == 'true'
         steps:
             - name: Calculate running time

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
     changes:
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
         timeout-minutes: 5
         if: github.repository == 'PostHog/posthog'
         name: Determine need to run E2E checks
@@ -55,7 +55,7 @@ jobs:
     chunks:
         needs: changes
         name: Cypress preparation
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
         timeout-minutes: 5
         outputs:
             chunks: ${{ steps.chunk.outputs.chunks }}
@@ -70,7 +70,7 @@ jobs:
 
     container:
         name: Build and cache container image
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
         timeout-minutes: 60
         needs: [changes]
         permissions:
@@ -94,7 +94,7 @@ jobs:
 
     cypress:
         name: Cypress E2E tests (${{ strategy.job-index }})
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
         timeout-minutes: 60
         needs: [chunks, changes, container]
         permissions:
@@ -279,7 +279,7 @@ jobs:
 
     calculate-running-time:
         name: Calculate running time
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
         needs: [cypress]
         if: needs.changes.outputs.shouldTriggerCypress == 'true'
         steps:

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -24,7 +24,7 @@ jobs:
     # Job to decide if we should run plugin server ci
     # See https://github.com/dorny/paths-filter#conditional-execution for more details
     changes:
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
         timeout-minutes: 5
         if: github.repository == 'PostHog/posthog'
         name: Determine need to run plugin server checks
@@ -54,7 +54,7 @@ jobs:
         name: Code quality
         needs: changes
         if: needs.changes.outputs.plugin-server == 'true'
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
         defaults:
             run:
                 working-directory: 'plugin-server'
@@ -85,7 +85,7 @@ jobs:
     tests:
         name: Plugin Server Tests (${{matrix.shard}})
         needs: changes
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
 
         strategy:
             fail-fast: false
@@ -180,7 +180,7 @@ jobs:
         name: Functional tests (POE=${{matrix.POE_EMBRACE_JOIN_FOR_TEAMS}},RDK=${{matrix.KAFKA_CONSUMPTION_USE_RDKAFKA}})
         needs: changes
         if: needs.changes.outputs.plugin-server == 'true'
-        runs-on: depot-ubuntu-latest-4
+        runs-on: ubuntu-latest-4
 
         strategy:
             fail-fast: false


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Still having caching issues: https://github.com/PostHog/posthog/actions/runs/8652449650/job/23725420585?pr=21485#step:3:4543

## Changes

Revert Depot runners until we debug the caching issue.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
