### PR TITLE
fix(insights): Fix UI glitch with HogQL expression as aggregation

### DIFF
--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -132,7 +132,7 @@ export function AggregationSelect({
 
     return (
         <LemonSelect
-            className={className}
+            className={className || 'flex-1'}
             value={value}
             onChange={(newValue) => {
                 if (newValue !== null) {


### PR DESCRIPTION
## Problem

When using a HogQL expression, the select field overflows.

## Changes

Before:

<img width="577" alt="image" src="https://github.com/PostHog/posthog/assets/59713/23b7201f-4cf2-4903-a096-f8d681160704">



After:

<img width="462" alt="Screenshot 2024-04-12 at 14 18 02" src="https://github.com/PostHog/posthog/assets/59713/49486cda-bf90-459f-bd26-cb90103930c5">

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

- 👀 