### PR TITLE
fix(activity): flag object not string

### DIFF
--- a/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesColumn.tsx
@@ -59,6 +59,6 @@ export function SeriesColumnItem({
 
 export const formatCompareLabel = (trendResult: TrendResult): string => {
     // label splitting ensures backwards compatibility for api results that don't contain the new compare_label
-    const labels = trendResult.label.split(' - ')
+    const labels = trendResult.label?.split(' - ')
     return capitalizeFirstLetter(trendResult.compare_label ?? labels?.[labels.length - 1] ?? 'current')
 }

--- a/frontend/src/scenes/teamActivityDescriber.tsx
+++ b/frontend/src/scenes/teamActivityDescriber.tsx
@@ -92,10 +92,11 @@ const teamActionsMapping: Record<
         return { description: descriptions }
     },
     session_recording_linked_flag(change: ActivityChange | undefined): ChangeMapping | null {
+        const key = (change?.after as any)?.key ?? (change?.before as any)?.key ?? String(change?.after)
         return {
             description: [
                 <>
-                    {change?.after ? 'linked' : 'unlinked'} session recording to feature flag {change?.after}
+                    {change?.after ? 'linked' : 'unlinked'} session recording to feature flag {key}
                 </>,
             ],
         }


### PR DESCRIPTION
## Problem

- https://posthoghelp.zendesk.com/agent/tickets/12766 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15560)
- https://posthoghelp.zendesk.com/agent/tickets/12919 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15578)

## Changes

- Fixes an unexpected null bug
- Fixes a bug with the activity page trying to display an object as a string for the feature flag's key

## How did you test this code?

Locally in the browser