### PR TITLE
fix: Pie chart was behaving poorly with null or other breakdown values

### DIFF
--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -124,13 +124,13 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
                     display &&
                     (display === ChartDisplayType.ActionsBarValue || display === ChartDisplayType.ActionsPie)
                 ) {
-                    indexedResults.sort((a, b) => {
-                        return a.breakdown_value === BREAKDOWN_OTHER_STRING_LABEL
+                    indexedResults.sort((a, b) =>
+                        a.breakdown_value === BREAKDOWN_OTHER_STRING_LABEL
                             ? BREAKDOWN_OTHER_NUMERIC_LABEL
                             : a.breakdown_value === BREAKDOWN_NULL_STRING_LABEL
                             ? BREAKDOWN_NULL_NUMERIC_LABEL
                             : b.aggregated_value - a.aggregated_value
-                    })
+                    )
                 } else if (lifecycleFilter) {
                     if (lifecycleFilter.toggledLifecycles) {
                         indexedResults = indexedResults.filter((result) =>

--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -124,13 +124,13 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
                     display &&
                     (display === ChartDisplayType.ActionsBarValue || display === ChartDisplayType.ActionsPie)
                 ) {
-                    indexedResults.sort((a, b) =>
-                        a.label === BREAKDOWN_OTHER_STRING_LABEL
+                    indexedResults.sort((a, b) => {
+                        return a.breakdown_value === BREAKDOWN_OTHER_STRING_LABEL
                             ? BREAKDOWN_OTHER_NUMERIC_LABEL
-                            : a.label === BREAKDOWN_NULL_STRING_LABEL
+                            : a.breakdown_value === BREAKDOWN_NULL_STRING_LABEL
                             ? BREAKDOWN_NULL_NUMERIC_LABEL
                             : b.aggregated_value - a.aggregated_value
-                    )
+                    })
                 } else if (lifecycleFilter) {
                     if (lifecycleFilter.toggledLifecycles) {
                         indexedResults = indexedResults.filter((result) =>

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -64,18 +64,17 @@ export function ActionsPie({
         isTrendsQuery(query.source)
 
     function updateData(): void {
-        const _data = [...indexedResults].sort((a, b) => b.aggregated_value - a.aggregated_value)
-        const days = _data.length > 0 ? _data[0].days : []
-        const colorList = _data.map(({ seriesIndex }) => getSeriesColor(seriesIndex))
+        const days = indexedResults.length > 0 ? indexedResults[0].days : []
+        const colorList = indexedResults.map(({ seriesIndex }) => getSeriesColor(seriesIndex))
 
         setData([
             {
                 id: 0,
-                labels: _data.map((item) => item.label),
-                data: _data.map((item) => item.aggregated_value),
-                actions: _data.map((item) => item.action),
-                breakdownValues: _data.map((item) => item.breakdown_value),
-                breakdownLabels: _data.map((item) => {
+                labels: indexedResults.map((item) => item.label),
+                data: indexedResults.map((item) => item.aggregated_value),
+                actions: indexedResults.map((item) => item.action),
+                breakdownValues: indexedResults.map((item) => item.breakdown_value),
+                breakdownLabels: indexedResults.map((item) => {
                     return formatBreakdownLabel(
                         cohorts,
                         formatPropertyValueForDisplay,
@@ -85,14 +84,16 @@ export function ActionsPie({
                         false
                     )
                 }),
-                compareLabels: _data.map((item) => item.compare_label),
-                personsValues: _data.map((item) => item.persons),
+                compareLabels: indexedResults.map((item) => item.compare_label),
+                personsValues: indexedResults.map((item) => item.persons),
                 days,
                 backgroundColor: colorList,
                 borderColor: colorList, // For colors to display in the tooltip
             },
         ])
-        setTotal(_data.reduce((prev, item, i) => prev + (!hiddenLegendKeys?.[i] ? item.aggregated_value : 0), 0))
+        setTotal(
+            indexedResults.reduce((prev, item, i) => prev + (!hiddenLegendKeys?.[i] ? item.aggregated_value : 0), 0)
+        )
     }
 
     useEffect(() => {


### PR DESCRIPTION



https://posthog.slack.com/archives/C0368RPHLQH/p1714468798325329

We are doing a special sort order in trendsDataLogic to put bad breakdowns at the end of the list and return the value as indexedResults
We were sorting indexedResults again in updateData for the Pie Chart.
This undid the special sorting we were doing in trends data logic to put null or other breakdowns at the end of the list.

A second bug was discovered here and fixed, which was that the new /query endpoints would return some other more readable strings for label, so we lost our special sorting logic with the hogql switch. Change the sort to look at the "breakdown_value" instead.


Old (bug)
https://github.com/PostHog/posthog/assets/1855120/bf0d4cfb-bd27-4b66-88b6-2f8b63d43681

New
https://github.com/PostHog/posthog/assets/1855120/c560953b-47d3-4f1a-8ddf-11af1e86addc