### PR TITLE
chore(ci): make separate hogql queries group

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -173,7 +173,16 @@ runs:
           if: ${{ inputs.segment == 'HogQL' }}
           shell: bash
           run: | # async_migrations covered in ci-async-migrations.yml
-              pytest posthog/hogql/ posthog/hogql_queries/ -m "not async_migrations" \
+              pytest posthog/hogql/ posthog/hogql_queries/ --ignore=posthog/hogql_queries/insights/funnels/ -m "not async_migrations" \
+                  --splits ${{ inputs.concurrency }} --group ${{ inputs.group }} \
+                  --durations=100 --durations-min=1.0 \
+                  $PYTEST_ARGS
+
+        - name: Run HogQL Funnels tests
+          if: ${{ inputs.segment == 'HogQL-Funnels' }}
+          shell: bash
+          run: | # async_migrations covered in ci-async-migrations.yml
+              pytest posthog/hogql_queries/insights/funnels/ -m "not async_migrations" \
                   --splits ${{ inputs.concurrency }} --group ${{ inputs.group }} \
                   --durations=100 --durations-min=1.0 \
                   $PYTEST_ARGS

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -12,16 +12,13 @@ inputs:
         description: ClickHouse server image tag, e.g. clickhouse/clickhouse-server:latest
     segment:
         required: true
-        description: Either 'FOSS' or 'EE' segment
+        description: Either 'FOSS', 'FOSS-PoE', 'EE', 'EE-PoE' or 'HogQL' segment
     concurrency:
         required: true
         description: Count of concurrency groups
     group:
         required: true
         description: Group number
-    person-on-events:
-        required: true
-        description: Whether testing with persons on events, true or false
     token:
         required: false
         description: GitHub token
@@ -139,41 +136,50 @@ runs:
         - name: Determine if --snapshot-update should be on
           # Skip on forks (due to GITHUB_TOKEN being read-only in PRs coming from them) except for persons-on-events
           # runs, as we want to ignore snapshots diverging there
-          if: github.event.pull_request.head.repo.full_name == github.repository || inputs.person-on-events == 'true'
+          if: github.event.pull_request.head.repo.full_name == github.repository || inputs.segment == 'EE-PoE' || inputs.segment == 'FOSS-PoE'
           shell: bash
           run: echo "PYTEST_ARGS=--snapshot-update" >> $GITHUB_ENV # We can only update snapshots within the PostHog org
 
         # Tests
         - name: Run FOSS tests
-          if: ${{ inputs.segment == 'FOSS' }}
+          if: ${{ inputs.segment == 'FOSS' || inputs.segment == 'FOSS-PoE' }}
           env:
-              PERSON_ON_EVENTS_V2_ENABLED: ${{ inputs.person-on-events }}
-              GROUPS_ON_EVENTS_ENABLED: ${{ inputs.person-on-events }}
+              PERSON_ON_EVENTS_V2_ENABLED: ${{ inputs.segment == 'FOSS-PoE' }}
+              GROUPS_ON_EVENTS_ENABLED: ${{ inputs.segment == 'FOSS-PoE' }}
           shell: bash
           run: | # async_migrations covered in ci-async-migrations.yml
               pytest ${{
-                  inputs.person-on-events == 'true'
+                  inputs.segment == 'FOSS-PoE'
                   && './posthog/clickhouse/ ./posthog/hogql/ ./posthog/queries/ ./posthog/api/test/test_insight* ./posthog/api/test/dashboards/test_dashboard.py'
-                  || 'hogvm posthog'
+                  || 'hogvm posthog --ignore=posthog/hogql --ignore=posthog/hogql_queries/'
               }} -m "not async_migrations" \
                   --splits ${{ inputs.concurrency }} --group ${{ inputs.group }} \
                   --durations=100 --durations-min=1.0 \
                   $PYTEST_ARGS
 
         - name: Run EE tests
-          if: ${{ inputs.segment == 'EE' }}
+          if: ${{ inputs.segment == 'EE' || inputs.segment == 'EE-PoE' }}
           env:
