### PR TITLE
feat: Add hidden properties list processEvent plugins can't see

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/pluginsProcessEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/pluginsProcessEventStep.ts
@@ -9,9 +9,6 @@ import { EventPipelineRunner } from './runner'
 // We don't want these to be passed to the processEvent plugins
 const hiddenProperties = [
     '$heatmap_data', // Is processed and removed at a later pipeline step
-    '$elements', // This is deprecated
-    '$groups', // To avoid dependencies if we want to change how we use this property
-    '$active_feature_flags', // To avoid dependencies if we want to change how we use this property
 ]
 
 export async function pluginsProcessEventStep(

--- a/plugin-server/src/worker/ingestion/event-pipeline/pluginsProcessEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/pluginsProcessEventStep.ts
@@ -5,22 +5,48 @@ import { runProcessEvent } from '../../plugins/run'
 import { droppedEventCounter } from './metrics'
 import { EventPipelineRunner } from './runner'
 
+// Some properties are internal, which plugins shouldn't be able to change
+// We don't want these to be passed to the processEvent plugins
+const hiddenProperties = [
+    '$heatmap_data', // Is processed and removed at a later pipeline step
+    '$elements', // This is deprecated
+    '$groups', // To avoid dependencies if we want to change how we use this property
+    '$active_feature_flags', // To avoid dependencies if we want to change how we use this property
+]
+
 export async function pluginsProcessEventStep(
     runner: EventPipelineRunner,
     event: PluginEvent
 ): Promise<PluginEvent | null> {
+    const limitedEvent = {
+        ...event,
+        properties: {
+            ...Object.fromEntries(
+                Object.entries(event.properties || {}).filter(([key]) => !hiddenProperties.includes(key))
+            ),
+        },
+    }
     const processedEvent = await runInstrumentedFunction({
         timeoutContext: () => ({
-            event: JSON.stringify(event),
+            event: JSON.stringify(limitedEvent),
         }),
-        func: () => runProcessEvent(runner.hub, event),
+        func: () => runProcessEvent(runner.hub, limitedEvent),
         statsKey: 'kafka_queue.single_event',
         timeoutMessage: 'Still running plugins on event. Timeout warning after 30 sec!',
         teamId: event.team_id,
     })
 
     if (processedEvent) {
-        return processedEvent
+        // re-add hidden properties overwriting any changes made by plugins
+        return {
+            ...processedEvent,
+            properties: {
+                ...processedEvent.properties,
+                ...Object.fromEntries(
+                    Object.entries(event.properties || {}).filter(([key]) => hiddenProperties.includes(key))
+                ),
+            },
+        }
     } else {
         // processEvent might not return an event. This is expected and plugins, e.g. downsample plugin uses it.
         droppedEventCounter.inc()

--- a/plugin-server/tests/worker/ingestion/event-pipeline/pluginsProcessEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/pluginsProcessEventStep.test.ts
@@ -45,4 +45,20 @@ describe('pluginsProcessEventStep()', () => {
         expect(response).toEqual(null)
         expect(droppedEventCounterSpy).toHaveBeenCalledTimes(1)
     })
+
+    it('hidden properties can not be seen nor overridden by plugins', async () => {
+        const processedEvent = { ...pluginEvent, event: 'processed', properties: { $heatmap_data: 'new data' } }
+        jest.mocked(runProcessEvent).mockResolvedValue(processedEvent)
+
+        const response = await pluginsProcessEventStep(runner, {
+            ...pluginEvent,
+            properties: { $heatmap_data: 'data', x: 'y', $groups: 'abc' },
+        })
+
+        expect(runProcessEvent).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ properties: { x: 'y' } })
+        )
+        expect(response).toEqual({ ...processedEvent, properties: { $heatmap_data: 'data', $groups: 'abc' } })
+    })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/pluginsProcessEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/pluginsProcessEventStep.test.ts
@@ -52,13 +52,10 @@ describe('pluginsProcessEventStep()', () => {
 
         const response = await pluginsProcessEventStep(runner, {
             ...pluginEvent,
-            properties: { $heatmap_data: 'data', x: 'y', $groups: 'abc' },
+            properties: { $heatmap_data: 'data', x: 'y' },
         })
 
-        expect(runProcessEvent).toHaveBeenCalledWith(
-            expect.anything(),
-            expect.objectContaining({ properties: { x: 'y' } })
-        )
-        expect(response).toEqual({ ...processedEvent, properties: { $heatmap_data: 'data', $groups: 'abc' } })
+        expect(runProcessEvent).toHaveBeenCalledWith(undefined, expect.objectContaining({ properties: { x: 'y' } }))
+        expect(response).toEqual({ ...processedEvent, properties: { $heatmap_data: 'data' } })
     })
 })


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
As new products are getting built on top of events and things are added to the ingestion pipeline we don't want plugins to get more data nor users to start to depend on stuff.

Related: 
- https://github.com/PostHog/flatten-properties-plugin/pull/8
- https://posthog.slack.com/archives/C0374DA782U/p1714568052844489

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
