### PR TITLE
feat: Cancel running backfills on reaching failure threshold

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -1,4 +1,3 @@
-import collections.abc
 import datetime as dt
 import typing
 from dataclasses import asdict, dataclass, fields
@@ -6,7 +5,7 @@ from uuid import UUID
 
 import structlog
 import temporalio
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import async_to_sync
 from temporalio.client import (
     Client,
     Schedule,
@@ -27,6 +26,7 @@ from posthog.batch_exports.models import (
 from posthog.constants import BATCH_EXPORTS_TASK_QUEUE
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.schedule import (
+    a_pause_schedule,
     create_schedule,
     delete_schedule,
     pause_schedule,
@@ -256,6 +256,34 @@ def pause_batch_export(temporal: Client, batch_export_id: str, note: str | None 
     return True
 
 
+async def apause_batch_export(temporal: Client, batch_export_id: str, note: str | None = None) -> bool:
+    """Pause this BatchExport.
+
+    We pass the call to the underlying Temporal Schedule.
+
+    Returns:
+        `True` if the batch export was paused, `False` if it was already paused.
+    """
+    try:
+        batch_export = await BatchExport.objects.aget(id=batch_export_id)
+    except BatchExport.DoesNotExist:
+        raise BatchExportIdError(batch_export_id)
+
+    if batch_export.paused is True:
+        return False
+
+    try:
+        await a_pause_schedule(temporal, schedule_id=batch_export_id, note=note)
+    except Exception as exc:
+        raise BatchExportServiceRPCError(f"BatchExport {batch_export_id} could not be paused") from exc
+
+    batch_export.paused = True
+    batch_export.last_paused_at = dt.datetime.now(dt.timezone.utc)
+    await batch_export.asave()
+
+    return True
+
+
 def unpause_batch_export(
     temporal: Client,
     batch_export_id: str,
@@ -318,9 +346,7 @@ def disable_and_delete_export(instance: BatchExport):
 
     instance.save()
 
-    backfill_iter = iter_running_backfills_for_batch_export(instance.id)
-
-    for backfill in backfill_iter:
+    for backfill in running_backfills_for_batch_export(instance.id):
         async_to_sync(cancel_running_batch_export_backfill)(temporal, backfill)
 
 
@@ -335,13 +361,11 @@ def batch_export_delete_schedule(temporal: Client, schedule_id: str) -> None:
             raise BatchExportServiceRPCError() from e
 
 
-def iter_running_backfills_for_batch_export(batch_export_id: UUID) -> collections.abc.Iterable[BatchExportBackfill]:
+def running_backfills_for_batch_export(batch_export_id: UUID):
     """Return an iterator over running batch export backfills."""
-    return (
-        BatchExportBackfill.objects.filter(batch_export_id=batch_export_id, status=BatchExportBackfill.Status.RUNNING)
-        .select_related("batch_export")
-        .iterator()
-    )
+    return BatchExportBackfill.objects.filter(
+        batch_export_id=batch_export_id, status=BatchExportBackfill.Status.RUNNING
+    ).select_related("batch_export")
 
 
 async def cancel_running_batch_export_backfill(temporal: Client, batch_export_backfill: BatchExportBackfill) -> None:
@@ -355,7 +379,7 @@ async def cancel_running_batch_export_backfill(temporal: Client, batch_export_ba
     await handle.cancel()
 
     batch_export_backfill.status = BatchExportBackfill.Status.CANCELLED
-    await sync_to_async(batch_export_backfill.save)()
+    await batch_export_backfill.asave()
 
 
 @dataclass
@@ -460,6 +484,36 @@ def create_batch_export_run(
     return run
 
 
+async def acreate_batch_export_run(
+    batch_export_id: UUID,
+    data_interval_start: str,
+    data_interval_end: str,
+    status: str = BatchExportRun.Status.STARTING,
+    records_total_count: int | None = None,
+) -> BatchExportRun:
+    """Create a BatchExportRun after a Temporal Workflow execution.
+
+    In a first approach, this method is intended to be called only by Temporal Workflows,
+    as only the Workflows themselves can know when they start.
+
+    Args:
+        batch_export_id: The UUID of the BatchExport the BatchExportRun to create belongs to.
+        data_interval_start: The start of the period of data exported in this BatchExportRun.
+        data_interval_end: The end of the period of data exported in this BatchExportRun.
+        status: The initial status for the created BatchExportRun.
+    """
+    run = BatchExportRun(
+        batch_export_id=batch_export_id,
+        status=status,
+        data_interval_start=dt.datetime.fromisoformat(data_interval_start),
+        data_interval_end=dt.datetime.fromisoformat(data_interval_end),
+        records_total_count=records_total_count,
+    )
+    await run.asave()
+
+    return run
+
+
 def update_batch_export_run(
     run_id: UUID,
     **kwargs,
@@ -483,6 +537,29 @@ def update_batch_export_run(
     return model.get()
 
 
+async def aupdate_batch_export_run(
+    run_id: UUID,
+    **kwargs,
+) -> BatchExportRun:
+    """Update the BatchExportRun with given run_id and provided **kwargs.
+
+    Arguments:
+        run_id: The id of the BatchExportRun to update.
+    """
+    model = BatchExportRun.objects.filter(id=run_id)
+    update_at = dt.datetime.now()
+
+    updated = await model.aupdate(
+        **kwargs,
+        last_updated_at=update_at,
+    )
+
+    if not updated:
+        raise ValueError(f"BatchExportRun with id {run_id} not found.")
+
+    return await model.aget()
+
+
 def count_failed_batch_export_runs(batch_export_id: UUID, last_n: int) -> int:
     """Count failed batch export runs in the 'last_n' runs."""
     count_of_failures = (
@@ -493,6 +570,21 @@ def count_failed_batch_export_runs(batch_export_id: UUID, last_n: int) -> int:
         )
         .filter(status=BatchExportRun.Status.FAILED)
         .count()
+    )
+
+    return count_of_failures
+
+
+async def acount_failed_batch_export_runs(batch_export_id: UUID, last_n: int) -> int:
+    """Count failed batch export runs in the 'last_n' runs."""
+    count_of_failures = (
+        await BatchExportRun.objects.filter(
+            id__in=BatchExportRun.objects.filter(batch_export_id=batch_export_id)
+            .order_by("-last_updated_at")
+            .values("id")[:last_n]
+        )
+        .filter(status=BatchExportRun.Status.FAILED)
+        .acount()
     )
 
     return count_of_failures
@@ -571,6 +663,35 @@ def create_batch_export_backfill(
     return backfill
 
 
+async def acreate_batch_export_backfill(
+    batch_export_id: UUID,
+    team_id: int,
+    start_at: str,
+    end_at: str | None,
+    status: str = BatchExportRun.Status.RUNNING,
+) -> BatchExportBackfill:
+    """Create a BatchExportBackfill.
+
+
+    Args:
+        batch_export_id: The UUID of the BatchExport the BatchExportBackfill to create belongs to.
+        team_id: The id of the Team the BatchExportBackfill to create belongs to.
+        start_at: The start of the period to backfill in this BatchExportBackfill.
+        end_at: The end of the period to backfill in this BatchExportBackfill.
+        status: The initial status for the created BatchExportBackfill.
+    """
+    backfill = BatchExportBackfill(
+        batch_export_id=batch_export_id,
+        status=status,
+        start_at=dt.datetime.fromisoformat(start_at),
+        end_at=dt.datetime.fromisoformat(end_at) if end_at else None,
+        team_id=team_id,
+    )
+    await backfill.asave()
+
+    return backfill
+
+
 def update_batch_export_backfill_status(backfill_id: UUID, status: str) -> BatchExportBackfill:
     """Update the status of an BatchExportBackfill with given id.
 
@@ -585,3 +706,19 @@ def update_batch_export_backfill_status(backfill_id: UUID, status: str) -> Batch
         raise ValueError(f"BatchExportBackfill with id {backfill_id} not found.")
 
     return model.get()
+
+
+async def aupdate_batch_export_backfill_status(backfill_id: UUID, status: str) -> BatchExportBackfill:
+    """Update the status of an BatchExportBackfill with given id.
+
+    Arguments:
+        id: The id of the BatchExportBackfill to update.
+        status: The new status to assign to the BatchExportBackfill.
+    """
+    model = BatchExportBackfill.objects.filter(id=backfill_id)
+    updated = await model.aupdate(status=status)
+
+    if not updated:
+        raise ValueError(f"BatchExportBackfill with id {backfill_id} not found.")
+
+    return await model.aget()

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -265,7 +265,7 @@ async def apause_batch_export(temporal: Client, batch_export_id: str, note: str 
         `True` if the batch export was paused, `False` if it was already paused.
     """
     try:
-        batch_export = await BatchExport.objects.aget(id=batch_export_id)
+        batch_export = await BatchExport.objects.aget(id=batch_export_id)  # type: ignore
     except BatchExport.DoesNotExist:
         raise BatchExportIdError(batch_export_id)
 
@@ -379,7 +379,7 @@ async def cancel_running_batch_export_backfill(temporal: Client, batch_export_ba
     await handle.cancel()
 
     batch_export_backfill.status = BatchExportBackfill.Status.CANCELLED
-    await batch_export_backfill.asave()
+    await batch_export_backfill.asave()  # type: ignore
 
 
 @dataclass
@@ -509,7 +509,7 @@ async def acreate_batch_export_run(
         data_interval_end=dt.datetime.fromisoformat(data_interval_end),
         records_total_count=records_total_count,
     )
-    await run.asave()
+    await run.asave()  # type: ignore
 
     return run
 
@@ -549,7 +549,7 @@ async def aupdate_batch_export_run(
     model = BatchExportRun.objects.filter(id=run_id)
     update_at = dt.datetime.now()
 
-    updated = await model.aupdate(
+    updated = await model.aupdate(  # type: ignore
         **kwargs,
         last_updated_at=update_at,
     )
@@ -557,7 +557,7 @@ async def aupdate_batch_export_run(
     if not updated:
         raise ValueError(f"BatchExportRun with id {run_id} not found.")
 
-    return await model.aget()
+    return await model.aget()  # type: ignore
 
 
 def count_failed_batch_export_runs(batch_export_id: UUID, last_n: int) -> int:
@@ -584,7 +584,7 @@ async def acount_failed_batch_export_runs(batch_export_id: UUID, last_n: int) ->
             .values("id")[:last_n]
         )
         .filter(status=BatchExportRun.Status.FAILED)
-        .acount()
+        .acount()  # type: ignore
     )
 
     return count_of_failures
@@ -687,7 +687,7 @@ async def acreate_batch_export_backfill(
         end_at=dt.datetime.fromisoformat(end_at) if end_at else None,
         team_id=team_id,
     )
-    await backfill.asave()
+    await backfill.asave()  # type: ignore
 
     return backfill
 
@@ -716,9 +716,9 @@ async def aupdate_batch_export_backfill_status(backfill_id: UUID, status: str) -
         status: The new status to assign to the BatchExportBackfill.
     """
     model = BatchExportBackfill.objects.filter(id=backfill_id)
-    updated = await model.aupdate(status=status)
+    updated = await model.aupdate(status=status)  # type: ignore
 
     if not updated:
         raise ValueError(f"BatchExportBackfill with id {backfill_id} not found.")
 
-    return await model.aget()
+    return await model.aget()  # type: ignore

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -335,7 +335,7 @@ def batch_export_delete_schedule(temporal: Client, schedule_id: str) -> None:
             raise BatchExportServiceRPCError() from e
 
 
-def iter_running_backfills_for_batch_export(batch_export_id: str) -> collections.abc.Iterable[BatchExportBackfill]:
+def iter_running_backfills_for_batch_export(batch_export_id: UUID) -> collections.abc.Iterable[BatchExportBackfill]:
     """Return an iterator over running batch export backfills."""
     return (
         BatchExportBackfill.objects.filter(batch_export_id=batch_export_id, status=BatchExportBackfill.Status.RUNNING)

--- a/posthog/temporal/batch_exports/backfill_batch_export.py
+++ b/posthog/temporal/batch_exports/backfill_batch_export.py
@@ -5,13 +5,13 @@ import datetime as dt
 import json
 import typing
 
-from asgiref.sync import sync_to_async
 import temporalio
 import temporalio.activity
 import temporalio.client
 import temporalio.common
 import temporalio.exceptions
 import temporalio.workflow
+from asgiref.sync import sync_to_async
 from django.conf import settings
 
 from posthog.batch_exports.models import BatchExportBackfill

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -429,10 +429,13 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
 
         from posthog.tasks.email import send_batch_export_run_failure
 
-        try:
-            await send_batch_export_run_failure(inputs.id)
-        except Exception:
-            logger.exception("Failure email notification could not be sent")
+        if batch_export_run.status == BatchExportRun.Status.FAILED:
+            from posthog.tasks.email import send_batch_export_run_failure
+
+            try:
+                await send_batch_export_run_failure(inputs.id)
+            except Exception:
+                logger.exception("Failure email notification could not be sent")
 
         try:
             was_paused = await pause_batch_export_if_over_failure_threshold(

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -570,7 +570,7 @@ async def cancel_running_backfills(batch_export_id: str) -> int:
 
     total_cancelled = 0
 
-    backfill_iter = iter_running_backfills_for_batch_export(batch_export_id)
+    backfill_iter = iter_running_backfills_for_batch_export(uuid.UUID(batch_export_id))
     backfills = await sync_to_async(list)(backfill_iter)  # type: ignore
 
     for backfill in backfills:

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -432,10 +432,12 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
         if batch_export_run.status == BatchExportRun.Status.FAILED:
             from posthog.tasks.email import send_batch_export_run_failure
 
-            try:
-                await send_batch_export_run_failure(inputs.id)
-            except Exception:
-                logger.exception("Failure email notification could not be sent")
+        from posthog.tasks.email import send_batch_export_run_failure
+
+        try:
+            await send_batch_export_run_failure(inputs.id)
+        except Exception:
+            logger.exception("Failure email notification could not be sent")
 
         try:
             was_paused = await pause_batch_export_if_over_failure_threshold(

--- a/posthog/temporal/common/schedule.py
+++ b/posthog/temporal/common/schedule.py
@@ -80,6 +80,12 @@ async def pause_schedule(temporal: Client, schedule_id: str, note: str | None = 
     await handle.pause(note=note)
 
 
+async def a_pause_schedule(temporal: Client, schedule_id: str, note: str | None = None) -> None:
+    """Pause a Temporal Schedule."""
+    handle = temporal.get_schedule_handle(schedule_id)
+    await handle.pause(note=note)
+
+
 @async_to_sync
 async def trigger_schedule(temporal: Client, schedule_id: str, note: str | None = None) -> None:
     """Trigger a Temporal Schedule."""

--- a/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
+++ b/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
@@ -1,6 +1,6 @@
 import datetime as dt
-from unittest import mock
 import uuid
+from unittest import mock
 
 import pytest
 import pytest_asyncio
@@ -10,6 +10,7 @@ import temporalio.common
 import temporalio.exceptions
 import temporalio.testing
 import temporalio.worker
+from asgiref.sync import sync_to_async
 from django.conf import settings
 
 from posthog.temporal.batch_exports.backfill_batch_export import (
@@ -21,11 +22,15 @@ from posthog.temporal.batch_exports.backfill_batch_export import (
     get_schedule_frequency,
     wait_for_schedule_backfill_in_range,
 )
+from posthog.temporal.tests.utils.datetimes import date_range
+from posthog.temporal.tests.utils.events import (
+    generate_test_events_in_clickhouse,
+)
 from posthog.temporal.tests.utils.models import (
     acreate_batch_export,
     adelete_batch_export,
-    afetch_batch_export_backfills,
     afetch_batch_export,
+    afetch_batch_export_backfills,
 )
 
 pytestmark = [pytest.mark.asyncio]
@@ -354,3 +359,94 @@ async def test_backfill_batch_export_workflow_fails_when_schedule_deleted_after_
     assert isinstance(err.__cause__, temporalio.exceptions.ActivityError)
     assert isinstance(err.__cause__.__cause__, temporalio.exceptions.ApplicationError)
     assert err.__cause__.__cause__.type == "TemporalScheduleNotFoundError"
+
+
+@pytest_asyncio.fixture
+async def failing_s3_batch_export(ateam, temporal_client):
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "this-bucket-doesn't-exist",
+            "region": "us-east-1",
+            "prefix": "/",
+            "aws_access_key_id": "object_storage_root_user",
+            "aws_secret_access_key": "object_storage_root_password",
+            "endpoint_url": settings.OBJECT_STORAGE_ENDPOINT,
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": destination_data,
+        "interval": "every 5 minutes",
+    }
+
+    batch_export = await acreate_batch_export(
+        team_id=ateam.pk,
+        name=batch_export_data["name"],
+        destination_data=batch_export_data["destination"],
+        interval=batch_export_data["interval"],
+    )
+
+    yield batch_export
+
+    await adelete_batch_export(batch_export, temporal_client)
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_backfill_batch_export_workflow_is_cancelled_on_repeated_failures(
+    temporal_worker, failing_s3_batch_export, temporal_client, ateam, clickhouse_client
+):
+    """Test BackfillBatchExportWorkflow will be cancelled on repeated failures."""
+    start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
+    end_at = dt.datetime(2023, 1, 1, 1, 0, 0, tzinfo=dt.timezone.utc)
+
+    # We need some data otherwise the S3 batch export will not fail as it short-circuits.
+    for d in date_range(start_at, end_at, dt.timedelta(minutes=5)):
+        await generate_test_events_in_clickhouse(
+            client=clickhouse_client,
+            team_id=ateam.pk,
+            start_time=start_at,
+            end_time=end_at,
+            count=10,
+            inserted_at=d,
+        )
+
+    inputs = BackfillBatchExportInputs(
+        team_id=ateam.pk,
+        batch_export_id=str(failing_s3_batch_export.id),
+        start_at=start_at.isoformat(),
+        end_at=end_at.isoformat(),
+        buffer_limit=2,
+        wait_delay=1.0,
+    )
+
+    # Need to recreate the specific ID the app would use when triggering a backfill
+    start_at_str = start_at.strftime("%Y-%m-%dT%H:%M:%S")
+    end_at_str = end_at.strftime("%Y-%m-%dT%H:%M:%S")
+    backfill_id = f"{failing_s3_batch_export.id}-Backfill-{start_at_str}-{end_at_str}"
+
+    handle = await temporal_client.start_workflow(
+        BackfillBatchExportWorkflow.run,
+        inputs,
+        id=backfill_id,
+        task_queue=settings.TEMPORAL_TASK_QUEUE,
+        execution_timeout=dt.timedelta(minutes=2),
+        retry_policy=temporalio.common.RetryPolicy(maximum_attempts=1),
+    )
+
+    with pytest.raises(temporalio.client.WorkflowFailureError) as exc_info:
+        await handle.result()
+
+    err = exc_info.value
+    assert isinstance(err.__cause__, temporalio.exceptions.CancelledError)
+
+    await sync_to_async(failing_s3_batch_export.refresh_from_db)()
+    assert failing_s3_batch_export.paused is True
+
+    backfills = await afetch_batch_export_backfills(batch_export_id=failing_s3_batch_export.id)
+
+    assert len(backfills) == 1, "Expected one backfill to have been created"
+
+    backfill = backfills.pop()
+    assert backfill.status == "Cancelled"

--- a/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
+++ b/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
@@ -375,7 +375,7 @@ async def failing_s3_batch_export(ateam, temporal_client):
         },
     }
 
-    batch_export_data = {
+    failing_batch_export_data = {
         "name": "my-production-s3-bucket-destination",
         "destination": destination_data,
         "interval": "every 5 minutes",
@@ -383,9 +383,11 @@ async def failing_s3_batch_export(ateam, temporal_client):
 
     batch_export = await acreate_batch_export(
         team_id=ateam.pk,
-        name=batch_export_data["name"],
-        destination_data=batch_export_data["destination"],
-        interval=batch_export_data["interval"],
+        # I don't know what is mypy's problem with all these parameters.
+        # The types are correct, the values are hardcoded just above.
+        name=failing_batch_export_data["name"],  # type: ignore
+        destination_data=failing_batch_export_data["destination"],  # type: ignore
+        interval=failing_batch_export_data["interval"],  # type: ignore
     )
 
     yield batch_export


### PR DESCRIPTION
## Problem

Besides pausing batch exports when they exceed a failure threshold, they should also cancel any ongoing backfills.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Cancel ongoing backfills when finishing a batch export if reached failure threshold.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added a unit test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
