### PR TITLE
fix(insights): Fix insights property change does not update filters

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
@@ -45,7 +45,14 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>([
     listeners(({ actions, props, values }) => ({
         // Only send update if value is set to something
         setFilter: async ({ property }) => {
-            if (props.sendAllKeyUpdates || property?.value || (property?.key && property.type === 'hogql')) {
+            if (
+                props.sendAllKeyUpdates ||
+                property?.value ||
+                ('operator' in property &&
+                    property?.operator &&
+                    ['is_set', 'is_not_set'].includes(property?.operator)) ||
+                (property?.key && property.type === 'hogql')
+            ) {
                 actions.update()
             }
         },


### PR DESCRIPTION
## Problem

Fixes #21824

## Changes

React also to property changes if operator `is_set` or `is_not_set`

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

- 👀 