### PR TITLE
feat: android onboarding tweak

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/feature-flags/android.tsx
+++ b/frontend/src/scenes/onboarding/sdks/feature-flags/android.tsx
@@ -1,3 +1,7 @@
+import { FlaggedFeature } from 'lib/components/FlaggedFeature'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { AdvertiseAndroidReplay } from 'scenes/onboarding/sdks/product-analytics'
+
 import { SDKKey } from '~/types'
 
 import { SDKInstallAndroidInstructions } from '../sdk-install-instructions'
@@ -8,6 +12,9 @@ export function FeatureFlagsAndroidInstructions(): JSX.Element {
         <>
             <SDKInstallAndroidInstructions />
             <FlagImplementationSnippet sdkKey={SDKKey.ANDROID} />
+            <FlaggedFeature flag={FEATURE_FLAGS.SESSION_REPLAY_MOBILE_ONBOARDING} match={true}>
+                <AdvertiseAndroidReplay />
+            </FlaggedFeature>
         </>
     )
 }

--- a/frontend/src/scenes/onboarding/sdks/feature-flags/android.tsx
+++ b/frontend/src/scenes/onboarding/sdks/feature-flags/android.tsx
@@ -13,7 +13,7 @@ export function FeatureFlagsAndroidInstructions(): JSX.Element {
             <SDKInstallAndroidInstructions />
             <FlagImplementationSnippet sdkKey={SDKKey.ANDROID} />
             <FlaggedFeature flag={FEATURE_FLAGS.SESSION_REPLAY_MOBILE_ONBOARDING} match={true}>
-                <AdvertiseAndroidReplay />
+                <AdvertiseAndroidReplay context="flags-onboarding" />
             </FlaggedFeature>
         </>
     )

