### PR TITLE
chore(batch-exports): add ability to override timestamp lookback per …

### DIFF
--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -1,6 +1,6 @@
 # serializer version: 1
 # name: TestDatabase.test_database_warehouse_joins_persons_poe_v2
-  'SELECT events__some_field.key AS key FROM events LEFT JOIN (SELECT groups.key AS key, key AS events__some_field___key FROM (SELECT groups.group_type_index AS index, groups.group_key AS key FROM groups WHERE equals(groups.team_id, 217) GROUP BY groups.group_type_index, groups.group_key) AS groups) AS events__some_field ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, %(hogql_val_0)s), \'\'), \'null\'), \'^"|"$\', \'\'), events__some_field.events__some_field___key) WHERE equals(events.team_id, 217) LIMIT 10000'
+  'SELECT events__some_field.key AS key FROM events LEFT JOIN (SELECT groups.key AS key, key AS events__some_field___key FROM (SELECT groups.group_type_index AS index, groups.group_key AS key FROM groups WHERE equals(groups.team_id, 219) GROUP BY groups.group_type_index, groups.group_key) AS groups) AS events__some_field ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, %(hogql_val_0)s), \'\'), \'null\'), \'^"|"$\', \'\'), events__some_field.events__some_field___key) WHERE equals(events.team_id, 219) LIMIT 10000'
 # ---
 # name: TestDatabase.test_serialize_database_no_person_on_events
   '''

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -19,6 +19,11 @@ BATCH_EXPORT_HTTP_UPLOAD_CHUNK_SIZE_BYTES = 1024 * 1024 * 10  # 10MB
 BATCH_EXPORT_HTTP_BATCH_SIZE = 1000
 
 UNCONSTRAINED_TIMESTAMP_TEAM_IDS = get_list(os.getenv("UNCONSTRAINED_TIMESTAMP_TEAM_IDS", ""))
+DEFAULT_TIMESTAMP_LOOKBACK_DAYS = 4
+# Comma separated list of overrides in the format "team_id:lookback_days"
+OVERRIDE_TIMESTAMP_TEAM_IDS: dict[int, int] = dict(
+    [map(int, o.split(":")) for o in os.getenv("OVERRIDE_TIMESTAMP_TEAM_IDS", "").split(",") if o]  # type: ignore
+)
 
 CLICKHOUSE_MAX_EXECUTION_TIME = get_from_env("CLICKHOUSE_MAX_EXECUTION_TIME", 0, type_cast=int)
 CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT = get_from_env("CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT", 10000, type_cast=int)

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -48,13 +48,22 @@ SELECT_QUERY_TEMPLATE = Template(
     """
 )
 
-TIMESTAMP_PREDICATES = """
+TIMESTAMP_PREDICATES = Template("""
 -- These 'timestamp' checks are a heuristic to exploit the sort key.
 -- Ideally, we need a schema that serves our needs, i.e. with a sort key on the _timestamp field used for batch exports.
 -- As a side-effect, this heuristic will discard historical loads older than a day.
-AND timestamp >= toDateTime64({data_interval_start}, 6, 'UTC') - INTERVAL 4 DAY
+AND timestamp >= toDateTime64({data_interval_start}, 6, 'UTC') - INTERVAL $lookback_days DAY
 AND timestamp < toDateTime64({data_interval_end}, 6, 'UTC') + INTERVAL 1 DAY
-"""
+""")
+
+
+def get_timestamp_predicates_for_team(team_id: int) -> str:
+    if str(team_id) in settings.UNCONSTRAINED_TIMESTAMP_TEAM_IDS:
+        return ""
+    else:
+        return TIMESTAMP_PREDICATES.substitute(
+            lookback_days=settings.OVERRIDE_TIMESTAMP_TEAM_IDS.get(team_id, settings.DEFAULT_TIMESTAMP_LOOKBACK_DAYS),
+        )
 
 
 async def get_rows_count(
@@ -83,9 +92,7 @@ async def get_rows_count(
         include_events_statement = ""
         events_to_include_tuple = ()
 
-    timestamp_predicates = TIMESTAMP_PREDICATES
-    if str(team_id) in settings.UNCONSTRAINED_TIMESTAMP_TEAM_IDS:
-        timestamp_predicates = ""
+    timestamp_predicates = get_timestamp_predicates_for_team(team_id)
 
     query = SELECT_QUERY_TEMPLATE.substitute(
         fields="count(DISTINCT event, cityHash64(distinct_id), cityHash64(uuid)) as count",
@@ -184,9 +191,7 @@ def iter_records(
         include_events_statement = ""
         events_to_include_tuple = ()
 
-    timestamp_predicates = TIMESTAMP_PREDICATES
-    if str(team_id) in settings.UNCONSTRAINED_TIMESTAMP_TEAM_IDS:
-        timestamp_predicates = ""
+    timestamp_predicates = timestamp_predicates = get_timestamp_predicates_for_team(team_id)
 
     if fields is None:
         query_fields = ",".join(f"{field['expression']} AS {field['alias']}" for field in default_fields())


### PR DESCRIPTION
…team

## Problem

We have customers too large to fix in `UNCONSTRAINED_TIMESTAMP_TEAM_IDS` but for whom the default of `4 is too small.
<!-- Who are we building for, what are their needs, why is this important? -->


## Changes

Add override setting.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Existing
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
