### PR TITLE
chore(data-warehouse): Updated get_columns to return the hogql type too

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -495,8 +495,6 @@ posthog/api/organization_member.py:0: error: Metaclass conflict: the metaclass o
 posthog/api/action.py:0: error: Argument 1 to <tuple> has incompatible type "*tuple[str, ...]"; expected "type[BaseRenderer]"  [arg-type]
 ee/api/role.py:0: error: Metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases  [misc]
 ee/clickhouse/views/insights.py:0: error: Metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases  [misc]
-posthog/warehouse/data_load/validate_schema.py:0: error: Item "None" of "DataWarehouseTable | None" has no attribute "get_columns"  [union-attr]
-posthog/warehouse/data_load/validate_schema.py:0: error: Item "None" of "DataWarehouseTable | None" has no attribute "columns"  [union-attr]
 posthog/temporal/data_imports/workflow_activities/create_job_model.py:0: error: Argument 6 has incompatible type "ExternalDataSchema"; expected "str"  [arg-type]
 posthog/temporal/data_imports/workflow_activities/create_job_model.py:0: error: Unused "type: ignore" comment  [unused-ignore]
 posthog/temporal/data_imports/pipelines/zendesk/helpers.py:0: error: Argument 1 to "ensure_pendulum_datetime" has incompatible type "DateTime | Date | datetime | date | str | float | int | None"; expected "DateTime | Date | datetime | date | str | float | int"  [arg-type]

--- a/posthog/warehouse/data_load/validate_schema.py
+++ b/posthog/warehouse/data_load/validate_schema.py
@@ -156,10 +156,13 @@ async def validate_schema_and_update_table(
         if not table_created:
             table_created = await acreate_datawarehousetable(external_data_source_id=job.pipeline.id, **data)
 
+        assert isinstance(table_created, DataWarehouseTable) and table_created is not None
+
         for schema in table_schema.values():
             if schema.get("resource") == _schema_name:
                 schema_columns = schema.get("columns") or {}
-                db_columns: dict[str, str] = await sync_to_async(table_created.get_columns)()
+                raw_db_columns: dict[str, dict[str, str]] = await sync_to_async(table_created.get_columns)()
+                db_columns = {key: column.get("clickhouse", "") for key, column in raw_db_columns.items()}
 
                 columns = {}
                 for column_name, db_column_type in db_columns.items():


### PR DESCRIPTION
## Problem
- Manual linking of S3 files were only storing the clickhouse version of the column type in the DB, whereas the DLT pipeline would store both the clickhouse and hogql version of types

## Changes
- Updated `get_columns` to return both types

## Does this work well for both Cloud and self-hosted?
- Yes

## How did you test this code?
- Tested both the DLT and manual linking method locally