### PR TITLE
fix: recording exports

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -257,7 +257,7 @@ const MenuActions = (): JSX.Element => {
     const items: LemonMenuItems = [
         {
             label: 'Export to file',
-            onClick: exportRecordingToFile,
+            onClick: () => exportRecordingToFile(false),
             icon: <IconDownload />,
             tooltip: 'Export recording to a file. This can be loaded later into PostHog for playback.',
         },


### PR DESCRIPTION
## Problem

When investigating recent customer issues I noticed that you cannot export recordings

## Changes

Looks like `exportRecordingToFile` is being set to the button click event e.g. a truthy HTML element

<img width="484" alt="Screenshot 2024-04-26 at 16 22 19" src="https://github.com/PostHog/posthog/assets/6685876/5396d23d-3825-41b8-84f2-f2ba8e516368">

Weirdly enough this doesn't happen locally (the value defaults to false). There's no harm in explicitly setting it