### PR TITLE
feat: allow asgi/wsgi to be configurable by env var

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,7 +33,7 @@
 !plugin-server/.prettierrc
 !share/GeoLite2-City.mmdb
 !hogvm/python
-!unit.json
+!unit.json.tpl
 !plugin-transpiler/src
 !plugin-transpiler/*.*
 !test-runner-jest.config.js

--- a/bin/docker-server-unit
+++ b/bin/docker-server-unit
@@ -11,6 +11,9 @@ trap 'rm -rf "$PROMETHEUS_MULTIPROC_DIR"' EXIT
 
 export PROMETHEUS_METRICS_EXPORT_PORT=8001
 export STATSD_PORT=${STATSD_PORT:-8125}
+export NGINX_UNIT_PYTHON_PROTOCOL=${NGINX_UNIT_PYTHON_PROTOCOL:-wsgi}
+envsubst < /docker-entrypoint.d/unit.json.tpl > /docker-entrypoint.d/unit.json
+
 
 # We need to run as --user root so that nginx unit can proxy the control socket for stats
 # However each application is run as "nobody"

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -249,7 +249,8 @@ RUN apt-get update && \
     "libpq-dev" \
     "libxmlsec1" \
     "libxmlsec1-dev" \
-    "libxml2"
+    "libxml2" \
+    "gettext-base"
 
 # Install NodeJS 18.
 RUN apt-get install -y --no-install-recommends \
@@ -311,6 +312,6 @@ EXPOSE 8000
 
 # Expose the port from which we serve OpenMetrics data.
 EXPOSE 8001
-COPY unit.json /docker-entrypoint.d/unit.json
+COPY unit.json.tpl /docker-entrypoint.d/unit.json.tpl
 USER root
 CMD ["./bin/docker"]

--- a/unit.json.tpl
+++ b/unit.json.tpl
@@ -43,8 +43,8 @@
             "processes": 4,
             "working_directory": "/code",
             "path": ".",
-            "module": "posthog.wsgi",
-            "protocol": "wsgi",
+            "module": "posthog.$NGINX_UNIT_PYTHON_PROTOCOL",
+            "protocol": "$NGINX_UNIT_PYTHON_PROTOCOL",
             "user": "nobody",
             "limits": {
                 "requests": 50000


### PR DESCRIPTION
## Problem

This will let us roll out asgi separate across services as we had issues with our recordings capture pods on asgi

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
