### PR TITLE
chore: remove 23.11 clickhouse from matrix testing

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -253,8 +253,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ['3.10.10']
-                clickhouse-server-image:
-                    ['clickhouse/clickhouse-server:23.11.2.11-alpine', 'clickhouse/clickhouse-server:23.12.5.81-alpine']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:23.12.5.81-alpine']
                 segment: ['Core']
                 person-on-events: [false, true]
                 # :NOTE: Keep concurrency and groups in sync
@@ -334,8 +333,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                clickhouse-server-image:
-                    ['clickhouse/clickhouse-server:23.11.2.11-alpine', 'clickhouse/clickhouse-server:23.12.5.81-alpine']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:23.12.5.81-alpine']
         if: needs.changes.outputs.backend == 'true'
         runs-on: ubuntu-latest
         steps:


### PR DESCRIPTION
## Problem

We have CI running against both 23.11 and 23.12 due to an emergency upgrade of clickhouse. We've resolved the issues with 23.12 so it's full steam ahead for all clusters on that version.

## Changes

- Remove ClickHouse 23.11 from CI Test matrix

## Does this work well for both Cloud and self-hosted?



## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
