### PR TITLE
fix(instance): improve wording for non-staff members

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/index.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/index.tsx
@@ -93,8 +93,12 @@ export function SystemStatus(): JSX.Element {
             <PageHeader
                 caption={
                     <>
-                        Here you can find all the critical runtime details and settings of your PostHog instance. You
-                        have access to this because you're a <b>staff user</b>.{' '}
+                        Here you can find all the critical runtime details and settings of your PostHog instance.{' '}
+                        {user?.is_staff && (
+                            <>
+                                You have access to modify these settings, because you're a <b>staff user</b>.{' '}
+                            </>
+                        )}
                         <Link
                             target="_blank"
                             targetBlankIcon

--- a/frontend/src/scenes/instance/SystemStatus/index.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/index.tsx
@@ -94,9 +94,13 @@ export function SystemStatus(): JSX.Element {
                 caption={
                     <>
                         Here you can find all the critical runtime details and settings of your PostHog instance.{' '}
-                        {user?.is_staff && (
+                        {user?.is_staff ? (
                             <>
                                 You have access to modify these settings, because you're a <b>staff user</b>.{' '}
+                            </>
+                        ) : (
+                            <>
+                                You can view these settings, but you need to be a <b>staff user</b> to modify them.{' '}
                             </>
                         )}
                         <Link


### PR DESCRIPTION
## Problem
I was trying to modify some instance settings, following the docs for [self host](https://posthog.com/docs/self-host/configure/instance-settings#staff-users). From the docs & current wording, It indicated that I'm a staff user, and I should have been able to modify these, but I couldn't find any relevant info here. Checking the code I found this, wanted to improve the wording.

## Changes
### Existing
![image](https://github.com/PostHog/posthog/assets/44131905/fbb12391-1976-4e01-b40f-81241eb252a8)

### New
![image](https://github.com/PostHog/posthog/assets/44131905/9910e4ff-52a1-4334-a294-f50409e7e820)

![image](https://github.com/PostHog/posthog/assets/44131905/dc182bab-6fdd-47f7-932f-00411591aab8)




## Does this work well for both Cloud and self-hosted?
it doesn't have an impact.

## How did you test this code?
NA
