### PR TITLE
fix: patch missing pause method in rrweb

### DIFF
--- a/patches/rrweb@2.0.0-alpha.13.patch
+++ b/patches/rrweb@2.0.0-alpha.13.patch
@@ -488,6 +488,46 @@ index 0d49411b1f6d31103bed898c0e81d1d74ab51234..0b2160ef08aa3ae5310f63c295abc0a5
          }
      }
      applyMutation(d, isSync) {
+diff --git a/es/rrweb/packages/rrweb/src/replay/media/index.js b/es/rrweb/packages/rrweb/src/replay/media/index.js
+index 22fee601e786c1d8dfb5c01d2e359c8bcbac7c42..20c3e14adfde860563e8dd902041bd14c860f462 100644
+--- a/es/rrweb/packages/rrweb/src/replay/media/index.js
++++ b/es/rrweb/packages/rrweb/src/replay/media/index.js
+@@ -21,7 +21,7 @@ class MediaManager {
+         this.mediaMap.forEach((mediaState, target) => {
+             this.syncTargetWithState(target);
+             if (options.pause) {
+-                target.pause();
++                target?.pause();
+             }
+         });
+     }
+@@ -49,7 +49,7 @@ class MediaManager {
+             target.currentTime = seekToTime;
+         }
+         else {
+-            target.pause();
++            target?.pause();
+             target.currentTime = mediaState.currentTimeAtLastInteraction;
+         }
+     }
+@@ -117,7 +117,7 @@ class MediaManager {
+                 void target.play();
+             }
+             else {
+-                target.pause();
++                target?.pause();
+             }
+         }
+         catch (error) {
+@@ -141,7 +141,7 @@ class MediaManager {
+             isPlaying = target.getAttribute('autoplay') !== null;
+         }
+         if (isPlaying && playerIsPaused)
+-            target.pause();
++            target?.pause();
+         let playbackRate = 1;
+         if (typeof mediaAttributes.rr_mediaPlaybackRate === 'number') {
+             playbackRate = mediaAttributes.rr_mediaPlaybackRate;
 diff --git a/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js b/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
 index 38a23aaae8d683fa584329eced277dd8de55d1ff..278e06bc6c8c964581d461405a0f0a4544344fa1 100644
 --- a/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: gydrxrztd4ruyhouu6tu7zh43e
     path: patches/heatmap.js@2.0.5.patch
   rrweb@2.0.0-alpha.13:
-    hash: awo7hmdoglvq4pl5b43lreupza
+    hash: g7jnlxuwyxkja3n62yb6xpim6q
     path: patches/rrweb@2.0.0-alpha.13.patch
 
 dependencies:
@@ -333,7 +333,7 @@ dependencies:
     version: 1.5.1
   rrweb:
     specifier: 2.0.0-alpha.13
-    version: 2.0.0-alpha.13(patch_hash=awo7hmdoglvq4pl5b43lreupza)
+    version: 2.0.0-alpha.13(patch_hash=g7jnlxuwyxkja3n62yb6xpim6q)
   sass:
     specifier: ^1.26.2
     version: 1.56.0
@@ -19277,7 +19277,7 @@ packages:
     resolution: {integrity: sha512-slbhNBCYjxLGCeH95a67ECCy5a22nloXp1F5wF7DCzUNw80FN7tF9Lef1sRGLNo32g3mNqTc2sWLATlKejMxYw==}
     dev: false
 
-  /rrweb@2.0.0-alpha.13(patch_hash=awo7hmdoglvq4pl5b43lreupza):
+  /rrweb@2.0.0-alpha.13(patch_hash=g7jnlxuwyxkja3n62yb6xpim6q):
     resolution: {integrity: sha512-a8GXOCnzWHNaVZPa7hsrLZtNZ3CGjiL+YrkpLo0TfmxGLhjNZbWY2r7pE06p+FcjFNlgUVTmFrSJbK3kO7yxvw==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.13


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/21874

## Changes

Looks like the pause method can be undefined sometimes in the latest rrweb version. Let's just conditionally call `.pause()` everywhere in this patch until https://github.com/rrweb-io/rrweb/pull/1461 is merged or another fix is found