### PR TITLE
feat(hogql): allow larger max query length

### DIFF
--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -16,7 +16,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_event_property_filter.1
@@ -36,7 +37,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_event_property_filter.2
@@ -56,7 +58,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_event_property_filter_materialized
@@ -76,7 +79,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_event_property_filter_materialized.1
@@ -96,7 +100,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_event_property_filter_materialized.2
@@ -116,7 +121,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_events_query_all_time_date
@@ -132,7 +138,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_events_query_all_time_date.1
@@ -148,7 +155,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_events_query_all_time_date.2
@@ -164,7 +172,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_full_hogql_query
@@ -182,7 +191,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_full_hogql_query_async
@@ -225,7 +235,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_full_hogql_query_view
@@ -243,7 +254,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_full_hogql_query_view.1
@@ -265,7 +277,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_hogql_property_filter
@@ -285,7 +298,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_hogql_property_filter.1
@@ -305,7 +319,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_hogql_property_filter.2
@@ -325,7 +340,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_hogql_property_filter.3
@@ -345,7 +361,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_hogql_property_filter_materialized
@@ -365,7 +382,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_hogql_property_filter_materialized.1
@@ -385,7 +403,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_hogql_property_filter_materialized.2
@@ -405,7 +424,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_hogql_property_filter_materialized.3
@@ -425,7 +445,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_person_property_filter
@@ -463,7 +484,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_person_property_filter_materialized
@@ -501,7 +523,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_property_filter_aggregations
@@ -519,7 +542,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_property_filter_aggregations.1
@@ -538,7 +562,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_property_filter_aggregations_materialized
@@ -556,7 +581,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_property_filter_aggregations_materialized.1
@@ -575,7 +601,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_select_event_person
@@ -593,7 +620,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_select_hogql_expressions
@@ -612,7 +640,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_select_hogql_expressions.1
@@ -629,7 +658,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_select_hogql_expressions.2
@@ -647,7 +677,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestQuery.test_select_hogql_expressions.3
@@ -665,6 +696,7 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---

--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -100,5 +100,6 @@ class HogQLGlobalSettings(HogQLQuerySettings):
     max_execution_time: Optional[int] = 60
     allow_experimental_object_type: Optional[bool] = True
     format_csv_allow_double_quotes: Optional[bool] = False
-    max_ast_elements: Optional[int] = 1000000
+    max_ast_elements: Optional[int] = 50000 * 20  # default value 50000
     max_expanded_ast_elements: Optional[int] = 1000000
