### PR TITLE
fix: Adds fallback to res.text in billing error handler

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -5,6 +5,7 @@ import jwt
 import requests
 import structlog
 from django.utils import timezone
+from requests.exceptions import JSONDecodeError
 from rest_framework.exceptions import NotAuthenticated
 from sentry_sdk import capture_exception
 
@@ -44,7 +45,11 @@ def build_billing_token(license: License, organization: Organization):
 def handle_billing_service_error(res: requests.Response, valid_codes=(200, 404, 401)) -> None:
     if res.status_code not in valid_codes:
         logger.error(f"Billing service returned bad status code: {res.status_code}, body: {res.text}")
-        raise Exception(f"Billing service returned bad status code: {res.status_code}", f"body:", res.json())
+        try:
+            response = res.json()
+            raise Exception(f"Billing service returned bad status code: {res.status_code}", f"body:", response)
+        except JSONDecodeError:
+            raise Exception(f"Billing service returned bad status code: {res.status_code}", f"body:", res.text)
 
 
 class BillingManager:

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta
 from typing import Any, Optional, cast
 
@@ -5,7 +6,6 @@ import jwt
 import requests
 import structlog
 from django.utils import timezone
-from requests.exceptions import JSONDecodeError
 from rest_framework.exceptions import NotAuthenticated
 from sentry_sdk import capture_exception
 
@@ -48,7 +48,7 @@ def handle_billing_service_error(res: requests.Response, valid_codes=(200, 404, 
         try:
             response = res.json()
             raise Exception(f"Billing service returned bad status code: {res.status_code}", f"body:", response)
-        except JSONDecodeError:
+        except json.decoder.JSONDecodeError:
             raise Exception(f"Billing service returned bad status code: {res.status_code}", f"body:", res.text)
 
 


### PR DESCRIPTION
## Problem

See related sentry error: https://posthog.sentry.io/issues/5257727384/?alert_rule_id=14968077&alert_type=issue&notification_uuid=657b771e-3e30-42fa-9a73-56cbba15ddf8&project=1899813&referrer=slack

We were trying to decode to json some responses that were not json encoded. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
