### PR TITLE
feat: Pause batch export on reaching failure threshold

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -465,6 +465,21 @@ def update_batch_export_run(
     return model.get()
 
 
+def count_failed_batch_export_runs(batch_export_id: UUID, last_n: int) -> int:
+    """Count failed batch export runs in the 'last_n' runs."""
+    count_of_failures = (
+        BatchExportRun.objects.filter(
+            id__in=BatchExportRun.objects.filter(batch_export_id=batch_export_id)
+            .order_by("-last_updated_at")
+            .values("id")[:last_n]
+        )
+        .filter(status=BatchExportRun.Status.FAILED)
+        .count()
+    )
+
+    return count_of_failures
+
+
 def sync_batch_export(batch_export: BatchExport, created: bool):
     workflow, workflow_inputs = DESTINATION_WORKFLOWS[batch_export.destination.type]
     state = ScheduleState(

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -476,7 +476,7 @@ async def pause_batch_export_if_over_failure_threshold(
     could be scattered between these successes.
 
     Keep in mind that if 'check_window' is less than 'failure_threshold', there is no point in even counting,
-    so we immediately return.
+    so we raise an exception.
 
     We check if the count of failed runs in the last 'check_window' runs exceeds 'failure_threshold'. This means
     that 'pause_batch_export_if_over_failure_threshold' should only be called when handling a failed run,
@@ -490,9 +490,13 @@ async def pause_batch_export_if_over_failure_threshold(
 
     Returns:
         A bool indicating if the batch export is paused.
+
+    Raises:
+        ValueError: If 'check_window' is smaller than 'failure_threshold' as that check would be redundant and,
+            likely, a bug.
     """
     if check_window < failure_threshold:
-        return False
+        raise ValueError("'failure_threshold' cannot be higher than 'check_window'")
 
     count = await sync_to_async(count_failed_batch_export_runs)(uuid.UUID(batch_export_id), last_n=check_window)
 

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -14,8 +14,10 @@ from temporalio.common import RetryPolicy
 from posthog.batch_exports.models import BatchExportBackfill, BatchExportRun
 from posthog.batch_exports.service import (
     BatchExportField,
+    count_failed_batch_export_runs,
     create_batch_export_backfill,
     create_batch_export_run,
+    pause_batch_export,
     update_batch_export_backfill_status,
     update_batch_export_run,
 )
@@ -24,6 +26,7 @@ from posthog.temporal.batch_exports.metrics import (
     get_export_started_metric,
 )
 from posthog.temporal.common.clickhouse import ClickHouseClient, get_client
+from posthog.temporal.common.client import connect
 from posthog.temporal.common.logger import bind_temporal_worker_logger
 
 SELECT_QUERY_TEMPLATE = Template(
@@ -370,33 +373,47 @@ class FinishBatchExportRunInputs:
 
     Attributes:
         id: The id of the batch export run. This should be a valid UUID string.
+        batch_export_id: The id of the batch export this run belongs to.
         team_id: The team id of the batch export.
         status: The status this batch export is finishing with.
         latest_error: The latest error message captured, if any.
         records_completed: Number of records successfully exported.
         records_total_count: Total count of records this run noted.
+        failure_threshold: Used when determining to pause a batch export that has failed.
+            See the docstring in 'pause_batch_export_if_over_failure_threshold'.
+        failure_check_window: Used when determining to pause a batch export that has failed.
+            See the docstring in 'pause_batch_export_if_over_failure_threshold'.
     """
 
     id: str
+    batch_export_id: str
     team_id: int
     status: str
     latest_error: str | None = None
     records_completed: int | None = None
     records_total_count: int | None = None
+    failure_threshold: int = 10
+    failure_check_window: int = 50
 
 
 @activity.defn
 async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
-    """Activity that finishes a BatchExportRun.
+    """Activity that finishes a 'BatchExportRun'.
 
-    Finishing means a final update to the status of the BatchExportRun model.
+    Finishing means setting and handling the status of a 'BatchExportRun' model, as well
+    as setting any additional supported model attributes.
+
+    The only status that requires handling is 'FAILED' as we also check if the number of failures in
+    'failure_check_window' exceeds 'failure_threshold' and attempt to pause the batch export if
+    that's the case. Also, a notification is sent to users on every failure.
     """
     logger = await bind_temporal_worker_logger(team_id=inputs.team_id)
 
+    not_model_params = ("id", "team_id", "batch_export_id", "failure_threshold", "failure_check_window")
     update_params = {
         key: value
         for key, value in dataclasses.asdict(inputs).items()
-        if key not in ("id", "team_id") and value is not None
+        if key not in not_model_params and value is not None
     }
     batch_export_run = await sync_to_async(update_batch_export_run)(
         run_id=uuid.UUID(inputs.id),
@@ -415,8 +432,28 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
             except Exception:
                 logger.exception("Failure email notification could not be sent")
 
+        try:
+            was_paused = await pause_batch_export_if_over_failure_threshold(
+                inputs.batch_export_id,
+                check_window=inputs.failure_check_window,
+                failure_threshold=inputs.failure_threshold,
+            )
+        except Exception:
+            # Pausing could error if the underlying schedule is deleted.
+            # Our application logic should prevent that, but I want to log it in case it ever happens
+            # as that would indicate a bug.
+            logger.exception("Batch export could not be automatically paused")
+            was_paused = False
+
+        if was_paused:
+            logger.warning(
+                "Batch export was automatically paused due to exceeding failure threshold and exhausting "
+                "all automated retries."
+                "The batch export can be manually unpaused after addressing any errors."
+            )
+
     elif batch_export_run.status == BatchExportRun.Status.CANCELLED:
-        logger.warning("BatchExport was cancelled.")
+        logger.warning("Batch export was cancelled")
 
     else:
         logger.info(
@@ -424,6 +461,55 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
             batch_export_run.data_interval_start,
             batch_export_run.data_interval_end,
         )
+
+
+async def pause_batch_export_if_over_failure_threshold(
+    batch_export_id: str, check_window: int, failure_threshold: int = 10
+) -> bool:
+    """Pause a batch export if it exceeds failure threshold.
+
+    A 'check_window' was added to account for batch exports that have a history of failures but have some
+    occassional successes in the middle. This is relevant particularly for low-volume exports:
+    A batch export without rows to export always succeeds, even if it's not properly configured. So, the failures
+    could be scattered between these successes.
+
+    Keep in mind that if 'check_window' is less than 'failure_threshold', there is no point in even counting,
+    so we immediately return.
+
+    We check if the count of failed runs in the last 'check_window' runs exceeds 'failure_threshold'. This means
+    that 'pause_batch_export_if_over_failure_threshold' should only be called when handling a failed run,
+    otherwise we could be pausing a batch export that is just now recovering (as old failed runs in 'check_window'
+    contribute to exceeding 'failure_threshold').
+
+    Arguments:
+        batch_export_id: The ID of the batch export to check and pause.
+        check_window: The window of runs to consider for computing a count of failures.
+        failure_threshold: The number of runs that must have failed for a batch export to be paused.
+
+    Returns:
+        A bool indicating if the batch export is paused.
+    """
+    if check_window < failure_threshold:
+        return False
+
+    count = await sync_to_async(count_failed_batch_export_runs)(uuid.UUID(batch_export_id), last_n=check_window)
+
+    if count < failure_threshold:
+        return False
+
+    client = await connect(
+        settings.TEMPORAL_HOST,
+        settings.TEMPORAL_PORT,
+        settings.TEMPORAL_NAMESPACE,
+        settings.TEMPORAL_CLIENT_ROOT_CA,
+        settings.TEMPORAL_CLIENT_CERT,
+        settings.TEMPORAL_CLIENT_KEY,
+    )
+
+    await sync_to_async(pause_batch_export)(
+        client, batch_export_id=batch_export_id, note="Paused due to exceeding failure threshold"
+    )
+    return True
 
 
 @dataclasses.dataclass

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -391,11 +391,8 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
         )
 
         finish_inputs = FinishBatchExportRunInputs(
-            id=run_id, status=BatchExportRun.Status.COMPLETED, team_id=inputs.team_id
-        )
-
-        finish_inputs = FinishBatchExportRunInputs(
             id=run_id,
+            batch_export_id=inputs.batch_export_id,
             status=BatchExportRun.Status.COMPLETED,
             team_id=inputs.team_id,
         )

--- a/posthog/temporal/batch_exports/http_batch_export.py
+++ b/posthog/temporal/batch_exports/http_batch_export.py
@@ -339,6 +339,7 @@ class HttpBatchExportWorkflow(PostHogWorkflow):
 
         finish_inputs = FinishBatchExportRunInputs(
             id=run_id,
+            batch_export_id=inputs.batch_export_id,
             status=BatchExportRun.Status.COMPLETED,
             team_id=inputs.team_id,
         )

--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -399,6 +399,7 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
 
         finish_inputs = FinishBatchExportRunInputs(
             id=run_id,
+            batch_export_id=inputs.batch_export_id,
             status=BatchExportRun.Status.COMPLETED,
             team_id=inputs.team_id,
         )

--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -428,6 +428,7 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
 
         finish_inputs = FinishBatchExportRunInputs(
             id=run_id,
+            batch_export_id=inputs.batch_export_id,
             status=BatchExportRun.Status.COMPLETED,
             team_id=inputs.team_id,
         )

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -645,6 +645,7 @@ class S3BatchExportWorkflow(PostHogWorkflow):
 
         finish_inputs = FinishBatchExportRunInputs(
             id=run_id,
+            batch_export_id=inputs.batch_export_id,
             status=BatchExportRun.Status.COMPLETED,
             team_id=inputs.team_id,
         )

--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -591,6 +591,7 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
 
         finish_inputs = FinishBatchExportRunInputs(
             id=run_id,
+            batch_export_id=inputs.batch_export_id,
             status=BatchExportRun.Status.COMPLETED,
             team_id=inputs.team_id,
         )

--- a/posthog/temporal/tests/batch_exports/test_run_updates.py
+++ b/posthog/temporal/tests/batch_exports/test_run_updates.py
@@ -3,6 +3,7 @@ import datetime as dt
 import pytest
 from asgiref.sync import sync_to_async
 
+from posthog.batch_exports.service import disable_and_delete_export, sync_batch_export
 from posthog.models import (
     BatchExport,
     BatchExportDestination,
@@ -63,12 +64,17 @@ def destination(team):
 @pytest.fixture
 def batch_export(destination, team):
     """A test BatchExport."""
-    batch_export = BatchExport.objects.create(name="test export", team=team, destination=destination, interval="hour")
+    batch_export = BatchExport.objects.create(
+        name="test export", team=team, destination=destination, interval="hour", paused=False
+    )
 
     batch_export.save()
 
+    sync_batch_export(batch_export, created=True)
+
     yield batch_export
 
+    disable_and_delete_export(batch_export)
     batch_export.delete()
 
 
@@ -125,6 +131,7 @@ async def test_finish_batch_export_run(activity_environment, team, batch_export)
 
     finish_inputs = FinishBatchExportRunInputs(
         id=str(run_id),
+        batch_export_id=str(batch_export.id),
         status="Completed",
         team_id=inputs.team_id,
     )
@@ -135,3 +142,77 @@ async def test_finish_batch_export_run(activity_environment, team, batch_export)
     assert run is not None
     assert run.status == "Completed"
     assert run.records_total_count == records_total_count
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_finish_batch_export_run_pauses_if_reaching_failure_threshold(activity_environment, team, batch_export):
+    """Test if 'finish_batch_export_run' will pause a batch export upon reaching failure_threshold."""
+    start = dt.datetime(2023, 4, 24, tzinfo=dt.timezone.utc)
+    end = dt.datetime(2023, 4, 25, tzinfo=dt.timezone.utc)
+
+    inputs = StartBatchExportRunInputs(
+        team_id=team.id,
+        batch_export_id=str(batch_export.id),
+        data_interval_start=start.isoformat(),
+        data_interval_end=end.isoformat(),
+    )
+
+    batch_export_id = str(batch_export.id)
+    failure_threshold = 10
+
+    for run_number in range(1, failure_threshold * 2):
+        run_id, _ = await activity_environment.run(start_batch_export_run, inputs)
+
+        finish_inputs = FinishBatchExportRunInputs(
+            id=str(run_id),
+            batch_export_id=batch_export_id,
+            status=BatchExportRun.Status.FAILED,
+            team_id=inputs.team_id,
+            latest_error="Oh No!",
+            failure_threshold=failure_threshold,
+        )
+
+        await activity_environment.run(finish_batch_export_run, finish_inputs)
+        await sync_to_async(batch_export.refresh_from_db)()
+
+        if run_number >= failure_threshold:
+            assert batch_export.paused is True
+        else:
+            assert batch_export.paused is False
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_finish_batch_export_run_never_pauses_with_small_check_window(activity_environment, team, batch_export):
+    """Test if 'finish_batch_export_run' will never pause a batch export with a small check window."""
+    start = dt.datetime(2023, 4, 24, tzinfo=dt.timezone.utc)
+    end = dt.datetime(2023, 4, 25, tzinfo=dt.timezone.utc)
+
+    inputs = StartBatchExportRunInputs(
+        team_id=team.id,
+        batch_export_id=str(batch_export.id),
+        data_interval_start=start.isoformat(),
+        data_interval_end=end.isoformat(),
+    )
+
+    batch_export_id = str(batch_export.id)
+    failure_threshold = 10
+
+    for _ in range(1, failure_threshold * 2):
+        run_id, _ = await activity_environment.run(start_batch_export_run, inputs)
+
+        finish_inputs = FinishBatchExportRunInputs(
+            id=str(run_id),
+            batch_export_id=batch_export_id,
+            status=BatchExportRun.Status.FAILED,
+            team_id=inputs.team_id,
+            latest_error="Oh No!",
+            failure_threshold=failure_threshold,
+            failure_check_window=failure_threshold - 1,
+        )
+
+        await activity_environment.run(finish_batch_export_run, finish_inputs)
+        await sync_to_async(batch_export.refresh_from_db)()
+
+        assert batch_export.paused is False


### PR DESCRIPTION
## Problem

Batch exports can keep running even if they constantly fail due to non-retryable errors. To save cost, and improve performance for batch exports that are not failing consistently, let's automatically pause batch exports that reach a certain failure threshold.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* On failure, check if failed runs over a given window of last runs exceeds a failure threshold.
  * The threshold is initially set to 10 runs over a window of 50, but happy to hear opinions for different values
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes.
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added unit tests.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
