### PR TITLE
fix(dashboards): HogQL support for dashboard filters on insights with property group filters

### DIFF
--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 from posthog.hogql.query import execute_hogql_query
 from rest_framework import status
+from parameterized import parameterized
 
 from posthog.api.test.dashboards import DashboardAPI
 from posthog.caching.fetch_from_cache import synchronously_update_cache
@@ -1135,8 +1136,26 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 ],
             )
 
+    @parameterized.expand(
+        [
+            [  # Property group filter, which is what's actually used these days
+                PropertyGroupFilter(
+                    type=FilterLogicalOperator.AND,
+                    values=[
+                        PropertyGroupFilterValue(
+                            type=FilterLogicalOperator.OR,
+                            values=[EventPropertyFilter(key="another", value="never_return_this", operator="is_not")],
+                        )
+                    ],
+                )
+            ],
+            [  # Classic list of filters
+                [EventPropertyFilter(key="another", value="never_return_this", operator="is_not")]
+            ],
+        ]
+    )
     @patch("posthog.hogql_queries.insights.trends.trends_query_runner.execute_hogql_query", wraps=execute_hogql_query)
-    def test_insight_refreshing_query(self, spy_execute_hogql_query) -> None:
+    def test_insight_refreshing_query(self, properties_filter, spy_execute_hogql_query) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({"filters": {"date_from": "-14d"}})
 
         with freeze_time("2012-01-14T03:21:34.000Z"):
@@ -1165,15 +1184,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                     event="$pageview",
                 )
             ],
-            properties=PropertyGroupFilter(
-                type=FilterLogicalOperator.AND,
-                values=[
-                    PropertyGroupFilterValue(
-                        type=FilterLogicalOperator.OR,
-                        values=[EventPropertyFilter(key="another", value="never_return_this", operator="is_not")],
-                    )
-                ],
-            ),
+            properties=properties_filter,
         ).model_dump()
 
         with freeze_time("2012-01-15T04:01:34.000Z"):

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -35,8 +35,11 @@ from posthog.schema import (
     EventPropertyFilter,
     EventsNode,
     EventsQuery,
+    FilterLogicalOperator,
     HogQLFilters,
     HogQLQuery,
+    PropertyGroupFilter,
+    PropertyGroupFilterValue,
     TrendsQuery,
 )
 from posthog.test.base import (
@@ -1162,7 +1165,15 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                     event="$pageview",
                 )
             ],
-            properties=[EventPropertyFilter(key="another", value="never_return_this", operator="is_not")],
+            properties=PropertyGroupFilter(
+                type=FilterLogicalOperator.AND,
+                values=[
+                    PropertyGroupFilterValue(
+                        type=FilterLogicalOperator.OR,
+                        values=[EventPropertyFilter(key="another", value="never_return_this", operator="is_not")],
+                    )
+                ],
+            ),
         ).model_dump()
 
         with freeze_time("2012-01-15T04:01:34.000Z"):

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -824,7 +824,11 @@ class TrendsQueryRunner(QueryRunner):
         if updated_query.breakdownFilter:
             updated_query.breakdownFilter.breakdown_limit = None
 
-        if updated_query.trendsFilter.compare and dashboard_filter.date_from == "all":
+        if (
+            updated_query.trendsFilter is not None
+            and updated_query.trendsFilter.compare
+            and dashboard_filter.date_from == "all"
+        ):
             updated_query.trendsFilter.compare = False
 
         return updated_query

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -50,6 +50,7 @@ from posthog.schema import (
     ChartDisplayType,
     Compare,
     CompareItem,
+    DashboardFilter,
     DayItem,
     EventsNode,
     DataWarehouseNode,
@@ -817,9 +818,13 @@ class TrendsQueryRunner(QueryRunner):
 
         return TrendsDisplay(display)
 
-    def apply_dashboard_filters(self, *args, **kwargs) -> RunnableQueryNode:
-        updated_query = super().apply_dashboard_filters(*args, **kwargs)
+    def apply_dashboard_filters(self, dashboard_filter: DashboardFilter) -> RunnableQueryNode:
+        updated_query: TrendsQuery = super().apply_dashboard_filters(dashboard_filter=dashboard_filter)
         # Remove any set breakdown limit for display on the dashboard
         if updated_query.breakdownFilter:
             updated_query.breakdownFilter.breakdown_limit = None
+
+        if updated_query.trendsFilter.compare and dashboard_filter.date_from == "all":
+            updated_query.trendsFilter.compare = False
+
         return updated_query

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -444,14 +444,10 @@ class QueryRunner(ABC, Generic[Q]):
                                 ),
                             ],
                         )
-                    except Exception as e:
+                    except Exception:
                         # If pydantic is unhappy about the shape of data, let's ignore property filters and carry on
                         capture_exception()
-                        logger.error(
-                            "Failed to apply dashboard property filters",
-                            exception=e,
-                            exc_info=True,
-                        )
+                        logger.exception("Failed to apply dashboard property filters")
                 else:
                     query_update["properties"] = dashboard_filter.properties
             if dashboard_filter.date_from or dashboard_filter.date_to:

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -445,7 +445,7 @@ class QueryRunner(ABC, Generic[Q]):
                             ],
                         )
                     except Exception as e:
-                        # If pydantic is unhappy about the shape of data, let's ignore dashboard filters and carry on
+                        # If pydantic is unhappy about the shape of data, let's ignore property filters and carry on
                         capture_exception()
                         logger.error(
                             "Failed to apply dashboard property filters",


### PR DESCRIPTION
## Problem

HogQL `apply_dashboard_filters` only worked if the insight's query uses filters in list form – but typically these days, property filter groups are used. This failed ([Sentry](https://posthog.sentry.io/issues/5260534837/?project=-1&query=is%3Aunresolved&referrer=issue-stream&sort=trends&statsPeriod=7d&stream_index=4&utc=true)).

## Changes

Fixed the bug.

## How did you test this code?

Updated `test_insight_refreshing_query` to use a property filter group instead of just list.

