### PR TITLE
fix(insights): Fix share/embed overflow hidden

### DIFF
--- a/frontend/src/exporter/Exporter.tsx
+++ b/frontend/src/exporter/Exporter.tsx
@@ -34,7 +34,7 @@ export function Exporter(props: ExportedData): JSX.Element {
         window.parent?.postMessage({ event: 'posthog:dimensions', name: window.name, height, width }, '*')
     }, [height, width])
 
-    useThemedHtml()
+    useThemedHtml(false)
 
     return (
         <div

--- a/frontend/src/lib/hooks/useThemedHtml.ts
+++ b/frontend/src/lib/hooks/useThemedHtml.ts
@@ -5,14 +5,16 @@ import { sceneLogic } from 'scenes/sceneLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
-export function useThemedHtml(): void {
+export function useThemedHtml(overflowHidden = true): void {
     const { isDarkModeOn } = useValues(themeLogic)
     const { sceneConfig } = useValues(sceneLogic)
 
     useEffect(() => {
         document.body.setAttribute('theme', isDarkModeOn ? 'dark' : 'light')
         // overflow-hidden since each area handles scrolling individually (e.g. navbar, scene, side panel)
-        document.body.classList.add('overflow-hidden')
+        if (overflowHidden) {
+            document.body.classList.add('overflow-hidden')
+        }
     }, [isDarkModeOn])
 
     useEffect(() => {


### PR DESCRIPTION
## Problem

A shared insight is not scrollable.

## Changes

Turns out here is overflow hidden on the body since #20542 
Remove it for exports/embeds

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

- 👀 