### PR TITLE
fix(ci): try to ignore temporal

### DIFF
--- a/bin/check_temporal_up
+++ b/bin/check_temporal_up
@@ -14,8 +14,8 @@ while true; do
     fi
     
     if [ $SECONDS -ge $TIMEOUT ]; then
-        echo "Timed out waiting for Temporal to be ready"
-        exit 1
+        echo "Timed out ($TIMEOUT sec) waiting for Temporal to be ready. Crossing fingers and trying to run tests anyway."
+        exit 0
     fi
     
     echo "Waiting for Temporal to be ready"


### PR DESCRIPTION
## Problem

Do we need Temporal for all tests? This is an annoyingly common sight:

<img width="572" alt="image" src="https://github.com/PostHog/posthog/assets/53387/1d8d6c79-cd16-4705-ab78-faf05fb370fb">

## Changes

Doesn't hard fail if temporal can't be started. Surely it's not always needed?

## Does this work well for both Cloud and self-hosted?

🤷 

## How did you test this code?

All tests just passed 🤯

I had a [few](https://github.com/PostHog/posthog/pull/21549) [other](https://github.com/PostHog/posthog/pull/21552) PRs where multiple tests kept failing with temporal. Cherry picking this commit made everything just pass.

It doesn't solve all problems, but seems to be a QoL improvement... so... let's merge?