### PR TITLE
fix(insights): Pass Limit Context to breakdowns

### DIFF
--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -97,7 +97,7 @@ class HogQLQuerySettings(BaseModel):
 class HogQLGlobalSettings(HogQLQuerySettings):
     model_config = ConfigDict(extra="forbid")
     readonly: Optional[int] = 2
-    max_execution_time: Optional[int] = 3 * 60  # three minutes (these guesses can be wildly off, might have to expand)
+    max_execution_time: Optional[int] = 60
     allow_experimental_object_type: Optional[bool] = True
     format_csv_allow_double_quotes: Optional[bool] = False
     max_ast_elements: Optional[int] = 50000 * 20  # default value 50000

--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -97,7 +97,7 @@ class HogQLQuerySettings(BaseModel):
 class HogQLGlobalSettings(HogQLQuerySettings):
     model_config = ConfigDict(extra="forbid")
     readonly: Optional[int] = 2
-    max_execution_time: Optional[int] = 60
+    max_execution_time: Optional[int] = 3 * 60  # three minutes (these guesses can be wildly off, might have to expand)
     allow_experimental_object_type: Optional[bool] = True
     format_csv_allow_double_quotes: Optional[bool] = False
     max_ast_elements: Optional[int] = 50000 * 20  # default value 50000

--- a/posthog/hogql_queries/insights/trends/breakdown_values.py
+++ b/posthog/hogql_queries/insights/trends/breakdown_values.py
@@ -75,6 +75,7 @@ class BreakdownValues:
         self.breakdown_limit = breakdown_filter.breakdown_limit or get_breakdown_limit_for_context(limit_context)
         self.query_date_range = query_date_range
         self.modifiers = modifiers
+        self.limit_context = limit_context
 
     def get_breakdown_values(self) -> list[str | int]:
         if self.breakdown_type == "cohort":
@@ -202,6 +203,7 @@ class BreakdownValues:
                 query=query,
                 team=self.team,
                 modifiers=self.modifiers,
+                limit_context=self.limit_context,
             )
             if response.results and len(response.results) > 0:
                 values = response.results[0][0]
@@ -215,6 +217,7 @@ class BreakdownValues:
                 query=query,
                 team=self.team,
                 modifiers=self.modifiers,
+                limit_context=self.limit_context,
             )
             value_index = (response.columns or []).index("value")
             values = [row[value_index] for row in response.results or []]


### PR DESCRIPTION
Fix a bug that breakdowns on async queries weren't being given context, so on large queries hogQL would error out.
