### PR TITLE
fix(experiments): update time/sample/mde on goal change

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Goal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Goal.tsx
@@ -91,7 +91,9 @@ export function ExposureMetric({ experimentId }: { experimentId: Experiment['id'
 }
 
 export function ExperimentGoalModal({ experimentId }: { experimentId: Experiment['id'] }): JSX.Element {
-    const { experiment, isExperimentGoalModalOpen, experimentLoading } = useValues(experimentLogic({ experimentId }))
+    const { experiment, isExperimentGoalModalOpen, experimentLoading, goalInsightDataLoading } = useValues(
+        experimentLogic({ experimentId })
+    )
     const { closeExperimentGoalModal, updateExperimentGoal, setNewExperimentInsight } = useActions(
         experimentLogic({ experimentId })
     )
@@ -108,6 +110,9 @@ export function ExperimentGoalModal({ experimentId }: { experimentId: Experiment
                         Cancel
                     </LemonButton>
                     <LemonButton
+                        disabledReason={
+                            goalInsightDataLoading && 'The insight needs to be loaded before saving the goal'
+                        }
                         form="edit-experiment-goal-form"
                         onClick={() => {
                             updateExperimentGoal(experiment.filters)

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -309,7 +309,7 @@ export const experimentLogic = kea<experimentLogicType>([
             // Terminate if the insight did not manage to load in time
             if (!minimumDetectableChange) {
                 eventUsageLogic.actions.reportExperimentInsightLoadFailed()
-                lemonToast.error(
+                return lemonToast.error(
                     'Failed to load insight. Experiment cannot be saved without this value. Try changing the experiment goal.'
                 )
             }
@@ -481,10 +481,26 @@ export const experimentLogic = kea<experimentLogicType>([
             values.experiment && actions.reportExperimentArchived(values.experiment)
         },
         updateExperimentGoal: async ({ filters }) => {
-            // We never want to update global properties in the experiment
+            const { recommendedRunningTime, recommendedSampleSize, minimumDetectableChange } = values
+            if (!minimumDetectableChange) {
+                eventUsageLogic.actions.reportExperimentInsightLoadFailed()
+                return lemonToast.error(
+                    'Failed to load insight. Experiment cannot be saved without this value. Try changing the experiment goal.'
+                )
+            }
+
             const filtersToUpdate = { ...filters }
             delete filtersToUpdate.properties
-            actions.updateExperiment({ filters: filtersToUpdate })
+
+            actions.updateExperiment({
+                filters: filtersToUpdate,
+                parameters: {
+                    ...values.experiment?.parameters,
+                    recommended_running_time: recommendedRunningTime,
+                    recommended_sample_size: recommendedSampleSize,
+                    minimum_detectable_effect: minimumDetectableChange,
+                },
+            })
             actions.closeExperimentGoalModal()
         },
         updateExperimentExposure: async ({ filters }) => {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -106,6 +106,8 @@ export const experimentLogic = kea<experimentLogicType>([
             ['conversionMetrics'],
             trendsDataLogic({ dashboardItemId: EXPERIMENT_INSIGHT_ID }),
             ['results as trendResults'],
+            insightDataLogic({ dashboardItemId: EXPERIMENT_INSIGHT_ID }),
+            ['insightDataLoading as goalInsightDataLoading'],
         ],
         actions: [
             experimentsLogic,


### PR DESCRIPTION
## Changes

Note - one possible edge case when:
- the Change goal modal is opened and the insight is loaded
- the goal is changed and the insight doesn't load before Save is clicked
- the time/sample/mde is now stale from the previous insight

Fixing this would require pulling the loading state from the Funnel and Trend insight logic, then checking the appropriate one. Not sure if this is worth the effort/complexity.

## How did you test this code?
👀 