### PR TITLE
fix(celery): Run celery locally as a single worker

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,6 @@
                 "--scheduler",
                 "redbeat.RedBeatScheduler",
                 "--without-heartbeat",
-                "--without-gossip",
                 "--without-mingle",
                 "--pool=solo",
                 "-Ofair",

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -7,7 +7,7 @@ trap 'kill $(jobs -p)' EXIT
 source ./bin/celery-queues.env
 
 # start celery worker with heartbeat (-B)
-SKIP_ASYNC_MIGRATIONS_SETUP=0 CELERY_WORKER_QUEUES=$CELERY_WORKER_QUEUES celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-mingle -Ofair -n node@%h &
+SKIP_ASYNC_MIGRATIONS_SETUP=0 CELERY_WORKER_QUEUES=$CELERY_WORKER_QUEUES celery -A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-mingle --pool=solo -Ofair -n node@%h &
 
 if [[ "$PLUGIN_SERVER_IDLE" != "1" && "$PLUGIN_SERVER_IDLE" != "true" ]]; then
   ./bin/plugin-server


### PR DESCRIPTION
## Problem
- Running Celery locally via the `start-worker` script attempts to fork the worker process, but this is failing for some reason
- See [Slack thread](https://posthog.slack.com/archives/C0113360FFV/p1713895234854239)

## Changes
- Align the `start-worker` script and VSCode launch config to the PyCharm launch config
  - This uses the `--pool=solo` parameter to run only a single worker and not as a pool

## How did you test this code?
- No more errors locally 