### PR TITLE
fix: Fixed launch.json billing url

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -71,7 +71,7 @@
                 "DATABASE_URL": "postgres://posthog:posthog@localhost:5432/posthog",
                 "SKIP_SERVICE_VERSION_REQUIREMENTS": "1",
                 "PRINT_SQL": "1",
-                "BILLING_SERVICE_URL": "http://localhost:8100" //"https://billing.dev.posthog.dev"
+                "BILLING_SERVICE_URL": "https://billing.dev.posthog.dev"
             },
             "console": "integratedTerminal",
             "python": "${workspaceFolder}/env/bin/python",


### PR DESCRIPTION
## Problem
The Billing URL for the backend in vscode launch.json config was accidentally changed in https://github.com/PostHog/posthog/pull/21957

## Changes
- Reverts the billing URL to the dev instance
