### PR TITLE
refactor: Switch feature request template to GitHub's beta issue tem…

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: "Let us know what you have in mind"
+description: "Suggest a feature for PostHog"
 labels: ["enhancement, feature"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
     id: feature_request
     attributes:
       label: Feature request
-      value: "## Is your feature request related to a problem?\n*Please describe.*\n\n## Describe the solution you'd like\n\n\n## Describe alternatives you've considered\n\n\n## Additional context\n\n\n
+      value: "## Is your feature request related to a problem?\n\n*Please describe.*\n\n## Describe the solution you'd like\n\n\n## Describe alternatives you've considered\n\n\n## Additional context\n\n\n
             
             "
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: "Let us know what you have in mind"
+labels: ["enhancement, feature"]
+body:
+  - type: textarea
+    id: feature_request
+    attributes:
+      label: Feature request
+      value: "## Is your feature request related to a problem?\n*Please describe.*\n\n## Describe the solution you'd like\n\n\n## Describe alternatives you've considered\n\n\n
+
+              ## Additional context\n\n\n
+            
+            "
+    validations:
+      required: true
+  
+  - type: textarea
+    id: debug-info
+    attributes:
+      label: Debug info
+      value: "- [ ] PostHog Cloud, Debug information: [please copy/paste from https://us.posthog.com/settings/project-details#variables]\n- [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n- [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
+      render: markdown
+    validations:
+      required: false
+    
+  - type: markdown
+    attributes:
+      value: "#### *Thank you* for your bug report – we love squashing them!"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,22 +6,15 @@ body:
     id: feature_request
     attributes:
       label: Feature request
-      value: "## Is your feature request related to a problem?\n*Please describe.*\n\n## Describe the solution you'd like\n\n\n## Describe alternatives you've considered\n\n\n
-
-              ## Additional context\n\n\n
+      value: "## Is your feature request related to a problem?\n*Please describe.*\n\n## Describe the solution you'd like\n\n\n## Describe alternatives you've considered\n\n\n## Additional context\n\n\n
             
             "
-    validations:
-      required: true
-  
   - type: textarea
     id: debug-info
     attributes:
       label: Debug info
       value: "- [ ] PostHog Cloud, Debug information: [please copy/paste from https://us.posthog.com/settings/project-details#variables]\n- [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n- [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
-      render: markdown
-    validations:
-      required: false
+      render: shell
     
   - type: markdown
     attributes:


### PR DESCRIPTION
Using GitHub's new issue templates, allowing us to add debug-info via url

## Problem

Previously we were unable to append session and debug info via URL content.

## Changes

Using GitHub's beta issue template structure, which also allows us to prepropulate fields via the URL used to open the new issue page


## Does this work well for both Cloud and self-hosted?

Works only for cloud, no impact on self-hosted.

## How did you test this code?

Tested via GitHub GUI and URLs with content to include