### PR TITLE
feat(experiment): add details for "Not significant"

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -1,7 +1,7 @@
 import '../Experiment.scss'
 
 import { IconCheck, IconX } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonDivider, LemonTag, LemonTagType, Link } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonDivider, LemonTag, LemonTagType, Link, Tooltip } from '@posthog/lemon-ui'
 import { Empty } from 'antd'
 import { useActions, useValues } from 'kea'
 import { AnimationType } from 'lib/animations/animations'
@@ -41,10 +41,20 @@ export function VariantTag({ variantKey }: { variantKey: string }): JSX.Element 
 }
 
 export function ResultsTag(): JSX.Element {
-    const { areResultsSignificant } = useValues(experimentLogic)
+    const { areResultsSignificant, significanceDetails } = useValues(experimentLogic)
     const result: { color: LemonTagType; label: string } = areResultsSignificant
         ? { color: 'success', label: 'Significant' }
         : { color: 'primary', label: 'Not significant' }
+
+    if (significanceDetails) {
+        return (
+            <Tooltip title={significanceDetails}>
+                <LemonTag className="cursor-pointer" type={result.color}>
+                    <b className="uppercase">{result.label}</b>
+                </LemonTag>
+            </Tooltip>
+        )
+    }
 
     return (
         <LemonTag type={result.color}>

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -773,6 +773,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 return experimentResults?.significant || false
             },
         ],
+        // TODO: remove with the old UI
         significanceBannerDetails: [
             (s) => [s.experimentResults],
             (experimentResults): string | ReactElement => {
@@ -806,6 +807,32 @@ export const experimentLogic = kea<experimentLogicType>([
                             .
                         </>
                     )
+                }
+
+                if (experimentResults?.significance_code === SignificanceCode.LowWinProbability) {
+                    return 'This is because the win probability of all test variants combined is less than 90%.'
+                }
+
+                if (experimentResults?.significance_code === SignificanceCode.NotEnoughExposure) {
+                    return 'This is because we need at least 100 people per variant to declare significance.'
+                }
+
+                return ''
+            },
+        ],
+        significanceDetails: [
+            (s) => [s.experimentResults],
+            (experimentResults): string => {
+                if (experimentResults?.significance_code === SignificanceCode.HighLoss) {
+                    return `This is because the expected loss in conversion is greater than 1% (current value is ${(
+                        (experimentResults?.expected_loss || 0) * 100
+                    )?.toFixed(2)}%).`
+                }
+
+                if (experimentResults?.significance_code === SignificanceCode.HighPValue) {
+                    return `This is because the p value is greater than 0.05 (current value is ${
+                        experimentResults?.p_value?.toFixed(3) || 1
+                    }).`
                 }
 
                 if (experimentResults?.significance_code === SignificanceCode.LowWinProbability) {


### PR DESCRIPTION
## Changes
Adds details as to why the results are not significant. Prompted by https://posthoghelp.zendesk.com/agent/tickets/12414. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15464)

<img width="391" alt="image" src="https://github.com/PostHog/posthog/assets/22996112/a5aeee2f-ad10-4c79-8d3d-90cf3421dd9a">

Repurposed text from `significanceBannerDetails`. Ideally, we would have a checklist here explaining which significance criteria have not been met, but that might require collecting multiple errors as we do with "no results." I think we should do it at some point, but this at least ensures we don't show _less_ information compared to the old UI.

## How did you test this code?
👀 