### PR TITLE
fix(web-analytics): Fix accessing property.key when getting scroll properties

### DIFF
--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -3,7 +3,13 @@ from typing import Union
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.parser import parse_select, parse_expr
-from posthog.hogql.property import property_to_expr, get_property_operator, get_property_value, get_property_type
+from posthog.hogql.property import (
+    property_to_expr,
+    get_property_operator,
+    get_property_value,
+    get_property_type,
+    get_property_key,
+)
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.web_analytics.web_analytics_query_runner import (
     WebAnalyticsQueryRunner,
@@ -366,7 +372,7 @@ ORDER BY "context.columns.visitors" DESC,
 
     def _event_properties_for_scroll(self) -> ast.Expr:
         def map_scroll_property(property: Union[EventPropertyFilter, PersonPropertyFilter]):
-            if get_property_type(property) == "event" and property.key == "$pathname":
+            if get_property_type(property) == "event" and get_property_key(property) == "$pathname":
                 return EventPropertyFilter(
                     key="$prev_pageview_pathname",
                     operator=get_property_operator(property),


### PR DESCRIPTION
## Problem

https://posthog.sentry.io/issues/5281773029/?referrer=github-open-pr-bot

More generally the problem is that it's not always the case that these arguments are either dicts or objects

## Changes

Use the method that will access `key` regardless of dict or object-ness

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tests still pass
