### PR TITLE
feat(hogql): support CTEs in UNION ALL

### DIFF
--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -101,15 +101,11 @@ class Resolver(CloningVisitor):
         return super().visit(node)
 
     def visit_select_union_query(self, node: ast.SelectUnionQuery):
-        if len(node.select_queries) == 0:
-            raise ImpossibleASTError("UNION ALL should have at least one select query")
-
         # all expressions combined by UNION ALL can use CTEs from the first expression
         # so we put these CTEs to the scope
-        default_ctes = node.select_queries[0].ctes
+        default_ctes = node.select_queries[0].ctes if node.select_queries else None
         if default_ctes:
-            select_with_ctes = ast.SelectQueryType(ctes=default_ctes)
-            self.scopes.append(select_with_ctes)
+            self.scopes.append(ast.SelectQueryType(ctes=default_ctes))
 
         node = super().visit_select_union_query(node)
         node.type = ast.SelectUnionQueryType(types=[expr.type for expr in node.select_queries])

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -101,6 +101,10 @@ class Resolver(CloningVisitor):
         return super().visit(node)
 
     def visit_select_union_query(self, node: ast.SelectUnionQuery):
+        for select_query in node.select_queries[1:]:
+            default_ctes = node.select_queries[0].ctes
+            select_query.ctes = select_query.ctes or default_ctes
+
         node = super().visit_select_union_query(node)
         node.type = ast.SelectUnionQueryType(types=[expr.type for expr in node.select_queries])
         return node

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -104,7 +104,8 @@ class Resolver(CloningVisitor):
         if len(node.select_queries) == 0:
             raise ImpossibleASTError("UNION ALL should have at least one select query")
 
-        # all expressions combined by UNION ALL can use ctes from the first expression
+        # all expressions combined by UNION ALL can use CTEs from the first expression
+        # so we put these CTEs to the scope
         select_with_ctes = ast.SelectQueryType(ctes=node.select_queries[0].ctes)
         self.scopes.append(select_with_ctes)
 

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -101,14 +101,18 @@ class Resolver(CloningVisitor):
         return super().visit(node)
 
     def visit_select_union_query(self, node: ast.SelectUnionQuery):
-        node = cast(ast.SelectUnionQuery, clone_expr(node))
+        if len(node.select_queries) == 0:
+            raise ImpossibleASTError("UNION ALL should have at least one select query")
 
-        # All parts of UNION ALL which don't have CTEs can use CTEs from the first statement
-        for select_query in node.select_queries[1:]:
-            select_query.ctes = select_query.ctes or node.select_queries[0].ctes
+        # all expressions combined by UNION ALL can use ctes from the first expression
+        select_with_ctes = ast.SelectQueryType(ctes=node.select_queries[0].ctes)
+        self.scopes.append(select_with_ctes)
 
         node = super().visit_select_union_query(node)
         node.type = ast.SelectUnionQueryType(types=[expr.type for expr in node.select_queries])
+
+        self.scopes.pop()
+
         return node
 
     def visit_select_query(self, node: ast.SelectQuery):

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -105,11 +105,7 @@ class Resolver(CloningVisitor):
 
         # All parts of UNION ALL which don't have CTEs can use CTEs from the first statement
         for select_query in node.select_queries[1:]:
-            default_ctes = node.select_queries[0].ctes
-            if select_query.ctes or not default_ctes:
-                continue
-
-            select_query.ctes = {key: cast(ast.CTE, clone_expr(expr)) for key, expr in default_ctes.items()}
+            select_query.ctes = select_query.ctes or node.select_queries[0].ctes
 
         node = super().visit_select_union_query(node)
         node.type = ast.SelectUnionQueryType(types=[expr.type for expr in node.select_queries])

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -106,13 +106,16 @@ class Resolver(CloningVisitor):
 
         # all expressions combined by UNION ALL can use CTEs from the first expression
         # so we put these CTEs to the scope
-        select_with_ctes = ast.SelectQueryType(ctes=node.select_queries[0].ctes)
-        self.scopes.append(select_with_ctes)
+        default_ctes = node.select_queries[0].ctes
+        if default_ctes:
+            select_with_ctes = ast.SelectQueryType(ctes=default_ctes)
+            self.scopes.append(select_with_ctes)
 
         node = super().visit_select_union_query(node)
         node.type = ast.SelectUnionQueryType(types=[expr.type for expr in node.select_queries])
 
-        self.scopes.pop()
+        if default_ctes:
+            self.scopes.pop()
 
         return node
 

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -1593,29 +1593,3 @@ class TestPrinter(BaseTest):
             self._expr("SuM(1)", context),
             "sum(1)",
         )
