### PR TITLE
fix(insights): Do NOT calculate non-cacheables when cache-only

### DIFF
--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -4,7 +4,6 @@ from typing import Optional
 from pydantic import BaseModel
 from rest_framework.exceptions import ValidationError
 
-from posthog.caching.fetch_from_cache import NothingInCacheResult
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.context import HogQLContext
@@ -12,7 +11,7 @@ from posthog.hogql.database.database import create_hogql_database, serialize_dat
 from posthog.hogql.autocomplete import get_hogql_autocomplete
 from posthog.hogql.metadata import get_hogql_metadata
 from posthog.hogql.modifiers import create_default_modifiers_for_team
-from posthog.hogql_queries.query_runner import ExecutionMode, get_query_runner
+from posthog.hogql_queries.query_runner import CacheMissResponse, ExecutionMode, get_query_runner
 from posthog.models import Team
 from posthog.queries.time_to_see_data.serializers import SessionEventsQuerySerializer, SessionsQuerySerializer
 from posthog.queries.time_to_see_data.sessions import get_session_events, get_sessions
@@ -86,7 +85,7 @@ def process_query_model(
     if execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE and not isinstance(
         query, QUERY_WITH_RUNNER_USING_CACHE
     ):
-        result = NothingInCacheResult()
+        result = CacheMissResponse()
 
     if isinstance(query, QUERY_WITH_RUNNER_USING_CACHE):  # type: ignore
         query_runner = get_query_runner(query, team, limit_context=limit_context)

--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -83,9 +83,10 @@ def process_query_model(
     result: dict | BaseModel
 
     if execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE and not isinstance(
-        query, QUERY_WITH_RUNNER_USING_CACHE
+        query,
+        QUERY_WITH_RUNNER_USING_CACHE,  # type: ignore
     ):
-        result = CacheMissResponse()
+        result = CacheMissResponse(cache_key=None)
 
     if isinstance(query, QUERY_WITH_RUNNER_USING_CACHE):  # type: ignore
         query_runner = get_query_runner(query, team, limit_context=limit_context)

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
-from posthog.api.services.query import ExecutionMode
 import structlog
 from sentry_sdk import capture_exception
 
@@ -110,7 +109,7 @@ def get_cache_type(cacheable: Optional[FilterType] | Optional[Dict]) -> CacheTyp
 def calculate_for_query_based_insight(
     insight: Insight, *, dashboard: Optional[Dashboard] = None, refresh_requested: bool
 ) -> "InsightResult":
-    from posthog.api.services.query import process_query
+    from posthog.api.services.query import process_query, ExecutionMode
     from posthog.caching.fetch_from_cache import InsightResult, NothingInCacheResult
 
     tag_queries(team_id=insight.team_id, insight_id=insight.pk)

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -329,7 +329,7 @@ class QueryRunner(ABC, Generic[Q]):
     def run(
         self, execution_mode: ExecutionMode = ExecutionMode.RECENT_CACHE_CALCULATE_IF_STALE
     ) -> CachedQueryResponse | CacheMissResponse:
-        cache_key = f"{self._cache_key()}_{self.limit_context or LimitContext.QUERY}"
+        cache_key = self.get_cache_key()
         tag_queries(cache_key=cache_key)
 
         if execution_mode != ExecutionMode.CALCULATION_ALWAYS:
@@ -406,10 +406,10 @@ class QueryRunner(ABC, Generic[Q]):
     def toJSON(self) -> str:
         return self.query.model_dump_json(exclude_defaults=True, exclude_none=True)
 
-    def _cache_key(self) -> str:
+    def get_cache_key(self) -> str:
         modifiers = self.modifiers.model_dump_json(exclude_defaults=True, exclude_none=True)
         return generate_cache_key(
-            f"query_{self.toJSON()}_{self.__class__.__name__}_{self.team.pk}_{self.team.timezone}_{modifiers}"
+            f"query_{self.toJSON()}_{self.__class__.__name__}_{self.team.pk}_{self.team.timezone}_{modifiers}_{self.limit_context or LimitContext.QUERY}"
         )
 
     @abstractmethod

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -102,7 +102,7 @@ class CacheMissResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    cache_key: str
+    cache_key: Optional[str]
 
 
 RunnableQueryNode = Union[

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -329,7 +329,9 @@ class QueryRunner(ABC, Generic[Q]):
     def run(
         self, execution_mode: ExecutionMode = ExecutionMode.RECENT_CACHE_CALCULATE_IF_STALE
     ) -> CachedQueryResponse | CacheMissResponse:
-        cache_key = self.get_cache_key()
+        cache_key = cache_key = f"{self.get_cache_key()}_{
+            self.limit_context or LimitContext.QUERY # TODO: This should probably just be in get_cache_key()
+        }"
         tag_queries(cache_key=cache_key)
 
         if execution_mode != ExecutionMode.CALCULATION_ALWAYS:
@@ -409,7 +411,7 @@ class QueryRunner(ABC, Generic[Q]):
     def get_cache_key(self) -> str:
         modifiers = self.modifiers.model_dump_json(exclude_defaults=True, exclude_none=True)
         return generate_cache_key(
-            f"query_{self.toJSON()}_{self.__class__.__name__}_{self.team.pk}_{self.team.timezone}_{modifiers}_{self.limit_context or LimitContext.QUERY}"
+            f"query_{self.toJSON()}_{self.__class__.__name__}_{self.team.pk}_{self.team.timezone}_{modifiers}"
         )
 
     @abstractmethod

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -329,9 +329,8 @@ class QueryRunner(ABC, Generic[Q]):
     def run(
         self, execution_mode: ExecutionMode = ExecutionMode.RECENT_CACHE_CALCULATE_IF_STALE
     ) -> CachedQueryResponse | CacheMissResponse:
-        cache_key = cache_key = f"{self.get_cache_key()}_{
-            self.limit_context or LimitContext.QUERY # TODO: This should probably just be in get_cache_key()
-        }"
+        # TODO: `self.limit_context` should probably just be in get_cache_key()
+        cache_key = cache_key = f"{self.get_cache_key()}_{self.limit_context or LimitContext.QUERY}"
         tag_queries(cache_key=cache_key)
 
         if execution_mode != ExecutionMode.CALCULATION_ALWAYS:

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -94,7 +94,7 @@ class TestQueryRunner(BaseTest):
 
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
-        cache_key = runner._cache_key()
+        cache_key = runner.get_cache_key()
         self.assertEqual(cache_key, "cache_b6f14c97c218e0b9c9a8258f7460fd5b")
 
     def test_cache_key_runner_subclass(self):
@@ -108,7 +108,7 @@ class TestQueryRunner(BaseTest):
 
         runner = TestSubclassQueryRunner(query={"some_attr": "bla"}, team=team)
 
-        cache_key = runner._cache_key()
+        cache_key = runner.get_cache_key()
         self.assertEqual(cache_key, "cache_ec1c2f9715cf9c424b1284b94b1205e6")
 
     def test_cache_key_different_timezone(self):
@@ -119,7 +119,7 @@ class TestQueryRunner(BaseTest):
 
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
-        cache_key = runner._cache_key()
+        cache_key = runner.get_cache_key()
         self.assertEqual(cache_key, "cache_a6614c0fb564f9c98b1d7b830928c7a1")
 
     def test_cache_response(self):

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -244,8 +244,8 @@ WHERE
             else n / self._sample_rate.numerator
         )
 
-    def _cache_key(self) -> str:
-        original = super()._cache_key()
+    def get_cache_key(self) -> str:
+        original = super().get_cache_key()
         return f"{original}_{self.team.path_cleaning_filters}"
 
 


### PR DESCRIPTION
## Problem

For existing dashboards and saved insights that contain non-cacheable queries, such as HogQLQuery, we currently always try calculating these when serializing the dashboard/insight. This breaks the CACHE_ONLY_NEVER_CALCULATE contract, and it's a waste of resources leading to serialization failures.

## Changes

Literally _never_ calculating in cache-only mode anymore.