### PR TITLE
feat: allow passed hogql context for execute_hogql_query

### DIFF
--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Dict, Optional, Union, cast
 
 from posthog.clickhouse.client.connection import Workload
@@ -39,9 +40,13 @@ def execute_hogql_query(
     timings: Optional[HogQLTimings] = None,
     explain: Optional[bool] = False,
     pretty: Optional[bool] = True,
+    context: Optional[HogQLContext] = None,
 ) -> HogQLQueryResponse:
     if timings is None:
         timings = HogQLTimings()
+
+    if context is None:
+        context = HogQLContext(team_id=team.pk)
 
     query_modifiers = create_default_modifiers_for_team(team, modifiers)
 
@@ -82,13 +87,16 @@ def execute_hogql_query(
     # Get printed HogQL query, and returned columns. Using a cloned query.
     with timings.measure("hogql"):
         with timings.measure("prepare_ast"):
-            hogql_query_context = HogQLContext(
+            hogql_query_context = dataclasses.replace(
+                context,
+                # set the team.pk here so someone can't pass a context for a different team 🤷‍️
                 team_id=team.pk,
                 team=team,
                 enable_select_queries=True,
                 timings=timings,
                 modifiers=query_modifiers,
             )
+
             with timings.measure("clone"):
                 cloned_query = clone_expr(select_query, True)
             select_query_hogql = cast(
@@ -125,13 +133,16 @@ def execute_hogql_query(
 
     # Print the ClickHouse SQL query
     with timings.measure("print_ast"):
-        clickhouse_context = HogQLContext(
+        clickhouse_context = dataclasses.replace(
+            context,
+            # set the team.pk here so someone can't pass a context for a different team 🤷‍️
             team_id=team.pk,
             team=team,
             enable_select_queries=True,
             timings=timings,
             modifiers=query_modifiers,
         )
+
         clickhouse_sql = print_ast(
             select_query,
             context=clickhouse_context,


### PR DESCRIPTION
In feat/heatmaps-3000-ingestion we need to add a higher select limit for a query that doesn't touch events or persons table

there are a lot of changes there, so I've validated in that branch that this change is necessary for me to be able to set the limit on the top level select I make

splitting it out here to make it easier to review 