### PR TITLE
refactor: Switch bug report template to GitHub's beta issue templates to allow pulling in debug info via URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,6 @@ body:
     attributes:
       label: Bug Description
       value: "## Bug description\n\n*Please describe.*\n*If this affects the front-end, screenshots would be of great help.*\n\n*If you are on PostHog Cloud it would be really valuable if you can share any links where the problem occurs. This speeds up our ability to troubleshoot tremendously.*\n\n## How to reproduce\n\n1. \n2.\n3. \n\n## Additional context\n\n"
-      render: markdown
     validations:
       required: true
   
@@ -16,7 +15,6 @@ body:
     attributes:
       label: Debug info
       value: "- [ ] PostHog Cloud, Debug information: [please copy/paste from https://us.posthog.com/settings/project-details#variables]\n- [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n- [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
-      render: markdown
     validations:
       required: false
     

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,42 @@
+name: Bug report
+description: Something not working as expected? Let us look into it.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      value: "## Bug description\n\n
+
+              *Please describe.*\n  
+              *If this affects the front-end, screenshots would be of great help.*\n\n  
+
+              *If you are on PostHog Cloud it would be really valuable if you can share any links where the problem occurs. This speeds up our ability to troubleshoot tremendously.*\n\n 
+
+              ## How to reproduce\n\n
+
+              1. \n
+              2. \n 
+              3. \n\n
+
+              ## Additional context\n\n
+            
+            "
+      render: markdown
+    validations:
+      required: true
+  
+  - type: textarea
+    id: debug-info
+    attributes:
+      label: Debug info
+      value: "- [ ] PostHog Cloud, Debug information: [please copy/paste from https://us.posthog.com/settings/project-details#variables]\n
+              - [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n
+              - [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
+      render: markdown
+    validations:
+      required: false
+    
+  - type: markdown
+    attributes:
+      value: "#### *Thank you* for your bug report – we love squashing them!"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,3 +1,4 @@
+
 name: Bug report
 description: Something not working as expected? Let us look into it.
 labels: ["bug"]
@@ -7,8 +8,6 @@ body:
     attributes:
       label: Bug Description
       value: "## Bug description\n\n*Please describe.*\n*If this affects the front-end, screenshots would be of great help.*\n\n*If you are on PostHog Cloud it would be really valuable if you can share any links where the problem occurs. This speeds up our ability to troubleshoot tremendously.*\n\n## How to reproduce\n\n1. \n2.\n3. \n\n## Additional context\n\n"
-    validations:
-      required: true
   
   - type: textarea
     id: debug-info
@@ -16,8 +15,6 @@ body:
       label: Debug info
       value: "- [ ] PostHog Cloud, Debug information: [please copy/paste from https://us.posthog.com/settings/project-details#variables]\n- [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n- [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
       render: shell
-    validations:
-      required: false
     
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,6 +15,7 @@ body:
     attributes:
       label: Debug info
       value: "- [ ] PostHog Cloud, Debug information: [please copy/paste from https://us.posthog.com/settings/project-details#variables]\n- [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n- [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
+      render: shell
     validations:
       required: false
     

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,22 +6,7 @@ body:
     id: bug-description
     attributes:
       label: Bug Description
-      value: "## Bug description\n\n
-
-              *Please describe.*\n  
-              *If this affects the front-end, screenshots would be of great help.*\n\n  
-
-              *If you are on PostHog Cloud it would be really valuable if you can share any links where the problem occurs. This speeds up our ability to troubleshoot tremendously.*\n\n 
-
-              ## How to reproduce\n\n
-
-              1. \n
-              2. \n 
-              3. \n\n
-
-              ## Additional context\n\n
-            
-            "
+      value: "## Bug description\n\n*Please describe.*\n*If this affects the front-end, screenshots would be of great help.*\n\n*If you are on PostHog Cloud it would be really valuable if you can share any links where the problem occurs. This speeds up our ability to troubleshoot tremendously.*\n\n## How to reproduce\n\n1. \n2.\n3. \n\n## Additional context\n\n"
       render: markdown
     validations:
       required: true
@@ -30,9 +15,7 @@ body:
     id: debug-info
     attributes:
       label: Debug info
-      value: "- [ ] PostHog Cloud, Debug information: [please copy/paste from https://us.posthog.com/settings/project-details#variables]\n
-              - [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n
-              - [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
+      value: "- [ ] PostHog Cloud, Debug information: [please copy/paste from https://us.posthog.com/settings/project-details#variables]\n- [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n- [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
       render: markdown
     validations:
       required: false


### PR DESCRIPTION
Using GitHub's new issue templates, allowing us to add debug-info via url

## Problem

Previously we were unable to append session and debug info via URL content.

## Changes

Using GitHub's beta issue template structure, which also allows us to prepropulate fields via the URL used to open the new issue page


## Does this work well for both Cloud and self-hosted?

Works only for cloud, no impact on self-hosted.

## How did you test this code?

Tested via GitHub GUI and URLs with content to include