### PR TITLE
feat: explain redaction

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemPerformanceEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemPerformanceEvent.tsx
@@ -359,7 +359,7 @@ export function BodyDisplay({
                     to="https://posthog.com/docs/session-replay/network-recording?utm_medium=in-product"
                     target="_blank"
                 >
-                    Learn how to provide your own redaction code.
+                    Learn how to override PostHog's automatic redaction code.
                 </Link>
             </p>
             <pre>received: {displayContent}</pre>

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemPerformanceEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemPerformanceEvent.tsx
@@ -1,4 +1,4 @@
-import { LemonButton, LemonDivider, LemonTabs, LemonTag, LemonTagType } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonTabs, LemonTag, LemonTagType, Link } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { Dayjs, dayjs } from 'lib/dayjs'
@@ -342,12 +342,29 @@ export function BodyDisplay({
     let displayContent = content
     if (typeof displayContent !== 'string') {
         displayContent = JSON.stringify(displayContent, null, 2)
+    } else if (displayContent.trim() === '') {
+        displayContent = '(empty string)'
     }
     if (headerContentType === 'application/json') {
         language = Language.JSON
     }
 
-    return (
+    const isAutoRedaction = /(\[SessionRecording\].*redacted)/.test(displayContent)
+
+    return isAutoRedaction ? (
+        <>
+            <p>
+                This content was redacted by PostHog to protect sensitive data.{' '}
+                <Link
+                    to="https://posthog.com/docs/session-replay/network-recording?utm_medium=in-product"
+                    target="_blank"
+                >
+                    Learn how to provide your own redaction code.
+                </Link>
+            </p>
+            <pre>received: {displayContent}</pre>
+        </>
+    ) : (
         <CodeSnippet language={language} wrap={true} thing="request body" compact={false}>
             {displayContent}
         </CodeSnippet>


### PR DESCRIPTION
While watching recordings of watching recordings (oooh meta) I noticed folk hovering over the "Redacted content" notices that posthog-js places when it does its auto-redaction. My guess is they were confused and having to parse the meaning and we didn't do anything to help them

This adds a clearer message and a pointer to the docs. 

And fly-by provides better display when the payload content is literally an empty string - because right now we display nothing 🙈 

<img width="429" alt="Screenshot 2024-05-06 at 19 53 01" src="https://github.com/PostHog/posthog/assets/984817/c3b2b076-a028-48be-a647-46fde3f19f99">
<img width="420" alt="Screenshot 2024-05-06 at 19 53 18" src="https://github.com/PostHog/posthog/assets/984817/3ff9b8e5-ae6e-4eb3-8004-10bfa5d469e3">
