### PR TITLE
fix: Correct pipeline node name and description

### DIFF
--- a/frontend/src/scenes/pipeline/PipelineNodeConfiguration.tsx
+++ b/frontend/src/scenes/pipeline/PipelineNodeConfiguration.tsx
@@ -9,10 +9,10 @@ import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import React from 'react'
 import { BatchExportsEditFields } from 'scenes/batch_exports/BatchExportEditForm'
 import { BatchExportConfigurationForm } from 'scenes/batch_exports/batchExportEditLogic'
-import { getConfigSchemaArray, isValidField } from 'scenes/pipeline/configUtils'
+import { isValidField } from 'scenes/pipeline/configUtils'
 import { PluginField } from 'scenes/plugins/edit/PluginField'
 
-import { AvailableFeature, PipelineStage, PluginType } from '~/types'
+import { AvailableFeature, PipelineStage } from '~/types'
 
 import { pipelineLogic } from './pipelineLogic'
 import { pipelineNodeLogic } from './pipelineNodeLogic'
@@ -100,7 +100,7 @@ export function PipelineNodeConfiguration(): JSX.Element {
                         {!isConfigurable ? (
                             <span>This {stage} isn't configurable.</span>
                         ) : maybeNodePlugin ? (
-                            <PluginConfigurationFields plugin={maybeNodePlugin} formValues={configuration} />
+                            <PluginConfigurationFields />
                         ) : (
                             <BatchExportConfigurationFields isNew={isNew} formValues={configuration} />
                         )}
@@ -129,11 +129,10 @@ export function PipelineNodeConfiguration(): JSX.Element {
     )
 }
 
-function PluginConfigurationFields({ plugin }: { plugin: PluginType; formValues: Record<string, any> }): JSX.Element {
-    const { hiddenFields, requiredFields } = useValues(pipelineNodeLogic)
+function PluginConfigurationFields(): JSX.Element {
+    const { hiddenFields, requiredFields, pluginConfigFields } = useValues(pipelineNodeLogic)
 
-    const configSchemaArray = getConfigSchemaArray(plugin.config_schema)
-    const fields = configSchemaArray.map((fieldConfig, index) => (
+    const fields = pluginConfigFields.map((fieldConfig, index) => (
         <React.Fragment key={fieldConfig.key || `__key__${index}`}>
             {fieldConfig.key &&
             fieldConfig.type &&

--- a/frontend/src/scenes/pipeline/configUtils.ts
+++ b/frontend/src/scenes/pipeline/configUtils.ts
@@ -46,13 +46,20 @@ export function getPluginConfigFormData(
     existingConfig: Record<string, any> | undefined,
     updatedConfig: Record<string, any>
 ): FormData {
-    const { __enabled: enabled, ...config } = updatedConfig
+    const { __enabled: enabled, name, description, ...config } = updatedConfig
 
     const configSchema = getConfigSchemaObject(rawConfigSchema)
 
     const formData = new FormData()
     const otherConfig: Record<string, any> = {}
     formData.append('enabled', Boolean(enabled).toString())
+
+    if (name) {
+        formData.append('name', name)
+    }
+    if (description) {
+        formData.append('description', description)
+    }
     for (const [key, value] of Object.entries(config)) {
         if (configSchema[key]?.type === 'attachment') {
             if (value && !value.saved) {

--- a/frontend/src/scenes/pipeline/configUtils.ts
+++ b/frontend/src/scenes/pipeline/configUtils.ts
@@ -46,20 +46,16 @@ export function getPluginConfigFormData(
     existingConfig: Record<string, any> | undefined,
     updatedConfig: Record<string, any>
 ): FormData {
-    const { __enabled: enabled, name, description, ...config } = updatedConfig
+    const { __enabled: enabled, ...config } = updatedConfig
 
     const configSchema = getConfigSchemaObject(rawConfigSchema)
 
     const formData = new FormData()
     const otherConfig: Record<string, any> = {}
-    formData.append('enabled', Boolean(enabled).toString())
+    if (enabled !== undefined) {
+        formData.append('enabled', Boolean(enabled).toString())
+    }
 
-    if (name) {
-        formData.append('name', name)
-    }
-    if (description) {
-        formData.append('description', description)
-    }
     for (const [key, value] of Object.entries(config)) {
         if (configSchema[key]?.type === 'attachment') {
             if (value && !value.saved) {
@@ -89,9 +85,12 @@ const doFieldRequirementsMatch = (
     return (targetAnyValue && formValueSet) || targetFieldValue === formActualValue
 }
 
-export const determineInvisibleFields = (getFieldValue: (fieldName: string) => any, plugin: PluginType): string[] => {
+export const determineInvisibleFields = (
+    getFieldValue: (fieldName: string) => any,
+    schema: PluginType['config_schema']
+): string[] => {
     const fieldsToSetAsInvisible = []
-    for (const field of Object.values(getConfigSchemaArray(plugin.config_schema || {}))) {
+    for (const field of Object.values(getConfigSchemaArray(schema || {}))) {
         if (!field.visible_if || !field.key) {
             continue
         }
@@ -107,9 +106,12 @@ export const determineInvisibleFields = (getFieldValue: (fieldName: string) => a
     return fieldsToSetAsInvisible
 }
 
-export const determineRequiredFields = (getFieldValue: (fieldName: string) => any, plugin: PluginType): string[] => {
+export const determineRequiredFields = (
+    getFieldValue: (fieldName: string) => any,
+    schema: PluginType['config_schema']
+): string[] => {
     const fieldsToSetAsRequired = []
-    for (const field of Object.values(getConfigSchemaArray(plugin.config_schema || {}))) {
+    for (const field of Object.values(getConfigSchemaArray(schema || {}))) {
         if (!field.key) {
             continue
         }

--- a/frontend/src/scenes/pipeline/pipelineNodeLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineNodeLogic.tsx
@@ -294,7 +294,11 @@ export const pipelineNodeLogic = kea<pipelineNodeLogicType>([
             (node, maybeNodePlugin): Record<string, any> | null => {
                 if (node) {
                     return node.backend === PipelineBackend.Plugin
-                        ? node.config || defaultConfigForPlugin(node.plugin)
+                        ? {
+                              name: node.name,
+                              description: node.description,
+                              ...(node.config || defaultConfigForPlugin(node.plugin)),
+                          }
                         : { interval: node.interval, destination: node.service.type, ...node.service.config }
                 }
                 if (maybeNodePlugin) {

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -66,8 +66,10 @@ export function PluginDrawer(): JSX.Element {
     const [requiredFields, setRequiredFields] = useState<string[]>([])
 
     const updateInvisibleAndRequiredFields = (): void => {
-        setInvisibleFields(editingPlugin ? determineInvisibleFields(form.getFieldValue, editingPlugin) : [])
-        setRequiredFields(editingPlugin ? determineRequiredFields(form.getFieldValue, editingPlugin) : [])
+        setInvisibleFields(
+            editingPlugin ? determineInvisibleFields(form.getFieldValue, editingPlugin.config_schema) : []
+        )
+        setRequiredFields(editingPlugin ? determineRequiredFields(form.getFieldValue, editingPlugin.config_schema) : [])
     }
 
     useEffect(() => {


### PR DESCRIPTION
## Problem

The name and description were parsed and saved as part of the normal config instead of being pulled out

## Changes

* Fix this both in the resetting and parsing of the form

NOTE: I don't love this solution as we are clobbering the meta config and the plugin config together. We should probably long term split them out somehow...

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
