### PR TITLE
refactor: Preventing mousewheel from altering port value

### DIFF
--- a/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
@@ -368,7 +368,7 @@ export function BatchExportsEditFields({
                         </LemonField>
 
                         <LemonField name="port" label="Port">
-                            <LemonInput placeholder="5432" type="number" min="0" max="65535" />
+                            <LemonInput placeholder="5432" type="tel" min="0" max="65535" />
                         </LemonField>
 
                         <LemonField name="database" label="Database">


### PR DESCRIPTION
## Problem

A user pointed out (in ZenDesk ticket 11999) that the value in the port number field, in the batch export config screen, can be changed unintentionally by scrolling with the mouse wheel.  This PR is to prevent that by changing the field type from `number` to `tel`.

## Changes
Changed field type from `number` to `tel` on line 371 of
`frontend/src/scenes/batch_exports/BatchExportEditForm.tsx`

Before:
![before-number](https://github.com/PostHog/posthog/assets/227448/2df02ee5-b3a5-4238-b49b-d2d4ffb071fc)

After:
![CleanShot 2024-05-02 at 14 21 16](https://github.com/PostHog/posthog/assets/227448/6a401b53-63c7-4549-837c-2188da862db0)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Tested on my local (see the 'after' gif above)
