### PR TITLE
chore: Delete Heroku Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,0 @@
-release: REDIS_URL='redis://' python manage.py migrate
-web: gunicorn posthog.wsgi --log-file -
-worker: ./bin/docker-worker
-celeryworker: ./bin/docker-worker-celery --with-scheduler # optional
-pluginworker: ./bin/plugin-server # optional


### PR DESCRIPTION
## Problem

PostHog has outgrown Heroku, but we still had a `Procfile`.
## Changes

`Procfile` is no more.