### PR TITLE
feat(hogql): replace filters with query backend side

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -53,7 +53,7 @@ from posthog.helpers.multi_property_breakdown import (
 )
 from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.timings import HogQLTimings
-from posthog.hogql_queries.apply_dashboard_filters import DATA_TABLE_LIKE_NODE_KINDS
+from posthog.hogql_queries.apply_dashboard_filters import WRAPPER_NODE_KINDS
 from posthog.hogql_queries.legacy_compatibility.feature_flag import (
     hogql_insights_replace_filters,
     should_use_hogql_backend_in_insight_serialization,
@@ -724,14 +724,10 @@ class InsightViewSet(
                 insight = request.GET[INSIGHT]
                 if insight == "JSON":
                     queryset = queryset.filter(query__isnull=False)
-                    queryset = queryset.exclude(
-                        query__kind__in=DATA_TABLE_LIKE_NODE_KINDS, query__source__kind="HogQLQuery"
-                    )
+                    queryset = queryset.exclude(query__kind__in=WRAPPER_NODE_KINDS, query__source__kind="HogQLQuery")
                 elif insight == "SQL":
                     queryset = queryset.filter(query__isnull=False)
-                    queryset = queryset.filter(
-                        query__kind__in=DATA_TABLE_LIKE_NODE_KINDS, query__source__kind="HogQLQuery"
-                    )
+                    queryset = queryset.filter(query__kind__in=WRAPPER_NODE_KINDS, query__source__kind="HogQLQuery")
                 else:
                     queryset = queryset.filter(query__isnull=True)
                     queryset = queryset.filter(filters__insight=insight)

--- a/posthog/hogql_queries/apply_dashboard_filters.py
+++ b/posthog/hogql_queries/apply_dashboard_filters.py
@@ -3,14 +3,14 @@ from posthog.hogql_queries.query_runner import get_query_runner
 from posthog.models import Team
 from posthog.schema import DashboardFilter, NodeKind
 
-DATA_TABLE_LIKE_NODE_KINDS = [NodeKind.DataTableNode, NodeKind.DataVisualizationNode]
+WRAPPER_NODE_KINDS = [NodeKind.DataTableNode, NodeKind.DataVisualizationNode, NodeKind.InsightVizNode]
 
 
 # Apply the filters from the django-style Dashboard object
 def apply_dashboard_filters(query: dict, filters: dict, team: Team) -> dict:
     kind = query.get("kind", None)
 
-    if kind in DATA_TABLE_LIKE_NODE_KINDS:
+    if kind in WRAPPER_NODE_KINDS:
         source = apply_dashboard_filters(query["source"], filters, team)
         return {**query, "source": source}
 

--- a/posthog/hogql_queries/legacy_compatibility/feature_flag.py
+++ b/posthog/hogql_queries/legacy_compatibility/feature_flag.py
@@ -1,6 +1,6 @@
 import posthoganalytics
 from django.conf import settings
-from posthog.models.user import User
+from posthog.models import User, Team
 
 
 def should_use_hogql_backend_in_insight_serialization(user: User) -> bool:
@@ -11,6 +11,21 @@ def should_use_hogql_backend_in_insight_serialization(user: User) -> bool:
         "hogql-in-insight-serialization",
         user.distinct_id,
         person_properties={"email": user.email},
+        only_evaluate_locally=True,
+        send_feature_flag_events=False,
+    )
+
+
+def hogql_insights_replace_filters(team: Team) -> bool:
+    return posthoganalytics.feature_enabled(
+        "hogql-insights-replace-filters",
+        str(team.uuid),
+        groups={"organization": str(team.organization.id)},
+        group_properties={
+            "organization": {
+                "id": str(team.organization.id),
+            }
+        },
         only_evaluate_locally=True,
         send_feature_flag_events=False,
     )

--- a/posthog/hogql_queries/legacy_compatibility/feature_flag.py
+++ b/posthog/hogql_queries/legacy_compatibility/feature_flag.py
@@ -20,12 +20,6 @@ def hogql_insights_replace_filters(team: Team) -> bool:
     return posthoganalytics.feature_enabled(
         "hogql-insights-replace-filters",
         str(team.uuid),
-        groups={"organization": str(team.organization.id)},
-        group_properties={
-            "organization": {
-                "id": str(team.organization.id),
-            }
-        },
         only_evaluate_locally=True,
         send_feature_flag_events=False,
     )

--- a/posthog/hogql_queries/legacy_compatibility/feature_flag.py
+++ b/posthog/hogql_queries/legacy_compatibility/feature_flag.py
@@ -20,6 +20,12 @@ def hogql_insights_replace_filters(team: Team) -> bool:
     return posthoganalytics.feature_enabled(
         "hogql-insights-replace-filters",
         str(team.uuid),
+        groups={"organization": str(team.organization_id)},
+        group_properties={
+            "organization": {
+                "id": str(team.organization_id),
+            }
+        },
         only_evaluate_locally=True,
         send_feature_flag_events=False,
     )

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -119,7 +119,7 @@ class Insight(models.Model):
         from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
 
         try:
-            return {"kind": "InsightVizNode", "source": filter_to_query(self.filters).model_dump()}
+            return {"kind": "InsightVizNode", "source": filter_to_query(self.filters).model_dump(), "full": True}
         except Exception as e:
             capture_exception(e)
 

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -1,5 +1,7 @@
+from functools import cached_property
 from typing import Optional
 
+from sentry_sdk import capture_exception
 import structlog
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
@@ -111,6 +113,15 @@ class Insight(models.Model):
             if state.dashboard_tile_id is None:
                 return state
         return None
+
+    @cached_property
+    def query_from_filters(self):
+        from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
+
+        try:
+            return {"kind": "InsightVizNode", "source": filter_to_query(self.filters).model_dump()}
+        except Exception as e:
+            capture_exception(e)
 
     class Meta:
         db_table = "posthog_dashboarditem"


### PR DESCRIPTION
## Problem

We eventually want to migrate the `filters` column of insights to the `query` column. In preparation for this, we do a live replace behind a feature flag in this PR - allowing us to fix any issues.

## Changes

This PR replaces the `filters` property of insights with a `query` (by converting existing filters using the `filter_to_query` method) based on a feature flag. This allows us to find places that break when replacing filters with queries.

There are three places where I could potentially handle the replacement: (1) in the insight model (2) in the insight serializer with a custom getter (3) in the `to_representation` method. I opted for (3) as this method contains code cleaning up filters and merges in dashboard overrides. Let me know if I'm missing something about how we handle dashboard filter overrides in the new query system.

Any fixes are out of scope for this PR and we just want to have a safe way to try out converted insights.

## Does this work well for both Cloud and self-hosted?

The flag should defaults to "off" in a self-hosted environment.

## How did you test this code?

Be sure to start the dev server with `POSTHOG_PERSONAL_API_KEY` set.

<img width="1100" alt="Screenshot 2024-04-08 at 12 22 04" src="https://github.com/PostHog/posthog/assets/1851359/2a430885-d3ed-44d9-99f0-cac21968b6b6">