### PR TITLE
Bump xmlsec version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -583,7 +583,7 @@ wrapt==1.15.0
     # via aiobotocore
 wsproto==1.1.0
     # via trio-websocket
-xmlsec==1.3.13
+xmlsec==1.3.14
     # via python3-saml
 yarl==1.7.2
     # via aiohttp


### PR DESCRIPTION
xmlsec released a new minor version that doesn't have the insane build issue mentioned on the "develop locally" page for macs anymore
```Friendly tip: If you see ERROR: Could not build wheels for xmlsec, refer to this [issue](https://github.com/xmlsec/python-xmlsec/issues/254).```

As discussed here: https://github.com/xmlsec/python-xmlsec/issues/284

Bump it.
