### PR TITLE
fix(data-warehouse): add data_warehouse as consideration in insight

### DIFF
--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -53,7 +53,9 @@ export function getDefaultEvent(): Entity {
 }
 
 export const isStepsUndefined = (filters: FunnelsFilterType): boolean =>
-    typeof filters.events === 'undefined' && (typeof filters.actions === 'undefined' || filters.actions.length === 0)
+    typeof filters.events === 'undefined' &&
+    (typeof filters.actions === 'undefined' || filters.actions.length === 0) &&
+    (typeof filters.data_warehouse === 'undefined' || filters.data_warehouse.length === 0)
 
 const findFirstNumber = (candidates: (number | undefined)[]): number | undefined =>
     candidates.find((s) => typeof s === 'number')


### PR DESCRIPTION
## Problem

- insight logics weren't treating data warehouse as a series type on null checks

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- add type check

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