--- a/frontend/src/scenes/onboarding/sdks/product-analytics/android.tsx
+++ b/frontend/src/scenes/onboarding/sdks/product-analytics/android.tsx
@@ -2,6 +2,7 @@ import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { OnboardingStepKey } from 'scenes/onboarding/onboardingLogic'
@@ -17,8 +18,9 @@ function AndroidCaptureSnippet(): JSX.Element {
 
 function AdvertiseAndroidReplay(): JSX.Element {
     return (
-        <LemonBanner type="info" className="mt-8">
-            <div>
+        <div>
+            <LemonDivider className="my-8" />
+            <LemonBanner type="info">
                 <h3>
                     Session Replay for Android <LemonTag type="highlight">NEW</LemonTag>
                 </h3>
@@ -31,20 +33,20 @@ function AdvertiseAndroidReplay(): JSX.Element {
                         Learn how to set it up
                     </Link>
                 </div>
-            </div>
-        </LemonBanner>
+            </LemonBanner>
+        </div>
     )
 }
 
 export function ProductAnalyticsAndroidInstructions(): JSX.Element {
     return (
         <>
-            <FlaggedFeature flag={FEATURE_FLAGS.SESSION_REPLAY_MOBILE_ONBOARDING} match={true}>
-                <AdvertiseAndroidReplay />
-            </FlaggedFeature>
             <SDKInstallAndroidInstructions />
             <h3>Send an Event</h3>
             <AndroidCaptureSnippet />
+            <FlaggedFeature flag={FEATURE_FLAGS.SESSION_REPLAY_MOBILE_ONBOARDING} match={true}>
+                <AdvertiseAndroidReplay />
+            </FlaggedFeature>
         </>
     )
 }

--- a/frontend/src/scenes/onboarding/sdks/product-analytics/android.tsx
+++ b/frontend/src/scenes/onboarding/sdks/product-analytics/android.tsx
@@ -1,6 +1,7 @@
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { OnboardingStepKey } from 'scenes/onboarding/onboardingLogic'
@@ -16,29 +17,36 @@ function AndroidCaptureSnippet(): JSX.Element {
 
 function AdvertiseAndroidReplay(): JSX.Element {
     return (
-        <div>
-            <h3 className="mt-8">
-                Session Replay for Android <LemonTag type="highlight">NEW</LemonTag>
-            </h3>
-            <div>
-                Session replay is now in beta for Android.{' '}
-                <Link to={urls.onboarding('session_replay', OnboardingStepKey.INSTALL, SDKKey.ANDROID)}>
-                    Learn how to set it up
-                </Link>
-            </div>
-        </div>
+        <>
+            <LemonBanner type="info" className="mt-8">
+                <div>
+                    <h3>
+                        Session Replay for Android <LemonTag type="highlight">NEW</LemonTag>
+                    </h3>
+                    <div>
+                        Session replay is now in beta for Android.{' '}
+                        <Link
+                            to={urls.onboarding('session_replay', OnboardingStepKey.INSTALL, SDKKey.ANDROID)}
+                            data-attr="product-analytics-onboarding-android-replay-cta"
+                        >
+                            Learn how to set it up
+                        </Link>
+                    </div>
+                </div>
+            </LemonBanner>
+        </>
     )
 }
 
 export function ProductAnalyticsAndroidInstructions(): JSX.Element {
     return (
         <>
-            <SDKInstallAndroidInstructions />
-            <h3>Send an Event</h3>
-            <AndroidCaptureSnippet />
             <FlaggedFeature flag={FEATURE_FLAGS.SESSION_REPLAY_MOBILE_ONBOARDING} match={true}>
                 <AdvertiseAndroidReplay />
             </FlaggedFeature>
+            <SDKInstallAndroidInstructions />
+            <h3>Send an Event</h3>
+            <AndroidCaptureSnippet />
         </>
     )
 }

--- a/frontend/src/scenes/onboarding/sdks/product-analytics/android.tsx
+++ b/frontend/src/scenes/onboarding/sdks/product-analytics/android.tsx
@@ -17,24 +17,22 @@ function AndroidCaptureSnippet(): JSX.Element {
 
 function AdvertiseAndroidReplay(): JSX.Element {
     return (
-        <>
-            <LemonBanner type="info" className="mt-8">
+        <LemonBanner type="info" className="mt-8">
+            <div>
+                <h3>
+                    Session Replay for Android <LemonTag type="highlight">NEW</LemonTag>
+                </h3>
                 <div>
-                    <h3>
-                        Session Replay for Android <LemonTag type="highlight">NEW</LemonTag>
-                    </h3>
-                    <div>
-                        Session replay is now in beta for Android.{' '}
-                        <Link
-                            to={urls.onboarding('session_replay', OnboardingStepKey.INSTALL, SDKKey.ANDROID)}
-                            data-attr="product-analytics-onboarding-android-replay-cta"
-                        >
-                            Learn how to set it up
-                        </Link>
-                    </div>
+                    Session replay is now in beta for Android.{' '}
+                    <Link
+                        to={urls.onboarding('session_replay', OnboardingStepKey.INSTALL, SDKKey.ANDROID)}
+                        data-attr="product-analytics-onboarding-android-replay-cta"
+                    >
+                        Learn how to set it up
+                    </Link>
                 </div>
-            </LemonBanner>
-        </>
+            </div>
+        </LemonBanner>
     )
 }
 

--- a/frontend/src/scenes/onboarding/sdks/product-analytics/android.tsx
+++ b/frontend/src/scenes/onboarding/sdks/product-analytics/android.tsx
@@ -16,7 +16,7 @@ function AndroidCaptureSnippet(): JSX.Element {
     return <CodeSnippet language={Language.Kotlin}>{`PostHog.capture(event = "test-event")`}</CodeSnippet>
 }
 
-function AdvertiseAndroidReplay(): JSX.Element {
+export function AdvertiseAndroidReplay(): JSX.Element {
     return (
         <div>
             <LemonDivider className="my-8" />

--- a/frontend/src/scenes/onboarding/sdks/product-analytics/android.tsx
+++ b/frontend/src/scenes/onboarding/sdks/product-analytics/android.tsx
@@ -16,7 +16,11 @@ function AndroidCaptureSnippet(): JSX.Element {
     return <CodeSnippet language={Language.Kotlin}>{`PostHog.capture(event = "test-event")`}</CodeSnippet>
 }
 
-export function AdvertiseAndroidReplay(): JSX.Element {
+export function AdvertiseAndroidReplay({
+    context,
+}: {
+    context: 'product-analytics-onboarding' | 'flags-onboarding'
+}): JSX.Element {
     return (
         <div>
             <LemonDivider className="my-8" />
@@ -28,7 +32,7 @@ export function AdvertiseAndroidReplay(): JSX.Element {
                     Session replay is now in beta for Android.{' '}
                     <Link
                         to={urls.onboarding('session_replay', OnboardingStepKey.INSTALL, SDKKey.ANDROID)}
-                        data-attr="product-analytics-onboarding-android-replay-cta"
+                        data-attr={`${context}-android-replay-cta`}
                     >
                         Learn how to set it up
                     </Link>
@@ -45,7 +49,7 @@ export function ProductAnalyticsAndroidInstructions(): JSX.Element {
             <h3>Send an Event</h3>
             <AndroidCaptureSnippet />
             <FlaggedFeature flag={FEATURE_FLAGS.SESSION_REPLAY_MOBILE_ONBOARDING} match={true}>
-                <AdvertiseAndroidReplay />
+                <AdvertiseAndroidReplay context="product-analytics-onboarding" />
             </FlaggedFeature>
         </>
     )


### PR DESCRIPTION
* add a data-attr to a link I know I want to track
* more room to breathe on the CTA, it looked really weird (the validation step is outside of the flow so I can't (easily go beneath it)

## CTA with room to breathe

| before | after | 
|-|-|
|<img width="594" alt="Screenshot 2024-04-29 at 15 12 53" src="https://github.com/PostHog/posthog/assets/984817/dac0537b-6026-4e2f-8feb-fb26913d3fcb">|<img width="598" alt="Screenshot 2024-04-29 at 15 15 02" src="https://github.com/PostHog/posthog/assets/984817/2abf355b-8cfd-4f28-8d07-a09345b6043b">|
