### PR TITLE
chore: split Persons using deterministic uuid

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -717,6 +717,12 @@ export class DB {
         update: Partial<InternalPerson>,
         tx?: TransactionClient
     ): Promise<[InternalPerson, ProducerRecord[]]> {
+        let versionString = 'COALESCE(version, 0)::numeric + 1'
+        if (update.version) {
+            versionString = update.version.toString()
+            delete update['version']
+        }
+
         const updateValues = Object.values(unparsePersonPartial(update))
 
         // short circuit if there are no updates to be made
@@ -727,11 +733,9 @@ export class DB {
         const values = [...updateValues, person.id].map(sanitizeJsonbValue)
 
         // Potentially overriding values badly if there was an update to the person after computing updateValues above
-        const queryString = `UPDATE posthog_person SET version = COALESCE(version, 0)::numeric + 1, ${Object.keys(
-            update
-        ).map((field, index) => `"${sanitizeSqlIdentifier(field)}" = $${index + 1}`)} WHERE id = $${
-            Object.values(update).length + 1
-        }
+        const queryString = `UPDATE posthog_person SET version = ${versionString}, ${Object.keys(update).map(
+            (field, index) => `"${sanitizeSqlIdentifier(field)}" = $${index + 1}`
+        )} WHERE id = $${Object.values(update).length + 1}
         RETURNING *`
 
         const { rows } = await this.postgres.query<RawPerson>(

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -2207,7 +2207,10 @@ describe('PersonState.update()', () => {
                         // then pros can be dropped, see https://docs.google.com/presentation/d/1Osz7r8bKkDD5yFzw0cCtsGVf1LTEifXS-dzuwaS8JGY
                         // properties: { first: true, second: true, third: true },
                         created_at: timestamp,
-                        version: 1, // the test intends for it to be a chain, so must get v1, we get v2 if second->first and third->first, but we want it to be third->second->first
+                        // This is 2 because they all start with version 0, and then: x
+                        //  third -> second = max(third(0), second(0)) + 1 == version 1
+                        //  second -> first = max(second(1), first(0)) + 1 == version 2
+                        version: 2,
                         is_identified: true,
                     })
                 )
@@ -2296,7 +2299,10 @@ describe('PersonState.update()', () => {
                         uuid: firstUserUuid, // guaranteed to be merged into this based on timestamps
                         properties: { first: true, second: true, third: true },
                         created_at: timestamp,
-                        version: 1, // the test intends for it to be a chain, so must get v1, we get v2 if second->first and third->first, but we want it to be third->second->first
+                        // This is 2 because they all start with version 0, and then:
+                        //  third -> second = max(third(0), second(0)) + 1 == version 1
+                        //  second -> first = max(second(1), first(0)) + 1 == version 2
+                        version: 2,
                         is_identified: true,
                     })
                 )

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -6,6 +6,7 @@ from django.db.models import F, Q
 from posthog.models.utils import UUIDT
 
 from ..team import Team
+from .missing_person import uuidFromDistinctId
 
 MAX_LIMIT_DISTINCT_IDS = 2500
 
@@ -51,7 +52,9 @@ class Person(models.Model):
             self.add_distinct_id(distinct_id)
 
     def split_person(self, main_distinct_id: Optional[str], max_splits: Optional[int] = None):
-        distinct_ids = Person.objects.get(pk=self.pk).distinct_ids
+        original_person = Person.objects.get(pk=self.pk)
+        distinct_ids = original_person.distinct_ids
+        original_person_version = original_person.version or 0
         if not main_distinct_id:
             self.properties = {}
             self.save()
@@ -65,7 +68,13 @@ class Person(models.Model):
             if not distinct_id == main_distinct_id:
                 with transaction.atomic():
                     pdi = PersonDistinctId.objects.select_for_update().get(person=self, distinct_id=distinct_id)
-                    person = Person.objects.create(team_id=self.team_id)
+                    person, _ = Person.objects.get_or_create(
+                        uuid=uuidFromDistinctId(self.team_id, distinct_id),
+                        team_id=self.team_id,
+                        defaults={
+                            "version": original_person_version + 1,
+                        },
+                    )
                     pdi.person_id = str(person.id)
                     pdi.version = (pdi.version or 0) + 1
                     pdi.save(update_fields=["version", "person_id"])
@@ -83,9 +92,7 @@ class Person(models.Model):
                     version=pdi.version,
                 )
                 create_person(
-                    team_id=self.team_id,
-                    uuid=str(person.uuid),
-                    version=person.version or 0,
+                    team_id=self.team_id, uuid=str(person.uuid), version=person.version, created_at=person.created_at
                 )
 
     objects = PersonManager()


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
No problem, per say, but I discussed with @tiina303 and one benefit of using deterministic Person UUIDs is that we can split `distinct_id`s back out to their original Person UUID, and drop an override for them, and things should just work.

## Changes

Use the deterministic UUID for Person rows in `split_person`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Existing
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
