### PR TITLE
Revert "fix: Wrap asgi application to ignore lifetime requests"

### DIFF
--- a/posthog/asgi.py
+++ b/posthog/asgi.py
@@ -1,17 +1,8 @@
 import os
 
 from django.core.asgi import get_asgi_application
-from django.http.response import HttpResponse
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
 os.environ.setdefault("SERVER_GATEWAY_INTERFACE", "ASGI")
 
-
-def lifetime_wrapper(func):
-    async def inner(scope, receive, send):
-        if scope["type"] != "http":
-            return HttpResponse(status=501)
-        return func(scope, receive, send)
-
-
-application = lifetime_wrapper(get_asgi_application())
+application = get_asgi_application()


### PR DESCRIPTION
Reverts PostHog/posthog#21802

`2024/04/25 15:19:40 [alert] 26#26 "application" in module "posthog.asgi" is not a callable object`

:(