### PR TITLE
chore(hogql): Added Sentry user and tags to async queries

### DIFF
--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import Optional
 import uuid
 
+from sentry_sdk import push_scope
 import structlog
 from prometheus_client import Histogram
 from rest_framework.exceptions import NotFound
@@ -85,50 +86,58 @@ def execute_process_query(
 
     from posthog.api.services.query import process_query, ExecutionMode
     from posthog.models import Team
+    from posthog.models.user import User
 
     team = Team.objects.get(pk=team_id)
+    user = User.objects.get(pk=user_id)
 
-    query_status = manager.get_query_status()
+    with push_scope() as scope:
+        scope.set_user({"email": user.email, "id": user_id, "username": user.email})
+        scope.set_tag("team_id", team_id)
 
-    if query_status.complete or query_status.error:
-        return
+        query_status = manager.get_query_status()
 
-    query_status.error = True  # Assume error in case nothing below ends up working
+        if query_status.complete or query_status.error:
+            return
 
-    pickup_time = datetime.datetime.now(datetime.timezone.utc)
-    if query_status.start_time:
-        wait_duration = (pickup_time - query_status.start_time) / datetime.timedelta(seconds=1)
-        QUERY_WAIT_TIME.observe(wait_duration)
+        query_status.error = True  # Assume error in case nothing below ends up working
 
-    try:
-        tag_queries(client_query_id=query_id, team_id=team_id, user_id=user_id)
-        results = process_query(
-            team=team,
-            query_json=query_json,
-            limit_context=limit_context,
-            execution_mode=ExecutionMode.CALCULATION_ALWAYS
-            if refresh_requested
-            else ExecutionMode.RECENT_CACHE_CALCULATE_IF_STALE,
-        )
-        logger.info("Got results for team %s query %s", team_id, query_id)
-        query_status.complete = True
-        query_status.error = False
-        query_status.results = results
-        query_status.end_time = datetime.datetime.now(datetime.timezone.utc)
-        query_status.expiration_time = query_status.end_time + datetime.timedelta(seconds=manager.STATUS_TTL_SECONDS)
-        process_duration = (query_status.end_time - pickup_time) / datetime.timedelta(seconds=1)
-        QUERY_PROCESS_TIME.observe(process_duration)
-    except (ExposedHogQLError, ExposedCHQueryError) as err:  # We can expose the error to the user
-        query_status.results = None  # Clear results in case they are faulty
-        query_status.error_message = str(err)
-        logger.error("Error processing query for team %s query %s: %s", team_id, query_id, err)
-        raise err
-    except Exception as err:  # We cannot reveal anything about the error
-        query_status.results = None  # Clear results in case they are faulty
-        logger.error("Error processing query for team %s query %s: %s", team_id, query_id, err)
-        raise err
-    finally:
-        manager.store_query_status(query_status)
+        pickup_time = datetime.datetime.now(datetime.timezone.utc)
+        if query_status.start_time:
+            wait_duration = (pickup_time - query_status.start_time) / datetime.timedelta(seconds=1)
+            QUERY_WAIT_TIME.observe(wait_duration)
+
+        try:
+            tag_queries(client_query_id=query_id, team_id=team_id, user_id=user_id)
+            results = process_query(
+                team=team,
+                query_json=query_json,
+                limit_context=limit_context,
+                execution_mode=ExecutionMode.CALCULATION_ALWAYS
+                if refresh_requested
+                else ExecutionMode.RECENT_CACHE_CALCULATE_IF_STALE,
+            )
+            logger.info("Got results for team %s query %s", team_id, query_id)
+            query_status.complete = True
+            query_status.error = False
+            query_status.results = results
+            query_status.end_time = datetime.datetime.now(datetime.timezone.utc)
+            query_status.expiration_time = query_status.end_time + datetime.timedelta(
+                seconds=manager.STATUS_TTL_SECONDS
+            )
+            process_duration = (query_status.end_time - pickup_time) / datetime.timedelta(seconds=1)
+            QUERY_PROCESS_TIME.observe(process_duration)
+        except (ExposedHogQLError, ExposedCHQueryError) as err:  # We can expose the error to the user
+            query_status.results = None  # Clear results in case they are faulty
+            query_status.error_message = str(err)
+            logger.error("Error processing query for team %s query %s: %s", team_id, query_id, err)
+            raise err
+        except Exception as err:  # We cannot reveal anything about the error
+            query_status.results = None  # Clear results in case they are faulty
+            logger.error("Error processing query for team %s query %s: %s", team_id, query_id, err)
+            raise err
+        finally:
+            manager.store_query_status(query_status)
 
 
 def kick_off_task(

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -7,6 +7,7 @@ from posthog.clickhouse.client import execute_async as client
 from posthog.client import sync_execute
 from posthog.hogql.errors import ExposedHogQLError
 from posthog.models import Organization, Team
+from posthog.models.user import User
 from posthog.test.base import ClickhouseTestMixin, snapshot_clickhouse_queries
 from unittest.mock import patch, MagicMock
 from posthog.clickhouse.client.execute_async import QueryStatusManager, execute_process_query
@@ -21,10 +22,11 @@ def build_query(sql):
 
 class TestExecuteProcessQuery(TestCase):
     def setUp(self):
+        user = User.objects.create(email="test@posthog.com")
         self.organization = Organization.objects.create(name="test")
         self.team = Team.objects.create(organization=self.organization)
         self.team_id = self.team.pk
-        self.user_id = 1337
+        self.user_id: int = user.id
         self.query_id = "test_query_id"
         self.query_json = {}
         self.limit_context = None
@@ -58,10 +60,11 @@ class TestExecuteProcessQuery(TestCase):
 
 class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
     def setUp(self):
+        user = User.objects.create(email="test@posthog.com")
         self.organization: Organization = Organization.objects.create(name="test")
         self.team: Team = Team.objects.create(organization=self.organization)
         self.team_id: int = self.team.pk
-        self.user_id: int = 2137
+        self.user_id: int = user.id
 
     @snapshot_clickhouse_queries
     def test_async_query_client(self):

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -60,7 +60,7 @@ class TestExecuteProcessQuery(TestCase):
 
 class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
     def setUp(self):
-        user = User.objects.create(email="test@posthog.com")
+        user = User.objects.create(email="test@posthog.com", id=1337)
         self.organization: Organization = Organization.objects.create(name="test")
         self.team: Team = Team.objects.create(organization=self.organization)
         self.team_id: int = self.team.pk


### PR DESCRIPTION
## Problem
- Async queries aren't getting tagged with team or user info in Sentry, making it hard to find errors for myself on prod (or any other user)

## Changes
- Manually set the sentry user and team id tag for async queries inside the celery task

## Does this work well for both Cloud and self-hosted?
- Yes

## How did you test this code?
- Tested that the scope gets tagged correctly