### PR TITLE
fix: Wrap asgi application to ignore lifetime requests

### DIFF
--- a/posthog/asgi.py
+++ b/posthog/asgi.py
@@ -1,8 +1,17 @@
 import os
 
 from django.core.asgi import get_asgi_application
+from django.http.response import HttpResponse
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
 os.environ.setdefault("SERVER_GATEWAY_INTERFACE", "ASGI")
 
-application = get_asgi_application()
+
+def lifetime_wrapper(func):
+    async def inner(scope, receive, send):
+        if scope["type"] != "http":
+            return HttpResponse(status=501)
+        return func(scope, receive, send)
+
+
+application = lifetime_wrapper(get_asgi_application())


### PR DESCRIPTION
## Problem
ASGI servers send "lifetime" requests to django at startup and shutdown.

The ASGI spec allows these to fail, in which case the server ignores them, however the way django fails them sends an exception to sentry which we don't want.

Overwrite the handler to return a 501 error without throwing an exception
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
