### PR TITLE
fix: Revert back from asgi to wsgi

### DIFF
--- a/unit.json
+++ b/unit.json
@@ -43,8 +43,8 @@
             "processes": 4,
             "working_directory": "/code",
             "path": ".",
-            "module": "posthog.asgi",
-            "protocol": "asgi",
+            "module": "posthog.wsgi",
+            "protocol": "wsgi",
             "user": "nobody",
             "limits": {
                 "requests": 50000


### PR DESCRIPTION


## Problem

Asgi was causing memory issues in recording capture

![image](https://github.com/PostHog/posthog/assets/2088870/a4db34e1-3f24-450c-b930-1483a738e127)
![image](https://github.com/PostHog/posthog/assets/2088870/aea7a1cf-0fd8-4fc1-b564-e6c43e58e9b3)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
