### PR TITLE
fix: Batch export edit form in new UI to have 1 destination selector

### DIFF
--- a/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
@@ -39,6 +39,7 @@ export function BatchExportsEditForm(props: BatchExportsEditLogicProps): JSX.Ele
                         formKey="batchExportConfigForm"
                         className="space-y-4"
                     >
+                        <BatchExportGeneralEditFields isNew={isNew} batchExportConfigForm={batchExportConfigForm} />
                         <div className="space-y-4 max-w-200 w-full ">
                             <LemonDivider />
                             <LemonField name="destination" label="Destination">

--- a/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
@@ -20,6 +20,7 @@ export function BatchExportsEditForm(props: BatchExportsEditLogicProps): JSX.Ele
     const { isNew, batchExportConfigForm, isBatchExportConfigFormSubmitting, batchExportConfigLoading } =
         useValues(logic)
     const { submitBatchExportConfigForm, cancelEditing } = useActions(logic)
+    const { user } = useValues(userLogic)
 
     return (
         <>
@@ -38,7 +39,26 @@ export function BatchExportsEditForm(props: BatchExportsEditLogicProps): JSX.Ele
                         formKey="batchExportConfigForm"
                         className="space-y-4"
                     >
-                        <BatchExportsEditFields isNew={isNew} batchExportConfigForm={batchExportConfigForm} />
+                        <div className="space-y-4 max-w-200 w-full ">
+                            <LemonDivider />
+                            <LemonField name="destination" label="Destination">
+                                <LemonSelect
+                                    options={[
+                                        { value: 'BigQuery', label: 'BigQuery' },
+                                        { value: 'Postgres', label: 'PostgreSQL' },
+                                        { value: 'Redshift', label: 'Redshift' },
+                                        { value: 'S3', label: 'S3' },
+                                        { value: 'Snowflake', label: 'Snowflake' },
+                                        ...(user?.is_impersonated ? [{ value: 'HTTP', label: 'HTTP' }] : []),
+                                    ]}
+                                />
+                            </LemonField>
+                        </div>
+                        {!batchExportConfigForm.destination ? (
+                            <p className="text-muted-alt italic">Select a destination to continue configuring</p>
+                        ) : (
+                            <BatchExportsEditFields isNew={isNew} batchExportConfigForm={batchExportConfigForm} />
+                        )}
 
                         <div className="flex gap-4">
                             <LemonButton
@@ -66,7 +86,7 @@ export function BatchExportsEditForm(props: BatchExportsEditLogicProps): JSX.Ele
     )
 }
 
-export function BatchExportsEditFields({
+export function BatchExportGeneralEditFields({
     isNew,
     isPipeline = false,
     batchExportConfigForm,
@@ -76,7 +96,6 @@ export function BatchExportsEditFields({
     batchExportConfigForm: BatchExportConfigurationForm
 }): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
-    const { user } = useValues(userLogic)
     const highFrequencyBatchExports = featureFlags[FEATURE_FLAGS.HIGH_FREQUENCY_BATCH_EXPORTS]
 
     return (
@@ -136,10 +155,17 @@ export function BatchExportsEditFields({
                     )}
                 </div>
 
-                <LemonBanner type="info">
-                    This batch exporter will schedule regular batch exports at your indicated interval until the end
-                    date. Once you have configured your exporter, you can trigger a manual export for historic data.
-                </LemonBanner>
+                {isPipeline ? (
+                    <LemonBanner type="info">
+                        The export will be created in a paused state, once configured your exporter, you can trigger a
+                        manual export for historic data or start the continous export.
+                    </LemonBanner>
+                ) : (
+                    <LemonBanner type="info">
+                        This batch exporter will schedule regular batch exports at your indicated interval until the end
+                        date. Once you have configured your exporter, you can trigger a manual export for historic data.
+                    </LemonBanner>
+                )}
 
                 {isNew && !isPipeline ? (
                     <LemonField name="paused">
@@ -161,25 +187,21 @@ export function BatchExportsEditFields({
                     </LemonField>
                 ) : null}
             </div>
+        </>
+    )
+}
 
-            <div className="space-y-4 max-w-200 w-full ">
-                <LemonDivider />
-                <LemonField name="destination" label="Destination">
-                    <LemonSelect
-                        options={[
-                            { value: 'BigQuery', label: 'BigQuery' },
-                            { value: 'Postgres', label: 'PostgreSQL' },
-                            { value: 'Redshift', label: 'Redshift' },
-                            { value: 'S3', label: 'S3' },
-                            { value: 'Snowflake', label: 'Snowflake' },
-                            ...(user?.is_impersonated ? [{ value: 'HTTP', label: 'HTTP' }] : []),
-                        ]}
-                    />
-                </LemonField>
-
-                {!batchExportConfigForm.destination ? (
-                    <p className="text-muted-alt italic">Select a destination to continue configuring</p>
-                ) : batchExportConfigForm.destination === 'S3' ? (
+export function BatchExportsEditFields({
+    isNew,
+    batchExportConfigForm,
+}: {
+    isNew: boolean
+    batchExportConfigForm: BatchExportConfigurationForm
+}): JSX.Element {
+    return (
+        <>
+            <div className="space-y-4 max-w-200">
+                {batchExportConfigForm.destination === 'S3' ? (
                     <>
                         <div className="flex gap-4">
                             <LemonField name="bucket_name" label="Bucket" className="flex-1">

--- a/frontend/src/scenes/pipeline/PipelineNodeConfiguration.tsx
+++ b/frontend/src/scenes/pipeline/PipelineNodeConfiguration.tsx
@@ -7,7 +7,7 @@ import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import React from 'react'
-import { BatchExportsEditFields } from 'scenes/batch_exports/BatchExportEditForm'
+import { BatchExportGeneralEditFields, BatchExportsEditFields } from 'scenes/batch_exports/BatchExportEditForm'
 import { BatchExportConfigurationForm } from 'scenes/batch_exports/batchExportEditLogic'
 import { getConfigSchemaArray, isValidField } from 'scenes/pipeline/configUtils'
 import { PluginField } from 'scenes/plugins/edit/PluginField'
@@ -183,10 +183,13 @@ function BatchExportConfigurationFields({
     formValues: Record<string, any>
 }): JSX.Element {
     return (
-        <BatchExportsEditFields
-            isNew={isNew}
-            isPipeline
-            batchExportConfigForm={formValues as BatchExportConfigurationForm}
-        />
+        <>
+            <BatchExportGeneralEditFields
+                isNew={isNew}
+                isPipeline
+                batchExportConfigForm={formValues as BatchExportConfigurationForm}
+            />
+            <BatchExportsEditFields isNew={isNew} batchExportConfigForm={formValues as BatchExportConfigurationForm} />
+        </>
     )
 }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
In the new UI we had 2 batch export destination selection options

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
