### PR TITLE
fix(ci): balance frontend tests, split kea typegen

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -154,9 +154,13 @@ jobs:
               if: needs.changes.outputs.frontend == 'true'
               run: pnpm install --frozen-lockfile
 
-            - name: Generate logic types and run typescript with strict
+            - name: Generate logic types
               if: needs.changes.outputs.frontend == 'true'
-              run: pnpm typegen:write && pnpm typescript:check
+              run: pnpm typegen:write
+
+            - name: Run typescript with strict
+              if: needs.changes.outputs.frontend == 'true'
+              run: pnpm typescript:check
 
     jest:
         runs-on: ubuntu-latest
@@ -168,7 +172,7 @@ jobs:
             fail-fast: false
             matrix:
                 segment: ['FOSS', 'EE']
-                chunk: [1, 2, 3]
+                chunk: [1, 2]
 
         steps:
             # we need at least one thing to run to make sure we include everything for required jobs

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -94,10 +94,6 @@ jobs:
               if: needs.changes.outputs.frontend == 'true'
               run: pnpm lint:css
 
-            - name: Generate logic types and run typescript with strict
-              if: needs.changes.outputs.frontend == 'true'
-              run: pnpm typegen:write && pnpm typescript:check
-
             - name: Lint with ESLint
               if: needs.changes.outputs.frontend == 'true'
               run: pnpm lint:js
@@ -119,6 +115,48 @@ jobs:
                   pattern: 'frontend/dist/toolbar.js'
                   # we only care if the toolbar will increase a lot
                   minimum-change-threshold: 1000
+
+    frontend-kea-types:
+        name: Kea type generation
+        needs: changes
+        # kea typegen and typescript:check need some more oomph
+        runs-on: ubuntu-latest
+        steps:
+            # we need at least one thing to run to make sure we include everything for required jobs
+            - uses: actions/checkout@v3
+
+            - name: Install pnpm
+              if: needs.changes.outputs.frontend == 'true'
+              uses: pnpm/action-setup@v2
+              with:
+                  version: 8.x.x
+
+            - name: Set up Node.js
+              if: needs.changes.outputs.frontend == 'true'
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 18.12.1
+
+            - name: Get pnpm cache directory path
+              if: needs.changes.outputs.frontend == 'true'
+              id: pnpm-cache-dir
+              run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+            - uses: actions/cache@v4
+              if: needs.changes.outputs.frontend == 'true'
+              id: pnpm-cache
+              with:
+                  path: ${{ steps.pnpm-cache-dir.outputs.PNPM_STORE_PATH }}
+                  key: ${{ runner.os }}-pnpm-cypress-${{ hashFiles('pnpm-lock.yaml') }}
+                  restore-keys: ${{ runner.os }}-pnpm-cypress-
+
+            - name: Install package.json dependencies with pnpm
+              if: needs.changes.outputs.frontend == 'true'
+              run: pnpm install --frozen-lockfile
+
+            - name: Generate logic types and run typescript with strict
+              if: needs.changes.outputs.frontend == 'true'
+              run: pnpm typegen:write && pnpm typescript:check
 
     jest:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Kea typegen takes up a lot more time in frontend tests compared to everything else

<img width="1719" alt="image" src="https://github.com/PostHog/posthog/assets/53387/9a416a78-2a19-41b7-bda0-a4604dad1c3a">

## Changes

Split to its own runner.

_screenshot WIP_

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
