### PR TITLE
chore(data-warehouse): use date not datetime

### DIFF
--- a/posthog/warehouse/data_load/validate_schema.py
+++ b/posthog/warehouse/data_load/validate_schema.py
@@ -5,6 +5,7 @@ from dlt.common.data_types.typing import TDataType
 from posthog.hogql.database.models import (
     BooleanDatabaseField,
     DatabaseField,
+    DateDatabaseField,
     DateTimeDatabaseField,
     IntegerDatabaseField,
     StringDatabaseField,
@@ -57,7 +58,7 @@ def dlt_to_hogql_type(dlt_type: TDataType | None) -> str:
     elif dlt_type == "wei":
         raise Exception("DLT type 'wei' is not a supported column type")
     elif dlt_type == "date":
-        hogql_type = DateTimeDatabaseField
+        hogql_type = DateDatabaseField
     elif dlt_type == "time":
         hogql_type = DateTimeDatabaseField
     else:


### PR DESCRIPTION
## Problem

- date types error because they aren't datetime in clickhouse

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- use date

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
