### PR TITLE
fix: Increase HogQL Expected Query Timeout

### DIFF
--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -12,7 +12,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -33,7 +33,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -54,7 +54,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -75,7 +75,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -96,7 +96,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -117,7 +117,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -134,7 +134,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -151,7 +151,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -168,7 +168,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -187,7 +187,7 @@
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -231,7 +231,7 @@
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -250,7 +250,7 @@
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -273,7 +273,7 @@
      ORDER BY toTimeZone(events.timestamp, 'UTC') ASC) AS event_view
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -294,7 +294,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -315,7 +315,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -336,7 +336,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -357,7 +357,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -378,7 +378,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -399,7 +399,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -420,7 +420,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -441,7 +441,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -480,7 +480,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -519,7 +519,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -538,7 +538,7 @@
   ORDER BY count() DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -558,7 +558,7 @@
   ORDER BY count() DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -577,7 +577,7 @@
   ORDER BY count() DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -597,7 +597,7 @@
   ORDER BY count() DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -616,7 +616,7 @@
   ORDER BY events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -636,7 +636,7 @@
   ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -654,7 +654,7 @@
   ORDER BY tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -673,7 +673,7 @@
   ORDER BY count() DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -692,7 +692,7 @@
   ORDER BY count() DESC, events.event ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,

--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -97,7 +97,7 @@ class HogQLQuerySettings(BaseModel):
 class HogQLGlobalSettings(HogQLQuerySettings):
     model_config = ConfigDict(extra="forbid")
     readonly: Optional[int] = 2
-    max_execution_time: Optional[int] = 60
+    max_execution_time: Optional[int] = 3 * 60  # three minutes (these guesses can be wildly off, might have to expand)
     allow_experimental_object_type: Optional[bool] = True
     format_csv_allow_double_quotes: Optional[bool] = False
     max_ast_elements: Optional[int] = 50000 * 20  # default value 50000

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
@@ -388,7 +388,7 @@
      HAVING ifNull(equals(steps, max_steps), isNull(steps)
                    and isNull(max_steps)))
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -496,7 +496,7 @@
      HAVING ifNull(equals(steps, max_steps), isNull(steps)
                    and isNull(max_steps)))
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -614,7 +614,7 @@
   ORDER BY toTimeZone(persons.created_at, 'UTC') DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -732,7 +732,7 @@
   ORDER BY toTimeZone(persons.created_at, 'UTC') DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -850,7 +850,7 @@
   ORDER BY toTimeZone(persons.created_at, 'UTC') DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -925,7 +925,7 @@
      HAVING ifNull(equals(steps, max_steps), isNull(steps)
                    and isNull(max_steps)))
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -988,7 +988,7 @@
      HAVING ifNull(equals(steps, max_steps), isNull(steps)
                    and isNull(max_steps)))
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_breakdowns_by_current_url.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_breakdowns_by_current_url.ambr
@@ -16,7 +16,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -105,7 +105,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -130,7 +130,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -219,7 +219,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -144,7 +144,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -306,7 +306,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -439,7 +439,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -457,7 +457,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -590,7 +590,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -608,7 +608,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -741,7 +741,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -759,7 +759,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -892,7 +892,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -910,7 +910,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -1048,7 +1048,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -1186,7 +1186,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -1318,7 +1318,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -1433,7 +1433,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1548,7 +1548,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1663,7 +1663,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1778,7 +1778,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1926,7 +1926,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -2041,7 +2041,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2156,7 +2156,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2288,7 +2288,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -2403,7 +2403,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2518,7 +2518,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2633,7 +2633,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2748,7 +2748,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2896,7 +2896,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -3011,7 +3011,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3126,7 +3126,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3273,7 +3273,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -3395,7 +3395,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3517,7 +3517,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3639,7 +3639,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3761,7 +3761,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3908,7 +3908,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -4055,7 +4055,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -4177,7 +4177,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4299,7 +4299,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4421,7 +4421,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4543,7 +4543,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4690,7 +4690,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -4837,7 +4837,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -4959,7 +4959,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -5081,7 +5081,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -5203,7 +5203,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -5325,7 +5325,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -5472,7 +5472,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -5619,7 +5619,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -5741,7 +5741,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -5863,7 +5863,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -5985,7 +5985,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -6107,7 +6107,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -6254,7 +6254,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -6401,7 +6401,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -6523,7 +6523,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -6645,7 +6645,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -6767,7 +6767,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -6889,7 +6889,7 @@
   ORDER BY source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -7036,7 +7036,7 @@
      WHERE ifNull(in(steps, [1, 2]), 0)
      ORDER BY aggregation_target ASC) AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -121,7 +121,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -139,7 +139,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -335,7 +335,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -353,7 +353,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -486,7 +486,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -504,7 +504,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -637,7 +637,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -655,7 +655,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -788,7 +788,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -806,7 +806,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s3']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_persons.ambr
