### PR TITLE
fix(insights): Fix data viz table loading state

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -77,7 +77,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
     )
 
     let component: JSX.Element | null = null
-    if (!response && responseLoading && !showEditingUI) {
+    if (!showEditingUI && (!response || responseLoading)) {
         return (
             <div className="flex flex-col flex-1 justify-center items-center border rounded bg-bg-light">
                 <Animation type={AnimationType.LaptopHog} />


### PR DESCRIPTION
## Problem

Not sure: We don't display the animation, means we don't run into this condition, but no table appears.

## Changes

Maybe due to cache or async or something the response is set. Adjust condition.

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

- couldn't reproduce locally