### PR TITLE
chore: Bump timestamp bounds in batch exports

### DIFF
--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -51,7 +51,7 @@ TIMESTAMP_PREDICATES = """
 -- These 'timestamp' checks are a heuristic to exploit the sort key.
 -- Ideally, we need a schema that serves our needs, i.e. with a sort key on the _timestamp field used for batch exports.
 -- As a side-effect, this heuristic will discard historical loads older than a day.
-AND timestamp >= toDateTime64({data_interval_start}, 6, 'UTC') - INTERVAL 2 DAY
+AND timestamp >= toDateTime64({data_interval_start}, 6, 'UTC') - INTERVAL 4 DAY
 AND timestamp < toDateTime64({data_interval_end}, 6, 'UTC') + INTERVAL 1 DAY
 """
 


### PR DESCRIPTION
## Problem

With the index materialized, this should provide some relief to folks who ingest events with delay and cannot then batch export them. The ultimate solution is a projection, which we will be trying out soon, but in the meantime this change does provide some value.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Extend timestamp bounds from 2 days to 4 days, maybe will do up to 1 week in a follow-up PR after monitoring how this behaves.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