+    max_query_size: Optional[int] = 262144 * 2  # default value 262144 (= 256 KiB)

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
@@ -389,7 +389,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFOSSFunnel.test_funnel_with_property_groups
@@ -496,7 +497,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFOSSFunnel.test_funnel_with_property_groups.1
@@ -613,7 +615,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFOSSFunnel.test_funnel_with_property_groups.2
@@ -730,7 +733,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFOSSFunnel.test_funnel_with_property_groups.3
@@ -847,7 +851,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFOSSFunnel.test_funnel_with_static_cohort_step_filter
@@ -921,7 +926,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFOSSFunnel.test_timezones
@@ -983,7 +989,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_breakdowns_by_current_url.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_breakdowns_by_current_url.ambr
@@ -20,7 +20,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelBreakdownsByCurrentURL.test_breakdown_by_current_url.1
@@ -108,7 +109,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelBreakdownsByCurrentURL.test_breakdown_by_pathname
@@ -132,7 +134,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelBreakdownsByCurrentURL.test_breakdown_by_pathname.1
@@ -220,6 +223,7 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -148,7 +148,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties
@@ -309,7 +310,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties.1
@@ -441,7 +443,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties.2
@@ -458,7 +461,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties.3
@@ -590,7 +594,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties.4
@@ -607,7 +612,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties.5
@@ -739,7 +745,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties.6
@@ -756,7 +763,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties.7
@@ -888,7 +896,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties.8
@@ -905,7 +914,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_event_properties_and_groups
@@ -1042,7 +1052,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_event_properties_and_groups_materialized
@@ -1179,7 +1190,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups
@@ -1310,7 +1322,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups.1
@@ -1424,7 +1437,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups.2
@@ -1538,7 +1552,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups.3
@@ -1652,7 +1667,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups.4
@@ -1766,7 +1782,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups.5
@@ -1913,7 +1930,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups.6
@@ -2027,7 +2045,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups.7
@@ -2141,7 +2160,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups_poe_v2
@@ -2272,7 +2292,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups_poe_v2.1
@@ -2386,7 +2407,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups_poe_v2.2
@@ -2500,7 +2522,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups_poe_v2.3
@@ -2614,7 +2637,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups_poe_v2.4
@@ -2728,7 +2752,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups_poe_v2.5
@@ -2875,7 +2900,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups_poe_v2.6
@@ -2989,7 +3015,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_events_and_groups_poe_v2.7
@@ -3103,7 +3130,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups
@@ -3249,7 +3277,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups.1
@@ -3370,7 +3399,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups.2
@@ -3491,7 +3521,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups.3
@@ -3612,7 +3643,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups.4
@@ -3733,7 +3765,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups.5
@@ -3879,7 +3912,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_materialized
@@ -4025,7 +4059,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_materialized.1
@@ -4146,7 +4181,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_materialized.2
@@ -4267,7 +4303,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_materialized.3
@@ -4388,7 +4425,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_materialized.4
@@ -4509,7 +4547,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_materialized.5
@@ -4655,7 +4694,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events
@@ -4801,7 +4841,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events.1
@@ -4922,7 +4963,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events.2
@@ -5043,7 +5085,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events.3
@@ -5164,7 +5207,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events.4
@@ -5285,7 +5329,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events.5
@@ -5431,7 +5476,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events_materialized
@@ -5577,7 +5623,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events_materialized.1
@@ -5698,7 +5745,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events_materialized.2
@@ -5819,7 +5867,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events_materialized.3
@@ -5940,7 +5989,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events_materialized.4
@@ -6061,7 +6111,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events_materialized.5
@@ -6207,7 +6258,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events_poe_v2
@@ -6353,7 +6405,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events_poe_v2.1
@@ -6474,7 +6527,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events_poe_v2.2
@@ -6595,7 +6649,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events_poe_v2.3
@@ -6716,7 +6771,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events_poe_v2.4
@@ -6837,7 +6893,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseFunnelCorrelation.test_funnel_correlation_with_properties_and_groups_person_on_events_poe_v2.5
@@ -6983,6 +7040,7 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -125,7 +125,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelCorrelationsActors.test_funnel_correlation_on_event_with_recordings.1
@@ -142,7 +143,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelCorrelationsActors.test_funnel_correlation_on_event_with_recordings.2
@@ -337,7 +339,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelCorrelationsActors.test_funnel_correlation_on_event_with_recordings.3
@@ -354,7 +357,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelCorrelationsActors.test_funnel_correlation_on_properties_with_recordings
@@ -486,7 +490,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelCorrelationsActors.test_funnel_correlation_on_properties_with_recordings.1
@@ -503,7 +508,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelCorrelationsActors.test_strict_funnel_correlation_with_recordings
@@ -635,7 +641,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelCorrelationsActors.test_strict_funnel_correlation_with_recordings.1
@@ -652,7 +659,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelCorrelationsActors.test_strict_funnel_correlation_with_recordings.2
@@ -784,7 +792,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelCorrelationsActors.test_strict_funnel_correlation_with_recordings.3
@@ -801,6 +810,7 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_persons.ambr
@@ -167,7 +167,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelPersons.test_funnel_person_recordings.1
@@ -184,7 +185,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelPersons.test_funnel_person_recordings.2
@@ -355,7 +357,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelPersons.test_funnel_person_recordings.3
@@ -372,7 +375,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelPersons.test_funnel_person_recordings.4
@@ -543,7 +547,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelPersons.test_funnel_person_recordings.5
@@ -560,6 +565,7 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -20,7 +20,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelStrictStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen.1
@@ -107,7 +108,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelStrictStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen_for_step
@@ -131,7 +133,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelStrictStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen_for_step.1
@@ -225,7 +228,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelStrictStepsBreakdown.test_funnel_step_multiple_breakdown_snapshot
@@ -249,7 +253,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelStrictStepsBreakdown.test_funnel_step_multiple_breakdown_snapshot.1
@@ -336,7 +341,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestStrictFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events
@@ -361,7 +367,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestStrictFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events.1
@@ -489,7 +496,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestStrictFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events_poe_v2
@@ -520,7 +528,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestStrictFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events_poe_v2.1
@@ -648,7 +657,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestStrictFunnelGroupBreakdown.test_funnel_breakdown_group
@@ -680,7 +690,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestStrictFunnelGroupBreakdown.test_funnel_breakdown_group.1
@@ -815,7 +826,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestStrictFunnelGroupBreakdown.test_funnel_breakdown_group.2

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
@@ -127,7 +127,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.1
@@ -144,7 +145,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.2
@@ -275,7 +277,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.3
@@ -292,7 +295,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.4
@@ -423,7 +427,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.5
@@ -440,6 +445,7 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
@@ -1506,6 +1506,7 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
@@ -414,7 +414,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelTimeToConvert.test_basic_strict
@@ -759,7 +760,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelTimeToConvert.test_basic_unordered

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends.ambr
@@ -86,7 +86,8 @@
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=1000000,
-                      max_expanded_ast_elements=1000000
+                      max_expanded_ast_elements=1000000,
+                      max_query_size=524288
   '''
 # ---
 # name: TestFunnelTrends.test_timezones_trends.1
@@ -176,7 +177,8 @@
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=1000000,
-                      max_expanded_ast_elements=1000000
+                      max_expanded_ast_elements=1000000,
+                      max_query_size=524288
   '''
 # ---
 # name: TestFunnelTrends.test_week_interval
