### PR TITLE
fix(insights): Support dashboard filters in EventsQuery

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -1194,7 +1194,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         )
         assert response.status_code == 400, response.json()
 
-    def test_create_from_template_json_cam_provide_text_tile(self) -> None:
+    def test_create_from_template_json_can_provide_text_tile(self) -> None:
         template: Dict = {
             **valid_template,
             "tiles": [{"type": "TEXT", "body": "hello world", "layouts": {}}],
@@ -1225,7 +1225,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             },
         ]
 
-    def test_create_from_template_json_cam_provide_query_tile(self) -> None:
+    def test_create_from_template_json_can_provide_query_tile(self) -> None:
         template: Dict = {
             **valid_template,
             # client provides an incorrect "empty" filter alongside a query
@@ -1288,8 +1288,22 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
                         "kind": "DataTableNode",
                         "columns": ["person", "id", "created_at", "person.$delete"],
                         "source": {
+                            "actionId": None,
+                            "after": None,
+                            "before": None,
+                            "event": None,
+                            "filterTestAccounts": None,
+                            "fixedProperties": None,
                             "kind": "EventsQuery",
+                            "limit": None,
+                            "modifiers": None,
+                            "offset": None,
+                            "orderBy": None,
+                            "personId": None,
+                            "properties": None,
+                            "response": None,
                             "select": ["*"],
+                            "where": None,
                         },
                     },
                     "result": [],

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -1279,7 +1279,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 ],
             )
 
-    def test_dashboard_filters_applied_to_data_table_node(self):
+    def test_dashboard_filters_applied_to_sql_data_table_node(self):
         dashboard_id, _ = self.dashboard_api.create_dashboard(
             {"name": "the dashboard", "filters": {"date_from": "-180d"}}
         )
@@ -1329,11 +1329,13 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["query"]["source"]["filters"]["dateRange"]["date_from"], "-180d")
 
-    def test_dashboard_filters_applied_to_events_query_node(self):
+    def test_dashboard_filters_applied_to_events_query_data_table_node(self):
         dashboard_id, _ = self.dashboard_api.create_dashboard(
             {"name": "the dashboard", "filters": {"date_from": "-180d"}}
         )
-        query = EventsQuery(select=["uuid", "event", "timestamp"], after="-3d").model_dump()
+        query = DataTableNode(
+            source=EventsQuery(select=["uuid", "event", "timestamp"], after="-3d").model_dump(),
+        ).model_dump()
         insight_id, _ = self.dashboard_api.create_insight(
             {"query": query, "name": "insight", "dashboards": [dashboard_id]}
         )
@@ -1348,7 +1350,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["query"]["after"], "-180d")
+        self.assertEqual(response.json()["query"]["source"]["after"], "-180d")
 
     # BASIC TESTING OF ENDPOINTS. /queries as in depth testing for each insight
 

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -34,6 +34,7 @@ from posthog.schema import (
     DateRange,
     EventPropertyFilter,
     EventsNode,
+    EventsQuery,
     HogQLFilters,
     HogQLQuery,
     TrendsQuery,
@@ -1327,6 +1328,27 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["query"]["source"]["filters"]["dateRange"]["date_from"], "-180d")
+
+    def test_dashboard_filters_applied_to_events_query_node(self):
+        dashboard_id, _ = self.dashboard_api.create_dashboard(
+            {"name": "the dashboard", "filters": {"date_from": "-180d"}}
+        )
+        query = EventsQuery(select=["uuid", "event", "timestamp"], after="-3d").model_dump()
+        insight_id, _ = self.dashboard_api.create_insight(
+            {"query": query, "name": "insight", "dashboards": [dashboard_id]}
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/{insight_id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["query"], query)
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/insights/{insight_id}/?refresh=true&from_dashboard={dashboard_id}"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["query"]["after"], "-180d")
 
     # BASIC TESTING OF ENDPOINTS. /queries as in depth testing for each insight
 

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -257,7 +257,7 @@ class EventsQueryRunner(QueryRunner):
         )
 
     def apply_dashboard_filters(self, dashboard_filter: DashboardFilter):
-        new_query = self.query.model_copy()
+        new_query = self.query.model_copy()  # Shallow copy!
 
         if dashboard_filter.date_to or dashboard_filter.date_from:
             new_query.before = dashboard_filter.date_to


### PR DESCRIPTION
## Changes

Fix for [`EventsQuery does not support dashboard filters out of the box
`](https://posthog.sentry.io/issues/5236763612/?project=-1&query=is%3Aunresolved+transaction%3A%2Fapi%2Fprojects%2F%7Bparent_lookup_team_id%7D%2Finsights%2F%7Bpk%7D%2F&referrer=issue-stream&statsPeriod=7d&stream_index=2&utc=true).