### PR TITLE
fix(webhooks): enforce public IPs on webhook connections from django

### DIFF
--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -11776,6 +11776,17 @@
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.28
   '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1
+  '''
+# ---
+# name: TestDashboard.test_retrieve_dashboard_list.29
+  '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
@@ -11800,14 +11811,6 @@
   LIMIT 21
   '''
 # ---
-# name: TestDashboard.test_retrieve_dashboard_list.29
-  '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_dashboard"
-  WHERE (NOT ("posthog_dashboard"."deleted")
-         AND "posthog_dashboard"."team_id" = 2)
-  '''
-# ---
 # name: TestDashboard.test_retrieve_dashboard_list.3
   '''
   SELECT "posthog_instancesetting"."id",
@@ -11820,6 +11823,14 @@
   '''
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.30
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_dashboard"
+  WHERE (NOT ("posthog_dashboard"."deleted")
+         AND "posthog_dashboard"."team_id" = 2)
+  '''
+# ---
+# name: TestDashboard.test_retrieve_dashboard_list.31
   '''
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -11945,7 +11956,7 @@
   LIMIT 100
   '''
 # ---
-# name: TestDashboard.test_retrieve_dashboard_list.31
+# name: TestDashboard.test_retrieve_dashboard_list.32
   '''
   SELECT "posthog_sharingconfiguration"."id",
          "posthog_sharingconfiguration"."team_id",
@@ -11963,7 +11974,7 @@
                                                           5 /* ... */)
   '''
 # ---
-# name: TestDashboard.test_retrieve_dashboard_list.32
+# name: TestDashboard.test_retrieve_dashboard_list.33
   '''
   SELECT "posthog_taggeditem"."id",
          "posthog_taggeditem"."tag_id",
@@ -11983,24 +11994,6 @@
                                                 3,
                                                 4,
                                                 5 /* ... */)
-  '''
-# ---
-# name: TestDashboard.test_retrieve_dashboard_list.33
-  '''
-  SELECT "posthog_sharingconfiguration"."id",
-         "posthog_sharingconfiguration"."team_id",
-         "posthog_sharingconfiguration"."dashboard_id",
-         "posthog_sharingconfiguration"."insight_id",
-         "posthog_sharingconfiguration"."recording_id",
-         "posthog_sharingconfiguration"."created_at",
-         "posthog_sharingconfiguration"."enabled",
-         "posthog_sharingconfiguration"."access_token"
-  FROM "posthog_sharingconfiguration"
-  WHERE "posthog_sharingconfiguration"."dashboard_id" IN (1,
-                                                          2,
-                                                          3,
-                                                          4,
-                                                          5 /* ... */) /*controller='project_dashboards-list',route='api/projects/%28%3FP%3Cparent_lookup_team_id%3E%5B%5E/.%5D%2B%29/dashboards/%3F%24'*/
   '''
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.4

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -11776,17 +11776,6 @@
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.28
   '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1
-  '''
-# ---
-# name: TestDashboard.test_retrieve_dashboard_list.29
-  '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
@@ -11811,6 +11800,14 @@
   LIMIT 21
   '''
 # ---
+# name: TestDashboard.test_retrieve_dashboard_list.29
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_dashboard"
+  WHERE (NOT ("posthog_dashboard"."deleted")
+         AND "posthog_dashboard"."team_id" = 2)
+  '''
+# ---
 # name: TestDashboard.test_retrieve_dashboard_list.3
   '''
   SELECT "posthog_instancesetting"."id",
@@ -11823,14 +11820,6 @@
   '''
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.30
-  '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_dashboard"
-  WHERE (NOT ("posthog_dashboard"."deleted")
-         AND "posthog_dashboard"."team_id" = 2)
-  '''
-# ---
-# name: TestDashboard.test_retrieve_dashboard_list.31
   '''
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -11956,7 +11945,7 @@
   LIMIT 100
   '''
 # ---
-# name: TestDashboard.test_retrieve_dashboard_list.32
+# name: TestDashboard.test_retrieve_dashboard_list.31
   '''
   SELECT "posthog_sharingconfiguration"."id",
          "posthog_sharingconfiguration"."team_id",
@@ -11972,6 +11961,28 @@
                                                           3,
                                                           4,
                                                           5 /* ... */)
+  '''
+# ---
+# name: TestDashboard.test_retrieve_dashboard_list.32
+  '''
+  SELECT "posthog_taggeditem"."id",
+         "posthog_taggeditem"."tag_id",
+         "posthog_taggeditem"."dashboard_id",
+         "posthog_taggeditem"."insight_id",
+         "posthog_taggeditem"."event_definition_id",
+         "posthog_taggeditem"."property_definition_id",
+         "posthog_taggeditem"."action_id",
+         "posthog_taggeditem"."feature_flag_id",
+         "posthog_tag"."id",
+         "posthog_tag"."name",
+         "posthog_tag"."team_id"
+  FROM "posthog_taggeditem"
+  INNER JOIN "posthog_tag" ON ("posthog_taggeditem"."tag_id" = "posthog_tag"."id")
+  WHERE "posthog_taggeditem"."dashboard_id" IN (1,
+                                                2,
+                                                3,
+                                                4,
+                                                5 /* ... */)
   '''
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.33

