### PR TITLE
chore(data-warehouse): update schema should pause, unpause, or create schedules

### DIFF
--- a/posthog/tasks/warehouse.py
+++ b/posthog/tasks/warehouse.py
@@ -45,7 +45,7 @@ def check_synced_row_limits_of_team(team_id: int) -> None:
                 logger.exception("Could not cancel external data workflow", exc_info=e)
 
             try:
-                pause_external_data_schedule(job.pipeline)
+                pause_external_data_schedule(str(job.pipeline.id))
             except Exception as e:
                 logger.exception("Could not pause external data schedule", exc_info=e)
 
@@ -58,7 +58,7 @@ def check_synced_row_limits_of_team(team_id: int) -> None:
         all_sources = ExternalDataSource.objects.filter(team_id=team_id, status=ExternalDataSource.Status.PAUSED)
         for source in all_sources:
             try:
-                unpause_external_data_schedule(source)
+                unpause_external_data_schedule(str(source.id))
             except Exception as e:
                 logger.exception("Could not unpause external data schedule", exc_info=e)
 

--- a/posthog/temporal/common/schedule.py
+++ b/posthog/temporal/common/schedule.py
@@ -93,6 +93,16 @@ async def a_trigger_schedule(temporal: Client, schedule_id: str, note: str | Non
     await handle.trigger()
 
 
+@async_to_sync
+async def schedule_exists(temporal: Client, schedule_id: str) -> bool:
+    """Check whether a schedule exists."""
+    try:
+        await temporal.get_schedule_handle(schedule_id).describe()
+        return True
+    except:
+        return False
+
+
 async def a_schedule_exists(temporal: Client, schedule_id: str) -> bool:
     """Check whether a schedule exists."""
     try:

--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -32,7 +32,6 @@ from posthog.warehouse.models import (
     ExternalDataJob,
     get_active_schemas_for_source_id,
     ExternalDataSource,
-    aget_schema_by_id,
 )
 from posthog.temporal.common.logger import bind_temporal_worker_logger
 from typing import Dict
@@ -118,12 +117,6 @@ async def check_schedule_activity(inputs: ExternalDataWorkflowInputs) -> bool:
         # Delete the source schedule in favour of the schema schedules
         await a_delete_external_data_schedule(ExternalDataSource(id=inputs.external_data_source_id))
         logger.info(f"Deleted schedule for source {inputs.external_data_source_id}")
-        return True
-
-    schema_model = await aget_schema_by_id(inputs.external_data_schema_id, inputs.team_id)
-
-    # schema turned off so don't sync
-    if schema_model and not schema_model.should_sync:
         return True
 
     logger.info("Schema ID is set. Continuing...")

--- a/posthog/warehouse/data_load/service.py
+++ b/posthog/warehouse/data_load/service.py
@@ -21,6 +21,7 @@ from posthog.temporal.common.schedule import (
     create_schedule,
     pause_schedule,
     a_schedule_exists,
+    schedule_exists,
     trigger_schedule,
     update_schedule,
     delete_schedule,
@@ -110,19 +111,24 @@ async def a_trigger_external_data_workflow(external_data_schema: ExternalDataSch
     await a_trigger_schedule(temporal, schedule_id=str(external_data_schema.id))
 
 
+def external_data_workflow_exists(id: str) -> bool:
+    temporal = sync_connect()
+    return schedule_exists(temporal, schedule_id=id)
+
+
 async def a_external_data_workflow_exists(id: str) -> bool:
     temporal = await async_connect()
     return await a_schedule_exists(temporal, schedule_id=id)
 
 
-def pause_external_data_schedule(external_data_source: ExternalDataSource):
+def pause_external_data_schedule(id: str):
     temporal = sync_connect()
-    pause_schedule(temporal, schedule_id=str(external_data_source.id))
+    pause_schedule(temporal, schedule_id=id)
 
 
-def unpause_external_data_schedule(external_data_source: ExternalDataSource):
+def unpause_external_data_schedule(id: str):
     temporal = sync_connect()
-    unpause_schedule(temporal, schedule_id=str(external_data_source.id))
+    unpause_schedule(temporal, schedule_id=id)
 
 
 def delete_external_data_schedule(schedule_id: str):


### PR DESCRIPTION
## Problem

- schema updates don't create/unpause/pause schedules

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- make sure schema creates new schedule

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
