### PR TITLE
fix(data-warehouse): Removed error being thrown for missing columns

### DIFF
--- a/posthog/warehouse/models/datawarehouse_saved_query.py
+++ b/posthog/warehouse/models/datawarehouse_saved_query.py
@@ -80,11 +80,10 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDModel, DeletedMetaFields):
     def hogql_definition(self) -> SavedQuery:
         from posthog.warehouse.models.table import CLICKHOUSE_HOGQL_MAPPING
 
-        if not self.columns:
-            raise Exception("Columns must be fetched and saved to use in HogQL.")
+        columns = self.columns or {}
 
         fields = {}
-        for column, type in self.columns.items():
+        for column, type in columns.items():
             if type.startswith("Nullable("):
                 type = type.replace("Nullable(", "")[:-1]
 

--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -168,12 +168,11 @@ class DataWarehouseTable(CreatedMetaFields, UUIDModel, DeletedMetaFields):
         return result[0][0]
 
     def hogql_definition(self) -> S3Table:
-        if not self.columns:
-            raise Exception("Columns must be fetched and saved to use in HogQL.")
+        columns = self.columns or {}
 
         fields: dict[str, FieldOrTable] = {}
         structure = []
-        for column, type in self.columns.items():
+        for column, type in columns.items():
             # Support for 'old' style columns
             if isinstance(type, str):
                 clickhouse_type = type


### PR DESCRIPTION
## Problem
- We throw an error if there are no columns defined in a data warehouse table when creating the hogql_database
- This is an issue because during data ingestion in warehouse, a table will have no columns defined for a short while, thus, during that period, creating a HogQL Database fails 
- Seen in this [Sentry ticket](https://posthog.sentry.io/issues/5152555336/?query=is%3Aunresolved+stack.filename%3A%2A%2Ftable.py&referrer=issue-stream&statsPeriod=14d&stream_index=0)

## Changes
- Don't throw an error, but just fallback to empty columns

## Does this work well for both Cloud and self-hosted?
- Yes
