### PR TITLE
feat: HogQL pagination for Replay

### DIFF
--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_filters.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_filters.ambr
@@ -21,7 +21,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -51,7 +52,8 @@
   GROUP BY s.session_id
   HAVING ifNull(greaterOrEquals(duration, 60), 0)
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -81,7 +83,8 @@
   GROUP BY s.session_id
   HAVING ifNull(greaterOrEquals(active_seconds, 60), 0)
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -111,7 +114,8 @@
   GROUP BY s.session_id
   HAVING ifNull(greaterOrEquals(inactive_seconds, 60), 0)
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -141,7 +145,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY active_seconds DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 4
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -171,7 +176,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY console_error_count DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 4
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -201,7 +207,101 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 4
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
+  '''
+# ---
+# name: TestSessionRecordingsListFromFilters.test_basic_query_with_paging
+  '''
+  SELECT s.session_id AS session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
+         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
+         dateDiff('SECOND', start_time, end_time) AS duration,
+         argMinMerge(s.first_url) AS first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
+         minus(duration, active_seconds) AS inactive_seconds,
+         sum(s.console_log_count) AS console_log_count,
+         sum(s.console_warn_count) AS console_warn_count,
+         sum(s.console_error_count) AS console_error_count
+  FROM session_replay_events AS s
+  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-11 13:46:23.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-25 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.max_last_timestamp, 'UTC'), toDateTime64('2021-01-01 13:46:23.000000', 6, 'UTC')), 0), true)
+  GROUP BY s.session_id
+  HAVING true
+  ORDER BY start_time DESC
+  LIMIT 2
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
+  '''
+# ---
+# name: TestSessionRecordingsListFromFilters.test_basic_query_with_paging.1
+  '''
+  SELECT s.session_id AS session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
+         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
+         dateDiff('SECOND', start_time, end_time) AS duration,
+         argMinMerge(s.first_url) AS first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
+         minus(duration, active_seconds) AS inactive_seconds,
+         sum(s.console_log_count) AS console_log_count,
+         sum(s.console_warn_count) AS console_warn_count,
+         sum(s.console_error_count) AS console_error_count
+  FROM session_replay_events AS s
+  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-11 13:46:23.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-25 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.max_last_timestamp, 'UTC'), toDateTime64('2021-01-01 13:46:23.000000', 6, 'UTC')), 0), true)
+  GROUP BY s.session_id
+  HAVING true
+  ORDER BY start_time DESC
+  LIMIT 2
+  OFFSET 1 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
+  '''
+# ---
+# name: TestSessionRecordingsListFromFilters.test_basic_query_with_paging.2
+  '''
+  SELECT s.session_id AS session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
+         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
+         dateDiff('SECOND', start_time, end_time) AS duration,
+         argMinMerge(s.first_url) AS first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
+         minus(duration, active_seconds) AS inactive_seconds,
+         sum(s.console_log_count) AS console_log_count,
+         sum(s.console_warn_count) AS console_warn_count,
+         sum(s.console_error_count) AS console_error_count
+  FROM session_replay_events AS s
+  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-11 13:46:23.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-25 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.max_last_timestamp, 'UTC'), toDateTime64('2021-01-01 13:46:23.000000', 6, 'UTC')), 0), true)
+  GROUP BY s.session_id
+  HAVING true
+  ORDER BY start_time DESC
+  LIMIT 2
+  OFFSET 2 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -231,7 +331,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -261,7 +362,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -291,7 +393,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -321,7 +424,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -351,7 +455,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -381,7 +486,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -411,7 +517,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -441,7 +548,8 @@
   GROUP BY s.session_id
   HAVING ifNull(greaterOrEquals(duration, 60), 0)
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -471,7 +579,8 @@
   GROUP BY s.session_id
   HAVING ifNull(lessOrEquals(duration, 60), 0)
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -506,7 +615,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -541,7 +651,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$autocapture'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -576,7 +687,8 @@
   GROUP BY s.session_id
   HAVING and(ifNull(greaterOrEquals(duration, 60), 0), hasAll(groupUniqArray(s__events.event), ['$pageview']))
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -611,7 +723,8 @@
   GROUP BY s.session_id
   HAVING and(ifNull(greaterOrEquals(active_seconds, 60), 0), hasAll(groupUniqArray(s__events.event), ['$pageview']))
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -647,7 +760,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -683,7 +797,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -719,7 +834,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -755,7 +871,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -790,7 +907,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -825,7 +943,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$autocapture'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -873,7 +992,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -909,7 +1029,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -945,7 +1066,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -981,7 +1103,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['a_different_event'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1017,7 +1140,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['a_different_event'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1053,7 +1177,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1089,7 +1214,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1125,7 +1251,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['a_different_event'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1161,7 +1288,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['a_different_event'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1197,7 +1325,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1233,7 +1362,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1269,7 +1399,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1305,7 +1436,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1341,7 +1473,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1377,7 +1510,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1413,7 +1547,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1449,7 +1584,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1485,7 +1621,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1521,7 +1658,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1557,7 +1695,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1593,7 +1732,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1629,7 +1769,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1665,7 +1806,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1725,10 +1867,13 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_with_events_and_cohorts
@@ -1788,10 +1933,13 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_with_events_and_cohorts.3
@@ -1831,10 +1979,13 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['custom_event'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_multiple_event_filters
@@ -1864,7 +2015,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview', 'new-event'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1899,7 +2051,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview', 'new-event2'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1936,7 +2089,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1971,7 +2125,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -2006,7 +2161,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -2041,7 +2197,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -2076,7 +2233,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -2111,7 +2269,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -2159,7 +2318,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -2194,7 +2354,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -2242,7 +2403,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -2277,7 +2439,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -2325,7 +2488,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -2360,7 +2524,8 @@
   GROUP BY s.session_id
   HAVING hasAll(groupUniqArray(s__events.event), ['$pageview'])
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -2408,7 +2573,8 @@
   GROUP BY s.session_id
   HAVING true
   ORDER BY start_time DESC
-  LIMIT 10 SETTINGS readonly=2,
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,

--- a/posthog/session_recordings/queries/test/test_session_recording_list_from_filters.py
+++ b/posthog/session_recordings/queries/test/test_session_recording_list_from_filters.py
@@ -135,7 +135,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             active_milliseconds=1980 * 1000 * 0.4,  # 40% of the total expected duration
         )
 
