### PR TITLE
fix(plugin-server): add time component to person.force_upgrade

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -112,8 +112,15 @@ export class PersonState {
                     // Ensure person properties don't propagate elsewhere, such as onto the event itself.
                     person.properties = {}
 
-                    // See documentation on the field.
-                    person.force_upgrade = true
+                    if (this.timestamp > person.created_at.plus({ minutes: 1 })) {
+                        // See documentation on the field.
+                        //
+                        // Note that we account for timestamp vs person creation time (with a little
+                        // padding for good measure) to account for ingestion lag. It's possible for
+                        // events to be processed after person creation even if they were sent prior
+                        // to person creation, and the user did nothing wrong in that case.
+                        person.force_upgrade = true
+                    }
 
                     return person
                 }

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -111,7 +111,8 @@ describe('PersonState.update()', () => {
         event: Partial<PluginEvent>,
         customHub?: Hub,
         processPerson = true,
-        lazyPersonCreation = false
+        lazyPersonCreation = false,
+        timestampParam = timestamp
     ) {
         const fullEvent = {
             team_id: teamId,
@@ -123,7 +124,7 @@ describe('PersonState.update()', () => {
             fullEvent as any,
             teamId,
             event.distinct_id!,
-            timestamp,
+            timestampParam,
             processPerson,
             customHub ? customHub.db : hub.db,
             lazyPersonCreation,
@@ -261,6 +262,7 @@ describe('PersonState.update()', () => {
             // `force_upgrade=true` and real Person `uuid` and `created_at`
             processPerson = false
             const event_uuid = new UUIDT().toString()
+            const timestampParam = timestamp.plus({ minutes: 5 }) // Event needs to happen after Person creation
             const fakePerson = await personState(
                 {
                     event: '$pageview',
@@ -270,7 +272,8 @@ describe('PersonState.update()', () => {
                 },
                 hubParam,
                 processPerson,
-                lazyPersonCreation
+                lazyPersonCreation,
+                timestampParam
             ).update()
             await hub.db.kafkaProducer.flush()
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Incoming anonymous events can race with events post-identify. We shouldn't force upgrade unless a Person is used via `$process_person_profile=false` well after creation.

## Changes

Add time diff component to `force_upgrade=true`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
