### PR TITLE
fix: Add Cache-Control: no-store to render_template function

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -420,7 +420,7 @@ def render_template(
 
     html = template.render(context, request=request)
     response = HttpResponse(html)
-    if not user.request.is_anonymous:
+    if not request.user.is_anonymous:
         patch_cache_control(response, no_store=True)
     return response
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -46,6 +46,7 @@ from django.db.utils import DatabaseError
 from django.http import HttpRequest, HttpResponse
 from django.template.loader import get_template
 from django.utils import timezone
+from django.utils.cache import patch_cache_control
 from rest_framework.request import Request
 from sentry_sdk import configure_scope
 from sentry_sdk.api import capture_exception
@@ -418,7 +419,10 @@ def render_template(
     context["posthog_js_uuid_version"] = settings.POSTHOG_JS_UUID_VERSION
 
     html = template.render(context, request=request)
-    return HttpResponse(html)
+    response = HttpResponse(html)
+    if not user.request.is_anonymous:
+        patch_cache_control(response, no_store=True)
+    return response
 
 
 def get_self_capture_api_token(request: Optional[HttpRequest]) -> Optional[str]:


### PR DESCRIPTION
## Problem
Our web app responses should not be cached as they can contain private information that can be retrieved by e.g. hitting the back button after logging out

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
