### PR TITLE
feat(session-table): Change lazy session fields to match property names

### DIFF
--- a/posthog/hogql/database/schema/sessions.py
+++ b/posthog/hogql/database/schema/sessions.py
@@ -66,8 +66,11 @@ LAZY_SESSIONS_FIELDS: Dict[str, FieldOrTable] = {
     "$event_count_map": DatabaseField(name="$event_count_map"),
     "$pageview_count": IntegerDatabaseField(name="$pageview_count"),
     "$autocapture_count": IntegerDatabaseField(name="$autocapture_count"),
-    "$session_duration": IntegerDatabaseField(name="duration"),
     "$channel_type": StringDatabaseField(name="$channel_type"),
+    "$session_duration": IntegerDatabaseField(name="$session_duration"),
+    "duration": IntegerDatabaseField(
+        name="duration"
+    ),  # alias of $session_duration, deprecated but included for backwards compatibility
 }
 
 
@@ -161,6 +164,7 @@ def select_from_sessions_table(
             gad_source=ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_gad_source"])]),
         ),
     }
+    aggregate_fields["duration"] = aggregate_fields["$session_duration"]
 
     select_fields: List[ast.Expr] = []
     group_by_fields: List[ast.Expr] = [ast.Field(chain=[table_name, "session_id"])]

--- a/posthog/hogql/database/schema/sessions.py
+++ b/posthog/hogql/database/schema/sessions.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, cast, Any
+from typing import Dict, List, cast, Any, TYPE_CHECKING
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
@@ -16,16 +16,19 @@ from posthog.hogql.database.schema.channel_type import create_channel_type_expr
 from posthog.hogql.database.schema.util.session_where_clause_extractor import SessionMinTimestampWhereClauseExtractor
 from posthog.hogql.errors import ResolutionError
 
-SESSIONS_COMMON_FIELDS: Dict[str, FieldOrTable] = {
-    "id": StringDatabaseField(
-        name="session_id"
-    ),  # TODO remove this, it's a duplicate of the correct session_id field below to get some trends working on a deadline
+if TYPE_CHECKING:
+    pass
+
+RAW_SESSIONS_FIELDS: Dict[str, FieldOrTable] = {
+    "id": StringDatabaseField(name="session_id"),
+    # TODO remove this, it's a duplicate of the correct session_id field below to get some trends working on a deadline
     "session_id": StringDatabaseField(name="session_id"),
     "team_id": IntegerDatabaseField(name="team_id"),
     "distinct_id": StringDatabaseField(name="distinct_id"),
     "min_timestamp": DateTimeDatabaseField(name="min_timestamp"),
     "max_timestamp": DateTimeDatabaseField(name="max_timestamp"),
     "urls": StringArrayDatabaseField(name="urls"),
+    # many of the fields in the raw tables are AggregateFunction state, rather than simple types
     "entry_url": DatabaseField(name="entry_url"),
     "exit_url": DatabaseField(name="exit_url"),
     "initial_utm_source": DatabaseField(name="initial_utm_source"),
@@ -41,9 +44,35 @@ SESSIONS_COMMON_FIELDS: Dict[str, FieldOrTable] = {
     "autocapture_count": IntegerDatabaseField(name="autocapture_count"),
 }
 
+LAZY_SESSIONS_FIELDS: Dict[str, FieldOrTable] = {
+    "id": StringDatabaseField(name="session_id"),
+    # TODO remove this, it's a duplicate of the correct session_id field below to get some trends working on a deadline
+    "session_id": StringDatabaseField(name="session_id"),
+    "team_id": IntegerDatabaseField(name="team_id"),
+    "distinct_id": StringDatabaseField(name="distinct_id"),
+    "$start_timestamp": DateTimeDatabaseField(name="$start_timestamp"),
+    "$end_timestamp": DateTimeDatabaseField(name="$end_timestamp"),
+    "$urls": StringArrayDatabaseField(name="$urls"),
+    "$entry_url": StringDatabaseField(name="$entry_url"),
+    "$exit_url": StringDatabaseField(name="$exit_url"),
+    "$initial_utm_source": StringDatabaseField(name="$initial_utm_source"),
+    "$initial_utm_campaign": StringDatabaseField(name="$initial_utm_campaign"),
+    "$initial_utm_medium": StringDatabaseField(name="$initial_utm_medium"),
+    "$initial_utm_term": StringDatabaseField(name="$initial_utm_term"),
+    "$initial_utm_content": StringDatabaseField(name="$initial_utm_content"),
+    "$initial_referring_domain": StringDatabaseField(name="$initial_referring_domain"),
+    "$initial_gclid": StringDatabaseField(name="$initial_gclid"),
+    "$initial_gad_source": StringDatabaseField(name="$initial_gad_source"),
+    "$event_count_map": DatabaseField(name="$event_count_map"),
+    "$pageview_count": IntegerDatabaseField(name="$pageview_count"),
+    "$autocapture_count": IntegerDatabaseField(name="$autocapture_count"),
+    "$session_duration": IntegerDatabaseField(name="duration"),
+    "$channel_type": StringDatabaseField(name="$channel_type"),
+}
+
 
 class RawSessionsTable(Table):
-    fields: Dict[str, FieldOrTable] = SESSIONS_COMMON_FIELDS
+    fields: Dict[str, FieldOrTable] = RAW_SESSIONS_FIELDS
 
     def to_printed_clickhouse(self, context):
         return "sessions"
@@ -80,9 +109,9 @@ def select_from_sessions_table(
 
     aggregate_fields = {
         "distinct_id": ast.Call(name="any", args=[ast.Field(chain=[table_name, "distinct_id"])]),
-        "min_timestamp": ast.Call(name="min", args=[ast.Field(chain=[table_name, "min_timestamp"])]),
-        "max_timestamp": ast.Call(name="max", args=[ast.Field(chain=[table_name, "max_timestamp"])]),
-        "urls": ast.Call(
+        "$start_timestamp": ast.Call(name="min", args=[ast.Field(chain=[table_name, "min_timestamp"])]),
+        "$end_timestamp": ast.Call(name="max", args=[ast.Field(chain=[table_name, "max_timestamp"])]),
+        "$urls": ast.Call(
             name="arrayDistinct",
             args=[
                 ast.Call(
@@ -91,29 +120,29 @@ def select_from_sessions_table(
                 )
             ],
         ),
-        "entry_url": ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "entry_url"])]),
-        "exit_url": ast.Call(name="argMaxMerge", args=[ast.Field(chain=[table_name, "exit_url"])]),
-        "initial_utm_source": ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_utm_source"])]),
-        "initial_utm_campaign": ast.Call(
+        "$entry_url": ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "entry_url"])]),
+        "$exit_url": ast.Call(name="argMaxMerge", args=[ast.Field(chain=[table_name, "exit_url"])]),
+        "$initial_utm_source": ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_utm_source"])]),
+        "$initial_utm_campaign": ast.Call(
             name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_utm_campaign"])]
         ),
