### PR TITLE
fix: clickabl home icon

### DIFF
--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -97,8 +97,8 @@ function HomeDashboard({ dashboardLogicProps }: { dashboardLogicProps: Dashboard
                     {!dashboard && <LemonSkeleton className="w-20 h-4" />}
                     {dashboard?.name && (
                         <>
-                            <IconHome className="mr-2 text-2xl opacity-50" />
                             <Link className="font-semibold text-xl text-default" to={urls.dashboard(dashboard.id)}>
+                                <IconHome className="mr-2 text-2xl opacity-50" />
                                 {dashboard?.name}
                             </Link>
                         </>


### PR DESCRIPTION
From the new heatmap data we can see that people are trying to click on the home icon next to the home dashboard's title

Let's move the icon into the link so clicking on it does something

<img width="274" alt="Screenshot 2024-05-01 at 09 47 53" src="https://github.com/PostHog/posthog/assets/984817/32571a35-9a38-438c-824e-d612162db3ee">

<img width="256" alt="Screenshot 2024-05-01 at 09 48 04" src="https://github.com/PostHog/posthog/assets/984817/1d3e1337-eba0-4ccf-a284-e3a1fdaa0d51">
