### PR TITLE
fix(csv-export): Use funnels formatting for HogQL-based funnels

### DIFF
--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -71,12 +71,23 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1
   '''
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.11
+  '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1
+  '''
+# ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.12
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -107,7 +118,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.12
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.13
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -128,22 +139,6 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
-  '''
-# ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.13
-  '''
-  SELECT "posthog_pluginconfig"."id",
-         "posthog_pluginconfig"."web_token",
-         "posthog_pluginsourcefile"."updated_at",
-         "posthog_plugin"."updated_at",
-         "posthog_pluginconfig"."updated_at"
-  FROM "posthog_pluginconfig"
-  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
-  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
-  WHERE ("posthog_pluginconfig"."enabled"
-         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
-         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
-         AND "posthog_pluginconfig"."team_id" = 2)
   '''
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.14
@@ -266,6 +261,17 @@
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1
+  '''
+# ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+  '''
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
          "posthog_organizationmembership"."user_id",
@@ -296,7 +302,7 @@
   WHERE "posthog_organizationmembership"."user_id" = 2
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."organization_id",
@@ -305,22 +311,11 @@
   WHERE "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid)
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
   '''
   SELECT 1 AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
-  LIMIT 1
-  '''
-# ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
-  '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1
   '''
 # ---
@@ -330,7 +325,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1
   '''

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -71,23 +71,12 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1
-  '''
-# ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.11
-  '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
   WHERE "posthog_instancesetting"."key" = 'constance:posthog:GROUPS_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.12
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.11
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -118,7 +107,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.13
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.12
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -139,6 +128,22 @@
   WHERE ("posthog_featureflag"."active"
          AND NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."team_id" = 2)
+  '''
+# ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.13
+  '''
+  SELECT "posthog_pluginconfig"."id",
+         "posthog_pluginconfig"."web_token",
+         "posthog_pluginsourcefile"."updated_at",
+         "posthog_plugin"."updated_at",
+         "posthog_pluginconfig"."updated_at"
+  FROM "posthog_pluginconfig"
+  INNER JOIN "posthog_plugin" ON ("posthog_pluginconfig"."plugin_id" = "posthog_plugin"."id")
+  INNER JOIN "posthog_pluginsourcefile" ON ("posthog_plugin"."id" = "posthog_pluginsourcefile"."plugin_id")
+  WHERE ("posthog_pluginconfig"."enabled"
+         AND "posthog_pluginsourcefile"."filename" = 'site.ts'
+         AND "posthog_pluginsourcefile"."status" = 'TRANSPILED'
+         AND "posthog_pluginconfig"."team_id" = 2)
   '''
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.14
@@ -261,17 +266,6 @@
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.5
   '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1
-  '''
-# ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
-  '''
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
          "posthog_organizationmembership"."user_id",
@@ -302,7 +296,7 @@
   WHERE "posthog_organizationmembership"."user_id" = 2
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.6
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."organization_id",
@@ -311,11 +305,22 @@
   WHERE "posthog_team"."organization_id" IN ('00000000-0000-0000-0000-000000000000'::uuid)
   '''
 # ---
-# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.7
   '''
   SELECT 1 AS "a"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."team_id" = 2
+  LIMIT 1
+  '''
+# ---
+# name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.8
+  '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1
   '''
 # ---
@@ -325,7 +330,7 @@
          "posthog_instancesetting"."key",
          "posthog_instancesetting"."raw_value"
   FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_V2_ENABLED'
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:PERSON_ON_EVENTS_ENABLED'
   ORDER BY "posthog_instancesetting"."id" ASC
   LIMIT 1
   '''

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -86,7 +86,7 @@ def _convert_response_to_csv_data(data: Any) -> Generator[Any, None, None]:
 
     if isinstance(data.get("results"), list):
         # query like
-        if len(results) > 0 and (isinstance(results[0], list) or isinstance(results[0], tuple)) and "types" in data:
+        if len(results) > 0 and (isinstance(results[0], list) or isinstance(results[0], tuple)) and data.get("types"):
             # e.g. {'columns': ['count()'], 'hasMore': False, 'results': [[1775]], 'types': ['UInt64']}
             # or {'columns': ['count()', 'event'], 'hasMore': False, 'results': [[551, '$feature_flag_called'], [265, '$autocapture']], 'types': ['UInt64', 'String']}
             for row in results:
@@ -104,14 +104,13 @@ def _convert_response_to_csv_data(data: Any) -> Generator[Any, None, None]:
 
         if not first_result:
             return
-        elif len(results) == 1 and set(results[0].keys()) == {"people", "count"}:
+        elif len(results) == 1 and isinstance(first_result, dict) and set(first_result.keys()) == {"people", "count"}:
             # persons modal like
             yield from results[0].get("people")
             return
         elif isinstance(first_result, list) or first_result.get("action_id"):
             multiple_items = results if isinstance(first_result, list) else [results]
             # FUNNELS LIKE
-
             for items in multiple_items:
                 yield from (
                     {

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -547,14 +547,15 @@ class TestCSVExporter(APIBaseTest):
         with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_EXPORTS_FOLDER="Test-Exports"):
             csv_exporter.export_tabular(exported_asset)
             content = object_storage.read(exported_asset.content_location)
-            lines = (content or "").split("\r\n")
-            self.assertEqual(len(lines), 3)
+            lines = (content or "").strip().split("\r\n")
             self.assertEqual(
-                lines[0],
-                "column_0.action_id,column_0.name,column_0.custom_name,column_0.order,column_0.count,column_0.type,column_0.average_conversion_time,column_0.median_conversion_time,column_0.breakdown.0,column_0.breakdown_value.0,column_1.action_id,column_1.name,column_1.custom_name,column_1.order,column_1.count,column_1.type,column_1.average_conversion_time,column_1.median_conversion_time,column_1.breakdown.0,column_1.breakdown_value.0",
+                lines,
+                [
+                    "name,breakdown_value,action_id,count,median_conversion_time (seconds),average_conversion_time (seconds)",
+                    "$pageview,test'123,$pageview,1,,",
+                    "$pageview,test'123,$pageview,1,60.0,60.0",
+                ],
             )
-            first_row = lines[1].split(",")
-            self.assertEqual(first_row[0], "$pageview")
 
     @patch("posthog.models.exported_asset.UUIDT")
     def test_csv_exporter_empty_result(self, mocked_uuidt: Any) -> None:


### PR DESCRIPTION
## Problem

This is actually an issue blocking #21956 that _also_ seems like some non-ideal behavior: If a query response has property `types` set – associated with SQL/event explorer queries – we treat it as an SQL/event explorer query response even if `types` is in fact None which means it came from a different query (like trends or funnels)!
This resulted in us never reaching the `# FUNNELS LIKE` branch for HogQL-based funnels.

Why is this blocking #21956? Because its cleanup of types eliminates the useless `types` from responses where it doesn't make sense, so we _were_ indeed on the way to the `# FUNNELS LIKE` branch. Except we crashed into `results[0].keys()` of the earlier `# persons modal like` branch. This call failed, because for funnels `results[0]` is a list and not a dict.

This is effectively a follow-up to https://github.com/PostHog/posthog/pull/21631.

## Changes

Both the issue of `types` being misused and `results[0].keys()` being unsafe are solved here.
Note that this means the format of CSV exports for HogQL-based funnels **changes here**. However, I _believe_ this is in fact the correct format, aligned with the legacy version. Is this true as far as you know @webjunkie? Take a close look please, would hate to break things for someone.

## How did you test this code?

Updated `test_csv_exporter_funnels_query`.