### PR TITLE
perf: Add index for `EventProperty.property`

### DIFF
--- a/latest_migrations.manifest
+++ b/latest_migrations.manifest
@@ -5,7 +5,7 @@ contenttypes: 0002_remove_content_type_name
 ee: 0016_rolemembership_organization_member
 otp_static: 0002_throttling
 otp_totp: 0002_auto_20190420_0723
-posthog: 0411_eventproperty_property_index
+posthog: 0411_eventproperty_indexes
 sessions: 0001_initial
 social_django: 0010_uid_db_index
 two_factor: 0007_auto_20201201_1019

--- a/latest_migrations.manifest
+++ b/latest_migrations.manifest
@@ -5,7 +5,7 @@ contenttypes: 0002_remove_content_type_name
 ee: 0016_rolemembership_organization_member
 otp_static: 0002_throttling
 otp_totp: 0002_auto_20190420_0723
-posthog: 0410_action_steps_population
+posthog: 0411_eventproperty_property_index
 sessions: 0001_initial
 social_django: 0010_uid_db_index
 two_factor: 0007_auto_20201201_1019

--- a/posthog/api/property_definition.py
+++ b/posthog/api/property_definition.py
@@ -119,10 +119,7 @@ class QueryContext:
     event_property_join_type: str = ""
     event_property_field: str = "NULL"
 
-    # the event name filter is used with and without a posthog_eventproperty_table_join_alias qualifier
     event_name_join_filter: str = ""
-
-    posthog_eventproperty_table_join_alias = "check_for_matching_event_property"
 
     params: dict = dataclasses.field(default_factory=dict)
 
@@ -215,8 +212,8 @@ class QueryContext:
             event_names = json.loads(event_names)
 
         if event_names and len(event_names) > 0:
-            event_property_field = f"{self.posthog_eventproperty_table_join_alias}.property is not null"
-            event_name_join_filter = "AND event = ANY(%(event_names)s)"
+            event_property_field = "posthog_eventproperty.property IS NOT NULL"
+            event_name_join_filter = "AND posthog_eventproperty.event = ANY(%(event_names)s)"
 
         return dataclasses.replace(
             self,
@@ -293,12 +290,10 @@ class QueryContext:
     def _join_on_event_property(self):
         return (
             f"""
-            {self.event_property_join_type} (
-                SELECT DISTINCT property
-                FROM posthog_eventproperty
-                WHERE team_id = %(team_id)s {self.event_name_join_filter}
-            ) {self.posthog_eventproperty_table_join_alias}
-            ON {self.posthog_eventproperty_table_join_alias}.property = name
+            {self.event_property_join_type} posthog_eventproperty ON
+                posthog_eventproperty.property = {self.table}.name
+                AND posthog_eventproperty.team_id = {self.table}.team_id
+                {self.event_name_join_filter}
             """
             if self.should_join_event_property
             else ""

--- a/posthog/migrations/0411_eventproperty_indexes.py
+++ b/posthog/migrations/0411_eventproperty_indexes.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            "CREATE INDEX CONCURRENTLY posthog_eventproperty_property_r32khd9s ON posthog_eventproperty(property)",
-            reverse_sql='DROP INDEX "posthog_eventproperty_property_r32khd9s"',
+            "CREATE INDEX CONCURRENTLY posthog_eventproperty_team_id_and_property_r32khd9s ON posthog_eventproperty(team_id, property)",
+            reverse_sql='DROP INDEX "posthog_eventproperty_team_id_and_property_r32khd9s"',
         ),
     ]

--- a/posthog/migrations/0411_eventproperty_property_index.py
+++ b/posthog/migrations/0411_eventproperty_property_index.py
@@ -1,0 +1,17 @@
+# Created manually on 2024-04-10 18:46
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    atomic = False
+    dependencies = [
+        ("posthog", "0410_action_steps_population"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "CREATE INDEX CONCURRENTLY posthog_eventproperty_property_r32khd9s ON posthog_eventproperty(property)",
+            reverse_sql='DROP INDEX "posthog_eventproperty_property_r32khd9s"',
+        ),
+    ]


### PR DESCRIPTION
## Problem

This join is _really_ slow:

https://github.com/PostHog/posthog/blob/320a7d57875c5de7900b1f588e52e3feff31d03c/posthog/api/property_definition.py#L293-L306

We don't have an index on `posthog_eventproperty.property`, so we have to scan the table a lot.

## Changes

Adds an index, added concurrently so that the table isn't locked.

EDIT: Also simplified the SQL of the `posthog_eventproperty` join, so that Postgres has a strong incentive to use the new index.

## Does this work well for both Cloud and self-hosted?

Yes, it's a simple migration.

## How did you test this code?

The migration just has to complete.