### PR TITLE
fix: Small typo

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -79,7 +79,7 @@ export const INSIGHT_TYPES_METADATA: Record<InsightType, InsightTypeMetadata> = 
     },
     [InsightType.RETENTION]: {
         name: 'Retention',
-        description: 'See how many users return on subsequent days after an intial action.',
+        description: 'See how many users return on subsequent days after an initial action.',
         icon: IconRetention,
         inMenu: true,
     },


### PR DESCRIPTION
## Problem
I'm just fixing a typo :)

## Changes
It's just a typo. I found this typo in a bunch of your repos (just search for `inti` instead of `init`, and you will this in `posthog-foss`, `clickhouse` and a couple repos more.

## Does this work well for both Cloud and self-hosted?
No impact.

## How did you test this code?
Didn't, sue me