### PR TITLE
fix(trends): use natsort for breakdown sorting

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -633,13 +633,13 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert len(response.results) == 2
 
         assert response.results[0]["label"] == "Formula (A+B)"
-        assert response.results[0]["breakdown_value"] == cohort1.pk
-        assert response.results[0]["count"] == 9
-        assert response.results[0]["data"] == [0, 0, 2, 2, 2, 0, 1, 0, 1, 0, 1, 0]
+        assert response.results[0]["breakdown_value"] == "all"
+        assert response.results[0]["count"] == 16
 
         assert response.results[1]["label"] == "Formula (A+B)"
-        assert response.results[1]["breakdown_value"] == "all"
+        assert response.results[1]["breakdown_value"] == cohort1.pk
         assert response.results[1]["count"] == 9
+        assert response.results[1]["data"] == [0, 0, 2, 2, 2, 0, 1, 0, 1, 0, 1, 0]
 
         # action needs to be unset to display custom label
         assert response.results[0]["action"] is None

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -601,6 +601,49 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         # action needs to be unset to display custom label
         assert response.results[0]["action"] is None
 
+    def test_formula_with_multi_cohort_all_breakdown(self):
+        self._create_test_events()
+        cohort1 = Cohort.objects.create(
+            team=self.team,
+            groups=[
+                {
+                    "properties": [
+                        {
+                            "key": "name",
+                            "value": "p1",
+                            "type": "person",
+                        }
+                    ]
+                }
+            ],
+            name="cohort p1",
+        )
+        cohort1.calculate_people_ch(pending_version=0)
+
+        response = self._run_trends_query(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.day,
+            [EventsNode(event="$pageview"), EventsNode(event="$pageleave")],
+            TrendsFilter(formula="A+B"),
+            BreakdownFilter(breakdown_type=BreakdownType.cohort, breakdown=[cohort1.pk, "all"]),
+        )
+
+        print(response)  # noqa: T201
+        assert len(response.results) == 2
+
+        assert response.results[0]["label"] == "Formula (A+B)"
+        assert response.results[0]["breakdown_value"] == cohort1.pk
+        assert response.results[0]["count"] == 9
+        assert response.results[0]["data"] == [0, 0, 2, 2, 2, 0, 1, 0, 1, 0, 1, 0]
+
+        assert response.results[1]["label"] == "Formula (A+B)"
+        assert response.results[1]["breakdown_value"] == "all"
+        assert response.results[1]["count"] == 9
+
+        # action needs to be unset to display custom label
+        assert response.results[0]["action"] is None
+
     def test_formula_with_breakdown_and_no_data(self):
         self._create_test_events()
 

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -1,4 +1,5 @@
 import copy
+from natsort import natsorted, ns
 from typing import Union
 from copy import deepcopy
 from datetime import timedelta
@@ -645,7 +646,12 @@ class TrendsQueryRunner(QueryRunner):
         # we need to apply the formula to a group of results when we have a breakdown or the compare option is enabled
         if has_compare or has_breakdown:
             keys = [*(["compare_label"] if has_compare else []), *(["breakdown_value"] if has_breakdown else [])]
-            sorted_results = sorted(results, key=itemgetter(*keys))
+            try:
+                sorted_results = natsorted(
+                    results, key=lambda x: tuple(str(itemgetter(k)(x)) for k in keys), alg=ns.IGNORECASE
+                )
+            except Exception:
+                sorted_results = results
 
             computed_results = []
             for _key, group in groupby(sorted_results, key=itemgetter(*keys)):

--- a/requirements.in
+++ b/requirements.in
@@ -53,6 +53,7 @@ kafka-python==2.0.2
 kafka-helper==0.2
 kombu==5.3.2
 lzstring==1.0.4
+natsort==8.4.0
 numpy==1.23.3
 openapi-spec-validator==0.7.1
 openpyxl==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -273,9 +273,7 @@ googleapis-common-protos==1.60.0
     #   google-api-core
     #   grpcio-status
 greenlet==3.0.3
-    # via
-    #   gevent
-    #   sqlalchemy
+    # via gevent
 grpcio==1.57.0
     # via
     #   google-api-core
@@ -373,6 +371,8 @@ multidict==6.0.2
     #   yarl
 mypy-boto3-s3==1.26.127
     # via boto3-stubs
+natsort==8.4.0
+    # via -r requirements.in
 nh3==0.2.14
     # via -r requirements.in
 numpy==1.23.3
@@ -449,9 +449,7 @@ protobuf==4.22.1
     #   proto-plus
     #   temporalio
 psycopg[binary]==3.1.13
-    # via
-    #   -r requirements.in
-    #   psycopg
+    # via -r requirements.in
 psycopg-binary==3.1.13
     # via psycopg
 psycopg2-binary==2.9.7


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/21326#issuecomment-2056646938

## Changes

Use `natsort` to stringify and then sort breakdown values

Now when cohorts return `["all", 1, 2]` as their ID-s, they're sorted correctly. As a bonus, other breakdown strings are sorted better as well, and fully numeric breakdowns keep working.

## How did you test this code?

Added a test for the string + int combination. Ran CI to see nothing else broke.