### PR TITLE
fix: Use team id in email URL

### DIFF
--- a/posthog/templates/email/batch_export_run_failure.html
+++ b/posthog/templates/email/batch_export_run_failure.html
@@ -9,7 +9,7 @@
 </p>
 
 <div class="mb mt text-center">
-  <a href="https://us.posthog.com/project/{{ team }}/batch_exports/{{ id }}"
+  <a href="{% absolute_uri '/project' %}/{{ team.id }}/batch_exports/{{ id }}"
      target="_blank"><b>Go to the batch export</b></a>
 </div>
 


### PR DESCRIPTION
## Problem

Batch export emails are currently using the project name, not id in the URL. For example, just got this one:

```
https://us.posthog.com/project/{{ team.name }}/batch_exports/{{ batch_export.id }}
```
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Explicitly use `{{ team.id }}`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
