### PR TITLE
fix: make code snippet safer for unexpected content

### DIFF
--- a/frontend/src/lib/components/CodeSnippet/CodeSnippet.tsx
+++ b/frontend/src/lib/components/CodeSnippet/CodeSnippet.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx'
 import { useValues } from 'kea'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter'
 import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash'
 import dart from 'react-syntax-highlighter/dist/esm/languages/prism/dart'
@@ -76,7 +76,7 @@ SyntaxHighlighter.registerLanguage(Language.SQL, sql)
 SyntaxHighlighter.registerLanguage(Language.Kotlin, kotlin)
 
 export interface CodeSnippetProps {
-    children: string
+    children: string | undefined | null
     language?: Language
     wrap?: boolean
     compact?: boolean
@@ -97,14 +97,25 @@ export function CodeSnippet({
     actions,
     thing = 'snippet',
     maxLinesWithoutExpansion,
-}: CodeSnippetProps): JSX.Element {
+}: CodeSnippetProps): JSX.Element | null {
     const { isDarkModeOn } = useValues(themeLogic)
 
     const [expanded, setExpanded] = useState(false)
+    const [indexOfLimitNewline, setIndexOfLimitNewline] = useState(-1)
+    const [lineCount, setLineCount] = useState(-1)
+    const [displayedText, setDisplayedText] = useState('')
 
-    const indexOfLimitNewline = maxLinesWithoutExpansion ? indexOfNth(text, '\n', maxLinesWithoutExpansion) : -1
-    const lineCount = text.split('\n').length
-    const displayedText = indexOfLimitNewline === -1 || expanded ? text : text.slice(0, indexOfLimitNewline)
+    useEffect(() => {
+        if (text) {
+            setIndexOfLimitNewline(maxLinesWithoutExpansion ? indexOfNth(text, '\n', maxLinesWithoutExpansion) : -1)
+            setLineCount(text.split('\n').length)
+            setDisplayedText(indexOfLimitNewline === -1 || expanded ? text : text.slice(0, indexOfLimitNewline))
+        }
+    }, [text, maxLinesWithoutExpansion, expanded])
+
+    if (lineCount == -1) {
+        return null
+    }
 
     return (
         // eslint-disable-next-line react/forbid-dom-props


### PR DESCRIPTION
see https://posthog.slack.com/archives/C04J1TJ11UZ/p1714756495613319

in this customer's account currently trying to view the raw json of a network request throws an error because we're treating a prop to the component as always a string and trying to split on undefined

it shouldn't be possible to get to this component and have not-a-string in the props but 🤷 

we've seen ten instances since the 25th april https://posthog.sentry.io/issues/5253960204/?project=4506999002234880&project=4506197739831296&project=6423401&project=1899813&project=4504751607644160&query=is%3Aunresolved+split&referrer=issue-stream&statsPeriod=1h&stream_index=0

let's be defensive in the component at least