### PR TITLE
fix: Default path in asgi_scope to empty string

### DIFF
--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -75,7 +75,7 @@ def traces_sampler(sampling_context: dict) -> float:
         path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
         force_sample = bool(sampling_context.get("wsgi_environ", {}).get("HTTP_FORCE_SAMPLE"))
         if os.environ.get("SERVER_GATEWAY_INTERFACE") == "ASGI":
-            path = sampling_context.get("asgi_scope", {}).get("path")
+            path = sampling_context.get("asgi_scope", {}).get("path", "")
             headers = sampling_context.get("asgi_scope", {}).get("headers", [])
             for name, value in headers:
                 if name.lower().replace(b"_", b"-") == "force-sample":


### PR DESCRIPTION
## Problem

Sometimes requests come in with an empty asgi scope Default path to "/" in these cases

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
