### PR TITLE
chore(dev): Allow mypy to run in VS Code extension

### DIFF
--- a/posthog/settings/access.py
+++ b/posthog/settings/access.py
@@ -63,11 +63,9 @@ SECRET_KEY = os.getenv("SECRET_KEY", DEFAULT_SECRET_KEY)
 if not DEBUG and not TEST and SECRET_KEY == DEFAULT_SECRET_KEY:
     logger.critical(
         """
-            You are using the default SECRET_KEY in a production environment!
-            For the safety of your instance, you must generate and set a unique key.,
-            More information on
-            https://posthog.com/docs/self-host/configure/securing-posthog,
-        """
+You are using the default SECRET_KEY in a production environment!
+For the safety of your instance, you must generate and set a unique key.
+"""
     )
     sys.exit("[ERROR] Default SECRET_KEY in production. Stopping Django server…\n")
 

--- a/posthog/settings/overrides.py
+++ b/posthog/settings/overrides.py
@@ -32,7 +32,7 @@ cmd = None
 if runner:
     cmd = sys.argv[1] if len(sys.argv) >= 2 else None
 
-    if cmd == "test" or runner.endswith("pytest") or runner.endswith("mypy"):
+    if cmd == "test" or runner.endswith("pytest") or runner.endswith("mypy") or "/mypy/" in runner:
         print("Running in test mode. Setting DEBUG and TEST environment variables.")
         os.environ["DEBUG"] = "1"
         os.environ["TEST"] = "1"


### PR DESCRIPTION
## Problem

Mypy doesn't work in the [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.mypy-type-checker).

## Changes

I'm seeing "You are using the default SECRET_KEY in a production environment!" in the extension's output, and looking at `overrides.py`, I see what's happening. For some reason DEBUG needs to be 1 during mypy analysis. That's what this PR updates.