-        "initial_utm_medium": ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_utm_medium"])]),
-        "initial_utm_term": ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_utm_term"])]),
-        "initial_utm_content": ast.Call(
+        "$initial_utm_medium": ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_utm_medium"])]),
+        "$initial_utm_term": ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_utm_term"])]),
+        "$initial_utm_content": ast.Call(
             name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_utm_content"])]
         ),
-        "initial_referring_domain": ast.Call(
+        "$initial_referring_domain": ast.Call(
             name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_referring_domain"])]
         ),
-        "initial_gclid": ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_gclid"])]),
-        "initial_gad_source": ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_gad_source"])]),
-        "event_count_map": ast.Call(
+        "$initial_gclid": ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_gclid"])]),
+        "$initial_gad_source": ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_gad_source"])]),
+        "$event_count_map": ast.Call(
             name="sumMap",
             args=[ast.Field(chain=[table_name, "event_count_map"])],
         ),
-        "pageview_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "pageview_count"])]),
-        "autocapture_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "autocapture_count"])]),
-        "duration": ast.Call(
+        "$pageview_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "pageview_count"])]),
+        "$autocapture_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "autocapture_count"])]),
+        "$session_duration": ast.Call(
             name="dateDiff",
             args=[
                 ast.Constant(value="second"),
@@ -121,7 +150,7 @@ def select_from_sessions_table(
                 ast.Call(name="max", args=[ast.Field(chain=[table_name, "max_timestamp"])]),
             ],
         ),
-        "channel_type": create_channel_type_expr(
+        "$channel_type": create_channel_type_expr(
             campaign=ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_utm_campaign"])]),
             medium=ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_utm_medium"])]),
             source=ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "initial_utm_source"])]),
@@ -156,11 +185,7 @@ def select_from_sessions_table(
 
 
 class SessionsTable(LazyTable):
-    fields: Dict[str, FieldOrTable] = {
-        **SESSIONS_COMMON_FIELDS,
-        "duration": IntegerDatabaseField(name="duration"),
-        "channel_type": StringDatabaseField(name="channel_type"),
-    }
+    fields: Dict[str, FieldOrTable] = LAZY_SESSIONS_FIELDS
 
     def lazy_select(self, requested_fields: Dict[str, List[str | int]], context, node: ast.SelectQuery):
         return select_from_sessions_table(requested_fields, node, context)

--- a/posthog/hogql/database/schema/test/test_sessions.py
+++ b/posthog/hogql/database/schema/test/test_sessions.py
@@ -44,7 +44,7 @@ class TestReferringDomainType(ClickhouseTestMixin, APIBaseTest):
 
         response = execute_hogql_query(
             parse_select(
-                "select channel_type from sessions where session_id = {session_id}",
+                "select $channel_type from sessions where session_id = {session_id}",
                 placeholders={"session_id": ast.Constant(value=session_id)},
             ),
             self.team,
@@ -68,7 +68,7 @@ class TestReferringDomainType(ClickhouseTestMixin, APIBaseTest):
 
         response = execute_hogql_query(
             parse_select(
-                "select events.session.channel_type from events where $session_id = {session_id}",
+                "select events.session.$channel_type from events where $session_id = {session_id}",
                 placeholders={"session_id": ast.Constant(value=session_id)},
             ),
             self.team,
@@ -92,7 +92,7 @@ class TestReferringDomainType(ClickhouseTestMixin, APIBaseTest):
 
         response = execute_hogql_query(
             parse_select(
-                "select session.channel_type from events where $session_id = {session_id}",
+                "select session.$channel_type from events where $session_id = {session_id}",
                 placeholders={"session_id": ast.Constant(value=session_id)},
             ),
             self.team,

--- a/posthog/hogql/database/schema/util/session_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/session_where_clause_extractor.py
@@ -297,9 +297,6 @@ class IsTimeOrIntervalConstantVisitor(Visitor[bool]):
     def visit_alias(self, node: ast.Alias) -> bool:
         return self.visit(node.expr)
 
-    def visit_select_query(self, node: ast.SelectQuery) -> bool:
-        return False
-
 
 def is_simple_timestamp_field_expression(expr: ast.Expr, context: HogQLContext) -> bool:
     return IsSimpleTimestampFieldExpressionVisitor(context).visit(expr)
@@ -393,9 +390,6 @@ class IsSimpleTimestampFieldExpressionVisitor(Visitor[bool]):
             )
 
         return self.visit(node.expr)
-
-    def visit_select_query(self, node: ast.SelectQuery) -> bool:
-        return False
 
 
 def rewrite_timestamp_field(expr: ast.Expr, context: HogQLContext) -> ast.Expr:

--- a/posthog/hogql/database/schema/util/test/test_session_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_session_where_clause_extractor.py
@@ -47,36 +47,36 @@ class TestSessionTimestampInliner(ClickhouseTestMixin, APIBaseTest):
         assert inner_where is None
 
     def test_handles_select_with_eq(self):
-        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE min_timestamp = '2021-01-01'")))
+        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE $start_timestamp = '2021-01-01'")))
         expected = f(
             "((raw_sessions.min_timestamp - toIntervalDay(3)) <= '2021-01-01') AND ((raw_sessions.min_timestamp + toIntervalDay(3)) >= '2021-01-01')"
         )
         assert expected == actual
 
     def test_handles_select_with_eq_flipped(self):
-        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE '2021-01-01' = min_timestamp")))
+        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE '2021-01-01' = $start_timestamp")))
         expected = f(
             "((raw_sessions.min_timestamp - toIntervalDay(3)) <= '2021-01-01') AND ((raw_sessions.min_timestamp + toIntervalDay(3)) >= '2021-01-01')"
         )
         assert expected == actual
 
     def test_handles_select_with_simple_gt(self):
-        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE min_timestamp > '2021-01-01'")))
+        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE $start_timestamp > '2021-01-01'")))
         expected = f("((raw_sessions.min_timestamp + toIntervalDay(3)) >= '2021-01-01')")
         assert expected == actual
 
     def test_handles_select_with_simple_gte(self):
-        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE min_timestamp >= '2021-01-01'")))
+        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE $start_timestamp >= '2021-01-01'")))
         expected = f("((raw_sessions.min_timestamp + toIntervalDay(3)) >= '2021-01-01')")
         assert expected == actual
 
     def test_handles_select_with_simple_lt(self):
-        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE min_timestamp < '2021-01-01'")))
+        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE $start_timestamp < '2021-01-01'")))
         expected = f("((raw_sessions.min_timestamp - toIntervalDay(3)) <= '2021-01-01')")
         assert expected == actual
 
     def test_handles_select_with_simple_lte(self):
-        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE min_timestamp <= '2021-01-01'")))
+        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE $start_timestamp <= '2021-01-01'")))
         expected = f("((raw_sessions.min_timestamp - toIntervalDay(3)) <= '2021-01-01')")
         assert expected == actual
 
@@ -84,7 +84,7 @@ class TestSessionTimestampInliner(ClickhouseTestMixin, APIBaseTest):
         actual = f(
             self.inliner.get_inner_where(
                 parse(
-                    "SELECT * FROM sessions WHERE min_timestamp > {timestamp}",
+                    "SELECT * FROM sessions WHERE $start_timestamp > {timestamp}",
                     placeholders={"timestamp": ast.Constant(value="2021-01-01")},
                 )
             )
@@ -94,14 +94,16 @@ class TestSessionTimestampInliner(ClickhouseTestMixin, APIBaseTest):
 
     def test_unrelated_equals(self):
         actual = self.inliner.get_inner_where(
-            parse("SELECT * FROM sessions WHERE initial_utm_campaign = initial_utm_source")
+            parse("SELECT * FROM sessions WHERE $initial_utm_campaign = $initial_utm_source")
         )
         assert actual is None
 
     def test_timestamp_and(self):
         actual = f(
             self.inliner.get_inner_where(
-                parse("SELECT * FROM sessions WHERE and(min_timestamp >= '2021-01-01', min_timestamp <= '2021-01-03')")
+                parse(
+                    "SELECT * FROM sessions WHERE and($start_timestamp >= '2021-01-01', $start_timestamp <= '2021-01-03')"
+                )
             )
         )
         expected = f(
@@ -140,7 +142,7 @@ class TestSessionTimestampInliner(ClickhouseTestMixin, APIBaseTest):
         actual = f(
             self.inliner.get_inner_where(
                 parse(
-                    "SELECT * FROM sessions WHERE or(min_timestamp > '2021-01-03', like(toString(min_timestamp), 'b'))"
+                    "SELECT * FROM sessions WHERE or($start_timestamp > '2021-01-03', like(toString($start_timestamp), 'b'))"
                 )
             )
         )
@@ -150,7 +152,7 @@ class TestSessionTimestampInliner(ClickhouseTestMixin, APIBaseTest):
         actual = f(
             self.inliner.get_inner_where(
                 parse(
-                    "SELECT * FROM sessions WHERE and(min_timestamp > '2021-01-03', like(toString(min_timestamp), 'b'))"
+                    "SELECT * FROM sessions WHERE and($start_timestamp > '2021-01-03', like(toString($start_timestamp), 'b'))"
                 )
             )
         )
@@ -160,7 +162,7 @@ class TestSessionTimestampInliner(ClickhouseTestMixin, APIBaseTest):
         actual = f(
             self.inliner.get_inner_where(
                 parse(
-                    "SELECT * FROM events JOIN sessions ON events.session_id = raw_sessions.session_id WHERE min_timestamp > '2021-01-03'"
+                    "SELECT * FROM events JOIN sessions ON events.session_id = sessions.session_id WHERE $start_timestamp > '2021-01-03'"
                 )
             )
         )
@@ -171,7 +173,7 @@ class TestSessionTimestampInliner(ClickhouseTestMixin, APIBaseTest):
         actual = f(
             self.inliner.get_inner_where(
                 parse(
-                    "SELECT * FROM events JOIN sessions ON events.session_id = raw_sessions.session_id WHERE timestamp > '2021-01-03'"
+                    "SELECT * FROM events JOIN sessions ON events.session_id = sessions.session_id WHERE timestamp > '2021-01-03'"
                 )
             )
         )
@@ -179,24 +181,24 @@ class TestSessionTimestampInliner(ClickhouseTestMixin, APIBaseTest):
         assert expected == actual
 
     def test_minus(self):
-        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE min_timestamp >= today() - 2")))
+        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE $start_timestamp >= today() - 2")))
         expected = f("((raw_sessions.min_timestamp + toIntervalDay(3)) >= (today() - 2))")
         assert expected == actual
 
     def test_minus_function(self):
         actual = f(
-            self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE min_timestamp >= minus(today() , 2)"))
+            self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE $start_timestamp >= minus(today() , 2)"))
         )
         expected = f("((raw_sessions.min_timestamp + toIntervalDay(3)) >= minus(today(), 2))")
         assert expected == actual
 
     def test_less_function(self):
-        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE less(min_timestamp, today())")))
+        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE less($start_timestamp, today())")))
         expected = f("((raw_sessions.min_timestamp - toIntervalDay(3)) <= today())")
         assert expected == actual
 
     def test_less_function_second_arg(self):
-        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE less(today(), min_timestamp)")))
+        actual = f(self.inliner.get_inner_where(parse("SELECT * FROM sessions WHERE less(today(), $start_timestamp)")))
         expected = f("((raw_sessions.min_timestamp + toIntervalDay(3)) >= today())")
         assert expected == actual
 
@@ -213,7 +215,7 @@ class TestSessionTimestampInliner(ClickhouseTestMixin, APIBaseTest):
         actual = f(
             self.inliner.get_inner_where(
                 parse(
-                    "SELECT * FROM events JOIN sessions ON events.session_id = raw_sessions.session_id WHERE event = '$pageview' AND toTimeZone(timestamp, 'US/Pacific') >= toDateTime('2024-03-12 00:00:00', 'US/Pacific') AND toTimeZone(timestamp, 'US/Pacific') <= toDateTime('2024-03-19 23:59:59', 'US/Pacific')"
+                    "SELECT * FROM events JOIN sessions ON events.session_id = sessions.session_id WHERE event = '$pageview' AND toTimeZone(timestamp, 'US/Pacific') >= toDateTime('2024-03-12 00:00:00', 'US/Pacific') AND toTimeZone(timestamp, 'US/Pacific') <= toDateTime('2024-03-19 23:59:59', 'US/Pacific')"
                 )
             )
         )
@@ -249,13 +251,13 @@ class TestSessionsQueriesHogQLToClickhouse(ClickhouseTestMixin, APIBaseTest):
         return pretty
 
     def test_select_with_timestamp(self):
-        actual = self.print_query("SELECT session_id FROM sessions WHERE min_timestamp > '2021-01-01'")
+        actual = self.print_query("SELECT session_id FROM sessions WHERE $start_timestamp > '2021-01-01'")
         expected = f"""SELECT
     sessions.session_id AS session_id
 FROM
     (SELECT
         sessions.session_id AS session_id,
-        min(sessions.min_timestamp) AS min_timestamp
+        min(sessions.min_timestamp) AS `$start_timestamp`
     FROM
         sessions
     WHERE
@@ -264,7 +266,7 @@ FROM
         sessions.session_id,
         sessions.session_id) AS sessions
 WHERE
-    ifNull(greater(toTimeZone(sessions.min_timestamp, %(hogql_val_2)s), %(hogql_val_3)s), 0)
+    ifNull(greater(toTimeZone(sessions.`$start_timestamp`, %(hogql_val_2)s), %(hogql_val_3)s), 0)
 LIMIT 10000"""
         assert expected == actual
 

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -236,8 +236,9 @@
                   "$event_count_map",
                   "$pageview_count",
                   "$autocapture_count",
+                  "$channel_type",
                   "$session_duration",
-                  "$channel_type"
+                  "duration"
               ]
           }
       ],
@@ -662,12 +663,16 @@
               "type": "integer"
           },
           {
+              "key": "$channel_type",
+              "type": "string"
+          },
+          {
               "key": "$session_duration",
               "type": "integer"
           },
           {
-              "key": "$channel_type",
-              "type": "string"
+              "key": "duration",
+              "type": "integer"
           }
       ],
       "raw_session_replay_events": [
@@ -1213,8 +1218,9 @@
                   "$event_count_map",
                   "$pageview_count",
                   "$autocapture_count",
+                  "$channel_type",
                   "$session_duration",
-                  "$channel_type"
+                  "duration"
               ]
           }
       ],
@@ -1639,12 +1645,16 @@
               "type": "integer"
           },
           {
+              "key": "$channel_type",
+              "type": "string"
+          },
+          {
               "key": "$session_duration",
               "type": "integer"
           },
           {
-              "key": "$channel_type",
-              "type": "string"
+              "key": "duration",
+              "type": "integer"
           }
       ],
       "raw_session_replay_events": [

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -220,24 +220,24 @@
                   "session_id",
                   "team_id",
                   "distinct_id",
-                  "min_timestamp",
-                  "max_timestamp",
-                  "urls",
-                  "entry_url",
-                  "exit_url",
-                  "initial_utm_source",
-                  "initial_utm_campaign",
-                  "initial_utm_medium",
-                  "initial_utm_term",
-                  "initial_utm_content",
-                  "initial_referring_domain",
-                  "initial_gclid",
-                  "initial_gad_source",
-                  "event_count_map",
-                  "pageview_count",
-                  "autocapture_count",
-                  "duration",
-                  "channel_type"
+                  "$start_timestamp",
+                  "$end_timestamp",
+                  "$urls",
+                  "$entry_url",
+                  "$exit_url",
+                  "$initial_utm_source",
+                  "$initial_utm_campaign",
+                  "$initial_utm_medium",
+                  "$initial_utm_term",
+                  "$initial_utm_content",
+                  "$initial_referring_domain",
+                  "$initial_gclid",
+                  "$initial_gad_source",
+                  "$event_count_map",
+                  "$pageview_count",
+                  "$autocapture_count",
+                  "$session_duration",
+                  "$channel_type"
               ]
           }
       ],
