### PR TITLE
fix(data-warehouse): Fix error with loading a warehouse insight

### DIFF
--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -251,7 +251,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
                     return []
                 }
 
-                return externalTablesMap[(series[0] as DataWarehouseNode).table_name].columns
+                return externalTablesMap[(series[0] as DataWarehouseNode)?.table_name]?.columns ?? []
             },
         ],
 


### PR DESCRIPTION
## Problem
When loading a warehouse insight, we'd often get this frontend error

<img width="1218" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/26af0b32-490c-4214-a8f7-88b02c15528d">


## Changes
- Added some safety fallbacks when loading `currentDataWarehouseSchemaColumns`
