### PR TITLE
fix(insights): retention time display on card

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/TopHeading.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/TopHeading.tsx
@@ -32,8 +32,11 @@ export function TopHeading({ insight }: { insight: InsightModel }): JSX.Element 
         }
     }
 
-    const defaultDateRange = query == undefined || isInsightQueryNode(query) ? 'Last 7 days' : null
-    const dateText = dateFilterToText(date_from, date_to, defaultDateRange)
+    let dateText: string | null = null
+    if (insightType?.name !== 'Retention') {
+        const defaultDateRange = query == undefined || isInsightQueryNode(query) ? 'Last 7 days' : null
+        dateText = dateFilterToText(date_from, date_to, defaultDateRange)
+    }
     return (
         <>
             <span title={insightType?.description}>{insightType?.name}</span>


### PR DESCRIPTION
## Problem

The retention chart always says "last 7 days", despite already showing weeks of data in the table:

<img width="1032" alt="Screenshot 2024-04-19 at 14 25 42" src="https://github.com/PostHog/posthog/assets/53387/01c45cd9-5d13-4091-9435-430cd2df845b">

## Changes

Removes "Last 7 days"

<img width="499" alt="Screenshot 2024-04-19 at 14 28 00" src="https://github.com/PostHog/posthog/assets/53387/9df17e40-8f46-493d-8baa-996a6e74fb0b">

## How did you test this code?

Looked at it in the UI. Hoping for some visual snapshots.