### PR TITLE
fix(plugin-server): sanitize nulls and check length on property manag…

### DIFF
--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -184,6 +184,10 @@ export function sanitizeJsonbValue(value: any): any {
     }
 }
 
+export function sanitizeString(value: string) {
+    return value.replace(/\u0000/g, '\uFFFD')
+}
+
 export const surrogatesSubstitutedCounter = new Counter({
     name: 'surrogates_substituted_total',
     help: 'Stray UTF16 surrogates detected and removed from user input.',

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -4,7 +4,7 @@ import { Message } from 'node-rdkafka'
 
 import { ClickHouseEvent, Element, PipelineEvent, PostIngestionEvent, RawClickHouseEvent } from '../types'
 import { chainToElements } from './db/elements-chain'
-import { personInitialAndUTMProperties } from './db/utils'
+import { personInitialAndUTMProperties, sanitizeString } from './db/utils'
 import {
     clickHouseTimestampSecondPrecisionToISO,
     clickHouseTimestampToDateTime,
@@ -144,7 +144,7 @@ export function normalizeProcessPerson(event: PluginEvent, processPerson: boolea
 }
 
 export function normalizeEvent(event: PluginEvent): PluginEvent {
-    event.distinct_id = event.distinct_id?.toString().replace(/\u0000/g, '\uFFFD')
+    event.distinct_id = sanitizeString(String(event.distinct_id))
 
     let properties = event.properties ?? {}
     if (event['$set']) {


### PR DESCRIPTION
…er inserts

## Problem

We didn't check for `\u0000` in these fields, and we blindly attempted to insert even though there is a `400` column length on a number of these columns.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Sanitize, check length.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Add tests, node that the `>400` test throws without the code changes.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