@@ -602,31 +602,71 @@
               "type": "string"
           },
           {
-              "key": "min_timestamp",
+              "key": "$start_timestamp",
               "type": "datetime"
           },
           {
-              "key": "max_timestamp",
+              "key": "$end_timestamp",
               "type": "datetime"
           },
           {
-              "key": "urls",
+              "key": "$urls",
               "type": "array"
           },
           {
-              "key": "pageview_count",
+              "key": "$entry_url",
+              "type": "string"
+          },
+          {
+              "key": "$exit_url",
+              "type": "string"
+          },
+          {
+              "key": "$initial_utm_source",
+              "type": "string"
+          },
+          {
+              "key": "$initial_utm_campaign",
+              "type": "string"
+          },
+          {
+              "key": "$initial_utm_medium",
+              "type": "string"
+          },
+          {
+              "key": "$initial_utm_term",
+              "type": "string"
+          },
+          {
+              "key": "$initial_utm_content",
+              "type": "string"
+          },
+          {
+              "key": "$initial_referring_domain",
+              "type": "string"
+          },
+          {
+              "key": "$initial_gclid",
+              "type": "string"
+          },
+          {
+              "key": "$initial_gad_source",
+              "type": "string"
+          },
+          {
+              "key": "$pageview_count",
               "type": "integer"
           },
           {
-              "key": "autocapture_count",
+              "key": "$autocapture_count",
               "type": "integer"
           },
           {
-              "key": "duration",
+              "key": "$session_duration",
               "type": "integer"
           },
           {
-              "key": "channel_type",
+              "key": "$channel_type",
               "type": "string"
           }
       ],
