### PR TITLE
feat: set caching and etag headers when loading blob snapshots

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -221,7 +221,7 @@ def ensure_not_weak(etag: str) -> str:
     so we can just strip it.
     """
     if etag.startswith("W/"):
-        return etag[2:]
+        return etag[2:].lstrip('"').rstrip('"')
     return etag
 
 
@@ -644,6 +644,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             with requests.get(url=url, stream=True, headers=headers) as streaming_response:
                 streaming_response.raise_for_status()
 
+                breakpoint()
                 response = HttpResponse(content=streaming_response.raw, status=streaming_response.status_code)
 
                 etag = streaming_response.headers.get("ETag")

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -644,7 +644,6 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             with requests.get(url=url, stream=True, headers=headers) as streaming_response:
                 streaming_response.raise_for_status()
 
-                breakpoint()
                 response = HttpResponse(content=streaming_response.raw, status=streaming_response.status_code)
 
                 etag = streaming_response.headers.get("ETag")
@@ -655,8 +654,6 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 # but let's cache for an hour since people won't re-watch too often
                 response["Cache-Control"] = streaming_response.headers.get("Cache-Control") or "max-age=3600"
 
-                # these are probably always going to be JSON,
-                # but we're setting it on the S3 object so let's allow that to control it
                 response["Content-Type"] = "application/json"
 
                 response["Content-Disposition"] = "inline"

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 from prometheus_client import Histogram
 import json
 from typing import Any, cast
+from collections.abc import Generator
 
 from django.conf import settings
 
@@ -227,7 +228,7 @@ def ensure_not_weak(etag: str) -> str:
 
 
 @contextmanager
-def stream_from(url: str, headers: dict | None = None) -> requests.Response:
+def stream_from(url: str, headers: dict | None = None) -> Generator[requests.Response, None, None]:
     """
     Stream data from a URL using optional headers.
 

--- a/posthog/session_recordings/test/__init__.py
+++ b/posthog/session_recordings/test/__init__.py
@@ -1,25 +1,26 @@
 from unittest.mock import Mock
 
 
-def setup_mock_requests_get(headers: dict | None = None) -> Mock:
+def setup_stream_from(headers: dict | None = None) -> Mock:
     if headers is None:
         # some header that is not None, so we know that we're not passing all headers through unchanged
         headers = {"blah": "desired-value"}
 
     # Create a mock response object
-    requests_get = Mock()
+    streaming_interaction = Mock()
 
     # Setup status code and content if necessary
-    requests_get.status_code = 200
-    requests_get.content = b"Example content"
+    streaming_interaction.status_code = 200
+    streaming_interaction.content = b"Example content"
+    streaming_interaction.raw = b"Example content"
 
     # Setup headers and the .get method for headers
-    requests_get.headers = headers
+    streaming_interaction.headers = headers
 
     # Mock the __enter__ and __exit__ methods to support the 'with' context
-    requests_get.__enter__ = Mock(return_value=requests_get)
-    requests_get.__exit__ = Mock(
+    streaming_interaction.__enter__ = Mock(return_value=streaming_interaction)
+    streaming_interaction.__exit__ = Mock(
         return_value=False
     )  # Normally handles exceptions, False means it does not suppress exceptions
 
-    return requests_get
+    return streaming_interaction

--- a/posthog/session_recordings/test/__init__.py
+++ b/posthog/session_recordings/test/__init__.py
@@ -1,0 +1,25 @@
+from unittest.mock import Mock
+
+
+def setup_mock_requests_get(headers: dict | None = None) -> Mock:
+    if headers is None:
+        # some header that is not None, so we know that we're not passing all headers through unchanged
+        headers = {"blah": "desired-value"}
+
+    # Create a mock response object
+    requests_get = Mock()
+
+    # Setup status code and content if necessary
+    requests_get.status_code = 200
+    requests_get.content = b"Example content"
+
+    # Setup headers and the .get method for headers
+    requests_get.headers = headers
+
+    # Mock the __enter__ and __exit__ methods to support the 'with' context
+    requests_get.__enter__ = Mock(return_value=requests_get)
+    requests_get.__exit__ = Mock(
+        return_value=False
+    )  # Normally handles exceptions, False means it does not suppress exceptions
+
+    return requests_get

--- a/posthog/session_recordings/test/test_lts_session_recordings.py
+++ b/posthog/session_recordings/test/test_lts_session_recordings.py
@@ -6,7 +6,7 @@ from rest_framework import status
 from posthog.models import Team
 from posthog.models.signals import mute_selected_signals
 from posthog.session_recordings.models.session_recording import SessionRecording
-from posthog.session_recordings.test import setup_mock_requests_get
+from posthog.session_recordings.test import setup_stream_from
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, QueryMatchingTest
 
 # this is the utf-16 surrogate pass encoded, gzipped and base64 encoded version of the above
@@ -125,7 +125,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         "posthog.session_recordings.queries.session_replay_events.SessionReplayEvents.exists",
         return_value=True,
     )
