### PR TITLE
test(hogql): use insight actor query instead instead of legacy for testing trends

### DIFF
--- a/posthog/api/test/__snapshots__/test_annotation.ambr
+++ b/posthog/api/test/__snapshots__/test_annotation.ambr
@@ -86,133 +86,6 @@
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.10
   '''
-  SELECT "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."pending_email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."is_email_verified",
-         "posthog_user"."has_seen_product_intro_for",
-         "posthog_user"."strapi_id",
-         "posthog_user"."email_opt_in",
-         "posthog_user"."theme_mode",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."events_column_config"
-  FROM "posthog_user"
-  WHERE "posthog_user"."id" = 2
-  LIMIT 21
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.11
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."extra_settings",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 2
-  LIMIT 21
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.12
-  '''
-  SELECT "posthog_organizationmembership"."id",
-         "posthog_organizationmembership"."organization_id",
-         "posthog_organizationmembership"."user_id",
-         "posthog_organizationmembership"."level",
-         "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist",
-         "posthog_organization"."available_features"
-  FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE "posthog_organizationmembership"."user_id" = 2
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
-  '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_annotation"
-  WHERE (NOT "posthog_annotation"."deleted"
-         AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-               AND "posthog_annotation"."scope" = 'organization')
-              OR "posthog_annotation"."team_id" = 2))
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
-  '''
   SELECT "posthog_annotation"."id",
          "posthog_annotation"."content",
          "posthog_annotation"."created_at",
@@ -288,6 +161,133 @@
               OR "posthog_annotation"."team_id" = 2))
   ORDER BY "posthog_annotation"."date_marker" DESC
   LIMIT 1000
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.11
+  '''
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."strapi_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 2
+  LIMIT 21
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.12
+  '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."extra_settings",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
+  '''
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."available_features"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE "posthog_organizationmembership"."user_id" = 2
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_annotation"
+  WHERE (NOT "posthog_annotation"."deleted"
+         AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+               AND "posthog_annotation"."scope" = 'organization')
+              OR "posthog_annotation"."team_id" = 2))
   '''
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.15
@@ -541,90 +541,22 @@
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.8
   '''
+  SELECT "posthog_instancesetting"."id",
+         "posthog_instancesetting"."key",
+         "posthog_instancesetting"."raw_value"
+  FROM "posthog_instancesetting"
+  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
+  ORDER BY "posthog_instancesetting"."id" ASC
+  LIMIT 1
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.9
+  '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_annotation"
   WHERE (NOT "posthog_annotation"."deleted"
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
               OR "posthog_annotation"."team_id" = 2))
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.9
-  '''
-  SELECT "posthog_annotation"."id",
-         "posthog_annotation"."content",
-         "posthog_annotation"."created_at",
-         "posthog_annotation"."updated_at",
-         "posthog_annotation"."dashboard_item_id",
-         "posthog_annotation"."team_id",
-         "posthog_annotation"."organization_id",
-         "posthog_annotation"."created_by_id",
-         "posthog_annotation"."scope",
-         "posthog_annotation"."creation_type",
-         "posthog_annotation"."date_marker",
-         "posthog_annotation"."deleted",
-         "posthog_annotation"."apply_all",
-         "posthog_dashboarditem"."id",
-         "posthog_dashboarditem"."name",
-         "posthog_dashboarditem"."derived_name",
-         "posthog_dashboarditem"."description",
-         "posthog_dashboarditem"."team_id",
-         "posthog_dashboarditem"."filters",
-         "posthog_dashboarditem"."filters_hash",
-         "posthog_dashboarditem"."query",
-         "posthog_dashboarditem"."order",
-         "posthog_dashboarditem"."deleted",
-         "posthog_dashboarditem"."saved",
-         "posthog_dashboarditem"."created_at",
-         "posthog_dashboarditem"."last_refresh",
-         "posthog_dashboarditem"."refreshing",
-         "posthog_dashboarditem"."created_by_id",
-         "posthog_dashboarditem"."is_sample",
-         "posthog_dashboarditem"."short_id",
-         "posthog_dashboarditem"."favorited",
-         "posthog_dashboarditem"."refresh_attempt",
-         "posthog_dashboarditem"."last_modified_at",
-         "posthog_dashboarditem"."last_modified_by_id",
-         "posthog_dashboarditem"."dashboard_id",
-         "posthog_dashboarditem"."layouts",
-         "posthog_dashboarditem"."color",
-         "posthog_dashboarditem"."dive_dashboard_id",
-         "posthog_dashboarditem"."updated_at",
-         "posthog_dashboarditem"."deprecated_tags",
-         "posthog_dashboarditem"."tags",
-         "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."pending_email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."is_email_verified",
-         "posthog_user"."requested_password_reset_at",
-         "posthog_user"."has_seen_product_intro_for",
-         "posthog_user"."strapi_id",
-         "posthog_user"."email_opt_in",
-         "posthog_user"."theme_mode",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."events_column_config"
-  FROM "posthog_annotation"
-  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
-  LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
-  WHERE (NOT "posthog_annotation"."deleted"
-         AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-               AND "posthog_annotation"."scope" = 'organization')
-              OR "posthog_annotation"."team_id" = 2))
-  ORDER BY "posthog_annotation"."date_marker" DESC
-  LIMIT 1000
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_annotation.ambr
+++ b/posthog/api/test/__snapshots__/test_annotation.ambr
@@ -86,6 +86,133 @@
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.10
   '''
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."strapi_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 2
+  LIMIT 21
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.11
+  '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."extra_settings",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.12
+  '''
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."available_features"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE "posthog_organizationmembership"."user_id" = 2
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_annotation"
+  WHERE (NOT "posthog_annotation"."deleted"
+         AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+               AND "posthog_annotation"."scope" = 'organization')
+              OR "posthog_annotation"."team_id" = 2))
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
+  '''
   SELECT "posthog_annotation"."id",
          "posthog_annotation"."content",
          "posthog_annotation"."created_at",
@@ -161,133 +288,6 @@
               OR "posthog_annotation"."team_id" = 2))
   ORDER BY "posthog_annotation"."date_marker" DESC
   LIMIT 1000
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.11
-  '''
-  SELECT "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."pending_email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."is_email_verified",
-         "posthog_user"."has_seen_product_intro_for",
-         "posthog_user"."strapi_id",
-         "posthog_user"."email_opt_in",
-         "posthog_user"."theme_mode",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."events_column_config"
-  FROM "posthog_user"
-  WHERE "posthog_user"."id" = 2
-  LIMIT 21
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.12
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."extra_settings",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 2
-  LIMIT 21
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.13
-  '''
-  SELECT "posthog_organizationmembership"."id",
-         "posthog_organizationmembership"."organization_id",
-         "posthog_organizationmembership"."user_id",
-         "posthog_organizationmembership"."level",
-         "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist",
-         "posthog_organization"."available_features"
-  FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE "posthog_organizationmembership"."user_id" = 2
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.14
-  '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_annotation"
-  WHERE (NOT "posthog_annotation"."deleted"
-         AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-               AND "posthog_annotation"."scope" = 'organization')
-              OR "posthog_annotation"."team_id" = 2))
   '''
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.15
@@ -541,22 +541,90 @@
 # ---
 # name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.8
   '''
-  SELECT "posthog_instancesetting"."id",
-         "posthog_instancesetting"."key",
-         "posthog_instancesetting"."raw_value"
-  FROM "posthog_instancesetting"
-  WHERE "posthog_instancesetting"."key" = 'constance:posthog:RATE_LIMIT_ENABLED'
-  ORDER BY "posthog_instancesetting"."id" ASC
-  LIMIT 1
-  '''
-# ---
-# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.9
-  '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_annotation"
   WHERE (NOT "posthog_annotation"."deleted"
          AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
                AND "posthog_annotation"."scope" = 'organization')
               OR "posthog_annotation"."team_id" = 2))
