### PR TITLE
fix(hogql): fix hogql trends actors

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -303,11 +303,7 @@ posthog/hogql_queries/insights/trends/trends_query_runner.py:0: error: Signature
 posthog/hogql_queries/insights/trends/trends_query_runner.py:0: note: Superclass:
 posthog/hogql_queries/insights/trends/trends_query_runner.py:0: note: def to_actors_query(self) -> SelectQuery | SelectUnionQuery
 posthog/hogql_queries/insights/trends/trends_query_runner.py:0: note: Subclass:
-posthog/hogql_queries/insights/trends/trends_query_runner.py:0: note: def to_actors_query(self, time_frame: str | None, series_index: int, breakdown_value: str | int | None = ..., compare: Compare | None = ...) -> SelectQuery | SelectUnionQuery
-posthog/hogql_queries/insights/trends/trends_query_runner.py:0: note: Superclass:
-posthog/hogql_queries/insights/trends/trends_query_runner.py:0: note: def to_actors_query(self) -> SelectQuery | SelectUnionQuery
-posthog/hogql_queries/insights/trends/trends_query_runner.py:0: note: Subclass:
-posthog/hogql_queries/insights/trends/trends_query_runner.py:0: note: def to_actors_query(self, time_frame: str | None, series_index: int, breakdown_value: str | int | None = ..., compare: Compare | None = ...) -> SelectQuery | SelectUnionQuery
+posthog/hogql_queries/insights/trends/trends_query_runner.py:0: note: def to_actors_query(self, time_frame: str | None, series_index: int, breakdown_value: str | int | None = ..., compare_value: Compare | None = ...) -> SelectQuery | SelectUnionQuery
 posthog/hogql_queries/insights/trends/trends_query_runner.py:0: error: Statement is unreachable  [unreachable]
 posthog/hogql_queries/insights/trends/trends_query_runner.py:0: error: Argument 1 to "_event_property" of "TrendsQueryRunner" has incompatible type "str | float | list[str | float] | None"; expected "str"  [arg-type]
 posthog/hogql_queries/insights/retention_query_runner.py:0: error: Incompatible types in assignment (expression has type "Expr", variable has type "Call")  [assignment]

--- a/posthog/hogql_queries/insights/insight_actors_query_runner.py
+++ b/posthog/hogql_queries/insights/insight_actors_query_runner.py
@@ -41,7 +41,7 @@ class InsightActorsQueryRunner(QueryRunner):
                 time_frame=cast(Optional[str], query.day),  # Other runner accept day as int, but not this one
                 series_index=query.series or 0,
                 breakdown_value=query.breakdown,
-                compare=query.compare,
+                compare_value=query.compare,
             )
         elif isinstance(self.source_runner, FunnelsQueryRunner):
             funnels_runner = cast(FunnelsQueryRunner, self.source_runner)

--- a/posthog/hogql_queries/insights/trends/aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/aggregation_operations.py
@@ -143,6 +143,9 @@ class AggregationOperations(DataWarehouseInsightQueryMixin):
             "p99_count_per_actor",
         ]
 
+    def is_active_users_math(self):
+        return self.series.math in ["weekly_active", "monthly_active"]
+
     def _math_func(self, method: str, override_chain: Optional[list[str | int]]) -> ast.Call:
         if override_chain is not None:
             return ast.Call(name=method, args=[ast.Field(chain=override_chain)])

--- a/posthog/hogql_queries/insights/trends/breakdown_values.py
+++ b/posthog/hogql_queries/insights/trends/breakdown_values.py
@@ -272,5 +272,5 @@ class BreakdownValues:
             self.series,
             self.chart_display_type,
             self.query_date_range,
-            should_aggregate_values=True,  # doesn't matter in this case
+            is_total_value=True,  # doesn't matter in this case
         )

--- a/posthog/hogql_queries/insights/trends/display.py
+++ b/posthog/hogql_queries/insights/trends/display.py
@@ -13,7 +13,7 @@ class TrendsDisplay:
             self.display_type = ChartDisplayType.ActionsAreaGraph
 
     # No time range
-    def should_aggregate_values(self) -> bool:
+    def is_total_value(self) -> bool:
         return (
             self.display_type == ChartDisplayType.BoldNumber
             or self.display_type == ChartDisplayType.ActionsPie
@@ -51,7 +51,7 @@ class TrendsDisplay:
     def modify_outer_query(
         self, outer_query: ast.SelectQuery, inner_query: ast.SelectQuery, dates_queries: ast.SelectUnionQuery
     ) -> ast.SelectQuery:
-        if not self.should_aggregate_values():
+        if not self.is_total_value():
             return outer_query
 
         return ast.SelectQuery(

--- a/posthog/hogql_queries/insights/trends/display.py
+++ b/posthog/hogql_queries/insights/trends/display.py
@@ -10,7 +10,7 @@ class TrendsDisplay:
         if display_type:
             self.display_type = display_type
         else:
-            self.display_type = ChartDisplayType.ActionsAreaGraph
+            self.display_type = ChartDisplayType.ActionsLineGraph
 
     # No time range
     def is_total_value(self) -> bool:

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -283,7 +283,7 @@
                e.uuid AS uuid,
                e.`$session_id` AS `$session_id`,
                e.`$window_id` AS `$window_id`
-        FROM events AS e SAMPLE 1
+        FROM events AS e
         LEFT JOIN
           (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), groups._timestamp) AS properties___industry,
                   groups.group_type_index AS index,
@@ -292,7 +292,7 @@
            WHERE and(equals(groups.team_id, 2), ifNull(equals(index, 0), 0))
            GROUP BY groups.group_type_index,
                     groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-        WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-02 00:00:00.000000', 6, 'UTC')), less(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-03 00:00:00.000000', 6, 'UTC')), equals(e.event, 'sign up'), ifNull(equals(toString(e__group_0.properties___industry), 'technology'), 0)))
+        WHERE and(equals(e.team_id, 2), equals(e.event, 'sign up'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-02 00:00:00.000000', 6, 'UTC')), less(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-03 00:00:00.000000', 6, 'UTC')), ifNull(equals(toString(e__group_0.properties___industry), 'technology'), 0)))
      GROUP BY actor_id) AS source
   INNER JOIN
     (SELECT argMax(person.created_at, person.version) AS created_at,
@@ -1338,7 +1338,7 @@
                e.uuid AS uuid,
                e.`$session_id` AS `$session_id`,
                e.`$window_id` AS `$window_id`
-        FROM events AS e SAMPLE 1
+        FROM events AS e
         LEFT JOIN
           (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), groups._timestamp) AS properties___name,
                   groups.group_type_index AS index,
@@ -1355,7 +1355,7 @@
            WHERE and(equals(groups.team_id, 2), ifNull(equals(index, 0), 0))
            GROUP BY groups.group_type_index,
                     groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-        WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-02 00:00:00.000000', 6, 'UTC')), less(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-03 00:00:00.000000', 6, 'UTC')), equals(e.event, 'sign up'), and(ifNull(equals(e__group_0.properties___industry, 'finance'), 0), ifNull(equals(e__group_2.properties___name, 'six'), 0))))