-              PERSON_ON_EVENTS_V2_ENABLED: ${{ inputs.person-on-events }}
-              GROUPS_ON_EVENTS_ENABLED: ${{ inputs.person-on-events }}
+              PERSON_ON_EVENTS_V2_ENABLED: ${{ inputs.segment == 'EE-PoE' }}
+              GROUPS_ON_EVENTS_ENABLED: ${{ inputs.segment == 'EE-PoE' }}
           shell: bash
           run: | # async_migrations covered in ci-async-migrations.yml
-              pytest ${{ inputs.person-on-events == 'true' && 'ee/clickhouse/' || 'ee/' }} -m "not async_migrations" \
+              pytest ${{ inputs.segment == 'EE-PoE' && 'ee/clickhouse/' || 'ee/' }} -m "not async_migrations" \
+                  --splits ${{ inputs.concurrency }} --group ${{ inputs.group }} \
+                  --durations=100 --durations-min=1.0 \
+                  $PYTEST_ARGS
+
+        - name: Run HogQL tests
+          if: ${{ inputs.segment == 'HogQL' }}
+          shell: bash
+          run: | # async_migrations covered in ci-async-migrations.yml
+              pytest posthog/hogql/ posthog/hogql_queries/ -m "not async_migrations" \
                   --splits ${{ inputs.concurrency }} --group ${{ inputs.group }} \
                   --durations=100 --durations-min=1.0 \
                   $PYTEST_ARGS
 
         - name: Run /decide read replica tests
-          if: ${{ inputs.segment == 'FOSS' && inputs.group == 1 && inputs.person-on-events != 'true' }}
+          if: ${{ inputs.segment == 'FOSS' && inputs.group == 1 }}
           env:
               POSTHOG_DB_NAME: posthog
               READ_REPLICA_OPT_IN: 'decide,PersonalAPIKey, local_evaluation'

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -244,7 +244,7 @@ jobs:
                 python-version: ['3.10.10']
                 clickhouse-server-image:
                     ['clickhouse/clickhouse-server:23.11.2.11-alpine', 'clickhouse/clickhouse-server:23.12.5.81-alpine']
-                segment: ['FOSS', 'FOSS-PoE', 'EE', 'EE-PoE', 'HogQL']
+                segment: ['FOSS', 'FOSS-PoE', 'EE', 'EE-PoE', 'HogQL', 'HogQL-Funnels']
                 # :NOTE: Keep concurrency and groups in sync
                 concurrency: [5]
                 group: [1, 2, 3, 4, 5]

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -235,7 +235,7 @@ jobs:
         needs: changes
         timeout-minutes: 30
 
-        name: Django tests – ${{ matrix.segment }} (persons-on-events ${{ matrix.person-on-events && 'on' || 'off' }}), Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
+        name: Django tests – ${{ matrix.segment }}, Py ${{ matrix.python-version }}, ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
         runs-on: depot-ubuntu-latest-4
 
         strategy:
@@ -244,8 +244,7 @@ jobs:
                 python-version: ['3.10.10']
                 clickhouse-server-image:
                     ['clickhouse/clickhouse-server:23.11.2.11-alpine', 'clickhouse/clickhouse-server:23.12.5.81-alpine']
-                segment: ['FOSS', 'EE']
-                person-on-events: [false, true]
+                segment: ['FOSS', 'FOSS-PoE', 'EE', 'EE-PoE', 'HogQL']
                 # :NOTE: Keep concurrency and groups in sync
                 concurrency: [5]
                 group: [1, 2, 3, 4, 5]
@@ -266,7 +265,6 @@ jobs:
               if: needs.changes.outputs.backend == 'true'
               with:
                   segment: ${{ matrix.segment }}
-                  person-on-events: ${{ matrix.person-on-events }}
                   python-version: ${{ matrix.python-version }}
                   clickhouse-server-image: ${{ matrix.clickhouse-server-image }}
                   concurrency: ${{ matrix.concurrency }}
@@ -276,7 +274,7 @@ jobs:
             - uses: EndBug/add-and-commit@v9
               # Skip on forks
               # Also skip for persons-on-events runs, as we want to ignore snapshots diverging there
-              if: ${{ github.repository == 'PostHog/posthog' && needs.changes.outputs.backend == 'true' && !matrix.person-on-events }}
+              if: ${{ github.repository == 'PostHog/posthog' && needs.changes.outputs.backend == 'true' && matrix.segment != 'FOSS-PoE' && matrix.segment != 'EE-PoE' }}
               with:
                   add: '["ee", "./**/*.ambr", "posthog/queries/", "posthog/migrations", "posthog/tasks", "posthog/hogql/"]'
                   message: 'Update query snapshots'
