### PR TITLE
chore(capture.py): remove the sha key code path

### DIFF
--- a/ee/api/test/test_capture.py
+++ b/ee/api/test/test_capture.py
@@ -1,11 +1,9 @@
-import hashlib
 import json
-from typing import Any
-from unittest.mock import patch
-
 from django.test.client import Client
 from kafka.errors import NoBrokersAvailable
 from rest_framework import status
+from typing import Any
+from unittest.mock import patch
 
 from posthog.settings.data_stores import KAFKA_EVENTS_PLUGIN_INGESTION
 from posthog.test.base import APIBaseTest
@@ -176,7 +174,7 @@ class TestCaptureAPI(APIBaseTest):
         kafka_produce_call = kafka_produce.call_args_list[0].kwargs
         self.assertEqual(
             kafka_produce_call["key"],
-            hashlib.sha256(default_partition_key.encode()).hexdigest(),
+            default_partition_key,
         )
 
         # Setting up an override via EVENT_PARTITION_KEYS_TO_OVERRIDE should cause us to pass None

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -1,8 +1,8 @@
-import hashlib
 import json
 import re
 import structlog
 import time
+from collections.abc import Iterator
 from datetime import datetime, timedelta
 from dateutil import parser
 from django.conf import settings
@@ -19,7 +19,6 @@ from sentry_sdk.api import capture_exception, start_span
 from statshog.defaults.django import statsd
 from token_bucket import Limiter, MemoryStorage
 from typing import Any, Optional
-from collections.abc import Iterator
 
 from ee.billing.quota_limiting import QuotaLimitingCaches
 from posthog.api.utils import get_data, get_token, safe_clickhouse_string
@@ -625,11 +624,7 @@ def capture_internal(
     ):
         kafka_partition_key = None
     else:
-        if settings.CAPTURE_SKIP_KEY_HASHING:
-            kafka_partition_key = candidate_partition_key
-        else:
-            # TODO: remove after progressive rollout of the option
-            kafka_partition_key = hashlib.sha256(candidate_partition_key.encode()).hexdigest()
+        kafka_partition_key = candidate_partition_key
 
     return log_event(parsed_event, event["event"], partition_key=kafka_partition_key, historical=historical)
 

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -17,9 +17,6 @@ BUFFER_CONVERSION_SECONDS = get_from_env("BUFFER_CONVERSION_SECONDS", default=60
 # partitioning-related settings below.
 CAPTURE_ALLOW_RANDOM_PARTITIONING = get_from_env("CAPTURE_ALLOW_RANDOM_PARTITIONING", True, type_cast=str_to_bool)
 
-# TOOD: make default after rollout on both prods: remove the superfluous hashing of the Kafka message key
-CAPTURE_SKIP_KEY_HASHING = get_from_env("CAPTURE_SKIP_KEY_HASHING", type_cast=bool, default=False)
-
 # A list of <team_id:distinct_id> pairs (in the format 2:myLovelyId) that we should use
 # random partitioning for when producing events to the Kafka topic consumed by the plugin server.
 # This is a measure to handle hot partitions in ad-hoc cases.


### PR DESCRIPTION
## Problem

Follow-up of https://github.com/PostHog/posthog/pull/21850: the config has been rolled out on all regions, let's remove the old code path now.

## Changes
- Remove the envvar added in https://github.com/PostHog/posthog/pull/21850
- Make non-hashed message key the default, to match capture-rs


## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
