### PR TITLE
fix: Wait for healthy db when starting temporal

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -169,8 +169,11 @@ services:
         volumes:
             - ./docker/temporal/dynamicconfig:/etc/temporal/config/dynamicconfig
         depends_on:
-            - db
-            - elasticsearch
+            db:
+                condition: service_healthy
+            elasticsearch:
+                condition: service_started
+
     temporal-admin-tools:
         environment:
             - TEMPORAL_CLI_ADDRESS=temporal:7233

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -121,6 +121,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: temporal
+
     temporal-admin-tools:
         extends:
             file: docker-compose.base.yml


### PR DESCRIPTION
## Problem

Temporal is still failing to start when PG is not ready. Temporal service itself should also wait for database to be healthy.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Added a `service_healthy` to the `depends_on` of temporal.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
