### PR TITLE
fix: canvas playback quality

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
@@ -88,7 +88,7 @@ export const CanvasReplayerPlugin = (events: eventWithTime[]): ReplayPlugin => {
 
                 const img = containers.get(e.data.id)
                 if (img) {
-                    img.src = target.toDataURL()
+                    img.src = target.toDataURL('image/jpeg', 0.6)
                 }
             }
         },


### PR DESCRIPTION
## Problem

Addesses https://posthoghelp.zendesk.com/agent/tickets/12887 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15502)

Canvas playback is causing the player to freeze up. This happens when the `toDataURL` function causes [long running tasks](https://web.dev/articles/optimize-long-tasks)

|Profile|Event|
|----|----|
| <img width="1161" alt="Screenshot 2024-04-29 at 15 44 12" src="https://github.com/PostHog/posthog/assets/6685876/f4345861-6616-44bb-af7c-b474e184a46d"> | <img width="558" alt="Screenshot 2024-04-29 at 15 44 31" src="https://github.com/PostHog/posthog/assets/6685876/9e868608-a188-4100-a74e-1b9127d3fc8f"> |

- Plenty of over running tasks (top row of the Main thread anywhere there is red) which causes the UI to seize up
- Individual `toDataURL` calls are >120ms

## Changes

Reduce the quality of the canvas

|Profile|Event|
|----|----|
| <img width="1323" alt="Screenshot 2024-04-29 at 15 46 11" src="https://github.com/PostHog/posthog/assets/6685876/549688f0-4b66-448d-8ace-0de415441763"> | <img width="293" alt="Screenshot 2024-04-29 at 15 46 47" src="https://github.com/PostHog/posthog/assets/6685876/2d90e07a-a8af-4590-8cf5-dd06cdc0a6aa"> |

- Much healthier looking profile (almost no tasks running long)
- Individual `toDataURL` calls are ~30ms

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

- There was no perceptual difference in the recordings I tested