### PR TITLE
fix(insights): persons modal keys

### DIFF
--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1240,6 +1240,15 @@ export interface InsightActorsQueryOptionsResponse {
         value: string
     }[]
 }
+export const insightActorsQueryOptionsResponseKeys: string[] = [
+    'day',
+    'status',
+    'interval',
+    'breakdown',
+    'series',
+    'compare',
+]
+
 export type CachedInsightActorsQueryOptionsResponse = InsightActorsQueryOptionsResponse & CachedQueryResponseMixin
 
 export interface InsightActorsQueryOptions extends Node<InsightActorsQueryOptionsResponse> {

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -19,6 +19,7 @@ import {
     InsightActorsQuery,
     InsightActorsQueryOptions,
     InsightActorsQueryOptionsResponse,
+    insightActorsQueryOptionsResponseKeys,
     NodeKind,
 } from '~/queries/schema'
 import {
@@ -181,7 +182,12 @@ export const personsModalLogic = kea<personsModalLogicType>([
                         source: query,
                     }
                     const response = await performQuery(optionsQuery)
-                    return response
+
+                    return Object.fromEntries(
+                        Object.entries(response).filter(([key, _]) =>
+                            insightActorsQueryOptionsResponseKeys.includes(key)
+                        )
+                    )
                 },
             },
         ],


### PR DESCRIPTION
## Problem

The `InsightActorsQueryOptions` query now also returns caching keys in its body, causing a pure `.map` to crash the app.

## Changes

Leave only the right keys.

## How did you test this code?

Locally the modal stopped crashing.