@@ -286,7 +284,7 @@ jobs:
 
             - name: Check if any snapshot changes were left uncomitted
               id: changed-files
-              if: ${{ github.repository == 'PostHog/posthog' && needs.changes.outputs.backend == 'true' && !matrix.person-on-events }}
+              if: ${{ github.repository == 'PostHog/posthog' && needs.changes.outputs.backend == 'true' && matrix.segment != 'FOSS-PoE' && matrix.segment != 'EE-PoE' }}
               run: |
                   if [[ -z $(git status -s | grep -v ".test_durations" | tr -d "\n") ]]
                   then
@@ -304,7 +302,7 @@ jobs:
 
             - name: Archive email renders
               uses: actions/upload-artifact@v3
-              if: needs.changes.outputs.backend == 'true' && matrix.segment == 'FOSS' && matrix.person-on-events == false
+              if: needs.changes.outputs.backend == 'true' && matrix.segment == 'FOSS'
               with:
                   name: email_renders
                   path: posthog/tasks/test/__emails__

--- a/bin/check_temporal_up
+++ b/bin/check_temporal_up
@@ -14,8 +14,8 @@ while true; do
     fi
     
     if [ $SECONDS -ge $TIMEOUT ]; then
-        echo "Timed out waiting for Temporal to be ready"
-        exit 1
+        echo "Timed out ($TIMEOUT sec) waiting for Temporal to be ready. Crossing fingers and trying to run tests anyway."
+        exit 0
     fi
     
     echo "Waiting for Temporal to be ready"

--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -157,7 +157,7 @@
 # ---
 # name: TestQuery.test_full_hogql_query_async
   '''
-  /* user_id:465 celery:posthog.tasks.tasks.process_query_task */
+  /* user_id:26 celery:posthog.tasks.tasks.process_query_task */
   SELECT events.uuid AS uuid,
          events.event AS event,
          events.properties AS properties,

--- a/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
@@ -31,7 +31,7 @@
   FROM events LEFT JOIN (
   SELECT person_static_cohort.person_id AS cohort_person_id, 1 AS matched, person_static_cohort.cohort_id AS cohort_id 
   FROM person_static_cohort 
-  WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [6]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
+  WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [2]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
   WHERE and(equals(events.team_id, 420), 1, ifNull(equals(__in_cohort.matched, 1), 0)) 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
@@ -42,7 +42,7 @@
   FROM events LEFT JOIN (
   SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
   FROM static_cohort_people 
-  WHERE in(cohort_id, [6])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
+  WHERE in(cohort_id, [2])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
   WHERE and(1, equals(__in_cohort.matched, 1)) 
   LIMIT 100
   '''
