### PR TITLE
fix: Remove concurrency group from container-images-cd

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -15,8 +15,6 @@ on:
             - master
     workflow_dispatch:
 
-concurrency: ${{ github.workflow }} # ensure only one of this runs at a time
-
 jobs:
     posthog_build:
         name: Build and push PostHog


### PR DESCRIPTION

## Problem

This can cause deploys to be skipped if another change is merged that doesn't trigger the same deploys. There's no harm in running this job concurrently as the triggered deploys will still be in concurrency groups

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
