### PR TITLE
fix(web-analytics): Fix float to float conversion for float properties e.g. scroll depth

### DIFF
--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -179,6 +179,7 @@ HOGQL_CLICKHOUSE_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "toJSONString": HogQLFunctionMeta("toJSONString", 1, 1),
     "parseDateTime": HogQLFunctionMeta("parseDateTimeOrNull", 2, 3, tz_aware=True),
     "parseDateTimeBestEffort": HogQLFunctionMeta("parseDateTime64BestEffortOrNull", 1, 2, tz_aware=True),
+    "_accurateCastOrNull": HogQLFunctionMeta("accurateCastOrNull", 2, 2),
     # dates and times
     "toTimeZone": HogQLFunctionMeta("toTimeZone", 2, 2),
     "timeZoneOf": HogQLFunctionMeta("timeZoneOf", 1, 1),

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -246,12 +246,12 @@ LEFT JOIN (
         SELECT
             {scroll_breakdown_value} AS breakdown_value, -- use $prev_pageview_pathname to find the scroll depth when leaving this pathname
             avgState(CASE
-                WHEN toFloat(events.properties.`$prev_pageview_max_content_percentage`) IS NULL THEN NULL
-                WHEN toFloat(events.properties.`$prev_pageview_max_content_percentage`) > 0.8 THEN 1
+                WHEN _accurateCastOrNull(events.properties.`$prev_pageview_max_content_percentage`, 'Float64') IS NULL THEN NULL
+                WHEN _accurateCastOrNull(events.properties.`$prev_pageview_max_content_percentage`, 'Float64') > 0.8 THEN 1
                 ELSE 0
                 END
             ) AS scroll_gt80_percentage_state,
-            avgState(toFloat(events.properties.`$prev_pageview_max_scroll_percentage`)) as average_scroll_percentage_state
+            avgState(_accurateCastOrNull(events.properties.`$prev_pageview_max_scroll_percentage`, 'Float64')) as average_scroll_percentage_state
         FROM events
         JOIN sessions
         ON events.`$session_id` = sessions.session_id


### PR DESCRIPTION
## Problem

Sentry link: https://posthog.sentry.io/issues/5283471199/?project=1899813&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=2

## Changes

Add a mapping to `accurateCastOrNull`, prefix with an underscore as we have this convention for other things that are not exactly public, e.g. `_toInt`.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
* Tests still pass
* Sanity checked that `SELECT accurateCastOrNull('0.3', 'Float64')` does actually return a float
* Sanity checked that `SELECT accurateCastOrNull(accurateCastOrNull('0.3', 'Float64'), 'Float64')` works