### PR TITLE
fix(funnels): actors modal for groups

### DIFF
--- a/posthog/hogql_queries/insights/insight_actors_query_runner.py
+++ b/posthog/hogql_queries/insights/insight_actors_query_runner.py
@@ -20,6 +20,7 @@ from posthog.schema import (
     HogQLQueryResponse,
     StickinessQuery,
     TrendsQuery,
+    FunnelsQuery,
 )
 from posthog.types import InsightActorsQueryNode
 
@@ -83,6 +84,11 @@ class InsightActorsQueryRunner(QueryRunner):
             assert isinstance(self.query, FunnelCorrelationActorsQuery)
             assert isinstance(self.query.source, FunnelCorrelationQuery)
             return self.query.source.source.source.aggregation_group_type_index
+
+        if isinstance(self.source_runner, FunnelsQueryRunner):
+            assert isinstance(self.query, FunnelsActorsQuery)
+            assert isinstance(self.query.source, FunnelsQuery)
+            return self.query.source.aggregation_group_type_index
 
         if (
             isinstance(self.source_runner, StickinessQueryRunner) and isinstance(self.query.source, StickinessQuery)

--- a/posthog/hogql_queries/insights/test/test_insight_actors_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_insight_actors_query_runner.py
@@ -269,3 +269,32 @@ class TestInsightActorsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertEqual([("p1",), ("p2",)], response.results)
+
+    def test_insight_groups_funnels_query(self):
+        self._create_test_groups()
+        self._create_test_events()
+        self.team.timezone = "US/Pacific"
+        self.team.save()
+
+        response = self.select(
+            """
+                select * from (
+                    <ActorsQuery select={['properties.name']}>
+                        <FunnelsActorsQuery funnelStep={2}>
+                            <FunnelsQuery
+                                aggregation_group_type_index={0}
+                                dateRange={<DateRange date_from='2020-01-01' date_to='2020-01-19' />}
+                                series={[<EventsNode event='$pageview' />, <EventsNode event='$pageview' />]}
+                            />
+                        </FunnelsActorsQuery>
+                    </ActorsQuery>
+                )
+                """
+        )
+
+        self.assertEqual(
+            [
+                ("org1",),
+            ],
+            response.results,
+        )


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/21584

## Changes

Takes the group type into account for funnel actors

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added a test. Locally the failures went away when opening a modal.