### PR TITLE
feat: update dashboard refresh button when returning

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -2,6 +2,7 @@ import { LemonButton, LemonDivider, LemonSwitch } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { dayjs } from 'lib/dayjs'
+import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { IconRefresh } from 'lib/lemon-ui/icons'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { Spinner } from 'lib/lemon-ui/Spinner'
@@ -27,7 +28,11 @@ const intervalOptions = [
 
 export function DashboardReloadAction(): JSX.Element {
     const { itemsLoading, autoRefresh, refreshMetrics, blockRefresh } = useValues(dashboardLogic)
-    const { refreshAllDashboardItemsManual, setAutoRefresh } = useActions(dashboardLogic)
+    const { refreshAllDashboardItemsManual, setAutoRefresh, setPageVisibility } = useActions(dashboardLogic)
+
+    usePageVisibility((pageIsVisible) => {
+        setPageVisibility(pageIsVisible)
+    })
 
     const options = intervalOptions.map((option) => {
         return {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -150,6 +150,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             loading,
             queued,
         }),
+        setPageVisibility: (visible: boolean) => ({ visible }),
         setRefreshError: (shortId: InsightShortId) => ({ shortId }),
         reportDashboardViewed: true, // Reports `viewed dashboard` and `dashboard analyzed` events
         setShouldReportOnAPILoad: (shouldReport: boolean) => ({ shouldReport }), // See reducer for details
@@ -276,6 +277,12 @@ export const dashboardLogic = kea<dashboardLogicType>([
         ],
     })),
     reducers(({ props }) => ({
+        pageVisibility: [
+            true,
+            {
+                setPageVisibility: (_, { visible }) => visible,
+            },
+        ],
         dashboardFailedToLoad: [
             false,
             {
@@ -640,7 +647,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
             },
         ],
         newestRefreshed: [
-            (s) => [s.sortedDates],
+            // page visibility is only here to trigger a recompute when the page is hidden/shown
+            (s) => [s.sortedDates, s.pageVisibility],
             (sortedDates): Dayjs | null => {
                 if (!sortedDates.length) {
                     return null
@@ -660,7 +668,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
             },
         ],
         blockRefresh: [
-            (s) => [s.newestRefreshed, s.placement],
+            // page visibility is only here to trigger a recompute when the page is hidden/shown
+            (s) => [s.newestRefreshed, s.placement, s.pageVisibility],
             (newestRefreshed: Dayjs, placement: DashboardPlacement) => {
                 return (
                     !!newestRefreshed &&


### PR DESCRIPTION
I came back to this dashboard in an open but background tab after several hours

<img width="409" alt="Screenshot 2024-05-07 at 21 45 37" src="https://github.com/PostHog/posthog/assets/984817/847aee77-b4ad-4cb3-af7d-a586612bce86">

but it won't let me refresh it because it doesn't know time has passed, I can load the entire page again but where's the fun in that

total fly-by - would something like this work to poke the selectors when page visibility changes?