### PR TITLE
refactor(insights): Remove redundant `query_type` under `QueryRunner`

### DIFF
--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -14,7 +14,6 @@ from posthog.schema import ActorsQuery, ActorsQueryResponse
 
 class ActorsQueryRunner(QueryRunner):
     query: ActorsQuery
-    query_type = ActorsQuery
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -37,7 +37,6 @@ SELECT_STAR_FROM_EVENTS_FIELDS = [
 
 class EventsQueryRunner(QueryRunner):
     query: EventsQuery
-    query_type = EventsQuery
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/posthog/hogql_queries/hogql_query_runner.py
+++ b/posthog/hogql_queries/hogql_query_runner.py
@@ -22,7 +22,6 @@ from posthog.schema import (
 
 class HogQLQueryRunner(QueryRunner):
     query: HogQLQuery
-    query_type = HogQLQuery
 
     def to_query(self) -> ast.SelectQuery:
         if self.timings is None:

--- a/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
@@ -86,7 +86,6 @@ class FunnelCorrelationQueryRunner(QueryRunner):
     MIN_PERSON_PERCENTAGE = 0.02
 
     query: FunnelCorrelationQuery
-    query_type = FunnelCorrelationQuery
     funnels_query: FunnelsQuery
     actors_query: FunnelsActorsQuery
     correlation_actors_query: Optional[FunnelCorrelationActorsQuery]

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -32,7 +32,6 @@ from posthog.schema import (
 
 class FunnelsQueryRunner(QueryRunner):
     query: FunnelsQuery
-    query_type = FunnelsQuery
     context: FunnelQueryContext
 
     def __init__(

--- a/posthog/hogql_queries/insights/insight_actors_query_options_runner.py
+++ b/posthog/hogql_queries/insights/insight_actors_query_options_runner.py
@@ -11,7 +11,6 @@ from posthog.schema import InsightActorsQueryOptions, InsightActorsQueryOptionsR
 
 class InsightActorsQueryOptionsRunner(QueryRunner):
     query: InsightActorsQueryOptions
-    query_type = InsightActorsQueryOptions
 
     @cached_property
     def source_runner(self) -> QueryRunner:

--- a/posthog/hogql_queries/insights/insight_actors_query_runner.py
+++ b/posthog/hogql_queries/insights/insight_actors_query_runner.py
@@ -27,7 +27,6 @@ from posthog.types import InsightActorsQueryNode
 
 class InsightActorsQueryRunner(QueryRunner):
     query: InsightActorsQueryNode
-    query_type = InsightActorsQueryNode  # type: ignore
 
     @cached_property
     def source_runner(self) -> QueryRunner:

--- a/posthog/hogql_queries/insights/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle_query_runner.py
@@ -30,7 +30,6 @@ from posthog.utils import format_label_date
 
 class LifecycleQueryRunner(QueryRunner):
     query: LifecycleQuery
-    query_type = LifecycleQuery
 
     def to_query(self) -> ast.SelectQuery | ast.SelectUnionQuery:
         if self.query.samplingFactor == 0:

--- a/posthog/hogql_queries/insights/paths_query_runner.py
+++ b/posthog/hogql_queries/insights/paths_query_runner.py
@@ -43,7 +43,6 @@ EDGE_LIMIT_DEFAULT = 50
 
 class PathsQueryRunner(QueryRunner):
     query: PathsQuery
-    query_type = PathsQuery
 
     def __init__(
         self,

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -35,7 +35,6 @@ DEFAULT_TOTAL_INTERVALS = 11
 
 class RetentionQueryRunner(QueryRunner):
     query: RetentionQuery
-    query_type = RetentionQuery
 
     def __init__(
         self,

--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -46,7 +46,6 @@ class SeriesWithExtras:
 
 class StickinessQueryRunner(QueryRunner):
     query: StickinessQuery
-    query_type = StickinessQuery
     series: list[SeriesWithExtras]
 
     def __init__(

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -70,7 +70,6 @@ from posthog.utils import format_label_date, multisort
 
 class TrendsQueryRunner(QueryRunner):
     query: TrendsQuery
-    query_type = TrendsQuery
     series: list[SeriesWithExtras]
 
     def __init__(

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -292,11 +292,14 @@ def get_query_runner(
 
 
 Q = TypeVar("Q", bound=RunnableQueryNode)
+# R (for Response) should have a structure similar to QueryResponse.
+# Due to the way schema.py is generated, we don't have a good inheritance story here.
+R = TypeVar("R", bound=BaseModel)
 
 
-class QueryRunner(ABC, Generic[Q]):
+class QueryRunner(ABC, Generic[Q, R]):
     query: Q
-    query_type: type[Q]
+
     team: Team
     timings: HogQLTimings
     modifiers: HogQLQueryModifiers
@@ -321,13 +324,15 @@ class QueryRunner(ABC, Generic[Q]):
         assert isinstance(query, self.query_type)
         self.query = query
 
+    @property
+    def query_type(self) -> type[Q]:
+        return self.__annotations__["query"]  # Enforcing the type annotation of `query` at runtime
+
     def is_query_node(self, data) -> TypeGuard[Q]:
         return isinstance(data, self.query_type)
 
     @abstractmethod
-    def calculate(self) -> BaseModel:
-        # The returned model should have a structure similar to QueryResponse.
-        # Due to the way schema.py is generated, we don't have a good inheritance story here.
+    def calculate(self) -> R:
         raise NotImplementedError()
 
     def run(
@@ -374,7 +379,7 @@ class QueryRunner(ABC, Generic[Q]):
                 if execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE:
                     return cached_response
 
-        fresh_response_dict = cast(QueryResponse, self.calculate()).model_dump()
+        fresh_response_dict = self.calculate().model_dump()
         fresh_response_dict["is_cached"] = False
         fresh_response_dict["last_refresh"] = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
         fresh_response_dict["next_allowed_client_refresh"] = (datetime.now() + self._refresh_frequency()).strftime(
@@ -408,13 +413,13 @@ class QueryRunner(ABC, Generic[Q]):
                 "hogql",
             )
 
-    def toJSON(self) -> str:
+    def to_json(self) -> str:
         return self.query.model_dump_json(exclude_defaults=True, exclude_none=True)
 
     def get_cache_key(self) -> str:
         modifiers = self.modifiers.model_dump_json(exclude_defaults=True, exclude_none=True)
         return generate_cache_key(
-            f"query_{self.toJSON()}_{self.__class__.__name__}_{self.team.pk}_{self.team.timezone}_{modifiers}"
+            f"query_{self.to_json()}_{self.__class__.__name__}_{self.team.pk}_{self.team.timezone}_{modifiers}"
         )
 
     @abstractmethod

--- a/posthog/hogql_queries/sessions_timeline_query_runner.py
+++ b/posthog/hogql_queries/sessions_timeline_query_runner.py
@@ -34,7 +34,6 @@ class SessionsTimelineQueryRunner(QueryRunner):
     EVENT_LIMIT = 1000
 
     query: SessionsTimelineQuery
-    query_type = SessionsTimelineQuery
 
     def _get_events_subquery(self) -> ast.SelectQuery:
         after = relative_date_parse(self.query.after or "-24h", self.team.timezone_info)

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -65,7 +65,7 @@ class TestQueryRunner(BaseTest):
 
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=self.team)
 
-        json = runner.toJSON()
+        json = runner.to_json()
         self.assertEqual(json, '{"some_attr":"bla"}')
 
     def test_serializes_to_json_ignores_empty_dict(self):
@@ -84,7 +84,7 @@ class TestQueryRunner(BaseTest):
 
         runner = TestQueryRunner(query={"some_attr": "bla", "other_attr": []}, team=self.team)
 
-        json = runner.toJSON()
+        json = runner.to_json()
         self.assertEqual(json, '{"some_attr":"bla"}')
 
     def test_cache_key(self):

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -21,7 +21,6 @@ from posthog.schema import (
 
 class WebStatsTableQueryRunner(WebAnalyticsQueryRunner):
     query: WebStatsTableQuery
-    query_type = WebStatsTableQuery
     paginator: HogQLHasMorePaginator
 
     def __init__(self, *args, **kwargs):

--- a/posthog/hogql_queries/web_analytics/top_clicks.py
+++ b/posthog/hogql_queries/web_analytics/top_clicks.py
@@ -13,7 +13,6 @@ from posthog.schema import WebTopClicksQuery, WebTopClicksQueryResponse
 
 class WebTopClicksQueryRunner(WebAnalyticsQueryRunner):
     query: WebTopClicksQuery
-    query_type = WebTopClicksQuery
 
     def to_query(self) -> ast.SelectQuery | ast.SelectUnionQuery:
         with self.timings.measure("top_clicks_query"):

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -16,7 +16,6 @@ from posthog.schema import WebOverviewQueryResponse, WebOverviewQuery
 
 class WebOverviewQueryRunner(WebAnalyticsQueryRunner):
     query: WebOverviewQuery
-    query_type = WebOverviewQuery
 
     def to_query(self) -> ast.SelectQuery | ast.SelectUnionQuery:
         if self.query.useSessionsTable:


### PR DESCRIPTION
## Changes

A bit of a refactor to reduce duplication and make typing more intelligent.