-        session_recordings, more_recordings_available = self._filter_recordings_by({"no_filter": None})
+        session_recordings, more_recordings_available, _ = self._filter_recordings_by({"no_filter": None})
 
         assert session_recordings == [
             {
@@ -229,10 +229,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             active_milliseconds=0,
         )
 
-        (
-            session_recordings,
-            _,
-        ) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "duration_type_filter": "duration",
                 "session_recording_duration": '{"type":"recording","key":"duration","value":60,"operator":"gt"}',
@@ -247,10 +244,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             (session_id_total_is_61, 61, 59.0),
         ]
 
-        (
-            session_recordings,
-            _,
-        ) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "duration_type_filter": "active_seconds",
                 "session_recording_duration": '{"type":"recording","key":"duration","value":60,"operator":"gt"}',
@@ -261,10 +255,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             (session_id_active_is_61, 59, 61.0)
         ]
 
-        (
-            session_recordings,
-            _,
-        ) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "duration_type_filter": "inactive_seconds",
                 "session_recording_duration": '{"type":"recording","key":"duration","value":60,"operator":"gt"}',
@@ -325,10 +316,9 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             active_milliseconds=1980 * 1000 * 0.4,  # 40% of the total expected duration
         )
 
-        (
-            session_recordings,
-            more_recordings_available,
-        ) = self._filter_recordings_by({"no_filter": None, "limit": 1, "offset": 0})
+        (session_recordings, more_recordings_available, _) = self._filter_recordings_by(
+            {"no_filter": None, "limit": 1, "offset": 0}
+        )
 
         assert session_recordings == [
             {
@@ -352,10 +342,9 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
 
         assert more_recordings_available is True
 
-        (
-            session_recordings,
-            more_recordings_available,
-        ) = self._filter_recordings_by({"no_filter": None, "limit": 1, "offset": 1})
+        (session_recordings, more_recordings_available, _) = self._filter_recordings_by(
+            {"no_filter": None, "limit": 1, "offset": 1}
+        )
 
         assert session_recordings == [
             {
@@ -379,10 +368,9 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
 
         assert more_recordings_available is False
 
-        (
-            session_recordings,
-            more_recordings_available,
-        ) = self._filter_recordings_by({"no_filter": None, "limit": 1, "offset": 2})
+        (session_recordings, more_recordings_available, _) = self._filter_recordings_by(
+            {"no_filter": None, "limit": 1, "offset": 2}
+        )
 
         assert session_recordings == []
 
@@ -557,7 +545,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             first_url="https://on-second-received-event-but-actually-first.com",
         )
 
-        session_recordings, more_recordings_available = self._filter_recordings_by({"no_filter": None})
+        session_recordings, more_recordings_available, _ = self._filter_recordings_by({"no_filter": None})
 
         assert sorted(
             [{"session_id": r["session_id"], "first_url": r["first_url"]} for r in session_recordings],
@@ -620,7 +608,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             active_milliseconds=20 * 1000 * 0.5,  # 50% of the total expected duration
         )
 
-        (session_recordings, _) = self._filter_recordings_by({"no_filter": None})
+        (session_recordings, _, _) = self._filter_recordings_by({"no_filter": None})
 
         assert [{"session": r["session_id"], "user": r["distinct_id"]} for r in session_recordings] == [
             {"session": session_id_two, "user": user}
@@ -649,7 +637,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -665,7 +653,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         assert len(session_recordings) == 1
         assert session_recordings[0]["session_id"] == session_id_one
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -700,7 +688,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             properties={"$session_id": session_id_one, "$window_id": str(uuid4())},
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -714,7 +702,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         )
         assert len(session_recordings) == 0
 
-        (session_recordings, _) = self._filter_recordings_by({})
+        (session_recordings, _, _) = self._filter_recordings_by({})
         # without an event filter the recording is present, showing that the TTL was applied to the events table too
         # we want this to limit the amount of event data we query
         assert len(session_recordings) == 1
@@ -787,10 +775,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             active_milliseconds=0,
         )
 
-        (
-            session_recordings,
-            _,
-        ) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "session_ids": [first_session_id],
             }
@@ -799,10 +784,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         assert len(session_recordings) == 1
         assert session_recordings[0]["session_id"] == first_session_id
 
-        (
-            session_recordings,
-            _,
-        ) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "session_ids": [first_session_id, second_session_id],
             }