+        WHERE and(equals(e.team_id, 2), equals(e.event, 'sign up'), and(ifNull(equals(e__group_0.properties___industry, 'finance'), 0), ifNull(equals(e__group_2.properties___name, 'six'), 0)), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-02 00:00:00.000000', 6, 'UTC')), less(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-03 00:00:00.000000', 6, 'UTC'))))
      GROUP BY actor_id) AS source
   INNER JOIN
     (SELECT argMax(person.created_at, person.version) AS created_at,

--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -91,7 +91,6 @@ class TestTrendsActorsQueryBuilder(BaseTest):
         self.team.timezone = "Europe/Berlin"
         trends_query = default_query.model_copy(update={"trendsFilter": TrendsFilter(compare=True)}, deep=True)
 
-        # daily interval
         self.assertEqual(
             self._get_date_where_sql(trends_query=trends_query, time_frame="2023-05-08", compare_value=Compare.current),
             "greaterOrEquals(timestamp, toDateTime('2023-05-07 22:00:00.000000')), less(timestamp, toDateTime('2023-05-08 22:00:00.000000'))",
@@ -103,23 +102,23 @@ class TestTrendsActorsQueryBuilder(BaseTest):
             "greaterOrEquals(timestamp, toDateTime('2023-04-30 22:00:00.000000')), less(timestamp, toDateTime('2023-05-01 22:00:00.000000'))",
         )
 
-        # TODO
-        # # hourly interval
-        # trends_query = default_query.model_copy(
-        #     update={"trendsFilter": TrendsFilter(compare=True), "interval": IntervalType.hour}, deep=True
-        # )
-        # self.assertEqual(
-        #     self._get_date_where_sql(
-        #         trends_query=trends_query, time_frame="2023-05-08T15:00:00", compare_value=Compare.current
-        #     ),
-        #     "greaterOrEquals(timestamp, toDateTime('2023-05-08 13:00:00.000000')), less(timestamp, toDateTime('2023-05-08 14:00:00.000000'))",
-        # )
-        # self.assertEqual(
-        #     self._get_date_where_sql(
-        #         trends_query=trends_query, time_frame="2023-05-08T15:00:00", compare_value=Compare.previous
-        #     ),
-        #     "greaterOrEquals(timestamp, toDateTime('2023-04-30 13:00:00.000000')), less(timestamp, toDateTime('2023-04-30 14:00:00.000000'))",
-        # )
+    def test_date_range_compare_previous_hourly(self):
+        self.team.timezone = "Europe/Berlin"
+        trends_query = default_query.model_copy(
+            update={"trendsFilter": TrendsFilter(compare=True), "interval": IntervalType.hour}, deep=True
+        )
+        self.assertEqual(
+            self._get_date_where_sql(
+                trends_query=trends_query, time_frame="2023-05-08T15:00:00", compare_value=Compare.current
+            ),
+            "greaterOrEquals(timestamp, toDateTime('2023-05-08 13:00:00.000000')), less(timestamp, toDateTime('2023-05-08 14:00:00.000000'))",
+        )
+        self.assertEqual(
+            self._get_date_where_sql(
+                trends_query=trends_query, time_frame="2023-05-08T15:00:00", compare_value=Compare.previous
+            ),
+            "greaterOrEquals(timestamp, toDateTime('2023-04-30 13:00:00.000000')), less(timestamp, toDateTime('2023-04-30 14:00:00.000000'))",
+        )
 
     def test_date_range_total_value(self):
         self.team.timezone = "Europe/Berlin"

--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -184,6 +184,22 @@ class TestTrendsActorsQueryBuilder(BaseTest):
                 "greaterOrEquals(timestamp, minus(toDateTime('2024-05-19 22:00:00.000000'), toIntervalDay(6))), less(timestamp, toDateTime('2024-05-20 22:00:00.000000'))",
             )
 
+    def test_date_range_weekly_active_users_math_total_value(self):
+        self.team.timezone = "Europe/Berlin"
+        trends_query = default_query.model_copy(
+            update={
+                "series": [EventsNode(event="$pageview", math=BaseMathType.weekly_active)],
+                "trendsFilter": TrendsFilter(display=ChartDisplayType.BoldNumber),
+            },
+            deep=True,
+        )
+
+        with freeze_time("2024-05-30T12:00:00.000Z"):
+            self.assertEqual(
+                self._get_date_where_sql(trends_query=trends_query),
+                "greaterOrEquals(timestamp, minus(toDateTime('2024-05-30 21:59:59.999999'), toIntervalDay(6))), lessOrEquals(timestamp, toDateTime('2024-05-30 21:59:59.999999'))",
+            )
+
     def test_date_range_monthly_active_users_math(self):
         self.team.timezone = "Europe/Berlin"
         trends_query = default_query.model_copy(

--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -121,11 +121,3 @@ class TestQueryBuilder(BaseTest):
                 self._get_date_where_sql(trends_query=trends_query),
                 "greaterOrEquals(timestamp, toDateTime('2022-06-07 22:00:00.000000')), lessOrEquals(timestamp, toDateTime('2022-06-15 21:59:59.999999'))",
             )
-
-    # def test_date_range_total_value_compare_previous(self)
-
-
-# wau
-# mau
-# count actor
-# explicit for ...

--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -132,6 +132,22 @@ class TestTrendsActorsQueryBuilder(BaseTest):
                 "greaterOrEquals(timestamp, toDateTime('2022-06-07 22:00:00.000000')), lessOrEquals(timestamp, toDateTime('2022-06-15 21:59:59.999999'))",
             )
 
+    def test_date_range_total_value_compare_previous(self):
+        self.team.timezone = "Europe/Berlin"
+        trends_query = default_query.model_copy(
+            update={"trendsFilter": TrendsFilter(display=ChartDisplayType.BoldNumber, compare=True)}, deep=True
+        )
+
+        with freeze_time("2022-06-15T12:00:00.000Z"):
+            self.assertEqual(
+                self._get_date_where_sql(trends_query=trends_query, compare_value=Compare.current),
+                "greaterOrEquals(timestamp, toDateTime('2022-06-07 22:00:00.000000')), lessOrEquals(timestamp, toDateTime('2022-06-15 21:59:59.999999'))",
+            )
+            self.assertEqual(
+                self._get_date_where_sql(trends_query=trends_query, compare_value=Compare.previous),
+                "greaterOrEquals(timestamp, toDateTime('2022-05-31 22:00:00.000000')), lessOrEquals(timestamp, toDateTime('2022-06-08 21:59:59.999999'))",
+            )
+
     def test_date_range_weekly_active_users_math(self):
         self.team.timezone = "Europe/Berlin"
         trends_query = default_query.model_copy(

--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -154,3 +154,45 @@ class TestTrendsActorsQueryBuilder(BaseTest):
                 self._get_date_where_sql(trends_query=trends_query, time_frame="2024-05-27"),
                 "greaterOrEquals(timestamp, minus(toDateTime('2024-05-26 22:00:00.000000'), toIntervalDay(29))), less(timestamp, toDateTime('2024-05-27 22:00:00.000000'))",
             )
+
+    def test_date_range_explicit_dates(self):
+        self.team.timezone = "Europe/Berlin"
+
+        trends_query = default_query.model_copy(
+            update={"dateRange": DateRange(date_from="2024-05-08T14:29:13.634000Z", date_to=None, explicitDate=True)},
+            deep=True,
+        )
+        with freeze_time("2024-05-08T15:32:00.000Z"):
+            self.assertEqual(
+                self._get_date_where_sql(trends_query=trends_query, time_frame="2024-05-08"),
+                "greaterOrEquals(timestamp, toDateTime('2024-05-08 14:29:13.634000')), lessOrEquals(timestamp, toDateTime('2024-05-08 15:32:00.000000'))",
+            )
+
+        trends_query = default_query.model_copy(
+            update={
+                "dateRange": DateRange(
+                    date_from="2024-05-08T14:29:13.634000Z", date_to="2024-05-08T14:32:57.692000Z", explicitDate=True
+                )
+            },
+            deep=True,
+        )
+        with freeze_time("2024-05-08T15:32:00.000Z"):
+            self.assertEqual(
+                self._get_date_where_sql(trends_query=trends_query, time_frame="2024-05-08"),
+                "greaterOrEquals(timestamp, toDateTime('2024-05-08 14:29:13.634000')), lessOrEquals(timestamp, toDateTime('2024-05-08 14:32:57.692000'))",
+            )
+
+        trends_query = default_query.model_copy(
+            update={
+                "series": [EventsNode(event="$pageview", math=BaseMathType.monthly_active)],
+                "dateRange": DateRange(
+                    date_from="2024-05-08T14:29:13.634000Z", date_to="2024-05-08T14:32:57.692000Z", explicitDate=True
+                ),
+            },
+            deep=True,
+        )
+        with freeze_time("2024-05-08T15:32:00.000Z"):
+            self.assertEqual(
+                self._get_date_where_sql(trends_query=trends_query, time_frame="2024-05-08"),
+                "greaterOrEquals(timestamp, toDateTime('2024-05-08 14:29:13.634000')), lessOrEquals(timestamp, toDateTime('2024-05-08 14:32:57.692000'))",
+            )

--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -23,7 +23,7 @@ from posthog.test.base import BaseTest
 default_query = TrendsQuery(series=[EventsNode(event="$pageview")], dateRange=DateRange(date_from="-7d"))
 
 
-class TestQueryBuilder(BaseTest):
+class TestTrendsActorsQueryBuilder(BaseTest):
     def setUp(self):
         super().setUp()
 

--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -1,0 +1,52 @@
+from typing import cast
+from hogql_parser import parse_select
+from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.modifiers import create_default_modifiers_for_team
+from posthog.hogql.printer import print_ast
+from posthog.hogql.timings import HogQLTimings
+from posthog.hogql_queries.insights.trends.trends_actors_query_builder import TrendsActorsQueryBuilder
+from posthog.schema import DateRange, EventsNode, TrendsQuery
+from posthog.test.base import BaseTest
+
+default_query = TrendsQuery(series=[EventsNode(event="$pageview")], dateRange=DateRange(date_from="-7d"))
+
+
+class TestQueryBuilder(BaseTest):
+    def setUp(self):
+        super().setUp()
+
+    def _get_builder(
+        self, time_frame: str, series_index: int = 0, trends_query: TrendsQuery = default_query
+    ) -> TrendsActorsQueryBuilder:
+        timings = HogQLTimings()
+        modifiers = create_default_modifiers_for_team(self.team)
+
+        return TrendsActorsQueryBuilder(
+            trends_query=trends_query,
+            team=self.team,
+            timings=timings,
+            modifiers=modifiers,
+            series_index=series_index,
+            time_frame=time_frame,
+        )
+
+    def _print_hogql_expr(self, conditions: list[ast.Expr]):
+        query = cast(ast.SelectQuery, parse_select("SELECT * FROM events"))
+        query.where = ast.And(exprs=conditions)
+        sql = print_ast(
+            query,
+            HogQLContext(team_id=self.team.pk, enable_select_queries=True),
+            "hogql",
+        )
+        return sql[sql.find("WHERE and(") + 10 : sql.find(") LIMIT 10000")]
+
+    def test_date_range(self):
+        builder = self._get_builder(time_frame="2024-03-03")
+
+        date_expr = builder._date_where_expr()
+
+        self.assertEqual(
+            self._print_hogql_expr(date_expr),
+            "greaterOrEquals(timestamp, toDateTime('2024-03-03 00:00:00.000000')), less(timestamp, toDateTime('2024-03-04 00:00:00.000000'))",
+        )

