### PR TITLE
fix: Use requests.exception.JSONDecodeError in try/except for billing service errors

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -1,4 +1,3 @@
-import json
 from datetime import datetime, timedelta
 from typing import Any, Optional, cast
 
@@ -6,6 +5,7 @@ import jwt
 import requests
 import structlog
 from django.utils import timezone
+from requests import JSONDecodeError  # type: ignore[attr-defined]
 from rest_framework.exceptions import NotAuthenticated
 from sentry_sdk import capture_exception
 
@@ -48,7 +48,7 @@ def handle_billing_service_error(res: requests.Response, valid_codes=(200, 404, 
         try:
             response = res.json()
             raise Exception(f"Billing service returned bad status code: {res.status_code}", f"body:", response)
-        except json.decoder.JSONDecodeError:
+        except JSONDecodeError:
             raise Exception(f"Billing service returned bad status code: {res.status_code}", f"body:", res.text)
 
 


### PR DESCRIPTION
## Problem

The exception type is correct. I'm simply silencing mypy errors that it doesn't exist so CI will pass. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