@@ -869,10 +851,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             active_milliseconds=61000,
         )
 
-        (
-            session_recordings,
-            _,
-        ) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "duration_type_filter": "duration",
                 "events": [
@@ -891,10 +870,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             (session_id_total_is_61, 61, 59.0)
         ]
 
-        (
-            session_recordings,
-            _,
-        ) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "duration_type_filter": "active_seconds",
                 "events": [
@@ -951,7 +927,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -974,7 +950,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         assert len(session_recordings) == 1
         assert session_recordings[0]["session_id"] == session_id_one
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -996,7 +972,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         )
         assert session_recordings == []
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -1018,7 +994,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         )
         assert len(session_recordings) == 0
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -1071,7 +1047,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -1093,7 +1069,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         assert len(session_recordings) == 1
         assert session_recordings[0]["session_id"] == session_id
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -1161,7 +1137,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "actions": [
                     {
@@ -1175,7 +1151,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         )
         assert session_recordings == []
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "actions": [
                     {
@@ -1192,7 +1168,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         assert session_recordings[0]["session_id"] == session_id_one
 
         # Adding properties to an action
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "actions": [
                     {
@@ -1215,7 +1191,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         assert session_recordings == []
 
         # Adding matching properties to an action
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "actions": [
                     {
@@ -1265,7 +1241,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -1321,12 +1297,12 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {"session_recording_duration": '{"type":"recording","key":"duration","value":60,"operator":"gt"}'}
         )
         assert [r["session_id"] for r in session_recordings] == [session_id_two]
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {"session_recording_duration": '{"type":"recording","key":"duration","value":60,"operator":"lt"}'}
         )
         assert [r["session_id"] for r in session_recordings] == [session_id_one]
@@ -1351,10 +1327,10 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by({"date_from": self.base_time.strftime("%Y-%m-%d")})
+        (session_recordings, _, _) = self._filter_recordings_by({"date_from": self.base_time.strftime("%Y-%m-%d")})
         assert session_recordings == []
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {"date_from": (self.base_time - relativedelta(days=2)).strftime("%Y-%m-%d")}
         )
         assert len(session_recordings) == 1
@@ -1382,19 +1358,19 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
                 team_id=self.team.id,
             )
 
-            (session_recordings, _) = self._filter_recordings_by(
+            (session_recordings, _, _) = self._filter_recordings_by(
                 {"date_from": (self.base_time - relativedelta(days=20)).strftime("%Y-%m-%d")}
             )
             assert len(session_recordings) == 1
             assert session_recordings[0]["session_id"] == "storage is not past ttl"
 
-            (session_recordings, _) = self._filter_recordings_by(
+            (session_recordings, _, _) = self._filter_recordings_by(
                 {"date_from": (self.base_time - relativedelta(days=21)).strftime("%Y-%m-%d")}
             )
             assert len(session_recordings) == 1
             assert session_recordings[0]["session_id"] == "storage is not past ttl"
 
-            (session_recordings, _) = self._filter_recordings_by(
+            (session_recordings, _, _) = self._filter_recordings_by(
                 {"date_from": (self.base_time - relativedelta(days=22)).strftime("%Y-%m-%d")}
             )
             assert len(session_recordings) == 1
@@ -1419,12 +1395,12 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {"date_to": (self.base_time - relativedelta(days=4)).strftime("%Y-%m-%d")}
         )
         assert session_recordings == []
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {"date_to": (self.base_time - relativedelta(days=3)).strftime("%Y-%m-%d")}
         )
 
@@ -1444,7 +1420,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "date_to": day_line.strftime("%Y-%m-%d"),
                 "date_from": (day_line - relativedelta(days=10)).strftime("%Y-%m-%d"),
@@ -1481,7 +1457,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by({"person_uuid": str(p.uuid)})
+        (session_recordings, _, _) = self._filter_recordings_by({"person_uuid": str(p.uuid)})
         assert sorted([r["session_id"] for r in session_recordings]) == sorted([session_id_two, session_id_one])
 
     @skip("TODO: Not implemented in HogQL")
@@ -1537,7 +1513,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
 
         flush_persons_and_events()
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "person_uuid": str(p.uuid),
                 "date_to": (self.base_time + relativedelta(days=3)).strftime("%Y-%m-%d"),
@@ -1583,7 +1559,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -1633,7 +1609,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "properties": [
                     {
@@ -1709,7 +1685,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
                     team_id=self.team.id,
                 )
 
-                (session_recordings, _) = self._filter_recordings_by(
+                (session_recordings, _, _) = self._filter_recordings_by(
                     {
                         "properties": [
                             {
@@ -1797,7 +1773,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
                     team_id=self.team.id,
                 )
 
-                (session_recordings, _) = self._filter_recordings_by(
+                (session_recordings, _, _) = self._filter_recordings_by(
                     {
                         # has to be in the cohort and pageview has to be in the events
                         # test data has one user in the cohort but no pageviews
@@ -1822,7 +1798,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
 
                 assert len(session_recordings) == 0
 
-                (session_recordings, _) = self._filter_recordings_by(
+                (session_recordings, _, _) = self._filter_recordings_by(
                     {
                         "properties": [
                             {
@@ -1879,7 +1855,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -1895,7 +1871,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         assert len(session_recordings) == 1
         assert session_recordings[0]["session_id"] == session_id
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -1940,7 +1916,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -1959,7 +1935,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         assert len(session_recordings) == 1
         assert session_recordings[0]["session_id"] == session_id
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -2006,7 +1982,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -2028,7 +2004,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         assert len(session_recordings) == 1
         assert session_recordings[0]["session_id"] == session_id
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -2112,7 +2088,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -2135,7 +2111,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             page_view_session_id,
         ]
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -2164,7 +2140,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             page_view_session_id,
         ]
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -2216,7 +2192,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["info"]})
+        (session_recordings, _, _) = self._filter_recordings_by({"console_logs": ["info"]})
 
         actual = sorted(
             [(sr["session_id"], sr["console_log_count"]) for sr in session_recordings],
@@ -2227,7 +2203,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             (with_logs_session_id, 4),
         ]
 
-        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["warn"]})
+        (session_recordings, _, _) = self._filter_recordings_by({"console_logs": ["warn"]})
         assert session_recordings == []
 
     @snapshot_clickhouse_queries
@@ -2260,7 +2236,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["warn"]})
+        (session_recordings, _, _) = self._filter_recordings_by({"console_logs": ["warn"]})
 
         assert sorted(
             [(sr["session_id"], sr["console_warn_count"]) for sr in session_recordings],
@@ -2269,7 +2245,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             (with_logs_session_id, 4),
         ]
 
-        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["info"]})
+        (session_recordings, _, _) = self._filter_recordings_by({"console_logs": ["info"]})
 
         assert session_recordings == []
 
@@ -2303,7 +2279,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["error"]})
+        (session_recordings, _, _) = self._filter_recordings_by({"console_logs": ["error"]})
 
         assert sorted(
             [(sr["session_id"], sr["console_error_count"]) for sr in session_recordings],
@@ -2312,7 +2288,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             (with_logs_session_id, 4),
         ]
 
-        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["info"]})
+        (session_recordings, _, _) = self._filter_recordings_by({"console_logs": ["info"]})
 
         assert session_recordings == []
 
@@ -2393,7 +2369,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             },
         )
 
-        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["warn", "error"]})
+        (session_recordings, _, _) = self._filter_recordings_by({"console_logs": ["warn", "error"]})
 
         assert sorted([sr["session_id"] for sr in session_recordings]) == sorted(
             [
@@ -2403,7 +2379,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             ]
         )
 
