### PR TITLE
fix(insights): timeless value chart actors modals

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/tooltip-data.ts
+++ b/frontend/src/scenes/insights/views/LineGraph/tooltip-data.ts
@@ -19,7 +19,10 @@ export function createTooltipData(
                 datasetIndex: dp.datasetIndex,
                 dotted: !!pointDataset?.dotted,
                 breakdown_value:
-                    pointDataset?.breakdown_value ?? pointDataset?.breakdownValues?.[dp.dataIndex] ?? undefined,
+                    pointDataset?.breakdown_value ??
+                    pointDataset?.breakdownLabels?.[dp.dataIndex] ??
+                    pointDataset?.breakdownValues?.[dp.dataIndex] ??
+                    undefined,
                 compare_label: pointDataset?.compare_label ?? pointDataset?.compareLabels?.[dp.dataIndex] ?? undefined,
                 action: pointDataset?.action ?? pointDataset?.actions?.[dp.dataIndex] ?? undefined,
                 label: pointDataset?.label ?? pointDataset.labels?.[dp.dataIndex] ?? undefined,

--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -13,10 +13,10 @@ import {
     isNullBreakdown,
     isOtherBreakdown,
 } from 'scenes/insights/utils'
+import { datasetToActorsQuery } from 'scenes/trends/viz/datasetToActorsQuery'
 
 import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { NodeKind } from '~/queries/schema'
 import { isInsightVizNode, isTrendsQuery } from '~/queries/utils'
 import { ChartParams, GraphType } from '~/types'
 
@@ -121,10 +121,7 @@ export function ActionsHorizontalBar({ showPersonsModal = true }: ChartParams): 
                           if (isTrendsQueryWithFeatureFlagOn) {
                               openPersonsModal({
                                   title: label || '',
-                                  query: {
-                                      kind: NodeKind.InsightActorsQuery,
-                                      source: query.source,
-                                  },
+                                  query: datasetToActorsQuery({ dataset, query: query.source, index }),
                                   additionalSelect: {
                                       value_at_data_point: 'event_count',
                                       matched_recordings: 'matched_recordings',

--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -6,13 +6,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useEffect, useState } from 'react'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
-import {
-    BREAKDOWN_NULL_DISPLAY,
-    BREAKDOWN_OTHER_DISPLAY,
-    formatBreakdownLabel,
-    isNullBreakdown,
-    isOtherBreakdown,
-} from 'scenes/insights/utils'
+import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { datasetToActorsQuery } from 'scenes/trends/viz/datasetToActorsQuery'
 
 import { cohortsModel } from '~/models/cohortsModel'
@@ -47,17 +41,12 @@ export function ActionsHorizontalBar({ showPersonsModal = true }: ChartParams): 
 
         setData([
             {
-                labels: _data.map((item) =>
-                    isOtherBreakdown(item.label)
-                        ? BREAKDOWN_OTHER_DISPLAY
-                        : isNullBreakdown(item.label)
-                        ? BREAKDOWN_NULL_DISPLAY
-                        : item.label
-                ),
+                labels: _data.map((item) => item.label),
                 data: _data.map((item) => item.aggregated_value),
                 actions: _data.map((item) => item.action),
                 personsValues: _data.map((item) => item.persons),
-                breakdownValues: _data.map((item) => {
+                breakdownValues: _data.map((item) => item.breakdown_value),
+                breakdownLabels: _data.map((item) => {
                     return formatBreakdownLabel(
                         cohorts,
                         formatPropertyValueForDisplay,

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -6,10 +6,10 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { capitalizeFirstLetter, isMultiSeriesFormula } from 'lib/utils'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { datasetToActorsQuery } from 'scenes/trends/viz/datasetToActorsQuery'
 
 import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { NodeKind } from '~/queries/schema'
 import { isInsightVizNode, isLifecycleQuery, isStickinessQuery, isTrendsQuery } from '~/queries/utils'
 import { ChartDisplayType, ChartParams, GraphType } from '~/types'
 
@@ -143,15 +143,7 @@ export function ActionsLineGraph({
                           ) {
                               openPersonsModal({
                                   title,
-                                  query: {
-                                      kind: NodeKind.InsightActorsQuery,
-                                      source: query.source,
-                                      day,
-                                      status: dataset.status,
-                                      series: dataset.action?.order ?? 0,
-                                      breakdown: dataset.breakdown_value,
-                                      compare: dataset.compare_label,
-                                  },
+                                  query: datasetToActorsQuery({ dataset, query: query.source, day }),
                                   additionalSelect: isLifecycle
                                       ? {}
                                       : {

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -10,13 +10,7 @@ import { useEffect, useState } from 'react'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
-import {
-    BREAKDOWN_NULL_DISPLAY,
-    BREAKDOWN_OTHER_DISPLAY,
-    formatBreakdownLabel,
-    isNullBreakdown,
-    isOtherBreakdown,
-} from 'scenes/insights/utils'
+import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { PieChart } from 'scenes/insights/views/LineGraph/PieChart'
 import { datasetToActorsQuery } from 'scenes/trends/viz/datasetToActorsQuery'
 
@@ -77,16 +71,11 @@ export function ActionsPie({
         setData([
             {
                 id: 0,
-                labels: _data.map((item) =>
-                    isOtherBreakdown(item.label)
-                        ? BREAKDOWN_OTHER_DISPLAY
-                        : isNullBreakdown(item.label)
-                        ? BREAKDOWN_NULL_DISPLAY
-                        : item.label
-                ),
+                labels: _data.map((item) => item.label),
                 data: _data.map((item) => item.aggregated_value),
                 actions: _data.map((item) => item.action),
-                breakdownValues: _data.map((item) => {
+                breakdownValues: _data.map((item) => item.breakdown_value),
+                breakdownLabels: _data.map((item) => {
                     return formatBreakdownLabel(
                         cohorts,
                         formatPropertyValueForDisplay,
@@ -96,6 +85,7 @@ export function ActionsPie({
                         false
                     )
                 }),
+                compareLabels: _data.map((item) => item.compare_label),
                 personsValues: _data.map((item) => item.persons),
                 days,
                 backgroundColor: colorList,

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -10,12 +10,18 @@ import { useEffect, useState } from 'react'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
-import { formatBreakdownLabel } from 'scenes/insights/utils'
+import {
+    BREAKDOWN_NULL_DISPLAY,
+    BREAKDOWN_OTHER_DISPLAY,
+    formatBreakdownLabel,
+    isNullBreakdown,
+    isOtherBreakdown,
+} from 'scenes/insights/utils'
 import { PieChart } from 'scenes/insights/views/LineGraph/PieChart'
+import { datasetToActorsQuery } from 'scenes/trends/viz/datasetToActorsQuery'
 
 import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { NodeKind } from '~/queries/schema'
 import { isInsightVizNode, isTrendsQuery } from '~/queries/utils'
 import { ChartDisplayType, ChartParams, GraphDataset, GraphType } from '~/types'
 
@@ -71,7 +77,13 @@ export function ActionsPie({
         setData([
             {
                 id: 0,
-                labels: _data.map((item) => item.label),
+                labels: _data.map((item) =>
+                    isOtherBreakdown(item.label)
+                        ? BREAKDOWN_OTHER_DISPLAY
+                        : isNullBreakdown(item.label)
+                        ? BREAKDOWN_NULL_DISPLAY
+                        : item.label
+                ),
                 data: _data.map((item) => item.aggregated_value),
                 actions: _data.map((item) => item.action),
                 breakdownValues: _data.map((item) => {
@@ -114,10 +126,7 @@ export function ActionsPie({
                   if (isTrendsQueryWithFeatureFlagOn) {
                       openPersonsModal({
                           title: label || '',
-                          query: {
-                              kind: NodeKind.InsightActorsQuery,
-                              source: query.source,
-                          },
+                          query: datasetToActorsQuery({ dataset, query: query.source, index }),
                           additionalSelect: {
                               value_at_data_point: 'event_count',
                               matched_recordings: 'matched_recordings',

--- a/frontend/src/scenes/trends/viz/datasetToActorsQuery.ts
+++ b/frontend/src/scenes/trends/viz/datasetToActorsQuery.ts
@@ -9,19 +9,19 @@ interface DatasetToActorsQueryProps {
 }
 
 export function datasetToActorsQuery({ query, dataset, day, index }: DatasetToActorsQueryProps): InsightActorsQuery {
+    const breakdown =
+        dataset.breakdown_value ??
+        (index !== undefined && Array.isArray(dataset.breakdownValues) ? dataset.breakdownValues[index] : undefined)
+    const compare =
+        dataset.compare_label ??
+        (index !== undefined && Array.isArray(dataset.compareLabels) ? dataset.compareLabels[index] : undefined)
     return {
         kind: NodeKind.InsightActorsQuery,
         source: query,
         day,
         status: dataset.status,
         series: dataset.action?.order ?? 0,
-        breakdown:
-            dataset.breakdown_value ??
-            (index !== undefined && Array.isArray(dataset.breakdownValues)
-                ? dataset.breakdownValues[index]
-                : undefined),
-        compare:
-            dataset.compare_label ??
-            (index !== undefined && Array.isArray(dataset.compareLabels) ? dataset.compareLabels[index] : undefined),
+        breakdown,
+        compare,
     }
 }

--- a/frontend/src/scenes/trends/viz/datasetToActorsQuery.ts
+++ b/frontend/src/scenes/trends/viz/datasetToActorsQuery.ts
@@ -1,0 +1,27 @@
+import { InsightActorsQuery, NodeKind } from '~/queries/schema'
+import { GraphDataset } from '~/types'
+
+interface DatasetToActorsQueryProps {
+    dataset: GraphDataset
+    query: InsightActorsQuery['source']
+    day?: string | number
+    index?: number
+}
+
+export function datasetToActorsQuery({ query, dataset, day, index }: DatasetToActorsQueryProps): InsightActorsQuery {
+    return {
+        kind: NodeKind.InsightActorsQuery,
+        source: query,
+        day,
+        status: dataset.status,
+        series: dataset.action?.order ?? 0,
+        breakdown:
+            dataset.breakdown_value ??
+            (index !== undefined && Array.isArray(dataset.breakdownValues)
+                ? dataset.breakdownValues[index]
+                : undefined),
+        compare:
+            dataset.compare_label ??
+            (index !== undefined && Array.isArray(dataset.compareLabels) ? dataset.compareLabels[index] : undefined),
+    }
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3113,11 +3113,13 @@ export type GraphDataset = ChartDataset<ChartType> &
         id: number
         /** Toggled on to draw incompleteness lines in LineGraph.tsx */
         dotted?: boolean
-        /** Array of breakdown values used only in ActionsHorizontalBar.tsx data */
+        /** Array of breakdown values used only in ActionsHorizontalBar/ActionsPie.tsx data */
         breakdownValues?: (string | number | undefined)[]
-        /** Array of compare labels used only in ActionsHorizontalBar.tsx data */
+        /** Array of breakdown labels used only in ActionsHorizontalBar/ActionsPie.tsx data */
+        breakdownLabels?: (string | number | undefined)[]
+        /** Array of compare labels used only in ActionsHorizontalBar/ActionsPie.tsx data */
         compareLabels?: (CompareLabelType | undefined)[]
-        /** Array of persons ussed only in (ActionsHorizontalBar|ActionsPie).tsx */
+        /** Array of persons used only in (ActionsHorizontalBar|ActionsPie).tsx */
         personsValues?: (Person | undefined)[]
         index?: number
         /** Value (count) for specific data point; only valid in the context of an xy intercept */

--- a/posthog/hogql_queries/insights/trends/breakdown.py
+++ b/posthog/hogql_queries/insights/trends/breakdown.py
@@ -131,7 +131,12 @@ class Breakdown:
             )
 
         # No need to filter if we're showing the "other" bucket, as we need to look at all events anyway.
-        if self.query.breakdownFilter is not None and not self.query.breakdownFilter.breakdown_hide_other_aggregation:
+        # Except when explicitly filtering
+        if (
+            self.query.breakdownFilter is not None
+            and not self.query.breakdownFilter.breakdown_hide_other_aggregation
+            and len(self.breakdown_values_override or []) == 0
+        ):
             return ast.Constant(value=True)
 
         if (

--- a/posthog/hogql_queries/insights/trends/display.py
+++ b/posthog/hogql_queries/insights/trends/display.py
@@ -12,6 +12,7 @@ class TrendsDisplay:
         else:
             self.display_type = ChartDisplayType.ActionsAreaGraph
 
+    # No time range
     def should_aggregate_values(self) -> bool:
         return (
             self.display_type == ChartDisplayType.BoldNumber

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -10,6 +10,7 @@ from posthog.hogql import ast
 from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS, LimitContext
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.query import INCREASED_MAX_EXECUTION_TIME
+from posthog.hogql_queries.insights.trends.breakdown_values import BREAKDOWN_OTHER_DISPLAY
 from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQueryRunner
 from posthog.models.cohort.cohort import Cohort
 from posthog.models.property_definition import PropertyDefinition
@@ -1792,7 +1793,7 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert response.day is not None
         assert response.series == [InsightActorsQuerySeries(label="$pageview", value=0)]
         assert response.breakdown == [
-            BreakdownItem(label="Other", value="$$_posthog_breakdown_other_$$"),
+            BreakdownItem(label=BREAKDOWN_OTHER_DISPLAY, value="$$_posthog_breakdown_other_$$"),
             BreakdownItem(label="Chrome", value="Chrome"),
             BreakdownItem(label="Firefox", value="Firefox"),
             BreakdownItem(label="Safari", value="Safari"),

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -1784,19 +1784,18 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             IntervalType.day,
             [EventsNode(event="$pageview")],
             None,
-            BreakdownFilter(breakdown_type=BreakdownType.event, breakdown="$browser"),
+            BreakdownFilter(breakdown_type=BreakdownType.event, breakdown="$browser", breakdown_limit=3),
         )
 
         response = runner.to_actors_query_options()
 
+        assert response.day is not None
         assert response.series == [InsightActorsQuerySeries(label="$pageview", value=0)]
-
         assert response.breakdown == [
-            # BreakdownItem(label="Other", value="$$_posthog_breakdown_other_$$"), # TODO: uncomment when "other" shows correct results
+            BreakdownItem(label="Other", value="$$_posthog_breakdown_other_$$"),
             BreakdownItem(label="Chrome", value="Chrome"),
             BreakdownItem(label="Firefox", value="Firefox"),
             BreakdownItem(label="Safari", value="Safari"),
-            BreakdownItem(label="Edge", value="Edge"),
         ]
 
     def test_to_actors_query_options_breakdowns_boolean(self):
@@ -1904,7 +1903,30 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert response.series == [InsightActorsQuerySeries(label="$pageview", value=0)]
 
         assert response.breakdown == [
-            # BreakdownItem(label="Other", value="$$_posthog_breakdown_other_$$"), # TODO: uncomment when "other" shows correct results
+            BreakdownItem(label="Chrome", value="Chrome"),
+            BreakdownItem(label="Firefox", value="Firefox"),
+            BreakdownItem(label="Safari", value="Safari"),
+            BreakdownItem(label="Edge", value="Edge"),
+        ]
+
+    def test_to_actors_query_options_bar_value(self):
+        self._create_test_events()
+        flush_persons_and_events()
+
+        runner = self._create_query_runner(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.day,
+            [EventsNode(event="$pageview")],
+            TrendsFilter(display=ChartDisplayType.ActionsBarValue),
+            BreakdownFilter(breakdown_type=BreakdownType.event, breakdown="$browser"),
+        )
+
+        response = runner.to_actors_query_options()
+
+        assert response.day is None
+        assert response.series == [InsightActorsQuerySeries(label="$pageview", value=0)]
+        assert response.breakdown == [
             BreakdownItem(label="Chrome", value="Chrome"),
             BreakdownItem(label="Firefox", value="Firefox"),
             BreakdownItem(label="Safari", value="Safari"),

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -189,13 +189,17 @@ class TrendsQueryRunner(QueryRunner):
         res_compare: List[CompareItem] | None = None
 
         # Days
-        res_days: list[DayItem] = [
-            DayItem(
-                label=format_label_date(value, self.query_date_range.interval_name),
-                value=value,
-            )
-            for value in self.query_date_range.all_values()
-        ]
+        res_days: Optional[list[DayItem]] = (
+            None
+            if self._trends_display.should_aggregate_values()
+            else [
+                DayItem(
+                    label=format_label_date(value, self.query_date_range.interval_name),
+                    value=value,
+                )
+                for value in self.query_date_range.all_values()
+            ]
+        )
 
         # Series
         for index, series in enumerate(self.query.series):


### PR DESCRIPTION
## Problem

Fixes https://posthoghelp.zendesk.com/agent/tickets/12256 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15458)

Opening an actors modal on a pie chart or bar value chart gave the following:

<img width="642" alt="image" src="https://github.com/PostHog/posthog/assets/53387/5f5c8132-fe60-4a91-80f0-063240664f90">

- The time field was there even though it's never used
- Nothing was preselected
- Selecting a breakdown option wouldn't do anything

## Changes

- Fixed all of the above
- Fixes selecting "Other" on the pie chart (copied what the bar chart was doing)

## Does this work well for both Cloud and self-hosted?

Ja ja

## How did you test this code?

Tested all the combinations locally, added a test to make sure we don't return the "day" option anymore.