### PR TITLE
fix(trends): session duration extraction

### DIFF
--- a/posthog/hogql/database/schema/util/session_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/session_where_clause_extractor.py
@@ -239,6 +239,9 @@ class IsTimeOrIntervalConstantVisitor(Visitor[bool]):
     def visit_constant(self, node: ast.Constant) -> bool:
         return True
 
+    def visit_select_query(self, node: ast.SelectQuery) -> bool:
+        return False
+
     def visit_compare_operation(self, node: ast.CompareOperation) -> bool:
         return self.visit(node.left) and self.visit(node.right)
 
@@ -304,6 +307,9 @@ class IsSimpleTimestampFieldExpressionVisitor(Visitor[bool]):
     context: HogQLContext
 
     def visit_constant(self, node: ast.Constant) -> bool:
+        return False
+
+    def visit_select_query(self, node: ast.SelectQuery) -> bool:
         return False
 
     def visit_field(self, node: ast.Field) -> bool:

--- a/posthog/hogql/database/schema/util/test/test_session_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_session_where_clause_extractor.py
@@ -200,6 +200,15 @@ class TestSessionTimestampInliner(ClickhouseTestMixin, APIBaseTest):
         expected = f("((raw_sessions.min_timestamp + toIntervalDay(3)) >= today())")
         assert expected == actual
 
+    def test_subquery_args(self):
+        actual = f(
+            self.inliner.get_inner_where(
+                parse("SELECT * FROM sessions WHERE true = (select false) and less(today(), min_timestamp)")
+            )
+        )
+        expected = f("((raw_sessions.min_timestamp + toIntervalDay(3)) >= today())")
+        assert expected == actual
+
     def test_real_example(self):
         actual = f(
             self.inliner.get_inner_where(


### PR DESCRIPTION
## Problem

The `IsTimeOrIntervalConstantVisitor` and `IsSimpleTimestampFieldExpressionVisitor` fail when encountering subqueries.

This causes cohort-breakdown-based trends insights over the session duration to fail.

## Changes

Adds the missing visitors.

## How did you test this code?

Locally in the browser fetching an insight with filters such as

<img width="1447" alt="image" src="https://github.com/PostHog/posthog/assets/53387/5b51d832-d8be-4e42-a72c-5dddb9361f8e">