-        (session_recordings, _) = self._filter_recordings_by({"console_logs": ["info"]})
+        (session_recordings, _, _) = self._filter_recordings_by({"console_logs": ["info"]})
 
         assert sorted([sr["session_id"] for sr in session_recordings]) == sorted(
             [
@@ -2486,7 +2462,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             },
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 # there are 5 warn and 4 error logs, message 4 matches in both
                 "console_logs": ["warn", "error"],
@@ -2502,7 +2478,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             ]
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 # there are 5 warn and 4 error logs, message 5 matches only matches in warn
                 "console_logs": ["warn", "error"],
@@ -2516,7 +2492,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             ]
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 # match is case-insensitive
                 "console_logs": ["warn", "error"],
@@ -2530,7 +2506,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             ]
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 # message 5 does not match log level "info"
                 "console_logs": ["info"],
@@ -2590,7 +2566,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             team_id=self.team.id,
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -2605,7 +2581,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         )
         self.assertEqual(len(session_recordings), 0)
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -2672,7 +2648,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         )
 
         # there are 2 pageviews
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 # pageview that matches the hogql test_accounts filter
                 "events": [
@@ -2693,7 +2669,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         ]
         self.team.save()
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 # only 1 pageview that matches the hogql test_accounts filter
                 "events": [
@@ -2716,7 +2692,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         self.team.save()
 
         # one user sessions matches the person + event test_account filter
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "filter_test_accounts": True,
             }
