### PR TITLE
fix(insights): default event name

### DIFF
--- a/frontend/src/lib/utils/getAppContext.ts
+++ b/frontend/src/lib/utils/getAppContext.ts
@@ -16,6 +16,11 @@ export function getDefaultEventName(): string {
     return getAppContext()?.default_event_name || PathType.PageView
 }
 
+export function getDefaultEventLabel(): string {
+    const name = getDefaultEventName()
+    return name === PathType.PageView ? 'Pageview' : name === PathType.Screen ? 'Screen' : name
+}
+
 // NOTE: Any changes to the teamId trigger a full page load so we don't use the logic
 // This helps avoid circular imports
 export function getCurrentTeamId(): TeamType['id'] {

--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
@@ -2,7 +2,7 @@ import { actions, connect, events, kea, key, listeners, path, props, reducers, s
 import { convertPropertyGroupToProperties } from 'lib/components/PropertyFilters/utils'
 import { uuid } from 'lib/utils'
 import { eventUsageLogic, GraphSeriesAddedSource } from 'lib/utils/eventUsageLogic'
-import { getDefaultEventName } from 'lib/utils/getAppContext'
+import { getDefaultEventLabel, getDefaultEventName } from 'lib/utils/getAppContext'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 
 import {
@@ -262,8 +262,9 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
             const newLength = previousLength + 1
             const precedingEntity = values.localFilters[previousLength - 1] as LocalFilter | undefined
             const order = precedingEntity ? precedingEntity.order + 1 : 0
-            const newFilter = {
+            const newFilter: LocalFilter = {
                 id: getDefaultEventName(),
+                name: getDefaultEventLabel(),
                 uuid: uuid(),
                 type: EntityTypes.EVENTS,
                 order: order,


### PR DESCRIPTION
## Problem

I was too hasty in merging https://github.com/PostHog/posthog/pull/21784

Newly added events didn't get a name.

<img width="431" alt="image" src="https://github.com/PostHog/posthog/assets/53387/25306fd9-58a8-44fd-9cb9-5f7703824cc7">

## Changes

Now they do

## How did you test this code?

<img width="484" alt="image" src="https://github.com/PostHog/posthog/assets/53387/ecf3d1ab-77ff-4907-ae84-f44be5a90c56">
