### PR TITLE
fix: Make sure event names are string

### DIFF
--- a/posthog/api/property_definition.py
+++ b/posthog/api/property_definition.py
@@ -216,7 +216,7 @@ class QueryContext:
             event_name_join_filter=event_name_join_filter,
             event_name_filter=event_name_filter,
             event_property_join_type="INNER JOIN" if filter_by_event_names else "LEFT JOIN",
-            params={**self.params, "event_names": event_names or []},
+            params={**self.params, "event_names": list(map(str, event_names or []))},
         )
 
     def with_search(self, search_query: str, search_kwargs: Dict) -> "QueryContext":

--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -1,3 +1,4 @@
+import json
 from typing import Dict, List, Optional, Union
 from unittest.mock import ANY, patch
 
@@ -412,6 +413,11 @@ class TestPropertyDefinitionAPI(APIBaseTest):
         assert activity_log.item_id == str(property_definition.id)
         assert activity_log.detail["name"] == "test_property"
         assert activity_log.activity == "deleted"
+
+    def test_event_name_filter_json_contains_int(self):
+        event_name_json = json.dumps([1])
+        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/?event_names={event_name_json}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_can_report_event_property_coexistence_when_custom_event_has_no_session_id(self) -> None:
         EventProperty.objects.create(team=self.team, event="$pageview", property="$session_id")


### PR DESCRIPTION
## Problem

POSTHOG-SHM

Relates to #18653

## Changes

Make sure everything is string.

## Does this work well for both Cloud and self-hosted?

it doesn't have an impact

## How did you test this code?

- made sure tests still work
- particular case not yet covered though