### PR TITLE
feat: Send email notifications on failure

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -465,6 +465,21 @@ def update_batch_export_run(
     return model.get()
 
 
+def count_failed_batch_export_runs(batch_export_id: UUID, last_n: int) -> int:
+    """Count failed batch export runs in the 'last_n' runs."""
+    count_of_failures = (
+        BatchExportRun.objects.filter(
+            id__in=BatchExportRun.objects.filter(batch_export_id=batch_export_id)
+            .order_by("-last_updated_at")
+            .values("id")[:last_n]
+        )
+        .filter(status=BatchExportRun.Status.FAILED)
+        .count()
+    )
+
+    return count_of_failures
+
+
 def sync_batch_export(batch_export: BatchExport, created: bool):
     workflow, workflow_inputs = DESTINATION_WORKFLOWS[batch_export.destination.type]
     state = ScheduleState(

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -21,9 +21,10 @@ from .utils import UUIDClassicModel, generate_random_token, sane_repr
 
 class Notifications(TypedDict, total=False):
     plugin_disabled: bool
+    batch_export_run_failure: bool
 
 
-NOTIFICATION_DEFAULTS: Notifications = {"plugin_disabled": True}
+NOTIFICATION_DEFAULTS: Notifications = {"plugin_disabled": True, "batch_export_run_failure": True}
 
 # We don't ned the following attributes in most cases, so we defer them by default
 DEFERED_ATTRS = ["requested_password_reset_at"]

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -193,7 +193,7 @@ async def send_batch_export_run_failure(
     memberships = OrganizationMembership.objects.select_related("user", "organization").filter(
         organization_id=team.organization_id
     )
-    all_memberships = await sync_to_async(list)(memberships)
+    all_memberships: list[OrganizationMembership] = await sync_to_async(list)(memberships)  # type: ignore
     for membership in all_memberships:
         has_notification_settings_enabled = await sync_to_async(membership.user.notification_settings.get)(
             "batch_export_run_failure", True

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -4,10 +4,12 @@ from typing import List, Optional
 
 import posthoganalytics
 import structlog
+from asgiref.sync import sync_to_async
 from celery import shared_task
 from django.conf import settings
 from django.utils import timezone
 
+from posthog.batch_exports.models import BatchExportRun
 from posthog.cloud_utils import is_cloud
 from posthog.email import EMAIL_TASK_KWARGS, EmailMessage, is_email_available
 from posthog.models import (
@@ -155,6 +157,56 @@ def send_fatal_plugin_error(
         for membership in memberships_to_email:
             message.add_recipient(email=membership.user.email, name=membership.user.first_name)
         message.send(send_async=False)
+
+
+@shared_task(**EMAIL_TASK_KWARGS)
+async def send_batch_export_run_failure(
+    batch_export_run_id: int,
+) -> None:
+    is_email_available_result = await sync_to_async(is_email_available)(with_absolute_urls=True)
+    if not is_email_available_result:
+        return
+
+    batch_export_run: BatchExportRun = await sync_to_async(
+        BatchExportRun.objects.select_related("batch_export__team").get
+    )(id=batch_export_run_id)
+    team: Team = batch_export_run.batch_export.team
+    campaign_key: str = f"batch_export_run_email_batch_export_{batch_export_run.batch_export.id}_data_interval_end_{batch_export_run.data_interval_end}"
+    message = await sync_to_async(EmailMessage)(
+        campaign_key=campaign_key,
+        subject=f"PostHog: {batch_export_run.batch_export.name} batch export run failure",
+        template_name="batch_export_run_failure",
+        template_context={
+            "time": batch_export_run.last_updated_at.strftime("%I:%M%p on %B %d"),
+            "team": team,
+            "id": batch_export_run.batch_export.id,
+            "name": batch_export_run.batch_export.name,
+        },
+    )
+    memberships_to_email = []
+    memberships = OrganizationMembership.objects.select_related("user", "organization").filter(
+        organization_id=team.organization_id
+    )
+    all_memberships = await sync_to_async(list)(memberships)
+    for membership in all_memberships:
+        has_notification_settings_enabled = await sync_to_async(membership.user.notification_settings.get)(
+            "batch_export_run_failure", True
+        )
+        if has_notification_settings_enabled is False:
+            continue
+        team_permissions = UserPermissions(membership.user).team(team)
+        # Only send the email to users who have access to the affected project
+        # Those without access have `effective_membership_level` of `None`
+        if (
+            team_permissions.effective_membership_level_for_parent_membership(membership.organization, membership)
+            is not None
+        ):
+            memberships_to_email.append(membership)
+
+    if memberships_to_email:
+        for membership in memberships_to_email:
+            message.add_recipient(email=membership.user.email, name=membership.user.first_name)
+        await sync_to_async(message.send)(send_async=True)
 
 
 @shared_task(**EMAIL_TASK_KWARGS)

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -171,7 +171,13 @@ async def send_batch_export_run_failure(
         BatchExportRun.objects.select_related("batch_export__team").get
     )(id=batch_export_run_id)
     team: Team = batch_export_run.batch_export.team
-    campaign_key: str = f"batch_export_run_email_batch_export_{batch_export_run.batch_export.id}_data_interval_end_{batch_export_run.data_interval_end}"
+    # NOTE: We are taking only the date component to cap the number of emails at one per day per batch export.
+    last_updated_at_date = batch_export_run.last_updated_at.strftime("%Y-%m-%d")
+
+    campaign_key: (
+        str
+    ) = f"batch_export_run_email_batch_export_{batch_export_run.batch_export.id}_last_updated_at_{last_updated_at_date}"
+
     message = await sync_to_async(EmailMessage)(
         campaign_key=campaign_key,
         subject=f"PostHog: {batch_export_run.batch_export.name} batch export run failure",

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -183,7 +183,7 @@ async def send_batch_export_run_failure(
         subject=f"PostHog: {batch_export_run.batch_export.name} batch export run failure",
         template_name="batch_export_run_failure",
         template_context={
-            "time": batch_export_run.last_updated_at.strftime("%I:%M%p on %B %d"),
+            "time": batch_export_run.last_updated_at.strftime("%I:%M%p %Z on %B %d"),
             "team": team,
             "id": batch_export_run.batch_export.id,
             "name": batch_export_run.batch_export.name,

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -1,10 +1,14 @@
+import datetime as dt
 from typing import Tuple
 from unittest.mock import MagicMock, patch
 
+import pytest
+from asgiref.sync import sync_to_async
 from freezegun import freeze_time
 
 from posthog.api.authentication import password_reset_token_generator
 from posthog.api.email_verification import email_verification_token_generator
+from posthog.batch_exports.models import BatchExport, BatchExportDestination, BatchExportRun
 from posthog.models import Organization, Team, User
 from posthog.models.instance_setting import set_instance_setting
 from posthog.models.organization import OrganizationInvite, OrganizationMembership
@@ -12,6 +16,7 @@ from posthog.models.plugin import Plugin, PluginConfig
 from posthog.tasks.email import (
     send_async_migration_complete_email,
     send_async_migration_errored_email,
+    send_batch_export_run_failure,
     send_canary_email,
     send_email_verification,
     send_fatal_plugin_error,
@@ -141,6 +146,62 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
         self.user.partial_notification_settings = {"plugin_disabled": True}
         self.user.save()
         send_fatal_plugin_error(plugin_config.id, "20222-01-01", error="It exploded!", is_system_error=False)
+        # should be sent to both
+        assert len(mocked_email_messages[1].to) == 2
+
+    @pytest.mark.asyncio
+    async def test_send_batch_export_run_failure(self, MockEmailMessage: MagicMock) -> None:
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+        _, user = await sync_to_async(create_org_team_and_user)("2022-01-02 00:00:00", "admin@posthog.com")
+        batch_export_destination = await sync_to_async(BatchExportDestination.objects.create)(
+            type=BatchExportDestination.Destination.S3, config={"bucket_name": "my_production_s3_bucket"}
+        )
+        batch_export = await sync_to_async(BatchExport.objects.create)(
+            team=user.team, name="A batch export", destination=batch_export_destination
+        )
+        now = dt.datetime.now()
+        batch_export_run = await sync_to_async(BatchExportRun.objects.create)(
+            batch_export=batch_export,
+            status=BatchExportRun.Status.FAILED,
+            data_interval_start=now - dt.timedelta(hours=1),
+            data_interval_end=now,
+        )
+
+        await send_batch_export_run_failure(batch_export_run.id)
+
+        assert len(mocked_email_messages) == 1
+        assert mocked_email_messages[0].send.call_count == 1
+        assert mocked_email_messages[0].html_body
+
+    @pytest.mark.asyncio
+    async def test_send_batch_export_run_failure_with_settings(self, MockEmailMessage: MagicMock) -> None:
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+        batch_export_destination = await sync_to_async(BatchExportDestination.objects.create)(
+            type=BatchExportDestination.Destination.S3, config={"bucket_name": "my_production_s3_bucket"}
+        )
+        batch_export = await sync_to_async(BatchExport.objects.create)(
+            team=self.user.team, name="A batch export", destination=batch_export_destination
+        )
+        now = dt.datetime.now()
+        batch_export_run = await sync_to_async(BatchExportRun.objects.create)(
+            batch_export=batch_export,
+            status=BatchExportRun.Status.FAILED,
+            data_interval_start=now - dt.timedelta(hours=1),
+            data_interval_end=now,
+        )
+
+        await sync_to_async(self._create_user)("test2@posthog.com")
+        self.user.partial_notification_settings = {"batch_export_run_failure": False}
+        await sync_to_async(self.user.save)()
+
+        await send_batch_export_run_failure(batch_export_run.id)
+        # Should only be sent to user2
+        assert mocked_email_messages[0].to == [{"recipient": "test2@posthog.com", "raw_email": "test2@posthog.com"}]
+
+        self.user.partial_notification_settings = {"batch_export_run_failure": True}
+        await sync_to_async(self.user.save)()
+
+        await send_batch_export_run_failure(batch_export_run.id)
         # should be sent to both
         assert len(mocked_email_messages[1].to) == 2
 

--- a/posthog/templates/email/batch_export_run_failure.html
+++ b/posthog/templates/email/batch_export_run_failure.html
@@ -1,0 +1,31 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% block preheader %}If failures keep occurring we will disable this batch export{% endblock %}
+{% block heading %}PostHog batch export {{ name }} has failed{% endblock %}
+{% block section %}
+<p>
+  There's been a fatal error with your batch export {{ name }} at {{ time }}. Due to the nature of the error, it cannot be retried automatically and requires manual intervention.
+
+  We recommend reviewing the batch export logs for error details:
+</p>
+
+<div class="mb mt text-center">
+  <a href="https://us.posthog.com/project/{{ team }}/batch_exports/{{ id }}"
+     target="_blank"><b>Go to the batch export</b></a>
+</div>
+
+<p>
+  After reviewing the logs, and addressing any errors in them, you can retry the batch export run manually. If the batch export continues to fail we will disable it.
+</p>
+{% endblock %}
+
+{% block footer %}
+Need help?
+<a href="https://posthog.com/questions?{{ utm_tags }}"
+    target="_blank"><b>Visit support</b></a>
+or
+<a href="https://posthog.com/docs?{{ utm_tags }}"
+    target="_blank"><b>read our documentation</b></a>.<br /><br />
+
+<a href="{% absolute_uri '/me/settings#notifications' %}">Manage these notifications in PostHog</a>
+
+{% endblock %}

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -14,8 +14,10 @@ from temporalio.common import RetryPolicy
 from posthog.batch_exports.models import BatchExportBackfill, BatchExportRun
 from posthog.batch_exports.service import (
     BatchExportField,
+    count_failed_batch_export_runs,
     create_batch_export_backfill,
     create_batch_export_run,
+    pause_batch_export,
     update_batch_export_backfill_status,
     update_batch_export_run,
 )
@@ -24,6 +26,7 @@ from posthog.temporal.batch_exports.metrics import (
     get_export_started_metric,
 )
 from posthog.temporal.common.clickhouse import ClickHouseClient, get_client
+from posthog.temporal.common.client import connect
 from posthog.temporal.common.logger import bind_temporal_worker_logger
 
 SELECT_QUERY_TEMPLATE = Template(
@@ -370,33 +373,47 @@ class FinishBatchExportRunInputs:
 
     Attributes:
         id: The id of the batch export run. This should be a valid UUID string.
+        batch_export_id: The id of the batch export this run belongs to.
         team_id: The team id of the batch export.
         status: The status this batch export is finishing with.
         latest_error: The latest error message captured, if any.
         records_completed: Number of records successfully exported.
         records_total_count: Total count of records this run noted.
+        failure_threshold: Used when determining to pause a batch export that has failed.
+            See the docstring in 'pause_batch_export_if_over_failure_threshold'.
+        failure_check_window: Used when determining to pause a batch export that has failed.
+            See the docstring in 'pause_batch_export_if_over_failure_threshold'.
     """
 
     id: str
+    batch_export_id: str
     team_id: int
     status: str
     latest_error: str | None = None
     records_completed: int | None = None
     records_total_count: int | None = None
+    failure_threshold: int = 10
+    failure_check_window: int = 50
 
 
 @activity.defn
 async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
-    """Activity that finishes a BatchExportRun.
+    """Activity that finishes a 'BatchExportRun'.
 
-    Finishing means a final update to the status of the BatchExportRun model.
+    Finishing means setting and handling the status of a 'BatchExportRun' model, as well
+    as setting any additional supported model attributes.
+
+    The only status that requires handling is 'FAILED' as we also check if the number of failures in
+    'failure_check_window' exceeds 'failure_threshold' and attempt to pause the batch export if
+    that's the case. Also, a notification is sent to users on every failure.
     """
     logger = await bind_temporal_worker_logger(team_id=inputs.team_id)
 
+    not_model_params = ("id", "team_id", "batch_export_id", "failure_threshold", "failure_check_window")
     update_params = {
         key: value
         for key, value in dataclasses.asdict(inputs).items()
-        if key not in ("id", "team_id") and value is not None
+        if key not in not_model_params and value is not None
     }
     batch_export_run = await sync_to_async(update_batch_export_run)(
         run_id=uuid.UUID(inputs.id),
@@ -404,19 +421,41 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
         **update_params,
     )
 
-    if batch_export_run.status in (BatchExportRun.Status.FAILED, BatchExportRun.Status.FAILED_RETRYABLE):
+    if batch_export_run.status == BatchExportRun.Status.FAILED_RETRYABLE:
         logger.error("Batch export failed with error: %s", batch_export_run.latest_error)
 
-        if batch_export_run.status == BatchExportRun.Status.FAILED:
-            from posthog.tasks.email import send_batch_export_run_failure
+    elif batch_export_run.status == BatchExportRun.Status.FAILED:
+        logger.error("Batch export failed with non-retryable error: %s", batch_export_run.latest_error)
 
-            try:
-                await send_batch_export_run_failure(inputs.id)
-            except Exception:
-                logger.exception("Failure email notification could not be sent")
+        from posthog.tasks.email import send_batch_export_run_failure
+
+        try:
+            await send_batch_export_run_failure(inputs.id)
+        except Exception:
+            logger.exception("Failure email notification could not be sent")
+
+        try:
+            was_paused = await pause_batch_export_if_over_failure_threshold(
+                inputs.batch_export_id,
+                check_window=inputs.failure_check_window,
+                failure_threshold=inputs.failure_threshold,
+            )
+        except Exception:
+            # Pausing could error if the underlying schedule is deleted.
+            # Our application logic should prevent that, but I want to log it in case it ever happens
+            # as that would indicate a bug.
+            logger.exception("Batch export could not be automatically paused")
+            was_paused = False
+
+        if was_paused:
+            logger.warning(
+                "Batch export was automatically paused due to exceeding failure threshold and exhausting "
+                "all automated retries."
+                "The batch export can be manually unpaused after addressing any errors."
+            )
 
     elif batch_export_run.status == BatchExportRun.Status.CANCELLED:
-        logger.warning("BatchExport was cancelled.")
+        logger.warning("Batch export was cancelled")
 
     else:
         logger.info(
@@ -424,6 +463,59 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
             batch_export_run.data_interval_start,
             batch_export_run.data_interval_end,
         )
+
+
+async def pause_batch_export_if_over_failure_threshold(
+    batch_export_id: str, check_window: int, failure_threshold: int = 10
+) -> bool:
+    """Pause a batch export if it exceeds failure threshold.
+
+    A 'check_window' was added to account for batch exports that have a history of failures but have some
+    occassional successes in the middle. This is relevant particularly for low-volume exports:
+    A batch export without rows to export always succeeds, even if it's not properly configured. So, the failures
+    could be scattered between these successes.
+
+    Keep in mind that if 'check_window' is less than 'failure_threshold', there is no point in even counting,
+    so we raise an exception.
+
+    We check if the count of failed runs in the last 'check_window' runs exceeds 'failure_threshold'. This means
+    that 'pause_batch_export_if_over_failure_threshold' should only be called when handling a failed run,
+    otherwise we could be pausing a batch export that is just now recovering (as old failed runs in 'check_window'
+    contribute to exceeding 'failure_threshold').
+
+    Arguments:
+        batch_export_id: The ID of the batch export to check and pause.
+        check_window: The window of runs to consider for computing a count of failures.
+        failure_threshold: The number of runs that must have failed for a batch export to be paused.
+
+    Returns:
+        A bool indicating if the batch export is paused.
+
+    Raises:
+        ValueError: If 'check_window' is smaller than 'failure_threshold' as that check would be redundant and,
+            likely, a bug.
+    """
+    if check_window < failure_threshold:
+        raise ValueError("'failure_threshold' cannot be higher than 'check_window'")
+
+    count = await sync_to_async(count_failed_batch_export_runs)(uuid.UUID(batch_export_id), last_n=check_window)
+
+    if count < failure_threshold:
+        return False
+
+    client = await connect(
+        settings.TEMPORAL_HOST,
+        settings.TEMPORAL_PORT,
+        settings.TEMPORAL_NAMESPACE,
+        settings.TEMPORAL_CLIENT_ROOT_CA,
+        settings.TEMPORAL_CLIENT_CERT,
+        settings.TEMPORAL_CLIENT_KEY,
+    )
+
+    await sync_to_async(pause_batch_export)(
+        client, batch_export_id=batch_export_id, note="Paused due to exceeding failure threshold"
+    )
+    return True
 
 
 @dataclasses.dataclass

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -406,12 +406,14 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
 
     if batch_export_run.status in (BatchExportRun.Status.FAILED, BatchExportRun.Status.FAILED_RETRYABLE):
         logger.error("Batch export failed with error: %s", batch_export_run.latest_error)
-        from posthog.tasks.email import send_batch_export_run_failure
 
-        try:
-            await send_batch_export_run_failure(inputs.id)
-        except Exception:
-            logger.exception("Failure email notification could not be sent")
+        if batch_export_run.status == BatchExportRun.Status.FAILED:
+            from posthog.tasks.email import send_batch_export_run_failure
+
+            try:
+                await send_batch_export_run_failure(inputs.id)
+            except Exception:
+                logger.exception("Failure email notification could not be sent")
 
     elif batch_export_run.status == BatchExportRun.Status.CANCELLED:
         logger.warning("BatchExport was cancelled.")

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -405,7 +405,13 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
     )
 
     if batch_export_run.status in (BatchExportRun.Status.FAILED, BatchExportRun.Status.FAILED_RETRYABLE):
-        logger.error("BatchExport failed with error: %s", batch_export_run.latest_error)
+        logger.error("Batch export failed with error: %s", batch_export_run.latest_error)
+        from posthog.tasks.email import send_batch_export_run_failure
+
+        try:
+            await send_batch_export_run_failure(inputs.id)
+        except Exception:
+            logger.exception("Failure email notification could not be sent")
 
     elif batch_export_run.status == BatchExportRun.Status.CANCELLED:
         logger.warning("BatchExport was cancelled.")

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -391,11 +391,8 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
         )
 
         finish_inputs = FinishBatchExportRunInputs(
-            id=run_id, status=BatchExportRun.Status.COMPLETED, team_id=inputs.team_id
-        )
-
-        finish_inputs = FinishBatchExportRunInputs(
             id=run_id,
+            batch_export_id=inputs.batch_export_id,
             status=BatchExportRun.Status.COMPLETED,
             team_id=inputs.team_id,
         )

--- a/posthog/temporal/batch_exports/http_batch_export.py
+++ b/posthog/temporal/batch_exports/http_batch_export.py
@@ -339,6 +339,7 @@ class HttpBatchExportWorkflow(PostHogWorkflow):
 
         finish_inputs = FinishBatchExportRunInputs(
             id=run_id,
+            batch_export_id=inputs.batch_export_id,
             status=BatchExportRun.Status.COMPLETED,
             team_id=inputs.team_id,
         )

--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -399,6 +399,7 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
 
         finish_inputs = FinishBatchExportRunInputs(
             id=run_id,
+            batch_export_id=inputs.batch_export_id,
             status=BatchExportRun.Status.COMPLETED,
             team_id=inputs.team_id,
         )

--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -428,6 +428,7 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
 
         finish_inputs = FinishBatchExportRunInputs(
             id=run_id,
+            batch_export_id=inputs.batch_export_id,
             status=BatchExportRun.Status.COMPLETED,
             team_id=inputs.team_id,
         )

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -645,6 +645,7 @@ class S3BatchExportWorkflow(PostHogWorkflow):
 
         finish_inputs = FinishBatchExportRunInputs(
             id=run_id,
+            batch_export_id=inputs.batch_export_id,
             status=BatchExportRun.Status.COMPLETED,
             team_id=inputs.team_id,
         )

--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -591,6 +591,7 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
 
         finish_inputs = FinishBatchExportRunInputs(
             id=run_id,
+            batch_export_id=inputs.batch_export_id,
             status=BatchExportRun.Status.COMPLETED,
             team_id=inputs.team_id,
         )

--- a/posthog/temporal/tests/batch_exports/test_run_updates.py
+++ b/posthog/temporal/tests/batch_exports/test_run_updates.py
@@ -3,6 +3,7 @@ import datetime as dt
 import pytest
 from asgiref.sync import sync_to_async
 
+from posthog.batch_exports.service import disable_and_delete_export, sync_batch_export
 from posthog.models import (
     BatchExport,
     BatchExportDestination,
@@ -63,12 +64,17 @@ def destination(team):
 @pytest.fixture
 def batch_export(destination, team):
     """A test BatchExport."""
-    batch_export = BatchExport.objects.create(name="test export", team=team, destination=destination, interval="hour")
+    batch_export = BatchExport.objects.create(
+        name="test export", team=team, destination=destination, interval="hour", paused=False
+    )
 
     batch_export.save()
 
+    sync_batch_export(batch_export, created=True)
+
     yield batch_export
 
+    disable_and_delete_export(batch_export)
     batch_export.delete()
 
 
@@ -125,6 +131,7 @@ async def test_finish_batch_export_run(activity_environment, team, batch_export)
 
     finish_inputs = FinishBatchExportRunInputs(
         id=str(run_id),
+        batch_export_id=str(batch_export.id),
         status="Completed",
         team_id=inputs.team_id,
     )
@@ -135,3 +142,77 @@ async def test_finish_batch_export_run(activity_environment, team, batch_export)
     assert run is not None
     assert run.status == "Completed"
     assert run.records_total_count == records_total_count
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_finish_batch_export_run_pauses_if_reaching_failure_threshold(activity_environment, team, batch_export):
+    """Test if 'finish_batch_export_run' will pause a batch export upon reaching failure_threshold."""
+    start = dt.datetime(2023, 4, 24, tzinfo=dt.timezone.utc)
+    end = dt.datetime(2023, 4, 25, tzinfo=dt.timezone.utc)
+
+    inputs = StartBatchExportRunInputs(
+        team_id=team.id,
+        batch_export_id=str(batch_export.id),
+        data_interval_start=start.isoformat(),
+        data_interval_end=end.isoformat(),
+    )
+
+    batch_export_id = str(batch_export.id)
+    failure_threshold = 10
+
+    for run_number in range(1, failure_threshold * 2):
+        run_id, _ = await activity_environment.run(start_batch_export_run, inputs)
+
+        finish_inputs = FinishBatchExportRunInputs(
+            id=str(run_id),
+            batch_export_id=batch_export_id,
+            status=BatchExportRun.Status.FAILED,
+            team_id=inputs.team_id,
+            latest_error="Oh No!",
+            failure_threshold=failure_threshold,
+        )
+
+        await activity_environment.run(finish_batch_export_run, finish_inputs)
+        await sync_to_async(batch_export.refresh_from_db)()
+
+        if run_number >= failure_threshold:
+            assert batch_export.paused is True
+        else:
+            assert batch_export.paused is False
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_finish_batch_export_run_never_pauses_with_small_check_window(activity_environment, team, batch_export):
+    """Test if 'finish_batch_export_run' will never pause a batch export with a small check window."""
+    start = dt.datetime(2023, 4, 24, tzinfo=dt.timezone.utc)
+    end = dt.datetime(2023, 4, 25, tzinfo=dt.timezone.utc)
+
+    inputs = StartBatchExportRunInputs(
+        team_id=team.id,
+        batch_export_id=str(batch_export.id),
+        data_interval_start=start.isoformat(),
+        data_interval_end=end.isoformat(),
+    )
+
+    batch_export_id = str(batch_export.id)
+    failure_threshold = 10
+
+    for _ in range(1, failure_threshold * 2):
+        run_id, _ = await activity_environment.run(start_batch_export_run, inputs)
+
+        finish_inputs = FinishBatchExportRunInputs(
+            id=str(run_id),
+            batch_export_id=batch_export_id,
+            status=BatchExportRun.Status.FAILED,
+            team_id=inputs.team_id,
+            latest_error="Oh No!",
+            failure_threshold=failure_threshold,
+            failure_check_window=failure_threshold - 1,
+        )
+
+        await activity_environment.run(finish_batch_export_run, finish_inputs)
+        await sync_to_async(batch_export.refresh_from_db)()
+
+        assert batch_export.paused is False


### PR DESCRIPTION
## Problem

Users are not being properly notified when something goes wrong with their batch exports. This is particularly relevant for `NonRetryableErrors` which require user input to fix (e.g. wrong credentials).

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Send an email notification when a batch export fails. This is done on a best effort basis, as I don't want to continuously fail if something goes wrong with the email sending.

NOTE: These are capped at one email per day per batch export to avoid spam. We achieve this by including the date component in the campaign key. 

Here's how the email looks while testing locally:
![Screenshot 2024-04-16 at 17-48-14 MailDev](https://github.com/PostHog/posthog/assets/18740659/8e79fa30-efcb-49f9-80c7-1bf82d2dcdeb)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

If self-hosted has an email server configured, should work too.

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added unit tests.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