@@ -1157,24 +1197,24 @@
                   "session_id",
                   "team_id",
                   "distinct_id",
-                  "min_timestamp",
-                  "max_timestamp",
-                  "urls",
-                  "entry_url",
-                  "exit_url",
-                  "initial_utm_source",
-                  "initial_utm_campaign",
-                  "initial_utm_medium",
-                  "initial_utm_term",
-                  "initial_utm_content",
-                  "initial_referring_domain",
-                  "initial_gclid",
-                  "initial_gad_source",
-                  "event_count_map",
-                  "pageview_count",
-                  "autocapture_count",
-                  "duration",
-                  "channel_type"
+                  "$start_timestamp",
+                  "$end_timestamp",
+                  "$urls",
+                  "$entry_url",
+                  "$exit_url",
+                  "$initial_utm_source",
+                  "$initial_utm_campaign",
+                  "$initial_utm_medium",
+                  "$initial_utm_term",
+                  "$initial_utm_content",
+                  "$initial_referring_domain",
+                  "$initial_gclid",
+                  "$initial_gad_source",
+                  "$event_count_map",
+                  "$pageview_count",
+                  "$autocapture_count",
+                  "$session_duration",
+                  "$channel_type"
               ]
           }
       ],
@@ -1539,31 +1579,71 @@
               "type": "string"
           },
           {
-              "key": "min_timestamp",
+              "key": "$start_timestamp",
               "type": "datetime"
           },
           {
-              "key": "max_timestamp",
+              "key": "$end_timestamp",
               "type": "datetime"
           },
           {
-              "key": "urls",
+              "key": "$urls",
               "type": "array"
           },
           {
-              "key": "pageview_count",
+              "key": "$entry_url",
+              "type": "string"
+          },
+          {
+              "key": "$exit_url",
+              "type": "string"
+          },
+          {
+              "key": "$initial_utm_source",
+              "type": "string"
+          },
+          {
+              "key": "$initial_utm_campaign",
+              "type": "string"
+          },
+          {
+              "key": "$initial_utm_medium",
+              "type": "string"
+          },
+          {
+              "key": "$initial_utm_term",
+              "type": "string"
+          },
+          {
+              "key": "$initial_utm_content",
+              "type": "string"
+          },
+          {
+              "key": "$initial_referring_domain",
+              "type": "string"
+          },
+          {
+              "key": "$initial_gclid",
+              "type": "string"
+          },
+          {
+              "key": "$initial_gad_source",
+              "type": "string"
+          },
+          {
+              "key": "$pageview_count",
               "type": "integer"
           },
           {
-              "key": "autocapture_count",
+              "key": "$autocapture_count",
               "type": "integer"
           },
           {
-              "key": "duration",
+              "key": "$session_duration",
               "type": "integer"
           },
           {
-              "key": "channel_type",
+              "key": "$channel_type",
               "type": "string"
           }
       ],

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -139,10 +139,8 @@ def property_to_expr(
         or property.type == "data_warehouse_person_property"
         or property.type == "session"
     ):
