### PR TITLE
chore: reduce messages to sentry

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -336,6 +336,7 @@ export class SessionRecordingIngester {
         await runInstrumentedFunction({
             statsKey: `recordingingester.handleEachBatch`,
             logExecutionTime: true,
+            sendTimeoutGuardToSentry: false,
             func: async () => {
                 histogramKafkaBatchSize.observe(messages.length)
                 histogramKafkaBatchSizeKb.observe(messages.reduce((acc, m) => (m.value?.length ?? 0) + acc, 0) / 1024)

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -335,7 +335,6 @@ export class SessionRecordingIngester {
         })
         await runInstrumentedFunction({
             statsKey: `recordingingester.handleEachBatch`,
-            logExecutionTime: true,
             sendTimeoutGuardToSentry: false,
             func: async () => {
                 histogramKafkaBatchSize.observe(messages.length)
@@ -647,7 +646,6 @@ export class SessionRecordingIngester {
         const startTime = Date.now()
         await runInstrumentedFunction({
             statsKey: `recordingingester.onRevokePartitions.revokeSessions`,
-            logExecutionTime: true,
             timeout: SHUTDOWN_FLUSH_TIMEOUT_MS, // same as the partition lock
             func: async () => {
                 if (this.config.SESSION_RECORDING_PARTITION_REVOKE_OPTIMIZATION) {

--- a/plugin-server/src/main/utils.ts
+++ b/plugin-server/src/main/utils.ts
@@ -12,6 +12,7 @@ interface FunctionInstrumentation<T> {
     timeoutContext?: () => Record<string, any>
     teamId?: number
     logExecutionTime?: boolean
+    sendTimeoutGuardToSentry?: boolean
 }
 
 const logTime = (startTime: number, statsKey: string, error?: any) => {
@@ -30,8 +31,14 @@ export async function runInstrumentedFunction<T>({
     statsKey,
     teamId,
     logExecutionTime = false,
+    sendTimeoutGuardToSentry = true,
 }: FunctionInstrumentation<T>): Promise<T> {
-    const t = timeoutGuard(timeoutMessage ?? `Timeout warning for '${statsKey}'!`, timeoutContext, timeout)
+    const t = timeoutGuard(
+        timeoutMessage ?? `Timeout warning for '${statsKey}'!`,
+        timeoutContext,
+        timeout,
+        sendTimeoutGuardToSentry
+    )
     const startTime = performance.now()
     const end = instrumentedFunctionDuration.startTimer({
         function: statsKey,


### PR DESCRIPTION
We send about 8k of these to Sentry each month https://posthog.sentry.io/issues/4493997212/?project=4506999002234880&project=4506197739831296&project=6423401&project=1899813&project=4504751607644160&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=30d&stream_index=12

But if this really times out then we'll also get an error to sentry so we don't need this warning in Sentry