### PR TITLE
test(decorators): fix decorator tests

### DIFF
--- a/posthog/test/test_decorators.py
+++ b/posthog/test/test_decorators.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from freezegun import freeze_time
-import pytest
 from posthog.decorators import cached_by_filters, is_stale_filter
 
 from django.core.cache import cache
@@ -26,7 +25,6 @@ class DummyViewSet(GenericViewSet):
         return {"result": "bla"}
 
 
-@pytest.mark.skip(reason="This test is failing on CI, not locally, and idk why")
 class TestCachedByFiltersDecorator(APIBaseTest):
     def setUp(self) -> None:
         cache.clear()

--- a/posthog/test/test_decorators.py
+++ b/posthog/test/test_decorators.py
@@ -25,13 +25,14 @@ class DummyViewSet(GenericViewSet):
         return {"result": "bla"}
 
 
+router.register(r"dummy", DummyViewSet, "dummy")
+
+
 class TestCachedByFiltersDecorator(APIBaseTest):
     maxDiff = None
 
     def setUp(self) -> None:
         cache.clear()
-
-        router.register(r"dummy", DummyViewSet, "dummy")
 
         super().setUp()
 

--- a/posthog/test/test_decorators.py
+++ b/posthog/test/test_decorators.py
@@ -26,6 +26,8 @@ class DummyViewSet(GenericViewSet):
 
 
 class TestCachedByFiltersDecorator(APIBaseTest):
+    maxDiff = None
+
     def setUp(self) -> None:
         cache.clear()
 
@@ -36,6 +38,7 @@ class TestCachedByFiltersDecorator(APIBaseTest):
     def test_returns_fresh_result(self) -> None:
         response = self.client.get(f"/api/dummy").json()
 
+        assert response is {}
         assert response["result"] == "bla"
         assert response["is_cached"] is False
         assert isinstance(response["last_refresh"], str)

--- a/posthog/test/test_decorators.py
+++ b/posthog/test/test_decorators.py
@@ -29,8 +29,6 @@ router.register(r"dummy", DummyViewSet, "dummy")
 
 
 class TestCachedByFiltersDecorator(APIBaseTest):
-    maxDiff = None
-
     def setUp(self) -> None:
         cache.clear()
 
@@ -39,7 +37,6 @@ class TestCachedByFiltersDecorator(APIBaseTest):
     def test_returns_fresh_result(self) -> None:
         response = self.client.get(f"/api/dummy").json()
 
-        assert response is {}
         assert response["result"] == "bla"
         assert response["is_cached"] is False
         assert isinstance(response["last_refresh"], str)


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C0368RPHLQH/p1713444704666819

## Changes

Fixes load order by moving the register call up.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

CI run