-
-    def test_ctes_with_union_all(self):
-        self.assertEqual(
-            self._select("""
-                    WITH cte1 AS (SELECT 1 AS a)
-                    SELECT 1 AS a
-                    UNION ALL
-                    WITH cte2 AS (SELECT 1 AS a)
-                    SELECT * FROM cte2
-                    UNION ALL
-                    SELECT * FROM cte1
-                         """),
-            "SELECT 1 AS a LIMIT 10000 UNION ALL SELECT cte2.a AS a FROM (SELECT 1 AS a) AS cte2 LIMIT 10000 UNION ALL SELECT cte1.a AS a FROM (SELECT 1 AS a) AS cte1 LIMIT 10000",
-        )
-
-    def test_ctes_with_join(self):
-        self.assertEqual(
-            self._select("""
-                         WITH cte AS (SELECT 1 AS value)
-                         SELECT cte.value FROM cte
-                         INNER JOIN
-                         (SELECT value FROM cte) AS r
-                         ON (cte.value=r.value)
-                         """),
-            "SELECT cte.value AS value FROM (SELECT 1 AS value) AS cte INNER JOIN (SELECT cte.value AS value FROM (SELECT 1 AS value) AS cte) AS r ON equals(cte.value, r.value) LIMIT 10000",
-        )

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -1593,3 +1593,29 @@ class TestPrinter(BaseTest):
             self._expr("SuM(1)", context),
             "sum(1)",
         )
+
+    def test_ctes_with_union_all(self):
+        self.assertEqual(
+            self._select("""
+                    WITH cte1 AS (SELECT 1 AS a)
+                    SELECT 1 AS a
+                    UNION ALL
+                    WITH cte2 AS (SELECT 1 AS a)
+                    SELECT * FROM cte2
+                    UNION ALL
+                    SELECT * FROM cte1
+                         """),
+            "SELECT 1 AS a LIMIT 10000 UNION ALL SELECT cte2.a AS a FROM (SELECT 1 AS a) AS cte2 LIMIT 10000 UNION ALL SELECT cte1.a AS a FROM (SELECT 1 AS a) AS cte1 LIMIT 10000",
+        )
+
+    def test_ctes_with_join(self):
+        self.assertEqual(
+            self._select("""
+                         WITH cte AS (SELECT 1 AS value)
+                         SELECT cte.value FROM cte
+                         INNER JOIN
+                         (SELECT value FROM cte) AS r
+                         ON (cte.value=r.value)
+                         """),
+            "SELECT cte.value AS value FROM (SELECT 1 AS value) AS cte INNER JOIN (SELECT cte.value AS value FROM (SELECT 1 AS value) AS cte) AS r ON equals(cte.value, r.value) LIMIT 10000",
+        )

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -250,14 +250,14 @@ class TestResolver(BaseTest):
                     SELECT * FROM cte2
                     UNION ALL
                     SELECT * FROM cte1
-                         """),
+                        """),
             self._print_hogql("""
                     SELECT 1 AS a
                     UNION ALL
                     SELECT * FROM (SELECT 1 AS a) AS cte2
                     UNION ALL
                     SELECT * FROM (SELECT 1 AS a) AS cte1
-                              """),
+                        """),
         )
 
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=False, PERSON_ON_EVENTS_V2_OVERRIDE=False)

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -246,7 +246,7 @@ class TestResolver(BaseTest):
                     WITH cte1 AS (SELECT 1 AS a)
                     SELECT 1 AS a
                     UNION ALL
-                    WITH cte2 AS (SELECT 1 AS a)
+                    WITH cte2 AS (SELECT 2 AS a)
                     SELECT * FROM cte2
                     UNION ALL
                     SELECT * FROM cte1
@@ -254,7 +254,7 @@ class TestResolver(BaseTest):
             self._print_hogql("""
                     SELECT 1 AS a
                     UNION ALL
-                    SELECT * FROM (SELECT 1 AS a) AS cte2
+                    SELECT * FROM (SELECT 2 AS a) AS cte2
                     UNION ALL
                     SELECT * FROM (SELECT 1 AS a) AS cte1
                         """),

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -240,6 +240,26 @@ class TestResolver(BaseTest):
             self._print_hogql("SELECT a FROM (SELECT 1 AS a) AS new_alias WHERE new_alias.a=1"),
         )
 
+    def test_ctes_with_union_all(self):
+        self.assertEqual(
+            self._print_hogql("""
+                    WITH cte1 AS (SELECT 1 AS a)
+                    SELECT 1 AS a
+                    UNION ALL
+                    WITH cte2 AS (SELECT 1 AS a)
+                    SELECT * FROM cte2
+                    UNION ALL
+                    SELECT * FROM cte1
+                         """),
+            self._print_hogql("""
+                    SELECT 1 AS a
+                    UNION ALL
+                    SELECT * FROM (SELECT 1 AS a) AS cte2
+                    UNION ALL
+                    SELECT * FROM (SELECT 1 AS a) AS cte1
+                              """),
+        )
+
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=False, PERSON_ON_EVENTS_V2_OVERRIDE=False)
     @pytest.mark.usefixtures("unittest_snapshot")
     def test_asterisk_expander_table(self):


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/20663

JFYI, ClickHouse doesn't allow one to use CTEs from the first statement if a statement has its own CTE.

This doesn't work in CH
```
WITH cte1 AS (SELECT 1 AS a)
SELECT 1 AS a
UNION ALL
WITH cte2 AS (SELECT 1 AS a)
SELECT * FROM cte1
```

## Changes

It adds CTEs from the initial statement to all statements in UNION ALL

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Automated tests