@@ -163,7 +163,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -181,7 +181,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s1']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -353,7 +353,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -371,7 +371,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -543,7 +543,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -561,7 +561,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -16,7 +16,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -104,7 +104,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -129,7 +129,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -224,7 +224,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -249,7 +249,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -337,7 +337,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -363,7 +363,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -492,7 +492,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -524,7 +524,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -653,7 +653,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -686,7 +686,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -822,7 +822,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
@@ -123,7 +123,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -141,7 +141,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s1']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -273,7 +273,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -291,7 +291,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -423,7 +423,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -441,7 +441,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
@@ -410,7 +410,7 @@
                                     WHERE isNotNull(step_runs.step_1_average_conversion_time_inner)) AS histogram_params), 0), 1)) AS numbers) AS fill ON equals(results.bin_from_seconds, fill.bin_from_seconds)
   ORDER BY fill.bin_from_seconds ASC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -756,7 +756,7 @@
                                     WHERE isNotNull(step_runs.step_1_average_conversion_time_inner)) AS histogram_params), 0), 1)) AS numbers) AS fill ON equals(results.bin_from_seconds, fill.bin_from_seconds)
   ORDER BY fill.bin_from_seconds ASC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
@@ -1502,7 +1502,7 @@
                                     WHERE isNotNull(step_runs.step_1_average_conversion_time_inner)) AS histogram_params), 0), 1)) AS numbers) AS fill ON equals(results.bin_from_seconds, fill.bin_from_seconds)
   ORDER BY fill.bin_from_seconds ASC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends.ambr
@@ -82,7 +82,7 @@
      FROM numbers(plus(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull(('2021-04-30 00:00:00'), 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull(('2021-05-07 23:59:59'), 6, 'UTC')))), 1)) AS period_offsets) AS fill ON equals(data.entrance_period_start, fill.entrance_period_start)
   ORDER BY fill.entrance_period_start ASC
   LIMIT 1000 SETTINGS readonly=2,
-                      max_execution_time=60,
+                      max_execution_time=180,
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=1000000,
@@ -173,7 +173,7 @@
      FROM numbers(plus(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull(('2021-04-30 00:00:00'), 6, 'US/Pacific'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull(('2021-05-07 23:59:59'), 6, 'US/Pacific')))), 1)) AS period_offsets) AS fill ON equals(data.entrance_period_start, fill.entrance_period_start)
   ORDER BY fill.entrance_period_start ASC
   LIMIT 1000 SETTINGS readonly=2,
-                      max_execution_time=60,
+                      max_execution_time=180,
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=1000000,
@@ -264,7 +264,7 @@
      FROM numbers(plus(dateDiff('week', toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull(('2021-05-01 00:00:00'), 6, 'UTC')), 0), toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull(('2021-05-07 23:59:59'), 6, 'UTC')), 0)), 1)) AS period_offsets) AS fill ON equals(data.entrance_period_start, fill.entrance_period_start)
   ORDER BY fill.entrance_period_start ASC
   LIMIT 1000 SETTINGS readonly=2,
-                      max_execution_time=60,
+                      max_execution_time=180,
                       allow_experimental_object_type=1,
                       format_csv_allow_double_quotes=0,
                       max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
