### PR TITLE
fix(cohorts): Restrict query by time range

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -387,7 +387,7 @@
   SELECT behavior_query.person_id AS id
   FROM
     (SELECT pdi.person_id AS person_id,
-            countIf(timestamp > '2024-04-02 13:01:01'
+            countIf(timestamp > 'explicit_timestamp'
                     AND timestamp < now()
                     AND event = '$pageview'
                     AND (has(['something'], replaceRegexpAll(JSONExtractRaw(properties, '$filter_prop'), '^"|"$', '')))) > 0 AS performed_event_condition_None_level_level_0_level_0_0
@@ -401,6 +401,8 @@
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
        AND event IN ['$pageview']
+       AND timestamp <= now()
+       AND timestamp >= now() - INTERVAL 4 day
      GROUP BY person_id) behavior_query
   WHERE 1 = 1
     AND (((performed_event_condition_None_level_level_0_level_0_0)))

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 
-from freezegun import freeze_time
 
 from ee.clickhouse.queries.enterprise_cohort_query import check_negation_clause
 from posthog.client import sync_execute
@@ -233,7 +232,6 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         self.assertEqual([p1.uuid], [r[0] for r in res])
 
     @snapshot_clickhouse_queries
-    @freeze_time("2024-04-05 13:01:01")
     def test_performed_event_with_event_filters_and_explicit_date(self):
         p1 = _create_person(
             team_id=self.team.pk,

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -1949,7 +1949,7 @@
 # ---
 # name: TestExperimentAuxiliaryEndpoints.test_create_exposure_cohort_for_experiment_with_custom_action_filters_exposure.1
   '''
-  /* user_id:31 cohort_calculation:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:115 cohort_calculation:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   INSERT INTO cohortpeople
   SELECT id,
          2 as cohort_id,
@@ -1960,7 +1960,7 @@
     (SELECT behavior_query.person_id AS id
      FROM
        (SELECT pdi.person_id AS person_id,
-               countIf(timestamp > '2024-04-12 16:53:16'
+               countIf(timestamp > '2024-04-12 17:00:59'
                        AND timestamp < now()
                        AND ((event = 'insight viewed'
                              AND (has(['RETENTION'], replaceRegexpAll(JSONExtractRaw(properties, 'insight'), '^"|"$', ''))
@@ -1989,7 +1989,7 @@
                             OR (match(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/123')
                                 AND event = '$autocapture'))
                        AND (has(['bonk'], replaceRegexpAll(JSONExtractRaw(properties, 'bonk'), '^"|"$', ''))
-                            AND ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), tuple('x', 'y')), 0))) > 0 AS performed_event_condition_61_level_level_0_level_0_0
+                            AND ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), tuple('x', 'y')), 0))) > 0 AS performed_event_condition_22_level_level_0_level_0_0
         FROM events e
         INNER JOIN
           (SELECT distinct_id,
@@ -2004,7 +2004,7 @@
           AND timestamp >= now() - INTERVAL 6 day
         GROUP BY person_id) behavior_query
      WHERE 1 = 1
-       AND (((performed_event_condition_61_level_level_0_level_0_0))) ) as person
+       AND (((performed_event_condition_22_level_level_0_level_0_0))) ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -1949,7 +1949,7 @@
 # ---
 # name: TestExperimentAuxiliaryEndpoints.test_create_exposure_cohort_for_experiment_with_custom_action_filters_exposure.1
   '''
-  /* user_id:115 cohort_calculation:posthog.tasks.calculate_cohort.calculate_cohort_ch */
+  /* user_id:31 cohort_calculation:posthog.tasks.calculate_cohort.calculate_cohort_ch */
   INSERT INTO cohortpeople
   SELECT id,
          2 as cohort_id,
@@ -1960,7 +1960,7 @@
     (SELECT behavior_query.person_id AS id
      FROM
        (SELECT pdi.person_id AS person_id,
-               countIf(timestamp > '2024-01-01 10:23:00'
+               countIf(timestamp > '2024-04-12 16:53:16'
                        AND timestamp < now()
                        AND ((event = 'insight viewed'
                              AND (has(['RETENTION'], replaceRegexpAll(JSONExtractRaw(properties, 'insight'), '^"|"$', ''))
@@ -1989,7 +1989,7 @@
                             OR (match(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/123')
                                 AND event = '$autocapture'))
                        AND (has(['bonk'], replaceRegexpAll(JSONExtractRaw(properties, 'bonk'), '^"|"$', ''))
-                            AND ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), tuple('x', 'y')), 0))) > 0 AS performed_event_condition_22_level_level_0_level_0_0
+                            AND ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), tuple('x', 'y')), 0))) > 0 AS performed_event_condition_61_level_level_0_level_0_0
         FROM events e
         INNER JOIN
           (SELECT distinct_id,
@@ -2000,9 +2000,11 @@
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
           AND event IN ['insight viewed', 'insight viewed', '$autocapture']
+          AND timestamp <= now()
+          AND timestamp >= now() - INTERVAL 6 day
         GROUP BY person_id) behavior_query
      WHERE 1 = 1
