### PR TITLE
fix(web-analytics): Re-restrict event properties

### DIFF
--- a/frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
@@ -32,6 +32,18 @@ export const WebPropertyFilters = ({
             propertyFilters={webAnalyticsFilters}
             pageKey="web-analytics"
             eventNames={useSessionTablePropertyFilters ? ['$pageview'] : ['$pageview', '$pageleave', '$autocapture']}
+            propertyAllowList={{
+                [TaxonomicFilterGroupType.EventProperties]: [
+                    '$pathname',
+                    '$host',
+                    '$browser',
+                    '$os',
+                    '$device_type',
+                    '$geoip_country_code',
+                    '$geoip_subdivision_1_code',
+                    '$geoip_city_name',
+                ],
+            }}
         />
     )
 }


### PR DESCRIPTION
## Problem

We have 600k event properties and it just takes a really long time to load. Not the best fix but this at least unblocks things for now.

## Changes

Re-restrict the event properties

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Just running locally.
