### PR TITLE
feat: explicit screenshot support in the mobile replay schema

### DIFF
--- a/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
+++ b/ee/frontend/mobile-replay/__snapshots__/transform.test.ts.snap
@@ -939,6 +939,200 @@ exports[`replay/transform transform can ignore unknown wireframe types 1`] = `
 ]
 `;
 
+exports[`replay/transform transform can process screenshot mutation 1`] = `
+[
+  {
+    "data": {
+      "height": 600,
+      "href": "",
+      "width": 300,
+    },
+    "timestamp": 1,
+    "type": 4,
+  },
+  {
+    "data": {
+      "adds": [
+        {
+          "nextId": null,
+          "node": {
+            "attributes": {
+              "data-rrweb-id": 151700670,
+              "height": 914,
+              "src": "data:image/png;base64,mutated-image-content",
+              "style": "background-color: #F3EFF7;width: 411px;height: 914px;position: fixed;left: 0px;top: 0px;",
+              "width": 411,
+            },
+            "childNodes": [],
+            "id": 151700670,
+            "tagName": "img",
+            "type": 2,
+          },
+          "parentId": 5,
+        },
+      ],
+      "attributes": [],
+      "removes": [
+        {
+          "id": 151700670,
+          "parentId": 5,
+        },
+      ],
+      "source": 0,
+      "texts": [],
+    },
+    "seen": 3551987272322930,
+    "timestamp": 1714397336836,
+    "type": 3,
+    "windowId": "5173a13e-abac-4def-b227-2f81dc2808b6",
+  },
+]
+`;
+
+exports[`replay/transform transform can process top level screenshot 1`] = `
+[
+  {
+    "data": {
+      "height": 600,
+      "href": "",
+      "width": 300,
+    },
+    "timestamp": 1,
+    "type": 4,
+  },
+  {
+    "data": {
+      "initialOffset": {
+        "left": 0,
+        "top": 0,
+      },
+      "node": {
+        "childNodes": [
+          {
+            "id": 2,
+            "name": "html",
+            "publicId": "",
+            "systemId": "",
+            "type": 1,
+          },
+          {
+            "attributes": {
+              "data-rrweb-id": 3,
+              "style": "height: 100vh; width: 100vw;",
+            },
+            "childNodes": [
+              {
+                "attributes": {
+                  "data-rrweb-id": 4,
+                },
+                "childNodes": [
+                  {
+                    "attributes": {
+                      "type": "text/css",
+                    },
+                    "childNodes": [
+                      {
+                        "id": 101,
+                        "textContent": "
+                    body {
+                      margin: unset;
+                    }
+                    input, button, select, textarea {
+                        font: inherit;
+                        margin: 0;
+                        padding: 0;
+                        border: 0;
+                        outline: 0;
+                        background: transparent;
+                        padding-block: 0 !important;
+                    }
+                    .input:focus {
+                        outline: none;
+                    }
+                    img {
+                      border-style: none;
+                    }
+                ",
+                        "type": 3,
+                      },
+                    ],
+                    "id": 100,
+                    "tagName": "style",
+                    "type": 2,
+                  },
+                ],
+                "id": 4,
+                "tagName": "head",
+                "type": 2,
+              },
+              {
+                "attributes": {
+                  "data-rrweb-id": 5,
+                  "style": "height: 100vh; width: 100vw;",
+                },
+                "childNodes": [
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 151700670,
+                      "height": 914,
+                      "src": "data:image/png;base64,image-content",
+                      "style": "background-color: #F3EFF7;width: 411px;height: 914px;position: fixed;left: 0px;top: 0px;",
+                      "width": 411,
+                    },
+                    "childNodes": [],
+                    "id": 151700670,
+                    "tagName": "img",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-render-reason": "a fixed placeholder to contain the keyboard in the correct stacking position",
+                      "data-rrweb-id": 9,
+                    },
+                    "childNodes": [],
+                    "id": 9,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 7,
+                    },
+                    "childNodes": [],
+                    "id": 7,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                  {
+                    "attributes": {
+                      "data-rrweb-id": 11,
+                    },
+                    "childNodes": [],
+                    "id": 11,
+                    "tagName": "div",
+                    "type": 2,
+                  },
+                ],
+                "id": 5,
+                "tagName": "body",
+                "type": 2,
+              },
+            ],
+            "id": 3,
+            "tagName": "html",
+            "type": 2,
+          },
+        ],
+        "id": 1,
+        "type": 0,
+      },
+    },
+    "timestamp": 1714397321578,
+    "type": 2,
+  },
+]
+`;
+
 exports[`replay/transform transform can process unknown types without error 1`] = `
 [
   {

--- a/ee/frontend/mobile-replay/mobile.types.ts
+++ b/ee/frontend/mobile-replay/mobile.types.ts
@@ -67,6 +67,7 @@ export type serializedNodeWithId = serializedNode & { id: number }
 export type MobileNodeType =
     | 'text'
     | 'image'
+    | 'screenshot'
     | 'rectangle'
     | 'placeholder'
     | 'web_view'
@@ -75,7 +76,6 @@ export type MobileNodeType =
     | 'radio_group'
     | 'status_bar'
     | 'navigation_bar'
-    | 'screenshot'
 
 export type MobileStyles = {
     /**
@@ -304,6 +304,7 @@ export type wireframeNavigationBar = wireframeBase & {
 export type wireframe =
     | wireframeText
     | wireframeImage
+    | wireframeScreenshot
     | wireframeRectangle
     | wireframeDiv
     | wireframeInputComponent
@@ -312,7 +313,6 @@ export type wireframe =
     | wireframePlaceholder
     | wireframeStatusBar
     | wireframeNavigationBar
-    | wireframeScreenshot
 
 // the rrweb full snapshot event type, but it contains wireframes not html
 export type fullSnapshotEvent = {

--- a/ee/frontend/mobile-replay/mobile.types.ts
+++ b/ee/frontend/mobile-replay/mobile.types.ts
@@ -262,12 +262,8 @@ export type wireframeImage = wireframeBase & {
 /**
  * @description a screenshot behaves exactly like an image, but it is expected to be a screenshot of the screen at the time of the event, when sent as a mutation it must always attached to the root of the playback, when sent as an initial snapshot it must be sent as the first or only snapshot so that it attaches to the body of the playback
  */
-export type wireframeScreenshot = wireframeBase & {
+export type wireframeScreenshot = wireframeImage & {
     type: 'screenshot'
-    /**
-     * @description a screenshot base64 behaves exactly like an image base64
-     */
-    base64?: string
 }
 
 export type wireframeRectangle = wireframeBase & {

--- a/ee/frontend/mobile-replay/mobile.types.ts
+++ b/ee/frontend/mobile-replay/mobile.types.ts
@@ -75,6 +75,7 @@ export type MobileNodeType =
     | 'radio_group'
     | 'status_bar'
     | 'navigation_bar'
+    | 'screenshot'
 
 export type MobileStyles = {
     /**
@@ -258,6 +259,17 @@ export type wireframeImage = wireframeBase & {
     base64?: string
 }
 
+/**
+ * @description a screenshot behaves exactly like an image, but it is expected to be a screenshot of the screen at the time of the event, when sent as a mutation it must always attached to the root of the playback, when sent as an initial snapshot it must be sent as the first or only snapshot so that it attaches to the body of the playback
+ */
+export type wireframeScreenshot = wireframeBase & {
+    type: 'screenshot'
+    /**
+     * @description a screenshot base64 behaves exactly like an image base64
+     */
+    base64?: string
+}
+
 export type wireframeRectangle = wireframeBase & {
     type: 'rectangle'
 }
@@ -304,6 +316,7 @@ export type wireframe =
     | wireframePlaceholder
     | wireframeStatusBar
     | wireframeNavigationBar
+    | wireframeScreenshot
 
 // the rrweb full snapshot event type, but it contains wireframes not html
 export type fullSnapshotEvent = {

--- a/ee/frontend/mobile-replay/schema/mobile/rr-mobile-schema.json
+++ b/ee/frontend/mobile-replay/schema/mobile/rr-mobile-schema.json
@@ -992,7 +992,7 @@
         },
         "wireframeScreenshot": {
             "additionalProperties": false,
-            "description": "a screenshot behaves exactly like an image, but it is expected to be a screenshot of the screen at the time of the event, when sent as a mutation it must always attached to the root of the playback, when sent as an initial snapshot it must be sent as the first or only snapshot so that it attaches to the body of the playback",
+            "description": "a screenshot behaves exactly like an image, but it is expected to be a screenshot of the screen at the time of the event. When sent as a mutation it must always attached to the root of the playback, when sent as an initial snapshot it must be sent as the first or only node so that it attaches to the body of the playback",
             "properties": {
                 "base64": {
                     "description": "this will be used as base64 encoded image source, with no other attributes it is assumed to be a PNG, if omitted a placeholder is rendered",

--- a/ee/frontend/mobile-replay/schema/mobile/rr-mobile-schema.json
+++ b/ee/frontend/mobile-replay/schema/mobile/rr-mobile-schema.json
@@ -285,7 +285,8 @@
                 "div",
                 "radio_group",
                 "status_bar",
-                "navigation_bar"
+                "navigation_bar",
+                "screenshot"
             ],
             "type": "string"
         },
@@ -405,6 +406,9 @@
                 },
                 {
                     "$ref": "#/definitions/wireframeNavigationBar"
+                },
+                {
+                    "$ref": "#/definitions/wireframeScreenshot"
                 }
             ]
         },
@@ -946,6 +950,54 @@
         "wireframeRectangle": {
             "additionalProperties": false,
             "properties": {
+                "childWireframes": {
+                    "items": {
+                        "$ref": "#/definitions/wireframe"
+                    },
+                    "type": "array"
+                },
+                "height": {
+                    "type": "number"
+                },
+                "id": {
+                    "type": "number"
+                },
+                "style": {
+                    "$ref": "#/definitions/MobileStyles"
+                },
+                "type": {
+                    "$ref": "#/definitions/MobileNodeType"
+                },
+                "width": {
+                    "anyOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "const": "100vw",
+                            "type": "string"
+                        }
+                    ]
+                },
+                "x": {
+                    "description": "x and y are the top left corner of the element, if they are present then the element is absolutely positioned, if they are not present this is equivalent to setting them to 0",
+                    "type": "number"
+                },
+                "y": {
+                    "type": "number"
+                }
+            },
+            "required": ["height", "id", "type", "width"],
+            "type": "object"
+        },
+        "wireframeScreenshot": {
+            "additionalProperties": false,
+            "description": "a screenshot behaves exactly like an image, but it is expected to be a screenshot of the screen at the time of the event, when sent as a mutation it must always attached to the root of the playback, when sent as an initial snapshot it must be sent as the first or only snapshot so that it attaches to the body of the playback",
+            "properties": {
+                "base64": {
+                    "description": "this will be used as base64 encoded image source, with no other attributes it is assumed to be a PNG, if omitted a placeholder is rendered",
+                    "type": "string"
+                },
                 "childWireframes": {
                     "items": {
                         "$ref": "#/definitions/wireframe"

--- a/ee/frontend/mobile-replay/schema/mobile/rr-mobile-schema.json
+++ b/ee/frontend/mobile-replay/schema/mobile/rr-mobile-schema.json
@@ -278,6 +278,7 @@
             "enum": [
                 "text",
                 "image",
+                "screenshot",
                 "rectangle",
                 "placeholder",
                 "web_view",
@@ -285,8 +286,7 @@
                 "div",
                 "radio_group",
                 "status_bar",
-                "navigation_bar",
-                "screenshot"
+                "navigation_bar"
             ],
             "type": "string"
         },
@@ -384,6 +384,9 @@
                     "$ref": "#/definitions/wireframeImage"
                 },
                 {
+                    "$ref": "#/definitions/wireframeScreenshot"
+                },
+                {
                     "$ref": "#/definitions/wireframeRectangle"
                 },
                 {
@@ -406,9 +409,6 @@
                 },
                 {
                     "$ref": "#/definitions/wireframeNavigationBar"
-                },
-                {
-                    "$ref": "#/definitions/wireframeScreenshot"
                 }
             ]
         },
@@ -992,7 +992,7 @@
         },
         "wireframeScreenshot": {
             "additionalProperties": false,
-            "description": "a screenshot behaves exactly like an image, but it is expected to be a screenshot of the screen at the time of the event. When sent as a mutation it must always attached to the root of the playback, when sent as an initial snapshot it must be sent as the first or only node so that it attaches to the body of the playback",
+            "description": "a screenshot behaves exactly like an image, but it is expected to be a screenshot of the screen at the time of the event, when sent as a mutation it must always attached to the root of the playback, when sent as an initial snapshot it must be sent as the first or only snapshot so that it attaches to the body of the playback",
             "properties": {
                 "base64": {
                     "description": "this will be used as base64 encoded image source, with no other attributes it is assumed to be a PNG, if omitted a placeholder is rendered",

--- a/ee/frontend/mobile-replay/transform.test.ts
+++ b/ee/frontend/mobile-replay/transform.test.ts
@@ -13,19 +13,6 @@ const unspecifiedBase64ImageURL =
 
 const heartEyesEmojiURL = 'data:image/png;base64,' + unspecifiedBase64ImageURL
 
-const SCREENSHOT_FULL_SNAPSHOT_EQUIVALENT = {
-    base64: 'image-content',
-    height: 914,
-    id: 151700670,
-    style: {
-        backgroundColor: '#F3EFF7',
-    },
-    type: 'screenshpt',
-    width: 411,
-    x: 0,
-    y: 0,
-}
-
 function fakeWireframe(type: string, children?: wireframe[]): wireframe {
     // this is a fake so we can force the type
     return { type, childWireframes: children || [] } as Partial<wireframe> as wireframe
@@ -83,7 +70,20 @@ describe('replay/transform', () => {
                     {
                         windowId: '5173a13e-abac-4def-b227-2f81dc2808b6',
                         data: {
-                            wireframes: [SCREENSHOT_FULL_SNAPSHOT_EQUIVALENT],
+                            wireframes: [
+                                {
+                                    base64: 'image-content',
+                                    height: 914,
+                                    id: 151700670,
+                                    style: {
+                                        backgroundColor: '#F3EFF7',
+                                    },
+                                    type: 'screenshpt',
+                                    width: 411,
+                                    x: 0,
+                                    y: 0,
+                                },
+                            ],
                         },
                         timestamp: 1714397321578,
                         type: 2,

--- a/ee/frontend/mobile-replay/transform.test.ts
+++ b/ee/frontend/mobile-replay/transform.test.ts
@@ -78,7 +78,7 @@ describe('replay/transform', () => {
                                     style: {
                                         backgroundColor: '#F3EFF7',
                                     },
-                                    type: 'screenshpt',
+                                    type: 'screenshot',
                                     width: 411,
                                     x: 0,
                                     y: 0,

--- a/ee/frontend/mobile-replay/transform.test.ts
+++ b/ee/frontend/mobile-replay/transform.test.ts
@@ -13,6 +13,19 @@ const unspecifiedBase64ImageURL =
 
 const heartEyesEmojiURL = 'data:image/png;base64,' + unspecifiedBase64ImageURL
 
+const SCREENSHOT_FULL_SNAPSHOT_EQUIVALENT = {
+    base64: 'image-content',
+    height: 914,
+    id: 151700670,
+    style: {
+        backgroundColor: '#F3EFF7',
+    },
+    type: 'screenshpt',
+    width: 411,
+    x: 0,
+    y: 0,
+}
+
 function fakeWireframe(type: string, children?: wireframe[]): wireframe {
     // this is a fake so we can force the type
     return { type, childWireframes: children || [] } as Partial<wireframe> as wireframe
@@ -57,6 +70,63 @@ describe('replay/transform', () => {
         let posthogEEModule: PostHogEE
         beforeEach(async () => {
             posthogEEModule = await posthogEE()
+        })
+
+        test('can process top level screenshot', () => {
+            expect(
+                posthogEEModule.mobileReplay?.transformToWeb([
+                    {
+                        data: { width: 300, height: 600 },
+                        timestamp: 1,
+                        type: 4,
+                    },
+                    {
+                        windowId: '5173a13e-abac-4def-b227-2f81dc2808b6',
+                        data: {
+                            wireframes: [SCREENSHOT_FULL_SNAPSHOT_EQUIVALENT],
+                        },
+                        timestamp: 1714397321578,
+                        type: 2,
+                    },
+                ])
+            ).toMatchSnapshot()
+        })
+
+        test('can process screenshot mutation', () => {
+            expect(
+                posthogEEModule.mobileReplay?.transformToWeb([
+                    {
+                        data: { width: 300, height: 600 },
+                        timestamp: 1,
+                        type: 4,
+                    },
+                    {
+                        windowId: '5173a13e-abac-4def-b227-2f81dc2808b6',
+                        data: {
+                            source: 0,
+                            updates: [
+                                {
+                                    wireframe: {
+                                        base64: 'mutated-image-content',
+                                        height: 914,
+                                        id: 151700670,
+                                        style: {
+                                            backgroundColor: '#F3EFF7',
+                                        },
+                                        type: 'screenshot',
+                                        width: 411,
+                                        x: 0,
+                                        y: 0,
+                                    },
+                                },
+                            ],
+                        },
+                        timestamp: 1714397336836,
+                        type: 3,
+                        seen: 3551987272322930,
+                    },
+                ])
+            ).toMatchSnapshot()
         })
 
         test('can process unknown types without error', () => {

--- a/ee/frontend/mobile-replay/transformer/transformers.ts
+++ b/ee/frontend/mobile-replay/transformer/transformers.ts
@@ -992,6 +992,10 @@ function isMobileIncrementalSnapshotEvent(x: unknown): x is MobileIncrementalSna
     return hasMutationSource && (hasAddedWireframe || hasUpdatedWireframe)
 }
 
+function chooseParentId(nodeType: MobileNodeType, providedParentId: number): number {
+    return nodeType === 'screenshot' ? BODY_ID : providedParentId
+}
+
 function makeIncrementalAdd(add: MobileNodeMutation, context: ConversionContext): addedNodeMutation[] | null {
     const converted = convertWireframe(add.wireframe, context)
 
@@ -1000,7 +1004,7 @@ function makeIncrementalAdd(add: MobileNodeMutation, context: ConversionContext)
     }
 
     const addition: addedNodeMutation = {
-        parentId: add.wireframe.type === 'screenshot' ? BODY_ID : add.parentId,
+        parentId: chooseParentId(add.wireframe.type, add.parentId),
         nextId: null,
         node: converted.result,
     }
@@ -1018,7 +1022,7 @@ function makeIncrementalAdd(add: MobileNodeMutation, context: ConversionContext)
  */
 function makeIncrementalRemoveForUpdate(update: MobileNodeMutation): removedNodeMutation {
     return {
-        parentId: update.wireframe.type === 'screenshot' ? BODY_ID : update.parentId,
+        parentId: chooseParentId(update.wireframe.type, update.parentId),
         id: update.wireframe.id,
     }
 }

--- a/ee/frontend/mobile-replay/transformer/transformers.ts
+++ b/ee/frontend/mobile-replay/transformer/transformers.ts
@@ -38,6 +38,7 @@ import {
     wireframeRadio,
     wireframeRadioGroup,
     wireframeRectangle,
+    wireframeScreenshot,
     wireframeSelect,
     wireframeStatusBar,
     wireframeText,
@@ -166,9 +167,8 @@ export const makeCustomEvent = (
             data: mutation,
             timestamp: mobileCustomEvent.timestamp,
         }
-    } else {
-        return mobileCustomEvent
     }
+    return mobileCustomEvent
 }
 
 export const makeMetaEvent = (
@@ -310,13 +310,14 @@ export function dataURIOrPNG(src: string): string {
 }
 
 function makeImageElement(
-    wireframe: wireframeImage,
+    wireframe: wireframeImage | wireframeScreenshot,
     children: serializedNodeWithId[],
     context: ConversionContext
 ): ConversionResult<serializedNodeWithId> | null {
     if (!wireframe.base64) {
         return makePlaceholderElement(wireframe, children, context)
     }
+
     const src = dataURIOrPNG(wireframe.base64)
     return {
         result: {
@@ -712,17 +713,16 @@ function makeProgressElement(
         }
     } else if (wireframe.style?.bar === 'rating') {
         return makeRatingBar(wireframe, children, context)
-    } else {
-        return {
-            result: {
-                type: NodeType.Element,
-                tagName: 'progress',
-                attributes: inputAttributes(wireframe),
-                id: wireframe.id,
-                childNodes: children,
-            },
-            context,
-        }
+    }
+    return {
+        result: {
+            type: NodeType.Element,
+            tagName: 'progress',
+            attributes: inputAttributes(wireframe),
+            id: wireframe.id,
+            childNodes: children,
+        },
+        context,
     }
 }
 
@@ -888,11 +888,10 @@ function makeInputElement(
 
     if ('label' in wireframe) {
         return makeLabelledInput(wireframe, theInputElement.result, theInputElement.context)
-    } else {
-        // when labelled no styles are needed, when un-labelled as here - we add the styling in.
-        ;(theInputElement.result as elementNode).attributes.style = makeStylesString(wireframe)
-        return theInputElement
     }
+    // when labelled no styles are needed, when un-labelled as here - we add the styling in.
+    ;(theInputElement.result as elementNode).attributes.style = makeStylesString(wireframe)
+    return theInputElement
 }
 
 function makeRectangleElement(
@@ -941,6 +940,7 @@ function chooseConverter<T extends wireframe>(
         placeholder: makePlaceholderElement as any,
         status_bar: makeStatusBar as any,
         navigation_bar: makeNavigationBar as any,
+        screenshot: makeImageElement as any,
     }
     return converterMapping[converterType]
 }
@@ -1000,7 +1000,7 @@ function makeIncrementalAdd(add: MobileNodeMutation, context: ConversionContext)
     }
 
     const addition: addedNodeMutation = {
-        parentId: add.parentId,
+        parentId: add.wireframe.type === 'screenshot' ? BODY_ID : add.parentId,
         nextId: null,
         node: converted.result,
     }
@@ -1009,9 +1009,8 @@ function makeIncrementalAdd(add: MobileNodeMutation, context: ConversionContext)
         const flattened = flattenMutationAdds(addition)
         flattened.forEach((x) => adds.push(x))
         return adds
-    } else {
-        return null
     }
+    return null
 }
 
 /**
@@ -1019,7 +1018,7 @@ function makeIncrementalAdd(add: MobileNodeMutation, context: ConversionContext)
  */
 function makeIncrementalRemoveForUpdate(update: MobileNodeMutation): removedNodeMutation {
     return {
-        parentId: update.parentId,
+        parentId: update.wireframe.type === 'screenshot' ? BODY_ID : update.parentId,
         id: update.wireframe.id,
     }
 }
@@ -1105,10 +1104,9 @@ function dedupeMutations<T extends addedNodeMutation | removedNodeMutation>(muta
 
             if (seen.has(toCompare)) {
                 return false
-            } else {
-                seen.add(toCompare)
-                return true
             }
+            seen.add(toCompare)
+            return true
         })
         .reverse()
 }
@@ -1237,25 +1235,24 @@ function stripBarsFromWireframe(wireframe: wireframe): {
         return { wireframe: undefined, statusBar: wireframe, navBar: undefined }
     } else if (wireframe.type === 'navigation_bar') {
         return { wireframe: undefined, statusBar: undefined, navBar: wireframe }
-    } else {
-        let statusBar: wireframeStatusBar | undefined
-        let navBar: wireframeNavigationBar | undefined
-        const wireframeToReturn: wireframe | undefined = { ...wireframe }
-        wireframeToReturn.childWireframes = []
-        for (const child of wireframe.childWireframes || []) {
-            const {
-                wireframe: childWireframe,
-                statusBar: childStatusBar,
-                navBar: childNavBar,
-            } = stripBarsFromWireframe(child)
-            statusBar = statusBar || childStatusBar
-            navBar = navBar || childNavBar
-            if (childWireframe) {
-                wireframeToReturn.childWireframes.push(childWireframe)
-            }
-        }
-        return { wireframe: wireframeToReturn, statusBar, navBar }
     }
+    let statusBar: wireframeStatusBar | undefined
+    let navBar: wireframeNavigationBar | undefined
+    const wireframeToReturn: wireframe | undefined = { ...wireframe }
+    wireframeToReturn.childWireframes = []
+    for (const child of wireframe.childWireframes || []) {
+        const {
+            wireframe: childWireframe,
+            statusBar: childStatusBar,
+            navBar: childNavBar,
+        } = stripBarsFromWireframe(child)
+        statusBar = statusBar || childStatusBar
+        navBar = navBar || childNavBar
+        if (childWireframe) {
+            wireframeToReturn.childWireframes.push(childWireframe)
+        }
+    }
+    return { wireframe: wireframeToReturn, statusBar, navBar }
 }
 
 /**

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -71,12 +71,23 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1
   '''
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.11
+  '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1
+  '''
+# ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.12
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -107,7 +118,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.12
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.13
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -130,7 +141,7 @@
          AND "posthog_featureflag"."team_id" = 2)
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.13
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.14
   '''
   SELECT "posthog_pluginconfig"."id",
          "posthog_pluginconfig"."web_token",
@@ -250,6 +261,17 @@
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1
+  '''
+# ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+  '''
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
          "posthog_organizationmembership"."user_id",
@@ -280,7 +302,7 @@
   WHERE "posthog_organizationmembership"."user_id" = 2
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."organization_id",
@@ -289,22 +311,11 @@
   WHERE "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid)
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '''
   SELECT 1 AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
-  LIMIT 1
-  '''
-# ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
-  '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1
   '''
 # ---
@@ -314,7 +325,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1
   '''

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -71,23 +71,12 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1
-  '''
-# ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.11
-  '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
   WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.12
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.11
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -118,7 +107,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.13
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.12
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -139,6 +128,22 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
+  '''
+# ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.13
+  '''
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
   '''
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.14
@@ -261,17 +266,6 @@
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1
-  '''
-# ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
-  '''
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
          "posthog_organizationmembership"."user_id",
@@ -302,7 +296,7 @@
   WHERE "posthog_organizationmembership"."user_id" = 2
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."organization_id",
@@ -311,11 +305,22 @@
   WHERE "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid)
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '''
   SELECT 1 AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
+  LIMIT 1
+  '''
+# ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+  '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1
   '''
 # ---
@@ -325,7 +330,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1
   '''


### PR DESCRIPTION
screenshots are going to behave slightly differently since they should always be (and implicitly be) attached to the player body when played back

let's add them to the schema explicitly so we can do that