@@ -55,7 +55,7 @@
   FROM events LEFT JOIN (
   SELECT person_static_cohort.person_id AS cohort_person_id, 1 AS matched, person_static_cohort.cohort_id AS cohort_id 
   FROM person_static_cohort 
-  WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [7]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
+  WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [3]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
   WHERE and(equals(events.team_id, 420), 1, ifNull(equals(__in_cohort.matched, 1), 0)) 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
@@ -66,7 +66,7 @@
   FROM events LEFT JOIN (
   SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
   FROM static_cohort_people 
-  WHERE in(cohort_id, [7])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
+  WHERE in(cohort_id, [3])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
   WHERE and(1, equals(__in_cohort.matched, 1)) 
   LIMIT 100
   '''

--- a/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
@@ -31,7 +31,7 @@
   FROM events LEFT JOIN (
   SELECT person_static_cohort.person_id AS cohort_person_id, 1 AS matched, person_static_cohort.cohort_id AS cohort_id 
   FROM person_static_cohort 
-  WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [11]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
+  WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [6]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
   WHERE and(equals(events.team_id, 420), 1, ifNull(equals(__in_cohort.matched, 1), 0)) 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
@@ -42,7 +42,7 @@
   FROM events LEFT JOIN (
   SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
   FROM static_cohort_people 
-  WHERE in(cohort_id, [11])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
+  WHERE in(cohort_id, [6])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
   WHERE and(1, equals(__in_cohort.matched, 1)) 
   LIMIT 100
   '''
@@ -55,7 +55,7 @@
   FROM events LEFT JOIN (
   SELECT person_static_cohort.person_id AS cohort_person_id, 1 AS matched, person_static_cohort.cohort_id AS cohort_id 
   FROM person_static_cohort 
-  WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [12]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
+  WHERE and(equals(person_static_cohort.team_id, 420), in(person_static_cohort.cohort_id, [7]))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, events.person_id) 
   WHERE and(equals(events.team_id, 420), 1, ifNull(equals(__in_cohort.matched, 1), 0)) 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1
@@ -66,7 +66,7 @@
   FROM events LEFT JOIN (
   SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
   FROM static_cohort_people 
-  WHERE in(cohort_id, [12])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
+  WHERE in(cohort_id, [7])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
   WHERE and(1, equals(__in_cohort.matched, 1)) 
   LIMIT 100
   '''

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
@@ -960,7 +960,6 @@
 # ---
 # name: TestFunnelBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen
   '''
-  /* cohort_calculation: */
   SELECT [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS value,
          count(*) AS count
   FROM events AS e
@@ -982,7 +981,6 @@
 # ---
 # name: TestFunnelBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen.1
   '''
-  /* cohort_calculation: */
   SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
          countIf(ifNull(equals(steps, 2), 0)) AS step_2,
          avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,
@@ -1068,7 +1066,6 @@
 # ---
 # name: TestFunnelBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen_for_step
   '''
-  /* cohort_calculation: */
   SELECT [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS value,
          count(*) AS count
   FROM events AS e
@@ -1090,7 +1087,6 @@
 # ---
 # name: TestFunnelBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen_for_step.1
   '''
-  /* cohort_calculation: */
   SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
          countIf(ifNull(equals(steps, 2), 0)) AS step_2,
          avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_lifecycle_query_runner.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_lifecycle_query_runner.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestLifecycleQueryRunner.test_cohort_filter
   '''
-  
+  /* cohort_calculation: */
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
   WHERE team_id = 2

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -85,7 +85,11 @@ class TestQueryRunner(BaseTest):
         self.assertEqual(json, '{"some_attr":"bla"}')
 
     def test_cache_key(self):
+        # Delete any previous team with pk 42
+        Team.objects.filter(pk=42).delete()
+
         TestQueryRunner = self.setup_test_query_runner_class()
+
         # set the pk directly as it affects the hash in the _cache_key call
         team = Team.objects.create(pk=42, organization=self.organization)
 
@@ -95,6 +99,9 @@ class TestQueryRunner(BaseTest):
         self.assertEqual(cache_key, "cache_b6f14c97c218e0b9c9a8258f7460fd5b")
 
     def test_cache_key_runner_subclass(self):
+        # Delete any previous team with pk 42
+        Team.objects.filter(pk=42).delete()
+
         TestQueryRunner = self.setup_test_query_runner_class()
 
         class TestSubclassQueryRunner(TestQueryRunner):
@@ -109,6 +116,9 @@ class TestQueryRunner(BaseTest):
         self.assertEqual(cache_key, "cache_ec1c2f9715cf9c424b1284b94b1205e6")
 
     def test_cache_key_different_timezone(self):
+        # Delete any previous team with pk 42
+        Team.objects.filter(pk=42).delete()
+
         TestQueryRunner = self.setup_test_query_runner_class()
         team = Team.objects.create(pk=42, organization=self.organization)
         team.timezone = "Europe/Vienna"


### PR DESCRIPTION
## Problem

HogQL tests are taking a large amount of time under CI. 

## Changes

Breaks the `posthog/hogql` and `posthog/hogql_queries`  folders out of the "poe on" vs "poe off" split. PoE differences are explicitly overridden and tested for in the HogQL tests, so no need to run the slowest tests twice for the same results.

Update:

The HogQL funnel and FOSS legacy funnel tests take up an outsized amount of time:

<img width="1353" alt="image" src="https://github.com/PostHog/posthog/assets/53387/cad28f0e-1c88-41e0-b18d-968cc7fa9cef">

<img width="1353" alt="image" src="https://github.com/PostHog/posthog/assets/53387/20f11043-9924-45f0-bc5c-8f3996509732">

## How did you test this code?

The cake is a lie.