### PR TITLE
feat: Add django admin cmd for adding explicit plugin access

### DIFF
--- a/posthog/management/commands/change_plugin_private_access.py
+++ b/posthog/management/commands/change_plugin_private_access.py
@@ -1,0 +1,67 @@
+import logging
+import uuid
+
+import structlog
+from django.core.management import CommandError
+from django.core.management.base import BaseCommand
+
+from posthog.models import Organization
+from posthog.models.plugin import Plugin
+
+logger = structlog.get_logger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class Command(BaseCommand):
+    help = "Change Plugin private access (either add or remove depending on state)."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--organization-id", default=None, type=uuid.UUID, help="Specify the organization.")
+        parser.add_argument("--plugin-id", default=None, type=int, help="Specify the plugin.")
+        parser.add_argument("--live-run", action="store_true", help="Run changes, default is dry-run")
+
+    def handle(self, *args, **options):
+        run(options)
+
+
+def run(options):
+    live_run = options["live_run"]
+
+    if options["plugin_id"] is None:
+        raise CommandError("You must specify --plugin-id to run this script")
+
+    if options["organization_id"] is None:
+        raise CommandError("You must specify --organization-id to run this script")
+
+    plugin_id = options["plugin_id"]
+    organization_id = options["organization_id"]
+
+    plugin = Plugin.objects.get(pk=plugin_id)
+    current_organizations = plugin.has_private_access.all()
+    logger.info(
+        f"Plugin {plugin.name} is currently explicitly allowed for organizations: [{', '.join([str(org.name) for org in current_organizations])}]"
+    )
+
+    org = Organization.objects.get(pk=organization_id)
+    org_current_plugins = org.plugin_set.all()
+    logger.info(
+        f"Organization {org.name} currently has explicit access to plugins: [{', '.join([str(plugin.name) for plugin in org_current_plugins])}]"
+    )
+
+    has_access = org in current_organizations
+    logger.info(
+        f"Target organization {organization_id} is named {org.name} currently {'has access' if has_access else 'does not have access'}"
+    )
+
+    if has_access:
+        if live_run:
+            plugin.has_private_access.remove(org)
+            logger.info("Removed access")
+        else:
+            logger.info("Skipping the access removal, pass --live-run to run it")
+    else:
+        if live_run:
+            plugin.has_private_access.add(org)
+            logger.info("Added access")
+        else:
+            logger.info("Skipping the access addition, pass --live-run to run it")


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Want to switch over to using explicit access instead of if org has any plugins that are enabled.
Follow-up to https://github.com/PostHog/posthog/pull/21680

Thought about adding a UI for this and realised it's only us + support engineers maybe using it and that's too much work for that.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Ran locally
```
DEBUG=1 python manage.py change_plugin_private_access --organization-id 018e628e-99d7-0000-ff0b-1c5490bdc38f --plugin-id 5 --live-run
2024-05-08 02:29:41 [warning  ] ['️Environment variable DEBUG is set - PostHog is running in DEVELOPMENT MODE!', 'Be sure to unset DEBUG if this is supposed to be a PRODUCTION ENVIRONMENT!']
/Users/tiina/posthog/posthog2/env/lib/python3.10/site-packages/dlt/common/configuration/specs/base_configuration.py:155: UserWarning: Missing default value for field subdomain on ZendeskCredentialsBase. None assumed. All fields in configspec must have default.
  warnings.warn(
2024-05-08T00:29:45.029100Z [warning  ] Skipping async migrations setup. This is unsafe in production! [posthog.apps] pid=2782 tid=4298851712
2024-05-08T00:29:45.032737Z [info     ] AXES: BEGIN LOG                [axes.apps] pid=2782 tid=4298851712
2024-05-08T00:29:45.033819Z [info     ] AXES: Using django-axes version 5.9.0 [axes.apps] pid=2782 tid=4298851712
2024-05-08T00:29:45.033872Z [info     ] AXES: blocking by IP only.     [axes.apps] pid=2782 tid=4298851712
2024-05-08T00:29:45.458294Z [info     ] Plugin Language URL stripper is currently explicitly allowed for organizations: [] [posthog.management.commands.change_plugin_private_access] pid=2782 tid=4298851712
2024-05-08T00:29:45.461122Z [info     ] Organization host currently has explicit access to plugins: [Taxonomy Plugin] [posthog.management.commands.change_plugin_private_access] pid=2782 tid=4298851712
2024-05-08T00:29:45.461201Z [info     ] Target organization 018e628e-99d7-0000-ff0b-1c5490bdc38f is named host currently does not have access [posthog.management.commands.change_plugin_private_access] pid=2782 tid=4298851712
2024-05-08T00:29:45.466706Z [info     ] Added access                   [posthog.management.commands.change_plugin_private_access] pid=2782 tid=4298851712
(env)
```
