### PR TITLE
feat(web-analytics): Use properties efficiently for scrollview calc

### DIFF
--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -240,12 +240,12 @@ LEFT JOIN (
         SELECT
             {scroll_breakdown_value} AS breakdown_value, -- use $prev_pageview_pathname to find the scroll depth when leaving this pathname
             avgState(CASE
-                WHEN toFloat(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage')) IS NULL THEN NULL
-                WHEN toFloat(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage')) > 0.8 THEN 1
+                WHEN toFloat(events.properties.`$prev_pageview_max_content_percentage`) IS NULL THEN NULL
+                WHEN toFloat(events.properties.`$prev_pageview_max_content_percentage`) > 0.8 THEN 1
                 ELSE 0
                 END
             ) AS scroll_gt80_percentage_state,
-            avgState(toFloat(JSONExtractRaw(events.properties, '$prev_pageview_max_scroll_percentage'))) as average_scroll_percentage_state
+            avgState(toFloat(events.properties.`$prev_pageview_max_scroll_percentage`)) as average_scroll_percentage_state
         FROM events
         JOIN sessions
         ON events.`$session_id` = sessions.session_id


### PR DESCRIPTION
## Problem

We're using the json blob, which is huge and slow.

## Changes

Use the materialized properties where possible (should already be materialized on US and EU)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Existing tests pass, which are pretty thorough and would catch things like null values being erroneously treated as zero