### PR TITLE
fix(admin): Don't load bogus `events` field in team admin

### DIFF
--- a/posthog/admin/inlines/action_inline.py
+++ b/posthog/admin/inlines/action_inline.py
@@ -8,3 +8,4 @@ class ActionInline(admin.TabularInline):
     model = Action
     classes = ("collapse",)
     autocomplete_fields = ("created_by",)
+    exclude = ("events",)


### PR DESCRIPTION
## Problem

Try opening this: https://us.posthog.com/admin/posthog/team/39981/change/
It takes extremely long, because we load a lot of `posthog_event` rows for `ActionInline`, which would be pointless even if that table were actually used for events (but now we have ClickHouse for that).

## Changes

Excluding events, team (project) admin should now load in milliseconds.