### PR TITLE
chore(plugin-server): set 'force_upgrade' for 'person_mode' when applicable

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -619,6 +619,7 @@ interface BaseEvent {
 export type ISOTimestamp = Brand<string, 'ISOTimestamp'>
 export type ClickHouseTimestamp = Brand<string, 'ClickHouseTimestamp'>
 export type ClickHouseTimestampSecondPrecision = Brand<string, 'ClickHouseTimestamp'>
+export type PersonMode = 'full' | 'propertyless' | 'force_upgrade'
 
 /** Raw event row from ClickHouse. */
 export interface RawClickHouseEvent extends BaseEvent {
@@ -638,7 +639,7 @@ export interface RawClickHouseEvent extends BaseEvent {
     group2_created_at?: ClickHouseTimestamp
     group3_created_at?: ClickHouseTimestamp
     group4_created_at?: ClickHouseTimestamp
-    person_mode: 'full' | 'propertyless'
+    person_mode: PersonMode
 }
 
 /** Parsed event row from ClickHouse. */
@@ -659,7 +660,7 @@ export interface ClickHouseEvent extends BaseEvent {
     group2_created_at?: DateTime | null
     group3_created_at?: DateTime | null
     group4_created_at?: DateTime | null
-    person_mode: 'full' | 'propertyless'
+    person_mode: PersonMode
 }
 
 /** Event in a database-agnostic shape, AKA an ingestion event.
@@ -746,6 +747,11 @@ export interface Person {
     properties: Properties
     uuid: string
     created_at: DateTime
+
+    // Set to `true` when an existing person row was found for this `distinct_id`, but the event was
+    // sent with `$process_person_profile=false`. This is an unexpected branch that we want to flag
+    // for debugging and billing purposes, and typically means a misconfigured SDK.
+    force_upgrade?: boolean
 }
 
 /** Clickhouse Person model. */

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -114,10 +114,15 @@ export class PersonState {
     async update(): Promise<Person> {
         if (!this.processPerson) {
             if (this.lazyPersonCreation) {
-                const person = await this.db.fetchPerson(this.teamId, this.distinctId, { useReadReplica: true })
-                if (person) {
+                const existingPerson = await this.db.fetchPerson(this.teamId, this.distinctId, { useReadReplica: true })
+                if (existingPerson) {
+                    const person = existingPerson as Person
+
                     // Ensure person properties don't propagate elsewhere, such as onto the event itself.
                     person.properties = {}
+
+                    // See documentation on the field.
+                    person.force_upgrade = true
 
                     return person
                 }

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -11,6 +11,7 @@ import {
     Hub,
     ISOTimestamp,
     Person,
+    PersonMode,
     PreIngestionEvent,
     RawClickHouseEvent,
     Team,
@@ -239,6 +240,13 @@ export class EventsProcessor {
 
         // TODO: Remove Redis caching for person that's not used anymore
 
+        let personMode: PersonMode = 'full'
+        if (person.force_upgrade) {
+            personMode = 'force_upgrade'
+        } else if (!processPerson) {
+            personMode = 'propertyless'
+        }
+
         const rawEvent: RawClickHouseEvent = {
             uuid,
             event: safeClickhouseString(event),
@@ -251,7 +259,7 @@ export class EventsProcessor {
             person_id: person.uuid,
             person_properties: eventPersonProperties,
             person_created_at: castTimestampOrNow(person.created_at, TimestampFormat.ClickHouseSecondPrecision),
-            person_mode: processPerson ? 'full' : 'propertyless',
+            person_mode: personMode,
             ...groupsColumns,
         }
 

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -25,7 +25,7 @@
       group2_created_at DateTime64,
       group3_created_at DateTime64,
       group4_created_at DateTime64,
-      person_mode Enum8('full' = 0, 'propertyless' = 1)
+      person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
       
       
       
@@ -108,7 +108,7 @@
       group2_created_at DateTime64,
       group3_created_at DateTime64,
       group4_created_at DateTime64,
-      person_mode Enum8('full' = 0, 'propertyless' = 1)
+      person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
       
       
       
@@ -519,7 +519,7 @@
       group2_created_at DateTime64,
       group3_created_at DateTime64,
       group4_created_at DateTime64,
-      person_mode Enum8('full' = 0, 'propertyless' = 1)
+      person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
       
       , $group_0 VARCHAR COMMENT 'column_materializer::$group_0'
       , $group_1 VARCHAR COMMENT 'column_materializer::$group_1'
@@ -840,7 +840,7 @@
       group2_created_at DateTime64,
       group3_created_at DateTime64,
       group4_created_at DateTime64,
-      person_mode Enum8('full' = 0, 'propertyless' = 1)
+      person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
       
       
       
@@ -1887,7 +1887,7 @@
       group2_created_at DateTime64,
       group3_created_at DateTime64,
       group4_created_at DateTime64,
-      person_mode Enum8('full' = 0, 'propertyless' = 1)
+      person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
       
       , $group_0 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_0'), '^"|"$', '') COMMENT 'column_materializer::$group_0'
       , $group_1 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_1'), '^"|"$', '') COMMENT 'column_materializer::$group_1'
@@ -2222,7 +2222,7 @@
       group2_created_at DateTime64,
       group3_created_at DateTime64,
       group4_created_at DateTime64,
-      person_mode Enum8('full' = 0, 'propertyless' = 1)
+      person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
       
       
   , _timestamp DateTime
@@ -2778,7 +2778,7 @@
       group2_created_at DateTime64,
       group3_created_at DateTime64,
       group4_created_at DateTime64,
-      person_mode Enum8('full' = 0, 'propertyless' = 1)
+      person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
       
       , $group_0 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_0'), '^"|"$', '') COMMENT 'column_materializer::$group_0'
       , $group_1 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_1'), '^"|"$', '') COMMENT 'column_materializer::$group_1'

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER '{cluster}'
     group2_created_at DateTime64,
     group3_created_at DateTime64,
     group4_created_at DateTime64,
-    person_mode Enum8('full' = 0, 'propertyless' = 1)
+    person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
     {materialized_columns}
     {extra_fields}
     {indexes}


### PR DESCRIPTION
…icable## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We need to note if `$process_person_profile=false` is used when a `Person` exists in the DB.

## Changes

Set the enum as applicable.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->
Yes

## How did you test this code?

Tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
