### PR TITLE
feat(debug): add query json to debug ch queries

### DIFF
--- a/ee/api/debug_ch_queries.py
+++ b/ee/api/debug_ch_queries.py
@@ -33,13 +33,15 @@ class DebugCHQueries(viewsets.ViewSet):
             SELECT
                 query_id,
                 argMax(query, type) AS query,
+                argMax(query_json, type) AS query_json,
                 argMax(query_start_time, type) AS query_start_time,
                 argMax(exception, type) AS exception,
                 argMax(query_duration_ms, type) AS query_duration_ms,
                 max(type) AS status
             FROM (
                 SELECT
-                    query_id, query, query_start_time, exception, query_duration_ms, toInt8(type) AS type
+                    query_id, query, query_start_time, exception, query_duration_ms, toInt8(type) AS type,
+                    JSONExtractRaw(log_comment, 'query') as query_json
                 FROM clusterAllReplicas(%(cluster)s, system, query_log)
                 WHERE
                     query LIKE %(query)s AND
@@ -62,10 +64,11 @@ class DebugCHQueries(viewsets.ViewSet):
                 {
                     "query_id": resp[0],
                     "query": resp[1],
-                    "timestamp": resp[2],
-                    "exception": resp[3],
-                    "execution_time": resp[4],
-                    "status": resp[5],
+                    "queryJson": resp[2],
+                    "timestamp": resp[3],
+                    "exception": resp[4],
+                    "execution_time": resp[5],
+                    "status": resp[6],
                     "path": self._get_path(resp[1]),
                 }
                 for resp in response

--- a/frontend/src/lib/components/CodeSnippet/CodeSnippet.scss
+++ b/frontend/src/lib/components/CodeSnippet/CodeSnippet.scss
@@ -17,10 +17,6 @@
         right: 0.5rem;
         display: flex;
         gap: 0.5rem;
-
-        .LemonButton .LemonIcon {
-            color: var(--default);
-        }
     }
 
     pre {

--- a/frontend/src/lib/components/CodeSnippet/CodeSnippet.tsx
+++ b/frontend/src/lib/components/CodeSnippet/CodeSnippet.tsx
@@ -103,6 +103,7 @@ export function CodeSnippet({
     const [expanded, setExpanded] = useState(false)
 
     const indexOfLimitNewline = maxLinesWithoutExpansion ? indexOfNth(text, '\n', maxLinesWithoutExpansion) : -1
+    const lineCount = text.split('\n').length
     const displayedText = indexOfLimitNewline === -1 || expanded ? text : text.slice(0, indexOfLimitNewline)
 
     return (
@@ -138,8 +139,11 @@ export function CodeSnippet({
                     size="small"
                     type="secondary"
                     icon={expanded ? <IconCollapse /> : <IconExpand />}
+                    className="mt-1 mb-0"
                 >
-                    {expanded ? 'Collapse' : 'Expand'} snippet
+                    {expanded
+                        ? `Collapse to ${maxLinesWithoutExpansion!} lines`
+                        : `Show ${lineCount - maxLinesWithoutExpansion!} more lines`}
                 </LemonButton>
             )}
         </div>

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -129,14 +129,14 @@ function DebugCHQueries(): JSX.Element {
                                 </span>
                                 {item.queryJson ? (
                                     <div className="flex">
-                                        <LemonButton type="primary" to={urls.debugQuery(item.queryJson)}>
+                                        <LemonButton type="primary" targetBlank to={urls.debugQuery(item.queryJson)}>
                                             {JSON.parse(item.queryJson).kind || 'Debug'}
                                         </LemonButton>
                                         <CopyToClipboardInline
                                             iconStyle={{ color: 'var(--lemon-button-icon-opacity)' }}
                                             className="font-normal text-sm"
                                             explicitValue={item.queryJson}
-                                            description="Query JSON"
+                                            description="query JSON"
                                             selectable
                                         />
                                     </div>

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -1,13 +1,14 @@
+import { IconCodeInsert, IconCopy } from '@posthog/icons'
 import { actions, afterMount, kea, path, reducers, selectors, useActions, useValues } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
-import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { dayjs } from 'lib/dayjs'
 import { IconRefresh } from 'lib/lemon-ui/icons'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { urls } from 'scenes/urls'
 
 import { CodeSnippet, Language } from '../CodeSnippet'
@@ -127,20 +128,6 @@ function DebugCHQueries(): JSX.Element {
                                 <span className="font-mono whitespace-pre">
                                     {dayjs.tz(item.timestamp, 'UTC').tz().format().replace('T', '\n')}
                                 </span>
-                                {item.queryJson ? (
-                                    <div className="flex">
-                                        <LemonButton type="primary" targetBlank to={urls.debugQuery(item.queryJson)}>
-                                            {JSON.parse(item.queryJson).kind || 'Debug'}
-                                        </LemonButton>
-                                        <CopyToClipboardInline
-                                            iconStyle={{ color: 'var(--lemon-button-icon-opacity)' }}
-                                            className="font-normal text-sm"
-                                            explicitValue={item.queryJson}
-                                            description="query JSON"
-                                            selectable
-                                        />
-                                    </div>
-                                ) : null}
                             </div>
                         ),
                         width: 160,
@@ -149,9 +136,9 @@ function DebugCHQueries(): JSX.Element {
                         title: 'Query',
                         render: function query(_, item) {
                             return (
-                                <div className="max-w-200">
+                                <div className="max-w-200 py-1 space-y-2">
                                     {item.exception && (
-                                        <LemonBanner type="error" className="text-xs font-mono mb-2">
+                                        <LemonBanner type="error" className="text-xs font-mono">
                                             {item.exception}
                                         </LemonBanner>
                                     )}
@@ -163,6 +150,25 @@ function DebugCHQueries(): JSX.Element {
                                     >
                                         {item.query}
                                     </CodeSnippet>
+                                    {item.queryJson ? (
+                                        <LemonButton
+                                            type="primary"
+                                            size="small"
+                                            fullWidth
+                                            center
+                                            icon={<IconCodeInsert />}
+                                            to={urls.debugQuery(item.queryJson)}
+                                            targetBlank
+                                            sideAction={{
+                                                icon: <IconCopy />,
+                                                onClick: () => void copyToClipboard(item.queryJson, 'query JSON'),
+                                                tooltip: 'Copy query JSON to clipboard',
+                                            }}
+                                            className="my-0"
+                                        >
+                                            Debug {JSON.parse(item.queryJson).kind || 'query'} in new tab
+                                        </LemonButton>
+                                    ) : null}
                                 </div>
                             )
                         },

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -1,12 +1,14 @@
 import { actions, afterMount, kea, path, reducers, selectors, useActions, useValues } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { dayjs } from 'lib/dayjs'
 import { IconRefresh } from 'lib/lemon-ui/icons'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { urls } from 'scenes/urls'
 
 import { CodeSnippet, Language } from '../CodeSnippet'
 import type { debugCHQueriesLogicType } from './DebugCHQueriesType'
@@ -24,6 +26,7 @@ export interface Query {
     /** @example '2023-07-27T10:06:11' */
     timestamp: string
     query: string
+    queryJson: string
     exception: string
     /**
      * 1 means running, 2 means finished, 3 means errored before execution, 4 means errored during execution.
@@ -120,9 +123,25 @@ function DebugCHQueries(): JSX.Element {
                     {
                         title: 'Timestamp',
                         render: (_, item) => (
-                            <span className="font-mono whitespace-pre">
-                                {dayjs.tz(item.timestamp, 'UTC').tz().format().replace('T', '\n')}
-                            </span>
+                            <div className="space-y-2">
+                                <span className="font-mono whitespace-pre">
+                                    {dayjs.tz(item.timestamp, 'UTC').tz().format().replace('T', '\n')}
+                                </span>
+                                {item.queryJson ? (
+                                    <div className="flex">
+                                        <LemonButton type="primary" to={urls.debugQuery(item.queryJson)}>
+                                            {JSON.parse(item.queryJson).kind || 'Debug'}
+                                        </LemonButton>
+                                        <CopyToClipboardInline
+                                            iconStyle={{ color: 'var(--lemon-button-icon-opacity)' }}
+                                            className="font-normal text-sm"
+                                            explicitValue={item.queryJson}
+                                            description="Query JSON"
+                                            selectable
+                                        />
+                                    </div>
+                                ) : null}
+                            </div>
                         ),
                         width: 160,
                     },
@@ -140,7 +159,7 @@ function DebugCHQueries(): JSX.Element {
                                         language={Language.SQL}
                                         thing="query"
                                         maxLinesWithoutExpansion={5}
-                                        style={{ fontSize: 12 }}
+                                        style={{ fontSize: 12, maxWidth: '60vw' }}
                                     >
                                         {item.query}
                                     </CodeSnippet>

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.scss
@@ -176,7 +176,8 @@
 
                 // Cancel the vertical margin for CodeSnippet actions
                 // This is annoyingly specific, but really needed for CodeSnippet to look good in expanded table rows
-                .CodeSnippet__actions .LemonButton {
+                .CodeSnippet__actions > .LemonButton,
+                .LemonButtonWithSideAction__side-button > .LemonButton {
                     margin-top: 0;
                     margin-bottom: 0;
                 }

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -14,7 +14,6 @@ import { DataTableVisualization } from '../nodes/DataVisualization/DataVisualiza
 import { SavedInsight } from '../nodes/SavedInsight/SavedInsight'
 import { TimeToSeeData } from '../nodes/TimeToSeeData/TimeToSeeData'
 import {
-    isDataNode,
     isDataTableNode,
     isDataVisualizationNode,
     isInsightVizNode,
@@ -88,8 +87,6 @@ export function Query(props: QueryProps): JSX.Element | null {
                 context={queryContext}
             />
         )
-    } else if (isDataNode(query)) {
-        component = <DataNode query={query} cachedResults={props.cachedResults} />
     } else if (isSavedInsightNode(query)) {
         component = <SavedInsight query={query} context={queryContext} />
     } else if (isInsightVizNode(query)) {
@@ -106,6 +103,8 @@ export function Query(props: QueryProps): JSX.Element | null {
         component = <TimeToSeeData query={query} cachedResults={props.cachedResults} />
     } else if (isWebOverviewQuery(query)) {
         component = <WebOverview query={query} cachedResults={props.cachedResults} context={queryContext} />
+    } else {
+        component = <DataNode query={query} cachedResults={props.cachedResults} />
     }
 
     if (component) {


### PR DESCRIPTION
## Problem

No problems, only solutions.

## Changes

Adds a button to open the query node directly under `/debug` from the "Debug CH queries" pane, or to copy it:

<img width="1004" alt="image" src="https://github.com/PostHog/posthog/assets/53387/d916c945-a3c6-4228-8c31-a640e30d6317">

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Opened the modal with different queries.