### PR TITLE
feat(data-warehouse): Pre populate the settings for selecting a data warehouse table in insights

### DIFF
--- a/frontend/src/lib/components/DefinitionPopover/definitionPopoverLogic.ts
+++ b/frontend/src/lib/components/DefinitionPopover/definitionPopoverLogic.ts
@@ -7,6 +7,7 @@ import { TaxonomicDefinitionTypes, TaxonomicFilterGroupType } from 'lib/componen
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { DataWarehouseTableType } from 'scenes/data-warehouse/types'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
@@ -42,13 +43,13 @@ export const definitionPopoverLogic = kea<definitionPopoverLogicType>([
     connect({
         values: [userLogic, ['hasAvailableFeature']],
     }),
-    actions({
-        setDefinition: (item: Partial<TaxonomicDefinitionTypes>) => ({ item }),
+    actions(({ values }) => ({
+        setDefinition: (item: Partial<TaxonomicDefinitionTypes>) => ({ item, isDataWarehouse: values.isDataWarehouse }),
         setLocalDefinition: (item: Partial<TaxonomicDefinitionTypes>) => ({ item }),
         setPopoverState: (state: DefinitionPopoverState) => ({ state }),
         handleCancel: true,
         recordHoverActivity: true,
-    }),
+    })),
     loaders(({ values, props, cache }) => ({
         definition: [
             {} as Partial<TaxonomicDefinitionTypes>,
@@ -120,7 +121,48 @@ export const definitionPopoverLogic = kea<definitionPopoverLogicType>([
         localDefinition: [
             {} as Partial<TaxonomicDefinitionTypes>,
             {
-                setDefinition: (_, { item }) => item,
+                setDefinition: (_, { item, isDataWarehouse }) => {
+                    if (isDataWarehouse && 'columns' in item) {
+                        // Pre-populate the data warehouse table settings for insights
+                        const warehouseItem = item as DataWarehouseTableType
+
+                        if (!('id_field' in item)) {
+                            const idField = warehouseItem.columns.find((n) => n.key === 'id')
+                            if (idField) {
+                                warehouseItem['id_field'] = idField.key
+                            }
+                        }
+
+                        if (!('distinct_id_field' in item)) {
+                            const idField = warehouseItem.columns.find((n) => n.key === 'id')
+                            if (idField) {
+                                warehouseItem['distinct_id_field'] = idField.key
+                            }
+                        }
+
+                        if (!('timestamp_field' in item)) {
+                            const timestampKeys = [
+                                'created',
+                                'created_at',
+                                'createdAt',
+                                'updated',
+                                'updated_at',
+                                'updatedAt',
+                            ]
+                            const timestampNameField = warehouseItem.columns.find((n) => timestampKeys.includes(n.key))
+                            const timestampTypeField = warehouseItem.columns.find(
+                                (n) => n.type == 'datetime' || n.type == 'date'
+                            )
+                            if (timestampNameField || timestampTypeField) {
+                                warehouseItem['timestamp_field'] = timestampNameField?.key || timestampTypeField?.key
+                            }
+                        }
+
+                        return warehouseItem
+                    }
+
+                    return item
+                },
                 setLocalDefinition: (state, { item }) => ({ ...state, ...item } as Partial<TaxonomicDefinitionTypes>),
             },
         ],


### PR DESCRIPTION
## Problem
- I was getting very frustrated with having to pick the `id` and `timestamp` field of data warehouse series in trends every time I wanted to plot something 

<img width="774" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/4adc5d72-e331-4746-9a15-21b812e1446d">


## Changes
- Auto populates the id, distinct id, and timestamp field for the user
- For the ids, it looks for a field labeled `id`
- For the timestamp, it looks like a variant of `created_at` or `updated_at` before looking for any `datetime` typed field afterward


https://github.com/PostHog/posthog/assets/1459269/5322b3a3-e91b-42c5-8075-c4277743cd03



## Does this work well for both Cloud and self-hosted?
- Yes

## How did you test this code?
- Tested locally