### PR TITLE
fix: replay timestamps

### DIFF
--- a/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
@@ -35,7 +35,7 @@ export function Timestamp(): JSX.Element {
 
     return (
         <LemonButton data-attr="recording-timestamp" onClick={rotateTimestampFormat} active>
-            <span className="text-center whitespace-nowrap">
+            <span className="text-center whitespace-nowrap font-mono">
                 {timestampFormat === TimestampFormat.Relative ? (
                     <>
                         {colonDelimitedDuration(startTimeSeconds, fixedUnits)} /{' '}

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
@@ -42,12 +42,12 @@ export function Timestamp(): JSX.Element {
                         {colonDelimitedDuration(endTimeSeconds, fixedUnits)}
                     </>
                 ) : currentTimestamp ? (
-                    <>
-                        {dayjs(currentTimestamp).tz('UTC').format('DD/MM/YYYY, HH:mm:ss')}{' '}
-                        {timestampFormat === TimestampFormat.UTC
-                            ? 'UTC'
-                            : shortTimeZone(undefined, dayjs(currentTimestamp).toDate())}
-                    </>
+                    `${(timestampFormat === TimestampFormat.UTC
+                        ? dayjs(currentTimestamp).tz('UTC')
+                        : dayjs(currentTimestamp)
+                    ).format('DD/MM/YYYY, HH:mm:ss')} ${
+                        TimestampFormat.UTC ? 'UTC' : shortTimeZone(undefined, dayjs(currentTimestamp).toDate())
+                    }`
                 ) : (
                     '--/--/----, 00:00:00'
                 )}

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
@@ -46,7 +46,9 @@ export function Timestamp(): JSX.Element {
                         ? dayjs(currentTimestamp).tz('UTC')
                         : dayjs(currentTimestamp)
                     ).format('DD/MM/YYYY, HH:mm:ss')} ${
-                        TimestampFormat.UTC ? 'UTC' : shortTimeZone(undefined, dayjs(currentTimestamp).toDate())
+                        timestampFormat === TimestampFormat.UTC
+                            ? 'UTC'
+                            : shortTimeZone(undefined, dayjs(currentTimestamp).toDate())
                     }`
                 ) : (
                     '--/--/----, 00:00:00'

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
@@ -14,7 +14,6 @@ import { SessionRecordingPlayerTab } from '~/types'
 import { IconWindow } from '../../icons'
 import { playerSettingsLogic, TimestampFormat } from '../../playerSettingsLogic'
 import { sessionRecordingPlayerLogic } from '../../sessionRecordingPlayerLogic'
-import { formattedTimestamp } from '../../utils/timestamp'
 import { InspectorListItem, playerInspectorLogic } from '../playerInspectorLogic'
 import { ItemConsoleLog } from './ItemConsoleLog'
 import { ItemDoctor } from './ItemDoctor'
@@ -202,9 +201,10 @@ export function PlayerInspectorListItem({
                 <LemonButton size="small" noPadding onClick={() => seekToEvent()}>
                     <span className="p-1 text-xs">
                         {timestampFormat != TimestampFormat.Relative ? (
-                            formattedTimestamp(
-                                timestampFormat === TimestampFormat.UTC ? item.timestamp.tz('UTC') : item.timestamp
-                            )
+                            (timestampFormat === TimestampFormat.UTC
+                                ? item.timestamp.tz('UTC')
+                                : item.timestamp
+                            ).format('DD, MMM HH:mm:ss')
                         ) : (
                             <>
                                 {item.timeInRecording < 0 ? (

--- a/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/PlayerInspectorListItem.tsx
@@ -1,4 +1,3 @@
-import { TZLabel } from '@posthog/apps-common'
 import { IconDashboard, IconEye, IconGear, IconTerminal } from '@posthog/icons'
 import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 import clsx from 'clsx'
@@ -15,6 +14,7 @@ import { SessionRecordingPlayerTab } from '~/types'
 import { IconWindow } from '../../icons'
 import { playerSettingsLogic, TimestampFormat } from '../../playerSettingsLogic'
 import { sessionRecordingPlayerLogic } from '../../sessionRecordingPlayerLogic'
+import { formattedTimestamp } from '../../utils/timestamp'
 import { InspectorListItem, playerInspectorLogic } from '../playerInspectorLogic'
 import { ItemConsoleLog } from './ItemConsoleLog'
 import { ItemDoctor } from './ItemDoctor'
@@ -202,12 +202,9 @@ export function PlayerInspectorListItem({
                 <LemonButton size="small" noPadding onClick={() => seekToEvent()}>
                     <span className="p-1 text-xs">
                         {timestampFormat != TimestampFormat.Relative ? (
-                            <TZLabel
-                                time={TimestampFormat.UTC ? item.timestamp.tz('utc') : item.timestamp}
-                                formatDate="DD, MMM"
-                                formatTime="HH:mm:ss"
-                                noStyles
-                            />
+                            formattedTimestamp(
+                                timestampFormat === TimestampFormat.UTC ? item.timestamp.tz('UTC') : item.timestamp
+                            )
                         ) : (
                             <>
                                 {item.timeInRecording < 0 ? (

--- a/frontend/src/scenes/session-recordings/player/utils/timestamp.ts
+++ b/frontend/src/scenes/session-recordings/player/utils/timestamp.ts
@@ -1,0 +1,5 @@
+import { dayjs } from 'lib/dayjs'
+
+export const formattedTimestamp = (currentTimestamp: dayjs.Dayjs): string => {
+    return currentTimestamp.format('DD/MM/YYYY, HH:mm:ss')
+}

--- a/frontend/src/scenes/session-recordings/player/utils/timestamp.ts
+++ b/frontend/src/scenes/session-recordings/player/utils/timestamp.ts
@@ -1,5 +1,0 @@
-import { dayjs } from 'lib/dayjs'
-
-export const formattedTimestamp = (currentTimestamp: dayjs.Dayjs): string => {
-    return currentTimestamp.format('DD/MM/YYYY, HH:mm:ss')
-}


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/21834
Addresses https://posthog.slack.com/archives/C03PB072FMJ/p1714032531933589

## Changes

Switch button to use monospaced font to stop jumping

----

On top of the issue called out by the customer the inspector timestamps did not match the player toggle

|Before|After|
|----|----|
| <img width="1004" alt="Screenshot 2024-04-29 at 18 00 37" src="https://github.com/PostHog/posthog/assets/6685876/8194d939-b87f-4781-930b-4f3f2ac0cd06"> | <img width="987" alt="Screenshot 2024-04-29 at 18 04 04" src="https://github.com/PostHog/posthog/assets/6685876/b52ac8f0-3135-4818-b3bc-953563240583"> |

----

Also fixes a performance issue given the `TZLabel` assumes that the timestamp is always changing which means unnecessary intervals being computed every second. And recomputes the timezone every second, for every timestamp on the page:

![timer](https://github.com/PostHog/posthog/assets/6685876/0646bfa8-ce4c-458a-a9f0-6aa3514fd6cb)

Luckily for us the inspector is a virtualized list or the number of intervals would be much greater.

You can see the blips in CPU every second as these timers are processed (even when the recording is paused). Afterwards the CPU line looks flat.
|Before|After|
|----|----|
| <img width="1120" alt="Screenshot 2024-04-29 at 17 42 47" src="https://github.com/PostHog/posthog/assets/6685876/2126a4f1-0ba9-45cb-87ff-de5d2aab04fa"> | <img width="1125" alt="Screenshot 2024-04-29 at 18 06 08" src="https://github.com/PostHog/posthog/assets/6685876/1afc337a-2cb9-43c3-bcc0-be0ca42bcd21"> |

(Fix for the `TZLabel` component coming in a future PR)