### PR TITLE
fix(filters): regex on numbers

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -237,7 +237,10 @@ def property_to_expr(
         elif operator == PropertyOperator.regex:
             return ast.Call(
                 name="ifNull",
-                args=[ast.Call(name="match", args=[field, ast.Constant(value=value)]), ast.Constant(value=False)],
+                args=[
+                    ast.Call(name="match", args=[ast.Call(name="toString", args=[field]), ast.Constant(value=value)]),
+                    ast.Constant(value=False),
+                ],
             )
         elif operator == PropertyOperator.not_regex:
             return ast.Call(
@@ -245,7 +248,11 @@ def property_to_expr(
                 args=[
                     ast.Call(
                         name="not",
-                        args=[ast.Call(name="match", args=[field, ast.Constant(value=value)])],
+                        args=[
+                            ast.Call(
+                                name="match", args=[ast.Call(name="toString", args=[field]), ast.Constant(value=value)]
+                            )
+                        ],
                     ),
                     ast.Constant(value=True),
                 ],

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -140,11 +140,11 @@ class TestProperty(BaseTest):
         )
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "a", "value": ".*", "operator": "regex"}),
-            self._parse_expr("ifNull(match(properties.a, '.*'), false)"),
+            self._parse_expr("ifNull(match(toString(properties.a), '.*'), false)"),
         )
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "a", "value": ".*", "operator": "not_regex"}),
-            self._parse_expr("ifNull(not(match(properties.a, '.*')), true)"),
+            self._parse_expr("ifNull(not(match(toString(properties.a), '.*')), true)"),
         )
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "a", "value": [], "operator": "exact"}),

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -217,7 +217,9 @@ class TestProperty(BaseTest):
         )
         self.assertEqual(
             self._property_to_expr({"type": "event", "key": "a", "value": ["b", "c"], "operator": "regex"}),
-            self._parse_expr("ifNull(match(properties.a, 'b'), false) or ifNull(match(properties.a, 'c'), false)"),
+            self._parse_expr(
+                "ifNull(match(toString(properties.a), 'b'), false) or ifNull(match(toString(properties.a), 'c'), false)"
+            ),
         )
         # negative
         self.assertEqual(
@@ -245,7 +247,7 @@ class TestProperty(BaseTest):
                 }
             ),
             self._parse_expr(
-                "ifNull(not(match(properties.a, 'b')), true) and ifNull(not(match(properties.a, 'c')), true)"
+                "ifNull(not(match(toString(properties.a), 'b')), true) and ifNull(not(match(toString(properties.a), 'c')), true)"
             ),
         )
 


### PR DESCRIPTION
## Problem

Numeric event/person properties plus the regex operator errored out. [Reported here](https://posthoghelp.zendesk.com/agent/tickets/12480)

## Changes

When using regex property filters, convert all inputs to string first.

## How did you test this code?

Updated the tests