### PR TITLE
feat(persons): single person query via postgres

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -101,26 +101,6 @@ export const personsLogic = kea<personsLogicType>([
             null as PersonType | null,
             {
                 loadPerson: async ({ id }): Promise<PersonType | null> => {
-                    if (values.featureFlags[FEATURE_FLAGS.PERSONS_HOGQL_QUERY]) {
-                        const response = await hogqlQuery(
-                            'select id, groupArray(pdi.distinct_id) as distinct_ids, properties, is_identified, created_at from persons where pdi.distinct_id={distinct_id} group by id, properties, is_identified, created_at',
-                            { distinct_id: id }
-                        )
-                        const row = response?.results?.[0]
-                        if (row) {
-                            const person: PersonType = {
-                                id: row[0],
-                                uuid: row[0],
-                                distinct_ids: row[1],
-                                properties: JSON.parse(row[2] || '{}'),
-                                is_identified: !!row[3],
-                                created_at: row[4],
-                            }
-                            actions.reportPersonDetailViewed(person)
-                            return person
-                        }
-                    }
-
                     const response = await api.persons.list({ distinct_id: id })
                     const person = response.results[0]
                     if (person) {


### PR DESCRIPTION
## Problem

Most users are currently on this mode:
- persons list: via postgres
- single person page: via postgres

We have the flag, [persons-hogql-query](https://us.posthog.com/project/2/feature_flags/19284), but it's disabled for most people. It enables the mode:

- persons list: most via hogql, person column later via postgres
- single person page: via hogql, joined with distinct ids (no postgres)

The problem is that while the persons list query loads really well, the "single person page" takes forever to load (~20sec for some teams), as ClickHouse really isn't great for one off searches.

## Changes

Makes the `persons-hogql-query` flag only enable the HogQL/ClickHouse persons list, leaving the single person's page as it is.

This allows us to release the HogQL powered persons list to everyone.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Locally, got the old behaviour back. 