--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 from hogql_parser import parse_select
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
@@ -6,7 +6,7 @@ from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.printer import print_ast
 from posthog.hogql.timings import HogQLTimings
 from posthog.hogql_queries.insights.trends.trends_actors_query_builder import TrendsActorsQueryBuilder
-from posthog.schema import DateRange, EventsNode, IntervalType, TrendsQuery
+from posthog.schema import Compare, DateRange, EventsNode, IntervalType, TrendsFilter, TrendsQuery
 from posthog.test.base import BaseTest
 
 default_query = TrendsQuery(series=[EventsNode(event="$pageview")], dateRange=DateRange(date_from="-7d"))
@@ -17,7 +17,11 @@ class TestQueryBuilder(BaseTest):
         super().setUp()
 
     def _get_builder(
-        self, time_frame: str, series_index: int = 0, trends_query: TrendsQuery = default_query
+        self,
+        time_frame: str,
+        series_index: int = 0,
+        trends_query: TrendsQuery = default_query,
+        compare_value: Optional[Compare] = None,
     ) -> TrendsActorsQueryBuilder:
         timings = HogQLTimings()
         modifiers = create_default_modifiers_for_team(self.team)
@@ -29,6 +33,7 @@ class TestQueryBuilder(BaseTest):
             modifiers=modifiers,
             series_index=series_index,
             time_frame=time_frame,
+            compare_value=compare_value,
         )
 
     def _print_hogql_expr(self, conditions: list[ast.Expr]):
@@ -41,35 +46,68 @@ class TestQueryBuilder(BaseTest):
         )
         return sql[sql.find("WHERE and(") + 10 : sql.find(") LIMIT 10000")]
 
-    def test_date_range(self):
-        builder = self._get_builder(time_frame="2023-05-08")
-
+    def _get_date_where_sql(self, **kwargs):
+        builder = self._get_builder(**kwargs)
         date_expr = builder._date_where_expr()
+        return self._print_hogql_expr(date_expr)
 
+    def test_date_range(self):
         self.assertEqual(
-            self._print_hogql_expr(date_expr),
-            "greaterOrEquals(timestamp, toDateTime('2023-05-08 00:00:00.000000')), less(timestamp, toDateTime('2024-05-08 00:00:00.000000'))",
+            self._get_date_where_sql(time_frame="2023-05-08"),
+            "greaterOrEquals(timestamp, toDateTime('2023-05-08 00:00:00.000000')), less(timestamp, toDateTime('2023-05-09 00:00:00.000000'))",
         )
 
     def test_date_range_with_timezone(self):
         self.team.timezone = "Europe/Berlin"
-        builder = self._get_builder(time_frame="2023-05-08")
-
-        date_expr = builder._date_where_expr()
 
         self.assertEqual(
-            self._print_hogql_expr(date_expr),
+            self._get_date_where_sql(time_frame="2023-05-08"),
             "greaterOrEquals(timestamp, toDateTime('2023-05-07 22:00:00.000000')), less(timestamp, toDateTime('2023-05-08 22:00:00.000000'))",
         )
 
     def test_date_range_hourly(self):
         self.team.timezone = "Europe/Berlin"
         trends_query = default_query.model_copy(update={"interval": IntervalType.hour}, deep=True)
-        builder = self._get_builder(trends_query=trends_query, time_frame="2023-05-08T15:00:00")
-
-        date_expr = builder._date_where_expr()
 
         self.assertEqual(
-            self._print_hogql_expr(date_expr),
+            self._get_date_where_sql(trends_query=trends_query, time_frame="2023-05-08T15:00:00"),
             "greaterOrEquals(timestamp, toDateTime('2023-05-08 13:00:00.000000')), less(timestamp, toDateTime('2023-05-08 14:00:00.000000'))",
         )
+
+    def test_date_range_compare_previous(self):
+        self.team.timezone = "Europe/Berlin"
+        trends_query = default_query.model_copy(update={"trendsFilter": TrendsFilter(compare=True)}, deep=True)
+
+        # daily interval
+        self.assertEqual(
+            self._get_date_where_sql(trends_query=trends_query, time_frame="2023-05-08", compare_value=Compare.current),
+            "greaterOrEquals(timestamp, toDateTime('2023-05-07 22:00:00.000000')), less(timestamp, toDateTime('2023-05-08 22:00:00.000000'))",
+        )
+        self.assertEqual(
+            self._get_date_where_sql(
+                trends_query=trends_query, time_frame="2023-05-08", compare_value=Compare.previous
+            ),
+            "greaterOrEquals(timestamp, toDateTime('2023-04-30 22:00:00.000000')), less(timestamp, toDateTime('2023-05-01 22:00:00.000000'))",
+        )
+
+        # TODO
+        # # hourly interval
+        # trends_query = default_query.model_copy(
+        #     update={"trendsFilter": TrendsFilter(compare=True), "interval": IntervalType.hour}, deep=True
+        # )
+        # self.assertEqual(
+        #     self._get_date_where_sql(
+        #         trends_query=trends_query, time_frame="2023-05-08T15:00:00", compare_value=Compare.current
+        #     ),
+        #     "greaterOrEquals(timestamp, toDateTime('2023-05-08 13:00:00.000000')), less(timestamp, toDateTime('2023-05-08 14:00:00.000000'))",
+        # )
+        # self.assertEqual(
+        #     self._get_date_where_sql(
+        #         trends_query=trends_query, time_frame="2023-05-08T15:00:00", compare_value=Compare.previous
+        #     ),
+        #     "greaterOrEquals(timestamp, toDateTime('2023-04-30 13:00:00.000000')), less(timestamp, toDateTime('2023-04-30 14:00:00.000000'))",
+        # )
+
+
+# total_value
+# explicit for ...

--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -200,6 +200,22 @@ class TestTrendsActorsQueryBuilder(BaseTest):
                 "greaterOrEquals(timestamp, minus(toDateTime('2024-05-30 21:59:59.999999'), toIntervalDay(6))), lessOrEquals(timestamp, toDateTime('2024-05-30 21:59:59.999999'))",
             )
 
+    def test_date_range_weekly_active_users_math_total_value_compare_previous(self):
+        self.team.timezone = "Europe/Berlin"
+        trends_query = default_query.model_copy(
+            update={
+                "series": [EventsNode(event="$pageview", math=BaseMathType.weekly_active)],
+                "trendsFilter": TrendsFilter(compare=True, display=ChartDisplayType.BoldNumber),
+            },
+            deep=True,
+        )
+
+        with freeze_time("2024-05-30T12:00:00.000Z"):
+            self.assertEqual(
+                self._get_date_where_sql(trends_query=trends_query, compare_value=Compare.previous),
+                "greaterOrEquals(timestamp, minus(toDateTime('2024-05-23 21:59:59.999999'), toIntervalDay(6))), lessOrEquals(timestamp, toDateTime('2024-05-23 21:59:59.999999'))",
+            )
+
     def test_date_range_monthly_active_users_math(self):
         self.team.timezone = "Europe/Berlin"
         trends_query = default_query.model_copy(

--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -160,6 +160,30 @@ class TestTrendsActorsQueryBuilder(BaseTest):
                 "greaterOrEquals(timestamp, minus(toDateTime('2024-05-26 22:00:00.000000'), toIntervalDay(6))), less(timestamp, toDateTime('2024-05-27 22:00:00.000000'))",
             )
 
