### PR TITLE
fix(web-analytics): Hide scroll depth when using sessions table

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.ts
@@ -584,7 +584,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                             properties: webAnalyticsFilters,
                                             breakdownBy: WebStatsBreakdown.Page,
                                             dateRange,
-                                            includeScrollDepth: statusCheck?.isSendingPageLeavesScroll,
+                                            includeScrollDepth:
+                                                statusCheck?.isSendingPageLeavesScroll && !useSessionsTable,
                                             includeBounceRate: true,
                                             sampling,
                                             doPathCleaning: isPathCleaningEnabled,
@@ -634,7 +635,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                                   properties: webAnalyticsFilters,
                                                   breakdownBy: WebStatsBreakdown.ExitPage,
                                                   dateRange,
-                                                  includeScrollDepth: statusCheck?.isSendingPageLeavesScroll,
+                                                  includeScrollDepth: false,
                                                   sampling,
                                                   doPathCleaning: isPathCleaningEnabled,
                                                   limit: 10,


### PR DESCRIPTION
## Problem

Right now the scroll depth insight is a little too slow - it might be faster to pull it out and make it itss own thing

## Changes

Hide scroll depth insight when using sessions table

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

n/a
