### PR TITLE
fix: Action step events typing

### DIFF
--- a/ee/clickhouse/queries/experiments/utils.py
+++ b/ee/clickhouse/queries/experiments/utils.py
@@ -26,7 +26,9 @@ def requires_flag_warning(filter: Filter, team: Team) -> bool:
     for entity in entities_to_use:
         if entity.type == TREND_FILTER_TYPE_ACTIONS:
             action = entity.get_action()
-            events.update(action.get_step_events())
+            for step_event in action.get_step_events():
+                if step_event:
+                    events.add(step_event)
         elif entity.id is not None:
             events.add(entity.id)
 

--- a/ee/clickhouse/queries/experiments/utils.py
+++ b/ee/clickhouse/queries/experiments/utils.py
@@ -28,6 +28,7 @@ def requires_flag_warning(filter: Filter, team: Team) -> bool:
             action = entity.get_action()
             for step_event in action.get_step_events():
                 if step_event:
+                    # TODO: Fix this to detect if "all events" (i.e. None) is in the list and change the entiry query to e.g. AND 1=1
                     events.add(step_event)
         elif entity.id is not None:
             events.add(entity.id)

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -580,7 +580,7 @@ class FunnelCorrelation:
         for entity in self._filter.entities:
             if entity.type == TREND_FILTER_TYPE_ACTIONS:
                 action = entity.get_action()
-                events.update(action.get_step_events())
+                events.update([x for x in action.get_step_events() if x])
             elif entity.id is not None:
                 events.add(entity.id)
 

--- a/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
@@ -831,7 +831,7 @@ class FunnelCorrelationQueryRunner(QueryRunner):
         for entity in self.funnels_query.series:
             if isinstance(entity, ActionsNode):
                 action = Action.objects.get(pk=int(entity.id), team=self.context.team)
-                events.update(action.get_step_events())
+                events.update([x for x in action.get_step_events() if x])
             elif isinstance(entity, EventsNode):
                 if entity.event is not None:
                     events.add(entity.event)

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -140,7 +140,7 @@ class FunnelEventQuery:
             elif isinstance(node, ActionsNode) or isinstance(node, FunnelExclusionActionsNode):
                 try:
                     action = Action.objects.get(pk=int(node.id), team=team)
-                    events.update(action.get_step_events())
+                    events.update([x for x in action.get_step_events() if x])
                 except Action.DoesNotExist:
                     raise ValidationError(f"Action ID {node.id} does not exist!")
             else:

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -140,7 +140,7 @@ class FunnelEventQuery:
             elif isinstance(node, ActionsNode) or isinstance(node, FunnelExclusionActionsNode):
                 try:
                     action = Action.objects.get(pk=int(node.id), team=team)
-                    events.update([x for x in action.get_step_events() if x])
+                    events.update(action.get_step_events())
                 except Action.DoesNotExist:
                     raise ValidationError(f"Action ID {node.id} does not exist!")
             else:

--- a/posthog/models/action/action.py
+++ b/posthog/models/action/action.py
@@ -1,6 +1,6 @@
 from dataclasses import asdict, dataclass
 import json
-from typing import Any, Literal, Optional, get_args
+from typing import Any, Literal, Optional, Union, get_args
 
 from django.db import models
 from django.db.models.signals import post_delete, post_save
@@ -97,9 +97,8 @@ class Action(models.Model):
         # TRICKY: This is a little tricky as DRF will deserialize this here as a dict but typing wise we would expect an ActionStepJSON
         self.steps_json = [asdict(ActionStepJSON(**step)) for step in value]
 
-    def get_step_events(self) -> list[str]:
-        # NOTE: This used to return [None] sometimes - was that on purpose...
-        return [action_step.event for action_step in self.steps if action_step.event]
+    def get_step_events(self) -> list[Union[str, None]]:
+        return [action_step.event for action_step in self.steps]
 
     def generate_bytecode(self) -> list[Any]:
         from posthog.hogql.property import action_to_expr

--- a/posthog/models/action/util.py
+++ b/posthog/models/action/util.py
@@ -25,7 +25,7 @@ def format_action_filter_event_only(
         # If selecting for "All events", disable entity pre-filtering
         return "1 = 1", {}
     entity_name = f"{prepend}_{action.pk}"
-    return f"event IN %({entity_name})s", {entity_name: sorted(events)}
+    return f"event IN %({entity_name})s", {entity_name: sorted([x for x in events if x])}
 
 
 def format_action_filter(

--- a/posthog/queries/funnels/funnel_event_query.py
+++ b/posthog/queries/funnels/funnel_event_query.py
@@ -160,4 +160,4 @@ class FunnelEventQuery(EventQuery):
         if None in events:
             return "AND 1 = 1", {}
 
-        return f"AND event IN %({entity_name})s", {entity_name: sorted(events)}
+        return f"AND event IN %({entity_name})s", {entity_name: sorted([x for x in events if x])}

--- a/posthog/session_recordings/queries/session_recording_list_from_filters.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_filters.py
@@ -259,7 +259,7 @@ class EventsSubQuery:
         for entity in self._filter.entities:
             if entity.type == TREND_FILTER_TYPE_ACTIONS:
                 action = entity.get_action()
-                event_names.update([ae for ae in action.get_step_events() if ae not in event_names])
+                event_names.update([ae for ae in action.get_step_events() if ae and ae not in event_names])
             else:
                 if entity.id and entity.id not in event_names:
                     event_names.add(entity.id)

--- a/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_replay_summary.py
@@ -389,7 +389,10 @@ class SessionIdEventsQuery(EventQuery):
         for index, entity in enumerate(self._filter.entities):
             if entity.type == TREND_FILTER_TYPE_ACTIONS:
                 action = entity.get_action()
-                event_names_to_filter.extend([ae for ae in action.get_step_events() if ae not in event_names_to_filter])
+                # NOTE: Do we need a short circuit here for "none" - i.e. all events?
+                event_names_to_filter.extend(
+                    [ae for ae in action.get_step_events() if ae and ae not in event_names_to_filter]
+                )
             else:
                 if entity.id and entity.id not in event_names_to_filter:
                     event_names_to_filter.append(entity.id)


### PR DESCRIPTION
## Problem

As part of [this change](https://github.com/PostHog/posthog/pull/22091/files/ce742c339cb615820c48e9448a756da616cda507#diff-0f1a26d852c8446510344f92cc852d497303cd0a131e4dc09e07e1e8ce0a895eR101) the types for a method are corrected to return action step events as `list[str, None]` instead of `list[str]` as they can be None if "all events" is selected.

## Changes

* Changes all the places it is used with my best judgement to fix their type issues - looking for reviews to check the assumptions are correct

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