@@ -2792,7 +2768,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         )
 
         # there are 2 pageviews
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 # pageview that matches the hogql test_accounts filter
                 "events": [
@@ -2808,7 +2784,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         )
         self.assertEqual(len(session_recordings), 2)
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 # only 1 pageview that matches the test_accounts filter
                 "filter_test_accounts": True,
@@ -2885,7 +2861,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             )
 
             # there are 2 pageviews
-            (session_recordings, _) = self._filter_recordings_by(
+            (session_recordings, _, _) = self._filter_recordings_by(
                 {
                     # pageview that matches the hogql test_accounts filter
                     "events": [
@@ -2901,7 +2877,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             )
             self.assertEqual(len(session_recordings), 2)
 
-            (session_recordings, _) = self._filter_recordings_by(
+            (session_recordings, _, _) = self._filter_recordings_by(
                 {
                     # only 1 pageview that matches the test_accounts filter
                     "filter_test_accounts": True,
@@ -2970,7 +2946,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         )
 
         # there are 2 pageviews
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 # pageview that matches the hogql test_accounts filter
                 "events": [
@@ -2986,7 +2962,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         )
         self.assertEqual(len(session_recordings), 2)
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 # only 1 pageview that matches the test_accounts filter
                 "filter_test_accounts": True,
@@ -3055,7 +3031,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         )
 
         # there are 2 pageviews
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 # pageview that matches the hogql test_accounts filter
                 "events": [
@@ -3071,7 +3047,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         )
         self.assertEqual(len(session_recordings), 2)
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 # only 1 pageview that matches the test_accounts filter
                 "filter_test_accounts": True,
@@ -3138,7 +3114,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         )
 
         # there are 2 pageviews
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 # pageview that matches the hogql test_accounts filter
                 "events": [
@@ -3154,7 +3130,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         )
         self.assertEqual(len(session_recordings), 2)
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 # only 1 pageview that matches the test_accounts filter
                 "filter_test_accounts": True,
@@ -3176,7 +3152,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
         self._a_session_with_two_events(self.team, "1")
         self._a_session_with_two_events(another_team, "2")
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {
@@ -3279,7 +3255,7 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             },
         )
 
-        (session_recordings, _) = self._filter_recordings_by(
+        (session_recordings, _, _) = self._filter_recordings_by(
             {
                 "events": [
                     {

--- a/posthog/session_recordings/queries/test/test_session_recording_list_from_filters.py
+++ b/posthog/session_recordings/queries/test/test_session_recording_list_from_filters.py
@@ -275,14 +275,13 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
             (session_id_inactive_is_61, 61, 61.0)
         ]
 
-    @skip("TODO: Not implemented in HogQL")
     @snapshot_clickhouse_queries
     def test_basic_query_with_paging(self):
         user = "test_basic_query_with_paging-user"
         Person.objects.create(team=self.team, distinct_ids=[user], properties={"email": "bla"})
 
-        session_id_one = f"test_basic_query_with_paging-{str(uuid4())}"
-        session_id_two = f"test_basic_query_with_paging-{str(uuid4())}"
+        session_id_one = f"id_one_test_basic_query_with_paging-{str(uuid4())}"
+        session_id_two = f"id_two_test_basic_query_with_paging-{str(uuid4())}"
 
         produce_replay_summary(
             session_id=session_id_one,

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -31,6 +31,7 @@ from posthog.constants import SESSION_RECORDINGS_FILTER_IDS
 from posthog.models import User
 from posthog.models.filters.session_recordings_filter import SessionRecordingsFilter
 from posthog.models.person.person import PersonDistinctId
+from posthog.schema import QueryTiming
 from posthog.session_recordings.models.session_recording import SessionRecording
 from posthog.session_recordings.models.session_recording_event import (
     SessionRecordingViewed,
@@ -732,6 +733,7 @@ def list_recordings(
     recordings: list[SessionRecording] = []
     more_recordings_available = False
     team = context["get_team"]()
+    hogql_timings: list[QueryTiming] | None = None
 
     timer = ServerTimingsGathered()
 
@@ -755,10 +757,9 @@ def list_recordings(
             has_hog_ql_filtering = request.GET.get("hog_ql_filtering", "false") == "true"
 
             if has_hog_ql_filtering:
-                (
-                    ch_session_recordings,
-                    more_recordings_available,
-                ) = SessionRecordingListFromFilters(filter=filter, team=team).run()
+                (ch_session_recordings, more_recordings_available, hogql_timings) = SessionRecordingListFromFilters(
+                    filter=filter, team=team
+                ).run()
             else:
                 # Only go to clickhouse if we still have remaining specified IDs, or we are not specifying IDs
                 (
@@ -810,7 +811,19 @@ def list_recordings(
     session_recording_serializer = SessionRecordingSerializer(recordings, context=context, many=True)
     results = session_recording_serializer.data
 
+    all_timings = _generate_timings(hogql_timings, timer)
     return (
         {"results": results, "has_next": more_recordings_available, "version": 3},
-        timer.get_all_timings(),
+        all_timings,
     )
+
+
+def _generate_timings(hogql_timings: list[QueryTiming] | None, timer: ServerTimingsGathered) -> dict[str, float]:
+    timings_dict = timer.get_all_timings()
+    hogql_timings_dict = {}
+    for key, value in hogql_timings or {}:
+        new_key = f"hogql_{key[1].lstrip('./')}"
+        # HogQL query timings are in seconds, convert to milliseconds
+        hogql_timings_dict[new_key] = value[1] * 1000
+    all_timings = {**timings_dict, **hogql_timings_dict}
+    return all_timings


### PR DESCRIPTION
Implements HogQL pagination
And copies the gathered HogQL timings into the existing server-timings header response. This will give us more detailed metrics in browser dev tools and in replay network inspector

<img width="469" alt="Screenshot 2024-05-03 at 15 29 49" src="https://github.com/PostHog/posthog/assets/984817/3ab15936-911d-42af-9b08-ddd8be1d2a91">