@@ -266,7 +268,8 @@
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=1000000,
-                      max_expanded_ast_elements=1000000
+                      max_expanded_ast_elements=1000000,
+                      max_query_size=524288
   '''
 # ---
 # name: TestFunnelTrends.test_week_interval.1

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
@@ -153,7 +153,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelTrendsPersons.test_funnel_trend_persons_returns_recordings.1
@@ -170,7 +171,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelTrendsPersons.test_funnel_trend_persons_with_drop_off
@@ -327,7 +329,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelTrendsPersons.test_funnel_trend_persons_with_drop_off.1
@@ -344,7 +347,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelTrendsPersons.test_funnel_trend_persons_with_no_to_step
@@ -501,7 +505,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelTrendsPersons.test_funnel_trend_persons_with_no_to_step.1
@@ -518,6 +523,7 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -20,7 +20,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelUnorderedStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen.1
@@ -159,7 +160,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelUnorderedStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen_for_step
@@ -183,7 +185,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelUnorderedStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen_for_step.1
@@ -336,7 +339,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestFunnelUnorderedStepsBreakdown.test_funnel_step_multiple_breakdown_snapshot
@@ -360,7 +364,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelUnorderedStepsBreakdown.test_funnel_step_multiple_breakdown_snapshot.1
@@ -499,7 +504,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestUnorderedFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events
@@ -524,7 +530,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestUnorderedFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events.1
@@ -652,7 +659,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestUnorderedFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events_poe_v2
@@ -683,7 +691,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestUnorderedFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events_poe_v2.1
@@ -811,7 +820,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestUnorderedFunnelGroupBreakdown.test_funnel_breakdown_group
@@ -843,7 +853,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestUnorderedFunnelGroupBreakdown.test_funnel_breakdown_group.1
@@ -978,7 +989,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestUnorderedFunnelGroupBreakdown.test_funnel_breakdown_group.10

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
@@ -271,7 +271,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestFunnelUnorderedStepsPersons.test_unordered_funnel_does_not_return_recordings.1
@@ -288,6 +289,7 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_lifecycle_query_runner.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_lifecycle_query_runner.ambr
@@ -94,7 +94,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestLifecycleQueryRunner.test_sampling
@@ -169,7 +170,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestLifecycleQueryRunner.test_timezones
@@ -244,7 +246,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestLifecycleQueryRunner.test_timezones.1
@@ -319,6 +322,7 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_paths_query_runner_ee.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_paths_query_runner_ee.ambr
@@ -78,7 +78,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_end.1
@@ -160,7 +161,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_end_materialized
@@ -242,7 +244,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_end_materialized.1
@@ -324,7 +327,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_event_exclusion_filters_with_wildcard_groups
@@ -405,7 +409,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_event_exclusion_filters_with_wildcard_groups.1
@@ -486,7 +491,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_event_inclusion_exclusion_filters
@@ -567,7 +573,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_event_inclusion_exclusion_filters.1
@@ -648,7 +655,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_event_inclusion_exclusion_filters.2
@@ -729,7 +737,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_event_inclusion_exclusion_filters.3
@@ -810,7 +819,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_event_ordering
@@ -891,7 +901,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_groups_filtering_person_on_events
@@ -980,7 +991,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_groups_filtering_person_on_events.1
@@ -1062,7 +1074,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_groups_filtering_person_on_events.2
@@ -1144,7 +1157,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_person_dropoffs
@@ -1263,7 +1277,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_person_dropoffs.1
@@ -1381,7 +1396,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_person_dropoffs.2
@@ -1499,7 +1515,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_person_dropoffs.3
@@ -1618,7 +1635,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_person_dropoffs.4
@@ -1736,7 +1754,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_person_dropoffs.5
@@ -1854,7 +1873,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_person_dropoffs.6
@@ -1973,7 +1993,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_person_dropoffs.7
@@ -2091,7 +2112,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_person_dropoffs.8
@@ -2209,7 +2231,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_person_on_events_v2
@@ -2303,7 +2326,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_recording
@@ -2425,7 +2449,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_recording.1
@@ -2442,7 +2467,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_recording_for_dropoff
@@ -2565,7 +2591,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_recording_for_dropoff.1
@@ -2582,7 +2609,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_recording_for_dropoff.2
@@ -2705,7 +2733,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_recording_for_dropoff.3
@@ -2722,7 +2751,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_recording_with_no_window_or_session_id
@@ -2844,7 +2874,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_recording_with_no_window_or_session_id.1
@@ -2861,7 +2892,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_recording_with_start_and_end
@@ -2992,7 +3024,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_recording_with_start_and_end.1
@@ -3009,7 +3042,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_respect_session_limits
@@ -3090,7 +3124,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_start_and_end
@@ -3176,7 +3211,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_start_and_end.1
@@ -3303,7 +3339,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_start_and_end.2
@@ -3389,7 +3426,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_start_and_end.3
@@ -3516,7 +3554,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_start_and_end_materialized
@@ -3602,7 +3641,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_start_and_end_materialized.1
@@ -3729,7 +3769,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_start_and_end_materialized.2
@@ -3815,7 +3856,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_start_and_end_materialized.3
@@ -3942,7 +3984,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_start_dropping_orphaned_edges
@@ -4024,7 +4067,8 @@
                    allow_experimental_object_type=1,
                    format_csv_allow_double_quotes=0,
                    max_ast_elements=1000000,
-                   max_expanded_ast_elements=1000000
+                   max_expanded_ast_elements=1000000,
+                   max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_step_conversion_times
@@ -4105,7 +4149,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_step_limit
@@ -4186,7 +4231,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_step_limit.1
@@ -4304,7 +4350,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_step_limit.2
@@ -4422,7 +4469,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_step_limit.3
@@ -4503,7 +4551,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_step_limit.4
@@ -4621,7 +4670,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_step_limit.5
@@ -4702,7 +4752,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_step_limit.6
@@ -4820,7 +4871,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_step_limit.7
@@ -4938,7 +4990,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_step_limit.8
@@ -5056,7 +5109,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_wildcard_groups_across_people
@@ -5137,7 +5191,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_wildcard_groups_evil_input
@@ -5223,6 +5278,7 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_retention_query_runner.ambr
@@ -45,7 +45,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestClickhouseRetentionGroupAggregation.test_groups_aggregating.1
@@ -110,7 +111,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseRetentionGroupAggregation.test_groups_aggregating.2
@@ -159,7 +161,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestClickhouseRetentionGroupAggregation.test_groups_aggregating_person_on_events
@@ -208,7 +211,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestClickhouseRetentionGroupAggregation.test_groups_aggregating_person_on_events.1
@@ -273,7 +277,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestClickhouseRetentionGroupAggregation.test_groups_aggregating_person_on_events.2
@@ -322,7 +327,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestRetention.test_day_interval_sampled
@@ -392,7 +398,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestRetention.test_month_interval_with_person_on_events_v2
@@ -473,7 +480,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestRetention.test_retention_event_action
@@ -543,7 +551,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestRetention.test_retention_with_user_properties_via_action
@@ -635,7 +644,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestRetention.test_timezones
@@ -705,7 +715,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestRetention.test_timezones.1
@@ -775,7 +786,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestRetention.test_week_interval
@@ -845,7 +857,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestRetention.test_week_interval.1
@@ -915,6 +928,7 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -96,7 +96,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_action_filtering_with_cohort_poe_v2
@@ -184,7 +185,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_by_group_props_person_on_events
@@ -208,7 +210,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_by_group_props_person_on_events.1
@@ -260,7 +263,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_by_group_props_person_on_events.2
@@ -303,7 +307,10 @@
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_by_group_props_person_on_events.3
@@ -318,7 +325,10 @@
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=0
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=1000000,
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_by_group_props_with_person_filter_person_on_events
@@ -342,7 +352,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_by_group_props_with_person_filter_person_on_events.1
@@ -394,7 +405,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_filtering_with_properties_in_new_format
@@ -410,7 +422,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_filtering_with_properties_in_new_format.1
@@ -454,7 +467,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_filtering_with_properties_in_new_format.2
@@ -470,7 +484,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_filtering_with_properties_in_new_format.3
@@ -514,7 +529,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_weekly_active_users_aggregated
@@ -537,7 +553,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_weekly_active_users_aggregated.1
@@ -578,7 +595,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_weekly_active_users_aggregated_materialized
@@ -601,7 +619,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_weekly_active_users_aggregated_materialized.1
@@ -642,7 +661,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_weekly_active_users_daily_based_on_action
@@ -699,7 +719,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_weekly_active_users_daily_based_on_action.3
@@ -780,7 +801,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_with_filter_groups_person_on_events
@@ -804,7 +826,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_with_filter_groups_person_on_events.1
@@ -856,7 +879,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_with_filter_groups_person_on_events_v2
@@ -894,7 +918,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_breakdown_with_filter_groups_person_on_events_v2.2
@@ -952,7 +977,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_dau_with_breakdown_filtering_with_sampling
@@ -968,7 +994,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_dau_with_breakdown_filtering_with_sampling.1
@@ -1019,7 +1046,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_dau_with_breakdown_filtering_with_sampling.2
@@ -1035,7 +1063,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_dau_with_breakdown_filtering_with_sampling.3
@@ -1086,7 +1115,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_filter_events_by_precalculated_cohort
@@ -1173,7 +1203,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_filter_events_by_precalculated_cohort_poe_v2
@@ -1242,7 +1273,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_filtering_by_multiple_groups_person_on_events
@@ -1287,7 +1319,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_filtering_by_multiple_groups_person_on_events.1
@@ -1338,7 +1371,10 @@
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_filtering_by_multiple_groups_person_on_events.2
@@ -1353,7 +1389,10 @@
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=0
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=1000000,
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_filtering_with_group_props_person_on_events
@@ -1390,7 +1429,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_mau_with_breakdown_filtering_and_prop_filter
@@ -1425,7 +1465,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_mau_with_breakdown_filtering_and_prop_filter.1
@@ -1504,7 +1545,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_mau_with_breakdown_filtering_and_prop_filter_poe_v2
@@ -1526,7 +1568,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_mau_with_breakdown_filtering_and_prop_filter_poe_v2.1
@@ -1592,7 +1635,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_non_deterministic_timezones
@@ -1621,7 +1665,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_person_filtering_in_cohort_in_action
@@ -1667,7 +1712,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_person_filtering_in_cohort_in_action.3
@@ -1721,7 +1767,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_person_filtering_in_cohort_in_action_poe_v2
@@ -1766,7 +1813,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_person_filtering_in_cohort_in_action_poe_v2.3
@@ -1819,7 +1867,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_person_property_filtering
@@ -1866,7 +1915,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_person_property_filtering_clashing_with_event_property
@@ -1913,7 +1963,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_person_property_filtering_clashing_with_event_property.1
@@ -1942,7 +1993,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_person_property_filtering_clashing_with_event_property_materialized
@@ -1989,7 +2041,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_person_property_filtering_clashing_with_event_property_materialized.1
@@ -2018,7 +2071,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_person_property_filtering_materialized
@@ -2065,7 +2119,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_same_day_with_person_on_events_v2
@@ -2108,7 +2163,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_same_day_with_person_on_events_v2.2
@@ -2143,7 +2199,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_same_day_with_person_on_events_v2_latest_override
@@ -2192,7 +2249,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_same_day_with_person_on_events_v2_latest_override.2
@@ -2241,7 +2299,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_same_day_with_person_on_events_v2_latest_override.4
@@ -2290,7 +2349,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily
@@ -2319,7 +2379,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily.1
@@ -2355,7 +2416,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily.2
@@ -2404,7 +2466,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily.3
@@ -2433,7 +2496,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily.4
@@ -2449,7 +2513,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily.5
@@ -2500,7 +2565,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily_minus_utc
@@ -2529,7 +2595,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily_minus_utc.1
@@ -2565,7 +2632,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily_minus_utc.2
@@ -2614,7 +2682,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily_minus_utc.3
@@ -2643,7 +2712,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily_minus_utc.4
@@ -2659,7 +2729,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily_minus_utc.5
@@ -2710,7 +2781,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily_plus_utc
@@ -2739,7 +2811,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily_plus_utc.1
@@ -2775,7 +2848,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily_plus_utc.2
@@ -2824,7 +2898,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily_plus_utc.3
@@ -2853,7 +2928,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily_plus_utc.4
@@ -2869,7 +2945,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_daily_plus_utc.5
@@ -2920,7 +2997,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_hourly_relative_from
@@ -2956,7 +3034,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_hourly_relative_from.1
@@ -2985,7 +3064,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_hourly_relative_from_minus_utc
@@ -3021,7 +3101,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_hourly_relative_from_minus_utc.1
@@ -3050,7 +3131,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_hourly_relative_from_plus_utc
@@ -3086,7 +3168,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_hourly_relative_from_plus_utc.1
@@ -3115,7 +3198,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_weekly
@@ -3144,7 +3228,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_weekly.1
@@ -3173,7 +3258,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_weekly_minus_utc
@@ -3202,7 +3288,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_weekly_minus_utc.1
@@ -3231,7 +3318,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_weekly_plus_utc
@@ -3260,7 +3348,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_timezones_weekly_plus_utc.1
@@ -3289,7 +3378,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trend_breakdown_user_props_with_filter_with_partial_property_pushdowns
@@ -3325,7 +3415,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trend_breakdown_user_props_with_filter_with_partial_property_pushdowns.1
@@ -3389,7 +3480,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trend_breakdown_user_props_with_filter_with_partial_property_pushdowns.2
@@ -3425,7 +3517,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trend_breakdown_user_props_with_filter_with_partial_property_pushdowns.3
@@ -3489,7 +3582,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_aggregate_by_distinct_id
@@ -3518,7 +3612,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_aggregate_by_distinct_id.1
@@ -3565,7 +3660,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_aggregate_by_distinct_id.2
@@ -3599,7 +3695,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_aggregate_by_distinct_id.3
@@ -3661,7 +3758,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_aggregate_by_distinct_id.4
@@ -3703,7 +3801,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_aggregate_by_distinct_id.5
@@ -3745,7 +3844,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_aggregate_by_distinct_id.6
@@ -3761,7 +3861,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_aggregate_by_distinct_id.7
@@ -3805,7 +3906,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_any_event_total_count
@@ -3834,7 +3936,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_any_event_total_count.1
@@ -3863,7 +3966,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_cumulative
@@ -3879,7 +3983,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_cumulative.1
@@ -3936,7 +4041,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_cumulative_poe_v2
@@ -3952,7 +4058,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_cumulative_poe_v2.1
@@ -4008,7 +4115,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_normalize_url
@@ -4026,7 +4134,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_normalize_url.1
@@ -4085,7 +4194,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_normalize_url_poe_v2
@@ -4103,7 +4213,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_normalize_url_poe_v2.1
@@ -4161,7 +4272,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_with_session_property_single_aggregate_math_and_breakdown
@@ -4184,7 +4296,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_with_session_property_single_aggregate_math_and_breakdown.1
@@ -4211,7 +4324,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_with_session_property_single_aggregate_math_and_breakdown.2
@@ -4234,7 +4348,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_with_session_property_single_aggregate_math_and_breakdown.3
@@ -4261,7 +4376,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_compare_day_interval_relative_range
@@ -4290,7 +4406,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_compare_day_interval_relative_range.1
@@ -4319,7 +4436,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_compare_day_interval_relative_range.2
@@ -4348,7 +4466,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_count_per_user_average_aggregated
@@ -4373,7 +4492,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_count_per_user_average_aggregated_poe_v2
@@ -4397,7 +4517,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_count_per_user_average_aggregated_with_event_property_breakdown_with_sampling
@@ -4413,7 +4534,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_count_per_user_average_aggregated_with_event_property_breakdown_with_sampling.1
@@ -4443,7 +4565,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_count_per_user_average_daily
@@ -4487,7 +4610,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_count_per_user_average_daily_poe_v2
@@ -4530,7 +4654,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_groups_per_day
@@ -4559,7 +4684,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_groups_per_day_cumulative
@@ -4593,7 +4719,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_per_day_cumulative
@@ -4627,7 +4754,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_per_day_dau_cumulative
@@ -4668,7 +4796,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_person_breakdown_with_session_property_single_aggregate_math_and_breakdown
@@ -4709,7 +4838,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_person_breakdown_with_session_property_single_aggregate_math_and_breakdown.1
@@ -4754,7 +4884,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_with_hogql_math
@@ -4783,7 +4914,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_with_session_property_single_aggregate_math
@@ -4806,7 +4938,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_with_session_property_single_aggregate_math.1
@@ -4829,7 +4962,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_with_session_property_total_volume_math
@@ -4871,7 +5005,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_with_session_property_total_volume_math.1
@@ -4913,7 +5048,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_with_session_property_total_volume_math_with_breakdowns
@@ -4936,7 +5072,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_with_session_property_total_volume_math_with_breakdowns.1
@@ -4995,7 +5132,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_with_session_property_total_volume_math_with_breakdowns.2
@@ -5018,7 +5156,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_trends_with_session_property_total_volume_math_with_breakdowns.3
@@ -5077,7 +5216,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_weekly_active_users_aggregated_range_narrower_than_week
@@ -5112,7 +5252,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_weekly_active_users_aggregated_range_wider_than_week
@@ -5147,7 +5288,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_weekly_active_users_aggregated_range_wider_than_week_with_sampling
@@ -5182,7 +5324,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_weekly_active_users_daily
@@ -5231,7 +5374,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_weekly_active_users_daily_minus_utc
@@ -5280,7 +5424,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_weekly_active_users_daily_plus_utc
@@ -5329,7 +5474,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_weekly_active_users_filtering
@@ -5389,7 +5535,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_weekly_active_users_filtering_materialized
@@ -5449,7 +5596,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_weekly_active_users_hourly
@@ -5498,7 +5646,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_weekly_active_users_weekly
@@ -5547,7 +5696,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_weekly_active_users_weekly_minus_utc
@@ -5596,7 +5746,8 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---
 # name: TestTrends.test_weekly_active_users_weekly_plus_utc
@@ -5645,6 +5796,7 @@
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
-                       max_expanded_ast_elements=1000000
+                       max_expanded_ast_elements=1000000,
+                       max_query_size=524288
   '''
 # ---

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends_data_warehouse_query.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends_data_warehouse_query.ambr
@@ -12,7 +12,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrendsDataWarehouseQuery.test_trends_breakdown.1
@@ -56,7 +57,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestTrendsDataWarehouseQuery.test_trends_breakdown_with_property
@@ -72,7 +74,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestTrendsDataWarehouseQuery.test_trends_breakdown_with_property.1
@@ -116,7 +119,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestTrendsDataWarehouseQuery.test_trends_data_warehouse
@@ -145,7 +149,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestTrendsDataWarehouseQuery.test_trends_entity_property
@@ -174,7 +179,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestTrendsDataWarehouseQuery.test_trends_property
@@ -203,6 +209,7 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---

