### PR TITLE
fix: replay web schema

### DIFF
--- a/ee/frontend/mobile-replay/schema/web/rr-web-schema.json
+++ b/ee/frontend/mobile-replay/schema/web/rr-web-schema.json
@@ -617,6 +617,9 @@
                 "id": {
                     "type": "number"
                 },
+                "loop": {
+                    "type": "boolean"
+                },
                 "muted": {
                     "type": "boolean"
                 },


### PR DESCRIPTION
## Problem

CI is failing because of an out of date schema

Caused when upgrading in https://github.com/PostHog/posthog/pull/21734 (https://github.com/rrweb-io/rrweb/releases/tag/rrweb%402.0.0-alpha.13)

Reported https://posthog.slack.com/archives/C03PB072FMJ/p1713889566497079

## Changes

Ran `mobile-replay:web:schema:build:json` locally