### PR TITLE
fix: skip custom split

### DIFF
--- a/patches/rrweb@2.0.0-alpha.13.patch
+++ b/patches/rrweb@2.0.0-alpha.13.patch
@@ -489,10 +489,18 @@ index 0d49411b1f6d31103bed898c0e81d1d74ab51234..0b2160ef08aa3ae5310f63c295abc0a5
      }
      applyMutation(d, isSync) {
 diff --git a/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js b/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
-index 38a23aaae8d683fa584329eced277dd8de55d1ff..a20f6c785ca3fde692295b7c80fa53d6211315b4 100644
+index 38a23aaae8d683fa584329eced277dd8de55d1ff..44efee95395f6612204e051724a108833741a492 100644
 --- a/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
 +++ b/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
-@@ -1278,8 +1278,15 @@ function parse(css, options = {}) {
+@@ -1271,15 +1271,22 @@ function parse(css, options = {}) {
+             .replace(/"(?:\\"|[^"])*"|'(?:\\'|[^'])*'/g, (m) => {
+             return m.replace(/,/g, '\u200C');
+         });
+-        return customSplit(cleanedInput).map((s) => s.replace(/\u200C/g, ',').trim());
++        return cleanedInput.split(/\s*(?![^(]*\)),\s*/).map((s) => s.replace(/\u200C/g, ',').trim());
+     }
+     function customSplit(input) {
+         const result = [];
          let currentSegment = '';
          let depthParentheses = 0;
          let depthBrackets = 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: gydrxrztd4ruyhouu6tu7zh43e
     path: patches/heatmap.js@2.0.5.patch
   rrweb@2.0.0-alpha.13:
-    hash: kfckshv6vjunfa5tljyhkshxxe
+    hash: yb2e6fk2apwhhkdrx63qgi45uq
     path: patches/rrweb@2.0.0-alpha.13.patch
 
 dependencies:
@@ -333,7 +333,7 @@ dependencies:
     version: 1.5.1
   rrweb:
     specifier: 2.0.0-alpha.13
-    version: 2.0.0-alpha.13(patch_hash=kfckshv6vjunfa5tljyhkshxxe)
+    version: 2.0.0-alpha.13(patch_hash=yb2e6fk2apwhhkdrx63qgi45uq)
   sass:
     specifier: ^1.26.2
     version: 1.56.0
@@ -19277,7 +19277,7 @@ packages:
     resolution: {integrity: sha512-slbhNBCYjxLGCeH95a67ECCy5a22nloXp1F5wF7DCzUNw80FN7tF9Lef1sRGLNo32g3mNqTc2sWLATlKejMxYw==}
     dev: false
 
-  /rrweb@2.0.0-alpha.13(patch_hash=kfckshv6vjunfa5tljyhkshxxe):
+  /rrweb@2.0.0-alpha.13(patch_hash=yb2e6fk2apwhhkdrx63qgi45uq):
     resolution: {integrity: sha512-a8GXOCnzWHNaVZPa7hsrLZtNZ3CGjiL+YrkpLo0TfmxGLhjNZbWY2r7pE06p+FcjFNlgUVTmFrSJbK3kO7yxvw==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.13


### PR DESCRIPTION
## Problem

Looking at the performance inspector we can see CPU spiking on the main thread and a ton of time being taken up in the `customSplit` method
<img width="1340" alt="Screenshot 2024-04-24 at 15 05 47" src="https://github.com/PostHog/posthog/assets/6685876/7e6f195f-e029-4c12-b0a6-a225e48e0e37">

This was introduced in https://github.com/rrweb-io/rrweb/pull/1401 which lines up with reports we've been getting of playback freezing in the last couple of days (we upgraded to alpha-13 yesterday https://github.com/PostHog/posthog/pull/21734)

## Changes

- Skip the `customSplit` method added
- This will reintroduce the bugs fixed by https://github.com/PostHog/posthog/pull/21427 but that seems like the less bad option right now

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Should see customers recordings playing back correctly