@@ -149,7 +149,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -167,7 +167,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s1b']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -325,7 +325,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -343,7 +343,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s1a']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -501,7 +501,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -519,7 +519,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s1c']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -16,7 +16,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -156,7 +156,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -181,7 +181,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -335,7 +335,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -360,7 +360,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -500,7 +500,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -526,7 +526,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -655,7 +655,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -687,7 +687,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -816,7 +816,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -849,7 +849,7 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -985,7 +985,7 @@
                    and isNull(max_steps)))
   GROUP BY prop
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
@@ -267,7 +267,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -285,7 +285,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, []), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_lifecycle_query_runner.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_lifecycle_query_runner.ambr
@@ -90,7 +90,7 @@
      ORDER BY start_of_period ASC)
   GROUP BY status
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -166,7 +166,7 @@
      ORDER BY start_of_period ASC)
   GROUP BY status
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -242,7 +242,7 @@
      ORDER BY start_of_period ASC)
   GROUP BY status
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -318,7 +318,7 @@
      ORDER BY start_of_period ASC)
   GROUP BY status
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_paths_query_runner_ee.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_paths_query_runner_ee.ambr
@@ -74,7 +74,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -157,7 +157,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -240,7 +240,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -323,7 +323,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -405,7 +405,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -487,7 +487,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -569,7 +569,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -651,7 +651,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -733,7 +733,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -815,7 +815,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -897,7 +897,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -987,7 +987,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1070,7 +1070,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1153,7 +1153,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1273,7 +1273,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1392,7 +1392,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1511,7 +1511,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1631,7 +1631,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1750,7 +1750,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1869,7 +1869,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1989,7 +1989,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2108,7 +2108,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2227,7 +2227,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2322,7 +2322,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2445,7 +2445,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2463,7 +2463,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s3', 's1', 's5']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -2587,7 +2587,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2605,7 +2605,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, []), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -2729,7 +2729,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2747,7 +2747,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s1']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -2870,7 +2870,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2888,7 +2888,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -3020,7 +3020,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3038,7 +3038,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['s1']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -3120,7 +3120,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3207,7 +3207,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3335,7 +3335,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3422,7 +3422,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3550,7 +3550,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3637,7 +3637,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3765,7 +3765,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3852,7 +3852,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3980,7 +3980,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4063,7 +4063,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 6 SETTINGS readonly=2,
-                   max_execution_time=60,
+                   max_execution_time=180,
                    allow_experimental_object_type=1,
                    format_csv_allow_double_quotes=0,
                    max_ast_elements=1000000,
@@ -4145,7 +4145,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4227,7 +4227,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4346,7 +4346,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4465,7 +4465,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4547,7 +4547,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4666,7 +4666,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4748,7 +4748,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4867,7 +4867,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4986,7 +4986,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -5105,7 +5105,7 @@
   ORDER BY persons.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -5187,7 +5187,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -5274,7 +5274,7 @@
            source_event ASC,
            target_event ASC
   LIMIT 50 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_retention_query_runner.ambr