+    def test_date_range_weekly_active_users_math_compare_previous(self):
+        self.team.timezone = "Europe/Berlin"
+        trends_query = default_query.model_copy(
+            update={
+                "series": [EventsNode(event="$pageview", math=BaseMathType.weekly_active)],
+                "trendsFilter": TrendsFilter(compare=True),
+            },
+            deep=True,
+        )
+
+        with freeze_time("2024-05-30T12:00:00.000Z"):
+            self.assertEqual(
+                self._get_date_where_sql(
+                    trends_query=trends_query, time_frame="2024-05-27", compare_value=Compare.current
+                ),
+                "greaterOrEquals(timestamp, minus(toDateTime('2024-05-26 22:00:00.000000'), toIntervalDay(6))), less(timestamp, toDateTime('2024-05-27 22:00:00.000000'))",
+            )
+            self.assertEqual(
+                self._get_date_where_sql(
+                    trends_query=trends_query, time_frame="2024-05-27", compare_value=Compare.previous
+                ),
+                "greaterOrEquals(timestamp, minus(toDateTime('2024-05-19 22:00:00.000000'), toIntervalDay(6))), less(timestamp, toDateTime('2024-05-20 22:00:00.000000'))",
+            )
+
     def test_date_range_monthly_active_users_math(self):
         self.team.timezone = "Europe/Berlin"
         trends_query = default_query.model_copy(

--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -24,6 +24,8 @@ default_query = TrendsQuery(series=[EventsNode(event="$pageview")], dateRange=Da
 
 
 class TestTrendsActorsQueryBuilder(BaseTest):
+    maxDiff = None
+
     def setUp(self):
         super().setUp()
 
@@ -155,7 +157,7 @@ class TestTrendsActorsQueryBuilder(BaseTest):
                 "greaterOrEquals(timestamp, minus(toDateTime('2024-05-26 22:00:00.000000'), toIntervalDay(29))), less(timestamp, toDateTime('2024-05-27 22:00:00.000000'))",
             )
 
-    def test_date_range_explicit_dates(self):
+    def test_date_range_explicit_date_from(self):
         self.team.timezone = "Europe/Berlin"
 
         trends_query = default_query.model_copy(
@@ -168,6 +170,7 @@ class TestTrendsActorsQueryBuilder(BaseTest):
                 "greaterOrEquals(timestamp, toDateTime('2024-05-08 14:29:13.634000')), lessOrEquals(timestamp, toDateTime('2024-05-08 15:32:00.000000'))",
             )
 
+    def test_date_range_explicit_date_to(self):
         trends_query = default_query.model_copy(
             update={
                 "dateRange": DateRange(
@@ -182,6 +185,8 @@ class TestTrendsActorsQueryBuilder(BaseTest):
                 "greaterOrEquals(timestamp, toDateTime('2024-05-08 14:29:13.634000')), lessOrEquals(timestamp, toDateTime('2024-05-08 14:32:57.692000'))",
             )
 
+    def test_date_range_explicit_monthly_active_users_math(self):
+        self.team.timezone = "Europe/Berlin"
         trends_query = default_query.model_copy(
             update={
                 "series": [EventsNode(event="$pageview", math=BaseMathType.monthly_active)],
@@ -194,5 +199,5 @@ class TestTrendsActorsQueryBuilder(BaseTest):
         with freeze_time("2024-05-08T15:32:00.000Z"):
             self.assertEqual(
                 self._get_date_where_sql(trends_query=trends_query, time_frame="2024-05-08"),
-                "greaterOrEquals(timestamp, toDateTime('2024-05-08 14:29:13.634000')), lessOrEquals(timestamp, toDateTime('2024-05-08 14:32:57.692000'))",
+                "greaterOrEquals(timestamp, greatest(minus(toDateTime('2024-05-07 22:00:00.000000'), toIntervalDay(29)), toDateTime('2024-05-08 14:29:13.634000'))), less(timestamp, least(toDateTime('2024-05-08 22:00:00.000000'), toDateTime('2024-05-08 14:32:57.692000')))",
             )

--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -92,14 +92,14 @@ class TestTrendsActorsQueryBuilder(BaseTest):
         trends_query = default_query.model_copy(update={"trendsFilter": TrendsFilter(compare=True)}, deep=True)
 
         self.assertEqual(
-            self._get_date_where_sql(trends_query=trends_query, time_frame="2023-05-08", compare_value=Compare.current),
-            "greaterOrEquals(timestamp, toDateTime('2023-05-07 22:00:00.000000')), less(timestamp, toDateTime('2023-05-08 22:00:00.000000'))",
+            self._get_date_where_sql(trends_query=trends_query, time_frame="2023-05-10", compare_value=Compare.current),
+            "greaterOrEquals(timestamp, toDateTime('2023-05-09 22:00:00.000000')), less(timestamp, toDateTime('2023-05-10 22:00:00.000000'))",
         )
         self.assertEqual(
             self._get_date_where_sql(
-                trends_query=trends_query, time_frame="2023-05-08", compare_value=Compare.previous
+                trends_query=trends_query, time_frame="2023-05-10", compare_value=Compare.previous
             ),
-            "greaterOrEquals(timestamp, toDateTime('2023-04-30 22:00:00.000000')), less(timestamp, toDateTime('2023-05-01 22:00:00.000000'))",
+            "greaterOrEquals(timestamp, toDateTime('2023-05-02 22:00:00.000000')), less(timestamp, toDateTime('2023-05-03 22:00:00.000000'))",
         )
 
     def test_date_range_compare_previous_hourly(self):
@@ -109,15 +109,15 @@ class TestTrendsActorsQueryBuilder(BaseTest):
         )
         self.assertEqual(
             self._get_date_where_sql(
-                trends_query=trends_query, time_frame="2023-05-08T15:00:00", compare_value=Compare.current
+                trends_query=trends_query, time_frame="2023-05-10T15:00:00", compare_value=Compare.current
             ),
-            "greaterOrEquals(timestamp, toDateTime('2023-05-08 13:00:00.000000')), less(timestamp, toDateTime('2023-05-08 14:00:00.000000'))",
+            "greaterOrEquals(timestamp, toDateTime('2023-05-10 13:00:00.000000')), less(timestamp, toDateTime('2023-05-10 14:00:00.000000'))",
         )
         self.assertEqual(
             self._get_date_where_sql(
-                trends_query=trends_query, time_frame="2023-05-08T15:00:00", compare_value=Compare.previous
+                trends_query=trends_query, time_frame="2023-05-10T15:00:00", compare_value=Compare.previous
             ),
-            "greaterOrEquals(timestamp, toDateTime('2023-04-30 13:00:00.000000')), less(timestamp, toDateTime('2023-04-30 14:00:00.000000'))",
+            "greaterOrEquals(timestamp, toDateTime('2023-05-03 13:00:00.000000')), less(timestamp, toDateTime('2023-05-03 14:00:00.000000'))",
         )
 
     def test_date_range_total_value(self):

--- a/posthog/hogql_queries/insights/trends/test/test_trends_persons.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_persons.py
@@ -407,7 +407,6 @@ class TestTrendsPersons(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(get_distinct_id(result[2]), "person3")
         self.assertEqual(get_event_count(result[2]), 1)
 
-    @skip("fails in resolver")
     def test_trends_math_monthly_active_persons(self):
         self._create_events()
         source_query = TrendsQuery(

--- a/posthog/hogql_queries/insights/trends/test/test_trends_persons.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_persons.py
@@ -407,20 +407,30 @@ class TestTrendsPersons(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(get_distinct_id(result[2]), "person3")
         self.assertEqual(get_event_count(result[2]), 1)
 
-    def test_trends_math_monthly_active_persons(self):
-        self._create_events()
+    def test_trends_math_weekly_active_persons(self):
+        for i in range(17, 24):
+            distinct_id = f"person_2023-04-{i}"
+            _create_person(
+                team_id=self.team.pk,
+                distinct_ids=[distinct_id],
+            )
+            _create_event(
+                event="$pageview",
+                distinct_id=distinct_id,
+                timestamp=f"2023-04-{i} 16:00",
+                team=self.team,
+            )
         source_query = TrendsQuery(
-            series=[EventsNode(event="$pageview", math=BaseMathType.monthly_active)],
+            series=[EventsNode(event="$pageview", math=BaseMathType.weekly_active)],
             dateRange=DateRange(date_from="-7d"),
         )
 
-        result = self._get_actors(trends_query=source_query, day="2023-05-05")
+        result = self._get_actors(trends_query=source_query, day="2023-04-28")
 
-        self.assertEqual(len(result), 99)
-        # self.assertEqual(get_distinct_id(result[0]), "person2")
-        # self.assertEqual(get_event_count(result[0]), 2)
-        # self.assertEqual(get_distinct_id(result[1]), "person3")
-        # self.assertEqual(get_event_count(result[1]), 1)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(
+            {get_distinct_id(result[0]), get_distinct_id(result[1])}, {"person_2023-04-22", "person_2023-04-23"}
+        )
 
     @skip("fails, as event_count isn't populated properly")
     def test_trends_math_property_sum_persons(self):

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_builder.py
@@ -21,7 +21,7 @@ from posthog.schema import (
 from posthog.test.base import BaseTest, _create_event, _create_person
 
 
-class TestQueryBuilder(BaseTest):
+class TestTrendsQueryBuilder(BaseTest):
     def setUp(self):
         super().setUp()
 

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -1962,7 +1962,9 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         # date_to starts at specific time
-        response = runner.to_actors_query(time_frame="2020-01-09", series_index=0, breakdown_value=None, compare=None)
+        response = runner.to_actors_query(
+            time_frame="2020-01-09", series_index=0, breakdown_value=None, compare_value=None
+        )
         assert response.select_from.table.where.exprs[0].right.value == datetime(  # type: ignore
             2020, 1, 9, 12, 37, 42, tzinfo=zoneinfo.ZoneInfo(key="UTC")
         )
@@ -1971,7 +1973,9 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         # date_from ends at specific time
-        response = runner.to_actors_query(time_frame="2020-01-20", series_index=0, breakdown_value=None, compare=None)
+        response = runner.to_actors_query(
+            time_frame="2020-01-20", series_index=0, breakdown_value=None, compare_value=None
+        )
         assert response.select_from.table.where.exprs[0].right.value == datetime(  # type: ignore
             2020, 1, 20, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="UTC")
         )

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -1965,10 +1965,10 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         response = runner.to_actors_query(
             time_frame="2020-01-09", series_index=0, breakdown_value=None, compare_value=None
         )
-        assert response.select_from.table.where.exprs[0].right.value == datetime(  # type: ignore
+        assert response.select_from.table.where.exprs[1].right.value == datetime(  # type: ignore
             2020, 1, 9, 12, 37, 42, tzinfo=zoneinfo.ZoneInfo(key="UTC")
         )
-        assert response.select_from.table.where.exprs[1].right.value == datetime(  # type: ignore
+        assert response.select_from.table.where.exprs[2].right.value == datetime(  # type: ignore
             2020, 1, 10, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="UTC")
         )
 
@@ -1976,9 +1976,9 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         response = runner.to_actors_query(
             time_frame="2020-01-20", series_index=0, breakdown_value=None, compare_value=None
         )
-        assert response.select_from.table.where.exprs[0].right.value == datetime(  # type: ignore
+        assert response.select_from.table.where.exprs[1].right.value == datetime(  # type: ignore
             2020, 1, 20, 0, 0, tzinfo=zoneinfo.ZoneInfo(key="UTC")
         )
-        assert response.select_from.table.where.exprs[1].right.value == datetime(  # type: ignore
+        assert response.select_from.table.where.exprs[2].right.value == datetime(  # type: ignore
             2020, 1, 20, 12, 37, 42, tzinfo=zoneinfo.ZoneInfo(key="UTC")
         )

--- a/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
@@ -291,12 +291,12 @@ class TrendsActorsQueryBuilder:
 
         # adjust date_from for weekly and monthly active calculations
         if self.is_active_users_math:
-            # if self.is_total_value:
-            #     # TRICKY: On total value (non-time-series) insights, WAU/MAU math is simply meaningless.
-            #     # There's no intuitive way to define the semantics of such a combination, so what we do is just turn it
-            #     # into a count of unique users between `date_to - INTERVAL (7|30) DAY` and `date_to`.
-            #     # This way we at least ensure the date range is the probably expected 7 or 30 days.
-            #     date_from_with_lookback = "{date_to} - {inclusive_lookback}"
+            if self.is_total_value:
+                # TRICKY: On total value (non-time-series) insights, WAU/MAU math is simply meaningless.
+                # There's no intuitive way to define the semantics of such a combination, so what we do is just turn it
+                # into a count of unique users between `date_to - INTERVAL (7|30) DAY` and `date_to`.
+                # This way we at least ensure the date range is the probably expected 7 or 30 days.
+                actors_from = actors_to
 
             if self.is_weekly_active_math:
                 actors_from_expr = ast.ArithmeticOperation(

--- a/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
@@ -141,15 +141,13 @@ class TrendsActorsQueryBuilder:
         return ast.Field(chain=["e", "person_id"])
 
     def _events_where_expr(self, with_breakdown_expr: bool = True) -> ast.And:
-        #         {self._get_not_null_actor_condition()}
-
         return ast.And(
             exprs=[
                 *self._entity_where_expr(),
                 *self._prop_where_expr(),
                 *self._date_where_expr(),
                 *(self._breakdown_where_expr() if with_breakdown_expr else []),
-                *self._filter_empty_groups_expr(),
+                *self._filter_empty_actors_expr(),
             ]
         )
 
@@ -325,7 +323,7 @@ class TrendsActorsQueryBuilder:
 
         return conditions
 
-    def _filter_empty_groups_expr(self) -> list[ast.Expr]:
+    def _filter_empty_actors_expr(self) -> list[ast.Expr]:
         conditions: list[ast.Expr] = []
 
         # Ignore empty groups

--- a/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
@@ -266,7 +266,9 @@ class TrendsActorsQueryBuilder:
             actors_to = query_to
             actors_to_op = ast.CompareOperationOp.LtEq
         else:
-            assert self.time_frame, "A `day` is required for trends actors queries without total value aggregation"
+            assert (
+                self.time_frame is not None
+            ), "A `day` is required for trends actors queries without total value aggregation"
 
             # use previous day/week/... for time_frame
             if self.is_compare_previous:

--- a/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
@@ -352,7 +352,7 @@ class TrendsActorsQueryBuilder:
             timings=self.timings,
             modifiers=self.modifiers,
             events_filter=self._events_where_expr(with_breakdown_expr=False),
-            breakdown_values_override=[self.breakdown_value] if self.breakdown_value is not None else None,
+            breakdown_values_override=[str(self.breakdown_value)] if self.breakdown_value is not None else None,
             limit_context=self.limit_context,
         )
 

--- a/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
@@ -52,19 +52,19 @@ class TrendsActorsQueryBuilder:
         self.breakdown_value = breakdown_value
         self.compare_value = compare_value
 
-        def build_actors_query(self) -> ast.SelectQuery | ast.SelectUnionQuery:
-            # TODO: add matching_events only when including recordings
-            return parse_select(
-                """
-                    SELECT
-                        actor_id,
-                        count() as event_count,
-                        groupUniqArray(100)((timestamp, uuid, $session_id, $window_id)) as matching_events
-                    FROM {events_query}
-                    GROUP BY actor_id
-                """,
-                placeholders={"events_query": self._get_events_query()},
-            )
+    def build_actors_query(self) -> ast.SelectQuery | ast.SelectUnionQuery:
+        # TODO: add matching_events only when including recordings
+        return parse_select(
+            """
+                SELECT
+                    actor_id,
+                    count() as event_count,
+                    groupUniqArray(100)((timestamp, uuid, $session_id, $window_id)) as matching_events
+                FROM {events_query}
+                GROUP BY actor_id
+            """,
+            placeholders={"events_query": self._get_events_query()},
+        )
 
     def _get_events_query(
         self,
@@ -95,7 +95,6 @@ class TrendsActorsQueryBuilder:
                 sample=(ast.SampleExpr(sample_value=self._sample_value_expr())),
             ),
             where=ast.And(exprs=[*self._entity_where_expr(), *self._prop_where_expr(), *self._date_where_expr()]),
-            group_by=[],
         )
         return query
 

--- a/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
@@ -1,0 +1,249 @@
+from typing import Optional
+from posthog.hogql import ast
+from posthog.hogql.constants import LimitContext
+from posthog.hogql.parser import parse_expr, parse_select
+from posthog.hogql.property import action_to_expr, property_to_expr
+from posthog.hogql.timings import HogQLTimings
+from posthog.hogql_queries.insights.trends.aggregation_operations import AggregationOperations
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.models import Action, Team
+from posthog.schema import ActionsNode, Compare, DataWarehouseNode, EventsNode, HogQLQueryModifiers, TrendsQuery
+
+
+class TrendsActorsQueryBuilder:
+    trends_query: TrendsQuery
+    team: Team
+    timings: HogQLTimings
+    modifiers: HogQLQueryModifiers
+    limit_context: LimitContext
+
+    entity: EventsNode | ActionsNode
+    time_frame: Optional[str]
+    breakdown_value: Optional[str | int] = None
+    compare_value: Optional[Compare] = None
+
+    def __init__(
+        self,
+        trends_query: TrendsQuery,
+        team: Team,
+        timings: HogQLTimings,
+        modifiers: HogQLQueryModifiers,
+        series_index: int,
+        time_frame: Optional[str],
+        breakdown_value: Optional[str | int] = None,
+        compare_value: Optional[Compare] = None,
+        limit_context: LimitContext = LimitContext.QUERY,
+    ):
+        self.trends_query = trends_query
+        self.team = team
+        self.timings = timings
+        self.modifiers = modifiers
+        self.limit_context = limit_context
+
+        entity = trends_query.series[series_index]
+
+        # TODO: Add support for DataWarehouseNode
+        if isinstance(entity, DataWarehouseNode):
+            raise Exception("DataWarehouseNodes are not supported for trends actors queries")
+        else:
+            self.entity = entity
+
+        self.time_frame = time_frame
+        self.breakdown_value = breakdown_value
+        self.compare_value = compare_value
+
+        def build_actors_query(self) -> ast.SelectQuery | ast.SelectUnionQuery:
+            # TODO: add matching_events only when including recordings
+            return parse_select(
+                """
+                    SELECT
+                        actor_id,
+                        count() as event_count,
+                        groupUniqArray(100)((timestamp, uuid, $session_id, $window_id)) as matching_events
+                    FROM {events_query}
+                    GROUP BY actor_id
+                """,
+                placeholders={"events_query": self._get_events_query()},
+            )
+
+    def _get_events_query(
+        self,
+        time_frame: Optional[str] = None,
+        breakdown_filter: Optional[str | int] = None,
+    ) -> ast.SelectQuery:
+        # breakdown = self._breakdown(is_actors_query=True, breakdown_filter=breakdown_filter)
+
+        # events_filter = self._events_filter(
+        #     ignore_breakdowns=False,
+        #     breakdown=breakdown,
+        #     is_actors_query=True,
+        #     breakdown_values_override=breakdown_values_override,
+        #     actors_query_time_frame=actors_query_time_frame,
+        # )
+
+        query = ast.SelectQuery(
+            select=[
+                ast.Alias(alias="actor_id", expr=self._actor_id_expr()),
+                ast.Field(chain=["e", "timestamp"]),
+                ast.Field(chain=["e", "uuid"]),
+                ast.Field(chain=["e", "$session_id"]),  # TODO: only when including recordings
+                ast.Field(chain=["e", "$window_id"]),  # TODO: only when including recordings
+            ],
+            select_from=ast.JoinExpr(
+                table=ast.Field(chain=["events"]),
+                alias="e",
+                sample=(ast.SampleExpr(sample_value=self._sample_value_expr())),
+            ),
+            where=ast.And(exprs=[*self._entity_where_expr(), *self._prop_where_expr(), *self._date_where_expr()]),
+            group_by=[],
+        )
+        return query
+
+    def _sample_value_expr(self) -> ast.RatioExpr:
+        if self.query.samplingFactor is None:
+            return ast.RatioExpr(left=ast.Constant(value=1))
+
+        return ast.RatioExpr(left=ast.Constant(value=self.query.samplingFactor))
+
+    def _actor_id_expr(self) -> ast.Expr:
+        if self.series.math == "unique_group" and self.series.math_group_type_index is not None:
+            return ast.Field(chain=["e", f"$group_{int(self.series.math_group_type_index)}"])
+        return ast.Field(chain=["e", "person_id"])
+
+        # @cached_property
+        # def _aggregation_operation(self) -> AggregationOperations:
+        #     return AggregationOperations(
+        #         self.team,
+        #         self.series,
+        #         self._trends_display.display_type,
+        #         self.query_date_range,
+        #         self._trends_display.is_total_value(),
+        #     )
+
+        # def _events_filter(
+        #     self,
+        #     is_actors_query: bool,
+        #     breakdown: Breakdown | None,
+        #     ignore_breakdowns: bool = False,
+        #     breakdown_values_override: Optional[str | int] = None,
+        #     actors_query_time_frame: Optional[str] = None,
+        # ) -> ast.Expr:
+
+        #         {self._get_not_null_actor_condition()}
+
+        #     # Breakdown
+        #     if not ignore_breakdowns and breakdown is not None:
+        #         if breakdown.enabled and not breakdown.is_histogram_breakdown:
+        #             breakdown_filter = breakdown.events_where_filter()
+        #             if breakdown_filter is not None:
+        #                 conditions.append(breakdown_filter)
+
+        #     # Ignore empty groups
+        #     if series.math == "unique_group" and series.math_group_type_index is not None:
+        #         conditions.append(
+        #             ast.CompareOperation(
+        #                 op=ast.CompareOperationOp.NotEq,
+        #                 left=ast.Field(chain=["e", f"$group_{int(series.math_group_type_index)}"]),
+        #                 right=ast.Constant(value=""),
+        #             )
+        #         )
+
+    def _entity_where_expr(self) -> list[ast.Expr]:
+        conditions: list[ast.Expr] = []
+
+        if isinstance(self.series, ActionsNode):
+            # Actions
+            try:
+                action = Action.objects.get(pk=int(self.series.id), team=self.team)
+                conditions.append(action_to_expr(action))
+            except Action.DoesNotExist:
+                # If an action doesn't exist, we want to return no events
+                conditions.append(parse_expr("1 = 2"))
+        elif isinstance(self.series, EventsNode):
+            if self.series.event is not None:
+                conditions.append(
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.Eq,
+                        left=ast.Field(chain=["event"]),
+                        right=ast.Constant(value=str(self.series.event)),
+                    )
+                )
+
+            if self.series.properties is not None and self.series.properties != []:
+                conditions.append(property_to_expr(self.series.properties, self.team))
+        else:
+            raise ValueError(f"Invalid series kind {self.series.kind}")
+
+        return conditions
+
+    def _prop_where_expr(self) -> list[ast.Expr]:
+        conditions: list[ast.Expr] = []
+
+        # Filter Test Accounts
+        if (
+            self.query.filterTestAccounts
+            and isinstance(self.team.test_account_filters, list)
+            and len(self.team.test_account_filters) > 0
+        ):
+            for property in self.team.test_account_filters:
+                conditions.append(property_to_expr(property, self.team))
+
+        # Properties
+        if self.query.properties is not None and self.query.properties != []:
+            conditions.append(property_to_expr(self.query.properties, self.team))
+
+        return conditions
+
+    def _date_where_expr(self) -> list[ast.Expr]:
+        conditions: list[ast.Expr] = []
+
+        #         if compare == Compare.previous:
+        #     query_date_range = self.query_previous_date_range
+
+        #     delta_mappings = self.query_previous_date_range.date_from_delta_mappings()
+        #     if delta_mappings is not None and time_frame is not None and isinstance(time_frame, str):
+        #         relative_delta = relativedelta(**delta_mappings)
+        #         parsed_dt = parser.isoparse(time_frame)
+        #         parse_dt_with_relative_delta = parsed_dt - relative_delta
+        #         time_frame = parse_dt_with_relative_delta.strftime("%Y-%m-%d")
+        # else:
+        #     query_date_range = self.query_date_range
+
+        if actors_query_time_frame is not None:
+            actors_from, actors_to = self.query_date_range.interval_bounds_from_str(actors_query_time_frame)
+            query_from, query_to = self.query_date_range.date_from(), self.query_date_range.date_to()
+            if self.query.dateRange and self.query.dateRange.explicitDate:
+                query_from, query_to = self.query_date_range.date_from(), self.query_date_range.date_to()
+                # exclude events before the query start
+                if query_from > actors_from:
+                    actors_from = query_from
+                # exclude events after the query end
+                if query_to < actors_to:
+                    actors_to = query_to
+            conditions.extend(
+                [
+                    ast.CompareOperation(
+                        left=ast.Field(chain=["timestamp"]),
+                        op=ast.CompareOperationOp.GtEq,
+                        right=ast.Constant(value=actors_from),
+                    ),
+                    ast.CompareOperation(
+                        left=ast.Field(chain=["timestamp"]),
+                        op=ast.CompareOperationOp.Lt,
+                        right=ast.Constant(value=actors_to),
+                    ),
+                ]
+            )
+        else:
+            raise ValueError("Actors query without day")
+        #     elif not self._aggregation_operation.requires_query_orchestration():
+        #         date_range_placeholders = self.query_date_range.to_placeholders()
+        #         conditions.extend(
+        #             [
+        #                 parse_expr(
+        #                     "timestamp >= {date_from_with_adjusted_start_of_interval}", placeholders=date_range_placeholders
+        #                 ),
+        #                 parse_expr("timestamp <= {date_to}", placeholders=date_range_placeholders),
+        #             ]
+        #         )
+        return conditions

--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -59,7 +59,7 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
 
         events_query: ast.SelectQuery | ast.SelectUnionQuery
 
-        if self._trends_display.should_aggregate_values():
+        if self._trends_display.is_total_value():
             events_query = self._get_events_subquery(False, is_actors_query=False, breakdown=breakdown)
             return events_query
         else:
@@ -207,7 +207,7 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
             group_by=[],
         )
 
-        if not self._trends_display.should_aggregate_values() and not is_actors_query:
+        if not self._trends_display.is_total_value() and not is_actors_query:
             # For cumulative unique users or groups, we want to count each user or group once per query, not per day
             if (
                 self.query.trendsFilter
@@ -260,7 +260,7 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
                 orchestrator.parent_select_query_builder.append_select(ast.Field(chain=["breakdown_value"]))
 
             if (
-                self._aggregation_operation.should_aggregate_values
+                self._aggregation_operation.is_total_value
                 and not self._aggregation_operation.is_count_per_actor_variant()
                 and not is_actors_query
             ):
@@ -282,7 +282,7 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
             wrapper = self.session_duration_math_property_wrapper(default_query)
             assert wrapper.group_by is not None
 
-            if not self._trends_display.should_aggregate_values() and not is_actors_query:
+            if not self._trends_display.is_total_value() and not is_actors_query:
                 default_query.select.append(day_start)
                 default_query.group_by.append(ast.Field(chain=["day_start"]))
 
@@ -315,7 +315,7 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
 
             wrapper = self.session_duration_math_property_wrapper(default_query)
 
-            if not self._trends_display.should_aggregate_values() and not is_actors_query:
+            if not self._trends_display.is_total_value() and not is_actors_query:
                 assert wrapper.group_by is not None
 
                 default_query.select.append(day_start)
@@ -448,7 +448,7 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
         query.group_by = []
         query.order_by = []
 
-        if not self._trends_display.should_aggregate_values():
+        if not self._trends_display.is_total_value():
             query.select.append(ast.Field(chain=["day_start"]))
             query.group_by.append(ast.Field(chain=["day_start"]))
             query.order_by.append(ast.OrderExpr(expr=ast.Field(chain=["day_start"]), order="ASC"))
@@ -619,7 +619,7 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
             self.series,
             self._trends_display.display_type,
             self.query_date_range,
-            self._trends_display.should_aggregate_values(),
+            self._trends_display.is_total_value(),
         )
 
     @cached_property

--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -174,6 +174,7 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
             where=events_filter,
             group_by=[],
         )
+        assert default_query.group_by
 
         day_start = ast.Alias(
             alias="day_start",

--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -416,32 +416,7 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
         filters: list[ast.Expr] = []
 
         # Dates
-        if is_actors_query and actors_query_time_frame is not None:
-            actors_from, actors_to = self.query_date_range.interval_bounds_from_str(actors_query_time_frame)
-            query_from, query_to = self.query_date_range.date_from(), self.query_date_range.date_to()
-            if self.query.dateRange and self.query.dateRange.explicitDate:
-                query_from, query_to = self.query_date_range.date_from(), self.query_date_range.date_to()
-                # exclude events before the query start
-                if query_from > actors_from:
-                    actors_from = query_from
-                # exclude events after the query end
-                if query_to < actors_to:
-                    actors_to = query_to
-            filters.extend(
-                [
-                    ast.CompareOperation(
-                        left=ast.Field(chain=["timestamp"]),
-                        op=ast.CompareOperationOp.GtEq,
-                        right=ast.Constant(value=actors_from),
-                    ),
-                    ast.CompareOperation(
-                        left=ast.Field(chain=["timestamp"]),
-                        op=ast.CompareOperationOp.Lt,
-                        right=ast.Constant(value=actors_to),
-                    ),
-                ]
-            )
-        elif not self._aggregation_operation.requires_query_orchestration():
+        if not self._aggregation_operation.requires_query_orchestration():
             date_range_placeholders = self.query_date_range.to_placeholders()
             filters.extend(
                 [

--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -174,7 +174,7 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
             where=events_filter,
             group_by=[],
         )
-        assert default_query.group_by
+        assert default_query.group_by is not None
 
         day_start = ast.Alias(
             alias="day_start",

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -152,7 +152,7 @@ class TrendsQueryRunner(QueryRunner):
         time_frame: Optional[str],
         series_index: int,
         breakdown_value: Optional[str | int] = None,
-        compare: Optional[Compare] = None,
+        compare_value: Optional[Compare] = None,
     ) -> ast.SelectQuery | ast.SelectUnionQuery:
         with self.timings.measure("trends_to_actors_query"):
             query_builder = TrendsActorsQueryBuilder(
@@ -165,10 +165,10 @@ class TrendsQueryRunner(QueryRunner):
                 time_frame=time_frame,
                 series_index=series_index,
                 breakdown_value=breakdown_value,
-                compare=compare,
+                compare_value=compare_value,
             )
 
-            query = query_builder.build_actors_query(time_frame=time_frame, breakdown_filter=str(breakdown_value))
+            query = query_builder.build_actors_query()
 
         return query
 

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -8,8 +8,6 @@ from math import ceil
 from operator import itemgetter
 import threading
 from typing import Optional, Any
-from dateutil import parser
-from dateutil.relativedelta import relativedelta
 from django.conf import settings
 
 from django.utils.timezone import datetime

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -194,7 +194,7 @@ class TrendsQueryRunner(QueryRunner):
         # Days
         res_days: Optional[list[DayItem]] = (
             None
-            if self._trends_display.should_aggregate_values()
+            if self._trends_display.is_total_value()
             else [
                 DayItem(
                     label=format_label_date(value, self.query_date_range.interval_name),
@@ -590,7 +590,7 @@ class TrendsQueryRunner(QueryRunner):
                 series_order=index,
                 is_previous_period_series=None,
                 overriden_query=None,
-                aggregate_values=self._trends_display.should_aggregate_values(),
+                aggregate_values=self._trends_display.is_total_value(),
             )
             for index, series in enumerate(self.query.series)
         ]
@@ -620,7 +620,7 @@ class TrendsQueryRunner(QueryRunner):
                             series_order=series.series_order,
                             is_previous_period_series=series.is_previous_period_series,
                             overriden_query=copied_query,
-                            aggregate_values=self._trends_display.should_aggregate_values(),
+                            aggregate_values=self._trends_display.is_total_value(),
                         )
                     )
             series_with_extras = updated_series
@@ -634,7 +634,7 @@ class TrendsQueryRunner(QueryRunner):
                         series_order=series.series_order,
                         is_previous_period_series=False,
                         overriden_query=series.overriden_query,
-                        aggregate_values=self._trends_display.should_aggregate_values(),
+                        aggregate_values=self._trends_display.is_total_value(),
                     )
                 )
                 updated_series.append(
@@ -643,7 +643,7 @@ class TrendsQueryRunner(QueryRunner):
                         series_order=series.series_order,
                         is_previous_period_series=True,
                         overriden_query=series.overriden_query,
-                        aggregate_values=self._trends_display.should_aggregate_values(),
+                        aggregate_values=self._trends_display.is_total_value(),
                     )
                 )
             series_with_extras = updated_series
@@ -653,7 +653,7 @@ class TrendsQueryRunner(QueryRunner):
     def apply_formula(self, formula: str, results: list[dict[str, Any]]) -> list[dict[str, Any]]:
         has_compare = bool(self.query.trendsFilter and self.query.trendsFilter.compare)
         has_breakdown = bool(self.query.breakdownFilter and self.query.breakdownFilter.breakdown)
-        is_total_value = self._trends_display.should_aggregate_values()
+        is_total_value = self._trends_display.is_total_value()
 
         if len(results) == 0:
             return []

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -86,6 +86,12 @@ class QueryDateRange:
 
         return date_from
 
+    def explicit(self) -> bool:
+        if self._date_range is None or self._date_range.explicitDate is None:
+            return False
+
+        return self._date_range.explicitDate
+
     @cached_property
     def previous_period_date_from(self) -> datetime:
         return self.date_from() - (self.date_to() - self.date_from())

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -4,7 +4,6 @@ from functools import cached_property
 from typing import Literal, Optional
 from zoneinfo import ZoneInfo
 
-from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 
 from posthog.hogql.errors import ImpossibleASTError
@@ -263,11 +262,6 @@ class QueryDateRange:
                 else self.date_from_as_hogql()
             ),
         }
-
-    def interval_bounds_from_str(self, time_frame: str) -> tuple[datetime, datetime]:
-        date_from = parse(time_frame, tzinfos={None: self._team.timezone_info})
-        date_to = date_from + self.interval_relativedelta()
-        return date_from, date_to
 
 
 class QueryDateRangeWithIntervals(QueryDateRange):

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -86,12 +86,6 @@ class QueryDateRange:
 
         return date_from
 
-    def explicit(self) -> bool:
-        if self._date_range is None or self._date_range.explicitDate is None:
-            return False
-
-        return self._date_range.explicitDate
-
     @cached_property
     def previous_period_date_from(self) -> datetime:
         return self.date_from() - (self.date_to() - self.date_from())
@@ -123,6 +117,13 @@ class QueryDateRange:
     @cached_property
     def interval_name(self) -> Literal["hour", "day", "week", "month"]:
         return self.interval_type.name
+
+    @cached_property
+    def explicit(self) -> bool:
+        if self._date_range is None or self._date_range.explicitDate is None:
+            return False
+
+        return self._date_range.explicitDate
 
     def align_with_interval(self, start: datetime) -> datetime:
         if self.interval_name == "hour":

--- a/posthog/queries/trends/trends_actors.py
+++ b/posthog/queries/trends/trends_actors.py
@@ -61,18 +61,18 @@ class TrendsActors(ActorBaseQuery):
                         value=lower_bound,
                         operator="gte",
                         type=self._filter.breakdown_type,
-                        group_type_index=(
-                            self._filter.breakdown_group_type_index if self._filter.breakdown_type == "group" else None
-                        ),
+                        group_type_index=self._filter.breakdown_group_type_index
+                        if self._filter.breakdown_type == "group"
+                        else None,
                     ),
                     Property(
                         key=self._filter.breakdown,
                         value=upper_bound,
                         operator="lt",
                         type=self._filter.breakdown_type,
-                        group_type_index=(
-                            self._filter.breakdown_group_type_index if self._filter.breakdown_type == "group" else None
-                        ),
+                        group_type_index=self._filter.breakdown_group_type_index
+                        if self._filter.breakdown_type == "group"
+                        else None,
                     ),
                 ]
             else:
