### PR TITLE
fix(insight): Convert `filters` to `query` in background cache updates

### DIFF
--- a/posthog/caching/insight_caching_state.py
+++ b/posthog/caching/insight_caching_state.py
@@ -9,6 +9,7 @@ from django.utils.timezone import now
 
 from posthog.caching.calculate_results import calculate_cache_key
 from posthog.caching.utils import active_teams
+from posthog.hogql_queries.legacy_compatibility.flagged_conversion_manager import flagged_conversion_to_query
 from posthog.hogql_queries.query_runner import get_query_runner_or_none
 from posthog.models.dashboard_tile import DashboardTile
 from posthog.models.insight import Insight, InsightViewed
@@ -117,21 +118,22 @@ def upsert(
     if cache_key is None:  # Non-cachable model
         return None
 
-    target_age = calculate_target_age(team, target, lazy_loader)
-    target_cache_age_seconds = target_age.value.total_seconds() if target_age.value is not None else None
+    with flagged_conversion_to_query(target.insight if isinstance(target, DashboardTile) else target):
+        target_age = calculate_target_age(team, target, lazy_loader)
+        target_cache_age_seconds = target_age.value.total_seconds() if target_age.value is not None else None
 
-    model = InsightCachingState(
-        team_id=team.pk,
-        insight=target if isinstance(target, Insight) else target.insight,
-        dashboard_tile=target if isinstance(target, DashboardTile) else None,
-        cache_key=cache_key,
-        target_cache_age_seconds=target_cache_age_seconds,
-    )
-    if execute:
-        _execute_insert([model])
-        return None
-    else:
-        return model
+        model = InsightCachingState(
+            team_id=team.pk,
+            insight=target if isinstance(target, Insight) else target.insight,
+            dashboard_tile=target if isinstance(target, DashboardTile) else None,
+            cache_key=cache_key,
+            target_cache_age_seconds=target_cache_age_seconds,
+        )
+        if execute:
+            _execute_insert([model])
+            return None
+        else:
+            return model
 
 
 def sync_insight_caching_state(


### PR DESCRIPTION
## Problem

Currently background insight cache updates don't know about our intention to move to HogQL-based insights. They keep on calculating results, but these results are for legacy filters, and don't end up being used. Meanwhile, users don't see the fresh-ish result they expect.

## Changes

This moves conversion logic to a `flagged_conversion_to_query` context manager, which allows us to wrap the existing cache `upsert` function in flagged `filters`-to-`query` conversion with extreme ease. (You might want to hide whitespaces changes in GitHub's diff view here.)

Also, `hogql-in-insight-serialization` is now oriented towards team- or organization-based rollout, rather than user-based (analogous to `hogql-insights-replace-filters`). This is important here, because naturally Celery tasks aren't user specific, but the insights always are team-specific.

So background calculation results are now useful again.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

TODO