-        if scope == "person" and property.type != "person":
-            raise NotImplementedError(
-                f"The '{property.type}' property filter only works in 'event' scope, not in '{scope}' scope"
-            )
+        if (scope == "person" and property.type != "person") or (scope == "session" and property.type != "session"):
+            raise NotImplementedError(f"The '{property.type}' property filter does not work in '{scope}' scope")
         operator = cast(Optional[PropertyOperator], property.operator) or PropertyOperator.exact
         value = property.value
         if property.type == "person" and scope != "person":

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -163,10 +163,6 @@ def property_to_expr(
         properties_field = ast.Field(chain=chain)
         field = ast.Field(chain=chain + [property.key])
 
-        if property.type == "session" and property.key == "$session_duration":
-            field = ast.Field(chain=["session", "duration"])
-            properties_field = field
-
         if isinstance(value, list):
             if len(value) == 0:
                 return ast.Constant(value=True)

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -71,8 +71,6 @@ def property_to_expr(
     team: Team,
     scope: Literal["event", "person", "session"] = "event",
 ) -> ast.Expr:
-    if scope == "session":
-        raise NotImplementedError("session scope is not implemented yet")
     if isinstance(property, dict):
         try:
             property = Property(**property)

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -69,8 +69,10 @@ class AggregationFinder(TraversingVisitor):
 def property_to_expr(
     property: Union[BaseModel, PropertyGroup, Property, dict, list, ast.Expr],
     team: Team,
-    scope: Literal["event", "person"] = "event",
+    scope: Literal["event", "person", "session"] = "event",
 ) -> ast.Expr:
+    if scope == "session":
+        raise NotImplementedError("session scope is not implemented yet")
     if isinstance(property, dict):
         try:
             property = Property(**property)

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -159,6 +159,10 @@ def property_to_expr(
             chain = [f"group_{property.group_type_index}", "properties"]
         elif property.type == "data_warehouse":
             chain = []
+        elif property.type == "session" and scope == "event":
+            chain = ["session"]
+        elif property.type == "session" and scope == "session":
+            chain = ["sessions"]
         else:
             chain = ["properties"]
 

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -663,5 +663,5 @@ class TestProperty(BaseTest):
                 {"type": "session", "key": "$session_duration", "value": 10, "operator": "exact"},
                 scope="event",
             ),
-            self._parse_expr("session.duration = 10"),
+            self._parse_expr("session.$session_duration = 10"),
         )

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -622,7 +622,7 @@ class TestProperty(BaseTest):
             )
         self.assertEqual(
             str(e.exception),
-            "The 'event' property filter only works in 'event' scope, not in 'person' scope",
+            "The 'event' property filter does not work in 'person' scope",
         )
 
     def test_entity_to_expr_actions_type_with_id(self):

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -1452,9 +1452,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 properties={"$session_id": random_uuid},
             )
 
-        query = (
-            "SELECT session.session_id, session.duration from events WHERE distinct_id={distinct_id} order by timestamp"
-        )
+        query = "SELECT session.session_id, session.$session_duration from events WHERE distinct_id={distinct_id} order by timestamp"
         response = execute_hogql_query(
             query, team=self.team, placeholders={"distinct_id": ast.Constant(value=random_uuid)}
         )

--- a/posthog/hogql_queries/insights/trends/breakdown_values.py
+++ b/posthog/hogql_queries/insights/trends/breakdown_values.py
@@ -119,7 +119,7 @@ class BreakdownValues:
 
         aggregation_expression: ast.Expr
         if self._aggregation_operation.aggregating_on_session_duration():
-            aggregation_expression = ast.Call(name="max", args=[ast.Field(chain=["session", "duration"])])
+            aggregation_expression = ast.Call(name="max", args=[ast.Field(chain=["session", "$session_duration"])])
         elif self.series.math == "dau":
             # When aggregating by (daily) unique users, run the breakdown aggregation on count(e.uuid).
             # This retains legacy compatibility and should be removed once we have the new trends in production.

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -3813,10 +3813,10 @@
 # name: TestTrends.test_trends_breakdown_with_session_property_single_aggregate_math_and_breakdown
   '''
   SELECT toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')) AS value,
-         max(e__session.duration) AS count
+         max(e__session.`$session_duration`) AS count
   FROM events AS e
   LEFT JOIN
-    (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS duration,
+    (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS `$session_duration`,
             sessions.session_id AS session_id
      FROM sessions
      WHERE equals(sessions.team_id, 2)
@@ -3835,11 +3835,11 @@
   SELECT quantile(0.5)(session_duration) AS total,
          breakdown_value AS breakdown_value
   FROM
-    (SELECT any(e__session.duration) AS session_duration,
+    (SELECT any(e__session.`$session_duration`) AS session_duration,
             transform(ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$'), ['value2', 'value1', '$$_posthog_breakdown_null_$$'], ['value2', 'value1', '$$_posthog_breakdown_null_$$'], '$$_posthog_breakdown_other_$$') AS breakdown_value
      FROM events AS e SAMPLE 1
      LEFT JOIN
-       (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS duration,
+       (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS `$session_duration`,
                sessions.session_id AS session_id
         FROM sessions
         WHERE equals(sessions.team_id, 2)
@@ -3857,10 +3857,10 @@
 # name: TestTrends.test_trends_breakdown_with_session_property_single_aggregate_math_and_breakdown.2
   '''
   SELECT toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')) AS value,
