### PR TITLE
fix(data-warehouse): Reset the source wizard after connecting a manual source

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -182,7 +182,12 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
             preflightLogic,
             ['preflight'],
         ],
-        actions: [dataWarehouseTableLogic, ['resetTable'], dataWarehouseSettingsLogic, ['loadSources']],
+        actions: [
+            dataWarehouseTableLogic,
+            ['resetTable', 'createTableSuccess'],
+            dataWarehouseSettingsLogic,
+            ['loadSources'],
+        ],
     }),
     reducers({
         manualLinkingProvider: [
@@ -437,6 +442,12 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
             if (values.currentStep === 4) {
                 actions.closeWizard()
             }
+        },
+        createTableSuccess: () => {
+            actions.onClear()
+            actions.clearSource()
+            actions.loadSources(null)
+            actions.resetSourceConnectionDetails()
         },
         closeWizard: () => {
             actions.onClear()


### PR DESCRIPTION
## Problem
- After using the manual link flow of the source wizard, the form retains the details inputted when you attempt to link a second source

## Changes
- Resets the source wizard form after linking a manual source

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
- Browser clicks