### PR TITLE
fix: heatmaps buttons copy pasta

### DIFF
--- a/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
+++ b/frontend/src/toolbar/stats/HeatmapToolbarMenu.tsx
@@ -270,20 +270,16 @@ export const HeatmapToolbarMenu = (): JSX.Element => {
                             >
                                 <div className="flex gap-2 justify-between items-center">
                                     <LemonSegmentedButton
-                                        onChange={setHeatmapFixedPositionMode}
-                                        value={heatmapFixedPositionMode}
+                                        onChange={(e) => patchHeatmapFilters({ aggregation: e })}
+                                        value={heatmapFilters.aggregation ?? 'total_count'}
                                         options={[
                                             {
-                                                value: 'fixed',
-                                                label: 'Show fixed',
+                                                value: 'total_count',
+                                                label: 'Total count',
                                             },
                                             {
-                                                value: 'relative',
-                                                label: 'Show scrolled',
-                                            },
-                                            {
-                                                value: 'hidden',
-                                                label: 'Hide',
+                                                value: 'unique_visitors',
+                                                label: 'Unique visitors',
                                             },
                                         ]}
                                         size="small"


### PR DESCRIPTION
some copy pasta in https://github.com/PostHog/posthog/pull/21886 needs fixing


<table>
<th>
<tr>
<td>before</td><td>after</td>
</tr>
</th>
<tbody>
<tr>
 <td>
<img width="474" alt="Screenshot 2024-05-01 at 09 28 51" src="https://github.com/PostHog/posthog/assets/984817/12e5e699-ed9b-4081-a979-5bbdd7290f07">
 </td>
 <td>
<img width="455" alt="Screenshot 2024-05-01 at 09 31 02" src="https://github.com/PostHog/posthog/assets/984817/b2bec338-7708-447b-9571-470fc933d547">
 </td>
</tr>
</tbody>
</table>