### PR TITLE
fix(capture): fail early if some events in batch are null

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -403,6 +403,14 @@ def get_event(request):
         else:
             events = [data]
 
+        if not all(data):  # Check that all items are truthy (not null, not empty dict)
+            return cors_response(
+                request,
+                generate_exception_response(
+                    "capture", f"Invalid payload: some events are null", code="invalid_payload"
+                ),
+            )
+
         try:
             events = drop_performance_events(events)
         except Exception as e:


### PR DESCRIPTION
## Problem

We receive invalid batches on the public `/capture` endpoint where some events of the array are `null`. The request gets a 400 eventually, but triggers several exceptions in its way there.

## Changes

- Check that all elements of the `data` array are truthy before moving forward with processing. Return a 400 otherwise.
- That does not guard us against an item being a string or a number, but it's an easy fix for the existing situation while waiting for the capture-rs switch.

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
