### PR TITLE
fix: Update docker-compose.dev-full.yml so it works out of the box

### DIFF
--- a/docker-compose.dev-full.yml
+++ b/docker-compose.dev-full.yml
@@ -89,16 +89,21 @@ services:
         ports:
             - 8000:8000
         build: .
+        command: ./bin/docker-server-unit
         volumes:
             - .:/app/posthog
         environment:
             - DEBUG=1
+            - OBJECT_STORAGE_ENDPOINT=http://objectstorage:19000
+            - POSTHOG_SKIP_MIGRATION_CHECKS=true
+            - JS_URL=http://localhost:8000
         depends_on:
             - db
             - redis
             - clickhouse
             - kafka
-            - object_storage
+        links:
+            - object_storage:objectstorage
 
     capture:
         extends:
@@ -120,7 +125,6 @@ services:
         volumes:
             - .:/app/posthog
         environment:
-            - DEBUG=1
             - DOCKER=1
         depends_on:
             - db


### PR DESCRIPTION
## Problem
Users should now be able to get started straight away with just docker by running `docker-compose -f docker-compose.dev-full.yml up --build`

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
