### PR TITLE
chore: Remove heatmaps preview config option

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -44,8 +44,6 @@ export function loadPostHogJS(): void {
                 },
                 process_person: 'identified_only',
 
-                __preview_heatmaps: true,
-
                 // Helper to capture events for assertions in Cypress
                 _onCapture: (window as any)._cypress_posthog_captures
                     ? (_, event) => (window as any)._cypress_posthog_captures.push(event)


### PR DESCRIPTION
## Changs

We have the remote config now so we don't need the preview flag
