### PR TITLE
fix: heatmap relative date to filtering

### DIFF
--- a/posthog/heatmaps/test/__snapshots__/test_heatmaps_api.ambr
+++ b/posthog/heatmaps/test/__snapshots__/test_heatmaps_api.ambr
@@ -344,7 +344,7 @@
                          format_csv_allow_double_quotes=0
   '''
 # ---
-# name: TestSessionRecordings.test_can_get_filter_by_relative_date_from
+# name: TestSessionRecordings.test_can_get_filter_by_relative_date
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT pointer_target_fixed AS pointer_target_fixed,
@@ -357,7 +357,30 @@
             round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
             multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
      FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'click'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08'))))
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'click'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), lessOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), plus(toDate('2023-03-14'), toIntervalDay(1)))))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0
+  '''
+# ---
+# name: TestSessionRecordings.test_can_get_filter_by_relative_date.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'click'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-15')), lessOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), plus(toDate('2023-03-15'), toIntervalDay(1)))))
   GROUP BY pointer_target_fixed,
            pointer_relative_x,
            client_y

--- a/posthog/heatmaps/test/test_heatmaps_api.py
+++ b/posthog/heatmaps/test/test_heatmaps_api.py
@@ -103,11 +103,12 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
 
     @snapshot_clickhouse_queries
     @freezegun.freeze_time("2023-03-15T09:00:00")
-    def test_can_get_filter_by_relative_date_from(self) -> None:
+    def test_can_get_filter_by_relative_date(self) -> None:
         self._create_heatmap_event("session_1", "click", "2023-03-07T07:00:00")
         self._create_heatmap_event("session_2", "click", "2023-03-08T08:00:00")
 
-        self._assert_heatmap_single_result_count({"date_from": "-7d"}, 1)
+        self._assert_heatmap_single_result_count({"date_from": "-7d", "date_to": "-1d"}, 1)
+        self._assert_heatmap_no_result_count({"date_from": "dStart", "date_to": "dEnd"})
 
     @snapshot_clickhouse_queries
     def test_can_get_filter_by_click(self) -> None:


### PR DESCRIPTION
Looking at other parts of the heatmap date filtering I realised I hadn't implemented date_to correctly

So, e/g/ "yesterday" didn't work at all

But now it does