@@ -81,9 +81,9 @@ class TrendsActors(ActorBaseQuery):
                         key=self._filter.breakdown,
                         value=self._filter.breakdown_value,
                         type=self._filter.breakdown_type,
-                        group_type_index=(
-                            self._filter.breakdown_group_type_index if self._filter.breakdown_type == "group" else None
-                        ),
+                        group_type_index=self._filter.breakdown_group_type_index
+                        if self._filter.breakdown_type == "group"
+                        else None,
                     )
                 ]
 
@@ -100,21 +100,21 @@ class TrendsActors(ActorBaseQuery):
             extra_fields += ["uuid"]
 
         events_query, params = TrendsEventQuery(
-            # filter=self._filter,
-            # team=self._team,
-            # entity=self.entity,
+            filter=self._filter,
+            team=self._team,
+            entity=self.entity,
             should_join_distinct_ids=not self.is_aggregating_by_groups
-            # and self._team.person_on_events_mode != PersonsOnEventsMode.person_id_no_override_properties_on_events,
-            # extra_event_properties=["$window_id", "$session_id"] if self._filter.include_recordings else [],
+            and self._team.person_on_events_mode != PersonsOnEventsMode.person_id_no_override_properties_on_events,
+            extra_event_properties=["$window_id", "$session_id"] if self._filter.include_recordings else [],
             extra_fields=extra_fields,
-            # person_on_events_mode=self._team.person_on_events_mode,
+            person_on_events_mode=self._team.person_on_events_mode,
         ).get_query()
 
