### PR TITLE
fix: Correct behavior of persons-on-events rollout flag

### DIFF
--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -327,8 +327,8 @@ class Team(UUIDClassicModel):
             return posthoganalytics.feature_enabled(
                 "persons-on-events-person-id-no-override-properties-on-events",
                 str(self.uuid),
-                groups={"team": str(self.id)},
-                group_properties={"team": {"id": str(self.id), "created_at": self.created_at, "uuid": self.uuid}},
+                groups={"project": str(self.id)},
+                group_properties={"project": {"id": str(self.id), "created_at": self.created_at, "uuid": self.uuid}},
                 only_evaluate_locally=True,
                 send_feature_flag_events=False,
             )


### PR DESCRIPTION
## Problem

This wasn't evaluating as expected, putting some projects (teams) on the wrong query path:

```
[FEATURE FLAGS] Can't compute group feature flag: persons-on-events-person-id-no-override-properties-on-events without group names passed in
```

## Changes

Use "project" group instead of "team".

## Does this work well for both Cloud and self-hosted?

😅 

## How did you test this code?

Manually tested in production Django shell to ensure returns the correct result with the different group name.

Internal details here: https://posthog.slack.com/archives/C0368RPHLQH/p1713220518198039?thread_ts=1713212512.229099&cid=C0368RPHLQH