### PR TITLE
fix(dashboards): Don't show erroring dashboards as not found

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -96,7 +96,7 @@ function DashboardScene(): JSX.Element {
         [setDashboardMode, dashboardMode, placement]
     )
 
-    if (!dashboard && !itemsLoading && receivedErrorsFromAPI) {
+    if (!dashboard && !itemsLoading && !receivedErrorsFromAPI) {
         return <NotFound object="dashboard" />
     }
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -216,7 +216,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         return dashboard
                     } catch (error: any) {
                         if (error.status === 404) {
-                            throw new Error('Dashboard not found')
+                            return null
                         }
                         throw error
                     }

--- a/posthog/models/dashboard.py
+++ b/posthog/models/dashboard.py
@@ -4,8 +4,6 @@ from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from posthog.models.utils import sane_repr
 
-from posthog.utils import absolute_uri
-
 
 class DashboardManager(models.Manager):
     def get_queryset(self):
@@ -88,10 +86,6 @@ class Dashboard(models.Model):
         # uses .all and not .first so that prefetching in serializers can be used
         sharing_configurations = self.sharingconfiguration_set.all()
         return sharing_configurations[0].enabled if sharing_configurations and sharing_configurations[0] else False
-
-    @property
-    def url(self):
-        return absolute_uri(f"/dashboard/{self.id}")
 
     def get_analytics_metadata(self) -> Dict[str, Any]:
         """

--- a/posthog/models/dashboard.py
+++ b/posthog/models/dashboard.py
@@ -4,6 +4,8 @@ from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from posthog.models.utils import sane_repr
 
+from posthog.utils import absolute_uri
+
 
 class DashboardManager(models.Manager):
     def get_queryset(self):
@@ -86,6 +88,10 @@ class Dashboard(models.Model):
         # uses .all and not .first so that prefetching in serializers can be used
         sharing_configurations = self.sharingconfiguration_set.all()
         return sharing_configurations[0].enabled if sharing_configurations and sharing_configurations[0] else False
+
+    @property
+    def url(self):
+        return absolute_uri(f"/dashboard/{self.id}")
 
     def get_analytics_metadata(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Problem

We're currently experiencing some issues with dashboard serialization. Currently our users see 404s, which is much worse in terms of the experiencing ("I've lost data/configuration") than an error page ("something's down").

## Changes

Fixing logic to show the error page.