### PR TITLE
chore: add CH migration to add new person_mode option

### DIFF
--- a/posthog/clickhouse/migrations/0060_person_mode_force_upgrade.py
+++ b/posthog/clickhouse/migrations/0060_person_mode_force_upgrade.py
@@ -1,0 +1,32 @@
+from infi.clickhouse_orm import migrations
+
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.client import sync_execute
+from posthog.models.event.sql import (
+    EVENTS_TABLE_JSON_MV_SQL,
+    KAFKA_EVENTS_TABLE_JSON_SQL,
+)
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+
+# Column was added in 0057_events_person_mode
+ALTER_COLUMNS_BASE_SQL = """
+ALTER TABLE {table}
+ON CLUSTER {cluster}
+MODIFY COLUMN person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
+"""
+
+
+def alter_columns_in_required_tables(_):
+    sync_execute(ALTER_COLUMNS_BASE_SQL.format(table="events", cluster=CLICKHOUSE_CLUSTER))
+    sync_execute(ALTER_COLUMNS_BASE_SQL.format(table="writable_events", cluster=CLICKHOUSE_CLUSTER))
+    sync_execute(ALTER_COLUMNS_BASE_SQL.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
+
+
+operations = [
+    run_sql_with_exceptions(f"DROP TABLE IF EXISTS events_json_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    run_sql_with_exceptions(f"DROP TABLE IF EXISTS kafka_events_json ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    migrations.RunPython(alter_columns_in_required_tables),
+    run_sql_with_exceptions(KAFKA_EVENTS_TABLE_JSON_SQL()),
+    run_sql_with_exceptions(EVENTS_TABLE_JSON_MV_SQL()),
+]


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We need to tag events as `force_upgrade` in some cases, for billing purposes.

Actual code change will (necessarily) follow the migration.

## Changes

Alter existing column, add 3rd option.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes.
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Existing / migration.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
