### PR TITLE
chore: also count force_upgrade events as personfull for usage reports

### DIFF
--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -46,7 +46,7 @@ def create_event(
     group2_created_at: Optional[Union[timezone.datetime, str]] = None,
     group3_created_at: Optional[Union[timezone.datetime, str]] = None,
     group4_created_at: Optional[Union[timezone.datetime, str]] = None,
-    person_mode: Literal["full", "propertyless"] = "full",
+    person_mode: Literal["full", "propertyless", "force_upgrade"] = "full",
 ) -> str:
     if properties is None:
         properties = {}

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -195,7 +195,8 @@
     AND event NOT IN ('survey sent',
                       'survey shown',
                       'survey dismissed')
-    AND person_mode = 'full'
+    AND person_mode IN ('full',
+                        'force_upgrade')
   GROUP BY team_id
   '''
 # ---

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -195,7 +195,7 @@
     AND event NOT IN ('survey sent',
                       'survey shown',
                       'survey dismissed')
-    AND person_mode = 'full'
+    AND person_mode IN ('full', 'force_upgrade')
   GROUP BY team_id
   '''
 # ---

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -345,6 +345,15 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                 team=self.org_1_team_1,
                 person_mode="propertyless",
             )
+            _create_event(
+                event_uuid=uuid4(),
+                distinct_id=distinct_id,
+                event="$propertyless_event",
+                properties={"$lib": "$web"},
+                timestamp=now() - relativedelta(hours=12),
+                team=self.org_1_team_1,
+                person_mode="force_upgrade",
+            )
 
             flush_persons_and_events()
 
@@ -400,10 +409,10 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     },
                     "plugins_enabled": {"Installed and enabled": 1},
                     "instance_tag": "none",
-                    "event_count_lifetime": 56,
-                    "event_count_in_period": 23,
-                    "enhanced_persons_event_count_in_period": 22,
-                    "event_count_in_month": 43,
+                    "event_count_lifetime": 57,
+                    "event_count_in_period": 24,
+                    "enhanced_persons_event_count_in_period": 23,
+                    "event_count_in_month": 44,
                     "event_count_with_groups_in_period": 2,
                     "recording_count_in_period": 5,
                     "recording_count_total": 16,
@@ -444,10 +453,10 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "team_count": 2,
                     "teams": {
                         str(self.org_1_team_1.id): {
-                            "event_count_lifetime": 45,
-                            "event_count_in_period": 13,
-                            "enhanced_persons_event_count_in_period": 12,
-                            "event_count_in_month": 33,
+                            "event_count_lifetime": 46,
+                            "event_count_in_period": 14,
+                            "enhanced_persons_event_count_in_period": 13,
+                            "event_count_in_month": 34,
                             "event_count_with_groups_in_period": 2,
                             "recording_count_in_period": 0,
                             "recording_count_total": 0,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -443,7 +443,7 @@ def get_teams_with_billable_enhanced_persons_event_count_in_period(
         f"""
         SELECT team_id, count({distinct_expression}) as count
         FROM events
-        WHERE timestamp between %(begin)s AND %(end)s AND event != '$feature_flag_called' AND event NOT IN ('survey sent', 'survey shown', 'survey dismissed') AND person_mode = 'full'
+        WHERE timestamp between %(begin)s AND %(end)s AND event != '$feature_flag_called' AND event NOT IN ('survey sent', 'survey shown', 'survey dismissed') AND person_mode IN ('full', 'force_upgrade')
         GROUP BY team_id
     """,
         {"begin": begin, "end": end},


### PR DESCRIPTION
## Problem

We want to bill people for personfull events if they are force-upgraded (meaning they tried to send a personless event for a distinct_id that's already been identified)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Looks for `full` or `force_upgrade` in the person_mode column

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

I should update the tests for this..

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
