### PR TITLE
fix(tasks): Add autoretry for too many simultaneous queries error in some tasks

### DIFF
--- a/ee/clickhouse/test/test_error.py
+++ b/ee/clickhouse/test/test_error.py
@@ -35,6 +35,12 @@ from posthog.errors import wrap_query_error
             "Query exceeds memory limits. Try reducing its scope by changing the time range.",
             241,
         ),
+        (
+            ServerException("Too many simultaneous queries. Maximum: 100.", code=202),
+            "CHQueryErrorTooManySimultaneousQueries",
+            "Code: 202.\nToo many simultaneous queries. Try again later.",
+            202,
+        ),
     ],
 )
 def test_wrap_query_error(error, expected_type, expected_message, expected_code):

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -562,7 +562,14 @@ def schedule_cache_updates_task() -> None:
     schedule_cache_updates()
 
 
-@shared_task(ignore_result=True)
+@shared_task(
+    ignore_result=True,
+    autoretry_for=(CHQueryErrorTooManySimultaneousQueries,),
+    retry_backoff=10,
+    retry_backoff_max=30,
+    max_retries=3,
+    retry_jitter=True,
+)
 def update_cache_task(caching_state_id: UUID) -> None:
     from posthog.caching.insight_cache import update_cache
 


### PR DESCRIPTION
## Problem

We throw a lot of simultaneous queries errors. We can retry.

Fixes POSTHOG-DNR
Fixes POSTHOG-DNR
Fixes POSTHOG-TMV

## Changes

- use Celery autoretry_for
- but for that to work, isolate the exception as a real one

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

- tested exception handling, added test
- not sure how to test locally for real cause needs reproducing too many queries somehow