### PR TITLE
fix(insights): Adjust dashboard latest refresh logic

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -10,8 +10,8 @@ import { humanFriendlyDuration } from 'lib/utils'
 import { DASHBOARD_MIN_REFRESH_INTERVAL_MINUTES, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 
 export const LastRefreshText = (): JSX.Element => {
-    const { lastRefreshed } = useValues(dashboardLogic)
-    return <span>Last updated {lastRefreshed ? dayjs(lastRefreshed).fromNow() : 'a while ago'}</span>
+    const { newestRefreshed } = useValues(dashboardLogic)
+    return <span>Last updated {newestRefreshed ? dayjs(newestRefreshed).fromNow() : 'a while ago'}</span>
 }
 
 const refreshIntervalSeconds = [1800, 3600]

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -727,7 +727,7 @@ describe('dashboardLogic', () => {
             await expectLogic(logic)
                 .toFinishAllListeners()
                 .toMatchValues({
-                    lastRefreshed: dayjs('2021-09-21T11:48:48.444504Z'),
+                    lastRefreshed: dayjs('2021-09-21T11:48:48.586Z'),
                 })
         })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -720,30 +720,30 @@ describe('dashboardLogic', () => {
         })
     })
 
-    describe('lastRefreshed', () => {
+    describe('newestRefreshed', () => {
         it('should be the earliest refreshed dashboard', async () => {
             logic = dashboardLogic({ id: 5 })
             logic.mount()
             await expectLogic(logic)
                 .toFinishAllListeners()
                 .toMatchValues({
-                    lastRefreshed: dayjs('2021-09-21T11:48:48.586Z'),
+                    newestRefreshed: dayjs('2021-09-21T11:48:48.586Z'),
                 })
         })
 
-        it('should refresh all dashboards if lastRefreshed is older than 3 hours', async () => {
+        it('should refresh all dashboards if newestRefreshed is older than 3 hours', async () => {
             logic = dashboardLogic({ id: 5 })
             logic.mount()
             await expectLogic(logic).toDispatchActions(['refreshAllDashboardItems']).toFinishAllListeners()
         })
 
-        it('should not refresh all dashboards if lastRefreshed is older than 3 hours but the feature flag is not set', async () => {
+        it('should not refresh all dashboards if newestRefreshed is older than 3 hours but the feature flag is not set', async () => {
             logic = dashboardLogic({ id: 5 })
             logic.mount()
             await expectLogic(logic).toNotHaveDispatchedActions(['refreshAllDashboardItems']).toFinishAllListeners()
         })
 
-        it('should not refresh if lastRefreshed is less than 3 hours', async () => {
+        it('should not refresh if newestRefreshed is less than 3 hours', async () => {
             logic = dashboardLogic({ id: 9 })
             logic.mount()
             await expectLogic(logic)

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -860,7 +860,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             const insights = values
                 .sortTilesByLayout(tiles || values.insightTiles || [])
                 .filter((t) => {
-                    if (!initialLoad) {
+                    if (!initialLoad || !t.last_refresh) {
                         return true
                     }
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -860,6 +860,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
             const insights = values
                 .sortTilesByLayout(tiles || values.insightTiles || [])
                 .filter((t) => {
+                    if (!initialLoad) {
+                        return true
+                    }
+
                     const lastRefreshed = dayjs(t.last_refresh)
                     return (
                         !lastRefreshed.isValid() ||

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -259,15 +259,14 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
                     if (fromDashboard !== props.id) {
                         return values.dashboard
-                    } else {
-                        return await api.update(
-                            `api/projects/${teamLogic.values.currentTeamId}/dashboards/${props.id}/move_tile`,
-                            {
-                                tile,
-                                toDashboard,
-                            }
-                        )
                     }
+                    return await api.update(
+                        `api/projects/${teamLogic.values.currentTeamId}/dashboards/${props.id}/move_tile`,
+                        {
+                            tile,
+                            toDashboard,
+                        }
+                    )
                 },
             },
         ],
@@ -601,8 +600,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 }
 
                 const validDates = insightTiles.map((i) => dayjs(i.last_refresh)).filter((date) => date.isValid())
-                const oldest = sortDayJsDates(validDates)
-                return oldest.length > 0 ? oldest[0] : null
+                const sortedDates = sortDayJsDates(validDates)
+                return sortedDates.length > 0 ? sortedDates[sortedDates.length - 1] : null
             },
         ],
         blockRefresh: [
@@ -704,9 +703,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         return -1
                     } else if (ay > by || (ay == by && ax > bx)) {
                         return 1
-                    } else {
-                        return 0
                     }
+                    return 0
                 })
             },
         ],


### PR DESCRIPTION
## Problem

Observation:
- load dashboard with stale items, all get refreshed
- if some tiles time out while refreshing, their `latest_refresh` will stay a e.g. 3 days in the past
- upon reload, the logic will see dashboard refresh is 3 days ago and reload *all* tiles
- we send `refresh=True` to the /insight endpoint which recalculates even if stale (other choice would be never-recalculate)

## Changes

- display actually latest refresh date (not oldest) in the dashboard reload button - I think this conveys it better to the users
- still use oldest to determine if a general refresh is needed
- when refreshing all, filter out those that are fresh within the last minutes already

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

- 👀 