### PR TITLE
chore: move file playback to header ellipse

### DIFF
--- a/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
+++ b/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
@@ -73,6 +73,7 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>([
                 // this every time it's rendered. Caching will happen within the scene's breadcrumb selector.
                 (state, props): Breadcrumb[] => {
                     const activeSceneLogic = sceneLogic.selectors.activeSceneLogic(state, props)
+                    // debugger
                     const activeScene = s.activeScene(state, props)
                     if (activeSceneLogic && 'breadcrumbs' in activeSceneLogic.selectors) {
                         const activeLoadedScene = sceneLogic.selectors.activeLoadedScene(state, props)

--- a/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
+++ b/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
@@ -73,7 +73,6 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>([
                 // this every time it's rendered. Caching will happen within the scene's breadcrumb selector.
                 (state, props): Breadcrumb[] => {
                     const activeSceneLogic = sceneLogic.selectors.activeSceneLogic(state, props)
-                    // debugger
                     const activeScene = s.activeScene(state, props)
                     if (activeSceneLogic && 'breadcrumbs' in activeSceneLogic.selectors) {
                         const activeLoadedScene = sceneLogic.selectors.activeLoadedScene(state, props)

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -22,6 +22,7 @@ export const appScenes: Record<Scene, () => any> = {
     [Scene.Replay]: () => import('./session-recordings/SessionRecordings'),
     [Scene.ReplaySingle]: () => import('./session-recordings/detail/SessionRecordingDetail'),
     [Scene.ReplayPlaylist]: () => import('./session-recordings/playlist/SessionRecordingsPlaylistScene'),
+    [Scene.ReplayFilePlayback]: () => import('./session-recordings/file-playback/SessionRecordingFilePlaybackScene'),
     [Scene.PersonsManagement]: () => import('./persons-management/PersonsManagementScene'),
     [Scene.Person]: () => import('./persons/PersonScene'),
     [Scene.Pipeline]: () => import('./pipeline/Pipeline'),

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -23,6 +23,7 @@ export enum Scene {
     Replay = 'Replay',
     ReplaySingle = 'ReplaySingle',
     ReplayPlaylist = 'ReplayPlaylist',
+    ReplayFilePlayback = 'ReplayFilePlayback',
     PersonsManagement = 'PersonsManagement',
     Person = 'Person',
     Pipeline = 'Pipeline',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -136,6 +136,12 @@ export const sceneConfigurations: Record<Scene, SceneConfig> = {
         activityScope: ActivityScope.REPLAY,
         defaultDocsPath: '/docs/session-replay',
     },
+    [Scene.ReplayFilePlayback]: {
+        projectBased: true,
+        name: 'File playback',
+        activityScope: ActivityScope.REPLAY,
+        defaultDocsPath: '/docs/session-replay',
+    },
     [Scene.Person]: {
         projectBased: true,
         name: 'Person',
@@ -436,6 +442,7 @@ export const redirects: Record<
     '/annotations/:id': ({ id }) => urls.annotation(id),
     '/recordings/:id': ({ id }) => urls.replaySingle(id),
     '/recordings/playlists/:id': ({ id }) => urls.replayPlaylist(id),
+    '/recordings/file-playback': () => urls.replayFilePlayback(),
     '/recordings': (_params, _searchParams, hashParams) => {
         if (hashParams.sessionRecordingId) {
             // Previous URLs for an individual recording were like: /recordings/#sessionRecordingId=foobar
@@ -494,6 +501,7 @@ export const routes: Record<string, Scene> = {
         acc[urls.replay(tab)] = Scene.Replay
         return acc
     }, {} as Record<string, Scene>),
+    [urls.replayFilePlayback()]: Scene.ReplayFilePlayback,
     [urls.replaySingle(':id')]: Scene.ReplaySingle,
     [urls.replayPlaylist(':id')]: Scene.ReplayPlaylist,
     [urls.personByDistinctId('*', false)]: Scene.Person,

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -1,5 +1,5 @@
-import { IconGear } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
+import { IconEllipsis, IconGear } from '@posthog/icons'
+import { LemonButton, LemonMenu } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { authorizedUrlListLogic, AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
@@ -22,7 +22,6 @@ import { sidePanelSettingsLogic } from '~/layout/navigation-3000/sidepanel/panel
 import { AvailableFeature, NotebookNodeType, ReplayTabs } from '~/types'
 
 import { SessionRecordingErrors } from './errors/SessionRecordingErrors'
-import { SessionRecordingFilePlayback } from './file-playback/SessionRecordingFilePlayback'
 import { createPlaylist } from './playlist/playlistUtils'
 import { SessionRecordingsPlaylist } from './playlist/SessionRecordingsPlaylist'
 import { SavedSessionRecordingPlaylists } from './saved-playlists/SavedSessionRecordingPlaylists'
@@ -66,6 +65,16 @@ export function SessionsRecordings(): JSX.Element {
                     <>
                         {tab === ReplayTabs.Recent && !recordingsDisabled && (
                             <>
+                                <LemonMenu
+                                    items={[
+                                        {
+                                            label: 'Playback from file',
+                                            to: urls.replayFilePlayback(),
+                                        },
+                                    ]}
+                                >
+                                    <LemonButton icon={<IconEllipsis />} />
+                                </LemonMenu>
                                 <NotebookSelectButton
                                     resource={{
                                         type: NotebookNodeType.RecordingPlaylist,
@@ -175,8 +184,6 @@ export function SessionsRecordings(): JSX.Element {
                     </div>
                 ) : tab === ReplayTabs.Playlists ? (
                     <SavedSessionRecordingPlaylists tab={ReplayTabs.Playlists} />
-                ) : tab === ReplayTabs.FilePlayback ? (
-                    <SessionRecordingFilePlayback />
                 ) : tab === ReplayTabs.Errors ? (
                     <SessionRecordingErrors />
                 ) : null}

--- a/frontend/src/scenes/session-recordings/file-playback/SessionRecordingFilePlaybackScene.tsx
+++ b/frontend/src/scenes/session-recordings/file-playback/SessionRecordingFilePlaybackScene.tsx
@@ -5,16 +5,22 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonFileInput } from 'lib/lemon-ui/LemonFileInput'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
 import { useRef } from 'react'
+import { SceneExport } from 'scenes/sceneTypes'
 import { userLogic } from 'scenes/userLogic'
 
 import { AvailableFeature } from '~/types'
 
 import { SessionRecordingPlayer } from '../player/SessionRecordingPlayer'
-import { sessionRecordingFilePlaybackLogic } from './sessionRecordingFilePlaybackLogic'
+import { sessionRecordingFilePlaybackSceneLogic } from './sessionRecordingFilePlaybackSceneLogic'
 
-export function SessionRecordingFilePlayback(): JSX.Element {
-    const { loadFromFile, resetSessionRecording } = useActions(sessionRecordingFilePlaybackLogic)
-    const { sessionRecording, sessionRecordingLoading, playerKey } = useValues(sessionRecordingFilePlaybackLogic)
+export const scene: SceneExport = {
+    component: SessionRecordingFilePlaybackScene,
+    logic: sessionRecordingFilePlaybackSceneLogic,
+}
+
+export function SessionRecordingFilePlaybackScene(): JSX.Element {
+    const { loadFromFile, resetSessionRecording } = useActions(sessionRecordingFilePlaybackSceneLogic)
+    const { sessionRecording, sessionRecordingLoading, playerKey } = useValues(sessionRecordingFilePlaybackSceneLogic)
     const { hasAvailableFeature } = useValues(userLogic)
     const filePlaybackEnabled = hasAvailableFeature(AvailableFeature.RECORDINGS_FILE_EXPORT)
 

--- a/frontend/src/scenes/session-recordings/file-playback/sessionRecordingFilePlaybackSceneLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/file-playback/sessionRecordingFilePlaybackSceneLogic.test.ts
@@ -2,10 +2,10 @@ import { expectLogic } from 'kea-test-utils'
 
 import { initKeaTests } from '~/test/init'
 
-import { sessionRecordingFilePlaybackLogic } from './sessionRecordingFilePlaybackLogic'
+import { sessionRecordingFilePlaybackSceneLogic } from './sessionRecordingFilePlaybackSceneLogic'
 
 describe('sessionRecordingFilePlaybackLogic', () => {
-    let logic: ReturnType<typeof sessionRecordingFilePlaybackLogic.build>
+    let logic: ReturnType<typeof sessionRecordingFilePlaybackSceneLogic.build>
 
     beforeEach(() => {
         initKeaTests()
@@ -13,7 +13,7 @@ describe('sessionRecordingFilePlaybackLogic', () => {
 
     describe('file-playback logic', () => {
         beforeEach(() => {
-            logic = sessionRecordingFilePlaybackLogic()
+            logic = sessionRecordingFilePlaybackSceneLogic()
             logic.mount()
         })
 

--- a/frontend/src/scenes/session-recordings/file-playback/sessionRecordingFilePlaybackSceneLogic.ts
+++ b/frontend/src/scenes/session-recordings/file-playback/sessionRecordingFilePlaybackSceneLogic.ts
@@ -9,7 +9,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
-import { Breadcrumb, ReplayTabs } from '~/types'
+import { Breadcrumb } from '~/types'
 
 import {
     deduplicateSnapshots,
@@ -17,7 +17,7 @@ import {
     sessionRecordingDataLogic,
 } from '../player/sessionRecordingDataLogic'
 import type { sessionRecordingDataLogicType } from '../player/sessionRecordingDataLogicType'
-import type { sessionRecordingFilePlaybackLogicType } from './sessionRecordingFilePlaybackLogicType'
+import type { sessionRecordingFilePlaybackSceneLogicType } from './sessionRecordingFilePlaybackSceneLogicType'
 import { ExportedSessionRecordingFileV1, ExportedSessionRecordingFileV2 } from './types'
 
 export const createExportedSessionRecording = (
@@ -103,8 +103,8 @@ const waitForDataLogic = async (playerKey: string): Promise<BuiltLogic<sessionRe
     throw new Error('Timeout reached: dataLogic is still null after 2 seconds')
 }
 
-export const sessionRecordingFilePlaybackLogic = kea<sessionRecordingFilePlaybackLogicType>([
-    path(['scenes', 'session-recordings', 'detail', 'sessionRecordingFilePlaybackLogic']),
+export const sessionRecordingFilePlaybackSceneLogic = kea<sessionRecordingFilePlaybackSceneLogicType>([
+    path(['scenes', 'session-recordings', 'detail', 'sessionRecordingFilePlaybackSceneLogic']),
     connect({
         actions: [eventUsageLogic, ['reportRecordingLoadedFromFile']],
         values: [featureFlagLogic, ['featureFlags']],
@@ -192,12 +192,13 @@ export const sessionRecordingFilePlaybackLogic = kea<sessionRecordingFilePlaybac
             (): Breadcrumb[] => [
                 {
                     key: Scene.Replay,
-                    name: 'Session replay',
+                    name: 'Replay',
                     path: urls.replay(),
                 },
                 {
-                    key: ReplayTabs.FilePlayback,
-                    name: 'Import',
+                    key: Scene.ReplayFilePlayback,
+                    name: 'File playback',
+                    path: urls.replayFilePlayback(),
                 },
             ],
         ],

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -37,7 +37,7 @@ import { userLogic } from 'scenes/userLogic'
 
 import { AvailableFeature, RecordingSegment, SessionPlayerData, SessionPlayerState } from '~/types'
 
-import { createExportedSessionRecording } from '../file-playback/sessionRecordingFilePlaybackLogic'
+import { createExportedSessionRecording } from '../file-playback/sessionRecordingFilePlaybackSceneLogic'
 import type { sessionRecordingsPlaylistLogicType } from '../playlist/sessionRecordingsPlaylistLogicType'
 import { playerSettingsLogic } from './playerSettingsLogic'
 import { COMMON_REPLAYER_CONFIG, CorsPlugin } from './rrweb'

--- a/frontend/src/scenes/session-recordings/sessionRecordingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsLogic.ts
@@ -16,8 +16,6 @@ export const humanFriendlyTabName = (tab: ReplayTabs): string => {
             return 'Recent recordings'
         case ReplayTabs.Playlists:
             return 'Playlists'
-        case ReplayTabs.FilePlayback:
-            return 'Playback from file'
         default:
             return capitalizeFirstLetter(tab)
     }

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -110,6 +110,7 @@ export const urls = {
         combineUrl(`/replay/playlists/${id}`, filters ? { filters } : {}).url,
     replaySingle: (id: string, filters?: Partial<FilterType>): string =>
         combineUrl(`/replay/${id}`, filters ? { filters } : {}).url,
+    replayFilePlayback: (): string => combineUrl('/replay/file-playback').url,
     personByDistinctId: (id: string, encode: boolean = true): string =>
         encode ? `/person/${encodeURIComponent(id)}` : `/person/${id}`,
     personByUUID: (uuid: string, encode: boolean = true): string =>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -596,7 +596,6 @@ export enum SavedInsightsTabs {
 export enum ReplayTabs {
     Recent = 'recent',
     Playlists = 'playlists',
-    FilePlayback = 'file-playback',
     Errors = 'errors',
 }
 


### PR DESCRIPTION
## Problem

Files are not loaded for playback very often ([event source](https://us.posthog.com/project/2/events#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22timestamp%22%5D%2C%22after%22%3A%22-30d%22%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22event%22%3A%22recording%20loaded%20from%20file%22%2C%22filterTestAccounts%22%3Atrue%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D)). We should deprioritise this as we've already had feedback that people never use the tab

## Changes

Move the "Playback from file" to an ellipse in the header

<img width="1094" alt="Screenshot 2024-04-15 at 11 17 02" src="https://github.com/PostHog/posthog/assets/6685876/85b0601a-aba5-47cb-873a-a50834d41694">
<img width="1089" alt="Screenshot 2024-04-15 at 11 16 41" src="https://github.com/PostHog/posthog/assets/6685876/bf1798fe-13b3-4f85-8ed6-fa06a6159249">


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Verified playback still works