### PR TITLE
fix(trends): calculate sampling results accordingly

### DIFF
--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -1,6 +1,6 @@
 # serializer version: 1
 # name: TestDatabase.test_database_warehouse_joins_persons_poe_v2
-  'SELECT events__some_field.key AS key FROM events LEFT JOIN (SELECT groups.key AS key, key AS events__some_field___key FROM (SELECT groups.group_type_index AS index, groups.group_key AS key FROM groups WHERE equals(groups.team_id, 218) GROUP BY groups.group_type_index, groups.group_key) AS groups) AS events__some_field ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, %(hogql_val_0)s), \'\'), \'null\'), \'^"|"$\', \'\'), events__some_field.events__some_field___key) WHERE equals(events.team_id, 218) LIMIT 10000'
+  'SELECT events__some_field.key AS key FROM events LEFT JOIN (SELECT groups.key AS key, key AS events__some_field___key FROM (SELECT groups.group_type_index AS index, groups.group_key AS key FROM groups WHERE equals(groups.team_id, 217) GROUP BY groups.group_type_index, groups.group_key) AS groups) AS events__some_field ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, %(hogql_val_0)s), \'\'), \'null\'), \'^"|"$\', \'\'), events__some_field.events__some_field___key) WHERE equals(events.team_id, 217) LIMIT 10000'
 # ---
 # name: TestDatabase.test_serialize_database_no_person_on_events
   '''


### PR DESCRIPTION
## Problem

10% sampling reduces trends results by 10%

## Changes

Restore the code to adjust the results back up.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added a test.