### PR TITLE
fix(insights): empty property filters

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -34,6 +34,7 @@ from posthog.schema import (
     PropertyGroupFilterValue,
     FilterLogicalOperator,
     RetentionEntity,
+    EmptyPropertyFilter,
 )
 
 
@@ -118,12 +119,13 @@ def property_to_expr(
             return ast.And(exprs=[property_to_expr(p, team, scope) for p in property.values])
         else:
             return ast.Or(exprs=[property_to_expr(p, team, scope) for p in property.values])
+    elif isinstance(property, EmptyPropertyFilter):
+        return ast.Constant(value=True)
     elif isinstance(property, BaseModel):
         try:
             property = Property(**property.dict())
         except ValueError:
             # The property was saved as an incomplete object. Instead of crashing the entire query, pretend it's not there.
-            # TODO: revert this when removing legacy insights?
             return ast.Constant(value=True)
     else:
         raise NotImplementedError(f"property_to_expr with property of type {type(property).__name__} not implemented")

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -24,7 +24,7 @@ from posthog.models import (
 )
 from posthog.models.property import PropertyGroup
 from posthog.models.property_definition import PropertyType
-from posthog.schema import HogQLPropertyFilter, PropertyOperator, RetentionEntity
+from posthog.schema import HogQLPropertyFilter, PropertyOperator, RetentionEntity, EmptyPropertyFilter
 from posthog.test.base import BaseTest
 
 elements_chain_match = lambda x: parse_expr("elements_chain =~ {regex}", {"regex": ast.Constant(value=str(x))})
@@ -157,6 +157,10 @@ class TestProperty(BaseTest):
         self.assertEqual(
             self._parse_expr("1"),
             self._property_to_expr({}),  # incomplete event
+        )
+        self.assertEqual(
+            self._parse_expr("1"),
+            self._property_to_expr(EmptyPropertyFilter()),  # type: ignore
         )
 
     def test_property_to_expr_boolean(self):


### PR DESCRIPTION
## Problem

Sometimes you can get a state where we send and empty property filter to the backend: https://posthog.slack.com/archives/C045L1VEG87/p1713879019202549

## Changes

Instead of crashing, the backend will now ignore it.

## How did you test this code?

Test