-    @patch("posthog.session_recordings.session_recording_api.requests.get")
+    @patch("posthog.session_recordings.session_recording_api.stream_from", return_value=setup_stream_from())
     @patch("posthog.session_recordings.session_recording_api.object_storage.get_presigned_url")
     @patch("posthog.session_recordings.session_recording_api.object_storage.list_objects")
     def test_2023_08_01_version_stored_snapshots_can_be_loaded(
@@ -152,8 +152,6 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         mock_list_objects.side_effect = list_objects_func
         mock_get_presigned_url.return_value = "https://example.com"
 
-        mock_requests.get.return_value = setup_mock_requests_get()
-
         SessionRecording.objects.create(
             team=self.team,
             session_id=session_id,
@@ -177,13 +175,13 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             call(f"{lts_storage_path}/1-2", expiration=60),
         ]
 
-        assert response_data == "the file contents"
+        assert response_data == "Example content"
 
     @patch(
         "posthog.session_recordings.queries.session_replay_events.SessionReplayEvents.exists",
         return_value=True,
     )
-    @patch("posthog.session_recordings.session_recording_api.requests.get")
+    @patch("posthog.session_recordings.session_recording_api.stream_from", return_value=setup_stream_from())
     @patch("posthog.session_recordings.session_recording_api.object_storage.tag")
     @patch("posthog.session_recordings.session_recording_api.object_storage.write")
     @patch("posthog.session_recordings.session_recording_api.object_storage.read")
@@ -208,8 +206,6 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         mock_list_objects.side_effect = list_objects_func
         mock_get_presigned_url.return_value = "https://example.com"
         mock_read.return_value = legacy_compressed_original
-
-        mock_requests.get.return_value = setup_mock_requests_get()
 
         with mute_selected_signals():
             SessionRecording.objects.create(
@@ -250,4 +246,4 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
 
         # and the mock content is returned
         response_data = response.content.decode("utf-8")
-        assert response_data == "the file contents"
+        assert response_data == "Example content"

--- a/posthog/session_recordings/test/test_lts_session_recordings.py
+++ b/posthog/session_recordings/test/test_lts_session_recordings.py
@@ -1,11 +1,12 @@
 import uuid
-from unittest.mock import patch, MagicMock, call, Mock
+from unittest.mock import patch, MagicMock, call
 
 from rest_framework import status
 
 from posthog.models import Team
 from posthog.models.signals import mute_selected_signals
 from posthog.session_recordings.models.session_recording import SessionRecording
+from posthog.session_recordings.test import setup_mock_requests_get
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, QueryMatchingTest
 
 # this is the utf-16 surrogate pass encoded, gzipped and base64 encoded version of the above
@@ -151,13 +152,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         mock_list_objects.side_effect = list_objects_func
         mock_get_presigned_url.return_value = "https://example.com"
 
-        mock_response = Mock()
-        mock_response.raise_for_status.return_value = None
-        mock_response.raw = "the file contents"
-
-        # Set up the mock to work as a context manager
-        mock_requests.return_value.__enter__.return_value = mock_response
-        mock_requests.return_value.__exit__.return_value = None
+        mock_requests.get.return_value = setup_mock_requests_get()
 
         SessionRecording.objects.create(
             team=self.team,
@@ -214,13 +209,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         mock_get_presigned_url.return_value = "https://example.com"
         mock_read.return_value = legacy_compressed_original
 
-        mock_response = Mock()
-        mock_response.raise_for_status.return_value = None
-        mock_response.raw = "the file contents"
-
-        # Set up the mock to work as a context manager
-        mock_requests.return_value.__enter__.return_value = mock_response
-        mock_requests.return_value.__exit__.return_value = None
+        mock_requests.get.return_value = setup_mock_requests_get()
 
         with mute_selected_signals():
             SessionRecording.objects.create(


### PR DESCRIPTION
We have etag stored in object storage, so we can do two things

1) we can use the etag to let object storage tell us the client already has the file
2) and we can cache blobs for an hour

strictly they're immutable but in practice people won't reload recordings too often and a short cache is even faster than the etag interaction

![Screenshot 2024-04-29 at 19 38 37](https://github.com/PostHog/posthog/assets/984817/f6200e4e-b348-40ee-9a40-847d2ca0738f)

----

Setting up mocks for the internals of the `requests` dependency so I could control the http status code was super painful, so I've wrapped it as `stream_from` so I can mock my own code - there's limited value in testing that a detailed mock of `requests` behaves correctly 🤷 