### PR TITLE
fix: hide legend by default as before

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -271,7 +271,7 @@ export function LineGraph_({
     hideAnnotations,
     hideXAxis,
     hideYAxis,
-    legend,
+    legend = { display: false },
 }: LineGraphProps): JSX.Element {
     let datasets = _datasets
 


### PR DESCRIPTION
Bug fix: Restore defaults for legend on line graphs to avoid showing legends on historical trends