### PR TITLE
fix(data-warehouse): update pagination to do a first pass completely before using water marking

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1954,6 +1954,9 @@ const api = {
         async reload(schemaId: ExternalDataSourceSchema['id']): Promise<void> {
             await new ApiRequest().externalDataSourceSchema(schemaId).withAction('reload').create()
         },
+        async resync(schemaId: ExternalDataSourceSchema['id']): Promise<void> {
+            await new ApiRequest().externalDataSourceSchema(schemaId).withAction('resync').create()
+        },
     },
 
     dataWarehouseViewLinks: {

--- a/frontend/src/scenes/data-warehouse/settings/DataWarehouseSettingsScene.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/DataWarehouseSettingsScene.tsx
@@ -181,7 +181,7 @@ interface SchemaTableProps {
 }
 
 const SchemaTable = ({ schemas }: SchemaTableProps): JSX.Element => {
-    const { updateSchema, reloadSchema } = useActions(dataWarehouseSettingsLogic)
+    const { updateSchema, reloadSchema, resyncSchema } = useActions(dataWarehouseSettingsLogic)
     const { schemaReloadingById } = useValues(dataWarehouseSettingsLogic)
 
     return (
@@ -308,6 +308,20 @@ const SchemaTable = ({ schemas }: SchemaTableProps): JSX.Element => {
                                                 >
                                                     Reload
                                                 </LemonButton>
+                                                {schema.incremental && (
+                                                    <Tooltip title="Completely resync incrementally loaded data. Only recommended if there is an issue with data quality in previously imported data">
+                                                        <LemonButton
+                                                            type="tertiary"
+                                                            key={`resync-data-warehouse-schema-${schema.id}`}
+                                                            onClick={() => {
+                                                                resyncSchema(schema)
+                                                            }}
+                                                            status="danger"
+                                                        >
+                                                            Resync
+                                                        </LemonButton>
+                                                    </Tooltip>
+                                                )}
                                             </>
                                         }
                                     />

--- a/frontend/src/scenes/data-warehouse/settings/dataWarehouseSettingsLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/dataWarehouseSettingsLogic.ts
@@ -19,6 +19,7 @@ export const dataWarehouseSettingsLogic = kea<dataWarehouseSettingsLogicType>([
         deleteSource: (source: ExternalDataStripeSource) => ({ source }),
         reloadSource: (source: ExternalDataStripeSource) => ({ source }),
         reloadSchema: (schema: ExternalDataSourceSchema) => ({ schema }),
+        resyncSchema: (schema: ExternalDataSourceSchema) => ({ schema }),
         sourceLoadingFinished: (source: ExternalDataStripeSource) => ({ source }),
         schemaLoadingFinished: (schema: ExternalDataSourceSchema) => ({ schema }),
         updateSchema: (schema: ExternalDataSourceSchema) => ({ schema }),
@@ -176,6 +177,33 @@ export const dataWarehouseSettingsLogic = kea<dataWarehouseSettingsLogicType>([
 
             try {
                 await api.externalDataSchemas.reload(schema.id)
+                actions.schemaLoadingFinished(schema)
+                actions.loadSources(null)
+            } catch (e: any) {
+                if (e.message) {
+                    lemonToast.error(e.message)
+                } else {
+                    lemonToast.error('Cant reload schema at this time')
+                }
+            }
+        },
+        // Complete refresh
+        resyncSchema: async ({ schema }) => {
+            const clonedSources = JSON.parse(
+                JSON.stringify(values.dataWarehouseSources?.results ?? [])
+            ) as ExternalDataStripeSource[]
+            const sourceIndex = clonedSources.findIndex((n) => n.schemas.find((m) => m.id === schema.id))
+            const schemaIndex = clonedSources[sourceIndex].schemas.findIndex((n) => n.id === schema.id)
+            clonedSources[sourceIndex].status = 'Running'
+            clonedSources[sourceIndex].schemas[schemaIndex].status = 'Running'
+
+            actions.loadSourcesSuccess({
+                ...values.dataWarehouseSources,
+                results: clonedSources,
+            })
+
+            try {
+                await api.externalDataSchemas.resync(schema.id)
                 actions.schemaLoadingFinished(schema)
                 actions.loadSources(null)
             } catch (e: any) {

--- a/frontend/src/scenes/data-warehouse/settings/dataWarehouseSettingsLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/dataWarehouseSettingsLogic.ts
@@ -81,6 +81,10 @@ export const dataWarehouseSettingsLogic = kea<dataWarehouseSettingsLogicType>([
                     ...state,
                     [schema.id]: true,
                 }),
+                resyncSchema: (state, { schema }) => ({
+                    ...state,
+                    [schema.id]: true,
+                }),
                 schemaLoadingFinished: (state, { schema }) => ({
                     ...state,
                     [schema.id]: false,

--- a/posthog/temporal/data_imports/pipelines/stripe/helpers.py
+++ b/posthog/temporal/data_imports/pipelines/stripe/helpers.py
@@ -61,7 +61,7 @@ async def stripe_pagination(
     endpoint: str,
     team_id: int,
     job_id: str,
-    source_id: str,
+    schema_id: str,
     starting_after: Optional[Any] = None,
     start_date: Optional[Any] = None,
     end_date: Optional[Any] = None,
@@ -82,14 +82,14 @@ async def stripe_pagination(
     logger.info(f"Stripe: getting {endpoint}")
 
     if endpoint in INCREMENTAL_ENDPOINTS:
-        _ending_before_state = dlt.current.resource_state(f"team_{team_id}_{source_id}_{endpoint}").setdefault(
-            "ending_before", {"last_value": None}
+        _cursor_state = dlt.current.resource_state(f"team_{team_id}_{schema_id}_{endpoint}").setdefault(
+            "cursors", {"ending_before": None, "starting_after": None}
         )
-        _ending_before = _ending_before_state.get("last_value", None)
-        _starting_after = None
+        _starting_after = _cursor_state.get("starting_after", None)
+        _ending_before = _cursor_state.get("ending_before", None) if _starting_after is None else None
     else:
         _starting_after = starting_after
-        _ending_before = starting_after
+        _ending_before = None
 
     while True:
         if _ending_before is not None:
@@ -110,20 +110,27 @@ async def stripe_pagination(
         )
 
         if len(response["data"]) > 0:
+            latest_value_in_response = response["data"][0]["id"]
+            earliest_value_in_response = response["data"][-1]["id"]
+
             if endpoint in INCREMENTAL_ENDPOINTS:
                 # First pass, store the latest value
                 if _starting_after is None and _ending_before is None:
-                    _ending_before_state["last_value"] = response["data"][0]["id"]
+                    _cursor_state["ending_before"] = latest_value_in_response
 
                 # currently scrolling from past to present
                 if _ending_before is not None:
-                    _ending_before_state["last_value"] = response["data"][0]["id"]
-                    _ending_before = response["data"][0]["id"]
+                    _cursor_state["ending_before"] = latest_value_in_response
+                    _ending_before = latest_value_in_response
                 # otherwise scrolling from present to past
                 else:
-                    _starting_after = response["data"][-1]["id"]
+                    _starting_after = earliest_value_in_response
+                    _cursor_state["starting_after"] = earliest_value_in_response
             else:
-                _starting_after = response["data"][-1]["id"]
+                _starting_after = earliest_value_in_response
+        else:
+            if endpoint in INCREMENTAL_ENDPOINTS:
+                _cursor_state["starting_after"] = None
 
         yield response["data"]
 
@@ -144,7 +151,7 @@ def stripe_source(
     endpoints: Tuple[str, ...],
     team_id,
     job_id,
-    source_id,
+    schema_id,
     starting_after: Optional[str] = None,
     start_date: Optional[Any] = None,
     end_date: Optional[Any] = None,
@@ -160,7 +167,7 @@ def stripe_source(
             endpoint=endpoint,
             team_id=team_id,
             job_id=job_id,
-            source_id=source_id,
+            schema_id=schema_id,
             starting_after=starting_after,
             start_date=start_date,
             end_date=end_date,

--- a/posthog/temporal/data_imports/workflow_activities/import_data.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data.py
@@ -81,7 +81,7 @@ async def import_data_activity(inputs: ImportDataActivityInputs) -> Tuple[TSchem
             endpoints=tuple(endpoints),
             team_id=inputs.team_id,
             job_id=inputs.run_id,
-            source_id=str(inputs.source_id),
+            schema_id=str(inputs.schema_id),
             start_date=start_date,
             end_date=end_date,
         )

--- a/posthog/warehouse/api/external_data_schema.py
+++ b/posthog/warehouse/api/external_data_schema.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 import structlog
 import temporalio
-from posthog.warehouse.models import ExternalDataSchema
+from posthog.warehouse.models import ExternalDataSchema, ExternalDataJob
 from typing import Optional, Dict, Any
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from rest_framework import viewsets, filters, status
@@ -11,6 +11,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from posthog.models import User
 from posthog.hogql.database.database import create_hogql_database
+
 from posthog.warehouse.data_load.service import (
     external_data_workflow_exists,
     is_any_external_data_job_paused,
@@ -18,6 +19,8 @@ from posthog.warehouse.data_load.service import (
     pause_external_data_schedule,
     trigger_external_data_workflow,
     unpause_external_data_schedule,
+    cancel_external_data_workflow,
+    delete_data_import_folder,
 )
 
 logger = structlog.get_logger(__name__)
@@ -100,13 +103,52 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         try:
             trigger_external_data_workflow(instance)
-
         except temporalio.service.RPCError as e:
             logger.exception(f"Could not trigger external data job for schema {instance.id}", exc_info=e)
 
         except Exception as e:
             logger.exception(f"Could not trigger external data job for schema {instance.id}", exc_info=e)
             raise
+
+        instance.status = ExternalDataSchema.Status.RUNNING
+        instance.save()
+        return Response(status=status.HTTP_200_OK)
+
+    @action(methods=["POST"], detail=True)
+    def resync(self, request: Request, *args: Any, **kwargs: Any):
+        instance: ExternalDataSchema = self.get_object()
+
+        if is_any_external_data_job_paused(self.team_id):
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": "Monthly sync limit reached. Please contact PostHog support to increase your limit."},
+            )
+
+        latest_running_job = (
+            ExternalDataJob.objects.filter(schema_id=instance.pk, team_id=instance.team_id)
+            .order_by("-created_at")
+            .first()
+        )
+
+        if latest_running_job and latest_running_job.workflow_id and latest_running_job.status == "Running":
+            cancel_external_data_workflow(latest_running_job.workflow_id)
+
+        all_jobs = ExternalDataJob.objects.filter(
+            schema_id=instance.pk, team_id=instance.team_id, status="Completed"
+        ).all()
+
+        # Unnecessary to iterate for incremental jobs since they'll all by identified by the schema_id. Be over eager just to clear remnants
+        for job in all_jobs:
+            try:
+                delete_data_import_folder(job.folder_path)
+            except Exception as e:
+                logger.exception(f"Could not clean up data import folder: {job.folder_path}", exc_info=e)
+                pass
+
+        try:
+            trigger_external_data_workflow(instance)
+        except temporalio.service.RPCError as e:
+            logger.exception(f"Could not trigger external data job for schema {instance.id}", exc_info=e)
 
         instance.status = ExternalDataSchema.Status.RUNNING
         instance.save()


### PR DESCRIPTION
## Problem

- incremental sync doesn't paginate all the way through

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- make sure stateful pagination completes first pass

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
