### PR TITLE
fix(ci): wait for DBs before starting Temporal

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -185,3 +185,8 @@ runs:
               pytest posthog/api/test/test_decide.py::TestDecideUsesReadReplica \
                   --durations=100 --durations-min=1.0 \
                   $PYTEST_ARGS
+
+        - name: Show docker compose logs on failure
+          if: failure()
+          shell: bash
+          run: docker compose -f docker-compose.dev.yml logs

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -168,6 +168,9 @@ services:
             kompose.volume.type: configMap
         volumes:
             - ./docker/temporal/dynamicconfig:/etc/temporal/config/dynamicconfig
+        depends_on:
+            - db
+            - elasticsearch
     temporal-admin-tools:
         environment:
             - TEMPORAL_CLI_ADDRESS=temporal:7233


### PR DESCRIPTION
## Problem

Temporal has been timing out in CI (#21489) - it appears that this may be due to the fact that Temporal is starting before the Postgres database is fully started itself, and so when the Temporal server starts to initialize its schema, it fails.

## Changes

This PR adds the `depends_on` for both Postgres and Elasticsearch, so that Temporal is started after - this matches the upstream `docker-compose.yml` too: https://github.com/temporalio/docker-compose/blob/4a2408b1ae75491295ae66bba21bf86918d74f8b/docker-compose-postgres-opensearch.yml#L39-L43. This way, Temporal should wait until the Postgres server is online.

I also added a change so that `docker compose logs` are printed on workflow failure, for better debugging - in the case of the Temporal timeouts, it did actually print an error about the database not being ready in the compose logs.

## Does this work well for both Cloud and self-hosted?

No impact.

## How did you test this code?

Tested by running several of these workflows on our fork.