-        # matching_events_select_statement = (
-        #     ", groupUniqArray(100)((timestamp, uuid, $session_id, $window_id)) as matching_events"
-        #     if self._filter.include_recordings
-        #     else ""
-        # )
+        matching_events_select_statement = (
+            ", groupUniqArray(100)((timestamp, uuid, $session_id, $window_id)) as matching_events"
+            if self._filter.include_recordings
+            else ""
+        )
 
         (
             actor_value_expression,
@@ -123,18 +123,18 @@ class TrendsActors(ActorBaseQuery):
 
         return (
             GET_ACTORS_FROM_EVENT_QUERY.format(
-                # id_field=self._aggregation_actor_field,
+                id_field=self._aggregation_actor_field,
                 actor_value_expression=actor_value_expression,
-                # matching_events_select_statement=matching_events_select_statement,
+                matching_events_select_statement=matching_events_select_statement,
                 events_query=events_query,
-                # limit="LIMIT %(limit)s" if limit_actors else "",
-                # offset="OFFSET %(offset)s" if limit_actors else "",
+                limit="LIMIT %(limit)s" if limit_actors else "",
+                offset="OFFSET %(offset)s" if limit_actors else "",
             ),
             {
                 **params,
                 **actor_value_params,
-                # "offset": self._filter.offset,
-                # "limit": self._filter.limit or 100,
+                "offset": self._filter.offset,
+                "limit": self._filter.limit or 100,
             },
         )
 

--- a/posthog/queries/trends/trends_actors.py
+++ b/posthog/queries/trends/trends_actors.py
@@ -61,18 +61,18 @@ class TrendsActors(ActorBaseQuery):
                         value=lower_bound,
                         operator="gte",
                         type=self._filter.breakdown_type,
-                        group_type_index=self._filter.breakdown_group_type_index
-                        if self._filter.breakdown_type == "group"
-                        else None,
+                        group_type_index=(
+                            self._filter.breakdown_group_type_index if self._filter.breakdown_type == "group" else None
+                        ),
                     ),
                     Property(
                         key=self._filter.breakdown,
                         value=upper_bound,
                         operator="lt",
                         type=self._filter.breakdown_type,
-                        group_type_index=self._filter.breakdown_group_type_index
-                        if self._filter.breakdown_type == "group"
-                        else None,
+                        group_type_index=(
+                            self._filter.breakdown_group_type_index if self._filter.breakdown_type == "group" else None
+                        ),
                     ),
                 ]
             else:
