### PR TITLE
fix(filters): group property types

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -267,17 +267,30 @@ def property_to_expr(
 
         # For Boolean and untyped properties, treat "true" and "false" as boolean values
         if (
-            op == ast.CompareOperationOp.Eq
-            or op == ast.CompareOperationOp.NotEq
+            (op == ast.CompareOperationOp.Eq or op == ast.CompareOperationOp.NotEq)
             and team is not None
             and (value == "true" or value == "false")
         ):
-            property_types = PropertyDefinition.objects.filter(
-                team=team,
-                name=property.key,
-                type=PropertyDefinition.Type.PERSON if property.type == "person" else PropertyDefinition.Type.EVENT,
-            )[0:1].values_list("property_type", flat=True)
-            property_type = property_types[0] if property_types else None
+            if property.type == "person":
+                property_types = PropertyDefinition.objects.filter(
+                    team=team,
+                    name=property.key,
+                    type=PropertyDefinition.Type.PERSON,
+                )
+            elif property.type == "group":
+                property_types = PropertyDefinition.objects.filter(
+                    team=team,
+                    name=property.key,
+                    type=PropertyDefinition.Type.GROUP,
+                    group_type_index=property.group_type_index,
+                )
+            else:
+                property_types = PropertyDefinition.objects.filter(
+                    team=team,
+                    name=property.key,
+                    type=PropertyDefinition.Type.EVENT,
+                )
+            property_type = property_types[0].property_type if len(property_types) > 0 else None
 
             if property_type == PropertyType.Boolean:
                 if value == "true":

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -68,17 +68,6 @@ class TestProperty(BaseTest):
         )
 
     def test_property_to_expr_group(self):
-        PropertyDefinition.objects.create(
-            team=self.team,
-            name="boolean_prop",
-            type=PropertyDefinition.Type.GROUP,
-            group_type_index=0,
-            property_type=PropertyType.Boolean,
-        )
-        self.assertEqual(
-            self._property_to_expr({"type": "group", "group_type_index": 0, "key": "boolean_prop", "value": ["true"]}),
-            self._parse_expr("group_0.properties.boolean_prop = true"),
-        )
         self.assertEqual(
             self._property_to_expr({"type": "group", "group_type_index": 0, "key": "a", "value": "b"}),
             self._parse_expr("group_0.properties.a = 'b'"),

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -68,6 +68,17 @@ class TestProperty(BaseTest):
         )
 
     def test_property_to_expr_group(self):
+        PropertyDefinition.objects.create(
+            team=self.team,
+            name="boolean_prop",
+            type=PropertyDefinition.Type.GROUP,
+            group_type_index=0,
+            property_type=PropertyType.Boolean,
+        )
+        self.assertEqual(
+            self._property_to_expr({"type": "group", "group_type_index": 0, "key": "boolean_prop", "value": ["true"]}),
+            self._parse_expr("group_0.properties.boolean_prop = true"),
+        )
         self.assertEqual(
             self._property_to_expr({"type": "group", "group_type_index": 0, "key": "a", "value": "b"}),
             self._parse_expr("group_0.properties.a = 'b'"),
@@ -88,6 +99,19 @@ class TestProperty(BaseTest):
         )
 
         self.assertEqual(self._property_to_expr({"type": "group", "key": "a", "value": "b"}), self._parse_expr("1"))
+
+    def test_property_to_expr_group_booleans(self):
+        PropertyDefinition.objects.create(
+            team=self.team,
+            name="boolean_prop",
+            type=PropertyDefinition.Type.GROUP,
+            group_type_index=0,
+            property_type=PropertyType.Boolean,
+        )
+        self.assertEqual(
+            self._property_to_expr({"type": "group", "group_type_index": 0, "key": "boolean_prop", "value": ["true"]}),
+            self._parse_expr("group_0.properties.boolean_prop = true"),
+        )
 
     def test_property_to_expr_event(self):
         self.assertEqual(


### PR DESCRIPTION
## Problem

Sometimes boolean group properties were compared against strings.

## Changes

Detect group property types properly when transforming HogQL property filters.

## How did you test this code?

Added a test.