### PR TITLE
fix(plugin-server): assert fields we iterate over are objects

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/normalizeEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/normalizeEventStep.ts
@@ -4,13 +4,79 @@ import { DateTime } from 'luxon'
 import { normalizeEvent, normalizeProcessPerson } from '../../../utils/event'
 import { status } from '../../../utils/status'
 import { parseEventTimestamp } from '../timestamps'
+import { captureIngestionWarning } from '../utils'
+import { EventPipelineRunner } from './runner'
 
-export function normalizeEventStep(event: PluginEvent, processPerson: boolean): Promise<[PluginEvent, DateTime]> {
+function isNotNullOrUndefinedOrObject(value: any): boolean {
+    return typeof value !== 'undefined' && value !== null && typeof value !== 'object'
+}
+
+function normalizeFieldTypes(runner: EventPipelineRunner, event: PluginEvent): Promise<void>[] {
+    // People sometimes send things like strings in fields where we expect an object. Because we
+    // don't do real schema validation and TypeScript is none the wiser at runtime, it's easy to
+    // accidentally splat a string into an object, for example:
+    //   event.properties.$set = { ...properties['$set'], ...event['$set'] }
+    // If event.$set is simply "foo" then this will iterate over the string and add
+    //   { 0: f, 1: o, 2: o }
+    // To the event.$set object, which is definitely not what we or the customer want.
+
+    const kafkaAcks: Promise<void>[] = []
+
+    const writeWarning = (field: string, found_type: string) =>
+        kafkaAcks.push(
+            captureIngestionWarning(runner.hub.db.kafkaProducer, event.team_id, 'invalid_type_for_object_field', {
+                field,
+                type: found_type,
+                eventUuid: event.uuid,
+                event: event.event,
+                distinctId: event.distinct_id,
+            })
+        )
+
+    if (event.properties) {
+        if (isNotNullOrUndefinedOrObject(event.properties)) {
+            event.properties = {}
+            writeWarning('properties', typeof event.properties)
+        } else {
+            if (isNotNullOrUndefinedOrObject(event.properties['$set'])) {
+                event.properties['$set'] = {}
+                writeWarning('properties.$set', typeof event.properties['$set'])
+            }
+
+            if (isNotNullOrUndefinedOrObject(event.properties['$set_once'])) {
+                event.properties['$set_once'] = {}
+                writeWarning('properties.$set_once', typeof event.properties['$set_once'])
+            }
+        }
+    }
+
+    if (isNotNullOrUndefinedOrObject(event.$set)) {
+        event.$set = {}
+        writeWarning('$set', typeof event.$set)
+    }
+
+    if (isNotNullOrUndefinedOrObject(event.$set_once)) {
+        event.$set_once = {}
+        writeWarning('$set_once', typeof event.$set_once)
+    }
+
+    return kafkaAcks
+}
+
+export function normalizeEventStep(
+    runner: EventPipelineRunner,
+    event: PluginEvent,
+    processPerson: boolean
+): Promise<[PluginEvent, DateTime, Promise<void>[]]> {
     let timestamp: DateTime
     try {
+        const kafkaAcks = normalizeFieldTypes(runner, event)
         event = normalizeEvent(event)
         event = normalizeProcessPerson(event, processPerson)
         timestamp = parseEventTimestamp(event)
+
+        // We need to be "async" to deal with how `runStep` currently works.
+        return Promise.resolve([event, timestamp, kafkaAcks])
     } catch (error) {
         status.warn('⚠️', 'Failed normalizing event', {
             team_id: event.team_id,
@@ -19,7 +85,4 @@ export function normalizeEventStep(event: PluginEvent, processPerson: boolean): 
         })
         throw error
     }
-
-    // We need to be "async" to deal with how `runStep` currently works.
-    return Promise.resolve([event, timestamp])
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -199,11 +199,15 @@ export class EventPipelineRunner {
             return this.registerLastStep('pluginsProcessEventStep', [event], kafkaAcks)
         }
 
-        const [normalizedEvent, timestamp] = await this.runStep(
+        const [normalizedEvent, timestamp, normalizeEventKafkaAcks] = await this.runStep(
             normalizeEventStep,
-            [processedEvent, processPerson],
+            [this, processedEvent, processPerson],
             event.team_id
         )
+
+        if (normalizeEventKafkaAcks.length > 0) {
+            kafkaAcks.push(...normalizeEventKafkaAcks)
+        }
 
         const [postPersonEvent, person] = await this.runStep(
             processPersonsStep,


### PR DESCRIPTION
This is a WIP that will require tests to be updated if we actually want to merge it.

However, it [[seems to me that capture-rs will reject events]](https://github.com/PostHog/hog-rs/blob/871441b400d3af766a5a012507dde6c1aaf45c7f/capture/src/v0_request.rs#L72) if the user sends a string as the toplevel `properties`, `$set`, or `$set_once`. We could just add an assertion for `properties.$set` and `properties.$set_once` and reject those events too, which seems cleaner...

Anyone have opinions on whether we should just reject these events as misshapen in capture?

Worth noting that Python capture definitely doesn't require (or check) that these are objects, to our detriment: https://posthog.sentry.io/issues/5321764413/