-         max(e__session.duration) AS count
+         max(e__session.`$session_duration`) AS count
   FROM events AS e
   LEFT JOIN
-    (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS duration,
+    (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS `$session_duration`,
             sessions.session_id AS session_id
      FROM sessions
      WHERE equals(sessions.team_id, 2)
@@ -3879,11 +3879,11 @@
   SELECT quantile(0.5)(session_duration) AS total,
          breakdown_value AS breakdown_value
   FROM
-    (SELECT any(e__session.duration) AS session_duration,
+    (SELECT any(e__session.`$session_duration`) AS session_duration,
             transform(ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$'), ['value2', 'value1', '$$_posthog_breakdown_null_$$'], ['value2', 'value1', '$$_posthog_breakdown_null_$$'], '$$_posthog_breakdown_other_$$') AS breakdown_value
      FROM events AS e SAMPLE 1
      LEFT JOIN
-       (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS duration,
+       (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS `$session_duration`,
                sessions.session_id AS session_id
         FROM sessions
         WHERE equals(sessions.team_id, 2)
@@ -4269,10 +4269,10 @@
 # name: TestTrends.test_trends_person_breakdown_with_session_property_single_aggregate_math_and_breakdown
   '''
   SELECT toString(e__pdi__person.`properties___$some_prop`) AS value,
-         max(e__session.duration) AS count
+         max(e__session.`$session_duration`) AS count
   FROM events AS e
   LEFT JOIN
-    (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS duration,
+    (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS `$session_duration`,
             sessions.session_id AS session_id
      FROM sessions
      WHERE equals(sessions.team_id, 2)
@@ -4309,11 +4309,11 @@
   SELECT quantile(0.5)(session_duration) AS total,
          breakdown_value AS breakdown_value
   FROM
-    (SELECT any(e__session.duration) AS session_duration,
+    (SELECT any(e__session.`$session_duration`) AS session_duration,
             transform(ifNull(nullIf(toString(e__pdi__person.`properties___$some_prop`), ''), '$$_posthog_breakdown_null_$$'), ['some_val', 'another_val'], ['some_val', 'another_val'], '$$_posthog_breakdown_other_$$') AS breakdown_value
      FROM events AS e SAMPLE 1
      LEFT JOIN
-       (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS duration,
+       (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS `$session_duration`,
                sessions.session_id AS session_id
         FROM sessions
         WHERE equals(sessions.team_id, 2)
@@ -4376,10 +4376,10 @@
   '''
   SELECT quantile(0.5)(session_duration) AS total
   FROM
-    (SELECT any(e__session.duration) AS session_duration
+    (SELECT any(e__session.`$session_duration`) AS session_duration
      FROM events AS e SAMPLE 1
      LEFT JOIN
-       (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS duration,
+       (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS `$session_duration`,
                sessions.session_id AS session_id
         FROM sessions
         WHERE equals(sessions.team_id, 2)
@@ -4396,10 +4396,10 @@
   '''
   SELECT quantile(0.5)(session_duration) AS total
   FROM
-    (SELECT any(e__session.duration) AS session_duration
+    (SELECT any(e__session.`$session_duration`) AS session_duration
      FROM events AS e SAMPLE 1
      LEFT JOIN
-       (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS duration,
+       (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS `$session_duration`,
                sessions.session_id AS session_id
         FROM sessions
         WHERE equals(sessions.team_id, 2)
@@ -4428,11 +4428,11 @@
         UNION ALL SELECT quantile(0.5)(session_duration) AS total,
                          day_start AS day_start
         FROM
-          (SELECT any(e__session.duration) AS session_duration,
+          (SELECT any(e__session.`$session_duration`) AS session_duration,
                   toStartOfWeek(toTimeZone(e.timestamp, 'UTC'), 0) AS day_start
            FROM events AS e SAMPLE 1
            LEFT JOIN
-             (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS duration,
+             (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS `$session_duration`,
                      sessions.session_id AS session_id
               FROM sessions
               WHERE equals(sessions.team_id, 2)
@@ -4467,11 +4467,11 @@
         UNION ALL SELECT quantile(0.5)(session_duration) AS total,
                          day_start AS day_start
         FROM
-          (SELECT any(e__session.duration) AS session_duration,
+          (SELECT any(e__session.`$session_duration`) AS session_duration,
                   toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
            FROM events AS e SAMPLE 1
            LEFT JOIN
-             (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS duration,
+             (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS `$session_duration`,
                      sessions.session_id AS session_id
               FROM sessions
               WHERE equals(sessions.team_id, 2)
@@ -4493,10 +4493,10 @@
 # name: TestTrends.test_trends_with_session_property_total_volume_math_with_breakdowns
   '''
   SELECT toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')) AS value,
-         max(e__session.duration) AS count
+         max(e__session.`$session_duration`) AS count
   FROM events AS e
   LEFT JOIN
-    (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS duration,
+    (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS `$session_duration`,
             sessions.session_id AS session_id
      FROM sessions
      WHERE equals(sessions.team_id, 2)
@@ -4537,12 +4537,12 @@
                          day_start AS day_start,
                          breakdown_value AS breakdown_value
         FROM
-          (SELECT any(e__session.duration) AS session_duration,
+          (SELECT any(e__session.`$session_duration`) AS session_duration,
                   transform(ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$'), ['value2', 'value1'], ['value2', 'value1'], '$$_posthog_breakdown_other_$$') AS breakdown_value,
                   toStartOfWeek(toTimeZone(e.timestamp, 'UTC'), 0) AS day_start
            FROM events AS e SAMPLE 1
            LEFT JOIN
-             (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS duration,
+             (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS `$session_duration`,
                      sessions.session_id AS session_id
               FROM sessions
               WHERE equals(sessions.team_id, 2)
@@ -4569,10 +4569,10 @@
 # name: TestTrends.test_trends_with_session_property_total_volume_math_with_breakdowns.2
   '''
   SELECT toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')) AS value,
-         max(e__session.duration) AS count
+         max(e__session.`$session_duration`) AS count
   FROM events AS e
   LEFT JOIN
-    (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS duration,
+    (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS `$session_duration`,
             sessions.session_id AS session_id
      FROM sessions
      WHERE equals(sessions.team_id, 2)
@@ -4613,12 +4613,12 @@
                          day_start AS day_start,
                          breakdown_value AS breakdown_value
         FROM
-          (SELECT any(e__session.duration) AS session_duration,
+          (SELECT any(e__session.`$session_duration`) AS session_duration,
                   transform(ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$'), ['value2', 'value1'], ['value2', 'value1'], '$$_posthog_breakdown_other_$$') AS breakdown_value,
                   toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
            FROM events AS e SAMPLE 1
            LEFT JOIN
-             (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS duration,
+             (SELECT dateDiff('second', min(sessions.min_timestamp), max(sessions.max_timestamp)) AS `$session_duration`,
                      sessions.session_id AS session_id
               FROM sessions
               WHERE equals(sessions.team_id, 2)

--- a/posthog/hogql_queries/insights/trends/test/test_utils.py
+++ b/posthog/hogql_queries/insights/trends/test/test_utils.py
@@ -13,13 +13,13 @@ def test_properties_chain_person():
 
 def test_properties_chain_session():
     p1 = get_properties_chain(breakdown_type=BreakdownType.session, breakdown_field="anything", group_type_index=None)
-    assert p1 == ["session", "duration"]
+    assert p1 == ["session", "$session_duration"]
 
     p2 = get_properties_chain(breakdown_type=BreakdownType.session, breakdown_field="", group_type_index=None)
-    assert p2 == ["session", "duration"]
+    assert p2 == ["session", "$session_duration"]
 
     p3 = get_properties_chain(breakdown_type=BreakdownType.session, breakdown_field="", group_type_index=1)
-    assert p3 == ["session", "duration"]
+    assert p3 == ["session", "$session_duration"]
 
 
 def test_properties_chain_groups():

--- a/posthog/hogql_queries/insights/trends/test/test_utils.py
+++ b/posthog/hogql_queries/insights/trends/test/test_utils.py
@@ -13,12 +13,14 @@ def test_properties_chain_person():
 
 def test_properties_chain_session():
     p1 = get_properties_chain(breakdown_type=BreakdownType.session, breakdown_field="anything", group_type_index=None)
-    assert p1 == ["session", "$session_duration"]
+    assert p1 == ["session", "anything"]
 
-    p2 = get_properties_chain(breakdown_type=BreakdownType.session, breakdown_field="", group_type_index=None)
-    assert p2 == ["session", "$session_duration"]
+    p2 = get_properties_chain(breakdown_type=BreakdownType.session, breakdown_field="anything", group_type_index=1)
+    assert p2 == ["session", "anything"]
 
-    p3 = get_properties_chain(breakdown_type=BreakdownType.session, breakdown_field="", group_type_index=1)
+    p3 = get_properties_chain(
+        breakdown_type=BreakdownType.session, breakdown_field="$session_duration", group_type_index=None
+    )
     assert p3 == ["session", "$session_duration"]
 
 

--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -270,7 +270,8 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
         elif breakdown.enabled and self._aggregation_operation.aggregating_on_session_duration():
             default_query.select = [
                 ast.Alias(
-                    alias="session_duration", expr=ast.Call(name="any", args=[ast.Field(chain=["session", "duration"])])
+                    alias="session_duration",
+                    expr=ast.Call(name="any", args=[ast.Field(chain=["session", "$session_duration"])]),
                 ),
                 breakdown.column_expr(),
             ]
@@ -305,7 +306,8 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
         elif self._aggregation_operation.aggregating_on_session_duration():
             default_query.select = [
                 ast.Alias(
-                    alias="session_duration", expr=ast.Call(name="any", args=[ast.Field(chain=["session", "duration"])])
+                    alias="session_duration",
+                    expr=ast.Call(name="any", args=[ast.Field(chain=["session", "$session_duration"])]),
                 )
             ]
             default_query.group_by.append(ast.Field(chain=["$session_id"]))

--- a/posthog/hogql_queries/insights/trends/utils.py
+++ b/posthog/hogql_queries/insights/trends/utils.py
@@ -17,7 +17,7 @@ def get_properties_chain(
         return ["person", "properties", breakdown_field]
 
     if breakdown_type == "session":
-        return ["session", "duration"]
+        return ["session", breakdown_field]
 
     if breakdown_type == "group" and group_type_index is not None:
         group_type_index_int = int(group_type_index)

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -95,7 +95,7 @@ CROSS JOIN sessions_query
                         "start": start,
                         "mid": mid,
                         "end": end,
-                        "event_properties": self.event_properties(),
+                        "event_properties": self.all_properties(),
                         "session_where": self.session_where(include_previous_period=True),
                         "session_having": self.session_having(include_previous_period=True),
                         "sample_rate": self._sample_ratio,
@@ -164,7 +164,7 @@ CROSS JOIN sessions_query
                         "start": start,
                         "mid": mid,
                         "end": end,
-                        "event_properties": self.event_properties(),
+                        "event_properties": self.all_properties(),
                         "session_where": self.session_where(include_previous_period=False),
                         "session_having": self.session_having(include_previous_period=False),
                         "sample_rate": self._sample_ratio,
@@ -181,27 +181,27 @@ CROSS JOIN sessions_query
             return parse_select(
                 """
 SELECT
-    uniq(if(min_timestamp >= {mid} AND min_timestamp < {end}, person_id, NULL)) AS unique_users,
-    uniq(if(min_timestamp >= {start} AND min_timestamp < {mid}, person_id, NULL)) AS previous_unique_users,
-    sumIf(filtered_pageview_count, min_timestamp >= {mid} AND min_timestamp < {end}) AS current_pageviews,
-    sumIf(filtered_pageview_count, min_timestamp >= {start} AND min_timestamp < {mid}) AS previous_pageviews,
-    uniq(if(min_timestamp >= {mid} AND min_timestamp < {end}, session_id, NULL)) AS unique_sessions,
-    uniq(if(min_timestamp >= {start} AND min_timestamp < {mid}, session_id, NULL)) AS previous_unique_sessions,
-    avg(if(min_timestamp >= {mid}, duration, NULL)) AS avg_duration_s,
-    avg(if(min_timestamp < {mid}, duration, NULL)) AS prev_avg_duration_s,
-    avg(if(min_timestamp >= {mid}, is_bounce, NULL)) AS bounce_rate,
-    avg(if(min_timestamp < {mid}, is_bounce, NULL)) AS prev_bounce_rate
+    uniq(if(start_timestamp >= {mid} AND start_timestamp < {end}, person_id, NULL)) AS unique_users,
+    uniq(if(start_timestamp >= {start} AND start_timestamp < {mid}, person_id, NULL)) AS previous_unique_users,
+    sumIf(filtered_pageview_count, start_timestamp >= {mid} AND start_timestamp < {end}) AS current_pageviews,
+    sumIf(filtered_pageview_count, start_timestamp >= {start} AND start_timestamp < {mid}) AS previous_pageviews,
+    uniq(if(start_timestamp >= {mid} AND start_timestamp < {end}, session_id, NULL)) AS unique_sessions,
+    uniq(if(start_timestamp >= {start} AND start_timestamp < {mid}, session_id, NULL)) AS previous_unique_sessions,
+    avg(if(start_timestamp >= {mid}, session_duration, NULL)) AS avg_duration_s,
+    avg(if(start_timestamp < {mid}, session_duration, NULL)) AS prev_avg_duration_s,
+    avg(if(start_timestamp >= {mid}, is_bounce, NULL)) AS bounce_rate,
+    avg(if(start_timestamp < {mid}, is_bounce, NULL)) AS prev_bounce_rate
 FROM (
     SELECT
         any(events.person_id) as person_id,
         events.`$session_id` as session_id,
-        min(sessions.min_timestamp) as min_timestamp,
-        any(sessions.duration) as duration,
-        any(sessions.pageview_count) as session_pageview_count,
-        any(sessions.autocapture_count) as session_autocapture_count,
+        min(sessions.$start_timestamp) as start_timestamp,
+        any(sessions.$session_duration) as session_duration,
+        any(sessions.$pageview_count) as session_pageview_count,
+        any(sessions.$autocapture_count) as session_autocapture_count,
         count() as filtered_pageview_count,
         and(
-             duration < 30,
+             session_duration < 30,
              session_pageview_count = 1,
             session_autocapture_count = 0
          ) as is_bounce
@@ -213,12 +213,13 @@ FROM (
         event = '$pageview',
         timestamp >= {start},
         timestamp < {end},
-        {event_properties}
+        {event_properties},
+        {session_properties}
     )
     GROUP BY `$session_id`
     HAVING and(
-        min_timestamp >= {start},
-        min_timestamp < {end}
+        start_timestamp >= {start},
+        start_timestamp < {end}
     )
 )
 
@@ -228,6 +229,7 @@ FROM (
                     "mid": mid,
                     "end": end,
                     "event_properties": self.event_properties(),
+                    "session_properties": self.session_properties(),
                 },
             )
         else:
@@ -240,7 +242,7 @@ FROM (
     NULL as previous_pageviews,
     uniq(session_id) AS unique_sessions,
     NULL as previous_unique_sessions,
-    avg(duration) AS avg_duration_s,
+    avg(session_duration) AS avg_duration_s,
     NULL as prev_avg_duration_s,
     avg(is_bounce) AS bounce_rate,
     NULL as prev_bounce_rate
@@ -248,13 +250,13 @@ FROM (
     SELECT
         any(events.person_id) as person_id,
         events.`$session_id` as session_id,
-        min(sessions.min_timestamp) as min_timestamp,
-        any(sessions.duration) as duration,
-        any(sessions.pageview_count) as session_pageview_count,
-        any(sessions.autocapture_count) as session_autocapture_count,
+        min(sessions.$start_timestamp) as $start_timestamp,
+        any(sessions.$session_duration) as session_duration,
+        any(sessions.$pageview_count) as session_pageview_count,
+        any(sessions.$autocapture_count) as session_autocapture_count,
         count() as filtered_pageview_count,
         and(
-             duration < 30,
+             session_duration < 30,
              session_pageview_count = 1,
             session_autocapture_count = 0
          ) as is_bounce
@@ -266,16 +268,22 @@ FROM (
         event = '$pageview',
         timestamp >= {mid},
         timestamp < {end},
-        {event_properties}
+        {event_properties},
+        {session_properties}
     )
     GROUP BY `$session_id`
     HAVING and(
-        min_timestamp >= {mid},
-        min_timestamp < {end}
+        $start_timestamp >= {mid},
+        $start_timestamp < {end}
     )
 )
                 """,
-                placeholders={"mid": mid, "end": end, "event_properties": self.event_properties()},
+                placeholders={
+                    "mid": mid,
+                    "end": end,
+                    "event_properties": self.event_properties(),
+                    "session_properties": self.session_properties(),
+                },
             )
 
     def calculate(self):
@@ -311,8 +319,21 @@ FROM (
             now=datetime.now(),
         )
 
+    def all_properties(self) -> ast.Expr:
+        properties = self.query.properties + self._test_account_filters
+        return property_to_expr(properties, team=self.team)
+
     def event_properties(self) -> ast.Expr:
-        return property_to_expr(self.query.properties + self._test_account_filters, team=self.team)
+        properties = [
+            p for p in self.query.properties + self._test_account_filters if get_property_type(p) in ["event", "person"]
+        ]
+        return property_to_expr(properties, team=self.team, scope="event")
+
+    def session_properties(self) -> ast.Expr:
+        properties = [
+            p for p in self.query.properties + self._test_account_filters if get_property_type(p) == "session"
+        ]
+        return property_to_expr(properties, team=self.team, scope="session")
 
 
 def to_data(
@@ -338,3 +359,10 @@ def to_data(
         if value is not None and previous is not None and previous != 0
         else None,
     }
+
+
+def get_property_type(property):
+    if isinstance(property, dict):
+        return property["type"]
+    else:
+        return property.type


### PR DESCRIPTION
## Problem
I'm pulling this out of a much larger PR as it's a pretty standalone change and I wanted to make it easier to review. It doesn't really solve a problem on its own, but it does allowing introspection of the lazy sessions table to figure out what session properties are available.

## Changes

Rename the columns in `SessionsTable` to match the naming of properties.

It's worth calling out here that `session.duration` in hogql will no longer work. I don't think this is a problem given
* hogql is in beta
* the fix is simple, rename to session.$session_duration
* hogql session.duration already changed recently, to using the session table. It's not stable

However it'd be pretty easy to add an alias if we felt strongly the other way.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Updated existing tests