-       AND (((performed_event_condition_22_level_level_0_level_0_0))) ) as person
+       AND (((performed_event_condition_61_level_level_0_level_0_0))) ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -1960,7 +1960,7 @@
     (SELECT behavior_query.person_id AS id
      FROM
        (SELECT pdi.person_id AS person_id,
-               countIf(timestamp > '2024-04-12 17:00:59'
+               countIf(timestamp > 'explicit_timestamp'
                        AND timestamp < now()
                        AND ((event = 'insight viewed'
                              AND (has(['RETENTION'], replaceRegexpAll(JSONExtractRaw(properties, 'insight'), '^"|"$', ''))

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -16,7 +16,6 @@ from posthog.test.base import (
     _create_event,
     _create_person,
     flush_persons_and_events,
-    snapshot_clickhouse_insert_cohortpeople_queries,
     snapshot_clickhouse_queries,
     FuzzyInt,
 )
@@ -1416,7 +1415,6 @@ class TestExperimentAuxiliaryEndpoints(ClickhouseTestMixin, APILicensedTest):
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(["person1", "person2"], sorted([res["name"] for res in response.json()["results"]]))
 
-    @snapshot_clickhouse_insert_cohortpeople_queries
     def test_create_exposure_cohort_for_experiment_with_custom_action_filters_exposure(self):
         cohort_extra = Cohort.objects.create(
             team=self.team,

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -16,6 +16,7 @@ from posthog.test.base import (
     _create_event,
     _create_person,
     flush_persons_and_events,
+    snapshot_clickhouse_insert_cohortpeople_queries,
     snapshot_clickhouse_queries,
     FuzzyInt,
 )
@@ -1415,6 +1416,7 @@ class TestExperimentAuxiliaryEndpoints(ClickhouseTestMixin, APILicensedTest):
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(["person1", "person2"], sorted([res["name"] for res in response.json()["results"]]))
 
+    @snapshot_clickhouse_insert_cohortpeople_queries
     def test_create_exposure_cohort_for_experiment_with_custom_action_filters_exposure(self):
         cohort_extra = Cohort.objects.create(
             team=self.team,

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -508,6 +508,9 @@ class QueryMatchingTest:
             query,
         )
 
+        # replace explicit timestamps in cohort queries
+        query = re.sub(r"timestamp > '20\d\d-\d\d-\d\d \d\d:\d\d:\d\d'", r"timestamp > 'explicit_timestamp'", query)
+
         # Replace organization_id and notebook_id lookups, for postgres
         query = re.sub(
             rf"""("organization_id"|"posthog_organization"\."id"|"posthog_notebook"."id") = '[^']+'::uuid""",


### PR DESCRIPTION
## Problem

I overlooked the part where we have a time range filter on cohorts, making exposure cohort queries (and any with explicit datetime) run farrr longer than they should 😬 

Fixes that!

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