@@ -81,9 +81,9 @@ class TrendsActors(ActorBaseQuery):
                         key=self._filter.breakdown,
                         value=self._filter.breakdown_value,
                         type=self._filter.breakdown_type,
-                        group_type_index=self._filter.breakdown_group_type_index
-                        if self._filter.breakdown_type == "group"
-                        else None,
+                        group_type_index=(
+                            self._filter.breakdown_group_type_index if self._filter.breakdown_type == "group" else None
+                        ),
                     )
                 ]
 
@@ -100,21 +100,21 @@ class TrendsActors(ActorBaseQuery):
             extra_fields += ["uuid"]
 
         events_query, params = TrendsEventQuery(
-            filter=self._filter,
-            team=self._team,
-            entity=self.entity,
+            # filter=self._filter,
+            # team=self._team,
+            # entity=self.entity,
             should_join_distinct_ids=not self.is_aggregating_by_groups
-            and self._team.person_on_events_mode != PersonsOnEventsMode.person_id_no_override_properties_on_events,
-            extra_event_properties=["$window_id", "$session_id"] if self._filter.include_recordings else [],
+            # and self._team.person_on_events_mode != PersonsOnEventsMode.person_id_no_override_properties_on_events,
+            # extra_event_properties=["$window_id", "$session_id"] if self._filter.include_recordings else [],
             extra_fields=extra_fields,
-            person_on_events_mode=self._team.person_on_events_mode,
+            # person_on_events_mode=self._team.person_on_events_mode,
         ).get_query()
 
