### PR TITLE
chore: Update psycopg to 3.1.18 (latest release.)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,10 @@ argcomplete==2.0.0
     # via datamodel-code-generator
 asgiref==3.7.2
     # via django
+async-timeout==4.0.2
+    # via
+    #   aiohttp
+    #   redis
 attrs==23.2.0
     # via
     #   aiohttp
@@ -53,6 +57,8 @@ docopt==0.6.2
     # via pytest-watch
 email-validator==2.0.0.post2
     # via pydantic
+exceptiongroup==1.2.1
+    # via pytest
 faker==17.5.0
 fakeredis==2.11.0
 flaky==3.7.0
@@ -203,7 +209,14 @@ sqlparse==0.4.4
     # via django
 syrupy==4.6.0
 toml==0.10.1
-    # via coverage
+    # via
+    #   coverage
+    #   datamodel-code-generator
+tomli==2.0.1
+    # via
+    #   black
+    #   mypy
+    #   pytest
 types-awscrt==0.20.9
     # via botocore-stubs
 types-freezegun==1.1.10
@@ -221,10 +234,14 @@ types-s3transfer==0.10.1
 types-tzlocal==5.1.0.1
 typing-extensions==4.7.1
     # via
+    #   asgiref
+    #   black
+    #   boto3-stubs
     #   django-stubs
     #   django-stubs-ext
     #   djangorestframework-stubs
     #   mypy
+    #   mypy-boto3-s3
     #   pydantic
     #   pydantic-core
 uritemplate==4.1.1

--- a/requirements.in
+++ b/requirements.in
@@ -53,7 +53,7 @@ pandas==2.2.0
 Pillow==10.2.0
 posthoganalytics==3.5.0
 psycopg2-binary==2.9.7
-psycopg[binary]==3.1.13
+psycopg[binary]==3.1.18
 pyarrow==15.0.0
 pydantic==2.5.3
 pyjwt==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -352,8 +352,8 @@ protobuf==4.22.1
     #   grpcio-status
     #   proto-plus
     #   temporalio
-psycopg==3.1.13
-psycopg-binary==3.1.13
+psycopg==3.1.18
+psycopg-binary==3.1.18
     # via psycopg
 psycopg2-binary==2.9.7
 py==1.11.0


### PR DESCRIPTION
## Problem

3.1.13 has [a bug](https://github.com/psycopg/psycopg/issues/695) when establishing connections to hosts that resolve to multiple IP addresses, causing problems with batch exports (and possibly data warehouse as well as it uses the same driver), see:

- https://posthoghelp.zendesk.com/agent/tickets/12853 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15213)
- https://posthog.sentry.io/issues/4698187785/events/17997d5c077e4305a662a8b2ba9946bc/

## Changes

Upgrades to latest version (3.1.18), which includes the fix that was added in 3.1.15.

Release notes are here: https://www.psycopg.org/psycopg3/docs/news.html

## Does this work well for both Cloud and self-hosted?

It should!

## How did you test this code?

Manually tested versions 3.1.13, 3.1.15 and 3.1.18 with the problematic connection parameters, able to reproduce the connection failure under 3.1.13, while the other versions were able to connect without issue. I'm assuming existing tests would otherwise catch any unlikely regressions from the version upgrade.