### PR TITLE
fix: Reduce nginx unit request limit to 7.5k

### DIFF
--- a/unit.json.tpl
+++ b/unit.json.tpl
@@ -47,7 +47,7 @@
             "protocol": "$NGINX_UNIT_PYTHON_PROTOCOL",
             "user": "nobody",
             "limits": {
-                "requests": 50000
+                "requests": 7500
             }
         },
         "metrics": {


### PR DESCRIPTION
## Problem

50k was very high, taking over 3 hours even at busy times to reach this Reduce it to 7.5k which should stop our memory usage creeping up constantly when we aren't deploying

memory usage over an hour:
<img width="367" alt="image" src="https://github.com/PostHog/posthog/assets/2088870/c6e95669-b8ed-4bf1-830e-48f0a1e57d7c">

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
