### PR TITLE
fix: Displaying of profile-less users

### DIFF
--- a/frontend/src/scenes/persons/PersonPreview.tsx
+++ b/frontend/src/scenes/persons/PersonPreview.tsx
@@ -28,9 +28,18 @@ export function PersonPreview(props: PersonPreviewProps): JSX.Element | null {
         return <Spinner />
     }
 
-    // NOTE: This should pretty much never happen, but it's here just in case
+    // NOTE: This can happen if the Person was deleted or the events associated with the distinct_id had person processing disabled
     if (!person) {
-        return <>Not found</>
+        return (
+            <div className="p-2 max-w-160">
+                <h4>Person not found</h4>
+                <p>
+                    The Person may have been deleted.
+                    <br />
+                    Alternatively, the events for this user may have had Person Profiles disabled.
+                </p>
+            </div>
+        )
     }
 
     const display = asDisplay(person)

--- a/frontend/src/scenes/persons/PersonPreview.tsx
+++ b/frontend/src/scenes/persons/PersonPreview.tsx
@@ -32,7 +32,7 @@ export function PersonPreview(props: PersonPreviewProps): JSX.Element | null {
     if (!person) {
         return (
             <div className="p-2 max-w-160">
-                <h4>Person not found</h4>
+                <h4>Person profile not found</h4>
                 <p>
                     The Person may have been deleted.
                     <br />

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -4,7 +4,6 @@ import { ProducerRecord } from 'kafkajs'
 import { DateTime } from 'luxon'
 import { Counter } from 'prom-client'
 import { KafkaProducerWrapper } from 'utils/db/kafka-producer-wrapper'
-import { parse as parseUuid, v5 as uuidv5 } from 'uuid'
 
 import { KAFKA_PERSON_OVERRIDE } from '../../config/kafka-topics'
 import { InternalPerson, Person, PropertyUpdateOperation, TimestampFormat } from '../../types'
@@ -15,6 +14,7 @@ import { PeriodicTask } from '../../utils/periodic-task'
 import { promiseRetry } from '../../utils/retries'
 import { status } from '../../utils/status'
 import { castTimestampOrNow } from '../../utils/utils'
+import { uuidFromDistinctId } from './person-uuid'
 import { captureIngestionWarning } from './utils'
 
 export const mergeFinalFailuresCounter = new Counter({
@@ -33,15 +33,6 @@ export const mergeTxnSuccessCounter = new Counter({
     help: 'Number of person merges that succeeded.',
     labelNames: ['call', 'oldPersonIdentified', 'newPersonIdentified', 'poEEmbraceJoin'],
 })
-
-// UUIDv5 requires a namespace, which is itself a UUID. This was a randomly generated UUIDv4
-// that must be used to deterministrically generate UUIDv5s for Person rows.
-const PERSON_UUIDV5_NAMESPACE = parseUuid('932979b4-65c3-4424-8467-0b66ec27bc22')
-
-function uuidFromDistinctId(teamId: number, distinctId: string): string {
-    // Deterministcally create a UUIDv5 based on the (team_id, distinct_id) pair.
-    return uuidv5(`${teamId}:${distinctId}`, PERSON_UUIDV5_NAMESPACE)
-}
 
 // used to prevent identify from being used with generic IDs
 // that we can safely assume stem from a bug or mistake

--- a/plugin-server/src/worker/ingestion/person-uuid.ts
+++ b/plugin-server/src/worker/ingestion/person-uuid.ts
@@ -1,0 +1,10 @@
+import { parse as parseUuid, v5 as uuidv5 } from 'uuid'
+
+// UUIDv5 requires a namespace, which is itself a UUID. This was a randomly generated UUIDv4
+// that must be used to deterministrically generate UUIDv5s for Person rows.
+const PERSON_UUIDV5_NAMESPACE = parseUuid('932979b4-65c3-4424-8467-0b66ec27bc22')
+
+export function uuidFromDistinctId(teamId: number, distinctId: string): string {
+    // Deterministcally create a UUIDv5 based on the (team_id, distinct_id) pair.
+    return uuidv5(`${teamId}:${distinctId}`, PERSON_UUIDV5_NAMESPACE)
+}

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -1,6 +1,5 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
-import { parse as parseUuid, v5 as uuidv5 } from 'uuid'
 
 import { waitForExpect } from '../../../functional_tests/expectations'
 import { Database, Hub, InternalPerson } from '../../../src/types'
@@ -15,6 +14,7 @@ import {
     FlatPersonOverrideWriter,
     PersonState,
 } from '../../../src/worker/ingestion/person-state'
+import { uuidFromDistinctId } from '../../../src/worker/ingestion/person-uuid'
 import { delayUntilEventIngested } from '../../helpers/clickhouse'
 import { WaitEvent } from '../../helpers/promises'
 import { createOrganization, createTeam, fetchPostgresPersons, insertRow } from '../../helpers/sql'
@@ -32,17 +32,6 @@ interface PersonOverridesMode {
         hub: Hub,
         teamId: number
     ): Promise<Set<{ override_person_id: string; old_person_id: string }>>
-}
-
-function uuidFromDistinctId(teamId: number, distinctId: string): string {
-    // The UUID generation code here is deliberately copied from `person-state` rather than imported,
-    // so that someone can't accidentally change how `person-state` UUID generation works and still
-    // have the tests pass.
-    //
-    // It is very important that Person UUIDs are deterministically generated and that this format
-    // doesn't change without a lot of thought and planning about side effects!
-    const namespace = parseUuid('932979b4-65c3-4424-8467-0b66ec27bc22')
-    return uuidv5(`${teamId}:${distinctId}`, namespace)
 }
 
 const PersonOverridesModes: Record<string, PersonOverridesMode | undefined> = {

--- a/plugin-server/tests/worker/ingestion/person-uuid.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-uuid.test.ts
@@ -1,0 +1,11 @@
+import { uuidFromDistinctId } from '../../../src/worker/ingestion/person-uuid'
+
+jest.setTimeout(5000) // 5 sec timeout
+
+describe('uuidFromDistinctId', () => {
+    it('generates deterministic UUIDs', () => {
+        expect(uuidFromDistinctId(1, 'test')).toMatchInlineSnapshot(`"246f7a43-5507-564f-b687-793ee3c2dd79"`)
+        expect(uuidFromDistinctId(2, 'test')).toMatchInlineSnapshot(`"00ce873a-549c-548e-bbec-cc804a385dd8"`)
+        expect(uuidFromDistinctId(1, 'test2')).toMatchInlineSnapshot(`"45c17302-ee44-5596-916a-0eba21f4b638"`)
+    })
+})

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -1,5 +1,6 @@
 import json
 import posthoganalytics
+from posthog.models.person.missing_person import MissingPerson
 from posthog.renderers import SafeJSONRenderer
 from datetime import datetime
 from typing import (  # noqa: UP035
@@ -7,6 +8,7 @@ from typing import (  # noqa: UP035
     List,
     Optional,
     TypeVar,
+    Union,
     cast,
 )
 from collections.abc import Callable
@@ -173,10 +175,20 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
         team = self.context["get_team"]()
         return get_person_name(team, person)
 
-    def to_representation(self, instance: Person) -> dict[str, Any]:
-        representation = super().to_representation(instance)
-        representation["distinct_ids"] = sorted(representation["distinct_ids"], key=is_anonymous_id)
-        return representation
+    def to_representation(self, instance: Union[Person, MissingPerson]) -> dict[str, Any]:
+        if isinstance(instance, Person):
+            representation = super().to_representation(instance)
+            representation["distinct_ids"] = sorted(representation["distinct_ids"], key=is_anonymous_id)
+            return representation
+        elif isinstance(instance, MissingPerson):
+            return {
+                "id": None,
+                "name": None,
+                "distinct_ids": [instance.distinct_id],
+                "properties": instance.properties,
+                "created_at": None,
+                "uuid": instance.uuid,
+            }
 
 
 # person distinct ids can grow to be a very large list

--- a/posthog/models/person/missing_person.py
+++ b/posthog/models/person/missing_person.py
@@ -1,0 +1,32 @@
+from uuid import uuid5, UUID
+
+# JS code
+# const PERSON_UUIDV5_NAMESPACE = parseUuid('932979b4-65c3-4424-8467-0b66ec27bc22')
+
+# function uuidFromDistinctId(teamId: number, distinctId: string): string {
+#     // Deterministcally create a UUIDv5 based on the (team_id, distinct_id) pair.
+#     return uuidv5(`${teamId}:${distinctId}`, PERSON_UUIDV5_NAMESPACE)
+# }
+
+
+def uuidFromDistinctId(team_id: int, distinct_id: str) -> UUID:
+    """
+    Deterministically create a UUIDv5 based on the (team_id, distinct_id) pair.
+    """
+    return uuid5(UUID("932979b4-65c3-4424-8467-0b66ec27bc22"), f"{team_id}:{distinct_id}")
+
+
+class MissingPerson:
+    uuid: UUID
+    properties: dict = {}
+
+    def __init__(self, team_id: int, distinct_id: str):
+        """
+        This is loosely based on the plugin-server `person-state.ts` file and is meant to represent a person that is "missing"
+        """
+        self.team_id = team_id
+        self.distinct_id = distinct_id
+        self.uuid = uuidFromDistinctId(team_id, distinct_id)
+
+    def __str__(self):
+        return f"MissingPerson({self.team_id}, {self.distinct_id})"

--- a/posthog/models/person/missing_person.py
+++ b/posthog/models/person/missing_person.py
@@ -1,19 +1,14 @@
 from uuid import uuid5, UUID
 
-# JS code
-# const PERSON_UUIDV5_NAMESPACE = parseUuid('932979b4-65c3-4424-8467-0b66ec27bc22')
 
-# function uuidFromDistinctId(teamId: number, distinctId: string): string {
-#     // Deterministcally create a UUIDv5 based on the (team_id, distinct_id) pair.
-#     return uuidv5(`${teamId}:${distinctId}`, PERSON_UUIDV5_NAMESPACE)
-# }
+PERSON_UUIDV5_NAMESPACE = UUID("932979b4-65c3-4424-8467-0b66ec27bc22")
 
 
 def uuidFromDistinctId(team_id: int, distinct_id: str) -> UUID:
     """
     Deterministically create a UUIDv5 based on the (team_id, distinct_id) pair.
     """
-    return uuid5(UUID("932979b4-65c3-4424-8467-0b66ec27bc22"), f"{team_id}:{distinct_id}")
+    return uuid5(PERSON_UUIDV5_NAMESPACE, f"{team_id}:{distinct_id}")
 
 
 class MissingPerson:

--- a/posthog/models/test/test_missing_person_model.py
+++ b/posthog/models/test/test_missing_person_model.py
@@ -1,0 +1,10 @@
+from uuid import UUID
+from posthog.models.person.missing_person import MissingPerson
+from posthog.test.base import BaseTest
+
+
+class TestMissingPersonModel(BaseTest):
+    def test_generates_deterministic_uuid(self):
+        assert MissingPerson(1, "test").uuid == UUID("246f7a43-5507-564f-b687-793ee3c2dd79")
+        assert MissingPerson(2, "test").uuid == UUID("00ce873a-549c-548e-bbec-cc804a385dd8")
+        assert MissingPerson(1, "test2").uuid == UUID("45c17302-ee44-5596-916a-0eba21f4b638")

--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -1,8 +1,9 @@
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, Union
 
 from django.conf import settings
 from django.db import models
 
+from posthog.models.person.missing_person import MissingPerson
 from posthog.models.person.person import Person
 from posthog.models.signals import mutable_receiver
 from posthog.models.team.team import Team
@@ -112,12 +113,12 @@ class SessionRecording(UUIDModel):
         return self._metadata.get("snapshot_source", "web") if self._metadata else "web"
 
     @property
-    def person(self) -> Person:
+    def person(self) -> Union[Person, MissingPerson]:
         if self._person:
             return self._person
 
-        person = Person()
-        person._distinct_ids = [self.distinct_id]
+        person = MissingPerson(team_id=self.team_id, distinct_id=self.distinct_id)
+
         return person
 
     @person.setter

--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -117,9 +117,7 @@ class SessionRecording(UUIDModel):
         if self._person:
             return self._person
 
-        person = MissingPerson(team_id=self.team_id, distinct_id=self.distinct_id)
-
-        return person
+        return MissingPerson(team_id=self.team_id, distinct_id=self.distinct_id)
 
     @person.setter
     def person(self, value: Person):

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -683,7 +683,9 @@ def list_recordings(
 
         for recording in recordings:
             recording.viewed = recording.session_id in viewed_session_recordings
-            recording.person = distinct_id_to_person.get(recording.distinct_id)
+            person = distinct_id_to_person.get(recording.distinct_id)
+            if person:
+                recording.person = person
 
     session_recording_serializer = SessionRecordingSerializer(recordings, context=context, many=True)
     results = session_recording_serializer.data

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -410,7 +410,18 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
 
         response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/id_no_person")
         response_data = response.json()
-        self.assertEqual(response_data["person"], None)
+
+        self.assertEqual(
+            response_data["person"],
+            {
+                "id": None,
+                "name": "d1",
+                "distinct_ids": ["d1"],
+                "properties": {},
+                "created_at": None,
+                "uuid": "018f1503-7a50-0000-7c5a-8ddabf481837",
+            },
+        )
 
     def test_session_recording_doesnt_exist(self):
         response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/non_existent_id")

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -415,11 +415,11 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             response_data["person"],
             {
                 "id": None,
-                "name": "d1",
+                "name": None,
                 "distinct_ids": ["d1"],
                 "properties": {},
                 "created_at": None,
-                "uuid": "018f1503-7a50-0000-7c5a-8ddabf481837",
+                "uuid": response_data["person"]["uuid"],
             },
         )
 


### PR DESCRIPTION
## Problem

Part of the personless work, I noticed that Replay in particular looked confusing / broken.

## Changes

* Modify the recording api to always return a person (matches what /query does for missing Person info)
* Update the messaging
* Refactored a little the person state processing so we can test the actual values (the existing tests were never checking that it was actually deterministic, only that it matched its own output...
* Added a `MissingPerson` model which mimics the plugin server behaviour.

|Before|After|
|----|----|
| <img width="501" alt="Screenshot 2024-04-25 at 13 22 59" src="https://github.com/PostHog/posthog/assets/2536520/61239bdd-f0df-4207-b87d-679de32fa7f2"> |  <img width="855" alt="Screenshot 2024-04-25 at 13 22 16" src="https://github.com/PostHog/posthog/assets/2536520/5c5671ae-9917-4372-bfac-2fb205a3a7e6"> |
| <img width="823" alt="Screenshot 2024-04-25 at 13 23 06" src="https://github.com/PostHog/posthog/assets/2536520/a35cf91a-f889-48ac-9a1a-5d3cf2ccde63"> | <img width="904" alt="Screenshot 2024-04-25 at 13 21 55" src="https://github.com/PostHog/posthog/assets/2536520/00b7618f-9a3c-4068-8054-81b9264a1f9c"> |

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