+  '''
+# ---
+# name: TestAnnotation.test_retrieving_annotation_is_not_n_plus_1.9
+  '''
+  SELECT "posthog_annotation"."id",
+         "posthog_annotation"."content",
+         "posthog_annotation"."created_at",
+         "posthog_annotation"."updated_at",
+         "posthog_annotation"."dashboard_item_id",
+         "posthog_annotation"."team_id",
+         "posthog_annotation"."organization_id",
+         "posthog_annotation"."created_by_id",
+         "posthog_annotation"."scope",
+         "posthog_annotation"."creation_type",
+         "posthog_annotation"."date_marker",
+         "posthog_annotation"."deleted",
+         "posthog_annotation"."apply_all",
+         "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."derived_name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."query",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt",
+         "posthog_dashboarditem"."last_modified_at",
+         "posthog_dashboarditem"."last_modified_by_id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."updated_at",
+         "posthog_dashboarditem"."deprecated_tags",
+         "posthog_dashboarditem"."tags",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."requested_password_reset_at",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."strapi_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_annotation"
+  LEFT OUTER JOIN "posthog_dashboarditem" ON ("posthog_annotation"."dashboard_item_id" = "posthog_dashboarditem"."id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_annotation"."created_by_id" = "posthog_user"."id")
+  WHERE (NOT "posthog_annotation"."deleted"
+         AND (("posthog_annotation"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+               AND "posthog_annotation"."scope" = 'organization')
+              OR "posthog_annotation"."team_id" = 2))
+  ORDER BY "posthog_annotation"."date_marker" DESC
+  LIMIT 1000
   '''
 # ---

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -257,33 +257,60 @@
 # ---
 # name: TestTrends.test_breakdown_by_group_props_person_on_events.2
   '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT person_id AS actor_id,
-         count() AS actor_value
+  SELECT persons.id,
+         persons.id AS id,
+         toTimeZone(persons.created_at, 'UTC') AS created_at,
+         source.event_count AS event_count,
+         source.matching_events AS matching_events
   FROM
-    (SELECT e.timestamp as timestamp,
-            e.person_id as person_id,
-            e.distinct_id as distinct_id,
-            e.team_id as team_id
-     FROM events e
-     LEFT JOIN
-       (SELECT group_key,
-               argMax(group_properties, _timestamp) AS group_properties_0
-        FROM groups
-        WHERE team_id = 2
-          AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
-     WHERE team_id = 2
-       AND event = 'sign up'
-       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-02 00:00:00', 'UTC')
-       AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-02 23:59:59', 'UTC')
-       AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
-       AND notEmpty(e.person_id) )
-  GROUP BY actor_id
-  ORDER BY actor_value DESC,
-           actor_id DESC
-  LIMIT 100
-  OFFSET 0
+    (SELECT actor_id AS actor_id,
+            count() AS event_count,
+            groupUniqArray(100)(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS matching_events
+     FROM
+       (SELECT e.person_id AS actor_id,
+               toTimeZone(e.timestamp, 'UTC') AS timestamp,
+               e.uuid AS uuid,
+               e.`$session_id` AS `$session_id`,
+               e.`$window_id` AS `$window_id`
+        FROM events AS e SAMPLE 1
+        LEFT JOIN
+          (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), groups._timestamp) AS properties___industry,
+                  groups.group_type_index AS index,
+                  groups.group_key AS key
+           FROM groups
+           WHERE and(equals(groups.team_id, 2), ifNull(equals(index, 0), 0))
+           GROUP BY groups.group_type_index,
+                    groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+        WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-02 00:00:00.000000', 6, 'UTC')), less(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-03 00:00:00.000000', 6, 'UTC')), equals(e.event, 'sign up'), ifNull(equals(toString(e__group_0.properties___industry), 'technology'), 0)))
+     GROUP BY actor_id) AS source
+  INNER JOIN
+    (SELECT argMax(person.created_at, person.version) AS created_at,
+            person.id AS id
+     FROM person
+     WHERE equals(person.team_id, 2)
+     GROUP BY person.id
+     HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons ON equals(persons.id, source.actor_id)
+  ORDER BY source.event_count DESC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0
+  '''
+# ---
+# name: TestTrends.test_breakdown_by_group_props_person_on_events.3
+  '''
+  SELECT DISTINCT session_replay_events.session_id AS session_id
+  FROM
+    (SELECT session_replay_events.session_id AS session_id
+     FROM session_replay_events
+     WHERE equals(session_replay_events.team_id, 2)
+     GROUP BY session_replay_events.session_id) AS session_replay_events
+  WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0
   '''
 # ---
 # name: TestTrends.test_breakdown_by_group_props_with_person_filter_person_on_events
