### PR TITLE
chore: remove data pipelines billing notice

### DIFF
--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -12,7 +12,6 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { capitalizeFirstLetter, compactNumber } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import posthog from 'posthog-js'
 import { useRef } from 'react'
 import { getProductIcon } from 'scenes/products/Products'
 
@@ -46,8 +45,6 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
     const { toggleIsPricingModalOpen, reportSurveyShown, setSurveyResponse } = useActions(
         billingProductLogic({ product: addon })
     )
-    const { featureFlags } = useValues(featureFlagLogic)
-    const { setProductSpecificAlert } = useActions(billingLogic)
 
     const productType = { plural: `${addon.unit}s`, singular: addon.unit }
     const tierDisplayOptions: LemonSelectOptions<string> = [
@@ -58,41 +55,6 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
         tierDisplayOptions.push({ label: `Current bill`, value: 'total' })
     }
 
-    const isOGPipelineAddon =
-        addon.type === 'data_pipelines' &&
-        addon.subscribed &&
-        addon.plans?.[0]?.plan_key === 'addon-20240111-og-customers'
-
-    if (isOGPipelineAddon && featureFlags['data-pipelines-notice']) {
-        setProductSpecificAlert({
-            status: 'info',
-            title: 'Welcome to the data pipelines addon!',
-            message: `We've moved data export features (and cost) here to better reflect user needs. Your overall
-                    price hasn't changed.`,
-            action: {
-                onClick: () => {
-                    posthog.capture('data pipelines notice clicked')
-                    // if they don't dismiss it now, we won't show it next time they come back
-                    posthog.capture('data pipelines notice dismissed', {
-                        $set: {
-                            dismissedDataPipelinesNotice: true,
-                        },
-                    })
-                },
-                children: 'Learn more',
-                to: 'https://posthog.com/changelog/2024#data-pipeline-add-on-launched',
-                targetBlank: true,
-            },
-            dismissKey: 'data-pipelines-notice',
-            onClose: () => {
-                posthog.capture('data pipelines notice dismissed', {
-                    $set: {
-                        dismissedDataPipelinesNotice: true,
-                    },
-                })
-            },
-        })
-    }
     return (
         <div className="bg-side rounded p-6 flex flex-col">
             <div className="flex justify-between gap-x-4">
@@ -110,17 +72,6 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
                             )}
                         </div>
                         <p className="ml-0 mb-0">{addon.description}</p>
-                        {isOGPipelineAddon && (
-                            <div className="mt-2">
-                                <Link
-                                    targetBlankIcon
-                                    target="_blank"
-                                    to="https://posthog.com/changelog/2024#data-pipeline-add-on-launched"
-                                >
-                                    <span className="text-xs italic">Why am I subscribed to this?</span>
-                                </Link>
-                            </div>
-                        )}
                     </div>
                 </div>
                 <div className="ml-4 mr-4 mt-2 self-center flex gap-x-2 whitespace-nowrap">


### PR DESCRIPTION
## Problem

We had a notice for data pipelines OG customers (those who never clicked subscribe, but were automatically placed on it when we split the pricing out from product analytics).

It's been long enough now, so we can remove.

As a note, this worked really well, after putting the "Why am I subscribed to this?" link people stopped being angry when they unsubscribed from it.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Removes it.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
