### PR TITLE
fix(debug): return things if results failed

### DIFF
--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -217,7 +217,7 @@ def execute_hogql_query(
         clickhouse=clickhouse_sql,
         error=error,
         timings=timings.to_list(),
-        results=results,
+        results=results or [],
         columns=print_columns,
         types=types,
         modifiers=query_modifiers,

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -188,6 +188,7 @@ def execute_hogql_query(
                 )
             except Exception as e:
                 if debug:
+                    results = []
                     if isinstance(e, ExposedCHQueryError | ExposedHogQLError):
                         error = str(e)
                     else:
@@ -217,7 +218,7 @@ def execute_hogql_query(
         clickhouse=clickhouse_sql,
         error=error,
         timings=timings.to_list(),
-        results=results or [],
+        results=results,
         columns=print_columns,
         types=types,
         modifiers=query_modifiers,


### PR DESCRIPTION
## Problem

If the query fails and returns `None` for results, we should still get back the HogQL query output and whatever else we got.

[Sentry issue](https://posthog.sentry.io/issues/5310302669/?alert_rule_id=1075039&alert_type=issue&notification_uuid=687fd02e-b496-4c15-aea5-dae0f1581057&project=1899813&referrer=slack)

```
ValidationError
1 validation error for HogQLQueryResponse
results
  Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.5/v/list_type
```

## Changes

`None or []`

## How did you test this code?

Didn't really, hoping it works.