### PR TITLE
fix: canvas client size

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
@@ -74,8 +74,8 @@ export const CanvasReplayerPlugin = (events: eventWithTime[]): ReplayPlugin => {
                     return
                 }
 
-                target.width = source.width
-                target.height = source.height
+                target.width = source.clientWidth
+                target.height = source.clientHeight
 
                 await canvasMutation({
                     event: e,


### PR DESCRIPTION
## Problem

Ticket https://posthoghelp.zendesk.com/agent/tickets/12137 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/14851)

## Changes

For the same reasons we use the client width / height when recording a canvas we should use them during playback to size the canvas

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Original webpage for context
<img width="1093" alt="Screenshot 2024-04-15 at 11 35 45" src="https://github.com/PostHog/posthog/assets/6685876/f356eac2-3ea8-4aca-b9c3-173d24ead304">

|Before|After|
|----|----|
| <img width="862" alt="Screenshot 2024-04-15 at 11 35 36" src="https://github.com/PostHog/posthog/assets/6685876/f9f9a874-2765-4d78-83df-a541a05b86ce"> | <img width="951" alt="Screenshot 2024-04-15 at 11 36 36" src="https://github.com/PostHog/posthog/assets/6685876/51720866-70ff-44ff-b27d-d520c13a9614"> |
