### PR TITLE
fix(data-warehouse): Disable table nesting for postgres

### DIFF
--- a/posthog/temporal/data_imports/pipelines/postgres/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/postgres/__init__.py
@@ -16,7 +16,6 @@ from .helpers import (
     engine_from_credentials,
     get_primary_key,
     SqlDatabaseTableConfiguration,
-    SqlTableResourceConfiguration,
 )
 
 
@@ -31,7 +30,7 @@ def postgres_source(
     return db_source
 
 
-@dlt.source
+@dlt.source(max_table_nesting=0)
 def sql_database(
     credentials: Union[ConnectionStringCredentials, Engine, str] = dlt.secrets.value,
     schema: Optional[str] = dlt.config.value,


### PR DESCRIPTION
## Problem
- We didn't have table nesting param set for the postgres source in data warehouse, meaning JSON columns were being expanded into multiple columns as opposed to being represented as a JSON column

## Changes
**Before:**
<img width="827" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/6cd637e3-b96e-4130-a424-4f0212352837">


**After:**
<img width="940" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/eae1cab6-4e2f-4f46-9ed3-99e771782028">


## Does this work well for both Cloud and self-hosted?
- Yes

## How did you test this code?
- See the screenshots above