### PR TITLE
fix(insights): Don't fail request on `filter_to_query` failure

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -2,6 +2,7 @@ import json
 from functools import lru_cache
 from typing import Any, Optional, Union, cast
 
+from sentry_sdk import capture_exception, set_tag
 import structlog
 from django.db import transaction
 from django.db.models import Count, Prefetch, QuerySet
@@ -536,15 +537,23 @@ class InsightSerializer(InsightBasicSerializer, UserPermissionsSerializerMixin):
             # TRICKY: As running `filters`-based insights on the HogQL-based engine is a transitional mechanism,
             # we fake the insight being properly `query`-based.
             # To prevent the lie from accidentally being saved to Postgres, we roll it back in the `finally` branch.
-            insight.query = filter_to_query(insight.filters).model_dump()
             try:
-                return calculate_for_query_based_insight(
-                    insight, dashboard=dashboard, refresh_requested=refresh_requested_by_client(self.context["request"])
-                )
-            except ExposedHogQLError as e:
-                raise ValidationError(str(e))
-            finally:
-                insight.query = None
+                insight.query = filter_to_query(insight.filters).model_dump()
+            except:
+                # If `filter_to_query` failed, let's capture this and proceed with legacy filters
+                set_tag("filter_to_query_todo", True)
+                capture_exception()
+            else:
+                try:
+                    return calculate_for_query_based_insight(
+                        insight,
+                        dashboard=dashboard,
+                        refresh_requested=refresh_requested_by_client(self.context["request"]),
+                    )
+                except ExposedHogQLError as e:
+                    raise ValidationError(str(e))
+                finally:
+                    insight.query = None
 
         is_shared = self.context.get("is_shared", False)
         refresh_insight_now, refresh_frequency = should_refresh_insight(


### PR DESCRIPTION
## Problem

`filter_to_query` works most of the time, but there isn't a guarantee for it to work _100%_ of the time. This [Sentry error](https://posthog.sentry.io/issues/5277136783/?project=-1&query=is%3Aunresolved+transaction%3A%2Fapi%2Fprojects%2F%7Bparent_lookup_team_id%7D%2Fdashboards%2F%7Bpk%7D%2F&referrer=issue-stream&statsPeriod=7d&stream_index=0&utc=true) is an example of a conversion failure, and the problem is that currently this causes the whole request to fail.

## Changes

It's safer to use the legacy `filters`, while still capturing the exception so that we can fix it without burning urgency.