--- a/posthog/api/test/test_utils.py
+++ b/posthog/api/test/test_utils.py
@@ -1,4 +1,5 @@
 import json
+import requests
 from typing import Any, cast
 
 from django.http import HttpRequest
@@ -13,6 +14,7 @@ from posthog.api.utils import (
     get_target_entity,
     raise_if_user_provided_url_unsafe,
     safe_clickhouse_string,
+    PublicIPOnlyHttpAdapter,
 )
 from posthog.models.filters.filter import Filter
 from posthog.test.base import BaseTest
@@ -216,3 +218,18 @@ class TestUtils(BaseTest):
             "Invalid hostname",
             lambda: raise_if_user_provided_url_unsafe("http://fgtggggzzggggfd.com"),
         )  # Non-existent
+
+    def test_public_ip_only_adapter(self):
+        address = "http://localhost:8123"  # Clickhouse's HTTP port
+
+        # We can connect OK by default
+        self.assertTrue(requests.get(address).ok)
+
+        # Adding the adapter makes the connection fail
+        session = requests.Session()
+        session.mount("http://", PublicIPOnlyHttpAdapter())
+        self.assertRaisesMessage(
+            ValueError,
+            "Internal IP",
+            lambda: session.get(address),
+        )

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -561,6 +561,5 @@ def test_slack_webhook(request):
             return JsonResponse({"success": True})
         else:
             return JsonResponse({"error": response.text})
-    except Exception as e:
-        logger.warning("invalid url", err=e)
+    except:
         return JsonResponse({"error": "invalid webhook URL"})

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -4,7 +4,9 @@ import socket
 import urllib.parse
 from enum import Enum, auto
 from ipaddress import ip_address
+from requests.adapters import HTTPAdapter
 from typing import Literal, Optional, Union
+from urllib3 import HTTPSConnectionPool, HTTPConnectionPool, PoolManager
 from uuid import UUID
 
 import structlog
@@ -329,3 +331,46 @@ def raise_if_user_provided_url_unsafe(url: str):
     for _, _, _, _, sockaddr in addrinfo:
         if ip_address(sockaddr[0]).is_private:  # Prevent addressing internal services
             raise ValueError("Internal hostname")
+
+
+def raise_if_connected_to_private_ip(conn):
+    if not getattr(conn, "sock", None):  # Force the connection open to check the remote IP
+        conn.connect()
+    addr = ip_address(conn.sock.getpeername()[0])
+    logger.warning("resolved IP", peer=conn.sock.getpeername(), addr=addr)
+    if addr.is_private:
+        raise ValueError("Internal hostname")
+
+
+class PublicIPOnlyHTTPConnectionPool(HTTPConnectionPool):
+    def _validate_conn(self, conn):
+        raise_if_connected_to_private_ip(conn)
+        super()._validate_conn(conn)
+
+
+class PublicIPOnlyHTTPSConnectionPool(HTTPSConnectionPool):
+    def _validate_conn(self, conn):
+        raise_if_connected_to_private_ip(conn)
+        super()._validate_conn(conn)
+
+
+class PublicIPOnlyHttpAdapter(HTTPAdapter):
+    """Transport adapter that enforces that we only connect to public IPs
+
+    Due to the lack of a hook after DNS resolution, we override the connection pool classes
+    to check the remote IP after we connect to it, but before we send the request.
+
+    Intended as a second line of defense after raise_if_user_provided_url_unsafe.
+    """
+
+    def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
+        self.poolmanager = PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            **pool_kwargs,
+        )
+        self.poolmanager.pool_classes_by_scheme = {
+            "http": PublicIPOnlyHTTPConnectionPool,
+            "https": PublicIPOnlyHTTPSConnectionPool,
+        }

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -339,7 +339,7 @@ def raise_if_connected_to_private_ip(conn):
         conn.connect()
     addr = ip_address(conn.sock.getpeername()[0])
     if addr.is_private:
-        raise ValueError("Internal hostname")
+        raise ValueError("Internal IP")
 
 
 class PublicIPOnlyHTTPConnectionPool(HTTPConnectionPool):

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -334,10 +334,10 @@ def raise_if_user_provided_url_unsafe(url: str):
 
 
 def raise_if_connected_to_private_ip(conn):
+    """Raise if the HTTPConnection / HTTPSConnection we are given points to a private IP."""
     if not getattr(conn, "sock", None):  # Force the connection open to check the remote IP
         conn.connect()
     addr = ip_address(conn.sock.getpeername()[0])
-    logger.warning("resolved IP", peer=conn.sock.getpeername(), addr=addr)
     if addr.is_private:
         raise ValueError("Internal hostname")
 


### PR DESCRIPTION
## Problem

Extends https://github.com/PostHog/posthog/pull/17147 with a second line of defense after we connect to the destination server: we check the remote IP of the socket before we sent the HTTP request.

## Changes

- Add a `PublicIPOnlyHttpAdapter` and a test, that connects to the Clickhouse HTTP port at `http://localhost:8123/`. We don't have a HTTPS server we could check against easily. @tomasfarias can we easily start a HTTPS server on a random port in python?
- Use this adapter in the `test_slack_webhook` endpoint

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Tested locally with a curl on `http://localhost:8000/api/user/test_slack_webhook/`. Outside IPs validate fine, IPs that resolve to local IPs fail