@@ -1211,41 +1238,68 @@
 # ---
 # name: TestTrends.test_filtering_by_multiple_groups_person_on_events.1
   '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT person_id AS actor_id,
-         count() AS actor_value
+  SELECT persons.id,
+         persons.id AS id,
+         toTimeZone(persons.created_at, 'UTC') AS created_at,
+         source.event_count AS event_count,
+         source.matching_events AS matching_events
   FROM
-    (SELECT e.timestamp as timestamp,
-            e.person_id as person_id,
-            e.distinct_id as distinct_id,
-            e.team_id as team_id
-     FROM events e
-     LEFT JOIN
-       (SELECT group_key,
-               argMax(group_properties, _timestamp) AS group_properties_0
-        FROM groups
-        WHERE team_id = 2
-          AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
-     LEFT JOIN
-       (SELECT group_key,
-               argMax(group_properties, _timestamp) AS group_properties_2
-        FROM groups
-        WHERE team_id = 2
-          AND group_type_index = 2
-        GROUP BY group_key) groups_2 ON "$group_2" == groups_2.group_key
-     WHERE team_id = 2
-       AND event = 'sign up'
-       AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-02 00:00:00', 'UTC')
-       AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-02 23:59:59', 'UTC')
-       AND ((has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
-            AND (has(['six'], replaceRegexpAll(JSONExtractRaw(group_properties_2, 'name'), '^"|"$', ''))))
-       AND notEmpty(e.person_id) )
-  GROUP BY actor_id
-  ORDER BY actor_value DESC,
-           actor_id DESC
-  LIMIT 100
-  OFFSET 0
+    (SELECT actor_id AS actor_id,
+            count() AS event_count,
+            groupUniqArray(100)(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS matching_events
+     FROM
+       (SELECT e.person_id AS actor_id,
+               toTimeZone(e.timestamp, 'UTC') AS timestamp,
+               e.uuid AS uuid,
+               e.`$session_id` AS `$session_id`,
+               e.`$window_id` AS `$window_id`
+        FROM events AS e SAMPLE 1
+        LEFT JOIN
+          (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), groups._timestamp) AS properties___name,
+                  groups.group_type_index AS index,
+                  groups.group_key AS key
+           FROM groups
+           WHERE and(equals(groups.team_id, 2), ifNull(equals(index, 2), 0))
+           GROUP BY groups.group_type_index,
+                    groups.group_key) AS e__group_2 ON equals(e.`$group_2`, e__group_2.key)
+        LEFT JOIN
+          (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), groups._timestamp) AS properties___industry,
+                  groups.group_type_index AS index,
+                  groups.group_key AS key
+           FROM groups
+           WHERE and(equals(groups.team_id, 2), ifNull(equals(index, 0), 0))
+           GROUP BY groups.group_type_index,
+                    groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+        WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-02 00:00:00.000000', 6, 'UTC')), less(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-03 00:00:00.000000', 6, 'UTC')), equals(e.event, 'sign up'), and(ifNull(equals(e__group_0.properties___industry, 'finance'), 0), ifNull(equals(e__group_2.properties___name, 'six'), 0))))
+     GROUP BY actor_id) AS source
+  INNER JOIN
+    (SELECT argMax(person.created_at, person.version) AS created_at,
+            person.id AS id
+     FROM person
+     WHERE equals(person.team_id, 2)
+     GROUP BY person.id
+     HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons ON equals(persons.id, source.actor_id)
+  ORDER BY source.event_count DESC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0
+  '''
+# ---
+# name: TestTrends.test_filtering_by_multiple_groups_person_on_events.2
+  '''
+  SELECT DISTINCT session_replay_events.session_id AS session_id
+  FROM
+    (SELECT session_replay_events.session_id AS session_id
+     FROM session_replay_events
+     WHERE equals(session_replay_events.team_id, 2)
+     GROUP BY session_replay_events.session_id) AS session_replay_events
+  WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0
   '''
 # ---
 # name: TestTrends.test_filtering_with_group_props_person_on_events

--- a/posthog/hogql_queries/insights/trends/test/test_trends.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends.py
@@ -12,13 +12,12 @@ import pytest
 from rest_framework.exceptions import ValidationError
 
 from posthog.constants import (
-    ENTITY_ID,
-    ENTITY_TYPE,
     TREND_FILTER_TYPE_EVENTS,
     TRENDS_BAR_VALUE,
     TRENDS_LINEAR,
     TRENDS_TABLE,
 )
+from posthog.hogql_queries.insights.trends.test.test_trends_persons import get_actors
 from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQueryRunner
 from posthog.hogql_queries.legacy_compatibility.filter_to_query import (
     clean_entity_properties,
@@ -215,21 +214,6 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         trend_query = convert_filter_to_trends_query(filter)
         tqr = TrendsQueryRunner(team=team, query=trend_query)
         return tqr.calculate().results
-
-    def _get_trend_people(self, filter: Filter, entity: Entity):
-        data = filter.to_dict()
-        # The test client doesn't serialize nested objects into JSON, so we need to do it ourselves
-        if data.get("events", None):
-            data["events"] = json.dumps(data["events"])
-        if data.get("properties", None):
-            data["properties"] = json.dumps(data["properties"])
-        with self.settings(DEBUG=True):
-            response = self.client.get(
-                f"/api/projects/{self.team.id}/persons/trends/",
-                data={**data, ENTITY_TYPE: entity.type, ENTITY_ID: entity.id},
-                content_type="application/json",
-            ).json()
-        return response["results"][0]["people"]
 
     def _create_event(self, **kwargs):
         _create_event(**kwargs)
@@ -4457,70 +4441,18 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             event_response = self._run(Filter(team=self.team, data=data), self.team)
             event_response = sorted(event_response, key=lambda resp: resp["breakdown_value"])
 
-            entity = Entity({"id": "watched movie", "type": "events", "math": "dau"})
+            people_value_1 = get_actors(data, self.team, series=0, breakdown="value_1", includeRecordings=True)
+            # Persons with higher value come first
+            self.assertEqual(people_value_1[0][0], person2.uuid)
+            self.assertEqual(people_value_1[0][3], 2)  # 2 events with fake_prop="value_1" in the time range
+            self.assertEqual(people_value_1[1][0], person3.uuid)
+            self.assertEqual(people_value_1[1][3], 1)  # 1 event with fake_prop="value_1" in the time range
+            self.assertEqual(people_value_1[2][0], person1.uuid)
+            self.assertEqual(people_value_1[2][3], 1)  # 1 event with fake_prop="value_1" in the time range
 
-            people_value_1 = self._get_trend_people(
-                Filter(team=self.team, data={**data, "breakdown_value": "value_1"}),
-                entity,
-            )
-            assert people_value_1 == [
-                # Persons with higher value come first
-                {
-                    "created_at": "2020-01-01T12:00:00Z",
-                    "distinct_ids": ["person2"],
-                    "id": str(person2.uuid),
-                    "is_identified": False,
-                    "matched_recordings": [],
-                    "name": "person2",
-                    "properties": {},
-                    "type": "person",
-                    "uuid": str(person2.uuid),
-                    "value_at_data_point": 2,  # 2 events with fake_prop="value_1" in the time range
-                },
-                {
-                    "created_at": "2020-01-01T12:00:00Z",
-                    "distinct_ids": ["person1"],
-                    "id": str(person1.uuid),
-                    "is_identified": False,
-                    "matched_recordings": [],
-                    "name": "person1",
-                    "properties": {},
-                    "type": "person",
-                    "uuid": str(person1.uuid),
-                    "value_at_data_point": 1,  # 1 event with fake_prop="value_1" in the time range
-                },
-                {
-                    "created_at": "2020-01-01T12:00:00Z",
-                    "distinct_ids": ["person3"],
-                    "id": str(person3.uuid),
-                    "is_identified": False,
-                    "matched_recordings": [],
-                    "name": "person3",
-                    "properties": {},
-                    "type": "person",
-                    "uuid": str(person3.uuid),
-                    "value_at_data_point": 1,  # 1 event with fake_prop="value_1" in the time range
-                },
-            ]
-
-            people_value_2 = self._get_trend_people(
-                Filter(team=self.team, data={**data, "breakdown_value": "value_2"}),
-                entity,
-            )
-            assert people_value_2 == [
-                {
-                    "created_at": "2020-01-01T12:00:00Z",
-                    "distinct_ids": ["person2"],
-                    "id": str(person2.uuid),
-                    "is_identified": False,
-                    "matched_recordings": [],
-                    "name": "person2",
-                    "properties": {},
-                    "type": "person",
-                    "uuid": str(person2.uuid),
-                    "value_at_data_point": 1,  # 1 event with fake_prop="value_2" in the time range
-                }
-            ]
+            people_value_2 = get_actors(data, self.team, series=0, breakdown="value_2", includeRecordings=True)
+            self.assertEqual(people_value_2[0][0], person2.uuid)
+            self.assertEqual(people_value_2[0][3], 1)  # 1 event with fake_prop="value_2" in the time range
 
     @also_test_with_materialized_columns(person_properties=["name"])
     def test_breakdown_by_person_property_pie(self):
@@ -8143,17 +8075,11 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response[1]["breakdown_value"], "technology")
         self.assertEqual(response[1]["count"], 1)
 
-        filter = filter.shallow_clone(
-            {
-                "breakdown_value": "technology",
-                "date_from": "2020-01-02T00:00:00Z",
-                "date_to": "2020-01-03",
-            }
+        res = get_actors(
+            filter.to_dict(), self.team, series=0, breakdown="technology", day="2020-01-02", includeRecordings=True
         )
-        entity = Entity({"id": "sign up", "name": "sign up", "type": "events", "order": 0})
-        res = self._get_trend_people(filter, entity)
 
-        self.assertEqual(res[0]["distinct_ids"], ["person1"])
+        self.assertEqual(res[0][1]["distinct_ids"], ["person1"])
 
     @also_test_with_materialized_columns(
         group_properties=[(0, "industry")], materialize_only_with_person_on_events=True
@@ -8209,17 +8135,11 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(response[1]["breakdown_value"], "technology")
             self.assertEqual(response[1]["count"], 1)
 
-            filter = filter.shallow_clone(
-                {
-                    "breakdown_value": "technology",
-                    "date_from": "2020-01-02T00:00:00Z",
-                    "date_to": "2020-01-02",
-                }
+            res = get_actors(
+                filter.to_dict(), self.team, series=0, breakdown="technology", day="2020-01-02", includeRecordings=True
             )
-            entity = Entity({"id": "sign up", "name": "sign up", "type": "events", "order": 0})
-            res = self._get_trend_people(filter, entity)
 
-            self.assertEqual(res[0]["distinct_ids"], ["person1"])
+            self.assertEqual(res[0][1]["distinct_ids"], ["person1"])
 
     # TODO: Delete this test when moved to person-on-events
     def test_breakdown_by_group_props_with_person_filter(self):
@@ -8578,11 +8498,9 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                 [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             )
 
-            filter = filter.shallow_clone({"date_from": "2020-01-02T00:00:00Z", "date_to": "2020-01-02T00:00:00Z"})
-            entity = Entity({"id": "sign up", "name": "sign up", "type": "events", "order": 0})
-            res = self._get_trend_people(filter, entity)
+            res = get_actors(filter.to_dict(), self.team, series=0, day="2020-01-02", includeRecordings=True)
 
-            self.assertEqual(res[0]["distinct_ids"], ["person1"])
+            self.assertEqual(res[0][1]["distinct_ids"], ["person1"])
 
     def test_yesterday_with_hourly_interval(self):
         journey = {

--- a/posthog/hogql_queries/insights/trends/test/test_trends.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends.py
@@ -4445,9 +4445,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             # Persons with higher value come first
             self.assertEqual(people_value_1[0][1]["distinct_ids"][0], "person2")
             self.assertEqual(people_value_1[0][3], 2)  # 2 events with fake_prop="value_1" in the time range
-            self.assertEqual(people_value_1[1][1]["distinct_ids"][0], "person3")
             self.assertEqual(people_value_1[1][3], 1)  # 1 event with fake_prop="value_1" in the time range
-            self.assertEqual(people_value_1[2][1]["distinct_ids"][0], "person1")
             self.assertEqual(people_value_1[2][3], 1)  # 1 event with fake_prop="value_1" in the time range
 
             people_value_2 = get_actors(data, self.team, series=0, breakdown="value_2", includeRecordings=True)

--- a/posthog/hogql_queries/insights/trends/test/test_trends.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends.py
@@ -4371,9 +4371,9 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
 
     def test_breakdown_by_property_pie(self):
         with freeze_time("2020-01-01T12:00:00Z"):  # Fake created_at for easier assertions
-            person1 = self._create_person(team_id=self.team.pk, distinct_ids=["person1"], immediate=True)
-            person2 = self._create_person(team_id=self.team.pk, distinct_ids=["person2"], immediate=True)
-            person3 = self._create_person(team_id=self.team.pk, distinct_ids=["person3"], immediate=True)
+            self._create_person(team_id=self.team.pk, distinct_ids=["person1"], immediate=True)
+            self._create_person(team_id=self.team.pk, distinct_ids=["person2"], immediate=True)
+            self._create_person(team_id=self.team.pk, distinct_ids=["person3"], immediate=True)
 
         self._create_event(
             team=self.team,
@@ -4443,15 +4443,15 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
 
             people_value_1 = get_actors(data, self.team, series=0, breakdown="value_1", includeRecordings=True)
             # Persons with higher value come first
-            self.assertEqual(people_value_1[0][0], person2.uuid)
+            self.assertEqual(people_value_1[0][1]["distinct_ids"][0], "person2")
             self.assertEqual(people_value_1[0][3], 2)  # 2 events with fake_prop="value_1" in the time range
-            self.assertEqual(people_value_1[1][0], person3.uuid)
+            self.assertEqual(people_value_1[1][1]["distinct_ids"][0], "person3")
             self.assertEqual(people_value_1[1][3], 1)  # 1 event with fake_prop="value_1" in the time range
-            self.assertEqual(people_value_1[2][0], person1.uuid)
+            self.assertEqual(people_value_1[2][1]["distinct_ids"][0], "person1")
             self.assertEqual(people_value_1[2][3], 1)  # 1 event with fake_prop="value_1" in the time range
 
             people_value_2 = get_actors(data, self.team, series=0, breakdown="value_2", includeRecordings=True)
-            self.assertEqual(people_value_2[0][0], person2.uuid)
+            self.assertEqual(people_value_2[0][1]["distinct_ids"][0], "person2")
             self.assertEqual(people_value_2[0][3], 1)  # 1 event with fake_prop="value_2" in the time range
 
     @also_test_with_materialized_columns(person_properties=["name"])

--- a/posthog/hogql_queries/insights/trends/test/test_trends_persons.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_persons.py
@@ -39,6 +39,7 @@ def get_actors(
             "event_count",
             *(["matched_recordings"] if includeRecordings else []),
         ],
+        orderBy=["event_count DESC"],
     )
     response = ActorsQueryRunner(query=actors_query, team=team).calculate()
     return response.results

--- a/posthog/hogql_queries/insights/trends/test/test_trends_persons.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_persons.py
@@ -1,0 +1,44 @@
+from typing import Any, Optional, Union, cast
+
+from posthog.hogql_queries.actors_query_runner import ActorsQueryRunner
+from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
+from posthog.models import Team
+from posthog.schema import ActorsQuery, Compare, InsightActorsQuery, TrendsQuery
+
+
+def get_actors(
+    filters: dict[str, Any],
+    team: Team,
+    breakdown: Optional[Union[str, int]] = None,
+    compare: Optional[Compare] = None,
+    day: Optional[Union[str, int]] = None,
+    interval: Optional[int] = None,
+    series: Optional[int] = None,
+    status: Optional[str] = None,
+    offset: Optional[int] = None,
+    includeRecordings: Optional[bool] = None,
+):
+    trends_query = cast(TrendsQuery, filter_to_query(filters))
+    insight_actors_query = InsightActorsQuery(
+        source=trends_query,
+        breakdown=breakdown,
+        compare=compare,
+        day=day,
+        interval=interval,
+        series=series,
+        status=status,
+        includeRecordings=includeRecordings,
+    )
+    actors_query = ActorsQuery(
+        source=insight_actors_query,
+        offset=offset,
+        select=[
+            "id",
+            "actor",
+            "created_at",
+            "event_count",
+            *(["matched_recordings"] if includeRecordings else []),
+        ],
+    )
+    response = ActorsQueryRunner(query=actors_query, team=team).calculate()
+    return response.results


### PR DESCRIPTION
## Problem

We've been calling the legacy trends persons API from HogQL tests.

## Changes

It'd be better if we tested the HogQL version of persons as well. The file `test_trends_persons.py` was intentionally added for follow up tests.

## How did you test this code?

Ran tests