@@ -41,7 +41,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -107,7 +107,7 @@
   ORDER BY length(source.appearances) DESC, source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -157,7 +157,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -207,7 +207,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -273,7 +273,7 @@
   ORDER BY length(source.appearances) DESC, source.actor_id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -323,7 +323,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -394,7 +394,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -476,7 +476,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -547,7 +547,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -640,7 +640,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -711,7 +711,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -782,7 +782,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -853,7 +853,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -924,7 +924,7 @@
   ORDER BY breakdown_values ASC,
            intervals_from_base ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -92,7 +92,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -181,7 +181,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -206,7 +206,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -259,7 +259,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -305,7 +305,7 @@
   ORDER BY source.event_count DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -323,7 +323,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -348,7 +348,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -401,7 +401,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -418,7 +418,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -463,7 +463,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -480,7 +480,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -525,7 +525,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -549,7 +549,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -591,7 +591,7 @@
   WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-11 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-11 23:59:59', 6, 'UTC'))), 0))
   GROUP BY breakdown_value
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -615,7 +615,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -657,7 +657,7 @@
   WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-11 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-11 23:59:59', 6, 'UTC'))), 0))
   GROUP BY breakdown_value
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -715,7 +715,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -797,7 +797,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -822,7 +822,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -875,7 +875,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -914,7 +914,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -973,7 +973,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -990,7 +990,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1042,7 +1042,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -1059,7 +1059,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1111,7 +1111,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -1199,7 +1199,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -1269,7 +1269,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -1315,7 +1315,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -1369,7 +1369,7 @@
   ORDER BY source.event_count DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1387,7 +1387,7 @@
      GROUP BY session_replay_events.session_id) AS session_replay_events
   WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -1425,7 +1425,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -1461,7 +1461,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1541,7 +1541,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -1564,7 +1564,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1631,7 +1631,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -1661,7 +1661,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -1708,7 +1708,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1763,7 +1763,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -1809,7 +1809,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1863,7 +1863,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -1911,7 +1911,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -1959,7 +1959,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -1989,7 +1989,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2037,7 +2037,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2067,7 +2067,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2115,7 +2115,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2159,7 +2159,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2195,7 +2195,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2245,7 +2245,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2295,7 +2295,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2345,7 +2345,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2375,7 +2375,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2412,7 +2412,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2462,7 +2462,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2492,7 +2492,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2509,7 +2509,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2561,7 +2561,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2591,7 +2591,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2628,7 +2628,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2678,7 +2678,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2708,7 +2708,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2725,7 +2725,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2777,7 +2777,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2807,7 +2807,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2844,7 +2844,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2894,7 +2894,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2924,7 +2924,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -2941,7 +2941,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2993,7 +2993,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3030,7 +3030,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3060,7 +3060,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3097,7 +3097,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3127,7 +3127,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3164,7 +3164,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3194,7 +3194,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3224,7 +3224,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3254,7 +3254,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3284,7 +3284,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3314,7 +3314,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3344,7 +3344,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3374,7 +3374,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3411,7 +3411,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3476,7 +3476,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3513,7 +3513,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3578,7 +3578,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3608,7 +3608,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3656,7 +3656,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3691,7 +3691,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3754,7 +3754,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3797,7 +3797,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3840,7 +3840,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3857,7 +3857,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3902,7 +3902,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3932,7 +3932,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3962,7 +3962,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -3979,7 +3979,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4037,7 +4037,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4054,7 +4054,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4111,7 +4111,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4130,7 +4130,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4190,7 +4190,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4209,7 +4209,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4268,7 +4268,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4292,7 +4292,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4320,7 +4320,7 @@
               breakdown_value)
   GROUP BY breakdown_value
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4344,7 +4344,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4372,7 +4372,7 @@
               breakdown_value)
   GROUP BY breakdown_value
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4402,7 +4402,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4432,7 +4432,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4462,7 +4462,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4488,7 +4488,7 @@
         WHERE and(equals(e.team_id, 2), equals(e.event, 'viewed video'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), minus(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-01 00:00:00', 6, 'UTC')), toIntervalDay(0))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-07 23:59:59', 6, 'UTC'))))
         GROUP BY e__pdi.person_id))
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4513,7 +4513,7 @@
         WHERE and(equals(e.team_id, 2), equals(e.event, 'viewed video'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), minus(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-01 00:00:00', 6, 'UTC')), toIntervalDay(0))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-07 23:59:59', 6, 'UTC'))))
         GROUP BY ifNull(nullIf(e__override.override_person_id, '00000000-0000-0000-0000-000000000000'), e.person_id)))
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4530,7 +4530,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4561,7 +4561,7 @@
                  breakdown_value)
      GROUP BY breakdown_value)
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4606,7 +4606,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4650,7 +4650,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4680,7 +4680,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4715,7 +4715,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4750,7 +4750,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4792,7 +4792,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4834,7 +4834,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -4880,7 +4880,7 @@
               breakdown_value)
   GROUP BY breakdown_value
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4910,7 +4910,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4934,7 +4934,7 @@
      WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')), 0)), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
      GROUP BY e.`$session_id`)
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -4958,7 +4958,7 @@
      WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
      GROUP BY e.`$session_id`)
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5001,7 +5001,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5044,7 +5044,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5068,7 +5068,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -5128,7 +5128,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5152,7 +5152,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -5212,7 +5212,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5248,7 +5248,7 @@
      ORDER BY d.timestamp ASC)
   WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-11 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-12 23:59:59', 6, 'UTC'))), 0))
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5284,7 +5284,7 @@
      ORDER BY d.timestamp ASC)
   WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-01 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-18 23:59:59', 6, 'UTC'))), 0))
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5320,7 +5320,7 @@
      ORDER BY d.timestamp ASC)
   WHERE and(ifNull(greaterOrEquals(timestamp, toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-01 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-18 23:59:59', 6, 'UTC'))), 0))
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5370,7 +5370,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5420,7 +5420,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5470,7 +5470,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5531,7 +5531,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5592,7 +5592,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5642,7 +5642,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5692,7 +5692,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5742,7 +5742,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,
@@ -5792,7 +5792,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 10000 SETTINGS readonly=2,
-                       max_execution_time=60,
+                       max_execution_time=180,
                        allow_experimental_object_type=1,
                        format_csv_allow_double_quotes=0,
                        max_ast_elements=1000000,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends_data_warehouse_query.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends_data_warehouse_query.ambr
@@ -8,7 +8,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -53,7 +53,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -70,7 +70,7 @@
   GROUP BY value
   ORDER BY count DESC, value DESC
   LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -115,7 +115,7 @@
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)),
            sum(count) DESC, breakdown_value ASC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -145,7 +145,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -175,7 +175,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -205,7 +205,7 @@
      ORDER BY day_start ASC)
   ORDER BY sum(count) DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/hogql_queries/test/__snapshots__/test_sessions_timeline_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_sessions_timeline_query_runner.ambr
