### PR TITLE
fix: Use sentence case for "Session properties"

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -490,7 +490,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getPopoverHeader: () => 'Notebooks',
                     },
                     {
-                        name: 'Session Properties',
+                        name: 'Session properties',
                         searchPlaceholder: 'sessions',
                         type: TaxonomicFilterGroupType.SessionProperties,
                         options: featureFlags[FEATURE_FLAGS.SESSION_TABLE_PROPERTY_FILTERS]


### PR DESCRIPTION
## Problem

One of these is not like the others:

<img width="399" alt="325228802-819d7285-849d-4216-a9b3-869a564c6998" src="https://github.com/PostHog/posthog/assets/4550621/17d2f656-665b-42cd-9094-60d5c2714814">