-        matching_events_select_statement = (
-            ", groupUniqArray(100)((timestamp, uuid, $session_id, $window_id)) as matching_events"
-            if self._filter.include_recordings
-            else ""
-        )
+        # matching_events_select_statement = (
+        #     ", groupUniqArray(100)((timestamp, uuid, $session_id, $window_id)) as matching_events"
+        #     if self._filter.include_recordings
+        #     else ""
+        # )
 
         (
             actor_value_expression,
@@ -123,18 +123,18 @@ class TrendsActors(ActorBaseQuery):
 
         return (
             GET_ACTORS_FROM_EVENT_QUERY.format(
-                id_field=self._aggregation_actor_field,
+                # id_field=self._aggregation_actor_field,
                 actor_value_expression=actor_value_expression,
-                matching_events_select_statement=matching_events_select_statement,
+                # matching_events_select_statement=matching_events_select_statement,
                 events_query=events_query,
-                limit="LIMIT %(limit)s" if limit_actors else "",
-                offset="OFFSET %(offset)s" if limit_actors else "",
+                # limit="LIMIT %(limit)s" if limit_actors else "",
+                # offset="OFFSET %(offset)s" if limit_actors else "",
             ),
             {
                 **params,
                 **actor_value_params,
-                "offset": self._filter.offset,
-                "limit": self._filter.limit or 100,
+                # "offset": self._filter.offset,
+                # "limit": self._filter.limit or 100,
             },
         )
 


### PR DESCRIPTION
## Problem

The HogQL version of the trends actors query has several problems. See https://github.com/PostHog/posthog/pull/22103.

## Changes

This PR re-implements the actors query in a separate `TrendsActorsQueryBuilder`, thereby fixing a number of issues.

### Follow ups

The following issues are out-or-scope for this PR (to get the other fixes in), and will be addressed in a follow up.

- [x] test_trends_all_cohort_breakdown_persons - fails, as 'all' cohort can't be resolved
- [x] test_trends_multi_cohort_breakdown_persons - fails, as cohort breakdown value is seemingly ignored
- [x] check that the frontend passes in the correct time zone info or better omits it
- [ ] check that the breakdown subquery date range is correct also for compare_value and wau/mau options
- [ ] test_trends_breakdown_others_persons - fails, as other returns all breakdowns, even those that should be display with the breakdown_limit
- [ ] test_trends_math_property_sum_persons - fails, as event_count isn't populated properly
- [ ] test_trends_math_count_per_actor_persons - fails, as event_count isn't populated properly
- [ ] event_count for unique_group isn't correct
- [ ] add test_trends_math_sum_person
- [x] implement includeRecordings=False

## How did you test this code?

Added unit tests and clicked around