### PR TITLE
fix(batch-exports): add more non-retryable errors

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -440,8 +440,11 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
                 "RefreshError",
                 # Usually means the dataset or project doesn't exist.
                 "NotFound",
-                # Raised when something about dataset is wrong (not alphanumeric, too long, etc)
+                # Raised when something about dataset is wrong (not alphanumeric, too long, etc).
                 "BadRequest",
+                # Raised when table_id isn't valid. Sadly, `ValueError` is rather generic, but we
+                # don't anticipate a `ValueError` thrown from our own export code.
+                "ValueError",
             ],
             finish_inputs=finish_inputs,
         )

--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -448,6 +448,8 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
                 "InvalidSchemaName",
                 # Missing permissions to, e.g., insert into table.
                 "InsufficientPrivilege",
+                # Issue with exported data compared to schema, retrying won't help.
+                "NotNullViolation",
             ],
             finish_inputs=finish_inputs,
             # Disable heartbeat timeout until we add heartbeat support.


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
These are more errors that don't make sense to retry.

http://metabase-prod-us/question/505-most-recent-batchexport-failures-retryable-only

## Changes

Add them, so we don't alert so loudly and we send the customers email notifications.



<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Existing
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