--- a/posthog/hogql_queries/test/__snapshots__/test_sessions_timeline_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_sessions_timeline_query_runner.ambr
@@ -63,7 +63,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestSessionsTimelineQueryRunner.test_before_and_after_defaults
@@ -130,7 +131,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestSessionsTimelineQueryRunner.test_event_limit_and_has_more
@@ -197,7 +199,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestSessionsTimelineQueryRunner.test_formal_and_informal_sessions_global
@@ -264,7 +267,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestSessionsTimelineQueryRunner.test_formal_session_with_recording
@@ -331,7 +335,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestSessionsTimelineQueryRunner.test_formal_sessions_for_person
@@ -398,7 +403,8 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestSessionsTimelineQueryRunner.test_formal_sessions_global
@@ -465,6 +471,7 @@
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---

--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_filters.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_filters.ambr
@@ -27,7 +27,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_basic_query_active_sessions
@@ -58,7 +59,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_basic_query_active_sessions.1
@@ -89,7 +91,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_basic_query_active_sessions.2
@@ -120,7 +123,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_basic_query_with_ordering
@@ -151,7 +155,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_basic_query_with_ordering.1
@@ -182,7 +187,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_basic_query_with_ordering.2
@@ -213,7 +219,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_basic_query_with_paging
@@ -244,7 +251,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_basic_query_with_paging.1
@@ -275,7 +283,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_basic_query_with_paging.2
@@ -306,7 +315,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_date_from_filter
@@ -337,7 +347,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_date_from_filter.1
@@ -368,7 +379,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_date_from_filter_cannot_search_before_ttl
@@ -399,7 +411,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_date_from_filter_cannot_search_before_ttl.1
@@ -430,7 +443,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_date_from_filter_cannot_search_before_ttl.2
@@ -461,7 +475,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_date_to_filter
@@ -492,7 +507,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_date_to_filter.1
@@ -523,7 +539,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_duration_filter
@@ -554,7 +571,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_duration_filter.1
@@ -585,7 +603,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter
@@ -621,7 +640,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter.1
@@ -657,7 +677,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_active_sessions
@@ -693,7 +714,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_active_sessions.1
@@ -729,7 +751,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_hogql_properties
@@ -766,7 +789,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_hogql_properties.1
@@ -803,7 +827,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_hogql_properties_materialized
@@ -840,7 +865,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_hogql_properties_materialized.1
@@ -877,7 +903,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_matching_on_session_id
@@ -913,7 +940,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_matching_on_session_id.1
@@ -949,7 +977,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_person_properties
@@ -998,7 +1027,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_properties
@@ -1035,7 +1065,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_properties.1
@@ -1072,7 +1103,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_properties.2
@@ -1109,7 +1141,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_properties.3
@@ -1146,7 +1179,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_properties_materialized
@@ -1183,7 +1217,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_properties_materialized.1
@@ -1220,7 +1255,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_properties_materialized.2
@@ -1257,7 +1293,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_properties_materialized.3
@@ -1294,7 +1331,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_by_console_text
@@ -1331,7 +1369,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_by_console_text.1
@@ -1368,7 +1407,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_by_console_text.2
@@ -1405,7 +1445,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_by_console_text.3
@@ -1442,7 +1483,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_with_console_errors
@@ -1479,7 +1521,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_with_console_errors.1
@@ -1516,7 +1559,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_with_console_logs
@@ -1553,7 +1597,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_with_console_logs.1
@@ -1590,7 +1635,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_with_console_warns
@@ -1627,7 +1673,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_with_console_warns.1
@@ -1664,7 +1711,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_with_mixed_console_counts
@@ -1701,7 +1749,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_with_mixed_console_counts.1
@@ -1738,7 +1787,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_on_session_ids
@@ -1775,7 +1825,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_on_session_ids.1
@@ -1812,7 +1863,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_with_cohort_properties
@@ -1873,7 +1925,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_with_events_and_cohorts
@@ -1939,7 +1992,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_with_events_and_cohorts.3
@@ -1985,7 +2039,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_multiple_event_filters
@@ -2021,7 +2076,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_multiple_event_filters.1
@@ -2057,7 +2113,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_person_id_filter
@@ -2095,7 +2152,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_top_level_hogql_event_property_test_account_filter
@@ -2131,7 +2189,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_top_level_hogql_event_property_test_account_filter.1
@@ -2167,7 +2226,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_top_level_hogql_event_property_test_account_filter_materialized
@@ -2203,7 +2263,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_top_level_hogql_event_property_test_account_filter_materialized.1
@@ -2239,7 +2300,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_top_level_hogql_person_property_test_account_filter
@@ -2275,7 +2337,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_top_level_hogql_person_property_test_account_filter.1
@@ -2324,7 +2387,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_top_level_hogql_person_property_test_account_filter_materialized
@@ -2360,7 +2424,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_top_level_hogql_person_property_test_account_filter_materialized.1
@@ -2409,7 +2474,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_top_level_person_property_test_account_filter
@@ -2445,7 +2511,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_top_level_person_property_test_account_filter.1
@@ -2494,7 +2561,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_top_level_person_property_test_account_filter_materialized
@@ -2530,7 +2598,8 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_top_level_person_property_test_account_filter_materialized.1
@@ -2579,6 +2648,7 @@
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
   '''
 # ---


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0368RPHLQH/p1714721151163149

## Changes

Doubles the default `max_query_length`.

## How did you test this code?

Verified the setting is present in "debug ch queries"