@@ -59,7 +59,7 @@
         GROUP BY session_replay_events.session_id) AS session_replay_events) AS sre ON equals(e.session_id, sre.session_id)
   ORDER BY e.timestamp DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -127,7 +127,7 @@
         GROUP BY session_replay_events.session_id) AS session_replay_events) AS sre ON equals(e.session_id, sre.session_id)
   ORDER BY e.timestamp DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -195,7 +195,7 @@
         GROUP BY session_replay_events.session_id) AS session_replay_events) AS sre ON equals(e.session_id, sre.session_id)
   ORDER BY e.timestamp DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -263,7 +263,7 @@
         GROUP BY session_replay_events.session_id) AS session_replay_events) AS sre ON equals(e.session_id, sre.session_id)
   ORDER BY e.timestamp DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -331,7 +331,7 @@
         GROUP BY session_replay_events.session_id) AS session_replay_events) AS sre ON equals(e.session_id, sre.session_id)
   ORDER BY e.timestamp DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -399,7 +399,7 @@
         GROUP BY session_replay_events.session_id) AS session_replay_events) AS sre ON equals(e.session_id, sre.session_id)
   ORDER BY e.timestamp DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,
@@ -467,7 +467,7 @@
         GROUP BY session_replay_events.session_id) AS session_replay_events) AS sre ON equals(e.session_id, sre.session_id)
   ORDER BY e.timestamp DESC
   LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
+                     max_execution_time=180,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
                      max_ast_elements=1000000,

--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_filters.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_filters.ambr
@@ -28,7 +28,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -65,7 +65,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -102,7 +102,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -139,7 +139,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -183,7 +183,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -220,7 +220,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -257,7 +257,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -294,7 +294,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -331,7 +331,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -368,7 +368,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -405,7 +405,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -437,7 +437,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -469,7 +469,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -501,7 +501,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -533,7 +533,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -565,7 +565,7 @@
   ORDER BY active_seconds DESC
   LIMIT 4
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -597,7 +597,7 @@
   ORDER BY console_error_count DESC
   LIMIT 4
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -629,7 +629,7 @@
   ORDER BY start_time DESC
   LIMIT 4
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -661,7 +661,7 @@
   ORDER BY start_time DESC
   LIMIT 2
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -693,7 +693,7 @@
   ORDER BY start_time DESC
   LIMIT 2
   OFFSET 1 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -725,7 +725,7 @@
   ORDER BY start_time DESC
   LIMIT 2
   OFFSET 2 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -757,7 +757,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -789,7 +789,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -821,7 +821,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -853,7 +853,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -885,7 +885,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -917,7 +917,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -949,7 +949,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -981,7 +981,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1013,7 +1013,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1050,7 +1050,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1087,7 +1087,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1124,7 +1124,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1156,7 +1156,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1193,7 +1193,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1230,7 +1230,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1272,7 +1272,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1309,7 +1309,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1364,7 +1364,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1419,7 +1419,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1456,7 +1456,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1511,7 +1511,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1566,7 +1566,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1603,7 +1603,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1640,7 +1640,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1677,7 +1677,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1714,7 +1714,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1751,7 +1751,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1788,7 +1788,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1838,7 +1838,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1875,7 +1875,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1912,7 +1912,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1949,7 +1949,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -1986,7 +1986,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2023,7 +2023,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2060,7 +2060,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2097,7 +2097,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2134,7 +2134,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2195,7 +2195,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2232,7 +2232,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2293,7 +2293,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2330,7 +2330,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2367,7 +2367,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2405,7 +2405,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2443,7 +2443,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2481,7 +2481,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2519,7 +2519,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2557,7 +2557,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2595,7 +2595,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2633,7 +2633,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2671,7 +2671,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2709,7 +2709,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2747,7 +2747,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2785,7 +2785,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2823,7 +2823,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2861,7 +2861,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2899,7 +2899,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -2961,7 +2961,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3028,7 +3028,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3075,7 +3075,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3112,7 +3112,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3149,7 +3149,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3188,7 +3188,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3225,7 +3225,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3262,7 +3262,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3299,7 +3299,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3336,7 +3336,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3373,7 +3373,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3410,7 +3410,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3447,7 +3447,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3484,7 +3484,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3521,7 +3521,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3558,7 +3558,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3595,7 +3595,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3632,7 +3632,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3669,7 +3669,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3719,7 +3719,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3756,7 +3756,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3806,7 +3806,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3843,7 +3843,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3893,7 +3893,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3930,7 +3930,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,
@@ -3980,7 +3980,7 @@
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
+                    max_execution_time=180,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
                     max_ast_elements=1000000,


### PR DESCRIPTION
Some queries aren't completing in HogQL mode because we're imposing a 60 second on expected query execution time.

Increase this to 180.