### PR TITLE
fix(hogql): autocomplete tables

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -137,7 +137,9 @@ class Database(BaseModel):
         raise QueryError(f'Unknown table "{table_name}".')
 
     def get_all_tables(self) -> list[str]:
-        return self._table_names + self._warehouse_table_names
+        all_keys = list(vars(self).keys())
+        table_names = [key for key in all_keys if isinstance(getattr(self, key), Table)]
+        return table_names + self._warehouse_table_names
 
     def add_warehouse_tables(self, **field_definitions: Any):
         for f_name, f_def in field_definitions.items():


### PR DESCRIPTION
## Problem

Autocomplete gives us the ClickHouse table names:

<img width="695" alt="image" src="https://github.com/PostHog/posthog/assets/53387/c162e7ab-af73-46ee-86a2-accbc9387030">

## Changes

Use the HogQL table names instead:

<img width="626" alt="Screenshot 2024-04-30 at 12 10 31" src="https://github.com/PostHog/posthog/assets/53387/e50e7cd8-aba5-4f23-b286-0563c479cf18">


## How did you test this code?

Locally in the browser