### PR TITLE
feat(web-analytics): Allow other session properties beyond $session_duration

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -4933,7 +4933,6 @@
             "additionalProperties": false,
             "properties": {
                 "key": {
-                    "const": "$session_duration",
                     "type": "string"
                 },
                 "label": {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -694,7 +694,6 @@ export interface ElementPropertyFilter extends BasePropertyFilter {
 
 export interface SessionPropertyFilter extends BasePropertyFilter {
     type: PropertyFilterType.Session
-    key: '$session_duration'
     operator: PropertyOperator
 }
 

--- a/posthog/hogql_queries/legacy_compatibility/clean_properties.py
+++ b/posthog/hogql_queries/legacy_compatibility/clean_properties.py
@@ -60,7 +60,8 @@ def clean_property_group_filter(properties: dict):
 
 
 def clean_property_group_filter_values(properties: list[dict]):
-    return [clean_property_group_filter_value(property) for property in properties]
+    cleaned = [clean_property_group_filter_value(property) for property in properties if property]
+    return cleaned
 
 
 def clean_property_group_filter_value(property: dict):

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -1230,7 +1230,7 @@ class TestFilterToQuery(BaseTest):
                 EventsNode(
                     event="$pageview",
                     name="$pageview",
-                    properties=[SessionPropertyFilter(value=1, operator=PropertyOperator.gt)],
+                    properties=[SessionPropertyFilter(key="$session_duration", value=1, operator=PropertyOperator.gt)],
                 ),
                 EventsNode(
                     event="$pageview",

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -820,7 +820,7 @@ class SessionPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    key: Literal["$session_duration"] = "$session_duration"
+    key: str
     label: Optional[str] = None
     operator: PropertyOperator
     type: Literal["session"] = "session"


### PR DESCRIPTION
## Problem

Pulled out of https://github.com/PostHog/posthog/pull/21512 as a PoC to show a weird test failure, and fix it (see the 2 separate commits)

## Changes

Allow session properties key to be any string, and fix the test that breaks when you do this.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Fixed the test, but also messaged in slack to sanity check it's the right fix https://posthog.slack.com/archives/C0368RPHLQH/p1712927167677569
