### PR TITLE
fix(data-warehouse): Fixed the toast message for updated views

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/dataWarehouseSceneLogic.ts
+++ b/frontend/src/scenes/data-warehouse/external/dataWarehouseSceneLogic.ts
@@ -176,9 +176,9 @@ export const dataWarehouseSceneLogic = kea<dataWarehouseSceneLogicType>([
         selectRow: () => {
             actions.setIsEditingSavedQuery(false)
         },
-        updateDataWarehouseSavedQuerySuccess: async (_, view) => {
+        updateDataWarehouseSavedQuerySuccess: async ({ payload }) => {
             actions.setIsEditingSavedQuery(false)
-            lemonToast.success(`${view.name} successfully updated`)
+            lemonToast.success(`${payload?.name ?? 'View'} successfully updated`)
         },
     })),
     afterMount(({ actions, values }) => {


### PR DESCRIPTION
## Problem
- When updating a saved view, the toast would use the name of the Kea `breakpoint` function as the name of the view instead of the actual view name

<img width="468" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/9081a014-98f9-44ee-96ed-fe90807f8988">

## Changes
- Use the actual view name in the toast

<img width="503" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/67bc239b-f68e-4173-bafb-4cb54ec5bbce">


## Does this work well for both Cloud and self-hosted?
- Yes

## How did you test this code?
- Browser