### PR TITLE
feat: Add hovering state for heatmaps

### DIFF
--- a/frontend/src/toolbar/elements/Heatmap.tsx
+++ b/frontend/src/toolbar/elements/Heatmap.tsx
@@ -1,8 +1,52 @@
 import heatmapsJs, { Heatmap as HeatmapJS } from 'heatmap.js'
 import { useValues } from 'kea'
-import { useCallback, useEffect, useRef } from 'react'
+import { MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
 import { heatmapLogic } from '~/toolbar/elements/heatmapLogic'
+
+import { useMousePosition } from './useMousePosition'
+
+function HeatmapMouseInfo({
+    heatmapJsRef,
+}: {
+    heatmapJsRef: MutableRefObject<HeatmapJS<'value', 'x', 'y'> | undefined>
+}): JSX.Element | null {
+    const { shiftPressed, heatmapFilters } = useValues(heatmapLogic)
+
+    const mousePosition = useMousePosition()
+    const value = heatmapJsRef.current?.getValueAt(mousePosition)
+
+    if (!mousePosition || (!value && !shiftPressed)) {
+        return null
+    }
+
+    const leftPosition = window.innerWidth - mousePosition.x < 100
+
+    return (
+        <div
+            className="absolute z-10"
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{
+                top: mousePosition.y,
+                left: mousePosition.x,
+            }}
+        >
+            <div
+                className="absolute border rounded bg-bg-light shadow-md p-2 mx-2"
+                // eslint-disable-next-line react/forbid-dom-props
+                style={{
+                    left: leftPosition ? undefined : 0,
+                    right: leftPosition ? 0 : undefined,
+                    transform: 'translateY(-50%)',
+                }}
+            >
+                <span className="font-semibold whitespace-nowrap">
+                    {value} {heatmapFilters.type + 's'}
+                </span>
+            </div>
+        </div>
+    )
+}
 
 export function Heatmap(): JSX.Element | null {
     const { heatmapJsData, heatmapEnabled, heatmapFilters } = useValues(heatmapLogic)
@@ -41,6 +85,7 @@ export function Heatmap(): JSX.Element | null {
     return (
         <div className="fixed inset-0 overflow-hidden">
             <div className="absolute inset-0" ref={setHeatmapContainer} />
+            <HeatmapMouseInfo heatmapJsRef={heatmapsJsRef} />
         </div>
     )
 }

--- a/frontend/src/toolbar/elements/ScrollDepth.tsx
+++ b/frontend/src/toolbar/elements/ScrollDepth.tsx
@@ -1,27 +1,15 @@
 import { useValues } from 'kea'
-import { useEffect, useState } from 'react'
 
 import { heatmapLogic } from '~/toolbar/elements/heatmapLogic'
 
 import { toolbarConfigLogic } from '../toolbarConfigLogic'
+import { useMousePosition } from './useMousePosition'
 
 function ScrollDepthMouseInfo(): JSX.Element | null {
     const { posthog } = useValues(toolbarConfigLogic)
     const { heatmapElements, rawHeatmapLoading } = useValues(heatmapLogic)
 
-    // Track the mouse position and render an indicator about how many people have scrolled to this point
-    const [mouseY, setMouseY] = useState<null | number>(0)
-
-    useEffect(() => {
-        const onMove = (e: MouseEvent): void => {
-            setMouseY(e.clientY)
-        }
-
-        window.addEventListener('mousemove', onMove)
-        return () => {
-            window.removeEventListener('mousemove', onMove)
-        }
-    }, [])
+    const { y: mouseY } = useMousePosition()
 
     if (!mouseY) {
         return null

--- a/frontend/src/toolbar/elements/useMousePosition.ts
+++ b/frontend/src/toolbar/elements/useMousePosition.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+
+export const useMousePosition = (): { x: number; y: number } => {
+    const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 })
+
+    useEffect(() => {
+        const onMove = (e: MouseEvent): void => {
+            setMousePosition({ x: e.clientX, y: e.clientY })
+        }
+
+        window.addEventListener('mousemove', onMove)
+        return () => {
+            window.removeEventListener('mousemove', onMove)
+        }
+    }, [])
+    return mousePosition
+}


### PR DESCRIPTION
## Problem

Heatmaps look great but you might want to better understand what the value of an area is.

## Changes

![2024-04-24 10 59 03](https://github.com/PostHog/posthog/assets/2536520/7cb4df23-0410-4332-a617-17e8bb8089c7)


* Adds a hovering tooltip
* Need to validate if the numbers make sense. I think its more like "there were N clicks in this area"...

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
