### PR TITLE
fix(plugin-server): move null replacement and add test

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -163,7 +163,6 @@ export async function eachBatchParallelIngestion(
                 // Process every message sequentially, stash promises to await on later
                 for (const { message, pluginEvent } of currentBatch) {
                     try {
-                        pluginEvent.distinct_id = pluginEvent.distinct_id.replaceAll('\u0000', '')
                         const result = (await retryIfRetriable(async () => {
                             const runner = new EventPipelineRunner(queue.pluginsServer, pluginEvent)
                             return await runner.runEventPipeline(pluginEvent)

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -144,7 +144,7 @@ export function normalizeProcessPerson(event: PluginEvent, processPerson: boolea
 }
 
 export function normalizeEvent(event: PluginEvent): PluginEvent {
-    event.distinct_id = event.distinct_id?.toString()
+    event.distinct_id = event.distinct_id?.toString().replace(/\u0000/g, '\uFFFD')
 
     let properties = event.properties ?? {}
     if (event['$set']) {

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -80,7 +80,6 @@ export class EventsProcessor {
             'Still inside "EventsProcessor.processEvent". Timeout warning after 30 sec!',
             () => ({ event: JSON.stringify(data) })
         )
-        distinctId = distinctId.replace('\u0000', '')
 
         let result: PreIngestionEvent | null = null
         try {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We should scrub `null` character after plugins.

(Additionally, we should use the Unicode replacement character for its intended purpose, and add a test.)

## Changes

Do those things!

I checked other `INSERT` statements in plugin-server and we look safe. We already do this replacement for JSON fields, which covers the other cases.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->


## Does this work well for both Cloud and self-hosted?

Yes.
## How did you test this code?

Added test.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
