### PR TITLE
fix: duplicate performance events

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -444,7 +444,9 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 // but we decided to instead store them in the recording data
                 // we gather more info than rrweb, so we mix the two back together here
 
-                return filterUnwanted(matchNetworkEvents(sessionPlayerData.snapshotsByWindowId))
+                return deduplicatePerformanceEvents(
+                    filterUnwanted(matchNetworkEvents(sessionPlayerData.snapshotsByWindowId))
+                )
             },
         ],
 
@@ -975,4 +977,25 @@ function filterUnwanted(events: PerformanceEvent[]): PerformanceEvent[] {
     return events.filter((event) => {
         return !(event.entry_type === 'navigation' && event.name && event.name.startsWith('about:'))
     })
+}
+
+function deduplicatePerformanceEvents(events: PerformanceEvent[]): PerformanceEvent[] {
+    // we capture performance entries in the `isInitial` requests
+    // which are those captured before we've wrapped fetch
+    // since we're trying hard to avoid missing requests we sometimes capture the same request twice
+    // once isInitial and once is the actual fetch
+    // the actual fetch will have more data, so we can discard the isInitial
+    const seen = new Set<string>()
+    return events
+        .reverse()
+        .filter((event) => {
+            const key = `${event.entry_type}-${event.name}-${event.timestamp}-${event.window_id}`
+            // we only want to drop is_initial events
+            if (seen.has(key) && event.is_initial) {
+                return false
+            }
+            seen.add(key)
+            return true
+        })
+        .reverse()
 }


### PR DESCRIPTION
While I was playing with something else I was poking around in the captured data and realised there's a race in the network recorder startup

    // we capture performance entries in the `isInitial` requests
    // which are those captured before we've wrapped fetch
    // since we're trying hard to avoid missing requests we sometimes capture the same request twice
    // once isInitial and once is the actual fetch
    // the actual fetch will have more data, so we can discard the isInitial

so we deduplicate and drop any isInitial that already exists

|before|after|
|-|-|
|<img width="449" alt="Screenshot 2024-05-06 at 22 52 15" src="https://github.com/PostHog/posthog/assets/984817/af449e69-7a15-4a55-bcf1-95d289bd9817">|<img width="454" alt="Screenshot 2024-05-06 at 22 52 53" src="https://github.com/PostHog/posthog/assets/984817/7eaaef0c-a1a7-4c1c-a9c6-d1672393286c">|

