### PR TITLE
chore(data-warehoues): fix back button bug

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -379,6 +379,11 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
         ],
     }),
     listeners(({ actions, values }) => ({
+        onBack: () => {
+            if (values.currentStep <= 2) {
+                actions.selectConnector(null)
+            }
+        },
         onClear: () => {
             actions.selectConnector(null)
             actions.clearSource()


### PR DESCRIPTION
## Problem

- when you click into an integration but click back, manual link will be hidden because a connector is still selected

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- set selected to null

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
