### PR TITLE
chore: ADD CODEOWNERS for team-feature-success

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+frontend/src/scenes/settings/project/SurveySettings.tsx
+frontend/src/scenes/surveys/ @team-feature-success
+posthog/admin/admins/survey_admin.py
+posthog/api/survey.py @team-feature-success
+posthog/api/test/test_survey.py @team-feature-success
+posthog/models/feedback/survey.py @team-feature-success
+posthog/tasks/stop_surveys_reached_target.py @team-feature-success
+posthog/tasks/test/test_stop_surveys_reached_target.py @team-feature-success

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
-frontend/src/scenes/settings/project/SurveySettings.tsx
-frontend/src/scenes/surveys/ @team-feature-success
-posthog/admin/admins/survey_admin.py
-posthog/api/survey.py @team-feature-success
-posthog/api/test/test_survey.py @team-feature-success
-posthog/models/feedback/survey.py @team-feature-success
-posthog/tasks/stop_surveys_reached_target.py @team-feature-success
-posthog/tasks/test/test_stop_surveys_reached_target.py @team-feature-success
+frontend/src/scenes/settings/project/SurveySettings.tsx @PostHog/team-feature-success
+frontend/src/scenes/surveys/ @PostHog/team-feature-success
+posthog/admin/admins/survey_admin.py @PostHog/team-feature-success
+posthog/api/survey.py @PostHog/team-feature-success
+posthog/api/test/test_survey.py @PostHog/team-feature-success
+posthog/models/feedback/survey.py @PostHog/team-feature-success
+posthog/tasks/stop_surveys_reached_target.py @PostHog/team-feature-success
+posthog/tasks/test/test_stop_surveys_reached_target.py @PostHog/team-feature-success


### PR DESCRIPTION
## Problem

This PR adds a CODEOWNERS file for all files owned by the @PostHog/team-feature-success team.

## Changes

Adds a new file to the repository to make reviews easier for the team.

Read more [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

GitHub specific file, no code changes made.