### PR TITLE
fix(batch-exports): add BadRequest to bigquery export non-retryable

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -440,6 +440,8 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
                 "RefreshError",
                 # Usually means the dataset or project doesn't exist.
                 "NotFound",
+                # Raised when something about dataset is wrong (not alphanumeric, too long, etc)
+                "BadRequest",
             ],
             finish_inputs=finish_inputs,
         )


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
These are coming up a lot, and should be non-retryable so we give up and email the customer: http://metabase-prod-us/question/505-most-recent-batchexport-failures-retryable-only

## Changes

Add to the ol' list.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->
Yes
## How did you test this code?
Existing
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
